### PR TITLE
sundog: Add argument handling for generator commands

### DIFF
--- a/workspaces/api/sundog/src/main.rs
+++ b/workspaces/api/sundog/src/main.rs
@@ -54,7 +54,7 @@ mod error {
             source: std::io::Error,
         },
 
-        #[snafu(display("Generator command is invalid (empty, etc.) - {}", command))]
+        #[snafu(display("Generator command is invalid (empty, etc.) - '{}'", command))]
         InvalidCommand { command: String },
 
         #[snafu(display(


### PR DESCRIPTION
I realized Sundog doesn't handle setting generator commands that have arguments.  (Oops) 🤷‍♂ 

*Issue #, if available:*

*Description of changes:*
* Add argument handling to `process::Command` call

*Testing*
* All unit tests continue to pass
* Tested a setting generator with no args (`/bin/pwd`): passes
```
bash-5.0# /usr/bin/sundog -v -v -v -v
2019-07-10T22:07:13.973+00:00 - INFO - Sundog started
2019-07-10T22:07:13.975+00:00 - INFO - Retrieving setting generators
2019-07-10T22:07:13.976+00:00 - DEBUG - Requesting setting generators from API
2019-07-10T22:07:13.980+00:00 - TRACE - Generators: {"settings.hostname": "/bin/pwd"}
2019-07-10T22:07:13.982+00:00 - INFO - Retrieving settings values
2019-07-10T22:07:13.983+00:00 - DEBUG - Running generator: '/bin/pwd'
2019-07-10T22:07:13.986+00:00 - TRACE - Generator '/bin/pwd' output: /
2019-07-10T22:07:13.987+00:00 - TRACE - Serialized output: "/"
2019-07-10T22:07:13.988+00:00 - INFO - Sending settings values to the API
2019-07-10T22:07:13.989+00:00 - TRACE - Settings to PATCH: {"hostname":"/"}
2019-07-10T22:07:13.991+00:00 - DEBUG - POST-ing to /commit to finalize the changes
```
* Tested an setting generator command that consists of empty space  (`"   "`): correctly fails
```
bash-5.0# /usr/bin/sundog -v -v -v -v
2019-07-10T22:09:23.509+00:00 - INFO - Sundog started
2019-07-10T22:09:23.510+00:00 - INFO - Retrieving setting generators
2019-07-10T22:09:23.512+00:00 - DEBUG - Requesting setting generators from API
2019-07-10T22:09:23.516+00:00 - TRACE - Generators: {"settings.hostname": "  "}
2019-07-10T22:09:23.518+00:00 - INFO - Retrieving settings values
2019-07-10T22:09:23.519+00:00 - DEBUG - Running generator: '  '
Error: InvalidCommand { command: "  " }
```
* Tested a setting generator command that is empty (`""`): correctly fails 
```
bash-5.0# /usr/bin/sundog -v -v -v -v
2019-07-10T22:11:14.195+00:00 - INFO - Sundog started
2019-07-10T22:11:14.197+00:00 - INFO - Retrieving setting generators
2019-07-10T22:11:14.198+00:00 - DEBUG - Requesting setting generators from API
2019-07-10T22:11:14.202+00:00 - TRACE - Generators: {"settings.hostname": ""}
2019-07-10T22:11:14.204+00:00 - INFO - Retrieving settings values
2019-07-10T22:11:14.205+00:00 - DEBUG - Running generator: ''
Error: InvalidCommand { command: "" }
```
* Tested a (kinda weird) setting generator with args (`"ls /var"`): correctly passes
```
bash-5.0# /usr/bin/sundog -v -v -v -v
2019-07-10T22:12:07.624+00:00 - INFO - Sundog started
2019-07-10T22:12:07.625+00:00 - INFO - Retrieving setting generators
2019-07-10T22:12:07.627+00:00 - DEBUG - Requesting setting generators from API
2019-07-10T22:12:07.631+00:00 - TRACE - Generators: {"settings.hostname": "ls /var"}
2019-07-10T22:12:07.633+00:00 - INFO - Retrieving settings values
2019-07-10T22:12:07.634+00:00 - DEBUG - Running generator: 'ls /var'
2019-07-10T22:12:07.636+00:00 - TRACE - Generator 'ls /var' output: cache
lib
lock
log
run
spool
tmp
2019-07-10T22:12:07.638+00:00 - TRACE - Serialized output: "cache\nlib\nlock\nlog\nrun\nspool\ntmp"
2019-07-10T22:12:07.640+00:00 - INFO - Sending settings values to the API
2019-07-10T22:12:07.641+00:00 - TRACE - Settings to PATCH: {"hostname":"cache\nlib\nlock\nlog\nrun\nspool\ntmp"}
2019-07-10T22:12:07.643+00:00 - DEBUG - POST-ing to /commit to finalize the changes
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
