### PR TITLE
ca-certificates: Update to 2019-08-28

### DIFF
--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2019-05-15.pem"
-sha512 = "6dff0130bdc7c9b211d437598d6caf1b5bb7f7268ce66713e9701890f8924c98ab5a4c0df28dac4fdfea439ad61b46861d0c5b2986ac8c8b4a47218a2b9ba02f"
+url = "https://curl.haxx.se/ca/cacert-2019-08-28.pem"
+sha512 = "527e23d1e83381583cc2efe4625b01a00baa990afc877bb617727e8bffab17a0dc4f36b60162bad375b576ff09bc27acc7e0f095a34150f23d61825b8a7fb81f"
 
 [build-dependencies]
 buildsys = { path = "../../tools/buildsys" }

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}ca-certificates
-Version: 2019.05.15
+Version: 2019.08.28
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL 2.0
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2019-05-15.pem
+Source0: https://curl.haxx.se/ca/cacert-2019-08-28.pem
 Source1: ca-certificates.conf
 
 %description


### PR DESCRIPTION
This removes a single CA: https://bugzilla.mozilla.org/show_bug.cgi?id=1552374

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.