### PR TITLE
Include rustdoc in Rust packaging

### DIFF
--- a/packages/rust/rust.spec
+++ b/packages/rust/rust.spec
@@ -55,10 +55,10 @@ rm %{buildroot}%{_prefix}/lib/rustlib/manifest-*
 %files
 %{_bindir}/cargo
 %{_bindir}/rustc
+%{_bindir}/rustdoc
 %exclude %{_bindir}/rust-gdb
 %exclude %{_bindir}/rust-gdbgui
 %exclude %{_bindir}/rust-lldb
-%exclude %{_bindir}/rustdoc
 %{_prefix}/lib/*.so
 %{_prefix}/lib/rustlib/%{_cross_arch}-unknown-linux-%{_cross_libc}
 %exclude %{_prefix}/lib/rustlib/etc


### PR DESCRIPTION
rustdoc is needed to run doctests during builds of Rust packages.

Signed-off-by: Tom Kirchner <tjk@amazon.com>

---

Testing: Without this, Rust packages using %cargo_test will fail because it tries to run doctests, but the rustdoc binary doesn't exist.  With this, rustdoc is included, and the doctests pass.  I confirmed an image build was successful, including rust, ripgrep, and first-party crates.