### PR TITLE
Clarify syntax of cluster configuration TOML

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -146,6 +146,8 @@ cluster-name = "thar"
 cluster-certificate = "YOUR-CERTIFICATE-AUTHORITY-HERE"
 ```
 
+Make sure you keep the quotes around the values you paste in!
+
 ### Subnet info
 
 Next, run this to get information about the subnets that eksctl created.


### PR DESCRIPTION
We had a customer contact about a cluster join failure.  In the end, it led to a syntax error in the user data - the string values for api-server and cluster-certificate were unquoted.  This just adds a note about those quotes.

I'm not 100% happy about the wording I have here, so please do chime in if you have other ideas about how to clarify this, or draw attention in better ways, etc.