### PR TITLE
migrator: fix verbosity going over max

### DIFF
--- a/packages/api/migrator.service
+++ b/packages/api/migrator.service
@@ -3,7 +3,7 @@ Description=Thar data store migrator
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/migrator --datastore-path /var/lib/thar/datastore/current --migration-directories /var/lib/thar/datastore/migrations --migrate-to-version-from-file /usr/share/thar/data-store-version -v -v -v
+ExecStart=/usr/bin/migrator --datastore-path /var/lib/thar/datastore/current --migration-directories /var/lib/thar/datastore/migrations --migrate-to-version-from-file /usr/share/thar/data-store-version -v -v
 RemainAfterExit=true
 
 [Install]


### PR DESCRIPTION
The old usage of 'stderrlog' would let you specify any number of -v arguments,
but 'tracing' looks for a specific verbosity number between 0 and 5.

migrator starts at 3 and we were adding 3 via -v, going over the max and
causing a parse error: "Failed to parse provided directive: invalid level"

---

The relevant code: https://docs.rs/tracing-subscriber/0.1.4/src/tracing_subscriber/filter/level.rs.html#108-134

**Testing done:**

With three -v, too many!
```
$ cargo run -- --datastore-path /tmp/data-store --migration-directories /tmp/kasdjf --migrate-to-version 42.0 -v -v -v                                                                          [15:05:08]
   Compiling data_store_version v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/data_store_version)
   Compiling migrator v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator)
    Finished dev [unoptimized + debuginfo] target(s) in 1.95s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/target/debug/migrator --datastore-path /tmp/data-store --migration-directories /tmp/kasdjf --migrate-to-version 42.0 -v -v -v`
Failed to parse provided directive: invalid level`
FAIL: 1
```

With two -v, just right for TRACE!  (it gets further...)
```
$ cargo run -- --datastore-path /tmp/data-store --migration-directories /tmp/kasdjf --migrate-to-version 42.0 -v -v                                                                             [15:04:56]
   Compiling data_store_version v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/data_store_version)
   Compiling migrator v0.1.0 (/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator)
    Finished dev [unoptimized + debuginfo] target(s) in 1.95s
     Running `/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/target/debug/migrator --datastore-path /tmp/data-store --migration-directories /tmp/kasdjf --migrate-to-version 42.0 -v -v`
Oct 03 15:05:08.053 TRACE data_store_version: Getting version from datastore path: /tmp/data-store
Oct 03 15:05:08.054 TRACE data_store_version: Parsing version from string: data-store
Unable to create version from data store path '/tmp/data-store': Given string 'data-store' not a version, must match re: ^(?P<version>v?(?P<major>[0-9]+)\.(?P<minor>[0-9]+))_(?P<id>.*)$
FAIL: 1
```