### PR TITLE
Add README for migrator

### DIFF
--- a/workspaces/api/Cargo.lock
+++ b/workspaces/api/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
 name = "migrator"
 version = "0.1.0"
 dependencies = [
+ "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "data_store_version 0.1.0",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/workspaces/api/migration/migrator/Cargo.toml
+++ b/workspaces/api/migration/migrator/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 edition = "2018"
 publish = false
+build = "build.rs"
 
 [dependencies]
 data_store_version = { path = "../../data_store_version" }
@@ -15,3 +16,6 @@ rand = { version = "0.7", default-features = false, features = ["std"] }
 regex = "1.1"
 snafu = "0.5"
 stderrlog = "0.4"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/workspaces/api/migration/migrator/README.md
+++ b/workspaces/api/migration/migrator/README.md
@@ -1,0 +1,25 @@
+# migrator
+
+Current version: 0.1.0
+
+migrator is a tool to run migrations built with the migration-helpers library.
+
+It must be given:
+* a data store to migrate
+* a version to migrate it to
+* where to find migration binaries
+
+Given those, it will:
+* confirm that the given data store has the appropriate versioned symlink structure
+* find the version of the given data store
+* find migrations between the two versions
+* copy the data store
+* run the migrations on the copy
+* do a symlink-flip so the copy takes the place of the original
+
+To understand motivation and more about the overall process, look at the migration system
+documentation, one level up.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/workspaces/api/migration/migrator/README.tpl
+++ b/workspaces/api/migration/migrator/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/workspaces/api/migration/migrator/build.rs
+++ b/workspaces/api/migration/migrator/build.rs
@@ -1,0 +1,25 @@
+// Automatically generate README.md from rustdoc.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/workspaces/api/migration/migrator/src/main.rs
+++ b/workspaces/api/migration/migrator/src/main.rs
@@ -1,7 +1,20 @@
-//! This is a tool to run migrations built with the migration-helpers library.
+//! migrator is a tool to run migrations built with the migration-helpers library.
 //!
-//! Given a data store and a version to migrate it to, it will find and run appropriate migrations
-//! for the version on a copy of the data store, then symlink-flip it into place.
+//! It must be given:
+//! * a data store to migrate
+//! * a version to migrate it to
+//! * where to find migration binaries
+//!
+//! Given those, it will:
+//! * confirm that the given data store has the appropriate versioned symlink structure
+//! * find the version of the given data store
+//! * find migrations between the two versions
+//! * copy the data store
+//! * run the migrations on the copy
+//! * do a symlink-flip so the copy takes the place of the original
+//!
+//! To understand motivation and more about the overall process, look at the migration system
+//! documentation, one level up.
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Addresses one bullet of #189.

Just a basic README for migrator, using cargo-readme as with our other crates.
