### PR TITLE
add kubernetes model to datastore

### DIFF
--- a/workspaces/api/apiserver/src/model.rs
+++ b/workspaces/api/apiserver/src/model.rs
@@ -5,17 +5,41 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
+
+use crate::modeled_types::ValidBase64;
 
 ///// Primary user-visible settings
 
 // Note: fields are marked with skip_serializing_if=Option::is_none so that settings GETs don't
 // show field=null for everything that isn't set in the relevant group of settings.
 
+// Kubernetes related settings. The dynamic settings are retrieved from
+// IMDS via Sundog's child "Pluto".
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
-pub struct DockerSettings {
+pub struct KubernetesSettings {
+    // Settings we require the user to specify, likely via user data.
+
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bridge_ip: Option<String>,
+    pub cluster_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cluster_certificate: Option<ValidBase64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_server: Option<String>,
+
+    // Dynamic settings.
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cluster_dns_ip: Option<Ipv4Addr>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_ip: Option<Ipv4Addr>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pod_infra_container_image: Option<String>,
 }
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -30,7 +54,7 @@ pub struct Settings {
     pub hostname: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub docker: Option<DockerSettings>,
+    pub kubernetes: Option<KubernetesSettings>,
 }
 
 ///// Internal services


### PR DESCRIPTION
*Description of changes:*

Replace the placeholder "DockerSettings" with "KubernetesSettings".

*Testing:*

Ran `cargo test` with this output:
`test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`

Ran curl commands against the API to change Kubernetes settings:
`curl -v -X PATCH 'localhost:4242/settings' -d '{"settings": {"kubernetes": {"cluster-name": "k9s"}}}'`
`curl -v -X POST 'localhost:4242/settings/commit'`
`curl -v 'localhost:4242/settings'`
output:
`{"timezone":"NewLosAngeles","hostname":"localhost","kubernetes":{"cluster-name":"k9s"}}`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
