### PR TITLE
thar-be-settings: Add trace debugging to client module

### DIFF
--- a/workspaces/api/thar-be-settings/src/client.rs
+++ b/workspaces/api/thar-be-settings/src/client.rs
@@ -27,6 +27,7 @@ where
     }
 
     let method = "GET";
+    trace!("{}ing from {}", method, uri);
     let (code, response_body) = apiclient::raw_request(socket_path, &uri, method, None)
         .context(error::APIRequest { method, uri: &uri })?;
 
@@ -39,6 +40,7 @@ where
         }
         .fail();
     }
+    trace!("JSON response: {}", response_body);
 
     serde_json::from_str(&response_body).context(error::ResponseJson { method, uri })
 }


### PR DESCRIPTION
This helped solve the question in #406.

**Testing done:**

Saw the trace messages when I called t-b-s with `-v -v`.  Example:
```
Oct 14 19:53:11.683 TRACE thar_be_settings::client: GETing from /settings?keys=this,settings.kubernetes.cluster-name,settings.updates.seed,settings.updates.metadata-base-url,settings.kubernetes.max-pods,settings.ntp.time-servers,settings.updates.target-base-url,settings.hostname,settings.kubernetes.cluster-certificate,settings.kubernetes.cluster-dns-ip,settings.kubernetes.pod-infra-container-image,settings.kubernetes.node-ip,settings.kubernetes.api-server
```