### PR TITLE
containerd: disable unused storage plugins

### DIFF
--- a/packages/containerd/containerd-config.toml
+++ b/packages/containerd/containerd-config.toml
@@ -1,5 +1,6 @@
 root = "/var/lib/containerd"
 state = "/run/containerd"
+disabled_plugins = ["aufs", "zfs"]
 
 [grpc]
 address = "/run/containerd/containerd.sock"

--- a/packages/release/host-containerd-config.toml
+++ b/packages/release/host-containerd-config.toml
@@ -1,6 +1,6 @@
 root = "/var/lib/host-containerd"
 state = "/run/host-containerd"
-disabled_plugins = ["cri"]
+disabled_plugins = ["aufs", "zfs", "cri"]
 
 [grpc]
 address = "/run/host-containerd/containerd.sock"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixes warnings like this.
>level=warning msg="could not use snapshotter aufs in metadata plugin" ...
>level=warning msg="could not use snapshotter zfs in metadata plugin" ...

*Testing done:*
Conformance tests passed on a cluster with this change applied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
