### PR TITLE
Add migrator service

### DIFF
--- a/packages/api/api.spec
+++ b/packages/api/api.spec
@@ -20,6 +20,7 @@ Source5: settings-committer.service
 Source6: migration-tmpfiles.conf
 Source7: settings-applier.service
 Source8: data-store-version
+Source9: migrator.service
 %cargo_bundle_crates -n %{workspace_name} -t 0
 BuildRequires: gcc-%{_cross_target}
 BuildRequires: %{_cross_os}glibc-devel
@@ -97,6 +98,7 @@ install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE3}
 install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE4}
 install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE5}
 install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE7}
+install -m 0644 -t %{buildroot}/%{systemd_systemdir} %{SOURCE9}
 
 install -d %{buildroot}/%{_cross_datadir}/thar
 install -m 0644 -t %{buildroot}/%{_cross_datadir}/thar %{SOURCE8}
@@ -131,6 +133,7 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 %files -n %{_cross_os}apiserver
 %{_cross_bindir}/apiserver
 %{systemd_systemdir}/apiserver.service
+%{systemd_systemdir}/migrator.service
 %{_cross_datadir}/thar/data-store-version
 
 %files -n %{_cross_os}apiclient

--- a/packages/api/apiserver.service
+++ b/packages/api/apiserver.service
@@ -1,9 +1,7 @@
 [Unit]
 Description=Thar API server
-After=network.target
-After=storewolf.service
-Requires=network.target
-Requires=storewolf.service
+After=network.target storewolf.service migrator.service
+Requires=network.target storewolf.service migrator.service
 
 [Service]
 Type=simple

--- a/packages/api/migrator.service
+++ b/packages/api/migrator.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Thar data store migrator
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/migrator --datastore-path /var/lib/thar/datastore/current --migration-directories /var/lib/thar/datastore/migrations --migrate-to-version-from-file /usr/share/thar/data-store-version -v -v -v
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/api/storewolf.service
+++ b/packages/api/storewolf.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Datastore creator
+After=migrator.service
+Requires=migrator.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The migrator service initiates migration of the data store to the version
specified in the image we just booted; this may be the same version, in which
case it will do nothing.

We want to run very early in boot so other components can rely on the fact that
the data store format version is what they expect.  In particular, it runs
before storewolf, because there's no need to migrate data that storewolf just
populated; storewolf comes from the new image and understands the new format.

**Issue number:**

Partially addresses #64.

**Testing done:**

Note: I included our test migration in the image.

In the normal case, where the incoming version file matches the data store, the migrator does nothing:
```
sh-5.0# systemctl status migrator
● migrator.service - Thar data store migrator
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/migrator.service; enabled; vendor preset: enabled)
   Active: active (exited) since Mon 2019-08-26 23:08:56 UTC; 2min 55s ago
  Process: 2570 ExecStart=/usr/bin/migrator --datastore-path /var/lib/thar/datastore/current --migration-directories /var/lib/thar/datastore/migrations --migrate-to-version-from-file /usr/share/thar/data-store-version -v -v -v (code=exited, status=0/SUCCESS)
 Main PID: 2570 (code=exited, status=0/SUCCESS)

Aug 26 23:08:56 localhost systemd[1]: Starting Thar data store migrator...
Aug 26 23:08:56 localhost migrator[2570]: 2019-08-26T23:08:56.754+00:00 - INFO - Requested version v0.0 matches version of given datastore at '/var/lib/thar/datastore/v0.0_bhIksZMKQhyMbho2'; nothing to do
Aug 26 23:08:56 localhost systemd[1]: Started Thar data store migrator.
sh-5.0# cat /usr/share/thar/data-store-version
0.0
```

If I change the incoming version, the migrator runs:
```
sh-5.0# mount -t tmpfs -o size=1M tmpfs /usr/share/thar
sh-5.0# echo 0.1 > /usr/share/thar/data-store-version
sh-5.0# cat /var/lib/thar/datastore/current/live/settings/timezone
"America/Los_Angeles"sh-5.0#
sh-5.0# systemctl restart migrator
```

It changed data correctly:
```
sh-5.0# cat /var/lib/thar/datastore/current/live/settings/timezone
"NewAmerica/Los_Angeles"sh-5.0#
```

Full migrator log:
```
sh-5.0# systemctl status migrator
● migrator.service - Thar data store migrator
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/migrator.service; enabled; vendor preset: enabled)
   Active: active (exited) since Mon 2019-08-26 23:14:27 UTC; 11s ago
  Process: 6016 ExecStart=/usr/bin/migrator --datastore-path /var/lib/thar/datastore/current --migration-directories /var/lib/thar/datastore/migrations --migrate-to-version-from-
file /usr/share/thar/data-store-version -v -v -v (code=exited, status=0/SUCCESS)
 Main PID: 6016 (code=exited, status=0/SUCCESS)

Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.782+00:00 - TRACE - Found potential migration: /var/lib/thar/datastore/migrations/migrate_v0.1_testmigration
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.783+00:00 - INFO - Found applicable forward migration 'migrate_v0.1_testmigration': v0.0 < (v0.1) <= v0.1
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.783+00:00 - DEBUG - Sorted migrations: ["migrate_v0.1_testmigration"]
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.783+00:00 - INFO - Copying datastore from /var/lib/thar/datastore/v0.0_bhIksZMKQhyMbho2 to work location /va
r/lib/thar/datastore/v0.1_Qs3h7TfCRRdQTUEl
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.792+00:00 - INFO - Running migration command: "/var/lib/thar/datastore/migrations/migrate_v0.1_testmigration
" "--forward" "--datastore-path" "/var/lib/thar/datastore/v0.1_Qs3h7TfCRRdQTUEl"
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.814+00:00 - DEBUG - Migration stdout:
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.814+00:00 - DEBUG - Migration stderr:
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.814+00:00 - INFO - Flipping /var/lib/thar/datastore/v0.1 to point to v0.1_Qs3h7TfCRRdQTUEl
Aug 26 23:14:27 ip-192-168-111-36 migrator[6016]: 2019-08-26T23:14:27.814+00:00 - INFO - Flipping /var/lib/thar/datastore/v0 to point to v0.1
Aug 26 23:14:27 ip-192-168-111-36 systemd[1]: Started Thar data store migrator.
```

I rebooted, which resets the version file back to 0.0, and the migration ran in reverse correctly:
```
sh-5.0# cat /var/lib/thar/datastore/current/live/settings/timezone
"America/Los_Angeles"sh-5.0#
```