### PR TITLE
Allow listing DataStore metadata

### DIFF
--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -26,6 +26,7 @@ name = "apiserver"
 version = "0.1.0"
 dependencies = [
  "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -464,6 +465,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "h2"
@@ -1878,6 +1884,7 @@ dependencies = [
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum h2 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2b53def7bb0253af7718036fe9338c15defd209136819464384f3a553e07481b"
 "checksum handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d82e5750d8027a97b9640e3fefa66bbaf852a35228e1c90790efd13c4b09c166"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"

--- a/workspaces/api/apiserver/Cargo.toml
+++ b/workspaces/api/apiserver/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 build = "build.rs"
 
 [dependencies]
+glob = "0.3"
 lazy_static = "1.2"
 log = "0.4"
 regex = "1.1"

--- a/workspaces/api/apiserver/src/datastore/error.rs
+++ b/workspaces/api/apiserver/src/datastore/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
     #[snafu(display("IO error on '{}': {}", path.display(), source))]
     Io { path: PathBuf, source: io::Error },
 
+    #[snafu(display("Can't handle non-Unicode file for {}: {}", context, file))]
+    NonUnicodeFile { file: String, context: String },
+
     #[snafu(display("Data store logic error: {}", msg))]
     Internal { msg: String },
 
@@ -51,6 +54,13 @@ pub enum Error {
     ListedKeyNotPresent { key: String },
 
     #[snafu(display(
+        "Listed metadata '{}' for key '{}' not found on disk",
+        meta_key,
+        data_key
+    ))]
+    ListedMetaNotPresent { meta_key: String, data_key: String },
+
+    #[snafu(display(
         "Key name '{}' has invalid format, should match regex: {}",
         name,
         pattern
@@ -59,6 +69,18 @@ pub enum Error {
 
     #[snafu(display("Key name beyond maximum length {}: {}", name, max))]
     KeyTooLong { name: String, max: usize },
+
+    #[snafu(display("Invalid glob '{}': {}", glob, source))]
+    GlobPattern {
+        glob: String,
+        source: glob::PatternError,
+    },
+
+    #[snafu(display("Error reading file for glob '{}': {}", glob, source))]
+    GlobIo {
+        glob: String,
+        source: glob::GlobError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/workspaces/api/apiserver/src/datastore/memory.rs
+++ b/workspaces/api/apiserver/src/datastore/memory.rs
@@ -58,6 +58,20 @@ impl DataStore for MemoryDataStore {
             .collect())
     }
 
+    fn list_populated_metadata<S: AsRef<str>>(
+        &self,
+        prefix: S,
+    ) -> Result<HashMap<Key, HashSet<Key>>> {
+        Ok(self
+            .metadata
+            .iter()
+            // Make sure the data keys start with the given prefix.
+            .filter(|(k, _v)| k.starts_with(prefix.as_ref()))
+            // We only want the inner keys, so we use 'map' to throw away the values.
+            .map(|(k, v)| (k.clone(), v.keys().cloned().collect()))
+            .collect())
+    }
+
     fn get_key(&self, key: &Key, committed: Committed) -> Result<Option<String>> {
         let map_key: &str = key.borrow();
         Ok(self.dataset(committed).get(map_key).cloned())


### PR DESCRIPTION
Depends on #42, and helps prepare for the migration prototype.

This lets you list/retrieve the metadata that the datastore knows about.  We need this for migrations so that we can allow the migration author to modify metadata as necessary.

**Testing**

Existing and new unit tests pass, and I tested all API endpoints and saw no change in behavior.

Since I don't want to expose bulk metadata in the API right now (ever?) I added a temporary route to call the main added method, `get_metadata_prefix`.

```rust
(GET) (/meta) => {
    use crate::datastore::DataStore;
    use std::collections::HashMap;
    let x: HashMap<String, HashMap<String, String>> = datastore.get_metadata_prefix("").unwrap()
        .into_iter()
        .map(|(k, v)| {
            (k.as_ref().to_owned(), v.into_iter().map(|(k2, v2)| (k2.as_ref().to_owned(), v2)).collect())
        }).collect();
    Response::json(&x)
},
```
(Just think of it as dumping the output of get_metadata_prefix; the ugly mapping just turns Keys into Strings for the response.)

Here's an example response with the single default metadata key:
```
$ curl -v 'localhost:4242/meta'; echo
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4242 (#0)
> GET /meta HTTP/1.1
> Host: localhost:4242
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: tiny-http (Rust)
< Date: Tue, 18 Jun 2019 21:28:30 GMT
< Content-Type: application/json
< Content-Length: 60
< 
* Connection #0 to host localhost left intact
{"settings.hostname":{"affected-services":"[\"hostname\"]"}}
```

Here's the response with an added metadata key:
```
$ echo -n hi > /tmp/thar/be/data/live/services/hostname/restart-commands.testmeta

$ curl -v 'localhost:4242/meta'; echo
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4242 (#0)
> GET /meta HTTP/1.1
> Host: localhost:4242
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: tiny-http (Rust)
< Date: Tue, 18 Jun 2019 21:29:29 GMT
< Content-Type: application/json
< Content-Length: 115
< 
* Connection #0 to host localhost left intact
{"services.hostname.restart-commands":{"testmeta":"hi"},"settings.hostname":{"affected-services":"[\"hostname\"]"}}
```

And if I change the requested prefix in that temporary route from "" to "set", we can see it only returns metadata for settings:
```
$ curl -v 'localhost:4242/meta'; echo
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4242 (#0)
> GET /meta HTTP/1.1
> Host: localhost:4242
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: tiny-http (Rust)
< Date: Tue, 18 Jun 2019 21:30:03 GMT
< Content-Type: application/json
< Content-Length: 60
< 
* Connection #0 to host localhost left intact
{"settings.hostname":{"affected-services":"[\"hostname\"]"}}
```