### PR TITLE
build: Write the bootable disk image as sparse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ define build_image
 		--opt build-arg:DATE=$(DATE) \
 		--output type=local,dest=$(OUTPUT) \
 		$(BUILDCTL_ARGS)
-	lz4 -d $(OUTPUT)/$(OS)-$(1).img.lz4 >$(OUTPUT)/$(OS)-$(1).img \
+	lz4 -d -f $(OUTPUT)/$(OS)-$(1).img.lz4 $(OUTPUT)/$(OS)-$(1).img \
 		&& rm -f $(OUTPUT)/$(OS)-$(1).img.lz4
 endef
 


### PR DESCRIPTION
I did all the work to make the image pass through BuildKit as an lz4-compressed image to save sparseness... and then forgot that redirecting output of lz4 -d does not make it sparse. :(

This speeds up incremental image builds.

```
$ ls -lsh build/*.img
757M -rw-r--r-- 1 ec2-user ec2-user 4.0G Aug 27 20:49 build/thar-x86_64.img
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
