### PR TITLE
INSTALL: Document kube-proxy settings

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,6 +206,26 @@ eksctl-thar-nodegroup-ng-IDENTIFIER-NodeInstanceProfile-IDENTIFIER
 
 Note this down as the INSTANCE_PROFILE_NAME for the final launch command.
 
+## kube-proxy settings
+By default `kube-proxy` will set the `nf_conntrack_max` kernel parameter to a default value that may differ from what Thar originally sets at boot.
+If you prefer to keep Thar's [default setting](packages/release/release-sysctl.conf), edit the kube-proxy configuration details with:
+
+```
+kubectl edit -n kube-system daemonset kube-proxy
+```
+
+Add `--conntrack-max-per-core` and `--conntrack-min` to the kube-proxy arguments like so (0 implies no change):
+```
+      containers:
+      - command:
+        - kube-proxy
+        - --v=2
+        - --config=/var/lib/kube-proxy-config/config
+        - --conntrack-max-per-core 0
+        - --conntrack-min 0
+
+```
+
 ## Final launch details
 
 For the instance to be able to communicate with the EKS cluster control plane and other worker nodes, we need to make sure the instance is launched with the right security groups.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazonlinux/PRIVATE-thar/issues/371

*Description of changes:*
The kube-proxy configuration must be updated to prevent it from
overriding Thar's sysctl change to nf_conntrack_max. Document the steps
to update the configuration in the install steps.

Fixes #371 for kernel settings.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
