### PR TITLE
Return empty Settings when there are no pending settings

### DIFF
--- a/workspaces/api/apiserver/src/server/controller/mod.rs
+++ b/workspaces/api/apiserver/src/server/controller/mod.rs
@@ -17,7 +17,20 @@ use crate::datastore::{
 use crate::model::{ConfigurationFiles, Services, Settings};
 use error::Result;
 
-/// Build a Settings based on the data in the datastore.
+/// Build a Settings based on pending data in the datastore; the Settings will be empty if there
+/// are no pending settings.
+pub(crate) fn get_pending_settings<D: DataStore>(datastore: &D) -> Result<Settings> {
+    get_prefix(
+        datastore,
+        Committed::Pending,
+        "settings.",
+        None as Option<&str>,
+        None,
+    )
+    .map(|maybe_settings| maybe_settings.unwrap_or_else(|| Settings::default()))
+}
+
+/// Build a Settings based on the data in the datastore.  Errors if no settings are found.
 pub(crate) fn get_settings<D: DataStore>(datastore: &D, committed: Committed) -> Result<Settings> {
     get_prefix(
         datastore,

--- a/workspaces/api/apiserver/src/server/router.rs
+++ b/workspaces/api/apiserver/src/server/router.rs
@@ -104,7 +104,7 @@ pub fn handle_request<P: AsRef<Path>>(request: &Request, datastore_path: P) -> R
 
         // Special subsets of settings
         (GET) (/settings/pending) => {
-            try_or!(500, get_settings(&datastore, Committed::Pending)
+            try_or!(500, get_pending_settings(&datastore)
                          .map(|ref s| Response::json(s)))
         },
 


### PR DESCRIPTION
Fixes #32, "Unfriendly error on /settings/pending when there's nothing pending"

Before, a 500 error with confusing message:
```
$ curl -v 'localhost:4242/settings/pending'; echo                                                                                                                                   
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4242 (#0)
> GET /settings/pending HTTP/1.1
> Host: localhost:4242
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< Server: tiny-http (Rust)
< Date: Thu,  6 Jun 2019 17:05:16 GMT
< Content-Type: application/json
< Content-Length: 50
< 
* Connection #0 to host localhost left intact
{"description":"Found no 'settings' in datastore"}
```

After, a 200 with empty Settings:
```
$ curl -v 'localhost:4242/settings/pending'; echo                                                                                                                                                                                                                                                                                                               [10:20:54]
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4242 (#0)
> GET /settings/pending HTTP/1.1
> Host: localhost:4242
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: tiny-http (Rust)
< Date: Thu,  6 Jun 2019 17:21:17 GMT
< Content-Type: application/json
< Content-Length: 2
< 
* Connection #0 to host localhost left intact
{}
```

And if you have pending settings, they still show OK:
```
$ curl -v 'localhost:4242/settings/pending'; echo                                                                                                                                                                                                                                                                                                               [12:07:15]
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4242 (#0)
> GET /settings/pending HTTP/1.1
> Host: localhost:4242
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: tiny-http (Rust)
< Date: Thu,  6 Jun 2019 19:07:15 GMT
< Content-Type: application/json
< Content-Length: 28
< 
* Connection #0 to host localhost left intact
{"timezone":"NewLosAngeles"}
```