### PR TITLE
signpost: Avoid updating into nothing

### DIFF
--- a/workspaces/updater/signpost/src/error.rs
+++ b/workspaces/updater/signpost/src/error.rs
@@ -40,6 +40,12 @@ pub enum Error {
     #[snafu(display("Failed to write GPT onto device {}: {}", device.display(), source))]
     GPTWrite { device: PathBuf, source: GPTError },
 
+    #[snafu(display("Inactive partition {} is already marked for upgrade", inactive.display()))]
+    InactiveAlreadyMarked { inactive: PathBuf },
+
+    #[snafu(display("Inactive partition {} has not been marked valid for upgrade", inactive.display()))]
+    InactiveNotValid { inactive: PathBuf },
+
     #[snafu(display(
         "Inactive partition is not valid to roll back to (priority={} tries_left={} successful={})",
         priority,

--- a/workspaces/updater/signpost/src/main.rs
+++ b/workspaces/updater/signpost/src/main.rs
@@ -9,8 +9,10 @@ use signpost::State;
 enum Command {
     Status,
     MarkSuccessfulBoot,
+    MarkInactiveValid,
     ClearInactive,
     UpgradeToInactive,
+    CancelUpgrade,
     RollbackToInactive,
     RewriteTable,
 }
@@ -24,7 +26,9 @@ SUBCOMMANDS:
     status                  Show partition sets and priority status
     mark-successful-boot    Mark the active partitions as successfully booted
     clear-inactive          Clears inactive priority information to prepare writing images to disk
-    upgrade-to-inactive     Sets the inactive partitions as new upgrade partitions
+    mark-inactive-valid     Marks the inactive partition as having a valid image
+    upgrade-to-inactive     Sets the inactive partitions as new upgrade partitions if marked valid
+    cancel-upgrade          Reverse upgrade-to-inactive
     rollback-to-inactive    Deprioritizes the inactive partitions
     rewrite-table           Rewrite the partition table with no changes to disk (used for testing this code)");
     std::process::exit(1)
@@ -45,8 +49,16 @@ fn main() {
                 state.mark_successful_boot();
                 state.write()?;
             }
+            Command::MarkInactiveValid => {
+                state.mark_inactive_valid();
+                state.write()?;
+            }
             Command::UpgradeToInactive => {
-                state.upgrade_to_inactive();
+                state.upgrade_to_inactive()?;
+                state.write()?;
+            }
+            Command::CancelUpgrade => {
+                state.cancel_upgrade();
                 state.write()?;
             }
             Command::RollbackToInactive => {

--- a/workspaces/updater/updog/src/error.rs
+++ b/workspaces/updater/updog/src/error.rs
@@ -80,6 +80,9 @@ pub(crate) enum Error {
     #[snafu(display("Duplicate version key: {}", key))]
     DuplicateVersionKey { backtrace: Backtrace, key: String },
 
+    #[snafu(display("Could not mark inactive partition for boot: {}", source))]
+    InactivePartitionUpgrade { source: signpost::Error },
+
     #[snafu(display("Failed to attach image to loop device"))]
     LoopAttachFailed {
         backtrace: Backtrace,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add two new commands to signpost:
- mark-inactive-valid, used to mark the inactive partition as having a
potentially valid image but not for boot.
- cancel-upgrade, which reverts the changes of upgrade-to-inactive.

In addition upgrade-to-inactive makes two initial checks; whether the
inactive partition has been marked valid with mark-inactive-valid, and
whether the inactive partition has already been marked for boot. The
first is to avoid accidentally booting into a blank partition, while the
second is a warning that makes it more clear that invoking
upgrade-to-inactive twice does not revert the change.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
