### PR TITLE
migrator: exit cleanly if data store does not exist

### DIFF
--- a/workspaces/api/migration/migrator/src/args.rs
+++ b/workspaces/api/migration/migrator/src/args.rs
@@ -3,7 +3,7 @@
 use data_store_version::Version;
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::str::FromStr;
 
@@ -56,6 +56,13 @@ impl Args {
                         .next()
                         .unwrap_or_else(|| usage_msg("Did not give argument to --datastore-path"));
                     trace!("Given --datastore-path: {}", path_str);
+
+                    // On first boot, the data store won't exist yet, because storewolf runs after.
+                    if !Path::new(&path_str).exists() {
+                        eprintln!("Data store does not exist at given path, exiting ({})", path_str);
+                        process::exit(0);
+                    }
+
                     let canonical = fs::canonicalize(path_str).unwrap_or_else(|e| {
                         usage_msg(format!(
                             "Could not canonicalize given data store path: {}",


### PR DESCRIPTION
I screwed up in #191.  I had originally used a Wanted dependency on migrator in storewolf, but changed to a Requires because we can't be sure installing new defaults is safe if migrations failed.  I thought I tested with this, but either I screwed up the build or the build system didn't include the change, and I didn't catch it.

What happens now is that the migrator fails to start on first boot because the data store doesn't exist yet (because storewolf hasn't run yet) which prevents storewolf and future services from starting, giving a broken system.

This seems like the cleanest solution - make the migrator understand that the data store may not exist yet, and just print a message and exit cleanly.

---

**Testing done:**

Made a new image; services come up OK now.  You can see the new message in migrator output:
```
sh-5.0# systemctl status migrator
● migrator.service - Thar data store migrator
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/migrator.service; enabled; vendor preset: enabled)
   Active: active (exited) since Wed 2019-08-28 17:19:28 UTC; 1min 6s ago
  Process: 2544 ExecStart=/usr/bin/migrator --datastore-path /var/lib/thar/datastore/current --migration-directories /var/lib/thar/datastore/migrations --migrate-to-version-from-file /usr/share/thar/data-sto
re-version -v -v -v (code=exited, status=0/SUCCESS)
 Main PID: 2544 (code=exited, status=0/SUCCESS)

Aug 28 17:19:28 localhost systemd[1]: Starting Thar data store migrator...
Aug 28 17:19:28 localhost migrator[2544]: Data store does not exist at given path, exiting (/var/lib/thar/datastore/current)
Aug 28 17:19:28 localhost systemd[1]: Started Thar data store migrator.
```

Everything else came up:
```
sh-5.0# systemctl status | head
● ip-192-168-107-161
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Wed 2019-08-28 17:19:23 UTC; 1min 38s ago
   CGroup: /
           ├─init.scope
           │ └─1 /sbin/init
           ├─system.slice
           │ ├─amazon-ssm-agent.service
```

Rerunning migrator makes it actually check things, now that the data store exists:
```
sh-5.0# systemctl restart migrator
sh-5.0# systemctl status migrator
● migrator.service - Thar data store migrator
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/migrator.service; enabled; vendor preset: enabled)
   Active: active (exited) since Wed 2019-08-28 17:21:47 UTC; 4s ago
  Process: 4186 ExecStart=/usr/bin/migrator --datastore-path /var/lib/thar/datastore/current --migration-directories /var/lib/thar/datastore/migrations --migrate-to-version-from-file /usr/share/thar/data-sto
re-version -v -v -v (code=exited, status=0/SUCCESS)
 Main PID: 4186 (code=exited, status=0/SUCCESS)

Aug 28 17:21:47 ip-192-168-107-161 systemd[1]: Starting Thar data store migrator...
Aug 28 17:21:47 ip-192-168-107-161 migrator[4186]: 2019-08-28T17:21:47.459+00:00 - INFO - Requested version v0.0 matches version of given datastore at '/var/lib/thar/datastore/v0.0_YDGurXYXUOipKXCR'; nothing
 to do
Aug 28 17:21:47 ip-192-168-107-161 systemd[1]: Started Thar data store migrator.
```