### PR TITLE
INSTALL: Update IAM role section to attach AmazonSSMManagedInstanceCore instead of AmazonEC2RoleforSSM

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -165,7 +165,7 @@ aws iam create-role \
 sleep 5
 aws iam attach-role-policy \
    --role-name TharInstance \
-   --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+   --policy-arn arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 aws iam attach-role-policy \
    --role-name TharInstance \
    --policy-arn arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy


### PR DESCRIPTION
AmazonEC2RoleforSSM is being deprecated and replaced by AmazonSSMManagedInstanceCore

*Issue #, if available:* Fixes #361

*Description of changes:* Updates `INSTALL.md`, replace AmazonEC2RoleforSSM with AmazonSSMManagedInstanceCore

*Testing:*
Followed through the steps in the *IAM role* section and successfully created instance role.
Verified that SSM sessions can be started with instances launched with said role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
