### PR TITLE
Add initial OpenAPI spec file

### DIFF
--- a/workspaces/api/openapi.yaml
+++ b/workspaces/api/openapi.yaml
@@ -160,7 +160,7 @@ paths:
             type: array
             items:
               type: string
-          # `style: form` and `explode: false` format parameters as such:  /configuration-files?names=docker-daemon,bar,baz
+          # `style: form` and `explode: false` format parameters as such:  /configuration-files?names=file1,file2
           style: form
           explode: false
           required: false


### PR DESCRIPTION
*Description of changes:*
This adds the initial OpenAPI spec which defines the API client and closes #29 . It is up-to-date with the current `apiserver` endpoints. The purpose of this review is to ensure that the endpoints are accurate and the file correctly represents a client's view of the API in its current form.

*Additional details*
This spec **does not** define the models or types that are returned or required by the requests. It is important to define the models so that the API documentation generated by OpenAPI is complete in terms of inputs/outputs. In the short term, we will use the models defined in the [api server code](https://github.com/amazonlinux/PRIVATE-thar/blob/develop/workspaces/api/apiserver/src/model.rs).  
 
Longer term we will either 
* Build/generate a standalone `Models` crate which we can reference in this spec(#27 ) or 
* Duplicate the models in this spec (less desirable).  



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
