### PR TITLE
Add apiclient README

### DIFF
--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
 name = "apiclient"
 version = "0.1.0"
 dependencies = [
+ "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/workspaces/api/apiclient/Cargo.toml
+++ b/workspaces/api/apiclient/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 edition = "2018"
 publish = false
+build = "build.rs"
 
 [dependencies]
 # TODO: move to futures 0.3 / stdlib futures when it's ready
@@ -13,3 +14,6 @@ hyper = "0.12"
 hyperlocal = "0.6"
 snafu = "0.4"
 tokio = "0.1"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/workspaces/api/apiclient/README.md
+++ b/workspaces/api/apiclient/README.md
@@ -1,0 +1,52 @@
+# apiclient
+
+Current version: 0.1.0
+
+## apiclient binary
+
+The `apiclient` binary helps you talk to an HTTP API over a Unix-domain socket.
+
+It talks to the Thar socket by default.
+It can be pointed to another socket using `--socket-path`, for example for local testing.
+
+The URI path is specified with `-u` or `--uri`, for example `-u /settings`.
+This should include the query string, if any.
+
+The HTTP method defaults to GET, and can be changed with `-m`, `-X`, or `--method`.
+
+If you change the method to POST or PATCH, you may also want to send data in the request body.
+Specify the data after `-d` or `--data`.
+
+To see verbose response data, including the HTTP status code, use `-v` or `--verbose`.
+
+### Example usage
+
+Getting settings:
+
+```
+apiclient -m GET -u /settings
+apiclient -m GET -u /settings/pending
+```
+
+Changing settings:
+
+```
+apiclient -X PATCH -u /settings -d '{"timezone": "OldLosAngeles"}'
+apiclient -m POST -u /settings/commit_and_apply
+```
+
+## apiclient library
+
+The apiclient library provides simple, synchronous methods to query an HTTP API over a
+Unix-domain socket.
+
+The `raw_request` method takes care of the basics of making an HTTP request on a Unix-domain
+socket, and requires you to specify the socket path, the URI (including query string), the
+HTTP method, and any request body data.
+
+In the future, we intend to add methods that understand the Thar API and help more with common
+types of requests.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/workspaces/api/apiclient/README.tpl
+++ b/workspaces/api/apiclient/README.tpl
@@ -1,0 +1,44 @@
+# {{crate}}
+
+Current version: {{version}}
+
+## apiclient binary
+
+The `apiclient` binary helps you talk to an HTTP API over a Unix-domain socket.
+
+It talks to the Thar socket by default.
+It can be pointed to another socket using `--socket-path`, for example for local testing.
+
+The URI path is specified with `-u` or `--uri`, for example `-u /settings`.
+This should include the query string, if any.
+
+The HTTP method defaults to GET, and can be changed with `-m`, `-X`, or `--method`.
+
+If you change the method to POST or PATCH, you may also want to send data in the request body.
+Specify the data after `-d` or `--data`.
+
+To see verbose response data, including the HTTP status code, use `-v` or `--verbose`.
+
+### Example usage
+
+Getting settings:
+
+```
+apiclient -m GET -u /settings
+apiclient -m GET -u /settings/pending
+```
+
+Changing settings:
+
+```
+apiclient -X PATCH -u /settings -d '{"timezone": "OldLosAngeles"}'
+apiclient -m POST -u /settings/commit_and_apply
+```
+
+## apiclient library
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/workspaces/api/apiclient/build.rs
+++ b/workspaces/api/apiclient/build.rs
@@ -1,0 +1,25 @@
+// Automatically generate README.md from rustdoc.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let mut source = File::open("src/lib.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/workspaces/api/apiclient/src/lib.rs
+++ b/workspaces/api/apiclient/src/lib.rs
@@ -1,5 +1,12 @@
-//! The apiclient library provides simple, synchronous methods to query the API server over a
+//! The apiclient library provides simple, synchronous methods to query an HTTP API over a
 //! Unix-domain socket.
+//!
+//! The `raw_request` method takes care of the basics of making an HTTP request on a Unix-domain
+//! socket, and requires you to specify the socket path, the URI (including query string), the
+//! HTTP method, and any request body data.
+//!
+//! In the future, we intend to add methods that understand the Thar API and help more with common
+//! types of requests.
 
 // Think "reqwest" but for Unix-domain sockets.  Would be nice to use the simpler reqwest instead
 // of hyper, but it lacks Unix-domain socket support:


### PR DESCRIPTION
Fixes #152.

You can only have one source file with cargo-readme.  I chose `lib.rs`, because `main.rs` already has the usage string, and libraries are easier to write docstrings in anyway.