### PR TITLE
model: Use SingleLineString for all appropriate Strings

### DIFF
--- a/workspaces/api/apiserver/src/model.rs
+++ b/workspaces/api/apiserver/src/model.rs
@@ -20,10 +20,10 @@ use crate::modeled_types::{SingleLineString, ValidBase64};
 #[serde(deny_unknown_fields, rename = "settings", rename_all = "kebab-case")]
 pub struct Settings {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timezone: Option<String>,
+    pub timezone: Option<SingleLineString>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub hostname: Option<String>,
+    pub hostname: Option<SingleLineString>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kubernetes: Option<KubernetesSettings>,
@@ -47,13 +47,13 @@ pub struct KubernetesSettings {
     // Settings we require the user to specify, likely via user data.
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cluster_name: Option<String>,
+    pub cluster_name: Option<SingleLineString>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_certificate: Option<ValidBase64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub api_server: Option<String>,
+    pub api_server: Option<SingleLineString>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_labels: Option<HashMap<SingleLineString, SingleLineString>>,
@@ -64,7 +64,7 @@ pub struct KubernetesSettings {
     // Dynamic settings.
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_pods: Option<String>,
+    pub max_pods: Option<SingleLineString>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_dns_ip: Option<Ipv4Addr>,
@@ -73,7 +73,7 @@ pub struct KubernetesSettings {
     pub node_ip: Option<Ipv4Addr>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pod_infra_container_image: Option<String>,
+    pub pod_infra_container_image: Option<SingleLineString>,
 }
 
 // Updog settings. Taken from userdata. The 'seed' setting is generated
@@ -82,10 +82,10 @@ pub struct KubernetesSettings {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct UpdatesSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata_base_url: Option<String>,
+    pub metadata_base_url: Option<SingleLineString>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_base_url: Option<String>,
+    pub target_base_url: Option<SingleLineString>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seed: Option<u32>,
@@ -109,7 +109,7 @@ pub struct ContainerImage {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct NtpSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub time_servers: Option<Vec<String>>,
+    pub time_servers: Option<Vec<SingleLineString>>,
 }
 
 ///// Internal services
@@ -126,7 +126,7 @@ pub type Services = HashMap<String, Service>;
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename = "", rename_all = "kebab-case")]
 pub struct Service {
-    pub configuration_files: Vec<String>,
+    pub configuration_files: Vec<SingleLineString>,
     pub restart_commands: Vec<String>,
 }
 
@@ -135,8 +135,8 @@ pub type ConfigurationFiles = HashMap<String, ConfigurationFile>;
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename = "", rename_all = "kebab-case")]
 pub struct ConfigurationFile {
-    pub path: String,
-    pub template_path: String,
+    pub path: SingleLineString,
+    pub template_path: SingleLineString,
 }
 
 ///// Metadata
@@ -144,7 +144,7 @@ pub struct ConfigurationFile {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename = "metadata", rename_all = "kebab-case")]
 pub struct Metadata {
-    pub key: String,
-    pub md: String,
+    pub key: SingleLineString,
+    pub md: SingleLineString,
     pub val: toml::Value,
 }

--- a/workspaces/api/apiserver/src/modeled_types.rs
+++ b/workspaces/api/apiserver/src/modeled_types.rs
@@ -74,6 +74,12 @@ impl fmt::Display for ValidBase64 {
     }
 }
 
+impl From<ValidBase64> for String {
+    fn from(x: ValidBase64) -> Self {
+        x.inner
+    }
+}
+
 #[cfg(test)]
 mod test_valid_base64 {
     use super::ValidBase64;
@@ -173,6 +179,12 @@ impl AsRef<str> for SingleLineString {
 impl fmt::Display for SingleLineString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.inner)
+    }
+}
+
+impl From<SingleLineString> for String {
+    fn from(x: SingleLineString) -> Self {
+        x.inner
     }
 }
 

--- a/workspaces/api/thar-be-settings/src/template.rs
+++ b/workspaces/api/thar-be-settings/src/template.rs
@@ -22,10 +22,10 @@ pub fn build_template_registry(
             &name, &metadata.template_path
         );
         template_registry
-            .register_template_file(&name, &metadata.template_path)
+            .register_template_file(&name, metadata.template_path.as_ref())
             .context(error::TemplateRegister {
                 name: name.as_str(),
-                path: &metadata.template_path,
+                path: metadata.template_path.as_ref(),
             })?;
     }
 


### PR DESCRIPTION
Don't want anyone inserting extra lines into our config files.

The String types that were not changed:
* retry_commands because it's conceivable to want a multi-line command; these are read-only so not relevant to API calls right now.
* The keys of Services and ConfigurationFiles maps, because they're handled dynamically in code and would require other changes I haven't figured out yet; these are read-only so not relevant to API calls right now.

**Testing done:**

Requests with newlines are now rejected in all these places; good requests are still OK.
```
bash-5.0# apiclient -u /settings -m PATCH -d '{"hostname": "hi\nthere"}'
Json deserialize error: Can't create SingleLineString with line terminator '2' at line 1 column 25

bash-5.0# apiclient -u /settings -m PATCH -d '{"hostname": "hi there"}' -v
204 No Content
```

All our templated files still show up OK, all units run OK, node joins cluster.
```
=== /etc/hostname ===
localhost

=== /etc/kubernetes/kubelet/env ===
NODE_IP=192.168.101.171
NODE_LABELS=
NODE_TAINTS=
POD_INFRA_CONTAINER_IMAGE=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1

=== /etc/kubernetes/kubelet/config ===
---
kind: KubeletConfiguration
...SNIP...
clusterDNS:
- 10.100.0.10
...SNIP...
MaxPods: 29

=== /etc/kubernetes/kubelet/kubeconfig ===
---
apiVersion: v1
kind: Config
clusters:
- cluster:
    certificate-authority: "/etc/kubernetes/pki/ca.crt"
    server: "https://16D8E306F5C75C5BF9C7FDA2A4DFAC90.yl4.us-west-2.eks.amazonaws.com"
    ...SNIP...

=== /etc/kubernetes/pki/ca.crt ===
-----BEGIN CERTIFICATE-----
MII ...SNIP... AA=
-----END CERTIFICATE-----

=== /etc/containerd/config.toml ===
...SNIP...
sandbox_image = "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1"
...SNIP...

=== /etc/updog.toml ===
...SNIP...
seed = 572

=== /etc/chrony.conf ===
pool 169.254.169.123 iburst

pool 2.amazon.pool.ntp.org iburst
...SNIP...
```