### PR TITLE
Sundog: Change arg 'verbosity' to 'verbose'

### DIFF
--- a/workspaces/api/sundog/src/main.rs
+++ b/workspaces/api/sundog/src/main.rs
@@ -312,7 +312,7 @@ fn parse_args(args: env::Args) -> Args {
 
     for arg in args.skip(1) {
         match arg.as_ref() {
-            "-v" | "--verbosity" => verbosity += 1,
+            "-v" | "--verbose" => verbosity += 1,
             _ => usage(),
         }
     }


### PR DESCRIPTION
Tom caught this last week when we reviewed Moondog; fixing it here as well.  thar-be-settings doesn't have this issue.

*Issue #, if available:* N/A

*Description of changes:*
* Change "verbosity" to "verbose"

*Testing done:*
* Unit tests all pass.
* Ran it manually with and without "verbose" arguments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
