### PR TITLE
Fix 'dyn' warnings

### DIFF
--- a/workspaces/api/apiclient/src/main.rs
+++ b/workspaces/api/apiclient/src/main.rs
@@ -90,7 +90,7 @@ fn parse_args(args: env::Args) -> Args {
     }
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = parse_args(env::args());
 
     let (status, body) =

--- a/workspaces/api/thar-be-settings/src/helpers.rs
+++ b/workspaces/api/thar-be-settings/src/helpers.rs
@@ -89,7 +89,7 @@ pub fn base64_decode(
     _: &Handlebars,
     _: &Context,
     renderctx: &mut RenderContext,
-    out: &mut Output,
+    out: &mut dyn Output,
 ) -> Result<(), RenderError> {
     // To give context to our errors, get the template name.
     // In the context of thar-be-settings, all of our templates have

--- a/workspaces/api/thar-be-settings/src/main.rs
+++ b/workspaces/api/thar-be-settings/src/main.rs
@@ -100,7 +100,7 @@ fn parse_args(args: env::Args) -> Args {
 fn write_config_files(
     args: &Args,
     files_limit: Option<HashSet<String>>,
-) -> Result<(), Box<std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error>> {
     // Create a vec of ConfigFile structs from the list of changed services
     info!("Requesting configuration file data for affected services");
     let config_files = config::get_affected_config_files(&args.socket_path, files_limit)?;
@@ -125,7 +125,7 @@ fn write_config_files(
     Ok(())
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse and store the args passed to the program
     let args = parse_args(env::args());
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #164

*Description of changes:* Fixes all the `warning: trait objects without an explicit ``dyn`` are deprecated` warnings in first party rust code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
