### PR TITLE
Fix bin/upload-sources to actually upload sources

### DIFF
--- a/bin/upload-sources
+++ b/bin/upload-sources
@@ -14,8 +14,10 @@ for path in "$@"; do
     checksum="$("${checksum_tool}" "${path}" | awk '{print $1}')"
 
     url="https://thar-upstream-lookaside-cache.s3.us-west-2.amazonaws.com/${filename}/${checksum}/${filename}"
+    set +e
     code="$(curl --write-out '%{http_code}' -fsIo /dev/null "${url}")"
     return=$?
+    set -e
     if [ "$return" -eq 22 ] && [ "$code" -eq "403" ]; then
         aws s3 cp "${path}" "s3://thar-upstream-lookaside-cache/${filename}/${checksum}/${filename}"
     elif [ "$return" -ne 0 ]; then


### PR DESCRIPTION
... or, "Work around horribleness of `set -e`"

Signed-off-by: iliana destroyer of worlds <iweller@amazon.com>

Tested with `make upload-sources` and now it doesn't instantly fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
