### PR TITLE
Fixes #56: Implements 'latest known time' when checking for expirations

### DIFF
--- a/workspaces/updater/tough/src/datastore.rs
+++ b/workspaces/updater/tough/src/datastore.rs
@@ -5,6 +5,7 @@ use std::fs::{self, File};
 use std::io::{ErrorKind, Read};
 use std::path::{Path, PathBuf};
 
+#[derive(Debug, Clone)]
 pub(crate) struct Datastore(PathBuf);
 
 impl Datastore {

--- a/workspaces/updater/tough/src/error.rs
+++ b/workspaces/updater/tough/src/error.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::default_trait_access)]
 
 use crate::serde::Role;
+use chrono::{DateTime, Utc};
 use snafu::{Backtrace, Snafu};
 use std::fmt::{self, Debug, Display};
 use std::path::PathBuf;
@@ -45,6 +46,16 @@ pub enum Error {
     /// A metadata file has expired.
     #[snafu(display("{} metadata is expired", role))]
     ExpiredMetadata { role: Role, backtrace: Backtrace },
+
+    /// System time is behaving irrationally, went back in time
+    #[snafu(display("System time is indicating a time earlier than latest known system time: System Time {}, Last known time {}",
+        sys_time,
+        latest_known_time,
+    ))]
+    IrrationalSystemTime {
+        sys_time: DateTime<Utc>,
+        latest_known_time: DateTime<Utc>,
+    },
 
     /// A downloaded target's checksum does not match the checksum listed in the repository
     /// metadata.

--- a/workspaces/updater/tough/src/lib.rs
+++ b/workspaces/updater/tough/src/lib.rs
@@ -34,6 +34,7 @@ use std::path::Path;
 pub struct Repository {
     client: Client,
     consistent_snapshot: bool,
+    datastore: Datastore,
     earliest_expiration: DateTime<Utc>,
     earliest_expiration_role: Role,
     target_base_url: Url,
@@ -106,6 +107,7 @@ impl Repository {
         Ok(Self {
             client,
             consistent_snapshot: root.signed.consistent_snapshot,
+            datastore,
             earliest_expiration: earliest_expiration.to_owned(),
             earliest_expiration_role: *earliest_expiration_role,
             target_base_url,
@@ -118,9 +120,34 @@ impl Repository {
         })
     }
 
+    /// Ensures the repository data has not expired since load
     fn check_expired(&self) -> Result<()> {
+        // Get 'current' system time
+        let sys_time = Utc::now();
+        // Load the latest known system time, if it exists
+        match self
+            .datastore
+            .reader("latest_known_time.json")?
+            .map(serde_json::from_reader::<_, DateTime<Utc>>)
+        {
+            Some(Ok(latest_known_time)) => {
+                // Make sure the sampled system time did not go back in time
+                ensure!(
+                    sys_time > latest_known_time,
+                    error::IrrationalSystemTime {
+                        sys_time,
+                        latest_known_time
+                    }
+                );
+            }
+            // If the file doesn't exist, create it and store the latest known time to it
+            _ => {
+                // Serializes RFC3339 time string and store to datastore
+                self.datastore.create("latest_known_time.json", &sys_time)?;
+            }
+        }
         ensure!(
-            Utc::now() < self.earliest_expiration,
+            sys_time < self.earliest_expiration,
             error::ExpiredMetadata {
                 role: self.earliest_expiration_role
             }
@@ -329,7 +356,7 @@ fn load_root<R: Read>(
     //   timestamp in the trusted root metadata file (version N). If the trusted root metadata file
     //   has expired, abort the update cycle, report the potential freeze attack. On the next
     //   update cycle, begin at step 0 and version N of the root metadata file.
-    root.check_expired()?;
+    root.check_expired(datastore)?;
 
     // 1.9. If the timestamp and / or snapshot keys have been rotated, then delete the trusted
     //   timestamp and snapshot metadata files. This is done in order to recover from fast-forward
@@ -408,7 +435,7 @@ fn load_timestamp(
     //   timestamp in the new timestamp metadata file. If so, the new timestamp metadata file
     //   becomes the trusted timestamp metadata file. If the new timestamp metadata file has
     //   expired, discard it, abort the update cycle, and report the potential freeze attack.
-    timestamp.check_expired()?;
+    timestamp.check_expired(datastore)?;
 
     // Now that everything seems okay, write the timestamp file to the datastore.
     datastore.create("timestamp.json", &timestamp)?;
@@ -539,7 +566,7 @@ fn load_snapshot(
     //   timestamp in the new snapshot metadata file. If so, the new snapshot metadata file becomes
     //   the trusted snapshot metadata file. If the new snapshot metadata file is expired, discard
     //   it, abort the update cycle, and report the potential freeze attack.
-    snapshot.check_expired()?;
+    snapshot.check_expired(datastore)?;
 
     // Now that everything seems okay, write the timestamp file to the datastore.
     datastore.create("snapshot.json", &snapshot)?;
@@ -644,7 +671,7 @@ fn load_targets(
     //   timestamp in the new targets metadata file. If so, the new targets metadata file becomes
     //   the trusted targets metadata file. If the new targets metadata file is expired, discard
     //   it, abort the update cycle, and report the potential freeze attack.
-    targets.check_expired()?;
+    targets.check_expired(datastore)?;
 
     // 4.5. Perform a preorder depth-first search for metadata about the desired target, beginning
     //   with the top-level targets role.
@@ -652,7 +679,7 @@ fn load_targets(
     // (This library does not yet handle delegated roles, so we just use the parsed targets from
     // targets.json.)
 
-    // Now that everything seems okay, write the timestamp file to the datastore.
+    // Now that everything seems okay, write the targets file to the datastore.
     datastore.create("targets.json", &targets)?;
 
     Ok(targets)


### PR DESCRIPTION
Everytime when the system time is sampled, it's checked against the last known system time. If such a record doesn't exist, it is serialized and stored in `latest_known_time.json`. If the sampled system time is somehow earlier than the latest known time, then the system time is irrational and an error is raised.

*Issue #, if available:* #56 

*Description of changes:*
- Adds new error variant `IrrationalSystemTime`
- Adds `datastore` as a field to the `Repository` struct to allow for checking expirations after the repository is loaded
- Modifies both the generic `check_expiration` and `Repository::check_expiration` to account for latest known time when checking for expirations.

*Testing:*
Currently thinking of ways to test. Any ideas are welcomed!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
