### PR TITLE
block-party: add from_device_node() method

### DIFF
--- a/workspaces/updater/block-party/src/lib.rs
+++ b/workspaces/updater/block-party/src/lib.rs
@@ -9,7 +9,6 @@
 #![deny(missing_docs, rust_2018_idioms)]
 #![warn(clippy::pedantic)]
 
-use std::convert::TryFrom;
 use std::ffi::OsString;
 use std::fmt;
 use std::fs;
@@ -149,23 +148,6 @@ impl fmt::Display for BlockDevice {
 impl PartialEq for BlockDevice {
     fn eq(&self, other: &Self) -> bool {
         self.major == other.major && self.minor == other.minor
-    }
-}
-
-impl PartialEq<fs::Metadata> for BlockDevice {
-    fn eq(&self, metadata: &fs::Metadata) -> bool {
-        self.major == metadata.st_dev() >> 8 && self.minor == metadata.st_dev() & 0xff
-    }
-}
-
-impl TryFrom<fs::Metadata> for BlockDevice {
-    type Error = Error;
-
-    fn try_from(metadata: fs::Metadata) -> Result<Self> {
-        // see /usr/include/linux/kdev_t.h
-        let major = metadata.st_dev() >> 8;
-        let minor = metadata.st_dev() & 0xff;
-        Self::from_major_minor(major, minor)
     }
 }
 


### PR DESCRIPTION
*Description of changes:*
While writing the tool to grow a partition to maximum size, @bcressey added the `from_device_node` method here.

Because of these two separate methods, `TryFrom<fs::Metadata>` and `PartialEq<fs::Metadata>` aren't clear about what they do. I've removed them, since we're not using them at this time. If we add them back, we'll need to be clearer about their use of `st_dev` vs `st_rdev`.

signpost still works as expected with this commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
