### PR TITLE
Expand on issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/build.md
+++ b/.github/ISSUE_TEMPLATE/build.md
@@ -1,0 +1,26 @@
+---
+title: Bug report - build process
+---
+
+<!--
+Tips:
+- Please search for similar issues, including closed issues.
+- Please include details about the environment you're running in.
+- Please include any error messages you received, with any required context.
+-->
+
+**Platform I'm building on:**
+
+
+
+**What I expected to happen:**
+
+
+
+**What actually happened:**
+
+
+
+**How to reproduce the problem:**
+
+

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,17 @@
+---
+title: Feature request
+---
+
+<!--
+Tips:
+- Please search for similar requests, including closed issues.
+- Please include details about the environment you're running in.
+-->
+
+**What I'd like:**
+
+
+
+**Any alternatives you've considered:**
+
+

--- a/.github/ISSUE_TEMPLATE/image.md
+++ b/.github/ISSUE_TEMPLATE/image.md
@@ -1,0 +1,26 @@
+---
+title: Bug report - Thar image
+---
+
+<!--
+Tips:
+- Please search for similar issues, including closed issues.
+- Please include details about the environment you're running in.
+- Please include any error messages you received, with any required context.
+-->
+
+**Image I'm using:**
+
+
+
+**What I expected to happen:**
+
+
+
+**What actually happened:**
+
+
+
+**How to reproduce the problem:**
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,0 @@
-*Issue #, if available:*
-
-*Description of changes:*
-
-
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.github/PULL_REQUEST_TEMPLATE/main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/main.md
@@ -1,0 +1,21 @@
+<!--
+Tips:
+- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
+- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
+-->
+
+**Issue number:**
+
+
+
+**Description of changes:**
+
+
+
+**Testing done:**
+
+
+
+**Terms of contribution:**
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
Based on discussion and docs we've started internally.

Having the YAML frontmatter on files in ISSUE_TEMPLATE will make that title show up in a drop-down when you create an issue.  PR templates don't support that yet, but they do support being in a directory, so we can add multiple later in case we want to create them via an API.