### PR TITLE
Enable dm_verity panic on corruption

### DIFF
--- a/bin/rpm2img
+++ b/bin/rpm2img
@@ -150,9 +150,9 @@ menuentry "Thar" {
    linux (\$root)/vmlinuz root=/dev/dm-0 rootwait ro init=/sbin/preinit \\
        audit=0 console=tty0 console=ttyS0 random.trust_cpu=on \\
        systemd.log_target=journal-or-kmsg net.ifnames=0 biosdevname=0 \\
-       dm_verity.error_behavior=3 dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\
+       dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\
        dm-mod.create="root,,,ro,0 $VERITY_DATA_512B_BLOCKS verity $VERITY_VERSION PARTUUID=\$boot_uuid/PARTNROFF=1 PARTUUID=\$boot_uuid/PARTNROFF=2 \\
-       $VERITY_DATA_BLOCK_SIZE $VERITY_HASH_BLOCK_SIZE $VERITY_DATA_4K_BLOCKS 1 $VERITY_HASH_ALGORITHM $VERITY_ROOT_HASH $VERITY_SALT"
+       $VERITY_DATA_BLOCK_SIZE $VERITY_HASH_BLOCK_SIZE $VERITY_DATA_4K_BLOCKS 1 $VERITY_HASH_ALGORITHM $VERITY_ROOT_HASH $VERITY_SALT 1 restart_on_corruption"
 }
 EOF
 


### PR DESCRIPTION
dm_verity.error_behavior doesn't seem to be a current setting; documentation
describes restart_on_corruption which does indeed restart when it detects a
changed block.

---

Fixes #441

Not the same version, but docs are here: https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/device-mapper/verity.rst

**Testing done:**

Played with error_behavior and discovered that neither `=1` nor `=3` did anything other than log corruption to dmesg.

After setting `restart_on_corruption` and letting an evil `dd` run for a bit, a read from disk causes a hang:
```
bash-5.0# dd if=/dev/zero of=/dev/xvda3 conv=fsync
^C1129545+0 records in
1129545+0 records out
578327040 bytes (578 MB, 552 MiB) copied, 67.6888 s, 8.5 MB/s
bash-5.0# md5sum /usr/bin/*
```

And I see the dm-verity restart in the instance screenshot, and the console system log shows things like this from then on; I also confirmed outside that the instance is in a reboot loop (as intended).
```
    1.666312] device-mapper: verity: 202:3: data block 0 is corrupted
[    2.225755] tsc: Refined TSC clocksource calibration: 2793.269 MHz
[    2.230391] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x284369f366d, max_idle_ns: 440795234812 ns
[    2.663507] xenbus: xenbus_dev_shutdown: device/pci/0: Initialising != Connected, skipping
[    2.677514] reboot: Restarting system with command 'dm-verity device corrupted'
[    2.686382] reboot: machine restart
```

...and the instance screenshot either shows grub or has a fun "Error getting console screenshot - An unknown error occurred" error from then on.