### PR TITLE
Limit `api.sock` rw access to `api` group

### DIFF
--- a/extras/admin-container/Dockerfile
+++ b/extras/admin-container/Dockerfile
@@ -35,7 +35,8 @@ ADD ./sheltie /usr/bin/
 RUN chmod 440 /etc/sudoers.d/ec2-user
 RUN chmod +x /usr/sbin/start_admin_sshd.sh
 RUN chmod +x /usr/bin/sheltie
-RUN useradd -m -G users ec2-user
+RUN groupadd -g 274 api
+RUN useradd -m -G users,api ec2-user
 
 CMD ["/usr/sbin/start_admin_sshd.sh"]
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/extras/control-container/Dockerfile
+++ b/extras/control-container/Dockerfile
@@ -2,6 +2,7 @@ FROM amazonlinux:2
 
 RUN yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm shadow-utils
 
-RUN useradd ssm-user
+RUN groupadd -g 274 api
+RUN useradd -m -G users,api ssm-user
 
 CMD ["/usr/bin/amazon-ssm-agent"]

--- a/packages/api/api-sysusers.conf
+++ b/packages/api/api-sysusers.conf
@@ -1,0 +1,2 @@
+# Create `api` group with gid of 274 to limit access to the Thar API socket
+g api 274 -

--- a/packages/api/api.spec
+++ b/packages/api/api.spec
@@ -21,6 +21,7 @@ Source6: migration-tmpfiles.conf
 Source7: settings-applier.service
 Source8: data-store-version
 Source9: migrator.service
+Source10: api-sysusers.conf
 BuildRequires: gcc-%{_cross_target}
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}systemd-devel
@@ -150,11 +151,15 @@ done
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 
+install -d %{buildroot}%{_cross_sysusersdir}
+install -p -m 0644 %{S:10} %{buildroot}%{_cross_sysusersdir}/api.conf
+
 %files -n %{_cross_os}apiserver
 %{_cross_bindir}/apiserver
 %{_cross_unitdir}/apiserver.service
 %{_cross_unitdir}/migrator.service
 %{_cross_datadir}/thar/data-store-version
+%{_cross_sysusersdir}/api.conf
 
 %files -n %{_cross_os}apiclient
 %{_cross_bindir}/apiclient

--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/workspaces/api/apiserver/Cargo.toml
+++ b/workspaces/api/apiserver/Cargo.toml
@@ -19,6 +19,7 @@ stderrlog = "0.4"
 toml = "0.5"
 walkdir = "2.2"
 systemd = { version = "0.4.0", default-features = false, features = [], optional = true }
+nix = "0.15.0"
 
 [features]
 default = []

--- a/workspaces/api/apiserver/src/server/error.rs
+++ b/workspaces/api/apiserver/src/server/error.rs
@@ -1,7 +1,8 @@
 use crate::datastore::{self, deserialization, serialization};
+use nix::unistd::Gid;
+use snafu::Snafu;
 use std::io;
 use std::path::PathBuf;
-use snafu::Snafu;
 
 // We want server (router/handler) and controller errors together so it's easy to define response
 // error codes for all the high-level types of errors that could happen during a request.
@@ -18,12 +19,16 @@ pub enum Error {
 
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-    // Set file permission errors
-    #[snafu(display("Failed to set file permissions on the API socket to {:o}: {}", mode, source))]
-    SetPermissions {
-        source: std::io::Error,
-        mode: u32,
-    },
+    // Set file metadata errors
+    #[snafu(display(
+        "Failed to set file permissions on the API socket to {:o}: {}",
+        mode,
+        source
+    ))]
+    SetPermissions { source: std::io::Error, mode: u32 },
+
+    #[snafu(display("Failed to set group owner on the API socket to {}: {}", gid, source))]
+    SetGroup { source: nix::Error, gid: Gid },
 
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 


### PR DESCRIPTION
*Issue #, if available:* #315

*Description of changes:* 
This changes the permissions on `/run/api.sock` to be mode 0660 to limit rw access to users under the `api` group (gid 274). 
The `api` package now also includes a sysusers conf file to add the `api` group.

*Testing*:

Just running the container process task with gid 274 or additional gid of 274 does not work.
Baking the `api` group and `ec2-user` under `api` into the admin container image works.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
