### PR TITLE
moondog: Add arg parsing for setting logging verbosity

### DIFF
--- a/workspaces/api/moondog/src/main.rs
+++ b/workspaces/api/moondog/src/main.rs
@@ -227,7 +227,7 @@ fn parse_args(args: env::Args) -> Args {
 
     for arg in args.skip(1) {
         match arg.as_ref() {
-            "-v" | "--verbosity" => verbosity += 1,
+            "-v" | "--verbose" => verbosity += 1,
             _ => usage(),
         }
     }


### PR DESCRIPTION
While debugging the base64 template helper, I realized that moondog didn't have the ability to set the verbosity of logging via args.  I copied over the exact arg parsing from sundog/tbs.

*Issue #, if available:* N/A

*Description of changes:*
* Add arg parsing for setting logging verbosity

*Testing:*
* Unit tests continue to pass
* Manually ran without args (default settings)
```
bash-5.0# /usr/bin/moondog
2019-07-18T02:57:14.384+00:00 - INFO - Moondog started
2019-07-18T02:57:14.386+00:00 - INFO - Detecting user data provider
2019-07-18T02:57:14.387+00:00 - INFO - Running on AWS: Using IMDS for user data
2019-07-18T02:57:14.389+00:00 - INFO - Retrieving user data
2019-07-18T02:57:14.392+00:00 - INFO - User data found
...
```
* Manually ran with a few extra v's. :)
```
bash-5.0# /usr/bin/moondog -v -v -v -v
2019-07-18T03:04:35.686+00:00 - INFO - Moondog started
2019-07-18T03:04:35.687+00:00 - INFO - Detecting user data provider
2019-07-18T03:04:35.689+00:00 - INFO - Running on AWS: Using IMDS for user data
2019-07-18T03:04:35.690+00:00 - INFO - Retrieving user data
2019-07-18T03:04:35.692+00:00 - DEBUG - Requesting user data from IMDS
2019-07-18T03:04:35.695+00:00 - TRACE - IMDS response: Response ...
...
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
