### PR TITLE
strace: fix build failure with new host environment

### DIFF
--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -16,7 +16,8 @@ Requires: %{_cross_os}glibc
 %autosetup -n strace-%{version} -p1
 
 %build
-%cross_configure
+%cross_configure \
+  --disable-mpers \
 
 %make_build
 


### PR DESCRIPTION
Now that `readelf` is available, strace runs a test to see
whether the compiler can build 32-bit binaries in order to
enable the mpers feature.

This works for x86_64 but not for aarch64.

Signed-off-by: Ben Cressey <bcressey@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
Fix failure to build for aarch64.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
