### PR TITLE
updog: Don't source migrations from a downloaded root image

### DIFF
--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -3191,7 +3191,6 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "data_store_version 0.1.0",
- "loopdev 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3201,8 +3200,6 @@ dependencies = [
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signpost 0.1.0",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sys-mount 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tough 0.1.0",

--- a/workspaces/updater/updog/Cargo.toml
+++ b/workspaces/updater/updog/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 chrono = "0.4.9"
 data_store_version = { path = "../../api/data_store_version" }
-loopdev = "0.2.1"
 lz4 = "1.23.1"
 rand = "0.7.0"
 regex = "1.1"
@@ -20,8 +19,6 @@ signpost = { path = "../signpost" }
 snafu = "0.5.0"
 tracing = "0.1"
 tracing-subscriber = "0.1"
-sys-mount = "1.2.1"
-tempfile = "3.1.0"
 time = "0.1"
 toml = "0.5.1"
 tough = { path = "../tough" }


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/amazonlinux/PRIVATE-thar/issues/414

*Description of changes:*
Updog downloads the root image before writing it to disk so that it can
be mounted and searched for existing migrations, in an effort to reduce
network traffic. However this has two problems in the current approach:
- It doesn't solve the issue of trust for the "other" side when it boots
and finds these migrations.
- If run from a container with smaller cgroup limits (eg. dogswatch)
it can invoke the OOM killer!

Be more conservative with memory and remove this approach. Future
patches will introduce a more trusted and less memory-hungry solution.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
