### PR TITLE
Add updated guide on how to update the Rust package

### DIFF
--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -8,6 +8,11 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[build-dependencies]
+buildsys = { path = "../../tools/buildsys" }
+
+# After this point, the file is generated.  See how-to-update.md.  Don't add anything manually after this.
+
 [[package.metadata.build-package.external-files]]
 url = "https://static.rust-lang.org/dist/cargo-0.39.0-aarch64-unknown-linux-gnu.tar.xz"
 sha512 = "1fb608a44cfd5a915e75d9d83eaf7f9f1b271521fae6e0da98eb78cd51db35ba4e7c1bbf0744e6a329d879f3b8a7573465eb3969d51c22c9886cefbcca4a669a"
@@ -31,6 +36,3 @@ sha512 = "b58381d01bb052599a881aa571e1ed8cac8d7afde79940942291f94b921de57e433c72
 [[package.metadata.build-package.external-files]]
 url = "https://static.rust-lang.org/dist/rust-std-1.38.0-x86_64-unknown-linux-gnu.tar.xz"
 sha512 = "6c9b925dd6ac465a33ce669920619c8c7ad9c22067d8e554450ea35edc10bfb5aabdd22f081a575b1f2b7b3237b43b15c3d62fb18bf32c8e5be4c1c785e8db21"
-
-[build-dependencies]
-buildsys = { path = "../../tools/buildsys" }

--- a/packages/rust/how-to-update.md
+++ b/packages/rust/how-to-update.md
@@ -1,0 +1,68 @@
+We currently package Rust binaries built upstream.
+Here's how to update to a new version, for example to 1.38:
+
+Import the Rust signing key if you don't have it:
+
+```
+curl https://static.rust-lang.org/rust-key.gpg.ascii | gpg --import
+```
+
+Get and check the artifacts.
+**Make sure to update the versions at the top!**
+
+```
+RUST_VERSION=1.38.0
+CARGO_VERSION=0.39.0
+RELEASE_DATE=2019-09-26
+
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rustc-${RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rustc-${RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz.asc"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rustc-${RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz.sha256"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rustc-${RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rustc-${RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz.asc"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rustc-${RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz.sha256"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/cargo-${CARGO_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/cargo-${CARGO_VERSION}-x86_64-unknown-linux-gnu.tar.xz.asc"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/cargo-${CARGO_VERSION}-x86_64-unknown-linux-gnu.tar.xz.sha256"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/cargo-${CARGO_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/cargo-${CARGO_VERSION}-aarch64-unknown-linux-gnu.tar.xz.asc"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/cargo-${CARGO_VERSION}-aarch64-unknown-linux-gnu.tar.xz.sha256"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rust-std-${RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rust-std-${RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz.asc"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rust-std-${RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz.sha256"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rust-std-${RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rust-std-${RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz.asc"
+curl -O "https://static.rust-lang.org/dist/${RELEASE_DATE}/rust-std-${RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz.sha256"
+
+for file in *.sha256; do sha256sum -c $file && echo OK || echo ERROR; done
+for file in *.asc; do gpg --verify $file && echo OK || echo ERROR; done
+```
+
+Confirm that the curl, sha256sum, and gpg commands finished and said the files were OK.
+Then you can remove the verification files:
+
+```
+rm *.asc *.sha256
+```
+
+Finally, update the packaging information.
+In `packages/rust/`:
+
+```
+sed -i \
+   -e "s/^Version: .*/Version: ${RUST_VERSION}/" \
+   -e "s/^%global cargo_version .*/%global cargo_version ${CARGO_VERSION}/" \
+   rust.spec
+
+sed -i -e '/After this point, the file is generated/q' Cargo.toml
+sha512sum *.tar.xz | awk '{print "\n[[package.metadata.build-package.external-files]]\nurl = \"https://static.rust-lang.org/dist/" $2 "\"\nsha512 = \"" $1 "\""}' >> Cargo.toml
+```
+
+Now you can remove the artifacts:
+
+```
+rm *.tar*
+```
+
+Then prepare a commit and a PR!
+See #309 for an example.


### PR DESCRIPTION
Updates the guide to work with the new build system.

This is based on the guide removed yesterday; with a little tweak to the section ordering in `Cargo.toml`, we can more easily script the updates.

Tested by running all of the commands, which reproduce `Cargo.toml` with no changes.