### PR TITLE
host-ctr: fixes mount options for api.sock for the control container

### DIFF
--- a/workspaces/host-containers/cmd/host-ctr/main.go
+++ b/workspaces/host-containers/cmd/host-ctr/main.go
@@ -175,8 +175,7 @@ func withTharMounts(targetCtr string) oci.SpecOpts {
 			oci.WithMounts([]runtimespec.Mount{
 				// Mount the Thar API server socket if it's the control container that's being launched
 				{
-					Type:        "bind",
-					Options:     []string{"rw"},
+					Options:     []string{"bind","rw"},
 					Destination: "/run/api.sock",
 					Source:      "/run/api.sock",
 				}}),
@@ -186,13 +185,11 @@ func withTharMounts(targetCtr string) oci.SpecOpts {
 			oci.WithMounts([]runtimespec.Mount{
 				// Mount host `/dev`
 				{
-					Type:        "bind",
 					Options:     []string{"rbind", "rshared", "rw"},
 					Destination: "/dev",
 					Source:      "/dev",
 				},
 				{
-					Type:        "bind",
 					Options:     []string{"rbind", "rw"},
 					Destination: "/var/log",
 					Source:      "/var/log",


### PR DESCRIPTION
host-ctr needs to mount in the API socket for the control container. It was not being mounted with the `bind` option properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
