### PR TITLE
host-ctr: Adds contexts to errors instead of overwriting them

### DIFF
--- a/workspaces/host-containers/cmd/host-ctr/go.mod
+++ b/workspaces/host-containers/cmd/host-ctr/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/containerd v1.2.9
 	github.com/opencontainers/runc v1.0.0-rc8
 	github.com/opencontainers/runtime-spec v1.0.1
+	github.com/pkg/errors v0.0.0-20190227000051-27936f6d90f9
 	github.com/stretchr/testify v1.2.2
 )
 

--- a/workspaces/host-containers/cmd/host-ctr/main.go
+++ b/workspaces/host-containers/cmd/host-ctr/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"os"
 	"os/signal"
@@ -18,6 +17,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
+	"github.com/pkg/errors"
 	cgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -235,12 +235,12 @@ func pullImage(ctx context.Context, source string, client *containerd.Client) (c
 		withDynamicResolver(ctx, source),
 		containerd.WithSchema1Conversion)
 	if err != nil {
-		return nil, errors.New("Failed to pull ctr image")
+		return nil, errors.Wrap(err, "Failed to pull ctr image")
 	}
 	log.G(ctx).WithField("img", img.Name()).Info("Pulled successfully")
 	log.G(ctx).WithField("img", img.Name()).Info("Unpacking...")
 	if err := img.Unpack(ctx, containerd.DefaultSnapshotter); err != nil {
-		return nil, errors.New("Failed to unpack image")
+		return nil, errors.Wrap(err, "Failed to unpack image")
 	}
 	return img, nil
 }
@@ -255,7 +255,7 @@ func withDynamicResolver(ctx context.Context, ref string) containerd.RemoteOpt {
 		// Create the ECR resolver
 		resolver, err := ecr.NewResolver()
 		if err != nil {
-			return errors.New("Failed to create ECR resolver")
+			return errors.Wrap(err, "Failed to create ECR resolver")
 		}
 		log.G(ctx).WithField("ref", ref).Info("Pulling from Amazon ECR")
 		c.Resolver = resolver


### PR DESCRIPTION
I was having trouble figuring out why calls to `Containerd.Client.Pull` were failing because I was overwriting the error that was being returned. Should add context to errors instead of overwriting them.

*Description of changes:*
Imports new `errors` package and use `Wrap` instead of `New` for errors returned by calls to external pkgs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
