### PR TITLE
ssm: Use our own service file

### DIFF
--- a/packages/ssm/amazon-ssm-agent.service
+++ b/packages/ssm/amazon-ssm-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=amazon-ssm-agent
+After=network-online.target
+StartLimitBurst=10
+StartLimitIntervalSec=60
+
+[Service]
+Type=simple
+WorkingDirectory=/
+ExecStart=/usr/bin/amazon-ssm-agent
+KillMode=process
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/ssm/ssm.spec
+++ b/packages/ssm/ssm.spec
@@ -15,6 +15,7 @@ License: ASL 2.0
 URL: https://%{goimport}
 Source0: https://%{goimport}/archive/%{gover}/%{gorepo}-%{gover}.tar.gz
 Source1: ssm-tmpfiles.conf
+Source2: amazon-ssm-agent.service
 Patch1: 0001-Use-absolute-path-to-launch-shell.patch
 Patch2: 0002-shell-Allow-root-user.patch
 BuildRequires: gcc-%{_cross_target}
@@ -53,7 +54,7 @@ install -p -m 0755 seelog_unix.xml %{buildroot}%{_cross_factorydir}%{_cross_sysc
 install -p -m 0755 amazon-ssm-agent.json.template %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/amazon/ssm/amazon-ssm-agent.json
 
 mkdir -p %{buildroot}/%{_cross_unitdir}
-install -p -m 0755 packaging/linux/amazon-ssm-agent.service %{buildroot}/%{_cross_unitdir}
+install -p -m 0644 %{S:2} %{buildroot}%{_cross_unitdir}/amazon-ssm-agent.service
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/ssm.conf


### PR DESCRIPTION
*Issue #, if available:*
#110

*Description of changes:*
Specify our own service file instead of the SSM default.
Fixes #110

Basic test done by checking that service is running and the installed service file is the new version.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
