### PR TITLE
systemd: update to 243

### DIFF
--- a/packages/systemd/0001-cgroup-Check-ancestor-memory-min-for-unified-memory-.patch
+++ b/packages/systemd/0001-cgroup-Check-ancestor-memory-min-for-unified-memory-.patch
@@ -1,0 +1,28 @@
+From 9f8b9ecdc890e7c135890997847a30b995615b54 Mon Sep 17 00:00:00 2001
+From: Chris Down <chris@chrisdown.name>
+Date: Mon, 30 Sep 2019 18:24:26 +0100
+Subject: [PATCH 1/3] cgroup: Check ancestor memory min for unified memory
+ config
+
+Otherwise we might not enable it when we should, ie. DefaultMemoryMin is
+set in a parent, but not MemoryMin in the current unit.
+---
+ src/core/cgroup.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/cgroup.c b/src/core/cgroup.c
+index 60a7799..4ff88fb 100644
+--- a/src/core/cgroup.c
++++ b/src/core/cgroup.c
+@@ -933,7 +933,7 @@ static bool unit_has_unified_memory_config(Unit *u) {
+         c = unit_get_cgroup_context(u);
+         assert(c);
+ 
+-        return c->memory_min > 0 || unit_get_ancestor_memory_low(u) > 0 ||
++        return unit_get_ancestor_memory_min(u) > 0 || unit_get_ancestor_memory_low(u) > 0 ||
+                c->memory_high != CGROUP_LIMIT_MAX || c->memory_max != CGROUP_LIMIT_MAX ||
+                c->memory_swap_max != CGROUP_LIMIT_MAX;
+ }
+-- 
+2.21.0
+

--- a/packages/systemd/0002-cgroup-Respect-DefaultMemoryMin-when-setting-memory..patch
+++ b/packages/systemd/0002-cgroup-Respect-DefaultMemoryMin-when-setting-memory..patch
@@ -1,0 +1,30 @@
+From a6f1a1fb95de9959e4fef8c7eccf3632f16e649a Mon Sep 17 00:00:00 2001
+From: Chris Down <chris@chrisdown.name>
+Date: Mon, 30 Sep 2019 18:25:09 +0100
+Subject: [PATCH 2/3] cgroup: Respect DefaultMemoryMin when setting memory.min
+
+This is an oversight from https://github.com/systemd/systemd/pull/12332.
+
+Sadly the tests didn't catch it since it requires a real cgroup
+hierarchy to see, and it wasn't seen in prod since we're only currently
+using DefaultMemoryLow, not DefaultMemoryMin. :-(
+---
+ src/core/cgroup.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/cgroup.c b/src/core/cgroup.c
+index 4ff88fb..94a83e0 100644
+--- a/src/core/cgroup.c
++++ b/src/core/cgroup.c
+@@ -1200,7 +1200,7 @@ static void cgroup_context_apply(
+                                         log_cgroup_compat(u, "Applying MemoryLimit=%" PRIu64 " as MemoryMax=", max);
+                         }
+ 
+-                        cgroup_apply_unified_memory_limit(u, "memory.min", c->memory_min);
++                        cgroup_apply_unified_memory_limit(u, "memory.min", unit_get_ancestor_memory_min(u));
+                         cgroup_apply_unified_memory_limit(u, "memory.low", unit_get_ancestor_memory_low(u));
+                         cgroup_apply_unified_memory_limit(u, "memory.high", c->memory_high);
+                         cgroup_apply_unified_memory_limit(u, "memory.max", max);
+-- 
+2.21.0
+

--- a/packages/systemd/0003-cgroup-Mark-memory-protections-as-explicitly-set-in-.patch
+++ b/packages/systemd/0003-cgroup-Mark-memory-protections-as-explicitly-set-in-.patch
@@ -1,0 +1,107 @@
+From 852e31226bb2ce3871fa98850a64b8e600b63a2c Mon Sep 17 00:00:00 2001
+From: Chris Down <chris@chrisdown.name>
+Date: Mon, 30 Sep 2019 18:36:13 +0100
+Subject: [PATCH 3/3] cgroup: Mark memory protections as explicitly set in
+ transient units
+
+A later version of the DefaultMemory{Low,Min} patch changed these to
+require explicitly setting memory_foo_set, but we only set that in
+load-fragment, not dbus-cgroup.
+
+Without these, we may fall back to either DefaultMemoryFoo or
+CGROUP_LIMIT_MIN when we really shouldn't.
+---
+ src/core/dbus-cgroup.c | 64 +++++++++++++++++++++++++++++++-----------
+ 1 file changed, 48 insertions(+), 16 deletions(-)
+
+diff --git a/src/core/dbus-cgroup.c b/src/core/dbus-cgroup.c
+index 2f2313c..accd831 100644
+--- a/src/core/dbus-cgroup.c
++++ b/src/core/dbus-cgroup.c
+@@ -749,17 +749,33 @@ int bus_cgroup_set_property(
+         if (streq(name, "MemoryAccounting"))
+                 return bus_cgroup_set_boolean(u, name, &c->memory_accounting, CGROUP_MASK_MEMORY, message, flags, error);
+ 
+-        if (streq(name, "MemoryMin"))
+-                return bus_cgroup_set_memory_protection(u, name, &c->memory_min, message, flags, error);
++        if (streq(name, "MemoryMin")) {
++                r = bus_cgroup_set_memory_protection(u, name, &c->memory_min, message, flags, error);
++                if (r > 0)
++                        c->memory_min_set = true;
++                return r;
++        }
+ 
+-        if (streq(name, "MemoryLow"))
+-                return bus_cgroup_set_memory_protection(u, name, &c->memory_low, message, flags, error);
++        if (streq(name, "MemoryLow")) {
++                r = bus_cgroup_set_memory_protection(u, name, &c->memory_low, message, flags, error);
++                if (r > 0)
++                        c->memory_low_set = true;
++                return r;
++        }
+ 
+-        if (streq(name, "DefaultMemoryMin"))
+-                return bus_cgroup_set_memory_protection(u, name, &c->default_memory_min, message, flags, error);
++        if (streq(name, "DefaultMemoryMin")) {
++                r = bus_cgroup_set_memory_protection(u, name, &c->default_memory_min, message, flags, error);
++                if (r > 0)
++                        c->default_memory_min_set = true;
++                return r;
++        }
+ 
+-        if (streq(name, "DefaultMemoryLow"))
+-                return bus_cgroup_set_memory_protection(u, name, &c->default_memory_low, message, flags, error);
++        if (streq(name, "DefaultMemoryLow")) {
++                r = bus_cgroup_set_memory_protection(u, name, &c->default_memory_low, message, flags, error);
++                if (r > 0)
++                        c->default_memory_low_set = true;
++                return r;
++        }
+ 
+         if (streq(name, "MemoryHigh"))
+                 return bus_cgroup_set_memory(u, name, &c->memory_high, message, flags, error);
+@@ -773,17 +789,33 @@ int bus_cgroup_set_property(
+         if (streq(name, "MemoryLimit"))
+                 return bus_cgroup_set_memory(u, name, &c->memory_limit, message, flags, error);
+ 
+-        if (streq(name, "MemoryMinScale"))
+-                return bus_cgroup_set_memory_protection_scale(u, name, &c->memory_min, message, flags, error);
++        if (streq(name, "MemoryMinScale")) {
++                r = bus_cgroup_set_memory_protection_scale(u, name, &c->memory_min, message, flags, error);
++                if (r > 0)
++                        c->memory_min_set = true;
++                return r;
++        }
+ 
+-        if (streq(name, "MemoryLowScale"))
+-                return bus_cgroup_set_memory_protection_scale(u, name, &c->memory_low, message, flags, error);
++        if (streq(name, "MemoryLowScale")) {
++                r = bus_cgroup_set_memory_protection_scale(u, name, &c->memory_low, message, flags, error);
++                if (r > 0)
++                        c->memory_low_set = true;
++                return r;
++        }
+ 
+-        if (streq(name, "DefaultMemoryMinScale"))
+-                return bus_cgroup_set_memory_protection_scale(u, name, &c->default_memory_min, message, flags, error);
++        if (streq(name, "DefaultMemoryMinScale")) {
++                r = bus_cgroup_set_memory_protection_scale(u, name, &c->default_memory_min, message, flags, error);
++                if (r > 0)
++                        c->default_memory_min_set = true;
++                return r;
++        }
+ 
+-        if (streq(name, "DefaultMemoryLowScale"))
+-                return bus_cgroup_set_memory_protection_scale(u, name, &c->default_memory_low, message, flags, error);
++        if (streq(name, "DefaultMemoryLowScale")) {
++                r = bus_cgroup_set_memory_protection_scale(u, name, &c->default_memory_low, message, flags, error);
++                if (r > 0)
++                        c->default_memory_low_set = true;
++                return r;
++        }
+ 
+         if (streq(name, "MemoryHighScale"))
+                 return bus_cgroup_set_memory_scale(u, name, &c->memory_high, message, flags, error);
+-- 
+2.21.0
+

--- a/packages/systemd/9001-move-stateful-paths-to-ephemeral-storage.patch
+++ b/packages/systemd/9001-move-stateful-paths-to-ephemeral-storage.patch
@@ -1,7 +1,7 @@
-From bdce8f1cf22cb9f88365deb2120fc91531527b82 Mon Sep 17 00:00:00 2001
+From 8189d4f9604c4e37eee6db75e2cea2a3e3935f34 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sun, 15 Sep 2019 00:21:26 +0000
-Subject: [PATCH 1/3] move stateful paths to ephemeral storage
+Subject: [PATCH 9001/9003] move stateful paths to ephemeral storage
 
 We reserve most of /var for persistent local storage controlled by
 the administrator, and want to avoid depending on it for our own
@@ -13,10 +13,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/src/libsystemd/sd-path/sd-path.c b/src/libsystemd/sd-path/sd-path.c
-index 9949c23..647e226 100644
+index ad56ddb..36cd0b4 100644
 --- a/src/libsystemd/sd-path/sd-path.c
 +++ b/src/libsystemd/sd-path/sd-path.c
-@@ -255,19 +255,19 @@ static int get_path(uint64_t type, char **buffer, const char **ret) {
+@@ -252,19 +252,19 @@ static int get_path(uint64_t type, char **buffer, const char **ret) {
                  return 0;
  
          case SD_PATH_SYSTEM_STATE_PRIVATE:

--- a/packages/systemd/9002-do-not-create-unused-state-directories.patch
+++ b/packages/systemd/9002-do-not-create-unused-state-directories.patch
@@ -1,7 +1,7 @@
-From 165d687789904531396afa3d852513b40397fb3f Mon Sep 17 00:00:00 2001
+From 1be1595d5d43f05481d5fbf08f3e75a5eec2873c Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sun, 15 Sep 2019 00:51:25 +0000
-Subject: [PATCH 2/3] do not create unused state directories
+Subject: [PATCH 9002/9003] do not create unused state directories
 
 We do not use the coredump handler, and the private directories have
 been relocated to `/run`.

--- a/packages/systemd/9003-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9003-use-absolute-path-for-var-run-symlink.patch
@@ -1,7 +1,7 @@
-From 34c8fd9a28879fa97ae7b826475f5f93f1941333 Mon Sep 17 00:00:00 2001
+From ce9b01ee7a39bfed3e96be6b4547188d4b49bed3 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 17 Sep 2019 01:35:51 +0000
-Subject: [PATCH 3/3] use absolute path for /var/run symlink
+Subject: [PATCH 9003/9003] use absolute path for /var/run symlink
 
 Otherwise the symlink may be broken if /var is a bind mount from
 somewhere else.
@@ -12,7 +12,7 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/tmpfiles.d/var.conf.m4 b/tmpfiles.d/var.conf.m4
-index 0e2c509..6068dcb 100644
+index 0e2c509..6716540 100644
 --- a/tmpfiles.d/var.conf.m4
 +++ b/tmpfiles.d/var.conf.m4
 @@ -9,7 +9,7 @@

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd/archive/v242/systemd-242.tar.gz"
-sha512 = "578f68a3c8f2d454198fc04ff8d943abcfb390531d57f9603d185857f7afa7f4dc641dafecf49ce50fe22f5837b252b181400891e8efd4459fd4f69bb4283cb4"
+url = "https://github.com/systemd/systemd/archive/v243/systemd-243.tar.gz"
+sha512 = "56b52a297aa5ac04d9667eb3afb1598725b197de73ff72baa1aabbc2844e36fba7b7fccdf6d214ae8b5b926616b2b7e15772763aaa80ec938d74333ff9c8673e"
 
 [build-dependencies]
 buildsys = { path = "../../tools/buildsys" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,16 +2,23 @@
 %global __arch_install_post /usr/lib/rpm/check-buildroot
 
 Name: %{_cross_os}systemd
-Version: 242
+Version: 243
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: LGPLv2+ and MIT and GPLv2+
 URL: https://www.freedesktop.org/wiki/Software/systemd
 Source0: https://github.com/systemd/systemd/archive/v%{version}/systemd-%{version}.tar.gz
 Source1: run-tmpfiles.conf
-Patch1: 0001-move-stateful-paths-to-ephemeral-storage.patch
-Patch2: 0002-do-not-create-unused-state-directories.patch
-Patch3: 0003-use-absolute-path-for-var-run-symlink.patch
+
+# Upstream fixes.
+Patch0001: 0001-cgroup-Check-ancestor-memory-min-for-unified-memory-.patch
+Patch0002: 0002-cgroup-Respect-DefaultMemoryMin-when-setting-memory..patch
+Patch0003: 0003-cgroup-Mark-memory-protections-as-explicitly-set-in-.patch
+
+# Local changes.
+Patch9001: 9001-move-stateful-paths-to-ephemeral-storage.patch
+Patch9002: 9002-do-not-create-unused-state-directories.patch
+Patch9003: 9003-use-absolute-path-for-var-run-symlink.patch
 
 BuildRequires: gperf
 BuildRequires: intltool
@@ -229,6 +236,7 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 %exclude %{_cross_datadir}/polkit-1
 
 %dir %{_cross_factorydir}
+%{_cross_factorydir}%{_cross_sysconfdir}/issue
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/nsswitch.conf
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d/other
@@ -236,6 +244,7 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 
 %exclude %{_cross_docdir}
 %exclude %{_cross_localedir}
+%exclude %{_cross_localstatedir}/log/README
 %exclude %{_cross_rundir}
 
 %files devel


### PR DESCRIPTION
Signed-off-by: Ben Cressey <bcressey@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
Updates systemd to 243. Includes three patches for cgroup handling that were included by Fedora, and backported by Facebook.

Testing done:
Launched new nodes, which came up correctly. Ran e2e conformance tests through sonobuoy; tests passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
