### PR TITLE
storewolf: Install new defaults to existing datastore

### DIFF
--- a/workspaces/api/storewolf/README.md
+++ b/workspaces/api/storewolf/README.md
@@ -7,7 +7,7 @@ Current version: 0.1.0
 storewolf is a small program to create the filesystem datastore.
 
 It creates the datastore at a provided path and populates any default
-settings given in the defaults.toml file.
+settings given in the defaults.toml file, unless they already exist.
 
 ## Colophon
 

--- a/workspaces/api/storewolf/src/main.rs
+++ b/workspaces/api/storewolf/src/main.rs
@@ -4,16 +4,17 @@
 storewolf is a small program to create the filesystem datastore.
 
 It creates the datastore at a provided path and populates any default
-settings given in the defaults.toml file.
+settings given in the defaults.toml file, unless they already exist.
 */
 
 use snafu::{OptionExt, ResultExt};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::io;
 use std::path::Path;
-use std::{env, process};
+use std::{env, fs, process};
 
 use apiserver::datastore::key::{Key, KeyType};
-use apiserver::datastore::serialization::to_pairs;
+use apiserver::datastore::serialization::{to_pairs, to_pairs_with_prefix};
 use apiserver::datastore::{self, DataStore, FilesystemDataStore, ScalarError};
 use apiserver::model;
 
@@ -21,6 +22,9 @@ use apiserver::model;
 extern crate log;
 
 mod error {
+    use std::io;
+    use std::path::PathBuf;
+
     use apiserver::datastore::key::KeyType;
     use apiserver::datastore::{self, serialization, ScalarError};
     use snafu::Snafu;
@@ -31,6 +35,12 @@ mod error {
     pub(super) enum StorewolfError {
         #[snafu(display("Logger setup error: {}", source))]
         Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Unable to clear pending settings: {}", source))]
+        DeletePending { source: io::Error },
+
+        #[snafu(display("Unable to create datastore at '{}': {}", path.display(), source))]
+        DatastoreCreation { path: PathBuf, source: io::Error },
 
         #[snafu(display("defaults.toml is not valid TOML: {}", source))]
         DefaultsFormatting { source: toml::de::Error },
@@ -43,6 +53,12 @@ mod error {
 
         #[snafu(display("defaults.toml's metadata is not a TOML list of Metadata"))]
         DefaultsMetadataNotTable { source: toml::de::Error },
+
+        #[snafu(display("Error querying datstore for populated keys: {}", source))]
+        QueryData { source: datastore::Error },
+
+        #[snafu(display("Error querying datstore for populated metadata: {}", source))]
+        QueryMetadata { source: datastore::Error },
 
         #[snafu(display("Error serializing {}: {} ", given, source))]
         Serialization {
@@ -75,7 +91,31 @@ type Result<T> = std::result::Result<T, StorewolfError>;
 /// Creates a new FilesystemDataStore at the given path, with data and metadata coming from
 /// defaults.toml at compile time.
 fn populate_default_datastore<P: AsRef<Path>>(base_path: P) -> Result<()> {
-    let mut datastore = FilesystemDataStore::new(base_path);
+    // NOTE: Variables prefixed with "def" refer to values from defaults.
+    //
+    // Variables prefixed with "existing..." refer to values from the
+    // existing datastore.
+
+    let mut datastore = FilesystemDataStore::new(&base_path);
+    let mut existing_data = HashSet::new();
+    let mut existing_metadata = HashMap::new();
+
+    // If the "live" path of the datastore exists, query it for populated
+    // meta/data.  Otherwise, create the datastore path.
+    let live_path = base_path.as_ref().join("live");
+    if live_path.exists() {
+        debug!("Gathering existing data from the datastore");
+        existing_metadata = datastore
+            .list_populated_metadata("", &None as &Option<&str>)
+            .context(error::QueryMetadata)?;
+        ;
+        existing_data = datastore
+            .list_populated_keys("", datastore::Committed::Live)
+            .context(error::QueryData)?;
+    } else {
+        info!("Creating datastore at: {}", &live_path.display());
+        fs::create_dir_all(&live_path).context(error::DatastoreCreation { path: live_path })?;
+    }
 
     // Read and parse defaults
     let defaults_str = include_str!("../defaults.toml");
@@ -94,9 +134,9 @@ fn populate_default_datastore<P: AsRef<Path>>(base_path: P) -> Result<()> {
     // state. This ensures the settings will go through a commit cycle when
     // first-boot services run, which will create config files for default
     // keys that require them.
-    if let Some(settings_val) = maybe_settings_val {
-        debug!("Serializing default settings and writing to datastore");
-        let settings_table = settings_val
+    if let Some(def_settings_val) = maybe_settings_val {
+        debug!("Serializing default settings and writing new ones to datastore");
+        let def_settings_table = def_settings_val
             .as_table()
             .context(error::DefaultSettingsNotTable)?;
 
@@ -105,26 +145,57 @@ fn populate_default_datastore<P: AsRef<Path>>(base_path: P) -> Result<()> {
         // before serializing so we have full dotted keys like
         // "settings.foo.bar" and not just "foo.bar". We use a HashMap
         // to rebuild the nested structure.
-        let mut temp = HashMap::new();
-        temp.insert("settings", settings_table);
-        let settings = to_pairs(&temp).context(error::Serialization {
-            given: "default settings",
-        })?;
+        let def_settings = to_pairs_with_prefix("settings".to_string(), &def_settings_table)
+            .context(error::Serialization {
+                given: "default settings",
+            })?;
 
+        // For each of the default settings, check if it exists in the
+        // datastore. If not, add it to the map of settings to write
+        let mut settings_to_write = HashMap::new();
+        for (key, val) in def_settings {
+            let setting = Key::new(KeyType::Data, &key).context(error::InvalidKey {
+                key_type: KeyType::Data,
+                key: key.to_string(),
+            })?;
+            if !existing_data.contains(&setting) {
+                settings_to_write.insert(key, val);
+            }
+        }
+
+        trace!(
+            "Writing default settings to datastore: {:#?}",
+            &settings_to_write
+        );
         datastore
-            .set_keys(&settings, datastore::Committed::Pending)
+            .set_keys(&settings_to_write, datastore::Committed::Pending)
             .context(error::WriteKeys)?;
     }
 
     // If we have metadata, write it out to the datastore in Live state
-    if let Some(metadata_val) = maybe_metadata_val {
-        debug!("Serializing metadata and writing to datastore");
-        let metadatas: Vec<model::Metadata> = metadata_val
+    if let Some(def_metadata_val) = maybe_metadata_val {
+        debug!("Serializing metadata and writing new keys to datastore");
+        let def_metadatas: Vec<model::Metadata> = def_metadata_val
             .try_into()
             .context(error::DefaultsMetadataNotTable)?;
 
-        for metadata in metadatas {
-            let model::Metadata { key, md, val } = metadata;
+        // Before this transformation, `existing_metadata` is a
+        // map of data key to set of metadata keys:
+        // HashMap(dataKey => HashSet(metaKey)).
+        //
+        // To make comparison easier, we
+        // flatten the map to a HashSet of tuples:
+        // HashSet((dataKey, metaKey)).
+        let existing_metadata: HashSet<(&Key, &Key)> = existing_metadata
+            .iter()
+            .flat_map(|data| data.1.iter().map(move |md_key| (data.0, md_key)))
+            .collect();
+
+        // For each of the default metadatas, check if it exists in the
+        // datastore. If not, add it to the set of metadatas to write
+        let mut metadata_to_write = HashSet::new();
+        for def_metadata in def_metadatas {
+            let model::Metadata { key, md, val } = def_metadata;
             let data_key = Key::new(KeyType::Data, &key).context(error::InvalidKey {
                 key_type: KeyType::Data,
                 key,
@@ -133,30 +204,60 @@ fn populate_default_datastore<P: AsRef<Path>>(base_path: P) -> Result<()> {
                 key_type: KeyType::Meta,
                 key: md,
             })?;
-            let value = datastore::serialize_scalar::<_, ScalarError>(&val).with_context(|| {
-                error::SerializeScalar {
-                    given: format!("metadata value '{}'", val),
-                }
-            })?;
 
+            // Put the `data_key` and `md_key` tuple into a variable so we
+            // can more easily read the subsequent `contains()` call
+            let def_metadata_keypair = (&data_key, &md_key);
+            if !existing_metadata.contains(&def_metadata_keypair) {
+                let value =
+                    datastore::serialize_scalar::<_, ScalarError>(&val).with_context(|| {
+                        error::SerializeScalar {
+                            given: format!("metadata value '{}'", val),
+                        }
+                    })?;
+                metadata_to_write.insert((md_key, data_key, value));
+            }
+        }
+
+        trace!(
+            "Writing default metadata to datastore: {:#?}",
+            metadata_to_write
+        );
+        for metadata in metadata_to_write {
+            let (md, key, val) = metadata;
             datastore
-                .set_metadata(&md_key, &data_key, value)
+                .set_metadata(&md, &key, val)
                 .context(error::WriteMetadata)?;
         }
     }
 
     // If any other defaults remain (configuration files, services, etc),
     // write them to the datastore in Live state
+    debug!("Serializing other defaults and writing new ones to datastore");
     let defaults = to_pairs(&defaults_val).context(error::Serialization {
         given: "other defaults",
     })?;
+
+    let mut other_defaults_to_write = HashMap::new();
     if !defaults.is_empty() {
-        debug!("Serializing other defaults and writing to datastore");
+        for (key, val) in defaults.iter() {
+            let data_key = Key::new(KeyType::Data, &key).context(error::InvalidKey {
+                key_type: KeyType::Data,
+                key,
+            })?;
+            if !existing_data.contains(&data_key) {
+                other_defaults_to_write.insert(key, val);
+            }
+        }
+
+        trace!(
+            "Writing other default data to datastore: {:#?}",
+            &other_defaults_to_write
+        );
         datastore
-            .set_keys(&defaults, datastore::Committed::Live)
+            .set_keys(&other_defaults_to_write, datastore::Committed::Live)
             .context(error::WriteKeys)?;
     }
-
     Ok(())
 }
 
@@ -228,12 +329,21 @@ fn main() -> Result<()> {
 
     info!("Storewolf started");
 
-    // Create default datastore if it doesn't exist
-    if !Path::new(&args.datastore_path).exists() {
-        info!("Creating datastore at: {}", &args.datastore_path);
-        populate_default_datastore(&args.datastore_path)?;
-        info!("Datastore created");
+    // If anything exists in Pending state, delete it
+    info!("Deleting pending settings");
+    let pending_path = Path::new(&args.datastore_path).join("pending");
+    if let Err(e) = fs::remove_dir_all(pending_path) {
+        // If there are no pending settings, the directory won't exist.
+        // Ignore the error in this case.
+        if e.kind() != io::ErrorKind::NotFound {
+            Err(e).context(error::DeletePending)?
+        }
     }
+
+    // Create the datastore if it doesn't exist
+    info!("Populating datastore at: {}", &args.datastore_path);
+    populate_default_datastore(&args.datastore_path)?;
+    info!("Datastore populated");
 
     Ok(())
 }


### PR DESCRIPTION
This change ensures that new defaults are written to the datastore on boot. For further context on the why, checkout #120.  It will not overwrite any existing settings, data or metadata.

*Issue #, if available:*
Fixes #120 
Fixes #137 

*Testing done:*
* All unit tests pass
* A newly booted image contains the datastore and all the data in the all the right places.
* Subsequent runs of `storewolf` don't add or change any existing settings
```
bash-5.0# echo "foobar" > /var/lib/thar/datastore/v1/live/settings/hostname
...
bash-5.0# /usr/bin/storewolf --datastore-path /var/lib/thar/datastore/v1
...
bash-5.0# cat /var/lib/thar/datastore/v1/live/settings/hostname
foobar
```
* Settings in pending are removed upon boot
```
bash-5.0# mkdir -p /var/lib/thar/datastore/v1/pending/settings
bash-5.0# echo "baz" > /var/lib/thar/datastore/v1/pending/settings/hostname
bash-5.0# cat  /var/lib/thar/datastore/v1/pending/settings/hostname
bash-5.0# reboot
...
bash-5.0# ls /var/lib/thar/datastore/v1/
live
bash-5.0# cat /var/lib/thar/datastore/v1/live/settings/hostname
foobar  <--- set to "foobar" in previous example
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
