### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Jacob Peddicord <peddicor@amazon.com> <jpeddicord@users.noreply.github.com>
+Michael Patraw <patraw@amazon.com> <52084153+patraw@users.noreply.github.com>
+Samuel Mendoza-Jonas <samjonas@amazon.com> <53018225+sam-aws@users.noreply.github.com>
+Tom Kirchner <tjk@amazon.com> <tjkirch@users.noreply.github.com>
+Zac Mrowicki <mrowicki@amazon.com>
+Zac Mrowicki <mrowicki@amazon.com> <zmrowicki@hotmail.com>


### PR DESCRIPTION
@tjkirch and I have been talking about doing this for a while but I'm finally getting around to it. :)

To quote git-shortlog(1):

> The **.mailmap** feature is used to coalesce together commits by the same person in the shortlog, where their name and/or email address was spelled differently.

This deduplicates people in `git shortlog -se`, and [in Git 2.23 it also rewrites names/emails in `git log` output as well](https://github.blog/2019-08-16-highlights-from-git-2-23/). Try it out!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.