### PR TITLE
build: ignore golang vendor paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
 *.tar.*
 **/target/
+**/vendor/
 /.cargo

--- a/tools/buildsys/src/project.rs
+++ b/tools/buildsys/src/project.rs
@@ -45,7 +45,7 @@ impl ProjectInfo {
         entry
             .file_name()
             .to_str()
-            .map(|s| s.starts_with('.') || s == "target")
+            .map(|s| s.starts_with('.') || s == "target" || s == "vendor")
             .unwrap_or(false)
     }
 }


### PR DESCRIPTION
Signed-off-by: Ben Cressey <bcressey@amazon.com>

*Issue #, if available:*
#271 

*Description of changes:*
Ignores vendored Go modules and excludes them from change tracking.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
