### PR TITLE
thar-be-settings: add "all" mode

### DIFF
--- a/workspaces/api/thar-be-settings/README.md
+++ b/workspaces/api/thar-be-settings/README.md
@@ -6,9 +6,13 @@ Current version: 0.1.0
 
 thar-be-settings is a simple configuration applier.
 
-It is intended to be called from, and work directly with, the API server in Thar, the OS.
-After a settings change, this program queries the API to determine which services and configuration files are affected by that change.
-Once it has done so, it renders and rewrites the affected configuration files and restarts any affected services.
+In the normal ("specific keys") mode, it's intended to be called by the Thar API server after a
+commit.  It's told the keys that changed, and then queries the API to determine which services and
+configuration files are affected by that change.  It then renders and rewrites the affected
+configuration files and restarts any affected services.
+
+In the standalone ("all keys") mode, it queries the API for all services and configuration files,
+then renders and rewrites all configuration files and restarts all services.
 
 ## Colophon
 

--- a/workspaces/api/thar-be-settings/src/config.rs
+++ b/workspaces/api/thar-be-settings/src/config.rs
@@ -12,19 +12,20 @@ use crate::{error, Result};
 use apiserver::model;
 
 /// Query the API for ConfigurationFile data
-pub fn get_affected_config_files<P, BH>(
+#[allow(clippy::implicit_hasher)]
+pub fn get_affected_config_files<P>(
     socket_path: P,
-    affected_files: HashSet<String, BH>,
+    files_limit: Option<HashSet<String>>,
 ) -> Result<model::ConfigurationFiles>
 where
     P: AsRef<Path>,
-    BH: std::hash::BuildHasher,
 {
-    let query = join(&affected_files, ",");
+    // Only want a query parameter if we had specific affected files, otherwise we want all
+    let query = files_limit.map(|files| ("names", join(&files, ",")));
 
     debug!("Querying API for configuration file metadata");
     let config_files: model::ConfigurationFiles =
-        client::get_json(socket_path, "/configuration-files", Some(("names", query)))?;
+        client::get_json(socket_path, "/configuration-files", query)?;
 
     Ok(config_files)
 }

--- a/workspaces/api/thar-be-settings/src/lib.rs
+++ b/workspaces/api/thar-be-settings/src/lib.rs
@@ -3,9 +3,13 @@
 
 thar-be-settings is a simple configuration applier.
 
-It is intended to be called from, and work directly with, the API server in Thar, the OS.
-After a settings change, this program queries the API to determine which services and configuration files are affected by that change.
-Once it has done so, it renders and rewrites the affected configuration files and restarts any affected services.
+In the normal ("specific keys") mode, it's intended to be called by the Thar API server after a
+commit.  It's told the keys that changed, and then queries the API to determine which services and
+configuration files are affected by that change.  It then renders and rewrites the affected
+configuration files and restarts any affected services.
+
+In the standalone ("all keys") mode, it queries the API for all services and configuration files,
+then renders and rewrites all configuration files and restarts all services.
 */
 
 #[macro_use]

--- a/workspaces/api/thar-be-settings/src/main.rs
+++ b/workspaces/api/thar-be-settings/src/main.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 use snafu::ResultExt;
+use std::collections::HashSet;
 use std::env;
 use std::process;
 
@@ -21,8 +22,18 @@ mod error {
     }
 }
 
+/// RunMode represents how thar-be-settings was requested to be run, either handling all
+/// configuration files and services, or handling configuration files and services based on
+/// specific keys given by the user.
+#[derive(Debug)]
+enum RunMode {
+    All,
+    SpecificKeys,
+}
+
 /// Store the args we receive on the command line
 struct Args {
+    mode: RunMode,
     verbosity: usize,
     socket_path: String,
 }
@@ -32,8 +43,14 @@ fn usage() -> ! {
     let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
     eprintln!(
         r"Usage: {}
+            [ --all ]
             [ --socket-path PATH ]
             [ --verbose --verbose ... ]
+
+    If --all is given, all configuration files will be written and all
+    services will have their restart-commands run.  Otherwise, settings keys
+    will be read from stdin; only files related to those keys will be written,
+    and only services related to those keys will be restarted.
 
     Socket path defaults to {}",
         program_name, DEFAULT_API_SOCKET,
@@ -49,12 +66,15 @@ fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
 
 /// Parse the args to the program and return an Args struct
 fn parse_args(args: env::Args) -> Args {
-    let mut socket_path = None;
+    let mut mode = RunMode::SpecificKeys;
     let mut verbosity = 2;
+    let mut socket_path = None;
 
     let mut iter = args.skip(1);
     while let Some(arg) = iter.next() {
         match arg.as_ref() {
+            "--all" => mode = RunMode::All,
+
             "-v" | "--verbose" => verbosity += 1,
 
             "--socket-path" => {
@@ -69,9 +89,40 @@ fn parse_args(args: env::Args) -> Args {
     }
 
     Args {
-        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        mode,
         verbosity,
+        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
     }
+}
+
+/// Render and write config files to disk.  If `files_limit` is Some, only
+/// write those files, otherwise write all known files.
+fn write_config_files(
+    args: &Args,
+    files_limit: Option<HashSet<String>>,
+) -> Result<(), Box<std::error::Error>> {
+    // Create a vec of ConfigFile structs from the list of changed services
+    info!("Requesting configuration file data for affected services");
+    let config_files = config::get_affected_config_files(&args.socket_path, files_limit)?;
+    trace!("Found config files: {:?}", config_files);
+
+    // Build the template registry from config file metadata
+    debug!("Building template registry");
+    let template_registry = template::build_template_registry(&config_files)?;
+
+    // Get all settings values for config file templates
+    debug!("Requesting settings values");
+    let settings = settings::get_settings_from_template(&args.socket_path, &template_registry)?;
+
+    // Ensure all files render properly
+    info!("Rendering config files...");
+    let rendered = config::render_config_files(&template_registry, config_files, settings)?;
+
+    // If all the config renders properly, write it to disk
+    info!("Writing config files to disk...");
+    config::write_config_files(rendered)?;
+
+    Ok(())
 }
 
 fn main() -> Result<(), Box<std::error::Error>> {
@@ -91,48 +142,45 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
     info!("thar-be-settings started");
 
-    // Get the settings that changed via stdin
-    info!("Parsing stdin for updated settings");
-    let changed_settings = get_changed_settings()?;
+    match args.mode {
+        RunMode::SpecificKeys => {
+            // Get the settings that changed via stdin
+            info!("Parsing stdin for updated settings");
+            let changed_settings = get_changed_settings()?;
 
-    // Create a HashSet of affected services
-    info!(
-        "Requesting affected services for settings: {:?}",
-        &changed_settings
-    );
-    let services = service::get_affected_services(&args.socket_path, changed_settings)?;
-    if services.is_empty() {
-        info!("No services are affected, exiting...");
-        process::exit(0)
+            // Create a HashSet of affected services
+            info!(
+                "Requesting affected services for settings: {:?}",
+                &changed_settings
+            );
+            let services =
+                service::get_affected_services(&args.socket_path, Some(changed_settings))?;
+            trace!("Found services: {:?}", services);
+            if services.is_empty() {
+                info!("No services are affected, exiting...");
+                process::exit(0)
+            }
+
+            // Create a HashSet of configuration file names
+            let config_file_names = config::get_config_file_names(&services);
+
+            if !config_file_names.is_empty() {
+                write_config_files(&args, Some(config_file_names))?;
+            }
+
+            // Now go bounce the affected services
+            info!("Restarting affected services...");
+            service::restart_services(services)?;
+        }
+        RunMode::All => {
+            write_config_files(&args, None)?;
+
+            info!("Restarting all services...");
+            let services = service::get_affected_services(&args.socket_path, None)?;
+            trace!("Found services: {:?}", services);
+            service::restart_services(services)?;
+        }
     }
-
-    // Create a HashSet of configuration file names
-    let config_file_names = config::get_config_file_names(&services);
-    if !config_file_names.is_empty() {
-        // Create a vec of ConfigFile structs from the list of changed services
-        info!("Requesting configuration file data for affected services");
-        let config_files = config::get_affected_config_files(&args.socket_path, config_file_names)?;
-
-        // Build the template registry from config file metadata
-        debug!("Building template registry");
-        let template_registry = template::build_template_registry(&config_files)?;
-
-        // Get all settings values for config file templates
-        debug!("Requesting settings values");
-        let settings = settings::get_settings_from_template(&args.socket_path, &template_registry)?;
-
-        // Ensure all files render properly
-        info!("Rendering config files...");
-        let rendered = config::render_config_files(&template_registry, config_files, settings)?;
-
-        // If all the config renders properly, write it to disk
-        info!("Writing config files to disk...");
-        config::write_config_files(rendered)?;
-    }
-
-    // Now go bounce all the services
-    info!("Restarting affected services...");
-    service::restart_all_services(services)?;
 
     Ok(())
 }


### PR DESCRIPTION
During boot, we need the ability to write out all configuration files,
regardless of whether there's been an API commit.  We won't always have a
commit at boot - during reboot, for example, we won't reapply user data and
usually won't have new dynamic settings to generate, so nothing changed that
needs committing.  Even so, our root filesystem isn't persistent, so we have to
render config files anyway or they'll be missing.

This change adds a --all flag that tells thar-be-settings to do its work for
all configuration files and services, without needing to be told specific keys
that changed.

(As before, service restart commands should be written not to start services
that weren't already running, for example using systemd's try-restart command
instead of restart.)

---

First part of addressing #146.

Implementation notes:
* I swapped the BuildHasher junk for a clippy allow because the BH bound infected main() in an ugly way.

**Testing done:**

In normal mode, with a setting that has no services, still correctly does nothing:
```
$ cargo run -- --socket-path /tmp/thar/api.sock -v -v -v -v
2019-08-14T10:57:19.410-07:00 - INFO - thar-be-settings started
2019-08-14T10:57:19.410-07:00 - INFO - Parsing stdin for updated settings
["settings.timezone"]
2019-08-14T10:57:24.544-07:00 - TRACE - Raw input from stdin: ["settings.timezone"]

2019-08-14T10:57:24.544-07:00 - DEBUG - Parsing stdin as JSON
2019-08-14T10:57:24.545-07:00 - TRACE - Parsed input: {"settings.timezone"}
2019-08-14T10:57:24.545-07:00 - INFO - Requesting affected services for settings: {"settings.timezone"}
2019-08-14T10:57:24.545-07:00 - DEBUG - Querying API for affected services names
2019-08-14T10:57:24.561-07:00 - TRACE - API response: {}
2019-08-14T10:57:24.561-07:00 - TRACE - Found services: {}
2019-08-14T10:57:24.561-07:00 - INFO - No services are affected, exiting...
```

In normal mode, with a setting that has a service and config file, still finds that file and tries to write it (my desktop doesn't have the template to finish doing so, but at that point we're past the changes):
```
$ cargo run -- --socket-path /tmp/thar/api.sock -v -v -v -v
2019-08-14T10:57:34.222-07:00 - INFO - thar-be-settings started
2019-08-14T10:57:34.223-07:00 - INFO - Parsing stdin for updated settings
["settings.hostname"]
2019-08-14T10:57:36.539-07:00 - TRACE - Raw input from stdin: ["settings.hostname"]

2019-08-14T10:57:36.539-07:00 - DEBUG - Parsing stdin as JSON
2019-08-14T10:57:36.540-07:00 - TRACE - Parsed input: {"settings.hostname"}
2019-08-14T10:57:36.540-07:00 - INFO - Requesting affected services for settings: {"settings.hostname"}
2019-08-14T10:57:36.540-07:00 - DEBUG - Querying API for affected services names
2019-08-14T10:57:36.552-07:00 - TRACE - API response: {"settings.hostname": ["hostname"]}
2019-08-14T10:57:36.552-07:00 - DEBUG - Building set of affected services
2019-08-14T10:57:36.552-07:00 - DEBUG - Found hostname
2019-08-14T10:57:36.552-07:00 - TRACE - Affected service names: {"hostname"}
2019-08-14T10:57:36.552-07:00 - DEBUG - Querying API for affected service metadata
2019-08-14T10:57:36.564-07:00 - TRACE - Service metadata: {"hostname": Service { configuration_files: ["hostname"], restart_commands: [] }}
2019-08-14T10:57:36.564-07:00 - TRACE - Found services: {"hostname": Service { configuration_files: ["hostname"], restart_commands: [] }}
2019-08-14T10:57:36.564-07:00 - DEBUG - Building set of affected configuration file names
2019-08-14T10:57:36.564-07:00 - TRACE - Config file names: {"hostname"}
2019-08-14T10:57:36.564-07:00 - INFO - Requesting configuration file data for affected services
2019-08-14T10:57:36.564-07:00 - DEBUG - Querying API for configuration file metadata
2019-08-14T10:57:36.575-07:00 - TRACE - Found config files: {"hostname": ConfigurationFile { path: "/etc/hostname", template_path: "/usr/share/templates/hostname" }}
2019-08-14T10:57:36.575-07:00 - DEBUG - Building template registry
2019-08-14T10:57:36.575-07:00 - DEBUG - Building template registry of configuration files
2019-08-14T10:57:36.575-07:00 - DEBUG - Registering hostname at path '/usr/share/templates/hostname'
Error: TemplateRegister { name: "hostname", path: "/usr/share/templates/hostname", source: IOError(Os { code: 2, kind: NotFound, message: "No such file or directory" }, "hostname") }
```

In "all" mode, all files are found (see the TRACE) and the same attempt is made to start rendering them:
```
$ cargo run -- --socket-path /tmp/thar/api.sock -v -v -v -v --all
2019-08-14T10:57:50.614-07:00 - INFO - thar-be-settings started
2019-08-14T10:57:50.614-07:00 - INFO - Requesting configuration file data for affected services
2019-08-14T10:57:50.614-07:00 - DEBUG - Querying API for configuration file metadata
2019-08-14T10:57:50.628-07:00 - TRACE - Found config files: {"hostname": ConfigurationFile { path: "/etc/hostname", template_path: "/usr/share/templates/hostname" }, "kubelet-config": ConfigurationFile { path: "/etc/kubernetes/kubelet/config", template_path: "/usr/share/templates/kubelet-config" }, "kubelet-env": ConfigurationFile { path: "/etc/kubernetes/kubelet/env", template_path: "/usr/share/templates/kubelet-env" }, "kubernetes-ca-crt": ConfigurationFile { path: "/etc/kubernetes/pki/ca.crt", template_path: "/usr/share/templates/kubernetes-ca-crt" }, "kubelet-kubeconfig": ConfigurationFile { path: "/etc/kubernetes/kubelet/kubeconfig", template_path: "/usr/share/templates/kubelet-kubeconfig" }}
2019-08-14T10:57:50.628-07:00 - DEBUG - Building template registry
2019-08-14T10:57:50.628-07:00 - DEBUG - Building template registry of configuration files
2019-08-14T10:57:50.628-07:00 - DEBUG - Registering hostname at path '/usr/share/templates/hostname'
Error: TemplateRegister { name: "hostname", path: "/usr/share/templates/hostname", source: IOError(Os { code: 2, kind: NotFound, message: "No such file or directory" }, "hostname") }
```