### PR TITLE
tough: URL can be parsed regardless of presence of trailing slash

### DIFF
--- a/workspaces/tough/src/error.rs
+++ b/workspaces/tough/src/error.rs
@@ -14,11 +14,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub enum Error {
-    /// A repository base URL provided to [`Repository::load`][crate::Repository::load] is missing
-    /// a trailing slash.
-    #[snafu(display("Base URL {:?} is missing trailing slash", url))]
-    BaseUrlMissingTrailingSlash { url: String, backtrace: Backtrace },
-
     /// The library failed to create a file in the datastore.
     #[snafu(display("Failed to create file at datastore path {}: {}", path.display(), source))]
     DatastoreCreate {


### PR DESCRIPTION
*Issue #, if available:* Issue #58 

*Description of changes:*
- Removes error type `BaseUrlMissingTrailingSlash` as `parse_url` is now trail-slash-agnostic
- Creates a small helper function to append trailing slash to a string
- Modifies `parse_url` wrapper to check for presence of trailing slash, if there's none, one is appended.
- Adds a small unit test to make sure a url without a trailing slash is treated the same as if it has trailing slash

*Testing:*
- Unit test passes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
