### PR TITLE
Make sd_notify functionality an optional feature

### DIFF
--- a/packages/api/api.spec
+++ b/packages/api/api.spec
@@ -91,8 +91,10 @@ Summary: Commits settings from user data, defaults, and generators at boot
 %cargo_prep
 
 %build
+%cargo_build --path %{workspace_dir}/apiserver --features sd_notify
+
 for p in \
-  apiclient apiserver \
+  apiclient \
   moondog netdog sundog pluto \
   thar-be-settings storewolf settings-committer \
   migration/migrator ;

--- a/workspaces/api/apiserver/Cargo.toml
+++ b/workspaces/api/apiserver/Cargo.toml
@@ -18,7 +18,12 @@ snafu = "0.5"
 stderrlog = "0.4"
 toml = "0.5"
 walkdir = "2.2"
-systemd = { version = "0.4.0", default-features = false, features = [] }
+systemd = { version = "0.4.0", default-features = false, features = [], optional = true }
+
+[features]
+default = []
+
+sd_notify = ["systemd"]
 
 [build-dependencies]
 cargo-readme = "3.1"


### PR DESCRIPTION
The `apiserver`'s `sd_notify` mechanism requires the `systemd` crate. It has a
dependency on `systemd-devel` which would make builds fail outside of package
builds which is troublesome for `cargo test`

*Description of changes:* 

Separated out the `sd_notify` related code into a crate feature named `sd_notify` and exclude it from default features. 
Adds specification to build with feature `sd_notify` when building `apiserver` in `api.spec`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
