### PR TITLE
api: set permissions of the API socket to 0666

### DIFF
--- a/workspaces/api/apiserver/src/server/error.rs
+++ b/workspaces/api/apiserver/src/server/error.rs
@@ -18,8 +18,16 @@ pub enum Error {
 
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-    // Server errors
+    // Set file permission errors
+    #[snafu(display("Failed to set file permissions on the API socket to {:o}: {}", mode, source))]
+    SetPermissions {
+        source: std::io::Error,
+        mode: u32,
+    },
 
+    // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    // Server errors
     #[snafu(display("Missing required input '{}'", input))]
     MissingInput { input: String },
 


### PR DESCRIPTION
The API socket needs to be writeable by everyone and not just root.

*Issue #, if available:*

*Description of changes:* Sets the permissions of the API socket to be 0666 after `apiserver` binds to it.

*Testing:* 
In the control-ssm container:
```
sh-4.2$ apiclient -u /settings
{"timezone":"America/Los_Angeles","hostname":"localhost","kubernetes":{"cluster-dns-ip":"10.100.0.10","node-ip":"172.31.31.111","pod-infra-container-image":"602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1"},"updates":{"metadata-base-url":"https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/metadata/","target-base-url":"https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/targets/","seed":"1777"},"host-containers":{"admin":{"source":"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.1","enabled":true,"superpowered":true},"control":{"source":"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.1","enabled":true,"superpowered":false}},"ntp":{"time-servers":["169.254.169.123","2.amazon.pool.ntp.org"]}}
sh-4.2$ ls -al /run/api.sock
srwxrwxrwt 1 root root 0 Sep 25 00:25 /run/api.sock
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
