### PR TITLE
Finish initial host container integration

### DIFF
--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -49,7 +49,6 @@ members = [
     "rust",
     "sdk",
     "socat",
-    "ssm",
     "strace",
     "systemd",
     "updater",

--- a/packages/release/host-containers-systemd-unit-admin.template
+++ b/packages/release/host-containers-systemd-unit-admin.template
@@ -1,0 +1,13 @@
+[Unit]
+Description=Admin container
+After=host-containerd.service
+Requires=host-containerd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/host-ctr -ctr-id admin -source {{ settings.host-containers.admin.source }} {{#if  settings.host-containers.admin.superpowered }}-superpowered{{/if}}
+Restart=always
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/release/host-containers-systemd-unit-control.template
+++ b/packages/release/host-containers-systemd-unit-control.template
@@ -1,0 +1,13 @@
+[Unit]
+Description=Control container
+After=host-containerd.service
+Requires=host-containerd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/host-ctr -ctr-id control -source {{ settings.host-containers.control.source }} {{#if settings.host-containers.control.superpowered }}-superpowered{{/if}}
+Restart=always
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -12,6 +12,8 @@ Source99: release-tmpfiles.conf
 
 # FIXME What should own system-level file templates?
 Source200: hostname.template
+Source201: host-containers-systemd-unit-admin.template
+Source202: host-containers-systemd-unit-control.template
 
 Source1000: eth0.xml
 Source1002: configured.target
@@ -48,7 +50,6 @@ Requires: %{_cross_os}thar-be-settings
 Requires: %{_cross_os}migration
 Requires: %{_cross_os}updog
 Requires: %{_cross_os}util-linux
-Requires: %{_cross_os}amazon-ssm-agent
 Requires: %{_cross_os}preinit
 Requires: %{_cross_os}wicked
 
@@ -88,6 +89,8 @@ install -p -m 0644 %{S:1002} %{S:1003} %{S:1005} %{S:1006} %{S:1007} %{S:1008} %
 
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/hostname
+install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/host-containers-systemd-unit-admin
+install -p -m 0644 %{S:202} %{buildroot}%{_cross_templatedir}/host-containers-systemd-unit-control
 
 %files
 %{_cross_bindir}/login
@@ -105,5 +108,7 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/hostname
 %{_cross_unitdir}/opt.mount
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/hostname
+%{_cross_templatedir}/host-containers-systemd-unit-admin
+%{_cross_templatedir}/host-containers-systemd-unit-control
 
 %changelog

--- a/workspaces/api/servicedog/src/main.rs
+++ b/workspaces/api/servicedog/src/main.rs
@@ -187,9 +187,9 @@ impl SystemdUnit {
         }
     }
 
-    /// Starts the current systemd unit
-    fn start(&self) -> Result<()> {
-        run(&["start", &self.unit])
+    /// Starts the current systemd unit with the `--no-block` option
+    fn start_no_block(&self) -> Result<()> {
+        run(&["start", "--no-block", &self.unit])
     }
 
     /// Stops the current systemd unit
@@ -321,9 +321,10 @@ fn main() -> Result<()> {
     match SettingState::query(args.setting)? {
         SettingState::Enabled => {
             info!("Starting and enabling unit {}", &args.systemd_unit);
-            systemd_unit.start()?;
-            systemd_unit.enable()?;
             systemd_daemon_reload()?;
+            systemd_unit.enable()?;
+            // Don't block on starting the unit
+            systemd_unit.start_no_block()?;
         }
 
         SettingState::Disabled => {

--- a/workspaces/api/storewolf/defaults.toml
+++ b/workspaces/api/storewolf/defaults.toml
@@ -83,26 +83,39 @@ val = ["updog"]
 
 [settings.host-containers.admin]
 enabled = false
-source = "FIXME.dkr.ecr.us-west-2.amazonaws.com/thar-admin:latest"
+source = "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.1"
 superpowered = true
 
 [settings.host-containers.control]
 enabled = true
-source = "FIXME.dkr.ecr.us-west-2.amazonaws.com/thar-ssm:latest"
+source = "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.1"
 superpowered = false
 
-# [services.host-containers]
-# configuration-files = ["host-containers"]
-# restart-commands = ["/bin/systemctl try-reload-or-restart host-containers"]
+[services.host-containers-admin]
+configuration-files = ["host-containers-systemd-unit-admin"]
+restart-commands = ["/usr/bin/servicedog -s settings.host-containers.admin.enabled -u host-containers@admin.service"]
 
-# [configuration-files.host-containers]
-# path = "/etc/hostcontainers/host-containers.toml"
-# template-path = "/usr/share/templates/host-containers-toml"
+[services.host-containers-control]
+configuration-files = ["host-containers-systemd-unit-control"]
+restart-commands = ["/usr/bin/servicedog -s settings.host-containers.control.enabled -u host-containers@control.service"]
 
-# [[metadata]]
-# key = "settings.host-containers"
-# md = "affected-services"
-# val = "[host-containers]"
+[configuration-files.host-containers-systemd-unit-admin]
+path = "/etc/systemd/system/host-containers@admin.service"
+template-path = "/usr/share/templates/host-containers-systemd-unit-admin"
+
+[configuration-files.host-containers-systemd-unit-control]
+path = "/etc/systemd/system/host-containers@control.service"
+template-path = "/usr/share/templates/host-containers-systemd-unit-control"
+
+[[metadata]]
+key = "settings.host-containers.admin"
+md = "affected-services"
+val = ["host-containers-admin"]
+
+[[metadata]]
+key = "settings.host-containers.control"
+md = "affected-services"
+val = ["host-containers-control"]
 
 # NTP
 


### PR DESCRIPTION
Putting this in draft for now as it depends on #218 and #219 .  After both of those are merged, I will rebase this on top of them and make sure it all works.

*Issue #, if available:*
#229 

*Description of changes:*
This commit adds the final pieces to integrate host containers. It adds
default settings for admin and control container metadata, configuration
files, and restart commands. The template files for also included in
the packaging so they end up on the OS's filesystem in the proper place.

*Testing done:*
* Boot an image and ensure that the unit files end up in the right place with the right values (they don't do anything yet until the dependent PR's are merged)

**TODO**: Put the actual SSM and Admin container images in ECR and update `defaults.toml` to point to those images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
