### PR TITLE
apiserver: Split commit and apply actions

### DIFF
--- a/workspaces/api/apiserver/src/datastore/key.rs
+++ b/workspaces/api/apiserver/src/datastore/key.rs
@@ -2,6 +2,7 @@
 
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde::{Serialize, Serializer};
 use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Deref;
@@ -115,6 +116,17 @@ impl AsRef<str> for Key {
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name)
+    }
+}
+
+// We can't implement Deserialize for Key because Key doesn't store its key type, but we can
+// serialize it to its name.
+impl Serialize for Key {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.name)
     }
 }
 

--- a/workspaces/api/openapi.yaml
+++ b/workspaces/api/openapi.yaml
@@ -77,11 +77,43 @@ paths:
 
   /settings/commit:
     post:
-      summary: "Commit pending settings"
+      summary: "Commit pending settings, without applying changes to config files or restarting services"
       operationId: "commit_settings"
       responses:
+        200:
+          description: "Successfully Staged settings - changed keys are returned"
+        500:
+          description: "Server error"
+
+  /settings/apply:
+    post:
+      summary: "Apply changes to config files and restart services"
+      operationId: "apply_settings"
+      parameters:
+        - in: query
+          name: keys
+          description: "Apply changes only if related to these keys; if not specified, applies for all known keys"
+          schema:
+            type: array
+            items:
+              type: string
+          # `style: form` and `explode: false` format parameters as such:  /settings/apply?keys=settings.foo,settings.bar
+          style: form
+          explode: false
+          required: false
+      responses:
         204:
-          description: "Successful settings update"
+          description: "Successfully started settings applier"
+        500:
+          description: "Server error"
+
+  /settings/commit_and_apply:
+    post:
+      summary: "Commit pending settings, and apply changes to relevant config files and services"
+      operationId: "commit_and_apply_settings"
+      responses:
+        200:
+          description: "Successful settings update, committed keys are returned"
         500:
           description: "Server error"
 


### PR DESCRIPTION
This changes the "commit" API into:
* "commit_and_apply" does what "commit" used to - move pending settings to live
     and run thar-be-settings
* "commit" just moves pending settings to live, telling you what was committed
* "apply" just runs thar-be-settings, for given settings or all settings

We need the ability to apply settings without having any changes to commit,
because that's what generates our config files.  We have to generate config
files on startup, even in the case of a reboot, where moondog won't run and
sundog usually won't have new settings to generate, meaning there's no changes
needing a commit.

Furthermore, we need *all* config files to be generated on startup, even though
we can't tell what (if any) settings have changed, because our root filesystem
isn't persistent and we won't have any config files generated last boot.  This
is why we need two modes in "apply", one for specific keys and one for all.

This API split will allow us to call "apply" during startup, after any services
that might have committed data are complete, so we can generate all files.

---

Requires #154.
Also requires the settings-applier service I'm building for the next PR, otherwise nothing would know to apply changes and we'd have no config files ever!

This is the second part of addressing #146.

Implementation notes:
* The commit* APIs were changed from a 204 No Content response to 200 so we could show the keys that were changed; this lets the user specify them later to the apply API if desired.
* `Serialize` was implemented for `Key` so we could use it those API responses.
* `fn apply_changes` was changed to take `AsRef<str>`, as it should have in the beginning, so it will take strings or `Key`s; thar-be-settings is a different process and so can't know about the `Key` structure we had.

**Testing done:**

Using the "commit_and_apply" API does the same thing that "commit" used to; we can see a pending setting going live, and that thar-be-settings runs for the specific key:
```
$ cargo run -- --socket-path /tmp/thar/api.sock -u /settings -X PATCH -d '{"timezone": "OldLosAngeles"}' -v
204 No Content

$ cargo run -- --socket-path /tmp/thar/api.sock -m POST -u /settings/commit_and_apply -v
200 OK
["settings.timezone"]
# Note: server shows thar-be-settings running for ["settings.timezone"]

$ cargo run -- --socket-path /tmp/thar/api.sock -m GET -u /settings -v
200 OK
{"timezone":"OldLosAngeles","hostname":"localhost"}
```

Using the "commit" API we can see settings going to live without thar-be-settings.  Following up with the "apply" API with a specific key, we can see thar-be-settings running for that key.  "apply" without specific keys runs thar-be-settings for all keys, which is what will be used at startup.
```
$ cargo run -- --socket-path /tmp/thar/api.sock -u /settings -X PATCH -d '{"timezone": "NewLosAngeles"}' -v
204 No Content

$ cargo run -- --socket-path /tmp/thar/api.sock -m POST -u /settings/commit -v
200 OK
["settings.timezone"]
# Note: server did not show thar-be-settings running, just the commit

$ cargo run -- --socket-path /tmp/thar/api.sock -m POST -u '/settings/apply?keys=settings.hostname' -v
204 No Content
# Note: server shows thar-be-settings running for ["settings.hostname"]

$ cargo run -- --socket-path /tmp/thar/api.sock -m POST -u /settings/apply -v
204 No Content
# Note: server shows thar-be-settings running with --all
```