### PR TITLE
Add API to delete pending settings

### DIFF
--- a/workspaces/api/apiserver/src/datastore/filesystem.rs
+++ b/workspaces/api/apiserver/src/datastore/filesystem.rs
@@ -377,6 +377,23 @@ impl DataStore for FilesystemDataStore {
 
         Ok(pending_keys)
     }
+
+    fn delete_pending(&mut self) -> Result<HashSet<Key>> {
+        // Get changed keys so we can return the list
+        let pending_data = self.get_prefix("settings.", Committed::Pending)?;
+
+        // Pull out just the keys so we can log them and return them
+        let pending_keys = pending_data.into_iter().map(|(key, _val)| key).collect();
+        debug!("Found pending keys: {:?}", &pending_keys);
+
+        // Delete pending from the filesystem, same as a commit
+        debug!("Removing all pending keys");
+        fs::remove_dir_all(&self.pending_path).context(error::Io {
+            path: &self.pending_path,
+        })?;
+
+        Ok(pending_keys)
+    }
 }
 
 #[cfg(test)]

--- a/workspaces/api/apiserver/src/datastore/mod.rs
+++ b/workspaces/api/apiserver/src/datastore/mod.rs
@@ -100,6 +100,9 @@ pub trait DataStore {
     /// Applies pending changes to the live datastore.  Returns the list of changed keys.
     fn commit(&mut self) -> Result<HashSet<Key>>;
 
+    /// Remove pending changes from the datastore.  Returns the list of removed keys.
+    fn delete_pending(&mut self) -> Result<HashSet<Key>>;
+
     /// Set multiple data keys at once in the data store.
     ///
     /// Implementers can replace the default implementation if there's a faster way than setting

--- a/workspaces/api/apiserver/src/server/controller.rs
+++ b/workspaces/api/apiserver/src/server/controller.rs
@@ -28,6 +28,13 @@ pub(crate) fn get_pending_settings<D: DataStore>(datastore: &D) -> Result<Settin
     .map(|maybe_settings| maybe_settings.unwrap_or_else(Settings::default))
 }
 
+/// Delete any settings that have been received but not committed
+pub(crate) fn delete_pending_settings<D: DataStore>(datastore: &mut D) -> Result<HashSet<Key>> {
+    datastore.delete_pending().context(error::DataStore {
+        op: "delete_pending",
+    })
+}
+
 /// Build a Settings based on the data in the datastore.  Errors if no settings are found.
 pub(crate) fn get_settings<D: DataStore>(datastore: &D, committed: Committed) -> Result<Settings> {
     get_prefix(

--- a/workspaces/api/apiserver/src/server/mod.rs
+++ b/workspaces/api/apiserver/src/server/mod.rs
@@ -67,6 +67,7 @@ where
                     .route("", web::get().to(get_settings))
                     .route("", web::patch().to(patch_settings))
                     .route("/pending", web::get().to(get_pending_settings))
+                    .route("/pending", web::delete().to(delete_pending_settings))
                     .route("/commit", web::post().to(commit_settings))
                     .route("/apply", web::post().to(apply_settings))
                     .route(
@@ -152,6 +153,13 @@ fn patch_settings(
 fn get_pending_settings(data: web::Data<SharedDataStore>) -> Result<Settings> {
     let datastore = data.ds.read().ok().context(error::DataStoreLock)?;
     controller::get_pending_settings(&*datastore)
+}
+
+/// Delete any settings that have been received but not committed
+fn delete_pending_settings(data: web::Data<SharedDataStore>) -> Result<ChangedKeysResponse> {
+    let mut datastore = data.ds.write().ok().context(error::DataStoreLock)?;
+    let deleted = controller::delete_pending_settings(&mut *datastore)?;
+    Ok(ChangedKeysResponse(deleted))
 }
 
 /// Save settings changes to the main data store and kick off appliers.

--- a/workspaces/api/openapi.yaml
+++ b/workspaces/api/openapi.yaml
@@ -74,6 +74,14 @@ paths:
                 $ref: "Settings"
         500:
           description: "Server error"
+    delete:
+      summary: "Delete pending settings"
+      operationId: "delete_pending_settings"
+      responses:
+        200:
+          description: "Successful deleted pending settings - deleted keys are returned"
+        500:
+          description: "Server error"
 
   /settings/commit:
     post:


### PR DESCRIPTION
Just struck me yesterday that we should be able to delete pending settings.  The alternative would be to query current live settings and change the pending setting to match what's live, so that a later commit wouldn't have any effect, but it's cleaner to be able to say "nope, don't do any of this."

Could argue about a delete-specific-pending-keys mode later...

**Testing done:**

You can set a setting and see it in pending, then delete pending and see which keys were deleted, and finally confirm that pending is empty:

```
$ cargo run -- --socket-path /tmp/thar-api.sock -u /settings -X PATCH -d '{"timezone": "NewOldLosAngeles"}' -v
204 No Content
 
$ cargo run -- --socket-path /tmp/thar-api.sock -u /settings/pending
{"timezone":"NewOldLosAngeles"}
 
$ cargo run -- --socket-path /tmp/thar-api.sock -u /settings/pending -X DELETE
["settings.timezone"]
 
$ cargo run -- --socket-path /tmp/thar-api.sock -u /settings/pending
{}
```