### PR TITLE
Update .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,6 @@
 Jacob Peddicord <peddicor@amazon.com> <jpeddicord@users.noreply.github.com>
+Jacob Vallejo <jakeev@amazon.com>
+Jamie Anderson <jamieand@amazon.com> <32437770+jamieand@users.noreply.github.com>
 Michael Patraw <patraw@amazon.com> <52084153+patraw@users.noreply.github.com>
 Samuel Mendoza-Jonas <samjonas@amazon.com> <53018225+sam-aws@users.noreply.github.com>
 Tom Kirchner <tjk@amazon.com> <tjkirch@users.noreply.github.com>


### PR DESCRIPTION
See #192 for details; this is to keep the `git shortlog` authors list clean and consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
