### PR TITLE
Add modeled base64 type

### DIFF
--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
 name = "apiserver"
 version = "0.1.0"
 dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/workspaces/api/apiserver/Cargo.toml
+++ b/workspaces/api/apiserver/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 build = "build.rs"
 
 [dependencies]
+base64 = "0.10"
 lazy_static = "1.2"
 log = "0.4"
 regex = "1.1"

--- a/workspaces/api/apiserver/src/lib.rs
+++ b/workspaces/api/apiserver/src/lib.rs
@@ -73,6 +73,7 @@ extern crate rouille;
 
 pub mod datastore;
 pub mod model;
+pub mod modeled_types;
 pub(crate) mod server;
 
 pub use server::handle_request;

--- a/workspaces/api/apiserver/src/modeled_types.rs
+++ b/workspaces/api/apiserver/src/modeled_types.rs
@@ -1,0 +1,94 @@
+//! This module contains data types that can be used in the model when special input/output
+//! (ser/de) behavior is desired.  For example, the ValidBase64 type can be used for a model field
+//! when we don't even want to accept an API call with invalid base64 data.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+// Just need serde's Error in scope to get its trait methods
+use serde::de::Error as _;
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
+
+/// ValidBase64 can only be created by deserializing from valid base64 text.  It stores the
+/// original text, not the decoded form.  Its purpose is input validation, namely being used as a
+/// field in a model structure so that you don't even accept a request with a field that has
+/// invalid base64.
+// Note: we use the default base64::STANDARD config which uses/allows "=" padding.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ValidBase64 {
+    inner: String,
+}
+
+/// Validate base64 format before we accept the input.
+impl<'de> Deserialize<'de> for ValidBase64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let original = String::deserialize(deserializer)?;
+        base64::decode(&original)
+            .map_err(|e| D::Error::custom(format!("Invalid base64: {}", e)))?;
+        Ok(ValidBase64 { inner: original })
+    }
+}
+
+/// We want to serialize the original string back out, not our structure, which is just there to
+/// force validation.
+impl Serialize for ValidBase64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.inner)
+    }
+}
+
+impl Deref for ValidBase64 {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl Borrow<String> for ValidBase64 {
+    fn borrow(&self) -> &String {
+        &self.inner
+    }
+}
+
+impl Borrow<str> for ValidBase64 {
+    fn borrow(&self) -> &str {
+        &self.inner
+    }
+}
+
+impl AsRef<str> for ValidBase64 {
+    fn as_ref(&self) -> &str {
+        &self.inner
+    }
+}
+
+impl fmt::Display for ValidBase64 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ValidBase64;
+
+    #[test]
+    fn valid_base64() {
+        let v: ValidBase64 = serde_json::from_str("\"aGk=\"").unwrap();
+        let decoded_bytes = base64::decode(v.as_ref()).unwrap();
+        let decoded = std::str::from_utf8(&decoded_bytes).unwrap();
+        assert_eq!(decoded, "hi");
+    }
+
+    #[test]
+    fn invalid_base64() {
+        assert!(serde_json::from_str::<ValidBase64>("\"invalid base64\"").is_err());
+        assert!(serde_json::from_str::<ValidBase64>("").is_err());
+    }
+}


### PR DESCRIPTION
Background: this is a dependency of EKS enablement in #22.  EKS expects a CA certificate in base64-encoded form, which later needs to be decoded and written to a file by thar-be-settings.  (t-b-s work is coming from @zmrow shortly.)  This change adds a type that we can use for input validation of the field that must be base64.

---

The ValidBase64 type can be used in the model for input that we want to
validate is base64.  If it's invalid, it won't deserialize, so it won't be
accepted by the API.

The resulting value acts like a string (via Deref and friends) and represents
the input base64 text; its purpose is input validation, not decoding.  When
serialized back out, for example for a GET /settings, the original input is
returned, for symmetry and understandability.

The encoded value can be used later on, for example to populate a template, by
base64-decoding the string.

Signed-off-by: Tom Kirchner <tjk@amazon.com>

---

**Testing done:**

New unit tests pass.

I also tested by adding a field to the Settings model:

```
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub b64_test: Option<ValidBase64>,
```

Here's a request with invalid base64:
```
$ curl -v -X PATCH 'localhost:4242/settings' -d '{"settings": {"b64-test": "invalid base64"}}'; echo
...
< HTTP/1.1 400 Bad Request
...
{"description":"Value inside {\"settings\": x} is not a valid Settings: Invalid base64: Invalid byte 32, offset 7."}
```

Here's a request with valid base64:

```
$ curl -v -X PATCH 'localhost:4242/settings' -d '{"settings": {"b64-test": "aGk="}}'; echo
...
< HTTP/1.1 204 No Content
```

And the result:

```
$ cat /tmp/thar/be/data/pending/settings/b64-test; echo
"aGk="
```