### PR TITLE
Add enable-admin-container helper to control container with instructions

### DIFF
--- a/extras/control-container/Dockerfile
+++ b/extras/control-container/Dockerfile
@@ -2,6 +2,22 @@ FROM amazonlinux:2
 
 RUN yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm shadow-utils
 
+# Add motd explaining the control container.
+RUN rm -f /etc/motd /etc/issue
+ADD --chown=root:root motd /etc/
+# Add bashrc that shows the motd.
+ADD ./bashrc /etc/skel/.bashrc
+# SSM starts sessions with 'sh', not 'bash', which for us is a link to bash.
+# Furthermore, it starts sh as an interactive shell, but not a login shell.
+# In this mode, the only startup file respected is the one pointed to by the
+# ENV environment variable.  Point it to our bashrc, which just prints motd.
+ENV ENV /etc/skel/.bashrc
+
+# Add our helper to quickly enable the admin container.
+ADD ./enable-admin-container /usr/bin/
+RUN chmod +x /usr/bin/enable-admin-container
+
+# Create our user in the group that allows API access.
 RUN groupadd -g 274 api
 RUN useradd -m -G users,api ssm-user
 

--- a/extras/control-container/bashrc
+++ b/extras/control-container/bashrc
@@ -1,0 +1,6 @@
+if [ -f /etc/bashrc ]; then
+   . /etc/bashrc
+fi
+
+cat /etc/motd
+echo

--- a/extras/control-container/enable-admin-container
+++ b/extras/control-container/enable-admin-container
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+error() {
+   echo -e "Error: ${*}\n" >&2
+   cat >&2 <<-EOF
+	You can manually enable the admin container like this:
+	   apiclient -u /settings -m PATCH -d '{"host-containers": {"admin": {"enabled": true}}}'
+	   apiclient -u /settings/commit_and_apply -m POST
+	EOF
+   exit 1
+}
+
+if ! command -v apiclient >/dev/null 2>&1; then
+   error "can't find 'apiclient'"
+fi
+
+echo "Checking whether there are pending settings; we don't want to silently commit other changes"
+PENDING="$(apiclient -u /settings/pending)"
+rc="${?}"
+if [ "${rc}" -ne 0 ]; then
+   error "apiclient returned ${rc} - couldn't check pending settings, so we don't know if it's safe to commit changes for enabling admin container.\nTry to check what's pending with \`apiclient -u /settings/pending\`"
+elif [ "${PENDING}" != "{}" ]; then
+   error "found pending settings in API, cowardly refusing to commit them.\nYou can commit them yourself with \`apiclient -u /settings/commit_and_apply -m POST\` and try again.\nPending settings: ${PENDING}"
+fi
+
+echo "Setting admin container to enabled"
+if ! apiclient -v -u /settings -m PATCH -d '{"host-containers": {"admin": {"enabled": true}}}'; then
+   error "failed to change enabled setting of admin container"
+fi
+
+echo "Committing and applying changes"
+if ! apiclient -v -u /settings/commit_and_apply -m POST; then
+   error "failed to commit and apply settings"
+fi
+
+echo "The admin container is now enabled - it should pull and start soon, and then you can SSH in"

--- a/extras/control-container/motd
+++ b/extras/control-container/motd
@@ -1,0 +1,19 @@
+Welcome to Thar's control container!
+
+This container gives you access to the Thar API, which in turn lets you inspect
+and configure the system.  You'll probably want to use the `apiclient` tool for
+that; for example, to inspect the system:
+
+   apiclient -u /settings
+
+You can run `apiclient --help` for usage details, and check the main Thar
+documentation for descriptions of all settings and examples of changing them.
+
+If you need to debug the system further, you can enable the admin container.
+This enables SSH access to the system using the key you specified when you
+launched the instance.  This environment has more debugging tools installed,
+and allows you to get root access to the host.
+
+To enable the admin container, run:
+
+   enable-admin-container


### PR DESCRIPTION
Fixes #402

The hack to show the motd in `sh` is fun; see the comments in the Dockerfile.  I figure it still makes sense to have a bashrc and point to that with ENV, even if we/ssm-agent are not using bash right now.

---

**Testing done:**

On login, we now see a helpful message:
```
$ aws ssm start-session --target i-00de67cefaed0840e                                                        [17:31:11]

Starting session with SessionId: tjk-03f919adca34f4e66
Welcome to Thar's control container!

This container gives you access to the Thar API, which in turn lets you inspect
and configure the system.  You'll probably want to use the `apiclient` tool for
that; for example, to inspect the system:

   apiclient -u /settings

You can run `apiclient --help` for usage details, and check the main Thar
documentation for descriptions of all settings and examples of changing them.

If you need to debug the system further, you can enable the admin container,
which enables SSH access to the system using the key you specified when you
launched the instance.

To enable the admin container, run:

   enable-admin-container

[ssm-user@ip-192-168-97-207 /]$
```

Here's the helper:
```
[ssm-user@ip-192-168-97-207 /]$ enable-admin-container
Checking whether there are pending settings; we don't want to silently commit other changes
Setting admin container to enabled
204 No Content
Committing and applying changes
200 OK
["settings.host-containers.admin.enabled"]
The admin container is now enabled - it should pull and start soon, and then you can SSH in
```

Here's with -x so you can see what it's doing:
```
sh-4.2$ sh -x /tmp/enable-admin-container 
+ command -v apiclient
+ echo 'Checking whether there are pending settings; we don'\''t want to silently commit other changes'
Checking whether there are pending settings; we don't want to silently commit other changes
++ apiclient -u /settings/pending
+ PENDING='{}'
+ rc=0
+ '[' 0 -ne 0 ']'
+ '[' '{}' '!=' '{}' ']'
+ echo 'Setting admin container to enabled'
Setting admin container to enabled
+ apiclient -v -u /settings -m PATCH -d '{"host-containers": {"admin": {"enabled": true}}}'
204 No Content
+ echo 'Committing and applying changes'
Committing and applying changes
+ apiclient -v -u /settings/commit_and_apply -m POST
200 OK
["settings.host-containers.admin.enabled"]
+ echo 'The admin container is now enabled - it should pull and start soon, and then you can SSH in'
The admin container is now enabled - it should pull and start soon, and then you can SSH in
```

If there are already pending settings, it doesn't want to quietly commit those, so it bails:
```
sh-4.2$ sh /tmp/enable-admin-container 
Checking whether there are pending settings; we don't want to silently commit other changes
Error: found pending settings in API, cowardly refusing to commit them.
You can commit them yourself first with `apiclient -u /settings/commit_and_apply -m POST` and try again.
Pending settings: {"host-containers":{"admin":{"enabled":true}}}

You can try manually enabling the admin container like this:
   apiclient -u /settings -m PATCH -d '{"host-containers": {"admin": {"enabled": true}}}'
   apiclient -u /settings/commit_and_apply -m POST
```