### PR TITLE
Do image builds directly in BuildKit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,22 +49,15 @@ endef
 define build_image
 	$(eval HASH:= $(shell sha1sum $(2) /dev/null | sha1sum - | awk '{print $$1}'))
 	@$(BUILDCTL) build \
-		--opt target=builder \
+		--opt target=image \
 		--opt build-arg:PACKAGE=$(OS)-$(1)-$(RECIPE) \
 		--opt build-arg:ARCH=$(1) \
 		--opt build-arg:HASH=$(HASH) \
 		--opt build-arg:DATE=$(DATE) \
-		--output type=docker,name=$(OS)-builder:$(1),dest=build/$(OS)-$(1)-builder.tar \
+		--output type=local,dest=$(OUTPUT) \
 		$(BUILDCTL_ARGS)
-	@$(DOCKER) load < build/$(OS)-$(1)-builder.tar
-	@$(DOCKER) run -t -v /dev:/dev -v $(OUTPUT):/local/output \
-		$(OS)-builder:$(1) \
-			--disk-image-name=$(OS)-$(1).img \
-			--boot-image-name=$(OS)-$(1)-boot.ext4.lz4 \
-			--verity-image-name=$(OS)-$(1)-root.verity.lz4 \
-			--root-image-name=$(OS)-$(1)-root.ext4.lz4 \
-			--package-dir=/local/rpms \
-			--output-dir=/local/output
+	lz4 -d $(OUTPUT)/$(OS)-$(1).img.lz4 >$(OUTPUT)/$(OS)-$(1).img \
+		&& rm -f $(OUTPUT)/$(OS)-$(1).img.lz4
 endef
 
 # `makedep` files are a hook to provide additional dependencies when

--- a/bin/rpm2img
+++ b/bin/rpm2img
@@ -6,20 +6,17 @@ shopt -qs failglob
 for opt in "$@"; do
    optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
    case "${opt}" in
-      --disk-image-name=*) DISK_IMAGE_NAME="${optarg}" ;;
-      --boot-image-name=*) BOOT_IMAGE_NAME="${optarg}" ;;
-      --verity-image-name=*) VERITY_IMAGE_NAME="${optarg}" ;;
-      --root-image-name=*) ROOT_IMAGE_NAME="${optarg}" ;;
       --package-dir=*) PACKAGE_DIR="${optarg}" ;;
       --output-dir=*) OUTPUT_DIR="${optarg}" ;;
    esac
 done
 
 mkdir -p "${OUTPUT_DIR}"
-rm -f "${OUTPUT_DIR}/${DISK_IMAGE_NAME}" \
-    "${OUTPUT_DIR}/${BOOT_IMAGE_NAME}" \
-    "${OUTPUT_DIR}/${VERITY_IMAGE_NAME}" \
-    "${OUTPUT_DIR}/${ROOT_IMAGE_NAME}"
+
+DISK_IMAGE_NAME="thar-${ARCH}.img.lz4"
+BOOT_IMAGE_NAME="thar-${ARCH}-boot.ext4.lz4"
+VERITY_IMAGE_NAME="thar-${ARCH}-root.verity.lz4"
+ROOT_IMAGE_NAME="thar-${ARCH}-root.ext4.lz4"
 
 DISK_IMAGE="$(mktemp)"
 BOOT_IMAGE="$(mktemp)"
@@ -43,7 +40,7 @@ THAR_ROOT_TYPECODE="5526016a-1a97-4ea4-b39a-b7c8c6ca4502"
 THAR_HASH_TYPECODE="598f10af-c955-4456-6a99-7720068a6cea"
 THAR_RESERVED_TYPECODE="0c5d99a5-d331-4147-baef-08e2b855bdc9"
 
-if [[ "$(uname -m)" == "x86_64" ]]; then
+if [[ "${ARCH}" == "x86_64" ]]; then
   FIRM_NAME="BIOS-BOOT"
   THAR_FIRM_TYPECODE="ef02"
 else
@@ -72,7 +69,7 @@ mkdir -p "${ROOT_MOUNT}"
 rpm -iv --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
 rm -rf "${ROOT_MOUNT}"/var/lib
 
-if [[ "$(uname -m)" == "x86_64" ]]; then
+if [[ "${ARCH}" == "x86_64" ]]; then
   # MBR and BIOS-BOOT
   echo "(hd0) ${DISK_IMAGE}" > ${ROOT_MOUNT}/boot/grub/device.map
   "${ROOT_MOUNT}/sbin/grub-bios-setup" \
@@ -160,7 +157,7 @@ dd if="${DATA_IMAGE}" of="${DISK_IMAGE}" conv=notrunc,sparse bs=512 seek=$((2048
 
 sgdisk -v "${DISK_IMAGE}"
 
-mv "${DISK_IMAGE}" "${OUTPUT_DIR}/${DISK_IMAGE_NAME}"
+lz4 -vc "${DISK_IMAGE}" >"${OUTPUT_DIR}/${DISK_IMAGE_NAME}"
 lz4 -9vc "${BOOT_IMAGE}" >"${OUTPUT_DIR}/${BOOT_IMAGE_NAME}"
 lz4 -9vc "${VERITY_IMAGE}" >"${OUTPUT_DIR}/${VERITY_IMAGE_NAME}"
 lz4 -9vc "${ROOT_IMAGE}" >"${OUTPUT_DIR}/${ROOT_IMAGE_NAME}"


### PR DESCRIPTION
Exporting the image build container and importing it in Docker is a holdover from when we needed `docker run --privileged` to build the image.

Fixes #169. This is draft mode because we're no longer bind mounting the build directory into a container, so the disk image is coming out as the full 4 GB instead of a sparse file, and I want to fix that before merging.

Testing done: Thar boots.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
