### PR TITLE
thar-be-settings fallible mode

### DIFF
--- a/workspaces/api/thar-be-settings/src/main.rs
+++ b/workspaces/api/thar-be-settings/src/main.rs
@@ -116,7 +116,11 @@ fn write_config_files(
 
     // Ensure all files render properly
     info!("Rendering config files...");
-    let rendered = config::render_config_files(&template_registry, config_files, settings)?;
+    let strict = match &args.mode {
+        RunMode::SpecificKeys => true,
+        RunMode::All => false,
+    };
+    let rendered = config::render_config_files(&template_registry, config_files, settings, strict)?;
 
     // If all the config renders properly, write it to disk
     info!("Writing config files to disk...");


### PR DESCRIPTION
Changes thar-be-settings to ignore failed config file renders if the program is run with the argument `--all`.

*Issue #, if available:*
Fixes #194 

*Description of changes:*
* Add a boolean flag to `config::render_config_files()` that will determine if failed renders are ignored.
* Use `RunMode` to determine the correct boolean to pass to the above function.

*Testing done:*
* Unit tests pass
* On a newly booted image:
All files and config files are populated on boot.  Removing all K8s related settings, and re-running `thar-be-settings --all` does not fail and does not render the kubernetes related files.
```
bash-5.0# rm -r /var/lib/thar/datastore/current/live/settings/kubernetes/*
bash-5.0# rm -r /etc/kubernetes/*
bash-5.0# thar-be-settings --all -v -v -v -v
...SNIP...
2019-08-27T21:17:29.712+00:00 - INFO - Writing config files to disk...
2019-08-27T21:17:29.713+00:00 - DEBUG - Writing "/etc/updog.toml"
2019-08-27T21:17:29.714+00:00 - DEBUG - Writing "/etc/hostname"
2019-08-27T21:17:29.715+00:00 - INFO - Restarting all services...
...SNIP...
bash-5.0# ls /etc/kubernetes/
bash-5.0#
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
