### PR TITLE
Implement 'latest known time' when checking for expirations

### DIFF
--- a/workspaces/updater/tough/src/datastore.rs
+++ b/workspaces/updater/tough/src/datastore.rs
@@ -5,6 +5,7 @@ use std::fs::{self, File};
 use std::io::{ErrorKind, Read};
 use std::path::{Path, PathBuf};
 
+#[derive(Debug, Clone)]
 pub(crate) struct Datastore(PathBuf);
 
 impl Datastore {

--- a/workspaces/updater/tough/src/error.rs
+++ b/workspaces/updater/tough/src/error.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::default_trait_access)]
 
 use crate::serde::Role;
+use chrono::{DateTime, Utc};
 use snafu::{Backtrace, Snafu};
 use std::fmt::{self, Debug, Display};
 use std::path::PathBuf;
@@ -45,6 +46,17 @@ pub enum Error {
     /// A metadata file has expired.
     #[snafu(display("{} metadata is expired", role))]
     ExpiredMetadata { role: Role, backtrace: Backtrace },
+
+    /// System time is behaving irrationally, went back in time
+    #[snafu(display(
+        "System time stepped backward: system time '{}', last known time '{}'",
+        sys_time,
+        latest_known_time,
+    ))]
+    SystemTimeSteppedBackward {
+        sys_time: DateTime<Utc>,
+        latest_known_time: DateTime<Utc>,
+    },
 
     /// A downloaded target's checksum does not match the checksum listed in the repository
     /// metadata.


### PR DESCRIPTION
Everytime when the system time is sampled, its checked against the last known system time. If the sampled system time is somehow earlier than the latest known time,  then the system time is irrational and an error is raised. The newly sampled system time is serialized and stored as `latest_known_time.json`.

*Issue #, if available:* Fixes #56 

*Description of changes:*
- Adds new error variant `SystemTimeSteppedBackward`
- Adds `datastore` as a field to the `Repository` struct to allow for checking expirations after the repository is loaded
- Modifies both the generic `check_expiration` and `Repository::check_expiration` to account for latest known time when checking for expirations.

*Testing:*
Tested by running `updog check-update`, verified that the latest known time is stored and updated with each check:
```
etung@u340e1ae367bc51:/var/lib/thar/updog$ cat latest_known_time.json 
"2019-07-31T22:54:49.263485014Z"
 .... Run updog again
etung@u340e1ae367bc51:/var/lib/thar/updog$ cat latest_known_time.json 
"2019-07-31T22:55:19.581607838Z"
```

Verified that updog throws error if system time steps back from last known system time when checking for expirations:
```
faketime '1 hour ago' ./updog check-update 
 ....
Metadata error: System time stepped backward: system time '2019-07-31 22:01:27.084650534 UTC', last known time '2019-07-31 22:55:19.581607838 UTC'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
