### PR TITLE
Add 'migrator' that runs data store migrations

### DIFF
--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -66,7 +66,7 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -84,7 +84,7 @@ dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -94,7 +94,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -179,6 +179,15 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "c2-chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,7 +350,7 @@ name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -404,7 +413,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -415,13 +424,18 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fnv"
 version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fs_extra"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -463,6 +477,15 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -573,7 +596,7 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -603,10 +626,13 @@ dependencies = [
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.55"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -664,6 +690,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "migrator"
+version = "0.1.0"
+dependencies = [
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -729,7 +769,7 @@ dependencies = [
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,8 +825,20 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -816,7 +868,7 @@ name = "num_cpus"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -851,7 +903,7 @@ name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -938,6 +990,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,7 +1033,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -989,7 +1046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1000,7 +1057,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1013,12 +1070,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1035,11 +1114,27 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rand_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1055,7 +1150,7 @@ name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1067,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1351,6 +1446,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,7 +1543,7 @@ name = "termion"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1502,7 +1602,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1779,6 +1879,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "walkdir"
 version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1979,7 @@ dependencies = [
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f802a8fcc14bebdf651fd33323654451bdd168c884b22c270dfd8afb403a50"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
@@ -1902,12 +2008,14 @@ dependencies = [
 "checksum filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "450537dc346f0c4d738dda31e790da1da5d4bd12145aad4da0d03d713cb3794f"
 "checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
+"checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum h2 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2b53def7bb0253af7718036fe9338c15defd209136819464384f3a553e07481b"
 "checksum handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d82e5750d8027a97b9640e3fefa66bbaf852a35228e1c90790efd13c4b09c166"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
@@ -1921,7 +2029,7 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
+"checksum libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "3262021842bf00fe07dbd6cf34ff25c99d7a7ebef8deea84db72be3ea3bb0aff"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -1939,6 +2047,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum multipart 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adba94490a79baf2d6a23eac897157047008272fa3eecb3373ae6377b91eca28"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
@@ -1957,6 +2066,7 @@ dependencies = [
 "checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+"checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -1964,10 +2074,14 @@ dependencies = [
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 "checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
@@ -2003,6 +2117,7 @@ dependencies = [
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5712353226e5ccb06c8f9b1cab819654b25514479523755ffa94703ceeb00e4f"
 "checksum snafu-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "78178fb0042da2d70bba6e3fb26b6412c4824a22b7fe434f5e082d2ca0b894ee"
+"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "61dc66b7ae72b65636dbf36326f9638fb3ba27871bb737a62e2c309b87d91b70"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
@@ -2048,6 +2163,7 @@ dependencies = [
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/workspaces/api/Cargo.toml
+++ b/workspaces/api/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "sundog",
     "thar-be-settings",
 
+    "migration/migrator",
     "migration/migration-helpers",
 
     # Migrations will be listed here.  They won't need to be listed as a

--- a/workspaces/api/migration/migrator/Cargo.toml
+++ b/workspaces/api/migration/migrator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "migrator"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+fs_extra = "1.1"
+lazy_static = "1.2"
+log = "0.4"
+nix = "0.14"
+rand = { version = "0.7", default-features = false, features = ["std"] }
+regex = "1.1"
+snafu = "0.4"
+stderrlog = "0.4"

--- a/workspaces/api/migration/migrator/src/args.rs
+++ b/workspaces/api/migration/migrator/src/args.rs
@@ -1,0 +1,92 @@
+//! This module handles argument parsing for the migrator binary.
+
+use crate::version::Version;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process;
+use std::str::FromStr;
+
+/// Informs the user about proper usage of the program and exits.
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            --datastore-path PATH
+            --migrate-to-version x.y
+            [ --no-color ]
+            [ --verbose --verbose ... ]",
+        program_name
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
+    eprintln!("{}\n", msg.as_ref());
+    usage();
+}
+
+/// Stores user-supplied arguments.
+pub(crate) struct Args {
+    pub(crate) datastore_path: PathBuf,
+    pub(crate) migrate_to_version: Version,
+    pub(crate) color: stderrlog::ColorChoice,
+    pub(crate) verbosity: usize,
+}
+
+impl Args {
+    /// Parses user arguments into an Args structure.
+    pub(crate) fn from_env(args: env::Args) -> Self {
+        // Required parameters.
+        let mut datastore_path = None;
+        let mut migrate_to_version = None;
+        // Optional parameters with their defaults.
+        let mut verbosity = 2; // default to INFO level
+        let mut color = stderrlog::ColorChoice::Auto;
+
+        let mut iter = args.skip(1);
+        while let Some(arg) = iter.next() {
+            match arg.as_ref() {
+                "--datastore-path" => {
+                    let path_str = iter
+                        .next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to --datastore-path"));
+                    trace!("Given --datastore-path: {}", path_str);
+                    let canonical = fs::canonicalize(path_str).unwrap_or_else(|e| {
+                        usage_msg(format!(
+                            "Could not canonicalize given data store path: {}",
+                            e
+                        ))
+                    });
+                    trace!("Canonicalized data store path: {}", canonical.display());
+                    datastore_path = Some(canonical);
+                }
+
+                "--migrate-to-version" => {
+                    let version_str = iter.next().unwrap_or_else(|| {
+                        usage_msg("Did not give argument to --migrate-to-version")
+                    });
+                    trace!("Given --migrate-to-version: {}", version_str);
+                    let version = Version::from_str(&version_str).unwrap_or_else(|e| {
+                        usage_msg(format!("Invalid argument to --migrate-to-version: {}", e))
+                    });
+                    migrate_to_version = Some(version)
+                }
+
+                "-v" | "--verbose" => verbosity += 1,
+
+                "--no-color" => color = stderrlog::ColorChoice::Never,
+
+                _ => usage(),
+            }
+        }
+
+        Self {
+            datastore_path: datastore_path.unwrap_or_else(|| usage()),
+            migrate_to_version: migrate_to_version.unwrap_or_else(|| usage()),
+            color,
+            verbosity,
+        }
+    }
+}

--- a/workspaces/api/migration/migrator/src/error.rs
+++ b/workspaces/api/migration/migrator/src/error.rs
@@ -1,0 +1,94 @@
+//! This module owns the error type used by the migrator.
+
+use crate::{Version, VersionComponent};
+use snafu::Snafu;
+use std::io;
+use std::num::ParseIntError;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+/// Error contains the errors that can happen during migration.
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub(crate) enum Error {
+    #[snafu(display("Logger setup error: {}", source))]
+    Logger { source: log::SetLoggerError },
+
+    #[snafu(display("Internal error: {}", msg))]
+    Internal { msg: String },
+
+    #[snafu(display("Given string '{}' not a version, must match re: {}", given, re))]
+    InvalidVersion { given: String, re: String },
+
+    #[snafu(display("Version component '{}' not an integer: {}", component, source))]
+    InvalidVersionComponent {
+        component: String,
+        source: ParseIntError,
+    },
+
+    #[snafu(display("Can only migrate minor versions; major version '{}' requested, major version of given data store is '{}'", given, found))]
+    MajorVersionMismatch {
+        given: VersionComponent,
+        found: VersionComponent,
+    },
+
+    #[snafu(display("Unable to open data store directory '{}': {}", path.display(), source))]
+    DataStoreDirOpen { path: PathBuf, source: nix::Error },
+
+    #[snafu(display("Data store link '{}' points to /", path.display()))]
+    DataStoreLinkToRoot { path: PathBuf },
+
+    #[snafu(display("Data store path '{}' contains invalid UTF-8", path.display()))]
+    DataStorePathNotUTF8 { path: PathBuf },
+
+    #[snafu(display("Data store path '{}' contains invalid version: {}", path.display(), source))]
+    InvalidDataStoreVersion {
+        path: PathBuf,
+        #[snafu(source(from(Error, Box::new)))]
+        source: Box<Error>,
+    },
+
+    #[snafu(display("Migration '{}' contains invalid version: {}", path.display(), source))]
+    InvalidMigrationVersion {
+        path: PathBuf,
+        #[snafu(source(from(Error, Box::new)))]
+        source: Box<Error>,
+    },
+
+    #[snafu(display("Data store for new version {} already exists at {}", version, path.display()))]
+    NewVersionAlreadyExists { version: Version, path: PathBuf },
+
+    #[snafu(display("Failed copying data store to work location: {}", source))]
+    DataStoreCopy { source: fs_extra::error::Error },
+
+    #[snafu(display("Unable to start migration command {:?} - {}", command, source))]
+    StartMigration { command: Command, source: io::Error },
+
+    #[snafu(display("Migration returned '{}' - stderr: {}",
+                    output.status.code()
+                        .map(|i| i.to_string()).unwrap_or_else(|| "signal".to_string()),
+                    std::str::from_utf8(&output.stderr)
+                        .unwrap_or_else(|_e| "<invalid UTF-8>")))]
+    MigrationFailure { output: Output },
+
+    #[snafu(display("Failed to create symlink for new version at {}: {}", path.display(), source))]
+    LinkCreate { path: PathBuf, source: io::Error },
+
+    #[snafu(display("Failed to swap symlink at {} to new version: {}", link.display(), source))]
+    LinkSwap { link: PathBuf, source: io::Error },
+
+    #[snafu(display("Failed listing migration directory '{}': {}", dir.display(), source))]
+    ListMigrations { dir: PathBuf, source: io::Error },
+
+    #[snafu(display("Failed reading migration directory entry: {}", source))]
+    ReadMigrationEntry { source: io::Error },
+
+    #[snafu(display("Failed reading metadata of '{}': {}", path.display(), source))]
+    PathMetadata { path: PathBuf, source: io::Error },
+
+    #[snafu(display("Migration path '{}' contains invalid UTF-8", path.display()))]
+    MigrationNameNotUTF8 { path: PathBuf },
+}
+
+/// Result alias containing our Error type.
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/workspaces/api/migration/migrator/src/main.rs
+++ b/workspaces/api/migration/migrator/src/main.rs
@@ -1,0 +1,467 @@
+//! This is a tool to run migrations built with the migration-helpers library.
+//!
+//! Given a data store and a version to migrate it to, it will find and run appropriate migrations
+//! for the version on a copy of the data store, then symlink-flip it into place.
+
+#[macro_use]
+extern crate log;
+
+use nix::{dir::Dir, fcntl::OFlag, sys::stat::Mode, unistd::fsync};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::env;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command};
+use std::str::FromStr;
+
+mod args;
+mod error;
+mod version;
+
+use args::Args;
+use error::Result;
+use version::{Direction, Version, VersionComponent, MIGRATION_FILENAME_RE};
+
+// TODO: handle multiple paths for migrations, e.g. stored in an image and downloaded at runtime
+const MIGRATIONS_PATH: &str = "/var/lib/thar/datastore/migrations";
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args = Args::from_env(env::args());
+
+    // TODO: starting with simple stderr logging, replace when we have a better idea.
+    stderrlog::new()
+        .module(module_path!())
+        .timestamp(stderrlog::Timestamp::Millisecond)
+        .verbosity(args.verbosity)
+        .color(args.color)
+        .init()
+        .context(error::Logger)?;
+
+    // We don't handle data store format (major version) migrations because they could change
+    // anything about our storage; they're handled by more free-form binaries run by a separate
+    // startup service.
+    let current_version = Version::from_datastore_path(&args.datastore_path)?;
+    if current_version.major != args.migrate_to_version.major {
+        return error::MajorVersionMismatch {
+            given: args.migrate_to_version.major,
+            found: current_version.major,
+        }
+        .fail();
+    }
+
+    let direction = Direction::from_versions(current_version, args.migrate_to_version)
+        .unwrap_or_else(|| {
+            info!(
+                "Requested version {} matches version of given datastore at '{}'; nothing to do",
+                args.migrate_to_version,
+                args.datastore_path.display()
+            );
+            process::exit(0);
+        });
+
+    let migrations = find_migrations(current_version, args.migrate_to_version)?;
+
+    let (copy_path, copy_id) = copy_datastore(&args.datastore_path, args.migrate_to_version)?;
+    run_migrations(direction, &migrations, &copy_path)?;
+    flip_to_new_minor_version(args.migrate_to_version, &copy_path, &copy_id)?;
+
+    Ok(())
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// Returns a list of all migrations found on disk.
+///
+/// TODO: This does not yet handle migrations that have been replaced by newer versions - we only
+/// look in one fixed location. We need to get the list of migrations from update metadata, and
+/// only return those.  That may also obviate the need for select_migrations.
+fn find_migrations_on_disk() -> Result<Vec<PathBuf>> {
+    let mut result = Vec::new();
+
+    trace!("Looking for potential migrations in {}", MIGRATIONS_PATH);
+    let entries = fs::read_dir(MIGRATIONS_PATH).context(error::ListMigrations {
+        dir: MIGRATIONS_PATH,
+    })?;
+    for entry in entries {
+        let entry = entry.context(error::ReadMigrationEntry)?;
+        let path = entry.path();
+
+        // Just check that it's a file; other checks to determine whether we should actually run
+        // a file we find are done by select_migrations.
+        let file_type = entry
+            .file_type()
+            .context(error::PathMetadata { path: &path })?;
+        if !file_type.is_file() {
+            debug!(
+                "Skipping non-file in migration directory: {}",
+                path.display()
+            );
+            continue;
+        }
+
+        trace!("Found potential migration: {}", path.display());
+        result.push(path);
+    }
+
+    Ok(result)
+}
+
+/// Returns the sublist of the given migrations that should be run, in the returned order, to move
+/// from the 'from' version to the 'to' version.
+fn select_migrations<P: AsRef<Path>>(
+    from: Version,
+    to: Version,
+    paths: &[P],
+) -> Result<Vec<PathBuf>> {
+    // Intermediate result where we also store the version and name, needed for sorting
+    let mut sortable: Vec<(Version, String, PathBuf)> = Vec::new();
+
+    for path in paths {
+        let path = path.as_ref();
+
+        // We pull the applicable version and the migration name out of the filename.
+        let file_name = path
+            .file_name()
+            .context(error::Internal {
+                msg: "Found '/' as migration",
+            })?
+            .to_str()
+            .context(error::MigrationNameNotUTF8 { path: &path })?;
+        let captures = match MIGRATION_FILENAME_RE.captures(&file_name) {
+            Some(captures) => captures,
+            None => {
+                debug!(
+                    "Skipping non-migration (bad name) in migration directory: {}",
+                    path.display()
+                );
+                continue;
+            }
+        };
+
+        let version_match = captures.name("version").context(error::Internal {
+            msg: "Migration name matched regex but we don't have a 'version' capture",
+        })?;
+        let version = Version::from_str(version_match.as_str())
+            .context(error::InvalidMigrationVersion { path: &path })?;
+
+        let name_match = captures.name("name").context(error::Internal {
+            msg: "Migration name matched regex but we don't have a 'name' capture",
+        })?;
+        let name = name_match.as_str().to_string();
+
+        // We don't want to include migrations for the "from" version we're already on.
+        // Note on possible confusion: when going backward it's the higher version that knows
+        // how to undo its changes and take you to the lower version.  For example, the v2
+        // migration knows what changes it made to go from v1 to v2 and therefore how to go
+        // back from v2 to v1.  See tests.
+        let applicable = if to > from && version > from && version <= to {
+            info!(
+                "Found applicable forward migration '{}': {} < ({}) <= {}",
+                file_name, from, version, to
+            );
+            true
+        } else if to < from && version > to && version <= from {
+            info!(
+                "Found applicable backward migration '{}': {} >= ({}) > {}",
+                file_name, from, version, to
+            );
+            true
+        } else {
+            debug!(
+                "Migration '{}' doesn't apply when going from {} to {}",
+                file_name, from, to
+            );
+            false
+        };
+
+        if applicable {
+            sortable.push((version, name, path.to_path_buf()));
+        }
+    }
+
+    // Sort the migrations using the metadata we stored -- version first, then name so that
+    // authors have some ordering control if necessary.
+    sortable.sort_unstable();
+
+    // For a Backward migration process, reverse the order.
+    if to < from {
+        sortable.reverse();
+    }
+
+    debug!(
+        "Sorted migrations: {:?}",
+        sortable
+            .iter()
+            // Want filename, which always applies for us, but fall back to name just in case
+            .map(|(_version, name, path)| path
+                .file_name()
+                .map(|osstr| osstr.to_string_lossy().into_owned())
+                .unwrap_or_else(|| name.to_string()))
+            .collect::<Vec<String>>()
+    );
+
+    // Get rid of the name; only needed it as a separate component for sorting
+    let result: Vec<PathBuf> = sortable
+        .into_iter()
+        .map(|(_version, _name, path)| path)
+        .collect();
+
+    Ok(result)
+}
+
+/// Given the versions we're migrating from and to, this will return an ordered list of paths to
+/// migration binaries we should run to complete the migration on a data store.
+fn find_migrations(from: Version, to: Version) -> Result<Vec<PathBuf>> {
+    // This separation allows for easy testing of select_migrations.
+    let candidates = find_migrations_on_disk()?;
+    select_migrations(from, to, &candidates)
+}
+
+/// Copies the data store at the given path to a new directory in the same parent direction, with
+/// the new copy being named appropriately for the given new version.
+fn copy_datastore<P: AsRef<Path>>(from: P, new_version: Version) -> Result<(PathBuf, String)> {
+    // First, we need a random ID to append; this helps us avoid timing issues, and lets us
+    // leave failed migrations for inspection, while being able to try again in a new path.
+    // Note: we use this rather than mktemp::new_path_in because that has a delete destructor.
+    // Note: consider using this as a more general migration ID?
+    let copy_id = thread_rng().sample_iter(&Alphanumeric).take(16).collect();
+
+    let to = from
+        .as_ref()
+        .with_file_name(format!("{}_{}", new_version, copy_id));
+    ensure!(
+        !to.exists(),
+        error::NewVersionAlreadyExists {
+            version: new_version,
+            path: to
+        }
+    );
+
+    info!(
+        "Copying datastore from {} to work location {}",
+        from.as_ref().display(),
+        to.display()
+    );
+
+    let mut copy_options = fs_extra::dir::CopyOptions::new();
+    // Set copy_inside true; if we're moving from v0.0 to v0.1, and this isn't set, it tries to
+    // copy "v0.0" itself inside "v0.1".
+    copy_options.copy_inside = true;
+    // Note: this copies file permissions but not directory permissions; OK?
+    fs_extra::dir::copy(&from, &to, &copy_options).context(error::DataStoreCopy)?;
+
+    Ok((to, copy_id))
+}
+
+/// Runs the given migrations in their given order on the given data store.  The given direction
+/// is passed to each migration so it knows which direction we're migrating.
+fn run_migrations<P1, P2>(direction: Direction, migrations: &[P1], datastore_path: P2) -> Result<()>
+where
+    P1: AsRef<Path>,
+    P2: AsRef<Path>,
+{
+    for migration in migrations {
+        let mut command = Command::new(migration.as_ref());
+
+        // Point each migration in the right direction, and at the given data store.
+        command.arg(direction.to_string());
+        command.args(&[
+            "--datastore-path".to_string(),
+            datastore_path.as_ref().display().to_string(),
+        ]);
+
+        info!("Running migration command: {:?}", command);
+
+        let output = command
+            .output()
+            .context(error::StartMigration { command })?;
+
+        debug!(
+            "Migration stdout: {}",
+            std::str::from_utf8(&output.stdout).unwrap_or("<invalid UTF-8>")
+        );
+        debug!(
+            "Migration stderr: {}",
+            std::str::from_utf8(&output.stderr).unwrap_or("<invalid UTF-8>")
+        );
+
+        ensure!(output.status.success(), error::MigrationFailure { output });
+    }
+    Ok(())
+}
+
+/// Atomically flips version symlinks to point to the given "to" datastore so that it becomes live.
+///
+/// This includes pointing the new minor version to the given `to_datastore` (which includes
+/// `copy_id` in its name), then pointing the major version to the new minor version, and finally
+/// fsyncing the directory to disk.
+///
+/// `copy_id` is the identifier for this migration attempt, as created by copy_datastore, which we
+/// use internally in this function for consistency.
+fn flip_to_new_minor_version<P, S>(version: Version, to_datastore: P, copy_id: S) -> Result<()>
+where
+    P: AsRef<Path>,
+    S: AsRef<str>,
+{
+    // Get the directory we're working in.
+    let to_dir = to_datastore
+        .as_ref()
+        .parent()
+        .context(error::DataStoreLinkToRoot {
+            path: to_datastore.as_ref(),
+        })?;
+    // We need a file descriptor for the directory so we can fsync after the symlink swap.
+    let raw_dir = Dir::open(
+        to_dir,
+        // Confirm it's a directory
+        OFlag::O_DIRECTORY,
+        // (mode doesn't matter for opening a directory)
+        Mode::empty(),
+    )
+    .context(error::DataStoreDirOpen { path: &to_dir })?;
+
+    // Get a unique temporary path in the directory; we need this to atomically swap.
+    // We use the same copy_id so that mistakes/errors here will be obviously related to a
+    // given copy attempt.
+    let temp_link = to_dir.join(copy_id.as_ref());
+    // Build the path to the major version link; this is what we're atomically swapping from
+    // pointing at the old minor version to pointing at the new minor version.
+    // Example: /path/to/datastore/v1
+    // FIXME: duplicating knowledge of formatting here
+    let major_version_link = to_dir.join(format!("v{}", version.major));
+    // Build the path to the minor version link.  If this already exists, it's because we've
+    // previously tried to migrate to this version.  We point it at the full `to_datastore` path.
+    // Example: /path/to/datastore/v1.5
+    let minor_version_link = to_dir.join(format!("{}", version));
+
+    // Get the final component of the paths we're linking to, so we can use relative links instead
+    // of absolute, for understandability.
+    let to_target = to_datastore
+        .as_ref()
+        .file_name()
+        .context(error::DataStoreLinkToRoot {
+            path: to_datastore.as_ref(),
+        })?;
+    let minor_target = minor_version_link
+        .file_name()
+        .context(error::DataStoreLinkToRoot {
+            path: to_datastore.as_ref(),
+        })?;
+
+    info!(
+        "Flipping {} to point to {}",
+        minor_version_link.display(),
+        to_target.to_string_lossy(),
+    );
+
+    // Create a symlink from the minor version to the new data store.  We create it at a temporary
+    // path so we can atomically swap it into the real path with a rename call.
+    // This will point at, for example, /path/to/datastore/v1.5_0123456789abcdef
+    symlink(&to_target, &temp_link).context(error::LinkCreate { path: &temp_link })?;
+    // Atomically swap the link into place, so that the minor version link points to the new data
+    // store copy.
+    fs::rename(&temp_link, &minor_version_link).context(error::LinkSwap {
+        link: &minor_version_link,
+    })?;
+
+    info!(
+        "Flipping {} to point to {}",
+        major_version_link.display(),
+        minor_target.to_string_lossy(),
+    );
+
+    // Create a symlink from the major version to the new minor version.
+    // This will point at, for example, /path/to/datastore/v1.5
+    symlink(&minor_target, &temp_link).context(error::LinkCreate { path: &temp_link })?;
+    // Atomically swap the link into place, so that the major version link points to the new minor
+    // version.
+    fs::rename(&temp_link, &major_version_link).context(error::LinkSwap {
+        link: &major_version_link,
+    })?;
+
+    // fsync the directory so the links point to the new version even if we crash right after
+    // this.  If fsync fails, warn but continue, because we likely can't swap the links back
+    // without hitting the same failure.
+    fsync(raw_dir.as_raw_fd()).unwrap_or_else(|e| {
+        warn!(
+            "fsync of data store directory '{}' failed, update may disappear if we crash now: {}",
+            to_dir.display(),
+            e
+        )
+    });
+
+    Ok(())
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[allow(unused_variables)]
+    fn select_migrations_works() {
+        // Migration paths for use in testing
+        let m00_1 = Path::new("migrate_v0.0_001");
+        let m01_1 = Path::new("migrate_v0.1_001");
+        let m01_2 = Path::new("migrate_v0.1_002");
+        let m02_1 = Path::new("migrate_v0.2_001");
+        let m03_1 = Path::new("migrate_v0.3_001");
+        let m04_1 = Path::new("migrate_v0.4_001");
+        let m04_2 = Path::new("migrate_v0.4_002");
+        let all_migrations = vec![&m00_1, &m01_1, &m01_2, &m02_1, &m03_1, &m04_1, &m04_2];
+
+        // Versions for use in testing
+        let v00 = Version::new(0, 0);
+        let v01 = Version::new(0, 1);
+        let v02 = Version::new(0, 2);
+        let v03 = Version::new(0, 3);
+        let v04 = Version::new(0, 4);
+        let v05 = Version::new(0, 5);
+
+        // Test going forward one minor version
+        assert_eq!(
+            select_migrations(v01, v02, &all_migrations).unwrap(),
+            vec![m02_1]
+        );
+
+        // Test going backward one minor version
+        assert_eq!(
+            select_migrations(v02, v01, &all_migrations).unwrap(),
+            vec![m02_1]
+        );
+
+        // Test going forward a few minor versions
+        assert_eq!(
+            select_migrations(v01, v04, &all_migrations).unwrap(),
+            vec![m02_1, m03_1, m04_1, m04_2]
+        );
+
+        // Test going backward a few minor versions
+        assert_eq!(
+            select_migrations(v04, v01, &all_migrations).unwrap(),
+            vec![m04_2, m04_1, m03_1, m02_1]
+        );
+
+        // Test no matching migrations
+        assert!(select_migrations(v04, v05, &all_migrations)
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/workspaces/api/migration/migrator/src/version.rs
+++ b/workspaces/api/migration/migrator/src/version.rs
@@ -1,0 +1,222 @@
+//! This module handles versioning of data stores - detecting their versions, ordering versions,
+//! determining whether a version change is forward or backward, etc.
+
+use crate::error::{self, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+use snafu::{OptionExt, ResultExt};
+use std::cmp::Ordering;
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+/// VersionComponent represents each integer segment of a version string.
+pub(crate) type VersionComponent = u32;
+
+lazy_static! {
+    /// Regular expression that captures the entire version string (1.2 or v1.2) along with the
+    /// major (1) and minor (2) separately.
+    pub(crate) static ref VERSION_RE: Regex =
+        Regex::new(r"(?P<version>v?(?P<major>[0-9]+)\.(?P<minor>[0-9]+))").unwrap();
+
+    /// Regular expression that captures the version and ID from the name of a data store
+    /// directory, e.g. matching "v1.5_0123456789abcdef" will let you retrieve version (v1.5),
+    /// major (1), minor (5), and id (0123456789abcdef).
+    pub(crate) static ref DATA_STORE_DIRECTORY_RE: Regex =
+        Regex::new(&format!(r"^{}_(?P<id>.*)$", *VERSION_RE)).unwrap();
+
+    /// Regular expression that will match migration file names and allow retrieving the
+    /// version and name components.
+    pub(crate) static ref MIGRATION_FILENAME_RE: Regex =
+        Regex::new(&format!(r"^migrate_{}_(?P<name>[a-zA-Z0-9-]+)$", *VERSION_RE)).unwrap();
+}
+
+/// Version represents the version identifiers of our data store.
+// Deriving Ord will check the fields in order, so as long as the more important fields (e.g.
+// 'major') are listed first, it will compare versions as expected.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct Version {
+    /// The data store format version, or major for short.
+    pub(crate) major: VersionComponent,
+    /// The content format version, or minor for short.
+    pub(crate) minor: VersionComponent,
+}
+
+impl FromStr for Version {
+    type Err = error::Error;
+
+    /// Parse a version string like "1.0" or "v1.0" into a Version.
+    fn from_str(input: &str) -> Result<Self> {
+        Self::from_str_with_re(input, &VERSION_RE)
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "v{}.{}", self.major, self.minor)
+    }
+}
+
+impl Version {
+    #[allow(dead_code)]
+    pub(crate) fn new(major: VersionComponent, minor: VersionComponent) -> Self {
+        Self { major, minor }
+    }
+
+    /// Parses the input string into a Version, with a given Regex that is expected to provide
+    /// "major" and "minor" captures.  Used to implement the pub(crate) entry points.
+    fn from_str_with_re(input: &str, re: &Regex) -> Result<Self> {
+        trace!("Parsing version from string: {}", input);
+
+        let captures = re.captures(&input).context(error::InvalidVersion {
+            given: input,
+            re: re.as_str(),
+        })?;
+
+        let major_str = captures.name("major").context(error::Internal {
+            msg: "Version matched regex but we don't have a 'major' capture",
+        })?;
+        let minor_str = captures.name("minor").context(error::Internal {
+            msg: "Version matched regex but we don't have a 'minor' capture",
+        })?;
+
+        let major = major_str
+            .as_str()
+            .parse::<VersionComponent>()
+            .with_context(|| error::InvalidVersionComponent {
+                component: major_str.as_str(),
+            })?;
+        let minor = minor_str
+            .as_str()
+            .parse::<VersionComponent>()
+            .with_context(|| error::InvalidVersionComponent {
+                component: minor_str.as_str(),
+            })?;
+
+        trace!("Parsed major '{}' and minor '{}'", major, minor);
+        Ok(Self { major, minor })
+    }
+
+    /// This pulls the version number out of the given datastore path.
+    ///
+    /// Returns Err if the given path isn't named like a versioned data store.
+    ///
+    /// Background: The data store path uses symlinks to represent versions and allow for easy
+    /// version flips.  This function expects the target directory path.
+    ///
+    /// An example setup for version 1.5:
+    ///    /path/to/datastore/current
+    ///    -> /path/to/datastore/v1
+    ///    -> /path/to/datastore/v1.5
+    ///    -> /path/to/datastore/v1.5_0123456789abcdef
+    pub(crate) fn from_datastore_path<P: Into<PathBuf>>(path: P) -> Result<Self> {
+        let path = path.into();
+        trace!("Getting version from datastore path: {}", path.display());
+
+        // Pull out the basename of the path, which contains the version
+        let version_os_str = path
+            .file_name()
+            .context(error::DataStoreLinkToRoot { path: &path })?;
+        let version_str = version_os_str
+            .to_str()
+            .context(error::DataStorePathNotUTF8 { path: &path })?;
+
+        // Parse and return the version
+        Self::from_str_with_re(version_str, &DATA_STORE_DIRECTORY_RE)
+    }
+}
+
+/// Direction represents whether we're moving forward toward a newer version, or rolling back to
+/// an older version.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum Direction {
+    Forward,
+    Backward,
+}
+
+impl fmt::Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Direction::Forward => write!(f, "--forward"),
+            Direction::Backward => write!(f, "--backward"),
+        }
+    }
+}
+
+impl Direction {
+    /// Determines the migration direction, given the outgoing ("from') and incoming ("to")
+    /// versions.
+    pub(crate) fn from_versions(from: Version, to: Version) -> Option<Self> {
+        match from.cmp(&to) {
+            Ordering::Less => Some(Direction::Forward),
+            Ordering::Greater => Some(Direction::Backward),
+            Ordering::Equal => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Direction, Version};
+    use std::str::FromStr;
+
+    #[test]
+    fn version_eq() {
+        assert_eq!(Version::new(0, 0), Version::new(0, 0));
+        assert_eq!(Version::new(1, 0), Version::new(1, 0));
+        assert_eq!(Version::new(1, 1), Version::new(1, 1));
+
+        assert_ne!(Version::new(0, 0), Version::new(0, 1));
+        assert_ne!(Version::new(0, 1), Version::new(1, 0));
+        assert_ne!(Version::new(1, 0), Version::new(0, 1));
+    }
+
+    #[test]
+    fn version_ord() {
+        assert!(Version::new(0, 1) > Version::new(0, 0));
+        assert!(Version::new(1, 0) > Version::new(0, 99));
+        assert!(Version::new(1, 1) > Version::new(1, 0));
+
+        assert!(Version::new(0, 0) < Version::new(0, 1));
+        assert!(Version::new(0, 99) < Version::new(1, 0));
+        assert!(Version::new(1, 0) < Version::new(1, 1));
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(Version::from_str("0.1").unwrap(), Version::new(0, 1));
+        assert_eq!(Version::from_str("1.0").unwrap(), Version::new(1, 0));
+        assert_eq!(Version::from_str("2.3").unwrap(), Version::new(2, 3));
+
+        assert_eq!(Version::from_str("v0.1").unwrap(), Version::new(0, 1));
+        assert_eq!(Version::from_str("v1.0").unwrap(), Version::new(1, 0));
+        assert_eq!(Version::from_str("v2.3").unwrap(), Version::new(2, 3));
+    }
+
+    #[test]
+    fn fmt() {
+        assert_eq!("v0.1", format!("{}", Version::new(0, 1)));
+        assert_eq!("v1.0", format!("{}", Version::new(1, 0)));
+        assert_eq!("v2.3", format!("{}", Version::new(2, 3)));
+    }
+
+    #[test]
+    fn direction() {
+        let v01 = Version::new(0, 1);
+        let v02 = Version::new(0, 2);
+        let v10 = Version::new(1, 0);
+
+        assert_eq!(Direction::from_versions(v01, v02), Some(Direction::Forward));
+        assert_eq!(
+            Direction::from_versions(v02, v01),
+            Some(Direction::Backward)
+        );
+        assert_eq!(Direction::from_versions(v01, v01), None);
+
+        assert_eq!(Direction::from_versions(v02, v10), Some(Direction::Forward));
+        assert_eq!(
+            Direction::from_versions(v10, v02),
+            Some(Direction::Backward)
+        );
+    }
+}


### PR DESCRIPTION
This tool finds migrations on disk, runs them on a copy of the data store, and
if successful, atomically updates the data store links to flip to the new
version.

You tell it the data store to migrate (from which it finds the current version)
and the version to migrate to, and it understands the available migrations and
which are necessary to move to the requested version.

Note: this still assumes there's a single, fixed MIGRATIONS_PATH.  We don't yet
have the systems and locations we need to find migrations from the image and
migrations that have been downloaded, so this temporarily makes this
simplifying assumption.

Signed-off-by: Tom Kirchner <tjk@amazon.com>

---

Note: OS integration is separate; this will include setting up the data store links, making a service for the migrator, etc.

Fixes #52.

Further background: migration library and prototype were added in #44.

---

**Testing done:**

I added a few new unit tests that pass.

I tested the migrator by copying a default data store to a temp directory and setting up links:

```
lrwxrwxrwx 1 tjk domain^users    2 07-10 11:37 current -> v0/
lrwxrwxrwx 1 tjk domain^users    4 07-15 12:55 v0 -> v0.0/
lrwxrwxrwx 1 tjk domain^users   21 07-15 10:32 v0.0 -> v0.0_aBIUdlQUclSbnHEv/
drwxr-xr-x 3 tjk domain^users 4.0K 07-11 13:12 v0.0_aBIUdlQUclSbnHEv/
```

I changed the hardcoded migration binaries path, and copied in our prototype migration:

```
-const MIGRATIONS_PATH: &str = "/var/lib/thar/datastore/migrations";
+const MIGRATIONS_PATH: &str = "./migration-binaries";
```

I ran the migrator:

```
$ cargo run -- -v -v -v -v --datastore-path datastore-sample/v0 --migrate-to-version 0.1
2019-07-15T12:55:56.612-07:00 - TRACE - Getting version from datastore path: /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.0_aBIUdlQUclSbnHEv
2019-07-15T12:55:56.613-07:00 - TRACE - Parsing version from string: v0.0_aBIUdlQUclSbnHEv
2019-07-15T12:55:56.613-07:00 - TRACE - Parsed major '0' and minor '0'
2019-07-15T12:55:56.613-07:00 - TRACE - Looking for potential migrations in ./migration-binaries
2019-07-15T12:55:56.614-07:00 - TRACE - Found potential migration: ./migration-binaries/migrate_v0.1_test
2019-07-15T12:55:56.616-07:00 - TRACE - Parsing version from string: v0.1
2019-07-15T12:55:56.616-07:00 - TRACE - Parsed major '0' and minor '1'
2019-07-15T12:55:56.616-07:00 - INFO - Found applicable forward migration 'migrate_v0.1_test': v0.0 < (v0.1) <= v0.1
2019-07-15T12:55:56.617-07:00 - DEBUG - Sorted migrations: ["migrate_v0.1_test"]
2019-07-15T12:55:56.617-07:00 - INFO - Copying datastore from /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.0_aBIUdlQUclSbnHEv to work location /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_xm064T32kGRb6IK7
2019-07-15T12:55:56.617-07:00 - INFO - Running migration command: "./migration-binaries/migrate_v0.1_test" "--forward" "--datastore-path" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_xm064T32kGRb6IK7"
2019-07-15T12:55:56.623-07:00 - DEBUG - Migration stdout: 
2019-07-15T12:55:56.623-07:00 - DEBUG - Migration stderr: 
2019-07-15T12:55:56.623-07:00 - INFO - Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1 to point to v0.1_xm064T32kGRb6IK7
2019-07-15T12:55:56.623-07:00 - INFO - Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0 to point to v0.1
```

We can see the new tree set up correctly:
```
lrwxrwxrwx 1 tjk domain^users    2 07-10 11:37 current -> v0/
lrwxrwxrwx 1 tjk domain^users    4 07-15 12:55 v0 -> v0.1/
lrwxrwxrwx 1 tjk domain^users   21 07-15 10:32 v0.0 -> v0.0_aBIUdlQUclSbnHEv/
drwxr-xr-x 3 tjk domain^users 4.0K 07-11 13:12 v0.0_aBIUdlQUclSbnHEv/
lrwxrwxrwx 1 tjk domain^users   21 07-15 12:55 v0.1 -> v0.1_xm064T32kGRb6IK7/
drwxr-xr-x 3 tjk domain^users 4.0K 07-15 12:55 v0.1_xm064T32kGRb6IK7/
```

And we can see that the migration ran correctly:
```
$ diff datastore-sample/v0.{0,1}
diff -NurwBd datastore-sample/v0.0/live/settings/timezone datastore-sample/v0.1/live/settings/timezone
--- datastore-sample/v0.0/live/settings/timezone	2019-06-28 13:03:05.428316615 -0700
+++ datastore-sample/v0.1/live/settings/timezone	2019-07-15 12:55:56.618927884 -0700
@@ -1 +1 @@
-"OldLosAngeles"
\ No newline at end of file
+"NewOldLosAngeles"
\ No newline at end of file
```