### PR TITLE
Install migrator and migration helpers

### DIFF
--- a/macros/cargo
+++ b/macros/cargo
@@ -46,9 +46,9 @@ do_cargo_build_registry $REGISTRY \
 
 %cargo_test CARGO_HOME="$PWD" %{__cargo} test %{__cargo_common_opts} --release --no-fail-fast %{?cargo_args}
 
-%cargo_install(p:) \
-CARGO_HOME="$PWD" %{__cargo} install %{__cargo_common_opts} --root %{buildroot}%{_cross_rootdir}%{_prefix} %{-p:--path %{-p*}}%{!-p:--path .} %{?cargo_args} \
-%{__rm} %{buildroot}%{_cross_rootdir}%{_prefix}/.crates.toml
+%cargo_install(p:d:) \
+CARGO_HOME="$PWD" %{__cargo} install %{__cargo_common_opts} %{-d:--root %{-d*}}%{!-d:--root %{buildroot}%{_cross_rootdir}%{_prefix}} %{-p:--path %{-p*}}%{!-p:--path .} %{?cargo_args} \
+%{__rm} %{-d:%{-d*}}%{!-d:%{buildroot}%{_cross_rootdir}%{_prefix}}/.crates.toml
 
 %__cargo_crate_source_url() https://crates.io/api/v1/crates/%1/%2/download#%3/%1-%2.crate
 %__cargo_crate_source_urls grep '^"checksum' | tr -d '"' | awk '{ print "Source" NR+9999 ": %%{__cargo_crate_source_url " $2 " " $3 " " $6 "}" } END { print "%%global __cargo_first_crate 10000\\n%%global __cargo_last_crate " NR+9999 }'

--- a/packages/api/migration-tmpfiles.conf
+++ b/packages/api/migration-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /var/lib/thar/datastore/migrations - - - -

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -41,6 +41,7 @@ Requires: %{_cross_os}pluto
 Requires: %{_cross_os}storewolf
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}thar-be-settings
+Requires: %{_cross_os}migration
 Requires: %{_cross_os}updog
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}amazon-ssm-agent


### PR DESCRIPTION
*Issue #, if available:*
#90 

*Description of changes:*
Install the migrator tool and individual migration helpers into the
image. This defines a 'migration' package that must be required-by the
release package, and extends the cargo_install macro to optionally
specify the root directory.
Migration versions are only specified in the install for-loop at the
moment, but otherwise are automatically handled by populating a
migration-binaries file to use with `%files -f`

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
