### PR TITLE
Only run moondog once, at first boot

### DIFF
--- a/packages/api/moondog.service
+++ b/packages/api/moondog.service
@@ -4,6 +4,9 @@ After=network-online.target
 After=apiserver.service
 Requires=network-online.target
 Requires=apiserver.service
+# We only want to run once, at first boot.  This file is created by moondog
+# after a successful run.
+ConditionPathExists=!/var/lib/thar/moondog.ran
 
 [Service]
 Type=oneshot

--- a/workspaces/api/moondog/src/main.rs
+++ b/workspaces/api/moondog/src/main.rs
@@ -27,6 +27,11 @@ const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
 const API_SETTINGS_URI: &str = "/settings";
 const API_COMMIT_URI: &str = "/settings/commit";
 
+// We only want to run moondog once, at first boot.  Our systemd unit file has a
+// ConditionPathExists that will prevent it from running again if this file exists.
+// We create it after running successfully.
+const MARKER_FILE: &str = "/var/lib/thar/moondog.ran";
+
 type Result<T> = std::result::Result<T, MoondogError>;
 
 mod error {
@@ -348,6 +353,13 @@ fn main() -> Result<()> {
             response_body,
         }
     );
+
+    fs::write(MARKER_FILE, "").unwrap_or_else(|e| {
+        warn!(
+            "Failed to create marker file {}, may unexpectedly run again: {}",
+            MARKER_FILE, e
+        )
+    });
 
     Ok(())
 }


### PR DESCRIPTION
```
    Moondog writes settings from user data to the API server.  If the user changes
    these settings after boot, and then they reboot, they wouldn't expect them to
    be overwritten by their original user data settings.
    
    This changes moondog to write to a marker file after successfully running, and
    adds a check to its unit file that prevents it from running again if the marker
    exists.  The user can override this by removing the file.
    
    Eventually we will probably want user data that applies at different times,
    with some of the flexibility of cloud-init, but this is a simple solution for
    now that can be easily changed.
    
    When we do need more flexibility, we'll likely want to store the relevant
    moondog state in the data store through the API, but we don't yet have
    application-level storage or APIs.
```

---

Fixes #71

We've talked about using the API and application storage for storing this state, but application storage may be a big design and won't be ready for a while, and I wanted something simple to meet our needs now.

Note: if we wanted to change the path to the marker file after launch, we could use multiple `ConditionPathExists` to check for the old and the new, or move more logic to moondog; we do have some flexibility.

---

**Testing done:**

I confirmed that the file isn't created when moondog fails, for example when running in qemu without IMDS.

When running in EC2, it runs successfully and creates the file:
```
sh-5.0# ls -l /var/lib/thar
total 20
drwxr-xr-x 4 root root  4096 Aug 12 20:41 datastore
drwx------ 2 root root 16384 Aug 12 20:40 lost+found
-rw-r--r-- 1 root root     0 Aug 12 20:49 moondog.ran
sh-5.0# systemctl status moondog
● moondog.service - Thar userdata configuration system
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/moondog.service; enabled; vendor preset: enabled)
   Active: active (exited) since Mon 2019-08-12 20:49:48 UTC; 2min 4s ago
  Process: 2700 ExecStart=/usr/bin/moondog (code=exited, status=0/SUCCESS)
 Main PID: 2700 (code=exited, status=0/SUCCESS)

Aug 12 20:49:48 ip-192-168-122-19 moondog[2700]: 2019-08-12T20:49:48.754+00:00 - INFO - Moondog started
...snip...
2019-08-12T20:49:48.784+00:00 - INFO - POST-ing to /commit to finalize the changes
Aug 12 20:49:48 ip-192-168-122-19 systemd[1]: Started Thar userdata configuration system.
```

Restarting moondog without removing the file will mark it as "start condition failed":
```
sh-5.0# systemctl restart moondog
sh-5.0# systemctl status moondog
● moondog.service - Thar userdata configuration system
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/moondog.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since Mon 2019-08-12 20:52:07 UTC; 2s ago
Condition: start condition failed at Mon 2019-08-12 20:52:07 UTC; 2s ago
           └─ ConditionPathExists=!/var/lib/thar/moondog.ran was not met
  Process: 2700 ExecStart=/usr/bin/moondog (code=exited, status=0/SUCCESS)
 Main PID: 2700 (code=exited, status=0/SUCCESS)

...snip...
Aug 12 20:52:07 ip-192-168-122-19 systemd[1]: Stopping Thar userdata configuration system...
Aug 12 20:52:07 ip-192-168-122-19 systemd[1]: Condition check resulted in Thar userdata configuration system being skipped.
```

Things depending on moondog (currently just configured.target) can still start; systemd doesn't consider condition failure a hard failure:
```
sh-5.0# systemctl restart configured.target
sh-5.0# systemctl status configured.target
● configured.target - Thar be configuration - user and dynamic configuration complete
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/configured.target; static; vendor preset: enabled)
   Active: active since Mon 2019-08-12 20:52:51 UTC; 4s ago

Aug 12 20:52:51 ip-192-168-122-19 systemd[1]: Stopped target Thar be configuration - user and dynamic configuration complete.
Aug 12 20:52:51 ip-192-168-122-19 systemd[1]: Stopping Thar be configuration - user and dynamic configuration complete.
Aug 12 20:52:51 ip-192-168-122-19 systemd[1]: Reached target Thar be configuration - user and dynamic configuration complete.
```

A reboot is OK, moondog shows the same condition failure, and configured.target still started OK:
```
sh-5.0# systemctl status moondog
● moondog.service - Thar userdata configuration system
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/moondog.service; enabled; vendor preset: enabled)
   Active: inactive (dead)
Condition: start condition failed at Mon 2019-08-12 20:53:58 UTC; 31s ago
           └─ ConditionPathExists=!/var/lib/thar/moondog.ran was not met

Aug 12 20:53:58 ip-192-168-122-19 systemd[1]: Condition check resulted in Thar userdata configuration system being skipped.
sh-5.0# systemctl status configured.target
● configured.target - Thar be configuration - user and dynamic configuration complete
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/configured.target; static; vendor preset: enabled)
   Active: active since Mon 2019-08-12 20:53:58 UTC; 36s ago

Aug 12 20:53:58 ip-192-168-122-19 systemd[1]: Reached target Thar be configuration - user and dynamic configuration complete.
```

Removing the file allows moondog to be rerun:
```
sh-5.0# rm /var/lib/thar/moondog.ran
sh-5.0# systemctl restart moondog
sh-5.0# systemctl status moondog
● moondog.service - Thar userdata configuration system
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/moondog.service; enabled; vendor preset: enabled)
   Active: active (exited) since Mon 2019-08-12 21:05:34 UTC; 2s ago
  Process: 14959 ExecStart=/usr/bin/moondog (code=exited, status=0/SUCCESS)
 Main PID: 14959 (code=exited, status=0/SUCCESS)

...snip...
Aug 12 21:05:34 ip-192-168-122-19 systemd[1]: Started Thar userdata configuration system.
```