### PR TITLE
macros: set PKG_CONFIG_ALLOW_CROSS for pkg-config

### DIFF
--- a/macros/cargo
+++ b/macros/cargo
@@ -9,7 +9,7 @@
 %__cargo_common_opts --offline --locked --verbose
 %__cargo_cross_opts %{__cargo_common_opts} --target %{_cross_arch}-unknown-linux-%{_cross_libc}
 %__cargo_env CARGO_TARGET_DIR="${HOME}/.cache" SKIP_README="true"
-%__cargo_cross_env %{__cargo_env} TARGET_CC="%{_cross_target}-gcc" PKG_CONFIG_PATH="%{_cross_pkgconfigdir}"
+%__cargo_cross_env %{__cargo_env} TARGET_CC="%{_cross_target}-gcc" PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" PKG_CONFIG_ALLOW_CROSS=1
 
 %cargo_prep (\
 %{__mkdir} -p %{_builddir}/.cargo \

--- a/macros/shared
+++ b/macros/shared
@@ -44,6 +44,7 @@
   CXXFLAGS="${CXXFLAGS:-%{_cross_cxxflags}}" ; export CXXFLAGS ; \
   LDFLAGS="${LDFLAGS:-%{_cross_ldflags}}" ; export LDFLAGS ; \
   PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" ; export PKG_CONFIG_PATH ; \
+  PKG_CONFIG_ALLOW_CROSS=1 ; export PKG_CONFIG_ALLOW_CROSS ; \
 
 %cross_configure \
   %set_cross_build_flags \
@@ -153,6 +154,7 @@ CROSS_COMPILATION_CONF_EOF\
   CXX_FOR_TARGET="%{_cross_target}-g++" ; export CXX_FOR_TARGET ; \
   CGO_ENABLED=1 ; export CGO_ENABLED ; \
   PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" ; export PKG_CONFIG_PATH ; \
+  PKG_CONFIG_ALLOW_CROSS=1 ; export PKG_CONFIG_ALLOW_CROSS ; \
 
 %cross_go_setup() \
   mkdir -p GOPATH/src/%2 ; \


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Appease `pkg-config` when it detects cross-compiling to fix the `api` package build for aarch64.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
