### PR TITLE
 kernel: Add attribution and license files

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -40,6 +40,8 @@
 %_cross_sysctldir %{_cross_rootdir}%{_sysctldir}
 %_cross_templatedir %{_cross_datadir}/templates
 
+%_defaultlicensedir %{_cross_datadir}/licenses
+
 %set_cross_build_flags \
   CFLAGS="${CFLAGS:-%{_cross_cflags}}" ; export CFLAGS ; \
   CXXFLAGS="${CXXFLAGS:-%{_cross_cxxflags}}" ; export CXXFLAGS ; \
@@ -164,6 +166,12 @@ CROSS_COMPILATION_CONF_EOF\
 %cross_go_configure() \
   %set_cross_go_flags \
   cd GOPATH/src/%1 ; \
+
+%_cross_attribution_file %{_licensedir}/%{name}/attribution.txt
+%cross_generate_attribution \
+  mkdir -p %{buildroot}%{_licensedir}/%{name} \
+  echo "%{name} - %{url}" >> %{buildroot}%{_cross_attribution_file} \
+  echo "SPDX-License-Identifier: %{license}" >> %{buildroot}%{_cross_attribution_file}
 
 %__nm %{_bindir}/%{_cross_target}-nm
 %__objcopy %{_bindir}/%{_cross_target}-objcopy

--- a/packages/kernel/kernel.spec
+++ b/packages/kernel/kernel.spec
@@ -4,7 +4,7 @@ Name: %{_cross_os}kernel
 Version: 4.19.72
 Release: 1%{?dist}
 Summary: The Linux kernel
-License: GPLv2 and Redistributable, no modification permitted
+License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
 Source0: https://cdn.amazonlinux.com/blobstore/376c4a8ffedb59b2a17019fd74811a1f804ca1edcdfb71cab6f64222052631b0/kernel-4.19.72-25.58.amzn2.src.rpm
@@ -81,7 +81,11 @@ find %{buildroot}%{_cross_prefix} \
    \( -name .install -o -name .check -o \
       -name ..install.cmd -o -name ..check.cmd \) -delete
 
+%cross_generate_attribution
+
 %files
+%license COPYING LICENSES/preferred/GPL-2.0 LICENSES/exceptions/Linux-syscall-note
+%{_cross_attribution_file}
 /boot/vmlinuz
 /boot/config
 /boot/System.map


### PR DESCRIPTION
*Description of changes:*
* Use SPDX license identifiers for RPM's License tag.
* Generate an attribution.txt document with the project URL and license.
* Mark relevant files as `%license`.

```
bash-5.0# cat /usr/share/licenses/thar-x86_64-kernel/attribution.txt
thar-x86_64-kernel - https://www.kernel.org/
License: GPL-2.0 WITH Linux-syscall-note
bash-5.0# ls /usr/share/licenses/thar-x86_64-kernel/
COPYING  GPL-2.0  Linux-syscall-note  attribution.txt
```

I think I'd prefer to use `%{summary}` in the attribution document instead of `%{name}`, but because RPM is RPM, by the time the generation is done `%{summary}` is the summary for the headers subpackage.

How users have access to this information is still to be determined. I don't think they should have to run `sheltie` to get to it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
