### PR TITLE
Tuftool - accept relative dates

### DIFF
--- a/workspaces/tuftool/src/create.rs
+++ b/workspaces/tuftool/src/create.rs
@@ -1,4 +1,5 @@
 use crate::copylike::Copylike;
+use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::key::{keys_for_root, sign_metadata, RootKeys};
 use crate::source::KeySource;
@@ -45,22 +46,25 @@ pub(crate) struct CreateArgs {
     /// Version of snapshot.json file
     #[structopt(long = "snapshot-version")]
     snapshot_version: NonZeroU64,
-    /// Expiration of snapshot.json file
-    #[structopt(long = "snapshot-expires")]
+    /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
+    /// 7 days'
+    #[structopt(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
     snapshot_expires: DateTime<Utc>,
 
     /// Version of targets.json file
     #[structopt(long = "targets-version")]
     targets_version: NonZeroU64,
-    /// Expiration of targets.json file
-    #[structopt(long = "targets-expires")]
+    /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
+    /// 7 days'
+    #[structopt(long = "targets-expires", parse(try_from_str = parse_datetime))]
     targets_expires: DateTime<Utc>,
 
     /// Version of timestamp.json file
     #[structopt(long = "timestamp-version")]
     timestamp_version: NonZeroU64,
-    /// Expiration of timestamp.json file
-    #[structopt(long = "timestamp-expires")]
+    /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
+    /// 7 days'
+    #[structopt(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
     timestamp_expires: DateTime<Utc>,
 
     /// Path to root.json file for the repository

--- a/workspaces/tuftool/src/datetime.rs
+++ b/workspaces/tuftool/src/datetime.rs
@@ -1,0 +1,56 @@
+use crate::error::{self, Result};
+
+use chrono::{DateTime, Duration, FixedOffset, Utc};
+use snafu::{ensure, ResultExt};
+
+/// Parses a user-specified datetime, either in full RFC 3339 format, or a shorthand like "in 7
+/// days"
+pub(crate) fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
+    // If the user gave an absolute date in a standard format, accept it.
+    let try_dt: std::result::Result<DateTime<FixedOffset>, chrono::format::ParseError> =
+        DateTime::parse_from_rfc3339(input);
+    if let Ok(dt) = try_dt {
+        let utc = dt.into();
+        return Ok(utc);
+    }
+
+    // Otherwise, pull apart a request like "in 5 days" to get an exact datetime.
+    let mut parts: Vec<&str> = input.split_whitespace().collect();
+    ensure!(
+        parts.len() == 3,
+        error::DateArgInvalid {
+            input,
+            msg: "expected RFC 3339, or something like 'in 7 days'"
+        }
+    );
+    let unit_str = parts.pop().unwrap();
+    let count_str = parts.pop().unwrap();
+    let prefix_str = parts.pop().unwrap();
+
+    ensure!(
+        prefix_str == "in",
+        error::DateArgInvalid {
+            input,
+            msg: "expected RFC 3339, or prefix 'in', something like 'in 7 days'",
+        }
+    );
+
+    let count: u32 = count_str.parse().context(error::DateArgCount { input })?;
+
+    let duration = match unit_str {
+        "hour" | "hours" => Duration::hours(i64::from(count)),
+        "day" | "days" => Duration::days(i64::from(count)),
+        "week" | "weeks" => Duration::weeks(i64::from(count)),
+        _ => {
+            return error::DateArgInvalid {
+                input,
+                msg: "date argument's unit must be hours/days/weeks",
+            }
+            .fail();
+        }
+    };
+
+    let now = Utc::now();
+    let then = now + duration;
+    Ok(then)
+}

--- a/workspaces/tuftool/src/error.rs
+++ b/workspaces/tuftool/src/error.rs
@@ -38,6 +38,19 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Date argument '{}' is invalid: {}", input, msg))]
+    DateArgInvalid { input: String, msg: &'static str },
+
+    #[snafu(display(
+        "Date argument had count '{}' that failed to parse as integer: {}",
+        input,
+        source
+    ))]
+    DateArgCount {
+        input: String,
+        source: std::num::ParseIntError,
+    },
+
     #[snafu(display("Failed to {} {} to {}: {}", action, src.display(), dst.display(), source))]
     FileCopy {
         action: crate::copylike::Copylike,

--- a/workspaces/tuftool/src/main.rs
+++ b/workspaces/tuftool/src/main.rs
@@ -5,6 +5,7 @@
 
 mod copylike;
 mod create;
+mod datetime;
 mod deref;
 mod download;
 mod error;

--- a/workspaces/tuftool/src/root.rs
+++ b/workspaces/tuftool/src/root.rs
@@ -1,3 +1,4 @@
+use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::key::KeyPair;
 use crate::source::KeySource;
@@ -29,7 +30,9 @@ pub(crate) enum Command {
     Expire {
         /// Path to root.json
         path: PathBuf,
-        /// When to expire
+        /// Expiration of root; can be in full RFC 3339 format, or something like 'in
+        /// 7 days'
+        #[structopt(parse(try_from_str = parse_datetime))]
         time: DateTime<Utc>,
     },
     /// Set the signature count threshold for a role


### PR DESCRIPTION
```
0df8d11 tuftool: allow for relative date arguments like 'in 7 days'
81c6a71 tuftool: disable clippy use_self lint for clearer identifiers
dd6cc7a tuftool: fix typo that put snapshot version/expires into timestamp
```

---

Fixes #213 

**Testing done:**

New usage message for `root expire`:
```
$ cargo run -- root expire --help
tuftool-root-expire 0.1.0
Set the expiration time for root.json

USAGE:
    tuftool root expire <path> <time>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <path>    Path to root.json
    <time>    Expiration of root; can be in full RFC 3339 format, or something like 'in 7 days'
```

And for create:
```
tuftool-create 0.1.0
Create a TUF repository

USAGE:
    tuftool create [FLAGS] [OPTIONS] <indir> <outdir> --root <root> --snapshot-expires <snapshot-expires> --snapshot-version <snapshot-version> --targets-expires <targets-expires> --targets-version <targets-version> --timestamp-expires <timestamp-expires> --timestamp-version <timestamp-version>

FLAGS:
    -c, --copy        Copy files into `outdir` instead of symlinking them
    -f, --follow      Follow symbolic links in `indir`
    -H, --hardlink    Hardlink files into `outdir` instead of symlinking them
    -h, --help        Prints help information
    -V, --version     Prints version information

OPTIONS:
    -j, --jobs <jobs>                              Number of target hashing threads to run (default: number of cores)
    -k, --key <keys>...                            Key files to sign with
    -r, --root <root>                              Path to root.json file for the repository
        --snapshot-expires <snapshot-expires>
            Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in 7 days'

        --snapshot-version <snapshot-version>      Version of snapshot.json file
        --targets-expires <targets-expires>
            Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in 7 days'

        --targets-version <targets-version>        Version of targets.json file
        --timestamp-expires <timestamp-expires>
            Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in 7 days'

        --timestamp-version <timestamp-version>    Version of timestamp.json file

ARGS:
    <indir>     Directory of targets
    <outdir>    Repository output directory
```

Root expire accepts relative:
```
$ cargo run -- root expire root.json 'in 52 weeks'

$ grep expire root.json
    "expires": "2020-10-19T17:07:33Z",
```

Create accepts relative:
```
$ cargo run -- create ./src ./outdir --root root.json --snapshot-expires 'in 2 days' --snapshot-version 42 --targets-expires 'in 1 hour' --targets-version 42 --timestamp-expires 'in 6 weeks' --timestamp-version 42
cargo run -- create ./src ./outdir --root root.json --snapshot-expires   42    6.64s user 1.11s system 102% cpu 7.596 total
 
$ grep expire outdir/metadata/*
grep: outdir/metadata/1.root.json: No such file or directory
outdir/metadata/42.snapshot.json:    "expires": "2019-10-23T17:13:42.305040769Z",
outdir/metadata/42.targets.json:    "expires": "2019-10-21T18:13:42.305052425Z",
outdir/metadata/timestamp.json:    "expires": "2019-12-02T17:13:42.305061253Z",

$ date --rfc-3339=seconds -u
2019-10-21 17:13:49+00:00
```

You can also see that the timestamp expiration is correct now; before, it showed the same as the snapshot expiration.

RFC 3339 format also works:
```
$ cargo run -- root expire root.json '2019-10-21T19:13:49+00:00'
$ grep expire root.json
    "expires": "2019-10-21T19:13:49Z",
```

Or with `Z`:
```
$ cargo run -- root expire root.json '2019-10-21T19:13:49Z'
$ grep expire root.json
    "expires": "2019-10-21T19:13:49Z",
```