### PR TITLE
ssm: Run in AL2 container

### DIFF
--- a/packages/ssm/Dockerfile
+++ b/packages/ssm/Dockerfile
@@ -1,0 +1,17 @@
+FROM amazonlinux:2
+
+RUN mkdir -p /var/lib/amazon/ssm
+RUN mkdir -p /etc/amazon/ssm
+
+ADD etc/amazon/* /etc/amazon/ssm/
+ADD usr/bin/amazon-ssm-agent /usr/bin/
+ADD usr/bin/ssm-cli /usr/bin/
+ADD usr/bin/ssm-document-worker /usr/bin/
+ADD usr/bin/ssm-session-worker /usr/bin/
+ADD usr/bin/ssm-session-logger /usr/bin/
+
+RUN chmod 755 /usr/bin/amazon-ssm-agent
+RUN chmod 755 /usr/bin/ssm-cli
+RUN chmod 755 /usr/bin/ssm-document-worker
+RUN chmod 755 /usr/bin/ssm-session-worker
+RUN chmod 755 /usr/bin/ssm-session-logger

--- a/packages/ssm/amazon-ssm-agent.service
+++ b/packages/ssm/amazon-ssm-agent.service
@@ -7,7 +7,8 @@ StartLimitIntervalSec=60
 [Service]
 Type=simple
 WorkingDirectory=/
-ExecStart=/usr/bin/amazon-ssm-agent
+ExecStartPre=/usr/bin/docker build -t ssm /var/lib/amazon/ssm/
+ExecStart=/usr/bin/docker run --net=host -v "/var/lib/thar/api.sock:/var/lib/thar/api.sock" ssm /usr/bin/amazon-ssm-agent
 KillMode=process
 Restart=always
 RestartSec=5

--- a/packages/ssm/ssm-tmpfiles.conf
+++ b/packages/ssm/ssm-tmpfiles.conf
@@ -1,3 +1,8 @@
-C /etc/amazon/ssm/seelog.xml - - - -
-C /etc/amazon/ssm/amazon-ssm-agent.json - - - -
-d /var/lib/amazon/ssm - - - -
+C /var/lib/amazon/ssm/etc/amazon/ssm/seelog.xml - - - -
+C /var/lib/amazon/ssm/etc/amazon/ssm/amazon-ssm-agent.json - - - -
+C /var/lib/amazon/ssm/Dockerfile - - - -
+C /var/lib/amazon/ssm/usr/bin/amazon-ssm-agent - - - -
+C /var/lib/amazon/ssm/usr/bin/ssm-cli - - - -
+C /var/lib/amazon/ssm/usr/bin/ssm-document-worker - - - -
+C /var/lib/amazon/ssm/usr/bin/ssm-session-worker - - - -
+C /var/lib/amazon/ssm/usr/bin/ssm-session-logger - - - -


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazonlinux/PRIVATE-thar/issues/114

*Description of changes:*
Run the SSM agent and tools inside a container instead of directly on
the host. For now this is built from an AL2 container with the SSM
resources added into the image. Since these files are now only used in
the container they are moved out of the normal file system hierarchy.

The API socket is mapped in and host networking enabled to give the SSM
agent access to the API server, but otherwise it has no access to the
rest of the system.

*Tested by:*
Launching an instance and verifying that an SSM session can be launched and presents a shell.

TODO: Double check that the SSM container can reach the API server, or add any other resources it should have access to.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
