### PR TITLE
Add servicedog: systemd unit supervisor

### DIFF
--- a/packages/api/api.spec
+++ b/packages/api/api.spec
@@ -70,6 +70,12 @@ Requires: %{_cross_os}apiserver = %{version}-%{release}
 %description -n %{_cross_os}thar-be-settings
 %{summary}.
 
+%package -n %{_cross_os}servicedog
+Summary: Manipulates systemd units based on setting changes
+Requires: %{_cross_os}apiserver = %{version}-%{release}
+%description -n %{_cross_os}servicedog
+%{summary}.
+
 %package -n %{_cross_os}storewolf
 Summary: Data store creator
 Requires: %{_cross_os}apiserver = %{version}-%{release}
@@ -96,7 +102,7 @@ Summary: Commits settings from user data, defaults, and generators at boot
 for p in \
   apiclient \
   moondog netdog sundog pluto \
-  thar-be-settings storewolf settings-committer \
+  thar-be-settings servicedog storewolf settings-committer \
   migration/migrator ;
 do
   %cargo_build --path %{workspace_dir}/${p}
@@ -115,7 +121,7 @@ install -d %{buildroot}%{_cross_bindir}
 for p in \
   apiclient apiserver \
   moondog netdog sundog pluto \
-  thar-be-settings storewolf settings-committer \
+  thar-be-settings servicedog storewolf settings-committer \
   migrator ;
 do
   install -p -m 0755 bin/${p} %{buildroot}%{_cross_bindir}
@@ -164,6 +170,9 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 %files -n %{_cross_os}thar-be-settings
 %{_cross_bindir}/thar-be-settings
 %{_cross_unitdir}/settings-applier.service
+
+%files -n %{_cross_os}servicedog
+%{_cross_bindir}/servicedog
 
 %files -n %{_cross_os}storewolf
 %{_cross_bindir}/storewolf

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -36,6 +36,7 @@ Requires: %{_cross_os}signpost
 Requires: %{_cross_os}sundog
 Requires: %{_cross_os}pluto
 Requires: %{_cross_os}storewolf
+Requires: %{_cross_os}servicedog
 Requires: %{_cross_os}settings-committer
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}thar-be-settings

--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -2342,6 +2342,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "servicedog"
+version = "0.1.0"
+dependencies = [
+ "apiclient 0.1.0",
+ "apiserver 0.1.0",
+ "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "settings-committer"
 version = "0.1.0"
 dependencies = [

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "api/netdog",
     "api/sundog",
     "api/pluto",
+    "api/servicedog",
     "api/storewolf",
     "api/thar-be-settings",
     "api/settings-committer",

--- a/workspaces/api/servicedog/Cargo.toml
+++ b/workspaces/api/servicedog/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "servicedog"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[dependencies]
+apiclient = { path = "../apiclient" }
+apiserver = { path = "../apiserver" }
+http = "0.1"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+snafu = "0.5"
+stderrlog = "0.4"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/workspaces/api/servicedog/README.md
+++ b/workspaces/api/servicedog/README.md
@@ -1,0 +1,20 @@
+# servicedog
+
+Current version: 0.1.0
+
+## Background
+
+servicedog is a simple systemd unit supervisor.
+Its job is to start/stop and enable/disable systemd units based on a setting value it is told to query.
+
+When a setting changes, thar-be-settings does its job and renders configuration files and calls all restart-commands for any affected services.
+For settings that represent the desire state of a service, servicedog can be included in the list of restart-commands to manipulate the state of the service based on the value of the setting.
+It's provided the name of a setting to query, as well as the systemd unit to act on.
+First it queries the value of the setting; the only supported values at this time are "true" and "false".
+If the setting is true, servicedog attempts to start and enable the given systemd unit. If the setting is false, it stops and disables the unit.
+As its very last step, service dog calls `systemd daemon-reload` to ensure all changes take affect.
+
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/workspaces/api/servicedog/README.tpl
+++ b/workspaces/api/servicedog/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/workspaces/api/servicedog/build.rs
+++ b/workspaces/api/servicedog/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/workspaces/api/servicedog/src/main.rs
+++ b/workspaces/api/servicedog/src/main.rs
@@ -1,0 +1,337 @@
+/*!
+# Background
+
+servicedog is a simple systemd unit supervisor.
+Its job is to start/stop and enable/disable systemd units based on a setting value it is told to query.
+
+When a setting changes, thar-be-settings does its job and renders configuration files and calls all restart-commands for any affected services.
+For settings that represent the desire state of a service, servicedog can be included in the list of restart-commands to manipulate the state of the service based on the value of the setting.
+It's provided the name of a setting to query, as well as the systemd unit to act on.
+First it queries the value of the setting; the only supported values at this time are "true" and "false".
+If the setting is true, servicedog attempts to start and enable the given systemd unit. If the setting is false, it stops and disables the unit.
+As its very last step, service dog calls `systemd daemon-reload` to ensure all changes take affect.
+
+*/
+use snafu::{ensure, OptionExt, ResultExt};
+use std::env;
+use std::ffi::OsStr;
+use std::process::{self, Command};
+
+use apiserver::datastore::serialization::to_pairs_with_prefix;
+use apiserver::model;
+
+#[macro_use]
+extern crate log;
+
+// FIXME Get from configuration in the future
+const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const API_SETTINGS_URI: &str = "/settings";
+
+const SYSTEMCTL_BIN: &str = "/bin/systemctl";
+
+mod error {
+    use http::StatusCode;
+    use snafu::Snafu;
+    use std::process::{Command, Output};
+
+    use apiserver::datastore::serialization;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Error sending {} to {}: {}", method, uri, source))]
+        APIRequest {
+            method: String,
+            uri: String,
+            source: apiclient::Error,
+        },
+
+        #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]
+        APIResponse {
+            method: String,
+            uri: String,
+            code: StatusCode,
+            response_body: String,
+        },
+
+        #[snafu(display(
+            "Error deserializing response as JSON from {} to {}: {}",
+            method,
+            uri,
+            source
+        ))]
+        ResponseJson {
+            method: &'static str,
+            uri: String,
+            source: serde_json::Error,
+        },
+
+        #[snafu(display("Error serializing settings: {} ", source))]
+        SerializeSettings { source: serialization::Error },
+
+        #[snafu(display(
+            "Unknown value for '{}': got '{}', expected 'true' or 'false'",
+            setting,
+            state
+        ))]
+        UnknownSettingState { setting: String, state: String },
+
+        #[snafu(display("Setting '{}' does not exist in the data store", setting))]
+        NonexistentSettting { setting: String },
+
+        #[snafu(display("Failed to execute '{:?}': {}", command, source))]
+        ExecutionFailure {
+            command: Command,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Systemd command failed - stderr: {}",
+                        std::str::from_utf8(&output.stderr).unwrap_or_else(|_| "<invalid UTF-8>")))]
+        SystemdCommandFailure { output: Output },
+    }
+}
+
+type Result<T> = std::result::Result<T, error::Error>;
+
+/// SettingState represents the possible states of systemd units for Thar
+enum SettingState {
+    Enabled,
+    Disabled,
+}
+
+impl SettingState {
+    /// Query the datastore for a given setting and return the corresponding
+    /// SettingState.
+    fn query<S>(setting: S) -> Result<Self>
+    where
+        S: AsRef<str>,
+    {
+        match query_setting_value(&setting)?.as_ref() {
+            "true" => Ok(SettingState::Enabled),
+            "false" => Ok(SettingState::Disabled),
+            other => {
+                return error::UnknownSettingState {
+                    setting: setting.as_ref(),
+                    state: other,
+                }
+                .fail()
+            }
+        }
+    }
+}
+
+/// Query the datastore for a given setting and return the setting's value.
+// Currently getting the value of a setting requires a few gyrations. The
+// API returns a nested structure that can be deserialized to a Settings struct.
+// We can then serialize this structure to a map of
+// dotted.key.setting -> value. Using this map we can get the setting value.
+// FIXME remove this when we have an API client.
+fn query_setting_value<S>(setting: S) -> Result<String>
+where
+    S: AsRef<str>,
+{
+    let setting = setting.as_ref();
+    debug!("Querying the API for setting: {}", setting);
+
+    let uri = format!("{}?keys={}", API_SETTINGS_URI, setting);
+    let (code, response_body) = apiclient::raw_request(DEFAULT_API_SOCKET, &uri, "GET", None)
+        .context(error::APIRequest {
+            method: "GET",
+            uri: uri.to_string(),
+        })?;
+    ensure!(
+        code.is_success(),
+        error::APIResponse {
+            method: "GET",
+            uri,
+            code,
+            response_body,
+        }
+    );
+
+    // Build a Settings struct from the response string
+    let settings: model::Settings =
+        serde_json::from_str(&response_body).context(error::ResponseJson { method: "GET", uri })?;
+
+    // Serialize the Settings struct into key/value pairs. This builds the dotted
+    // string representation of the setting
+    let setting_keypair = to_pairs_with_prefix("settings".to_string(), &settings)
+        .context(error::SerializeSettings)?;
+    debug!("Retrieved setting keypair: {:#?}", &setting_keypair);
+
+    // (Hopefully) get the value from the map using the dotted string supplied
+    // to the function
+    Ok(setting_keypair
+        .get(setting)
+        .context(error::NonexistentSettting { setting: setting })?
+        .to_string())
+}
+
+/// SystemdUnit stores the systemd unit being manipulated
+struct SystemdUnit {
+    unit: String,
+}
+
+// FIXME: In the future we should probably look into interfacing directly
+// with systemd either via dbus or Rust bindings to systemd
+impl SystemdUnit {
+    fn new<S>(unit: S) -> Self
+    where
+        S: AsRef<str>,
+    {
+        SystemdUnit {
+            unit: unit.as_ref().to_string(),
+        }
+    }
+
+    /// Starts the current systemd unit
+    fn start(&self) -> Result<()> {
+        run(&["start", &self.unit])
+    }
+
+    /// Stops the current systemd unit
+    fn stop(&self) -> Result<()> {
+        run(&["stop", &self.unit])
+    }
+
+    /// Enables the current systemd unit
+    fn enable(&self) -> Result<()> {
+        run(&["enable", &self.unit])
+    }
+
+    /// Disables the current systemd unit
+    fn disable(&self) -> Result<()> {
+        run(&["disable", &self.unit])
+    }
+}
+
+/// Calls `systemd daemon-reload` which reloads the systemd configuration.
+/// According to docs, this *shouldn't* be necessary but experience
+/// has show this isn't always the case. It shoudn't hurt to call it
+fn systemd_daemon_reload() -> Result<()> {
+    run(&["daemon-reload"])
+}
+
+/// Wrapper around process::Command that does error handling.
+fn run<I, S>(args: I) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    // Instantiate command before adding args. Command::new() returns
+    // a `Command` whereas `.args()` returns a `&mut Command`. We use
+    // `Command` in our error reporting, which does not play nice with
+    // mutable references.
+    let mut command = Command::new(SYSTEMCTL_BIN);
+    command.args(args);
+    let output = command
+        .output()
+        .context(error::ExecutionFailure { command })?;
+
+    ensure!(
+        output.status.success(),
+        error::SystemdCommandFailure { output }
+    );
+    Ok(())
+}
+
+/// Store the args we receive on the command line
+struct Args {
+    setting: String,
+    systemd_unit: String,
+    verbosity: usize,
+}
+
+/// Print a usage message in the event a bad arg is passed
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            [ -s | --setting SETTING ]
+            [ -u | --systemd-unit UNIT ]
+            [ --verbose --verbose ... ]",
+        program_name
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
+    eprintln!("{}\n", msg.as_ref());
+    usage();
+}
+
+/// Parse the args to the program and return an Args struct
+fn parse_args(args: env::Args) -> Args {
+    let mut setting = None;
+    let mut systemd_unit = None;
+    let mut verbosity = 2;
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "-v" | "--verbose" => verbosity += 1,
+
+            "-s" | "--setting" => {
+                setting = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to -s | --setting")),
+                )
+            }
+            "-u" | "--systemd-unit" => {
+                systemd_unit =
+                    Some(iter.next().unwrap_or_else(|| {
+                        usage_msg("Did not give argument to -u | --systemd-unit")
+                    }))
+            }
+
+            _ => usage(),
+        }
+    }
+
+    Args {
+        setting: setting.unwrap_or_else(|| usage_msg("-s|--setting is a required argument")),
+        systemd_unit: systemd_unit
+            .unwrap_or_else(|| usage_msg("-u|--systemd-unit is a required argument")),
+        verbosity,
+    }
+}
+
+fn main() -> Result<()> {
+    // Parse and store the args passed to the program
+    let args = parse_args(env::args());
+
+    // TODO Fix this later when we decide our logging story
+    // Start the logger
+    stderrlog::new()
+        .module(module_path!())
+        .timestamp(stderrlog::Timestamp::Millisecond)
+        .verbosity(args.verbosity)
+        .color(stderrlog::ColorChoice::Never)
+        .init()
+        .context(error::Logger)?;
+
+    info!("servicedog started for unit {}", &args.systemd_unit);
+
+    let systemd_unit = SystemdUnit::new(&args.systemd_unit);
+
+    match SettingState::query(args.setting)? {
+        SettingState::Enabled => {
+            info!("Starting and enabling unit {}", &args.systemd_unit);
+            systemd_unit.start()?;
+            systemd_unit.enable()?;
+            systemd_daemon_reload()?;
+        }
+
+        SettingState::Disabled => {
+            info!("Stopping and disabling unit {}", &args.systemd_unit);
+            systemd_unit.stop()?;
+            systemd_unit.disable()?;
+            systemd_daemon_reload()?;
+        }
+    };
+    Ok(())
+}


### PR DESCRIPTION
This adds a new program "servicedog". This main purpose of this program
is to manage the state of systemd units based on setting status and
will most often be used as a restart command to be run when settings
change.

*Issue #, if available:*
Implements #218 

*Description of changes:*
* Add servicedog and related README generation code
* Add servicedog to packaging for Thar

*Testing done:*
* Unit tests pass
* Image builds and I can run the binary, it doesn't really do anything yet without all the other pieces.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
