### PR TITLE
apiserver: Add --dev-mode flag to skip chown of socket

### DIFF
--- a/workspaces/api/apiserver/src/server/error.rs
+++ b/workspaces/api/apiserver/src/server/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     ))]
     SetPermissions { source: std::io::Error, mode: u32 },
 
-    #[snafu(display("Failed to set group owner on the API socket to {}: {}", gid, source))]
+    #[snafu(display("Failed to set group owner on the API socket to {} (for local development, try --dev-mode) - {}", gid, source))]
     SetGroup { source: nix::Error, gid: Gid },
 
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=


### PR DESCRIPTION
The developer likely won't have the group on their system, which causes the
apiserver to fail to start.

---

We could use this flag for other small behavior changes needed for local development, too, or we could replace it with more specific things if the behaviors are quite different.

**Testing done:**

Without flag, still uses the old behavior, which fails locally:
```
$ cargo run -- --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock -v -v -v -v
   Compiling apiserver v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/apiserver)
    Finished dev [unoptimized + debuginfo] target(s) in 6.57s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/target/debug/apiserver --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock -v -v -v -v`
Oct 03 09:58:31.405  INFO apiserver: Starting server at /tmp/thar-api.sock with 1 thread and datastore at /tmp/data-store/current
Error: Server { source: SetGroup { source: Sys(EPERM), gid: Gid(274) } }
```

With flag, skips the chown, so it can start locally:
```
$ cargo run -- --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock -v -v -v -v --dev-mode
   Compiling apiserver v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/apiserver)
    Finished dev [unoptimized + debuginfo] target(s) in 6.94s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/target/debug/apiserver --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock -v -v -v -v --dev-mode`
Oct 03 10:00:21.666  INFO apiserver: Starting server at /tmp/thar-api.sock with 1 thread and datastore at /tmp/data-store/current

$ ll /tmp/thar-api.sock
srw-rw---- 1 tjk domain^users 0 10-03 10:00 /tmp/thar-api.sock=
```