### PR TITLE
settings: adds new `node-labels`, `node-taints` settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,19 @@ See the [setup guide](INSTALL.md) for *much* more detail on setting up Thar and 
 * `settings.kubernetes.cluster-certificate`: This is the base64-encoded certificate authority of the cluster.
 * `settings.kubernetes.api-server`: This is the cluster's Kubernetes API endpoint.
 
+The following settings can be optionally set to customize the node labels and taints. 
+* `settings.kubernetes.node-labels`: [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) in the form of key, value pairs added when registering the node in the cluster.
+* `settings.kubernetes.node-taints`: [Taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) in the form of key, value and effect entries added when registering the node in the cluster.
+  * Example user data for setting up labels and taints:
+    ```
+    [settings.kubernetes.node-labels]
+    label1 = "foo"
+    label2 = "bar"
+    [settings.kubernetes.node-taints]
+    dedicated = "experimental:PreferNoSchedule"
+    special = "true:NoSchedule"
+    ```
+
 The following settings are set for you automatically by [pluto](workspaces/api/) based on runtime instance information, but you can override them if you know what you're doing!
 * `settings.kubernetes.max-pods`: The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)
 * `settings.kubernetes.cluster-dns-ip`: The CIDR block of the primary network interface.

--- a/packages/kubernetes/kubelet-env
+++ b/packages/kubernetes/kubelet-env
@@ -1,2 +1,4 @@
 NODE_IP={{settings.kubernetes.node-ip}}
+NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
+NODE_TAINTS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-taints}}
 POD_INFRA_CONTAINER_IMAGE={{settings.kubernetes.pod-infra-container-image}}

--- a/packages/kubernetes/kubelet.service
+++ b/packages/kubernetes/kubelet.service
@@ -19,6 +19,8 @@ ExecStart=/usr/bin/kubelet \
     --cert-dir /var/lib/kubelet/pki \
     --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
     --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
     --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
 
 Restart=on-failure

--- a/workspaces/api/apiserver/src/model.rs
+++ b/workspaces/api/apiserver/src/model.rs
@@ -55,6 +55,12 @@ pub struct KubernetesSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_server: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_labels: Option<HashMap<SingleLineString, SingleLineString>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_taints: Option<HashMap<SingleLineString, SingleLineString>>,
+
     // Dynamic settings.
 
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
*Issue #, if available:* Fixes #366

*Description of changes:*
Adds `node-labels` and `node-taints` settings for `kubelet.service`, both are modelled as `HashMap<SingleLineString, SingleLineString>`.
Allows users to label and taint the node through said settings in `userdata.toml`

*Testing:*
Launch Thar nodes with `node-labels` and `node-taints` set as follows in user data:
```
[settings.kubernetes.node-labels]
testLabel = "foo"
testLabel2 = "bar"

[settings.kubernetes.node-taints]
dedicated = "experimental:PreferNoSchedule"
special = "true:PreferNoSchedule"
```

Confirmed that `kubelet` starts successfully:
```
bash-5.0# systemctl status kubelet
● kubelet.service - Kubelet
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-10-15 01:14:53 UTC; 17min ago
     Docs: https://github.com/kubernetes/kubernetes
  Process: 2684 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT (code=exited, status=0/SUCCESS)
 Main PID: 2769 (kubelet)
    Tasks: 18
   Memory: 132.0M
      CPU: 12.846s
   CGroup: /system.slice/kubelet.service
           └─2769 /usr/bin/kubelet --cloud-provider aws --config /etc/kubernetes/kubelet/config --kubeconfig /etc/kubernetes/kubelet/kubeconfig --container-runt
ime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --network-plugin cni --root-dir /var/lib/kubelet --cert-dir /var/lib/kubelet/pk
i --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec --node-ip 192.168.33.144 --node-labels testLabel=foo,testLabel2=bar --register-with-taints dedicate
d=experimental:PreferNoSchedule,special=true:PreferNoSchedule --pod-infra-container-image 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1
```

And the nodes are labelled and tainted accordingly:
```
$ kubectl describe nodes ip-192-168-33-144.us-west-2.compute.internal                                                                
Name:               ip-192-168-33-144.us-west-2.compute.internal                                                                                              Roles:              <none>     
Labels:             beta.kubernetes.io/arch=amd64               
                    beta.kubernetes.io/instance-type=c5.large
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=us-west-2
                    failure-domain.beta.kubernetes.io/zone=us-west-2a
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=ip-192-168-33-144.us-west-2.compute.internal
                    kubernetes.io/os=linux
                    testLabel=foo
                    testLabel2=bar
Annotations:        node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
CreationTimestamp:  Mon, 14 Oct 2019 18:14:54 -0700
Taints:             dedicated=experimental:PreferNoSchedule
                    special=true:PreferNoSchedule
...
```

Without `node-lables` and `node-taints` specified. `kubelet` still successfully runs and registers the node:
```
bash-5.0# systemctl status kubelet                         
● kubelet.service - Kubelet                                                                                                                                   
   Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)                                   
   Active: active (running) since Tue 2019-10-15 19:22:18 UTC; 4min 31s ago
     Docs: https://github.com/kubernetes/kubernetes
  Process: 2634 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT (code=exited, status=0/SUCCESS)
 Main PID: 2759 (kubelet)
    Tasks: 17
   Memory: 128.6M
      CPU: 3.726s
   CGroup: /system.slice/kubelet.service
           └─2759 /usr/bin/kubelet --cloud-provider aws --config /etc/kubernetes/kubelet/config --kubeconfig /etc/kubernetes/kubelet/kubeconfig --container-ru
nt
ime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --network-plugin cni --root-dir /var/lib/kubelet --cert-dir /var/lib/kubelet/pk
i --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec --node-ip 192.168.35.147 --node-labels  --register-with-taints  --pod-infra-container-image 6024011
43452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
