### PR TITLE
storewolf: create data store symlink tree if it doesn't exist

### DIFF
--- a/packages/api/apiserver.service
+++ b/packages/api/apiserver.service
@@ -7,7 +7,7 @@ Requires=storewolf.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/apiserver --datastore-path /var/lib/thar/datastore/v1 -v -v -v
+ExecStart=/usr/bin/apiserver --datastore-path /var/lib/thar/datastore/current -v -v -v
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/api/storewolf.service
+++ b/packages/api/storewolf.service
@@ -3,7 +3,7 @@ Description=Datastore creator
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/storewolf --datastore-path /var/lib/thar/datastore/v1
+ExecStart=/usr/bin/storewolf --data-store-base-path /var/lib/thar/datastore
 RemainAfterExit=true
 
 [Install]

--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -1829,7 +1829,9 @@ version = "0.1.0"
 dependencies = [
  "apiserver 0.1.0",
  "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "data_store_version 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/workspaces/api/storewolf/Cargo.toml
+++ b/workspaces/api/storewolf/Cargo.toml
@@ -8,7 +8,9 @@ build = "build.rs"
 
 [dependencies]
 apiserver = { path = "../apiserver" }
+data_store_version = { path = "../data_store_version" }
 log = "0.4"
+rand = { version = "0.7", default-features = false, features = ["std"] }
 snafu = "0.4"
 stderrlog = "0.4"
 toml = "0.5"


### PR DESCRIPTION
Storewolf previously created the data store at a static path.  Because we now have working migrations, it's necessary to create the data store as a set of symlinks that we can manipulate for major/minor versions of the data store, etc.  The top-level symlink where other tools will interact with the data store will be at `/path/to/datastore/current`.

This PR creates those symlinks using the previously added data store version file at `/usr/share/thar/data-store-version`. (Added in #166 )

*Issue #, if available:*
Related to #64 

*Description of changes:*
* Using the datastore version file, create the set of symlinks corresponding to the datastore version.
* Add a `from_file` method to `datastore::Version`.
* Update the unit files for `apiserver` and `storewolf`.
* Updated the `storewolf` arg from `--datastore-path` to `--data-store-base-path`
* Update the pending path for deleting `/pending` settings

*Testing done:*
* Unit tests pass
* On a newly booted Thar image:

The datastore structure is created successfully:
```
bash-5.0# ls -lah /var/lib/thar/datastore/
total 16K
drwxr-xr-x 4 root root 4.0K Aug 21 20:52 .
drwxr-xr-x 4 root root 4.0K Aug 21 20:53 ..
lrwxrwxrwx 1 root root    2 Aug 21 20:52 current -> v0
drwxr-xr-x 2 root root 4.0K Aug 21 20:27 migrations
lrwxrwxrwx 1 root root    4 Aug 21 20:52 v0 -> v0.0
lrwxrwxrwx 1 root root   21 Aug 21 20:52 v0.0 -> v0.0_lAFgWg5l97s7jl2H
drwxr-xr-x 3 root root 4.0K Aug 21 20:53 v0.0_lAFgWg5l97s7jl2H
```

Data is properly populated:
```
bash-5.0# cat /var/lib/thar/datastore/current/live/settings/kubernetes/node-ip
"10.0.60.75"
bash-5.0# cat /var/lib/thar/datastore/current/live/settings/hostname
"localhost"
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
