### PR TITLE
migrator: Add --migrate-to-version-from-file option

### DIFF
--- a/workspaces/api/migration/migrator/src/args.rs
+++ b/workspaces/api/migration/migrator/src/args.rs
@@ -13,7 +13,7 @@ fn usage() -> ! {
     eprintln!(
         r"Usage: {}
             --datastore-path PATH
-            --migrate-to-version x.y
+            (--migrate-to-version x.y | --migrate-to-version-from-file PATH)
             [ --no-color ]
             [ --verbose --verbose ... ]",
         program_name
@@ -70,6 +70,23 @@ impl Args {
                     trace!("Given --migrate-to-version: {}", version_str);
                     let version = Version::from_str(&version_str).unwrap_or_else(|e| {
                         usage_msg(format!("Invalid argument to --migrate-to-version: {}", e))
+                    });
+                    migrate_to_version = Some(version)
+                }
+
+                "--migrate-to-version-from-file" => {
+                    let path_str = iter.next().unwrap_or_else(|| {
+                        usage_msg("Did not give argument to --migrate-to-version-from-file")
+                    });
+                    trace!("Given --migrate-to-version-from-file: {}", path_str);
+
+                    let version_str = fs::read_to_string(&path_str).unwrap_or_else(|e| {
+                        usage_msg(format!("Could not read version from {}: {}", path_str, e))
+                    });
+                    trace!("Read version string from file: {}", version_str);
+
+                    let version = Version::from_str(&version_str).unwrap_or_else(|e| {
+                        usage_msg(format!("Invalid version in {}: {}", path_str, e))
                     });
                     migrate_to_version = Some(version)
                 }


### PR DESCRIPTION
Part of #64, migration OS integration.

We plan to mark the data store version that an incoming image expects using a
file on the filesystem.  Rather than needing to read that file elsewhere and
pass it to the migrator, we can add an option to read the version to which
we're migrating from a file.

This will make a systemd migrator service easier, because we can specify the version file path in the service, rather than needing another binary to tell the migrator the version.

---

**Testing done:**

I ran the same test as in #62, but with the new option, and migration worked:

```
$ cat migrate-to-this
0.1

$ cargo run -- -v -v -v -v --datastore-path datastore-sample/v0 --migrate-to-version-from-file ./migrate-to-this
   Compiling migrator v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator)
    Finished dev [unoptimized + debuginfo] target(s) in 1.45s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/target/debug/migrator -v -v -v -v --datastore-path datastore-sample/v0 --migrate-to-version-from-file ./migrate-to-this`
2019-08-09T15:19:31.709-07:00 - TRACE - Getting version from datastore path: /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.0_aBIUdlQUclSbnHEv
2019-08-09T15:19:31.710-07:00 - TRACE - Parsing version from string: v0.0_aBIUdlQUclSbnHEv
2019-08-09T15:19:31.710-07:00 - TRACE - Parsed major '0' and minor '0'
2019-08-09T15:19:31.710-07:00 - TRACE - Looking for potential migrations in ./migration-binaries
2019-08-09T15:19:31.711-07:00 - TRACE - Found potential migration: ./migration-binaries/migrate_v0.1_test
2019-08-09T15:19:31.713-07:00 - TRACE - Parsing version from string: v0.1
2019-08-09T15:19:31.714-07:00 - TRACE - Parsed major '0' and minor '1'
2019-08-09T15:19:31.714-07:00 - INFO - Found applicable forward migration 'migrate_v0.1_test': v0.0 < (v0.1) <= v0.1
2019-08-09T15:19:31.714-07:00 - DEBUG - Sorted migrations: ["migrate_v0.1_test"]
2019-08-09T15:19:31.714-07:00 - INFO - Copying datastore from /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.0_aBIUdlQUclSbnHEv to work location /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_OA6XnGjErRBDcW5N
2019-08-09T15:19:31.715-07:00 - INFO - Running migration command: "./migration-binaries/migrate_v0.1_test" "--forward" "--datastore-path" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_OA6XnGjErRBDcW5N"
2019-08-09T15:19:31.740-07:00 - DEBUG - Migration stdout: 
2019-08-09T15:19:31.740-07:00 - DEBUG - Migration stderr: 
2019-08-09T15:19:31.740-07:00 - INFO - Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1 to point to v0.1_OA6XnGjErRBDcW5N
2019-08-09T15:19:31.740-07:00 - INFO - Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0 to point to v0.1
```

Invalid version errors as expected:
```
$ echo -n nope > migrate-to-this
$ cargo run -- -v -v -v -v --datastore-path datastore-sample/v0 --migrate-to-version-from-file ./migrate-to-this
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/target/debug/migrator -v -v -v -v --datastore-path datastore-sample/v0 --migrate-to-version-from-file ./migrate-to-this`
Invalid version in ./migrate-to-this: Given string 'nope' not a version, must match re: (?P<version>v?(?P<major>[0-9]+)\.(?P<minor>[0-9]+))

Usage: ...
```