### PR TITLE
chrony: enable system call filter and switch to non-root user

### DIFF
--- a/packages/chrony/chrony-conf
+++ b/packages/chrony/chrony-conf
@@ -5,3 +5,4 @@ driftfile /run/lib/chrony/drift
 makestep 1.0 3
 dumponexit
 dumpdir /run/lib/chrony/state
+user chrony

--- a/packages/chrony/chrony-sysusers.conf
+++ b/packages/chrony/chrony-sysusers.conf
@@ -1,0 +1,1 @@
+u chrony - "chrony user"

--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -7,13 +7,16 @@ URL: https://chrony.tuxfamily.org
 Source0: https://download.tuxfamily.org/chrony/chrony-3.5.tar.gz
 Source1: chronyd.service
 Source2: chrony-conf
+Source3: chrony-sysusers.conf
 BuildRequires: gcc-%{_cross_target}
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libcap-devel
+BuildRequires: %{_cross_os}libseccomp-devel
 BuildRequires: %{_cross_os}ncurses-devel
 BuildRequires: %{_cross_os}readline-devel
 Requires: %{_cross_os}glibc
 Requires: %{_cross_os}libcap
+Requires: %{_cross_os}libseccomp
 Requires: %{_cross_os}ncurses
 Requires: %{_cross_os}readline
 
@@ -24,7 +27,12 @@ Requires: %{_cross_os}readline
 %autosetup -n chrony-%{version} -p1
 
 %build
-%cross_configure
+# chrony uses a custom hand-rolled configure script
+%set_cross_build_flags \
+CC=%{_cross_target}-gcc \
+./configure \
+ --prefix="%{_cross_prefix}" \
+ --enable-scfilter
 
 %make_build
 
@@ -35,6 +43,8 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{SOURCE1} %{buildroot}%{_cross_unitdir}/chronyd.service
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{SOURCE2} %{buildroot}%{_cross_templatedir}/chrony-conf
+install -d %{buildroot}%{_cross_sysusersdir}
+install -p -m 0644 %{SOURCE3} %{buildroot}%{_cross_sysusersdir}/chrony.conf
 
 %files
 %dir %{_cross_templatedir}
@@ -42,6 +52,7 @@ install -p -m 0644 %{SOURCE2} %{buildroot}%{_cross_templatedir}/chrony-conf
 %{_cross_sbindir}/chronyd
 %{_cross_templatedir}/chrony-conf
 %{_cross_unitdir}/chronyd.service
+%{_cross_sysusersdir}/chrony.conf
 %exclude %{_cross_mandir}
 
 %changelog

--- a/packages/chrony/chronyd.service
+++ b/packages/chrony/chronyd.service
@@ -6,7 +6,7 @@ Requires=network-online.target configured.target
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/chronyd -d
+ExecStart=/usr/sbin/chronyd -d -F -1
 StateDirectory=chrony/state
 
 [Install]


### PR DESCRIPTION
Creates system user `chrony` for running `chronyd`.
Adds seccomp filtering for `chronyd`.

*Issue #, if available:* Fixes #302 

*Description of changes:* 
* Updated `chrony.spec` `%build` step so the libraries and includes are specified correctly for `chrony`'s configuration script. 
* Create system user `chrony` with sysusers.
* Make chronyd switch user to `chrony` after start up.
* Enable `chronyd` seccomp filtering so when a forbidden system call is made, `chronyd` will throw a SIGSYS signal.

*Testing done*:

* Successfully built `chrony` with new `%build` step.
* On Thar host, chrony successfully runs and switches to user `chrony` after start up.
* Seccomp filtering also loads succesfully
```
[ec2-user@ip-192-168-39-97 ~]$ ps aux | grep chronyd
983       2603  0.0  0.0  11904  2636 ?        Ss   23:22   0:00 /usr/sbin/chronyd -d -d -F -1
983       2628  0.0  0.0   3724  1964 ?        S    23:22   0:00 /usr/sbin/chronyd -d -d -F -1
ec2-user  4603  0.0  0.0  10648   988 pts/0    S+   23:27   0:00 grep --color=auto chronyd
[ec2-user@ip-192-168-39-97 ~]$ sudo sheltie
bash-5.0# cat /etc/passwd
root:x:0:0:Super User:/root:/bin/sh
nobody:x:65534:65534:Nobody:/:/sbin/nologin
chrony:x:983:983:chrony user:/:/sbin/nologin
dbus:x:81:81::/:/sbin/nologin
bash-5.0# git status
bash: git: command not found
bash-5.0# systemctl status chronyd
● chronyd.service - A versatile implementation of the Network Time Protocol
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
   Active: active (running) since Fri 2019-10-04 23:22:20 UTC; 6min ago
     Docs: https://chrony.tuxfamily.org
 Main PID: 2603 (chronyd)
    Tasks: 2 (limit: 4435)
   Memory: 1.1M
   CGroup: /system.slice/chronyd.service
           ├─2603 /usr/sbin/chronyd -d -d -F -1
           └─2628 /usr/sbin/chronyd -d -d -F -1

Oct 04 23:22:20 ip-192-168-39-97.us-west-2.compute.internal systemd[1]: Started A versatile implementation of the Network Time Protocol.
Oct 04 23:22:20 ip-192-168-39-97.us-west-2.compute.internal chronyd[2603]: 2019-10-04T23:22:20Z chronyd version 3.5 starting (+CMDMON +NTP +REFCLOCK +RTC +PRI
VDROP +SCFILTER -SIGND +ASYNCDNS -SECHASH +IPV6 -DEBUG)
Oct 04 23:22:20 ip-192-168-39-97.us-west-2.compute.internal chronyd[2603]: 2019-10-04T23:22:20Z Loaded seccomp filter
Oct 04 23:22:26 ip-192-168-39-97.us-west-2.compute.internal chronyd[2603]: 2019-10-04T23:22:26Z Selected source 169.254.169.123
bash-5.0# 

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
