### PR TITLE
release: Add several security-related sysctls

### DIFF
--- a/packages/kernel/config-thar
+++ b/packages/kernel/config-thar
@@ -21,3 +21,6 @@ CONFIG_BLK_DEV_DM=y
 CONFIG_DAX=y
 CONFIG_DM_INIT=y
 CONFIG_DM_VERITY=y
+
+# yama LSM for ptrace restrictions
+CONFIG_SECURITY_YAMA=y

--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -38,6 +38,9 @@ kernel.dmesg_restrict = 1
 # Turn off kexec, even if it's built in.
 kernel.kexec_load_disabled = 1
 
+# Avoid non-ancestor ptrace access to running processes and their credentials.
+kernel.yama.ptrace_scope = 1
+
 # Disable User Namespaces, as it opens up a large attack surface to unprivileged users.
 user.max_user_namespaces = 0
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add recommended settings from the Kernel Self Protection Project
[wiki]. Most of these are straightforward, some notes on the others:

- kernel.perf_event_paranoid: Omitted since the Thar kernel does not
include the required patch for '3' and the default is '2'.
- kernel.yama.ptrace_scope: The Yama LSM is now enabled in the kernel in order to support this option.
- user.max_user_namespaces: Included since Kubernetes doesn't yet
support [user namespaces], but could be something to review later on.

[wiki]: https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings#sysctls
[user namespaces]: https://github.com/kubernetes/enhancements/issues/127

Tested by building and launching an instance and confirming the values were correct under `/proc/sys/...`

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
