### PR TITLE
 buildsys: start buildkitd if not running

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,7 +18,9 @@ IMAGE = "aws-k8s"
 BUILDSYS_ALLOW_UPSTREAM_SOURCE_URL = "true"
 
 [tasks.setup]
-dependencies = [ "setup-buildkitd" ]
+dependencies = [ "setup-build-dirs", "setup-buildkitd" ]
+
+[tasks.setup-build-dirs]
 script = [
 '''
 mkdir -p ${BUILDSYS_OUTPUT_DIR}


### PR DESCRIPTION
Changes split from #451 to discuss the buildkitd handling as was initiated in https://github.com/amazonlinux/PRIVATE-thar/pull/451#discussion_r339192608 .

*Description of changes:*

This allows the user to forget about needing a buildkitd process running
and configured properly for build use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
