### PR TITLE
add settings-committer.

### DIFF
--- a/packages/api/api.spec
+++ b/packages/api/api.spec
@@ -16,7 +16,8 @@ Source1: apiserver.service
 Source2: moondog.service
 Source3: sundog.service
 Source4: storewolf.service
-Source5: migration-tmpfiles.conf
+Source5: settings-committer.service
+Source6: migration-tmpfiles.conf
 %cargo_bundle_crates -n %{workspace_name} -t 0
 BuildRequires: gcc-%{_cross_target}
 BuildRequires: %{_cross_os}glibc-devel
@@ -70,6 +71,10 @@ Requires: %{_cross_os}apiserver = %{version}-%{release}
 Summary: Tools to migrate version formats
 Requires: %{_cross_os}apiserver = %{version}-%{release}
 %description -n %{_cross_os}migration
+
+%package -n %{_cross_os}settings-committer
+Summary: Commits settings from user data, defaults, and generators at boot
+%description -n %{_cross_os}settings-committer
 %{summary}.
 
 %prep
@@ -88,6 +93,7 @@ install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE1}
 install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE2}
 install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE3}
 install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE4}
+install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE5}
 
 %cargo_install -p apiserver
 %cargo_install -p apiclient
@@ -96,6 +102,7 @@ install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE4}
 %cargo_install -p pluto
 %cargo_install -p thar-be-settings
 %cargo_install -p storewolf
+%cargo_install -p settings-committer
 %cargo_install -p migration/migrator
 
 install -d %{buildroot}%{migrationdir}
@@ -143,5 +150,9 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 %files -n %{_cross_os}migration -f migration-binaries
 %dir %{migrationdir}
 %{_cross_tmpfilesdir}/migration.conf
+
+%files -n %{_cross_os}settings-committer
+%{_cross_bindir}/settings-committer
+%{systemd_systemdir}/settings-committer.service
 
 %changelog

--- a/packages/api/settings-committer.service
+++ b/packages/api/settings-committer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Commit pending settings
+After=storewolf.service apiserver.service sundog.service moondog.service
+Requires=apiserver.service
+Wants=storewolf.service sundog.service moondog.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/settings-committer
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -40,6 +40,7 @@ Requires: %{_cross_os}signpost
 Requires: %{_cross_os}sundog
 Requires: %{_cross_os}pluto
 Requires: %{_cross_os}storewolf
+Requires: %{_cross_os}settings-committer
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}thar-be-settings
 Requires: %{_cross_os}migration

--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -1252,55 +1252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1694,20 @@ dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "settings-committer"
+version = "0.1.0"
+dependencies = [
+ "apiclient 0.1.0",
+ "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/workspaces/api/Cargo.toml
+++ b/workspaces/api/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "pluto",
     "storewolf",
     "thar-be-settings",
+    "settings-committer",
 
     "migration/migrator",
     "migration/migration-helpers",

--- a/workspaces/api/moondog/README.md
+++ b/workspaces/api/moondog/README.md
@@ -7,7 +7,7 @@ Current version: 0.1.0
 moondog is a minimal user data agent.
 
 It accepts TOML-formatted settings from a user data provider such as an instance metadata service.
-These are sent to a known Thar API server endpoint, then committed.
+These are sent to a known Thar API server endpoint.
 
 Currently, Amazon EC2 user data support is implemented.
 User data can also be retrieved from a file for testing.

--- a/workspaces/api/moondog/src/main.rs
+++ b/workspaces/api/moondog/src/main.rs
@@ -4,7 +4,7 @@
 moondog is a minimal user data agent.
 
 It accepts TOML-formatted settings from a user data provider such as an instance metadata service.
-These are sent to a known Thar API server endpoint, then committed.
+These are sent to a known Thar API server endpoint.
 
 Currently, Amazon EC2 user data support is implemented.
 User data can also be retrieved from a file for testing.
@@ -25,7 +25,6 @@ use std::{env, fs, process};
 // FIXME Get these from configuration in the future
 const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
 const API_SETTINGS_URI: &str = "/settings";
-const API_COMMIT_URI: &str = "/settings/commit";
 
 // We only want to run moondog once, at first boot.  Our systemd unit file has a
 // ConditionPathExists that will prevent it from running again if this file exists.
@@ -331,24 +330,6 @@ fn main() -> Result<()> {
         error::APIResponse {
             method: "PATCH",
             uri: API_SETTINGS_URI,
-            code,
-            response_body,
-        }
-    );
-
-    // POST to /commit to actually make the changes
-    let (code, response_body) =
-        apiclient::raw_request(&args.socket_path, API_COMMIT_URI, "POST", None).context(
-            error::APIRequest {
-                method: "POST",
-                uri: API_COMMIT_URI,
-            },
-        )?;
-    ensure!(
-        code.is_success(),
-        error::APIResponse {
-            method: "POST",
-            uri: API_COMMIT_URI,
             code,
             response_body,
         }

--- a/workspaces/api/settings-committer/Cargo.toml
+++ b/workspaces/api/settings-committer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-committer"
+version = "0.1.0"
+authors = ["Michael Patraw <patraw@amazon.com>"]
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[dependencies]
+apiclient = { path = "../apiclient" }
+snafu = "0.4"
+http = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+log = "0.4"
+stderrlog = "0.4"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/workspaces/api/settings-committer/README.md
+++ b/workspaces/api/settings-committer/README.md
@@ -1,0 +1,13 @@
+# settings-committer
+
+Current version: 0.1.0
+
+## Introduction
+
+settings-committer runs on boot after any services that can update
+settings. It logs any pending settings, then commits them to live.
+
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/workspaces/api/settings-committer/README.tpl
+++ b/workspaces/api/settings-committer/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/workspaces/api/settings-committer/build.rs
+++ b/workspaces/api/settings-committer/build.rs
@@ -1,0 +1,25 @@
+// Automatically generate README.md from rustdoc.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/workspaces/api/settings-committer/src/main.rs
+++ b/workspaces/api/settings-committer/src/main.rs
@@ -1,0 +1,182 @@
+/*!
+# Introduction
+
+settings-committer runs on boot after any services that can update
+settings. It logs any pending settings, then commits them to live.
+
+*/
+
+#[macro_use]
+extern crate log;
+
+use std::{collections::HashMap, env, process};
+
+use snafu::{ensure, ResultExt};
+
+const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const API_PENDING_URI: &str = "/settings/pending";
+const API_COMMIT_URI: &str = "/settings/commit";
+
+type Result<T> = std::result::Result<T, error::SettingsCommitterError>;
+
+mod error {
+    use http::StatusCode;
+    use snafu::Snafu;
+
+    /// Potential errors during user data management.
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum SettingsCommitterError {
+        #[snafu(display("Error sending {} to {}: {}", method, uri, source))]
+        APIRequest {
+            method: String,
+            uri: String,
+            source: apiclient::Error,
+        },
+
+        #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]
+        APIResponse {
+            method: String,
+            uri: String,
+            code: StatusCode,
+            response_body: String,
+        },
+
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger { source: log::SetLoggerError },
+    }
+}
+
+/// Checks pending settings and logs them. We don't want to prevent a
+/// commit if there's a blip in retrieval or parsing of the pending
+/// settings.  We know the system won't be functional without a commit,
+/// but we can live without logging what was committed.
+fn check_pending_settings<S: AsRef<str>>(socket_path: S) {
+    let uri = API_PENDING_URI;
+
+    debug!("GET-ing {} to determine if there are pending settings", uri);
+    let get_result = apiclient::raw_request(socket_path.as_ref(), uri, "GET", None);
+    let response_body = match get_result {
+        Ok((code, response_body)) => {
+            if !code.is_success() {
+                warn!(
+                    "Got {} when sending GET to {}: {}",
+                    code, uri, response_body
+                );
+                return;
+            }
+            response_body
+        }
+        Err(err) => {
+            warn!("Failed to GET pending settings from {}: {}", uri, err);
+            return;
+        }
+    };
+
+    let pending_result: serde_json::Result<HashMap<String, serde_json::Value>> =
+        serde_json::from_str(&response_body);
+    match pending_result {
+        Ok(pending) => {
+            debug!("Pending settings: {:?}", &pending);
+        }
+        Err(err) => {
+            warn!("Failed to parse response from {}: {}", uri, err);
+        }
+    }
+}
+
+/// Commits pending settings to live.
+fn commit_pending_settings<S: AsRef<str>>(socket_path: S) -> Result<()> {
+    let uri = API_COMMIT_URI;
+
+    debug!("POST-ing to {} to move pending settings to live", uri);
+    let (code, response_body) = apiclient::raw_request(socket_path.as_ref(), uri, "POST", None)
+        .context(error::APIRequest {
+            method: "POST",
+            uri,
+        })?;
+    ensure!(
+        // 422 is returned when there are no pending settings.
+        code.is_success() || code == 422,
+        error::APIResponse {
+            method: "POST",
+            uri,
+            code,
+            response_body,
+        }
+    );
+    Ok(())
+}
+
+/// Store the args we receive on the command line
+struct Args {
+    socket_path: String,
+    verbosity: usize,
+}
+
+/// Print a usage message in the event a bad arg is passed
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            [ --socket-path PATH ]
+            [ --verbose --verbose ... ]
+    Socket path defaults to {}",
+        program_name, DEFAULT_API_SOCKET
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
+    eprintln!("{}\n", msg.as_ref());
+    usage();
+}
+
+/// Parse the args to the program and return an Args struct
+fn parse_args(args: env::Args) -> Args {
+    let mut socket_path = None;
+    let mut verbosity = 2;
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "-v" | "--verbose" => verbosity += 1,
+            "--socket-path" => {
+                socket_path = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to --socket-path")),
+                )
+            }
+            _ => usage(),
+        }
+    }
+
+    Args {
+        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        verbosity,
+    }
+}
+
+fn main() -> Result<()> {
+    // Parse and store the args passed to the program
+    let args = parse_args(env::args());
+
+    // TODO Fix this later when we decide our logging story
+    // Start the logger
+    stderrlog::new()
+        .module(module_path!())
+        .timestamp(stderrlog::Timestamp::Millisecond)
+        .verbosity(args.verbosity)
+        .color(stderrlog::ColorChoice::Never)
+        .init()
+        .context(error::Logger)?;
+
+    info!("Checking pending settings.");
+    check_pending_settings(&args.socket_path);
+
+    info!("Committing settings.");
+    commit_pending_settings(&args.socket_path)?;
+
+    Ok(())
+}

--- a/workspaces/api/sundog/README.md
+++ b/workspaces/api/sundog/README.md
@@ -7,7 +7,7 @@ Current version: 0.1.0
 sundog is a small program to handle settings that must be generated at OS runtime.
 
 It requests settings generators from the API and runs them.
-The output is collected and sent to a known Thar API server endpoint and committed.
+The output is collected and sent to a known Thar API server endpoint.
 
 ## Colophon
 


### PR DESCRIPTION
*Description of changes:*

Add settings-committer service, and remove commit calls from sundog and moondog.

settings-committer commits any pending default settings and pending generated settings. It runs after storewolf, sundog, and moondog.

*Testing:*

Removed commit calls from sundog and moondog, pending existed on boot.
Added settings committer, pending settings were pushed to live.

Note: tested on an ec2 instance with an AMI. Running in qemu runs into #163 
