### PR TITLE
Add script to export HTML docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/vendor/
 /.cargo
 /.gomodcache
+/html

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -114,6 +114,9 @@ dependencies = [
     "check-licenses",
 ]
 
+[tasks.preview-docs]
+script = ['tools/gen-docs.sh']
+
 [tasks.clean]
 script = [
 '''
@@ -123,6 +126,7 @@ done
 for ext in rpm tar lz4 img ; do
   rm -f ${BUILDSYS_OUTPUT_DIR}/*.${ext}
 done
+rm -rf html
 '''
 ]
 

--- a/tools/gen-docs.sh
+++ b/tools/gen-docs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+if ! hash grip; then
+    >&2 echo "grip is not installed, run 'pip3 install --user grip'"
+    exit 1
+fi
+
+top=$(git rev-parse --show-toplevel)
+mkdir -p "${top}/html"
+for doc in README.md INSTALL.md CHANGELOG.md; do
+    out="${top}/html/${doc%.md}.html"
+    grip --title="${doc}" --export \
+        <(
+            cat <<'EOF'
+@@THAR-SENTINEL-START@@
+**The best way to get in touch with the Thar development team** during this early preview
+is via [thar-preview@amazon.com](mailto:thar-preview@amazon.com)
+or #thar-preview on the [awsdevelopers Slack workspace](https://awsdevelopers.slack.com) (email us for an invite).
+We'd love to talk with you and hear your feedback on Thar!
+
+---
+
+EOF
+            cat "${top}/${doc}"
+        ) \
+        "${out}"
+    sed -i \
+        -e '/<link rel="stylesheet".*octicons\.css/d' \
+        -e '/<link rel="icon"/d' \
+        -e 's/<p>@@THAR-SENTINEL-START@@/<p style="background-color: #a8dfee; border: 1px solid #008296; padding: 1em;">/' \
+        "${out}"
+done


### PR DESCRIPTION
For private preview customers we're distributing documentation out-of-band. We were using PDFs, but it turns out that some PDF viewers missed a critical `-` in some copy-paste instructions.

This script generates HTML docs with [grip](https://github.com/joeyespo/grip) and massages the output with sed. It looks like this:

![Screenshot from 2019-10-28 10-35-20](https://user-images.githubusercontent.com/52814/67702266-a9ae4500-f96e-11e9-8952-2617d8a367c8.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
