### PR TITLE
tuftool: Allow multiple roles for add-key, gen-rsa-key

### DIFF
--- a/workspaces/tuftool/src/root.rs
+++ b/workspaces/tuftool/src/root.rs
@@ -238,7 +238,7 @@ fn clear_sigs<T>(role: &mut Signed<T>) {
 }
 
 /// Adds a key to the root role if not already present, and adds its key ID to the specified role.
-fn add_key(root: &mut Root, role: &Vec<RoleType>, key: Key) -> Result<Decoded<Hex>> {
+fn add_key(root: &mut Root, role: &[RoleType], key: Key) -> Result<Decoded<Hex>> {
     let key_id = if let Some((key_id, _)) = root
         .keys
         .iter()


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Allow setting multiple roles via `--role`

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
