### PR TITLE
Double output image size

### DIFF
--- a/bin/rpm2img
+++ b/bin/rpm2img
@@ -41,17 +41,18 @@ THAR_HASH_TYPECODE="598f10af-c955-4456-6a99-7720068a6cea"
 THAR_ROOT_TYPECODE="5526016a-1a97-4ea4-b39a-b7c8c6ca4502"
 THAR_RESERVED_TYPECODE="0c5d99a5-d331-4147-baef-08e2b855bdc9"
 
-truncate -s 2G "${DISK_IMAGE}"
+truncate -s 4G "${DISK_IMAGE}"
+# boot: 20M + root: 900M + hash: 8M + reserved: 95M = 1023M
 # boot partition attributes (-A): 48 = gptprio priority bit; 56 = gptprio successful bit
 # partitions are backwards so that we don't make things inconsistent when specifying a wrong end sector :)
 sgdisk --clear \
-   -n 0:1024M:2047M -c 0:"THAR-DATA"       -t 0:8300 \
-   -n 0:937M:0      -c 0:"THAR-RESERVED-B" -t 0:"${THAR_RESERVED_TYPECODE}" \
-   -n 0:933M:0      -c 0:"THAR-HASH-B"     -t 0:"${THAR_HASH_TYPECODE}" \
-   -n 0:533M:0      -c 0:"THAR-ROOT-B"     -t 0:"${THAR_ROOT_TYPECODE}" \
-   -n 0:513M:0      -c 0:"THAR-BOOT-B"     -t 0:"${THAR_BOOT_TYPECODE}" -A 0:"clear":48 -A 0:"clear":56 \
-   -n 0:426M:0      -c 0:"THAR-RESERVED-A" -t 0:"${THAR_RESERVED_TYPECODE}" \
-   -n 0:422M:0      -c 0:"THAR-HASH-A"     -t 0:"${THAR_HASH_TYPECODE}" \
+   -n 0:2048M:4095M -c 0:"THAR-DATA"       -t 0:8300 \
+   -n 0:1953M:0     -c 0:"THAR-RESERVED-B" -t 0:"${THAR_RESERVED_TYPECODE}" \
+   -n 0:1945M:0     -c 0:"THAR-HASH-B"     -t 0:"${THAR_HASH_TYPECODE}" \
+   -n 0:1045M:0     -c 0:"THAR-ROOT-B"     -t 0:"${THAR_ROOT_TYPECODE}" \
+   -n 0:1025M:0     -c 0:"THAR-BOOT-B"     -t 0:"${THAR_BOOT_TYPECODE}" -A 0:"clear":48 -A 0:"clear":56 \
+   -n 0:930M:0      -c 0:"THAR-RESERVED-A" -t 0:"${THAR_RESERVED_TYPECODE}" \
+   -n 0:922M:0      -c 0:"THAR-HASH-A"     -t 0:"${THAR_HASH_TYPECODE}" \
    -n 0:22M:0       -c 0:"THAR-ROOT-A"     -t 0:"${THAR_ROOT_TYPECODE}" \
    -n 0:2M:0        -c 0:"THAR-BOOT-A"     -t 0:"${THAR_BOOT_TYPECODE}" -A 0:"set":48 -A 0:"set":56 \
    -n 0:1M:0        -c 0:"BIOS-BOOT"          -t 0:ef02 \
@@ -78,12 +79,12 @@ mkdir "${BOOT_MOUNT}"
 mv "${ROOT_MOUNT}/boot"/* "${BOOT_MOUNT}"
 
 # THAR-ROOT-A
-mkfs.ext4 -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" 400M
+mkfs.ext4 -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" 900M
 resize2fs -M "${ROOT_IMAGE}"
 dd if="${ROOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((22*2048))
 
 # THAR-VERITY-A
-truncate -s 4M "${VERITY_IMAGE}"
+truncate -s 8M "${VERITY_IMAGE}"
 veritysetup_output="$(veritysetup format \
     --format "$VERITY_VERSION" \
     --hash "$VERITY_HASH_ALGORITHM" \
@@ -91,7 +92,7 @@ veritysetup_output="$(veritysetup format \
     --hash-block-size "$VERITY_HASH_BLOCK_SIZE" \
     "${ROOT_IMAGE}" "${VERITY_IMAGE}" \
     | tee /dev/stderr)"
-if ! stat -c %s "${VERITY_IMAGE}" | grep -q '^4194304$'; then
+if ! stat -c %s "${VERITY_IMAGE}" | grep -q '^8388608$'; then
     "verity partition is larger than expected (4M)"
     exit 1
 fi
@@ -100,7 +101,7 @@ VERITY_DATA_512B_BLOCKS="$(($VERITY_DATA_4K_BLOCKS * 8))"
 VERITY_ROOT_HASH="$(grep '^Root hash:' <<<$veritysetup_output | awk '{ print $NF }')"
 VERITY_SALT="$(grep '^Salt:' <<<$veritysetup_output | awk '{ print $NF }')"
 veritysetup verify "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${VERITY_ROOT_HASH}"
-dd if="${VERITY_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((422*2048))
+dd if="${VERITY_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((922*2048))
 
 # write GRUB config
 cat <<EOF > ${BOOT_MOUNT}/grub/grub.cfg
@@ -121,8 +122,8 @@ resize2fs -M "${BOOT_IMAGE}"
 dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((2*2048))
 
 # THAR-DATA
-mkfs.ext4 "${DATA_IMAGE}" 1023M
-dd if="${DATA_IMAGE}" of="${DISK_IMAGE}" conv=notrunc,sparse bs=512 seek=$((1024*2048))
+mkfs.ext4 "${DATA_IMAGE}" 2047M
+dd if="${DATA_IMAGE}" of="${DISK_IMAGE}" conv=notrunc,sparse bs=512 seek=$((2048*2048))
 
 sgdisk -v "${DISK_IMAGE}"
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Sizes below in MiB:

| Partition | Old size | New size |
| --------- | -------- | -------- |
| BOOT      |       20 |       20 |
| ROOT      |      400 |      900 |
| HASH      |        4 |        8 |
| RESERVED  |       87 |       95 |
| DATA      |     1023 |     2047 |

Signed-off-by: iliana destroyer of worlds <iweller@amazon.com>

*Testing done*: built and booted image. 

```
$ sgdisk -v build/thar-x86_64.img

No problems found. 4028 free sectors (2.0 MiB) available in 2
segments, the largest of which is 2014 (1007.0 KiB) in size.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
