### PR TITLE
Update to v0.2 control container by default

### DIFF
--- a/workspaces/api/storewolf/defaults.toml
+++ b/workspaces/api/storewolf/defaults.toml
@@ -102,7 +102,7 @@ superpowered = true
 
 [settings.host-containers.control]
 enabled = true
-source = "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.1"
+source = "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.2"
 superpowered = false
 
 [services.host-containers]


### PR DESCRIPTION
This is to get #405.

**Testing done:**

Launched with this change as user data, confirmed it got the new container:

```
$ aws ssm start-session --target i-01739b31f4f65d2cb

Starting session with SessionId: tjk-059240cd729ac0535
Welcome to Thar's control container!
...SNIP...
To enable the admin container, run:

   enable-admin-container

[ssm-user@ip-192-168-126-46 /]$ enable-admin-container 
Checking whether there are pending settings; we don't want to silently commit other changes
...SNIP...
The admin container is now enabled - it should pull and start soon, and then you can SSH in
```