### PR TITLE
Move api socket to /run/api.sock

### DIFF
--- a/workspaces/api/apiclient/src/main.rs
+++ b/workspaces/api/apiclient/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::process;
 
-const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 
 /// Stores user-supplied arguments.
 struct Args {

--- a/workspaces/api/apiserver/src/bin/apiserver.rs
+++ b/workspaces/api/apiserver/src/bin/apiserver.rs
@@ -10,7 +10,7 @@ use std::process;
 
 use apiserver::serve;
 
-const DEFAULT_BIND_PATH: &str = "/var/lib/thar/api.sock";
+const DEFAULT_BIND_PATH: &str = "/run/api.sock";
 
 type Result<T> = std::result::Result<T, error::Error>;
 

--- a/workspaces/api/moondog/src/main.rs
+++ b/workspaces/api/moondog/src/main.rs
@@ -23,7 +23,7 @@ use std::{env, fs, process};
 // Tests!
 
 // FIXME Get these from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const API_SETTINGS_URI: &str = "/settings";
 
 // We only want to run moondog once, at first boot.  Our systemd unit file has a

--- a/workspaces/api/openapi.yaml
+++ b/workspaces/api/openapi.yaml
@@ -9,7 +9,7 @@ info:
     url: ""
 
 servers:
-- url: file:///var/lib/thar/api.sock
+- url: file:///run/api.sock
   description: The production API server
 
 paths:

--- a/workspaces/api/servicedog/src/main.rs
+++ b/workspaces/api/servicedog/src/main.rs
@@ -24,7 +24,7 @@ use apiserver::model;
 extern crate log;
 
 // FIXME Get from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const API_SETTINGS_URI: &str = "/settings";
 
 const SYSTEMCTL_BIN: &str = "/bin/systemctl";

--- a/workspaces/api/settings-committer/src/main.rs
+++ b/workspaces/api/settings-committer/src/main.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, env, process};
 
 use snafu::{ensure, ResultExt};
 
-const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const API_PENDING_URI: &str = "/settings/pending";
 const API_COMMIT_URI: &str = "/settings/commit";
 

--- a/workspaces/api/sundog/src/main.rs
+++ b/workspaces/api/sundog/src/main.rs
@@ -22,7 +22,7 @@ use apiserver::model;
 extern crate log;
 
 // FIXME Get from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const API_SETTINGS_URI: &str = "/settings";
 const API_PENDING_SETTINGS_URI: &str = "/settings/pending";
 const API_SETTING_GENERATORS_URI: &str = "/metadata/setting-generators";

--- a/workspaces/api/thar-be-settings/src/main.rs
+++ b/workspaces/api/thar-be-settings/src/main.rs
@@ -9,7 +9,7 @@ use std::process;
 use thar_be_settings::{config, get_changed_settings, service, settings, template};
 
 // FIXME Get from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/var/lib/thar/api.sock";
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 
 mod error {
     use snafu::Snafu;


### PR DESCRIPTION
*Issue #, if available:*
Implements #226 

*Description of changes:*
*Change all references to `/var/lib/thar/api.sock` to `/run/api.sock`

*Testing done:*
* Unit tests pass
* Built and booted an image and all services start and run successfully
* apiclient pulls data as normal:
```
bash-5.0# apiclient -u /settings
{"timezone":"America/Los_Angeles","hostname":"localhost","kubernetes":{"cluster-name":"thar-be-a-cluster","cluster-certificate.......
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
