### PR TITLE
add settings for updog.

### DIFF
--- a/packages/updater/updater.spec
+++ b/packages/updater/updater.spec
@@ -1,5 +1,7 @@
 %global workspace_name updater
 
+%global templatedir %{_cross_datadir}/templates
+
 Name: %{_cross_os}%{workspace_name}
 Version: 0.0
 Release: 0%{?dist}
@@ -7,7 +9,7 @@ Summary: Thar updater packages
 License: FIXME
 Source0: %{workspace_name}.crate
 Source1: root.json
-Source2: updog.toml
+Source2: updog-toml
 Source3: updog.conf
 %cargo_bundle_crates -n %{workspace_name} -t 0
 BuildRequires: gcc-%{_cross_target}
@@ -42,8 +44,8 @@ not much what's up with you
 install -d %{buildroot}/%{_cross_datadir}/updog
 install -m 0644 -t %{buildroot}/%{_cross_datadir}/updog %{SOURCE1}
 
-install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
-install -p -m 0644 %{SOURCE2} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/updog.toml
+install -d %{buildroot}%{templatedir}
+install -p -m 0644 %{SOURCE2} %{buildroot}%{templatedir}/updog-toml
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{SOURCE3} %{buildroot}%{_cross_tmpfilesdir}/updog.conf
@@ -57,7 +59,8 @@ install -p -m 0644 %{SOURCE3} %{buildroot}%{_cross_tmpfilesdir}/updog.conf
 %files -n %{_cross_os}updog
 %{_cross_bindir}/updog
 %{_cross_datadir}/updog
-%{_cross_factorydir}%{_cross_sysconfdir}/updog.toml
 %{_cross_tmpfilesdir}/updog.conf
+%dir %{templatedir}
+%{templatedir}/updog-toml
 
 %changelog

--- a/packages/updater/updog-toml
+++ b/packages/updater/updog-toml
@@ -1,0 +1,2 @@
+metadata_base_url = "{{settings.updates.metadata-base-url}}"
+target_base_url = "{{settings.updates.target-base-url}}"

--- a/packages/updater/updog.toml
+++ b/packages/updater/updog.toml
@@ -1,2 +1,0 @@
-metadata_base_url = "https://cdn.thar.amazonlinux.a2z.com/updates/metadata/"
-target_base_url = "https://cdn.thar.amazonlinux.a2z.com/updates/targets/"

--- a/workspaces/api/apiserver/src/model.rs
+++ b/workspaces/api/apiserver/src/model.rs
@@ -42,6 +42,17 @@ pub struct KubernetesSettings {
     pub pod_infra_container_image: Option<String>,
 }
 
+// Updog settings. Taken from userdata.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct UpdatesSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_base_url: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_base_url: Option<String>,
+}
+
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that poitns to it
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -55,6 +66,9 @@ pub struct Settings {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kubernetes: Option<KubernetesSettings>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updates: Option<UpdatesSettings>,
 }
 
 ///// Internal services

--- a/workspaces/api/storewolf/defaults.toml
+++ b/workspaces/api/storewolf/defaults.toml
@@ -5,6 +5,10 @@
 timezone = "America/Los_Angeles"
 hostname = "localhost"
 
+[settings.updates]
+metadata-base-url = "https://cdn.thar.amazonlinux.a2z.com/updates/metadata/"
+target-base-url = "https://cdn.thar.amazonlinux.a2z.com/updates/targets/"
+
 [services.hostname]
 configuration-files = ["hostname"]
 restart-commands = []
@@ -59,4 +63,19 @@ val = "pluto pod-infra-container-image"
 key = "settings.kubernetes"
 md = "affected-services"
 val = ["kubernetes"]
+
+# Updog.
+
+[services.updog]
+configuration-files = ["updog-toml"]
+restart-commands = []
+
+[configuration-files.updog-toml]
+path = "/etc/updog.toml"
+template-path = "/usr/share/templates/updog-toml"
+
+[[metadata]]
+key = "settings.updates"
+md = "affected-services"
+val = ["updog"]
 


### PR DESCRIPTION
*Issue #, if available:* #112 

*Description of changes:*

Add the ability to configure updog through userdata. Falls back to some defaults if no settings are provided.

*Testing:*

Tested on an ec2. Output from the console when supplying no custom updog settings:
```
sh-5.0# journalctl -u apiserver
-- Logs begin at Thu 2019-08-15 23:27:53 UTC, end at Thu 2019-08-15 23:28:23 UTC. --
Aug 15 23:27:58 localhost systemd[1]: Started Thar API server.
Aug 15 23:27:58 localhost apiserver[2661]: 2019-08-15T23:27:58.116+00:00 - INFO - Starting server at /var/lib/thar/api.sock with 1 thread and datastore at /var/lib/thar/datastore/v1
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.655+00:00 - DEBUG - Writing pending keys to live
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.656+00:00 - DEBUG - Removing old pending keys
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.656+00:00 - DEBUG - Launching thar-be-settings to apply changes
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.704+00:00 - INFO - thar-be-settings started
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.707+00:00 - INFO - Parsing stdin for updated settings
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.707+00:00 - INFO - Requesting affected services for settings: {"settings.kubernetes.api-server", "settings.hostnam
e", "settings.kubernetes.node-ip", "settings.updates.target-base-url", "settings.timezone", "settings.kubernetes.cluster-dns-ip", "settings.updates.metadata-base-url", "settings.kubernetes.cluster-name", "settings.
kubernetes.cluster-certificate", "settings.kubernetes.pod-infra-container-image"}
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.764+00:00 - INFO - Requesting configuration file data for affected services
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.799+00:00 - INFO - Rendering config files...
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.820+00:00 - INFO - Writing config files to disk...
Aug 15 23:28:08 ip-172-31-63-19.us-west-2.compute.internal apiserver[2661]: 2019-08-15T23:28:08.821+00:00 - INFO - Restarting affected services...
sh-5.0# cat /etc/updog.toml
metadata_base_url = "https://cdn.thar.amazonlinux.a2z.com/updates/metadata/"
target_base_url = "https://cdn.thar.amazonlinux.a2z.com/updates/targets/"
```
When supplying userdata with (required kubernetes settings omitted):
```
[settings.updates]
metadata-base-url = "example.com"
target-base-url = "example.com"
```

Output:
```
sh-5.0# cat /etc/updog.toml
metadata_base_url = "example.com"
target_base_url = "example.com"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
