### PR TITLE
updog: chill

### DIFF
--- a/workspaces/updater/updog/src/main.rs
+++ b/workspaces/updater/updog/src/main.rs
@@ -488,7 +488,7 @@ struct Arguments {
 /// Parse the command line arguments to get the user-specified values
 fn parse_args(args: std::env::Args) -> Arguments {
     let mut subcommand = None;
-    let mut verbosity: usize = 3; // Default log level to 3 (Info)
+    let mut verbosity: usize = 2; // Default log level to 2 (Info)
     let mut update_version = None;
     let mut ignore_wave = false;
     let mut json = false;


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
2 is the equivalent to the `Info` log level, not 3.

I do plan on a solid logging pass with the entire tough stack soon, and at that point will use a better default logging filter on updog. But for now this will make me happier.

Tested with and without several `-v`s.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.