### PR TITLE
build: reduce size of build script binaries

### DIFF
--- a/images/Cargo.toml
+++ b/images/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "aws-k8s",
 ]
 
-[profile.release]
-debug = true
+[profile.dev]
+debug = false
+opt-level = 'z'

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -56,3 +56,7 @@ members = [
     "util-linux",
     "wicked",
 ]
+
+[profile.dev]
+debug = false
+opt-level = 'z'


### PR DESCRIPTION
*Issue #, if available:*
#241 

*Description of changes:*
Adjust the default `dev` profile so our build script binaries are smaller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
