### PR TITLE
Migrate pending data to pending, not live

### DIFF
--- a/workspaces/api/migration/migration-helpers/src/datastore.rs
+++ b/workspaces/api/migration/migration-helpers/src/datastore.rs
@@ -54,6 +54,7 @@ pub(crate) fn get_input_data<D: DataStore>(
 pub(crate) fn set_output_data<D: DataStore>(
     datastore: &mut D,
     input: &MigrationData,
+    committed: Committed,
 ) -> Result<()> {
     // Prepare serialized data
     let mut data = HashMap::new();
@@ -62,11 +63,11 @@ pub(crate) fn set_output_data<D: DataStore>(
         data.insert(data_key, value);
     }
 
-    // This is one of the rare cases where we want to set keys directly to the live datastore:
+    // This is one of the rare cases where we want to set keys directly in the datastore:
     // * We're operating on a temporary copy of the datastore, so no concurrency issues
     // * We're either about to reboot or just have, and the settings applier will run afterward
     datastore
-        .set_keys(&data, Committed::Live)
+        .set_keys(&data, committed)
         .context(error::DataStoreWrite)?;
 
     // Set metadata in a loop (currently no batch API)

--- a/workspaces/api/migration/migration-helpers/src/lib.rs
+++ b/workspaces/api/migration/migration-helpers/src/lib.rs
@@ -96,7 +96,7 @@ pub fn run_migration<D: DataStore>(
 
         validate_migrated_data(&migrated)?;
 
-        set_output_data(datastore, &migrated)?;
+        set_output_data(datastore, &migrated, *committed)?;
     }
     Ok(())
 }


### PR DESCRIPTION
If there's any pending data when running a migration, it should be migrated
into the new pending/ directory, not into live/, or it will also have the
effect of committing changes.  This was a miss in testing.

---

**Testing done:**

Migration still runs OK:
```
$ cargo run -- -v -v -v -v --datastore-path datastore-sample/current --migration-directories ./migration-binaries --migrate-to-version 0.1
2019-08-19T15:41:54.857-07:00 - TRACE - Getting version from datastore path: /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.0_aBIUdlQUclSbnHEv
2019-08-19T15:41:54.858-07:00 - TRACE - Parsing version from string: v0.0_aBIUdlQUclSbnHEv
2019-08-19T15:41:54.858-07:00 - TRACE - Parsed major '0' and minor '0'
2019-08-19T15:41:54.858-07:00 - TRACE - Looking for potential migrations in ./migration-binaries
2019-08-19T15:41:54.858-07:00 - TRACE - Found potential migration: ./migration-binaries/migrate_v0.1_test
2019-08-19T15:41:54.860-07:00 - TRACE - Parsing version from string: v0.1
2019-08-19T15:41:54.860-07:00 - TRACE - Parsed major '0' and minor '1'
2019-08-19T15:41:54.860-07:00 - INFO - Found applicable forward migration 'migrate_v0.1_test': v0.0 < (v0.1) <= v0.1
2019-08-19T15:41:54.860-07:00 - DEBUG - Sorted migrations: ["migrate_v0.1_test"]
2019-08-19T15:41:54.860-07:00 - INFO - Copying datastore from /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.0_aBIUdlQUclSbnHEv to work location /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_s8O1RHCJhbYHJbG1
2019-08-19T15:41:54.861-07:00 - INFO - Running migration command: "./migration-binaries/migrate_v0.1_test" "--forward" "--datastore-path" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_s8O1RHCJhbYHJbG1"
2019-08-19T15:41:54.869-07:00 - DEBUG - Migration stdout: 
2019-08-19T15:41:54.869-07:00 - DEBUG - Migration stderr: [migration/migration-helpers/src/lib.rs:90] committed = Live
2019-08-19T15:41:54.870-07:00 - INFO - Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1 to point to v0.1_s8O1RHCJhbYHJbG1
2019-08-19T15:41:54.870-07:00 - INFO - Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0 to point to v0.1
```

Now, we can see that pending and live were converted, separately and each correctly:
```
$ cat datastore-sample/v0.0/pending/settings/timezone; echo
"OldNewYork"
$ cat datastore-sample/v0.1/pending/settings/timezone; echo
"NewOldNewYork"

$ cat datastore-sample/v0.0/live/settings/timezone; echo
"OldLosAngeles"
$ cat datastore-sample/v0.1/live/settings/timezone; echo
"NewOldLosAngeles"
```