### PR TITLE
filesystem: add directories and links for container access

### DIFF
--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -35,6 +35,24 @@ ln -s .%{_cross_libdir} %{buildroot}/lib
 ln -s .%{_cross_libdir} %{buildroot}/lib64
 ln -s lib %{buildroot}%{_cross_prefix}/lib64
 
+# HACK: the following use cases are not part of our "API" and
+# should be removed when we no longer need to mount the host's
+# binaries and mutable state into the update agent container.
+
+# Simplify mounting the sys-root into a container and use of `chroot`.
+ln -s usr/lib %{buildroot}%{_cross_rootdir}/lib
+ln -s usr/lib %{buildroot}%{_cross_rootdir}/lib64
+mkdir -p %{buildroot}%{_cross_rootdir}/%{_cross_target}
+ln -s ../ %{buildroot}%{_cross_rootdir}%{_cross_rootdir}
+ln -s .%{_cross_rootdir} %{buildroot}/sys-root
+
+# Add mount points for configuration, ephemeral storage, a subset of
+# persistent storage, and the API socket.
+mkdir -p %{buildroot}%{_cross_rootdir}/etc
+mkdir -p %{buildroot}%{_cross_rootdir}/run
+mkdir -p %{buildroot}%{_cross_rootdir}/var/lib/thar
+touch %{buildroot}%{_cross_rootdir}/run/api.sock
+
 %files
 %dir %{_cross_rootdir}
 %{_cross_rootdir}/*
@@ -61,5 +79,7 @@ ln -s lib %{buildroot}%{_cross_prefix}/lib64
 /mnt
 /opt
 /srv
+
+/sys-root
 
 %changelog


### PR DESCRIPTION
This enables mounting the host's directores into a container, running
its binaries using `chroot` to deal with sys-root'ed paths, reading
its configuration files, and interacting with both ephemeral and
persistent data storage.

Signed-off-by: Ben Cressey <bcressey@amazon.com>

*Issue #, if available:*
#246 

*Description of changes:*
This allows us to run the host's copy of `updog` by mounting various paths into a container.

*Testing done*
Ran `chroot /sys-root updog check-update` inside a container.

It failed with a "Hash mismatch" error, but it does that outside the container also.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
