### PR TITLE
containerd: update to 1.3.0

### DIFF
--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.2.9/containerd-1.2.9.tar.gz"
-sha512 = "60c7d08db3796caa8148f242f8386ff530943cef19fe73c72787fd7bbf2420feac06cadd558afc93d2baf168817d679245bf2ac9feb169547286cb312818be85"
+url = "https://github.com/containerd/containerd/archive/v1.3.0/containerd-1.3.0.tar.gz"
+sha512 = "cff9f0189b9fdc2b5492c92129af284aa8cd099e48de94cafd90aed191e2d20060c96008111b05fe081de0d4fc41d35f8cba5a3dc2d8cc0a5c37f695fd3cedc1"
 
 [build-dependencies]
 buildsys = { path = "../../tools/buildsys" }

--- a/packages/containerd/containerd-config.toml
+++ b/packages/containerd/containerd-config.toml
@@ -1,16 +1,27 @@
+version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"
-disabled_plugins = ["aufs", "zfs"]
+disabled_plugins = [
+    "io.containerd.snapshotter.v1.aufs",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.snapshotter.v1.devmapper",
+]
 
 [grpc]
 address = "/run/containerd/containerd.sock"
 
-[plugins.cri]
-systemd_cgroup = true
+[plugins."io.containerd.grpc.v1.cri".containerd]
+default_runtime_name = "runc"
 
-[plugins.cri.cni]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+
+[plugins."io.containerd.grpc.v1.cri".cni]
 bin_dir = "/opt/cni/bin"
 conf_dir = "/etc/cni/net.d"
 
-[plugins.opt]
+[plugins."io.containerd.internal.v1.opt"]
 path = "/opt/containerd"

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.2.9
+%global gover 1.3.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -39,15 +39,27 @@ Requires: %{_cross_os}systemd
 %build
 %cross_go_configure %{goimport}
 export BUILDTAGS="no_btrfs rpm_crashtraceback seccomp selinux"
-for bin in containerd containerd-shim ctr ; do
+for bin in \
+  containerd \
+  containerd-shim \
+  containerd-shim-runc-v1 \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
   go build -buildmode pie -tags="${BUILDTAGS}" -o ${bin} %{goimport}/cmd/${bin}
 done
 
 %install
 install -d %{buildroot}%{_cross_bindir}
-install -p -m 0755 containerd %{buildroot}%{_cross_bindir}
-install -p -m 0755 containerd-shim %{buildroot}%{_cross_bindir}
-install -p -m 0755 ctr %{buildroot}%{_cross_bindir}
+for bin in \
+  containerd \
+  containerd-shim \
+  containerd-shim-runc-v1 \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
+  install -p -m 0755 ${bin} %{buildroot}%{_cross_bindir}
+done
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/containerd.service
@@ -61,6 +73,8 @@ install -p -m 0644 %{S:3} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
 %files
 %{_cross_bindir}/containerd
 %{_cross_bindir}/containerd-shim
+%{_cross_bindir}/containerd-shim-runc-v1
+%{_cross_bindir}/containerd-shim-runc-v2
 %{_cross_bindir}/ctr
 %{_cross_unitdir}/containerd.service
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/containerd

--- a/packages/release/host-containerd-config.toml
+++ b/packages/release/host-containerd-config.toml
@@ -1,9 +1,15 @@
+version = 2
 root = "/var/lib/host-containerd"
 state = "/run/host-containerd"
-disabled_plugins = ["aufs", "zfs", "cri"]
+disabled_plugins = [
+    "io.containerd.snapshotter.v1.aufs",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.grpc.v1.cri",
+]
 
 [grpc]
 address = "/run/host-containerd/containerd.sock"
 
-[plugins.opt]
+[plugins."io.containerd.internal.v1.opt"]
 path = "/opt/host-containerd"


### PR DESCRIPTION
Signed-off-by: Ben Cressey <bcressey@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
Updates containerd to 1.3.0. Migrates the config file to version 2 format, which unlocks the syntax needed to express that the default runtime is `runc` and that it should integrate with systemd cgroups. Also switches to the newer `io.containerd.runc.v2` runtime for CRI.

*Testing done:*
Launched new nodes, which came up correctly. Ran e2e conformance tests through sonobuoy; tests passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
