### PR TITLE
Use Unix-domain sockets for API clients

### DIFF
--- a/packages/api/api.spec
+++ b/packages/api/api.spec
@@ -31,6 +31,11 @@ Summary: Thar API server
 %description -n %{_cross_os}apiserver
 %{summary}.
 
+%package -n %{_cross_os}apiclient
+Summary: Thar API client
+%description -n %{_cross_os}apiclient
+%{summary}.
+
 %package -n %{_cross_os}moondog
 Summary: Thar userdata configuration system
 Requires: %{_cross_os}apiserver = %{version}-%{release}
@@ -85,6 +90,7 @@ install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE3}
 install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE4}
 
 %cargo_install -p apiserver
+%cargo_install -p apiclient
 %cargo_install -p moondog
 %cargo_install -p sundog
 %cargo_install -p pluto
@@ -112,6 +118,9 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 %files -n %{_cross_os}apiserver
 %{_cross_bindir}/apiserver
 %{systemd_systemdir}/apiserver.service
+
+%files -n %{_cross_os}apiclient
+%{_cross_bindir}/apiclient
 
 %files -n %{_cross_os}moondog
 %{_cross_bindir}/moondog

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -22,6 +22,7 @@ Source1002: fqdn.service
 Source1003: configured.target
 
 BuildArch: noarch
+Requires: %{_cross_os}apiclient
 Requires: %{_cross_os}apiserver
 Requires: %{_cross_os}bash
 Requires: %{_cross_os}ca-certificates

--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -236,6 +236,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "apiclient"
+version = "0.1.0"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyperlocal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "apiserver"
 version = "0.1.0"
 dependencies = [
@@ -775,6 +787,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +853,19 @@ dependencies = [
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1082,7 +1112,10 @@ dependencies = [
 name = "moondog"
 version = "0.1.0"
 dependencies = [
+ "apiclient 0.1.0",
+ "apiserver 0.1.0",
  "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1797,10 +1830,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "sundog"
 version = "0.1.0"
 dependencies = [
+ "apiclient 0.1.0",
  "apiserver 0.1.0",
  "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1866,14 +1900,15 @@ dependencies = [
 name = "thar-be-settings"
 version = "0.1.0"
 dependencies = [
+ "apiclient 0.1.0",
  "apiserver 0.1.0",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1915,14 +1950,19 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1961,6 +2001,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-fs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2434,11 +2484,13 @@ dependencies = [
 "checksum h2 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2b53def7bb0253af7718036fe9338c15defd209136819464384f3a553e07481b"
 "checksum handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df044dd42cdb7e32f28557b661406fc0f2494be75199779998810dbc35030e0d"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
+"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)" = "e2cd6adf83b3347d36e271f030621a8cf95fd1fd0760546b9fc5a24a0f1447c7"
+"checksum hyperlocal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d063d6d5658623c6ef16f452e11437c0e7e23a6d327470573fe78892dafbc4fb"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -2557,6 +2609,7 @@ dependencies = [
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "83ea44c6c0773cc034771693711c35c677b4b5a4b21b9e7071704c54de7d555e"
+"checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
 "checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"

--- a/workspaces/api/Cargo.toml
+++ b/workspaces/api/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "apiserver",
+    "apiclient",
     "moondog",
     "sundog",
     "pluto",

--- a/workspaces/api/apiclient/Cargo.toml
+++ b/workspaces/api/apiclient/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "apiclient"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+# TODO: move to futures 0.3 / stdlib futures when it's ready
+futures = "0.1"
+http = "0.1"
+hyper = "0.12"
+hyperlocal = "0.6"
+snafu = "0.4"
+tokio = "0.1"

--- a/workspaces/api/apiclient/src/lib.rs
+++ b/workspaces/api/apiclient/src/lib.rs
@@ -1,0 +1,108 @@
+//! The apiclient library provides simple, synchronous methods to query the API server over a
+//! Unix-domain socket.
+
+// Think "reqwest" but for Unix-domain sockets.  Would be nice to use the simpler reqwest instead
+// of hyper, but it lacks Unix-domain socket support:
+// https://github.com/seanmonstar/reqwest/issues/39
+
+use futures::Future;
+use hyper::rt::Stream;
+use hyper::{header, Body, Client, Request};
+use hyperlocal::{UnixConnector, Uri};
+use snafu::ResultExt;
+use std::path::Path;
+use tokio::runtime::Runtime;
+
+mod error {
+    use snafu::Snafu;
+    use std::io;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub enum Error {
+        #[snafu(display("Failed to initialize client: {}", source))]
+        ClientSetup { source: io::Error },
+
+        #[snafu(display("Failed to build request: {}", source))]
+        RequestSetup { source: http::Error },
+
+        #[snafu(display("Failed to send request: {}", source))]
+        RequestSend { source: hyper::Error },
+
+        #[snafu(display("Failed to read body of response: {}", source))]
+        ResponseBodyRead { source: hyper::Error },
+
+        #[snafu(display("Response was not UTF-8: {}", source))]
+        NonUtf8Response { source: std::str::Utf8Error },
+    }
+}
+pub use error::Error;
+pub type Result<T> = std::result::Result<T, error::Error>;
+
+/// Makes an HTTP request to a Unix-domain socket.
+///
+/// The socket is specified as a path, for example "/tmp/api.sock".
+/// The URI on that server is specified as a string, for example "/settings".
+/// The HTTP method is also specified as a string, for example "GET".
+///
+/// For read-only methods like GET, `data` should be None, otherwise you can use Some(string) to
+/// specify the body of the request.
+///
+/// If we were able to talk to the server, returns an Ok value with the status code of the response
+/// as an http::StatusCode, and the response body as a String.  (Binary responses are not supported
+/// and will return an error.)  You should check the status code if you want to consider 4xx/5xx
+/// responses as an error; `StatusCode` has various methods to help check.
+///
+/// If we failed to talk to the server, returns Err.
+pub fn raw_request<P, S1, S2>(
+    socket_path: P,
+    uri: S1,
+    method: S2,
+    data: Option<String>,
+) -> Result<(http::StatusCode, String)>
+where
+    P: AsRef<Path>,
+    S1: AsRef<str>,
+    S2: AsRef<str>,
+{
+    let request_data = if let Some(data) = data {
+        Body::from(data)
+    } else {
+        Body::empty()
+    };
+    let uri: hyper::Uri = Uri::new(socket_path, uri.as_ref()).into();
+
+    let mut runtime = Runtime::new().context(error::ClientSetup)?;
+
+    let client = Client::builder().build::<_, ::hyper::Body>(UnixConnector::new());
+
+    let request = Request::builder()
+        .method(method.as_ref())
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(request_data))
+        .context(error::RequestSetup)?;
+
+    // `block_on` is what waits on the asynchronous response future and returns a real response;
+    // it's the simplest way to switch to a synchronous mode.
+    //
+    // hyper's "into_parts" method splits the response into two parts: (1) the head, which we have
+    // immediately, and (2) the body, which may be streamed back in chunks.  Therefore, the second
+    // return value here is another future.
+    let (head, body_future) = runtime
+        .block_on(client.request(request).map(|res| res.into_parts()))
+        .context(error::RequestSend)?;
+
+    // Wait on the second future (the streaming body) and concatenate all the pieces together so we
+    // have a single response body.  We make sure each piece is a string, as we go; we assume that
+    // we're not handling binary data.
+    let body_stream = body_future
+        .concat2()
+        .map(|chunk| std::str::from_utf8(&chunk).map(|s| s.to_string()));
+    let body = runtime
+        .block_on(body_stream)
+        .context(error::ResponseBodyRead)?
+        .context(error::NonUtf8Response)?;
+
+    Ok((head.status, body))
+}

--- a/workspaces/api/apiclient/src/main.rs
+++ b/workspaces/api/apiclient/src/main.rs
@@ -1,0 +1,106 @@
+use std::env;
+use std::process;
+
+const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+
+/// Stores user-supplied arguments.
+struct Args {
+    verbosity: usize,
+    socket_path: String,
+    method: String,
+    uri: String,
+    data: Option<String>,
+}
+
+/// Informs the user about proper usage of the program and exits.
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            (-u | --uri) URI
+            [ (-X | -m | --method) METHOD ]
+            [ (-d | --data) DATA ]
+            [ (-s | --socket-path) PATH ]
+            [ -v | --verbose ... ]
+
+    Method defaults to GET
+    Socket path defaults to {}",
+        program_name, DEFAULT_API_SOCKET
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
+    eprintln!("{}\n", msg.as_ref());
+    usage();
+}
+
+/// Parses user arguments into an Args structure.
+fn parse_args(args: env::Args) -> Args {
+    let mut socket_path = None;
+    let mut verbosity = 3; // default to INFO
+    let mut method = None;
+    let mut uri = None;
+    let mut data = None;
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "-v" | "--verbose" => verbosity += 1,
+
+            "--socket-path" => {
+                socket_path = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to --socket-path")),
+                )
+            }
+
+            "-X" | "-m" | "--method" => {
+                method = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to -m | --method")),
+                )
+            }
+
+            "-u" | "--uri" => {
+                uri = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to -u | --uri")),
+                )
+            }
+
+            "-d" | "--data" => {
+                data = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to -d | --data")),
+                )
+            }
+
+            _ => usage(),
+        }
+    }
+
+    Args {
+        verbosity,
+        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        method: method.unwrap_or_else(|| "GET".to_string()),
+        uri: uri.unwrap_or_else(|| usage()),
+        data,
+    }
+}
+
+fn main() -> Result<(), Box<std::error::Error>> {
+    let args = parse_args(env::args());
+
+    let (status, body) =
+        apiclient::raw_request(args.socket_path, args.uri, args.method, args.data)?;
+
+    if args.verbosity > 3 {
+        eprintln!("{}", status);
+    }
+    if !body.is_empty() {
+        println!("{}", body);
+    }
+    Ok(())
+}

--- a/workspaces/api/moondog/Cargo.toml
+++ b/workspaces/api/moondog/Cargo.toml
@@ -7,13 +7,16 @@ publish = false
 build = "build.rs"
 
 [dependencies]
+apiclient = { path = "../apiclient" }
+apiserver = { path = "../apiserver" }
+http = "0.1"
+log = "0.4"
 reqwest = { version = "0.9", default-features = false, features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 snafu = "0.4"
-toml = "0.4"
-log = "0.4"
 stderrlog = "0.4"
+toml = "0.4"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/workspaces/api/sundog/Cargo.toml
+++ b/workspaces/api/sundog/Cargo.toml
@@ -7,12 +7,13 @@ publish = false
 build = "build.rs"
 
 [dependencies]
+apiclient = { path = "../apiclient" }
 apiserver = { path = "../apiserver" }
-reqwest = { version = "0.9", default-features = false, features = [] }
+http = "0.1"
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 snafu = "0.4"
-log = "0.4"
 stderrlog = "0.4"
 
 [build-dependencies]

--- a/workspaces/api/thar-be-settings/Cargo.toml
+++ b/workspaces/api/thar-be-settings/Cargo.toml
@@ -7,12 +7,13 @@ publish = false
 build = "build.rs"
 
 [dependencies]
+apiclient = { path = "../apiclient" }
 apiserver = { path = "../apiserver" }
 base64 = "0.10"
 handlebars = "2.0"
+http = "0.1"
 itertools = "0.8"
 log = "0.4"
-reqwest = { version = "0.9", default-features = false, features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 snafu = "0.4"

--- a/workspaces/api/thar-be-settings/src/client.rs
+++ b/workspaces/api/thar-be-settings/src/client.rs
@@ -1,41 +1,44 @@
 use serde::de::DeserializeOwned;
 use snafu::ResultExt;
+use std::path::Path;
 
 use crate::{error, Result};
 
-/// This trait extends the client from reqwest, abstracting the repeated
-/// request logic and returning JSON or an error if there was one.
-pub(crate) trait ReqwestClientExt {
-    fn get_json<T: DeserializeOwned>(
-        &self,
-        uri: String,
-        query_param: String,
-        query: String,
-    ) -> Result<T>;
-}
-
-impl ReqwestClientExt for reqwest::Client {
-    fn get_json<T: DeserializeOwned>(
-        &self,
-        uri: String,
-        query_param: String,
-        query: String,
-    ) -> Result<T> {
-        self.get(&uri)
-            .query(&[(query_param, query)])
-            .send().context(error::APIRequest {
-                method: "GET",
-                uri: uri.as_str(),
-            })?
-            .error_for_status()
-            .context(error::APIResponse {
-                method: "GET",
-                uri: uri.as_str(),
-            })?
-            .json()
-            .context(error::ResponseJson {
-                method: "GET",
-                uri: uri.as_str(),
-            })
+/// Simple helper that extends the API client, abstracting the repeated request logic and
+/// deserialization from JSON.
+pub(crate) fn get_json<T, P, S1, S2, S3>(
+    socket_path: P,
+    uri: S1,
+    // Query parameter name, query parameter value
+    query: Option<(S2, S3)>,
+) -> Result<T>
+where
+    T: DeserializeOwned,
+    P: AsRef<Path>,
+    S1: AsRef<str>,
+    S2: AsRef<str>,
+    S3: AsRef<str>,
+{
+    let mut uri = uri.as_ref().to_string();
+    // Simplest query string handling; parameters come from API responses so we trust them enough
+    // to send back
+    if let Some((query_param, query_arg)) = query {
+        uri = format!("{}?{}={}", uri, query_param.as_ref(), query_arg.as_ref());
     }
+
+    let method = "GET";
+    let (code, response_body) = apiclient::raw_request(socket_path, &uri, method, None)
+        .context(error::APIRequest { method, uri: &uri })?;
+
+    if !code.is_success() {
+        return error::APIResponse {
+            method,
+            uri,
+            code,
+            response_body,
+        }
+        .fail();
+    }
+
+    serde_json::from_str(&response_body).context(error::ResponseJson { method, uri })
 }

--- a/workspaces/api/thar-be-settings/src/error.rs
+++ b/workspaces/api/thar-be-settings/src/error.rs
@@ -1,3 +1,4 @@
+use http::StatusCode;
 use snafu::Snafu;
 use std::io;
 use std::path::PathBuf;
@@ -48,18 +49,19 @@ pub enum TBSError {
         source: handlebars::TemplateFileError,
     },
 
-    #[snafu(display("Error sending {} to '{}': {}", method, uri, source))]
+    #[snafu(display("Error sending {} to {}: {}", method, uri, source))]
     APIRequest {
-        method: &'static str,
+        method: String,
         uri: String,
-        source: reqwest::Error,
+        source: apiclient::Error,
     },
 
-    #[snafu(display("Error response from {} to '{}': {}", method, uri, source))]
+    #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]
     APIResponse {
-        method: &'static str,
+        method: String,
         uri: String,
-        source: reqwest::Error,
+        code: StatusCode,
+        response_body: String,
     },
 
     #[snafu(display(
@@ -71,6 +73,6 @@ pub enum TBSError {
     ResponseJson {
         method: &'static str,
         uri: String,
-        source: reqwest::Error,
+        source: serde_json::Error,
     },
 }

--- a/workspaces/api/thar-be-settings/src/lib.rs
+++ b/workspaces/api/thar-be-settings/src/lib.rs
@@ -26,12 +26,6 @@ pub mod template;
 pub use error::TBSError;
 type Result<T> = std::result::Result<T, TBSError>;
 
-// FIXME Get these from configuration in the future
-const API_CONFIGURATION_URI: &str = "http://localhost:4242/configuration-files";
-const API_METADATA_URI: &str = "http://localhost:4242/metadata";
-const API_SETTINGS_URI: &str = "http://localhost:4242/settings";
-const API_SERVICES_URI: &str = "http://localhost:4242/services";
-
 /// Read stdin and parse into JSON
 pub fn get_changed_settings() -> Result<HashSet<String>> {
     let mut input = String::new();
@@ -45,7 +39,7 @@ pub fn get_changed_settings() -> Result<HashSet<String>> {
     let changed_settings: HashSet<String> =
         serde_json::from_str(&input).context(error::InvalidInput {
             reason: "Input must be a JSON array of strings",
-            input: input,
+            input,
         })?;
     trace!("Parsed input: {:?}", &changed_settings);
 

--- a/workspaces/api/thar-be-settings/src/settings.rs
+++ b/workspaces/api/thar-be-settings/src/settings.rs
@@ -1,17 +1,21 @@
 use itertools::join;
+use std::path::Path;
 
-use crate::client::ReqwestClientExt;
+use crate::client;
 use crate::template::TemplateKeys;
-use crate::{Result, API_SETTINGS_URI};
+use crate::Result;
 
 use apiserver::model;
 
 /// Using the template registry, gather all keys and request
 /// their values from the API
-pub fn get_settings_from_template(
-    client: &reqwest::Client,
+pub fn get_settings_from_template<P>(
+    socket_path: P,
     registry: &handlebars::Handlebars,
-) -> Result<model::Settings> {
+) -> Result<model::Settings>
+where
+    P: AsRef<Path>,
+{
     // Using the template registry, pull the keys out of the templates
     // and query the API to get a structure of Settings which we can
     // use to render the templates
@@ -24,7 +28,7 @@ pub fn get_settings_from_template(
     // Query the settings
     debug!("Querying API for settings data");
     let settings: model::Settings =
-        client.get_json(API_SETTINGS_URI.to_string(), "keys".to_string(), query)?;
+        client::get_json(socket_path, "/settings", Some(("keys", query)))?;
 
     trace!("Settings values: {:?}", settings);
     Ok(settings)


### PR DESCRIPTION
Fixes the second half of #121  (first half is server in #138)

This adds an apiclient library, which allows the dogs to talk to the server over a Unix-domain socket, and a client binary that we can use from Thar.

The client uses hyperlocal, which adapts hyper for Unix-domain sockets.  hyper is async, based on tokio, but we don't want that complication in our clients, so it's made synchronous with `block_on` calls.

moondog, sundog, and thar-be-settings were updated to use apiclient instead of reqwest for talking to the API.  moondog is mostly about that communication, so it changed the most.  They all needed arg parsing for `--socket-path`.

---

**Testing done:**

See #138 for the full API surface.

client works OK:
```
$ cargo run -- --socket-path /tmp/thar/api.sock -u /settings -v
200 OK
{"timezone":"NewLosAngeles","hostname":"localhost"}

$ cargo run -- --socket-path /tmp/thar/api.sock -u /settings -X PATCH -d '{"timezone": "OldLosAngeles"}' -v
204 No Content
 
$ cargo run -- --socket-path /tmp/thar/api.sock -m GET -u /settings/pending -v
200 OK
{"timezone":"OldLosAngeles"}
 
$ cargo run -- --socket-path /tmp/thar/api.sock -m POST -u /settings/commit -v
204 No Content
```

moondog running OK:
```
sh-5.0# systemctl status moondog
● moondog.service - Thar userdata configuration system
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/moondog.service; enabled; vendor preset: enabled)
   Active: active (exited) since Fri 2019-08-09 20:33:14 UTC; 3min 17s ago
  Process: 2708 ExecStart=/usr/bin/moondog (code=exited, status=0/SUCCESS)
 Main PID: 2708 (code=exited, status=0/SUCCESS)

Aug 09 20:33:14 ip-192-168-111-202 systemd[1]: Starting Thar userdata configuration system...
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.593+00:00 - INFO - Moondog started
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.593+00:00 - INFO - Detecting user data provider
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.593+00:00 - INFO - Running on AWS: Using IMDS for user data
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.593+00:00 - INFO - Retrieving user data
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.627+00:00 - INFO - User data found
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.629+00:00 - INFO - Parsing TOML user data
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.629+00:00 - INFO - Serializing settings to JSON for API request
Aug 09 20:33:14 ip-192-168-111-202 moondog[2708]: 2019-08-09T20:33:14.630+00:00 - INFO - Sending user data to the API
Aug 09 20:33:14 ip-192-168-111-202 systemd[1]: Started Thar userdata configuration system.
```

sundog running OK:
```
sh-5.0# systemctl status sundog
● sundog.service - User-specified setting generators
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/sundog.service; enabled; vendor preset: enabled)
   Active: active (exited) since Fri 2019-08-09 20:33:14 UTC; 3min 20s ago
  Process: 2841 ExecStart=/usr/bin/sundog (code=exited, status=0/SUCCESS)
 Main PID: 2841 (code=exited, status=0/SUCCESS)

Aug 09 20:33:14 ip-192-168-111-202 systemd[1]: Starting User-specified setting generators...
Aug 09 20:33:14 ip-192-168-111-202 sundog[2841]: 2019-08-09T20:33:14.672+00:00 - INFO - Sundog started
Aug 09 20:33:14 ip-192-168-111-202 sundog[2841]: 2019-08-09T20:33:14.672+00:00 - INFO - Retrieving setting generators
Aug 09 20:33:14 ip-192-168-111-202 sundog[2841]: 2019-08-09T20:33:14.688+00:00 - INFO - Retrieving settings values
Aug 09 20:33:14 ip-192-168-111-202 sundog[2841]: 2019-08-09T20:33:14.739+00:00 - INFO - Sending settings values to the API
Aug 09 20:33:14 ip-192-168-111-202 systemd[1]: Started User-specified setting generators.
```