### PR TITLE
Specify apiserver socket group ID via argument

### DIFF
--- a/packages/api/apiserver.service
+++ b/packages/api/apiserver.service
@@ -5,7 +5,7 @@ Requires=network.target storewolf.service migrator.service
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/apiserver --datastore-path /var/lib/thar/datastore/current -v -v -v
+ExecStart=/usr/bin/apiserver --datastore-path /var/lib/thar/datastore/current --socket-gid 274 -v -v -v
 
 [Install]
 WantedBy=multi-user.target

--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/workspaces/api/apiserver/Cargo.toml
+++ b/workspaces/api/apiserver/Cargo.toml
@@ -20,6 +20,7 @@ toml = "0.5"
 walkdir = "2.2"
 systemd = { version = "0.4.0", default-features = false, features = [], optional = true }
 nix = "0.15.0"
+libc = "0.2"
 
 [features]
 default = []


### PR DESCRIPTION
This lets us grant access to the API group in production, but skip the chown
during local development, since the group likely doesn't exist on the
developer's machine.

---

This is an alternative to #362 suggested by @bcressey.

**Testing done:**

With no parameter, acts like it used to with no chown, meaning it works locally:
```
$ cargo run -- --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock -v -v -v -v
   Compiling apiserver v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/apiserver)
    Finished dev [unoptimized + debuginfo] target(s) in 9.11s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/target/debug/apiserver --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock -v -v -v -v`
Oct 03 10:39:59.547  INFO apiserver: Starting server at /tmp/thar-api.sock with 1 thread and datastore at /tmp/data-store/current

$ ll /tmp/thar-api.sock
srw-rw---- 1 tjk domain^users 0 10-03 10:39 /tmp/thar-api.sock=
```

Can use the parameter locally to change ownership to a group that exists, like 100 (users), if I run as root to be able to chown:
```
$ sudo =cargo run -- --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock --socket-gid 100 -v -v -v -v
   Compiling apiserver v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/apiserver)
    Finished dev [unoptimized + debuginfo] target(s) in 6.65s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/target/debug/apiserver --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock --socket-gid 100 -v -v -v -v`
Oct 03 10:45:55.350  INFO apiserver: Starting server at /tmp/thar-api.sock with 1 thread and datastore at /tmp/data-store/current

$ ll /tmp/thar-api.sock
srw-rw---- 1 root users 0 10-03 10:45 /tmp/thar-api.sock=
```

Made an AMI, system came to "running" OK, apiserver started, socket permissions correct, and I was able to talk to the API from the control container.
```
srw-rw----  1 root api    0 Oct  3 19:52 api.sock
```