### PR TITLE
build: remove cache volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN --mount=target=/host \
 
 USER builder
 RUN --mount=source=.cargo,target=/home/builder/.cargo \
-    --mount=type=cache,target=/home/builder/.cache,uid=1000,id=${PACKAGE} \
     --mount=source=workspaces,target=/home/builder/rpmbuild/BUILD/workspaces \
     rpmbuild -ba --clean rpmbuild/SPECS/${PACKAGE}.spec
 


### PR DESCRIPTION
The cache `id` was not set correctly, leading to various undefined
behaviors as the overlay volume was reused across parallel builds.

Adding it back is gated on the ability to use variables this way:
  https://github.com/moby/buildkit/issues/815

Signed-off-by: Ben Cressey <bcressey@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
