### PR TITLE
README: add commit+apply to sample of admin container

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ If Thar is already running, you can change the setting with an API call:
 
 ```
 apiclient -u /settings -m PATCH -d '{"host-containers": {"admin": {"enabled": true}}}'
+apiclient -u /settings/commit_and_apply -m POST
 ```
 
 (To make an API call like this, you need to use an authenticated channel like [SSM](#control-container).)


### PR DESCRIPTION
This is the beginning of the README where the user is just getting acquainted
with Thar.  Don't assume they've read the rest of the document and understand
they need to commit and apply changes, put the command right there for them.