### PR TITLE
Return error 422 if trying to commit with no pending changes

### DIFF
--- a/workspaces/api/apiserver/src/datastore/filesystem.rs
+++ b/workspaces/api/apiserver/src/datastore/filesystem.rs
@@ -353,6 +353,11 @@ impl DataStore for FilesystemDataStore {
         // Get data for changed keys
         let pending_data = self.get_prefix("settings.", Committed::Pending)?;
 
+        // Nothing to do if no keys are present in pending
+        if pending_data.is_empty() {
+            return Ok(Default::default())
+        }
+
         // Turn String keys of pending data into Key keys, for return
         let try_pending_keys: Result<HashSet<Key>> = pending_data
             .keys()

--- a/workspaces/api/apiserver/src/server/error.rs
+++ b/workspaces/api/apiserver/src/server/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     #[snafu(display("Unable to start server: {}", source))]
     ServerStart { source: io::Error },
 
+    #[snafu(display("Tried to commit with no pending changes"))]
+    CommitWithNoPending,
+
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
     // Controller errors


### PR DESCRIPTION
This returns an HTTP 422 error if the user asked to commit settings when there was nothing pending.  (Currently, it returns a 500 error because it's trying to do filesystem errors on a "/pending" path that doesn't exist.)

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422

I think a 422 is cleaner than a 2xx because it indicates that the user was requesting something that they probably didn't intend or understand.  There's not really a 2xx that fits.  https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#Successful_responses

---

**Testing done:**

Commit still works if pending data:

```
$ curl --unix-socket /tmp/thar/api.sock 'localhost/settings/pending'; echo
{"timezone":"OldLosAngeles"}
 
$ curl -v --unix-socket /tmp/thar/api.sock 'localhost/settings/commit' -X POST; echo
...
< HTTP/1.1 204 No Content
...
```

New error if no pending data:

```
$ curl -v --unix-socket /tmp/thar/api.sock 'localhost/settings/commit' -X POST; echo
...
< HTTP/1.1 422 Unprocessable Entity
...
Tried to commit with no pending changes
```