### PR TITLE
host-ctr: fix references for non-ECR images

### DIFF
--- a/workspaces/host-ctr/cmd/host-ctr/main.go
+++ b/workspaces/host-ctr/cmd/host-ctr/main.go
@@ -69,7 +69,7 @@ func _main() int {
 	defer client.Close()
 
 	// Check if the image is from ECR, if it is, convert the image name into a resolvable reference
-	var ref string
+	ref := source
 	match := ecrRegex.MatchString(source)
 	if match {
 		var err error


### PR DESCRIPTION
Discovered this bug when I was working on #433.

*Issue #, if available:* n/a

*Description of changes:* Fixes a bug introduced in #382 where `ref` isn't set when pulling images from non-ECR registries

*Testing:* 
Before the fix:
```
$ sudo ./host-ctr -source registry.hub.docker.com/library/busybox:latest -pull-image-only -containerd-socket /run/containerd/containerd.sock
ERRO[0000] Failed to pull ctr image: failed to resolve reference "": hostname required  ref=
```

Now can pull images from docker hub, etc and not just ECR:
```
$ sudo ./host-ctr -source registry.hub.docker.com/library/busybox:latest -pull-image-only -containerd-socket /run/containerd/containerd.sock
INFO[0000] Pulled successfully                           img="registry.hub.docker.com/library/busybox:latest"
INFO[0000] Unpacking...                                  img="registry.hub.docker.com/library/busybox:latest"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
