### PR TITLE
rust: Skip check-rpaths

### DIFF
--- a/packages/rust/rust.spec
+++ b/packages/rust/rust.spec
@@ -3,6 +3,10 @@
 %global __strip /bin/true
 %global _build_id_links none
 
+# Skip check-rpaths since rust needs them to find its libs, and this package
+# doesn't end up on final systems.
+%global __arch_install_post /usr/lib/rpm/check-buildroot
+
 Name: %{_cross_os}rust
 Version: 1.36.0
 %global cargo_version 0.37.0


### PR DESCRIPTION
We currently use pre-compiled Rust binaries (the same ones distributed by rustup), which have rpaths. Since turning on the rpath checker in #92 this causes clean rebuilds of Thar to fail here.

The Rust binaries don't end up in the final image and we're not at a point where we want to build Rust from source, so disable the rpath checker in this single package.

A clean rebuild of Thar now succeeds and boots.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.