### PR TITLE
Remove host-containers.user setting

### DIFF
--- a/workspaces/api/apiserver/src/model.rs
+++ b/workspaces/api/apiserver/src/model.rs
@@ -85,9 +85,6 @@ pub struct HostContainersSettings {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub control: Option<ContainerImage>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<Vec<ContainerImage>>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/workspaces/api/storewolf/defaults.toml
+++ b/workspaces/api/storewolf/defaults.toml
@@ -91,9 +91,6 @@ enabled = true
 source = "FIXME.dkr.ecr.us-west-2.amazonaws.com/thar-ssm:latest"
 superpowered = false
 
-[settings.host-containers]
-user = []
-
 # [services.host-containers]
 # configuration-files = ["host-containers"]
 # restart-commands = ["/bin/systemctl try-reload-or-restart host-containers"]


### PR DESCRIPTION
Signed-off-by: Jamie Anderson <jamieand@amazon.com>

We decided to remove the host-containers.user setting until we have a firmer idea of how to implement support for it.
