### PR TITLE
host-containers: Specify KillMode to `mixed` for admin, control unit templates

### DIFF
--- a/packages/release/host-containers-systemd-unit-admin.template
+++ b/packages/release/host-containers-systemd-unit-admin.template
@@ -9,6 +9,7 @@ ExecStart=/usr/bin/host-ctr -ctr-id admin -source {{ settings.host-containers.ad
 Restart=always
 RestartSec=10
 TimeoutStopSec=60
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/release/host-containers-systemd-unit-control.template
+++ b/packages/release/host-containers-systemd-unit-control.template
@@ -9,6 +9,7 @@ ExecStart=/usr/bin/host-ctr -ctr-id control -source {{ settings.host-containers.
 Restart=always
 RestartSec=10
 TimeoutStopSec=60
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Specifies the KillMode to `mixed` for the admin and control systemd
unit templates.

*Issue #, if available:* #128 (more specifically https://github.com/amazonlinux/PRIVATE-thar/issues/128#issuecomment-536105277)

*Description of changes:* Specifies KillMode to `mixed` for host-containers@admin and host-containers@control unit template

*Testing:* 
Launched thar host with both admin and control containers enabled.
Started an SSM session with my thar instance.

Set the `TimeoutStopSec` to 1 to make systemd kill `host-containers@control` and its children as specified by `KillMode` after an one second timeout.
Ran `systemctl stop host-containers@control` on the thar host
and verified `host-ctr` process gets killed after 1 second and my ssm session is terminated indicating that the container task got killed by systemd.
```
Oct 01 19:44:41 systemd[1]: Stopping Control container...
Oct 01 19:44:41 host-ctr[13390]: time="2019-10-01T19:44:41Z" level=info msg="Received signal: terminated"
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO Got signal:terminated value:0xbb5ef0
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO Stopping agent
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [instanceID=i-05c2e2750e52c68df] core manager stop requested. Stop type: HardStop
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] Stopping MessageGatewayService.
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] Closing controlchannel with channel Id i-05c2e2750e52c68df
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] Closing websocket channel connection to: wss://ssmmessages.us-west-2.amazona
ws.com/v1/control-channel/i-05c2e2750e52c68df?role=subscribe&stream=input
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] Successfully closed websocket connection to: 52.119.161.149:443
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] Ending the channel listening routine since the channel is closed
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] [EngineProcessor] [OutOfProcExecuter] [etung-Isengard-041d930fba3effce4] req
uested shutdown, prepare to stop messaging
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] [EngineProcessor] [OutOfProcExecuter] [etung-Isengard-041d930fba3effce4] cha
nnel /var/lib/amazon/ssm/i-05c2e2750e52c68df/channels/etung-Isengard-041d930fba3effce4 requested close
Oct 01 19:44:41 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] [EngineProcessor] [OutOfProcExecuter] [etung-Isengard-041d930fba3effce4] cha
nnel /var/lib/amazon/ssm/i-05c2e2750e52c68df/channels/etung-Isengard-041d930fba3effce4 closed
Oct 01 19:44:42 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] [EngineProcessor] [OutOfProcExecuter] [etung-Isengard-041d930fba3effce4] ipc
 channel closed, stop messaging worker
Oct 01 19:44:42 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] [EngineProcessor] [OutOfProcExecuter] [etung-Isengard-041d930fba3effce4] Exe
cuter closed
Oct 01 19:44:42 host-ctr[13390]: 2019-10-01 19:44:41 INFO [MessageGatewayService] [EngineProcessor] document etung-Isengard-041d930fba3effce4 still in progres
s, shutting down...
Oct 01 19:44:42 systemd[1]: host-containers@control.service: State 'stop-sigterm' timed out. Killing.
Oct 01 19:44:42 systemd[1]: host-containers@control.service: Killing process 13390 (host-ctr) with signal SIGKILL.
Oct 01 19:44:42 systemd[1]: host-containers@control.service: Main process exited, code=killed, status=9/KILL
Oct 01 19:44:42 systemd[1]: host-containers@control.service: Failed with result 'timeout'.
```
Verified that container process is stopped (killed) by systemd
```
bash-5.0# ctr -a /run/host-containerd/containerd.sock task list
TASK       PID      STATUS    
admin      3610     RUNNING
control    13455    STOPPED
```
Then to restart the control container, the snapshot and container needs to be manually cleaned-up since host-ctr didn't have the chance to.
`ctr -a /run/host-containerd/containerd.sock container rm control`
`ctr -a /run/host-containerd/containerd.sock snapshot rm control-snapshot`
and `host-containers@control` can be successfully started up again.
```
bash-5.0# systemctl status host-containers@control
● host-containers@control.service - Control container
   Loaded: loaded (/etc/systemd/system/host-containers@control.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-10-01 19:59:05 UTC; 14min ago
...
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
