### PR TITLE
Add migration helpers and prototype migration

### DIFF
--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -655,6 +655,15 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "migration-helpers"
+version = "0.1.0"
+dependencies = [
+ "apiserver 0.1.0",
+ "snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1433,13 @@ dependencies = [
  "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "testmigration"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
 ]
 
 [[package]]

--- a/workspaces/api/Cargo.toml
+++ b/workspaces/api/Cargo.toml
@@ -3,6 +3,12 @@ members = [
     "apiserver",
     "moondog",
     "thar-be-settings",
+
+    "migration/migration-helpers",
+
+    # Migrations will be listed here.  They won't need to be listed as a
+    # workspace member when we add cross-workspace dependencies.
+    "migration/migrations/v1.1/testmigration",
 ]
 
 [profile.release]

--- a/workspaces/api/apiserver/src/datastore/mod.rs
+++ b/workspaces/api/apiserver/src/datastore/mod.rs
@@ -203,10 +203,10 @@ pub trait DataStore {
 // parent module of serialization and deserialization.
 
 /// Concrete error type for scalar ser/de.
-pub(crate) type ScalarError = serde_json::Error;
+pub type ScalarError = serde_json::Error;
 
 /// Serialize a given scalar value to the module-standard serialization format.
-pub(crate) fn serialize_scalar<S, E>(scalar: &S) -> std::result::Result<String, E>
+pub fn serialize_scalar<S, E>(scalar: &S) -> std::result::Result<String, E>
 where
     S: Serialize,
     E: From<ScalarError>,
@@ -215,7 +215,7 @@ where
 }
 
 /// Deserialize a given scalar value from the module-standard serialization format.
-pub(crate) fn deserialize_scalar<'de, D, E>(scalar: &'de str) -> std::result::Result<D, E>
+pub fn deserialize_scalar<'de, D, E>(scalar: &'de str) -> std::result::Result<D, E>
 where
     D: Deserialize<'de>,
     E: From<ScalarError>,
@@ -233,7 +233,7 @@ fn deserializer_for_scalar(scalar: &str) -> ScalarDeserializer {
 
 /// Serde generic "Value" type representing a tree of deserialized values.  Should be able to hold
 /// anything returned by the deserialization bits above.
-pub(crate) type Value = serde_json::Value;
+pub type Value = serde_json::Value;
 
 #[cfg(test)]
 mod test {

--- a/workspaces/api/migration/migration-helpers/Cargo.toml
+++ b/workspaces/api/migration/migration-helpers/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "migration-helpers"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+apiserver = { path = "../../apiserver" }
+snafu = "0.4"
+toml = "0.5"

--- a/workspaces/api/migration/migration-helpers/src/args.rs
+++ b/workspaces/api/migration/migration-helpers/src/args.rs
@@ -1,0 +1,58 @@
+//! Helpers for parsing arguments common to migrations.
+
+use std::env;
+use std::process;
+
+use crate::{MigrationType, Result};
+
+/// Stores user-supplied arguments.
+pub struct Args {
+    pub datastore_path: String,
+    pub migration_type: MigrationType,
+}
+
+/// Informs the user about proper usage of the program and exits.
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            --datastore-path PATH
+            ( --forward | --backward )",
+        program_name
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
+    eprintln!("{}\n", msg.as_ref());
+    usage();
+}
+
+/// Parses user arguments into an Args structure.
+pub(crate) fn parse_args(args: env::Args) -> Result<Args> {
+    let mut migration_type = None;
+    let mut datastore_path = None;
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--datastore-path" => {
+                datastore_path = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to --datastore-path")),
+                )
+            }
+
+            "--forward" => migration_type = Some(MigrationType::Forward),
+            "--backward" => migration_type = Some(MigrationType::Backward),
+
+            _ => usage(),
+        }
+    }
+
+    Ok(Args {
+        datastore_path: datastore_path.unwrap_or_else(|| usage()),
+        migration_type: migration_type.unwrap_or_else(|| usage()),
+    })
+}

--- a/workspaces/api/migration/migration-helpers/src/datastore.rs
+++ b/workspaces/api/migration/migration-helpers/src/datastore.rs
@@ -1,0 +1,83 @@
+//! This module contains the functions that interact with the data store, retrieving data to
+//! migrate and writing back migrated data.
+
+use snafu::ResultExt;
+use std::collections::HashMap;
+
+use crate::{error, MigrationData, Result};
+use apiserver::datastore::{deserialize_scalar, serialize_scalar, Committed, DataStore};
+
+// To get input data from the existing data store, we use datastore methods, because we assume
+// breaking changes in the basic data store API would be a major-version migration of the data
+// store, and that would be handled separately.  This method is private to the crate, so we can
+// reconsider as needed.
+/// Retrieves data from the specified data store in a consistent format for easy modification.
+pub(crate) fn get_input_data<D: DataStore>(
+    datastore: &D,
+    committed: Committed,
+) -> Result<MigrationData> {
+    let raw_data = datastore
+        .get_prefix("", committed)
+        .context(error::GetData { committed })?;
+
+    // Deserialize values to Value so there's a consistent input type.  (We can't specify item
+    // types because we'd have to know the model structure.)
+    let mut data = HashMap::new();
+    for (data_key, value) in raw_data.into_iter() {
+        let value = deserialize_scalar(&value).context(error::Deserialize { input: value })?;
+        data.insert(data_key, value);
+    }
+
+    // Metadata isn't committed, it goes live immediately, so we only populate the metadata
+    // output for Committed::Live.
+    let mut metadata = HashMap::new();
+    if let Committed::Live = committed {
+        let raw_metadata = datastore
+            .get_metadata_prefix("", &None as &Option<&str>)
+            .context(error::GetMetadata)?;
+        for (data_key, meta_map) in raw_metadata.into_iter() {
+            let data_entry = metadata.entry(data_key).or_insert_with(HashMap::new);
+            for (metadata_key, value) in meta_map.into_iter() {
+                let value =
+                    deserialize_scalar(&value).context(error::Deserialize { input: value })?;
+                data_entry.insert(metadata_key, value);
+            }
+        }
+    }
+
+    Ok(MigrationData { data, metadata })
+}
+
+// Similar to get_input_data, we use datastore methods here; please read the comment on
+// get_input_data.  This method is also private to the crate, so we can reconsider as needed.
+/// Updates the given data store with the given (migrated) data.
+pub(crate) fn set_output_data<D: DataStore>(
+    datastore: &mut D,
+    input: &MigrationData,
+) -> Result<()> {
+    // Prepare serialized data
+    let mut data = HashMap::new();
+    for (data_key, raw_value) in &input.data {
+        let value = serialize_scalar(raw_value).context(error::Serialize)?;
+        data.insert(data_key, value);
+    }
+
+    // This is one of the rare cases where we want to set keys directly to the live datastore:
+    // * We're operating on a temporary copy of the datastore, so no concurrency issues
+    // * We're either about to reboot or just have, and the settings applier will run afterward
+    datastore
+        .set_keys(&data, Committed::Live)
+        .context(error::DataStoreWrite)?;
+
+    // Set metadata in a loop (currently no batch API)
+    for (data_key, meta_map) in &input.metadata {
+        for (metadata_key, raw_value) in meta_map.into_iter() {
+            let value = serialize_scalar(&raw_value).context(error::Serialize)?;
+            datastore
+                .set_metadata(&metadata_key, &data_key, value)
+                .context(error::DataStoreWrite)?;
+        }
+    }
+
+    Ok(())
+}

--- a/workspaces/api/migration/migration-helpers/src/error.rs
+++ b/workspaces/api/migration/migration-helpers/src/error.rs
@@ -1,0 +1,51 @@
+//! Contains the Error and Result types used by the migration helper functions and migrations.
+
+use snafu::Snafu;
+
+use apiserver::datastore;
+
+/// Error contains the errors that can happen in the migration helper functions and in migrations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+pub enum Error {
+    #[snafu(display("Unable to get {:?} data for migration: {}", committed, source))]
+    GetData {
+        committed: datastore::Committed,
+        source: datastore::Error,
+    },
+
+    #[snafu(display("Unable to get metadata for migration: {}", source))]
+    GetMetadata { source: datastore::Error },
+
+    #[snafu(display("Unable to deserialize to Value from '{}': {}", input, source))]
+    Deserialize {
+        input: String,
+        source: datastore::ScalarError,
+    },
+
+    #[snafu(display("Unable to serialize Value: {}", source))]
+    Serialize { source: datastore::ScalarError },
+
+    #[snafu(display("Unable to write to data store: {}", source))]
+    DataStoreWrite { source: datastore::Error },
+
+    #[snafu(display("Migrated data failed validation: {}", msg))]
+    Validation { msg: String },
+
+    // Generic error variant for migration authors
+    #[snafu(display("Migration returned error: {}", msg))]
+    Migration { msg: String },
+
+    // More specific error variants for migration authors to handle common cases
+    #[snafu(display("Migration requires missing key: {}", key))]
+    MissingData { key: String },
+
+    #[snafu(display("Migration used invalid key '{}': {}", key, source))]
+    InvalidKey {
+        key: String,
+        source: datastore::Error,
+    },
+}
+
+/// Result alias containing our Error type.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/workspaces/api/migration/migration-helpers/src/lib.rs
+++ b/workspaces/api/migration/migration-helpers/src/lib.rs
@@ -1,0 +1,135 @@
+//! This module aims to make it as easy as possible to migrate a data store between minor
+//! versions.  Migration authors just implement one trait, and can then use helper methods to take
+//! care of everything else in their main function.
+//!
+//! Note that you must still name your migration binary according to spec for it to be handled
+//! properly by the migration runner.
+
+// Note that migrations must be run serially; technically, this is because the data store isn't
+// locked, and also because migration authors are given an interface for ordering via migration
+// name, and running in parallel would violate that.
+
+mod args;
+mod datastore;
+pub mod error;
+
+use std::collections::HashMap;
+use std::env;
+use std::fmt;
+
+use apiserver::datastore::{Committed, Value};
+pub use apiserver::datastore::{DataStore, FilesystemDataStore, Key, KeyType};
+
+use args::parse_args;
+use datastore::{get_input_data, set_output_data};
+pub use error::Result;
+
+/// The data store implementation currently in use.  Used by the simpler `migrate` interface; can
+/// be overridden by using the `run_migration` interface.
+type DataStoreImplementation = FilesystemDataStore;
+
+/// Migrations must implement this trait, and can then use the migrate method to let this module
+/// do the rest of the work.
+///
+/// Migrations must implement forward and backward methods so changes can be rolled back as
+/// necessary.
+///
+/// Migrations must not assume any key will exist because they're run on pending data as well as
+/// live, and pending may be empty.  For the same reason, migrations must not add a key in all
+/// cases if it's missing, because you could add a key to the pending data when the user didn't
+/// have any pending data.  Instead, make sure you're adding a key to an existing structure.
+pub trait Migration {
+    /// Migrates data forward from the prior version to the version specified in the migration
+    /// name.
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData>;
+
+    /// Migrates data backward from the version specified in the migration name to the prior
+    /// version.
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData>;
+}
+
+/// Mapping of metadata key to arbitrary value.  Each data key can have a Metadata describing its
+/// metadata keys.
+pub type Metadata = HashMap<Key, Value>;
+
+/// MigrationData holds all data that can be migrated in a migration, and serves as the input and
+/// output format of migrations.  A serde Value type is used to hold the arbitrary data of each
+/// key because we can't represent types when they could change in the migration.
+#[derive(Debug)]
+pub struct MigrationData {
+    /// Mapping of data keys to their arbitrary values.
+    pub data: HashMap<Key, Value>,
+    /// Mapping of data keys to their metadata.
+    pub metadata: HashMap<Key, Metadata>,
+}
+
+/// Returns the default settings for a given path so you can easily replace a given section of the
+/// datastore with new defaults.  For example, you could request "settings" to get all new default
+/// settings, or "settings.serviceX.subsection" to scope it down.
+pub fn defaults_for<S: AsRef<str>>(_path: S) -> Result<Value> {
+    unimplemented!()
+}
+
+/// Ensures we can use the migrated data in the new data store.  Can use this result to stop the
+/// migration process before saving any data.
+fn validate_migrated_data(input: &MigrationData) -> Result<()> {
+    // Make sure we don't have metadata describing data keys that don't exist
+    for data_key in input.metadata.keys() {
+        if !input.data.contains_key(data_key) {
+            return error::Validation {
+                msg: format!("Metadata describes nonexistent data key: {}", data_key),
+            }
+            .fail();
+        }
+    }
+    Ok(())
+}
+
+/// If you need a little more control over a migration than with migrate, or you're using this
+/// module as a library, you can call run_migration directly with the arguments that would
+/// normally be parsed from the migration binary's command line.
+pub fn run_migration<D: DataStore>(
+    mut migration: impl Migration,
+    datastore: &mut D,
+    migration_type: MigrationType,
+) -> Result<()> {
+    for committed in &[Committed::Live, Committed::Pending] {
+        let input = get_input_data(datastore, *committed)?;
+
+        let migrated = match migration_type {
+            MigrationType::Forward => migration.forward(input),
+            MigrationType::Backward => migration.backward(input),
+        }?;
+
+        validate_migrated_data(&migrated)?;
+
+        set_output_data(datastore, &migrated)?;
+    }
+    Ok(())
+}
+
+/// Represents the type of migration, so we know which Migration trait method to call.
+#[derive(Debug, Copy, Clone)]
+pub enum MigrationType {
+    Forward,
+    Backward,
+}
+
+impl fmt::Display for MigrationType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MigrationType::Forward => write!(f, "forward"),
+            MigrationType::Backward => write!(f, "backward"),
+        }
+    }
+}
+
+/// This is the primary entry point for migration authors.  When you've implemented the Migration
+/// trait, you should just be able to pass it to this function from your main function and let it
+/// take care of the rest.  The migration runner will pass in the appropriate datastore path and
+/// migration type.
+pub fn migrate(migration: impl Migration) -> Result<()> {
+    let args = parse_args(env::args())?;
+    let mut datastore = DataStoreImplementation::new(args.datastore_path);
+    run_migration(migration, &mut datastore, args.migration_type)
+}

--- a/workspaces/api/migration/migrations/v1.1/testmigration/Cargo.toml
+++ b/workspaces/api/migration/migrations/v1.1/testmigration/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "testmigration"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/workspaces/api/migration/migrations/v1.1/testmigration/src/main.rs
+++ b/workspaces/api/migration/migrations/v1.1/testmigration/src/main.rs
@@ -1,0 +1,38 @@
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+
+/// Example migration that prepends "New" to the system time zone.
+struct TestMigration;
+
+impl Migration for TestMigration {
+    fn forward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(timezone) = input.data.get_mut("settings.timezone") {
+            if let Some(tz_str) = timezone.as_str() {
+                // Some modification to the value
+                *timezone = ("New".to_string() + tz_str).into();
+            } else {
+                // We can handle some easy error conditions using defaults
+                *timezone = "Default".into();
+            }
+        }
+        Ok(input)
+    }
+
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(timezone) = input.data.get_mut("settings.timezone") {
+            if let Some(tz_str) = timezone.as_str() {
+                // Revert modification if we find it
+                if tz_str.starts_with("New") {
+                    *timezone = tz_str[3..].into();
+                }
+            } else {
+                // We can handle some easy error conditions using defaults
+                *timezone = "Default".into();
+            }
+        }
+        Ok(input)
+    }
+}
+
+fn main() -> Result<()> {
+    migrate(TestMigration)
+}


### PR DESCRIPTION
This adds a migration helper crate that defines the common Migration trait that
migrations must implement.  It also handles the common work of migrating data:
parsing arguments used by the migrator process, retrieving data from the
data store and writing it back, and ordering these steps.  A migration only has
to implement Migration and call migrate().

A sample migration is included that modifies the timezone setting.

Remaining work:
* the migrator that runs the migrations
* integration into the OS, build process, and update process
* implementing defaults_for so it's easy for migrations to set OS defaults
* further helpers for migrations, as we discover what's most useful

Signed-off-by: Tom Kirchner <tjk@amazon.com>

---

Depends on cleanup in #42 and metadata listing in #43.

Fixes #34.

---

**Testing**

I copied a default data store to run the sample migration against, with the default timezone changed to "NewLosAngeles".  The sample migration prefixes the timezone with "New".  You can see the forward migrations adding it, and the backward migrations removing it, if it's still there.

```
$ rm -rf datastore-test && cp -a /tmp/thar/be/data datastore-test
$ for type in forward forward backward backward backward backward; do
../target/debug/testmigration --datastore-path ./datastore-test --${type}
diff /tmp/thar/be/data datastore-test && echo -e "\nNO DIFFERENCE THIS ROUND\n"
done

diff -NurwBd /tmp/thar/be/data/live/settings/timezone datastore-test/live/settings/timezone
--- /tmp/thar/be/data/live/settings/timezone	2019-06-18 15:12:27.241559981 -0700
+++ datastore-test/live/settings/timezone	2019-06-20 10:28:23.877331447 -0700
@@ -1 +1 @@
-"NewLosAngeles"
\ No newline at end of file
+"NewNewLosAngeles"
\ No newline at end of file
diff -NurwBd /tmp/thar/be/data/live/settings/timezone datastore-test/live/settings/timezone
--- /tmp/thar/be/data/live/settings/timezone	2019-06-18 15:12:27.241559981 -0700
+++ datastore-test/live/settings/timezone	2019-06-20 10:28:23.885331311 -0700
@@ -1 +1 @@
-"NewLosAngeles"
\ No newline at end of file
+"NewNewNewLosAngeles"
\ No newline at end of file
diff -NurwBd /tmp/thar/be/data/live/settings/timezone datastore-test/live/settings/timezone
--- /tmp/thar/be/data/live/settings/timezone	2019-06-18 15:12:27.241559981 -0700
+++ datastore-test/live/settings/timezone	2019-06-20 10:28:23.897331107 -0700
@@ -1 +1 @@
-"NewLosAngeles"
\ No newline at end of file
+"NewNewLosAngeles"
\ No newline at end of file

NO DIFFERENCE THIS ROUND

diff -NurwBd /tmp/thar/be/data/live/settings/timezone datastore-test/live/settings/timezone
--- /tmp/thar/be/data/live/settings/timezone	2019-06-18 15:12:27.241559981 -0700
+++ datastore-test/live/settings/timezone	2019-06-20 10:28:23.913330834 -0700
@@ -1 +1 @@
-"NewLosAngeles"
\ No newline at end of file
+"LosAngeles"
\ No newline at end of file
diff -NurwBd /tmp/thar/be/data/live/settings/timezone datastore-test/live/settings/timezone
--- /tmp/thar/be/data/live/settings/timezone	2019-06-18 15:12:27.241559981 -0700
+++ datastore-test/live/settings/timezone	2019-06-20 10:28:23.925330630 -0700
@@ -1 +1 @@
-"NewLosAngeles"
\ No newline at end of file
+"LosAngeles"
\ No newline at end of file
```