### PR TITLE
thar-be-settings: log a render error when running in --all mode

### DIFF
--- a/workspaces/api/thar-be-settings/src/config.rs
+++ b/workspaces/api/thar-be-settings/src/config.rs
@@ -73,8 +73,11 @@ pub fn render_config_files(
             let rendered = try_rendered.context(error::TemplateRender { template: name })?;
             rendered_configs.push(RenderedConfigFile::new(&metadata.path, rendered));
         } else {
-            if let Ok(rendered) = try_rendered {
-                rendered_configs.push(RenderedConfigFile::new(&metadata.path, rendered));
+            match try_rendered {
+                Ok(rendered) => {
+                    rendered_configs.push(RenderedConfigFile::new(&metadata.path, rendered))
+                }
+                Err(err) => warn!("Unable to render template '{}': {}", &name, err),
             }
         }
     }


### PR DESCRIPTION
When running in `--all` mode, thar-be-settings (intentionally) does not fail
when a template fails to render. This commit logs a message
with the appropriate details in the event of a failure.

*Issue #, if available:*
Fixes #412 

*Description of changes:*
* Add `match` statement to catch and log the `Err()` case.

*Testing done:*

Run `thar-be-settings` with a setting passed on the command line:
```
bash-5.0# thar-be-settings <<< '["settings.hostname"]'
Oct 17 16:18:29.582  INFO thar_be_settings: thar-be-settings started
Oct 17 16:18:29.584  INFO thar_be_settings: Parsing stdin for updated settings
Oct 17 16:18:29.586  INFO thar_be_settings: Requesting affected services for settings: {"settings.hostname"}
Oct 17 16:18:29.592  INFO thar_be_settings: Requesting configuration file data for affected services
Oct 17 16:18:29.597  INFO thar_be_settings: Rendering config files...
Oct 17 16:18:29.599  INFO thar_be_settings: Writing config files to disk...
Oct 17 16:18:29.600  INFO thar_be_settings: Restarting affected services...
```

Run `thar-be-settings --all` on a system where a few kubernetes settings don't exist:
```
bash-5.0# thar-be-settings --all
Oct 17 16:18:35.319  INFO thar_be_settings: thar-be-settings started
Oct 17 16:18:35.320  INFO thar_be_settings: Requesting configuration file data for affected services
Oct 17 16:18:35.329  INFO thar_be_settings: Rendering config files...
Oct 17 16:18:35.331  INFO thar_be_settings::config: Unable to render template 'kubernetes-ca-crt': RenderError { desc: "TemplateHelperError :: InvalidTemplateValue", template_name: Some("kubernetes-ca-crt"), line_no: Some(1), column_no: Some(1), cause: Some(InvalidTemplateValue { expected:}...SNIP...
Oct 17 16:18:35.336  INFO thar_be_settings::config: Unable to render template 'kubelet-kubeconfig': RenderError { desc: "Variable \"settings.kubernetes.api-server\" not found in strict mode.", template_name: Some("kubelet-kubeconfig"), line_no: Some(7), column_no: Some(14), cause: None }  
Oct 17 16:18:35.341  INFO thar_be_settings: Writing config files to disk...
Oct 17 16:18:35.342  INFO thar_be_settings: Restarting all services...

bash-5.0# echo $?
0
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
