### PR TITLE
spec2pkg: Fail if filename not found in sources file

### DIFF
--- a/bin/spec2pkg
+++ b/bin/spec2pkg
@@ -48,6 +48,10 @@ for url in ${SOURCE_URLS}; do
         CHECKSUM="$(awk -F / '{print $1}' <<<"${url##*#}")"
     elif [[ -f "packages/${PKG}/sources" ]]; then
         CHECKSUM="$(awk -v filename="(${FILENAME})" '$2 == filename {print $4}' "packages/${PKG}/sources")"
+        if [[ -z "$CHECKSUM" ]]; then
+            echo -e "# download rule for packages/${PKG}/${FILENAME} couldn't be generated; filename not found in sources\n" 1>&2
+            exit 1
+        fi
     else
         echo -e "# download rule for packages/${PKG}/${FILENAME} couldn't be generated\n" 1>&2
         exit 1


### PR DESCRIPTION
*Issue #, if available:*
Fixes #53

*Description of changes:*
Fails checksum check if the filename is not found in the sources file for the package.
Tested by changing the name in a package's source file and running `make buildkitd; make` to ensure it fails. Tested with a different name and also a name appended with something. Build proceeds as normal with actual name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
