### PR TITLE
Add a service to call signpost when we determine that the boot was successful

### DIFF
--- a/packages/kubernetes/kubelet.service
+++ b/packages/kubernetes/kubelet.service
@@ -6,6 +6,7 @@ Wants=configured.target
 BindsTo=containerd.service
 
 [Service]
+Type=notify
 EnvironmentFile=/etc/kubernetes/kubelet/env
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Pull the pause container image before starting `kubelet` so `containerd/cri` wouldn't have to
@@ -38,3 +39,4 @@ MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target
+RequiredBy=mark-successful-boot.service

--- a/packages/workspaces/mark-successful-boot.service
+++ b/packages/workspaces/mark-successful-boot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Call signpost to mark the boot as successful after all required targets are met.
+After=multi-user.target
+# Each service that must start correctly in order for a boot to be successful should be of type "notify"
+# and include "RequiredBy=mark-successful-boot.service" in its [Install] section.
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/signpost mark-successful-boot
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/workspaces/workspaces.spec
+++ b/packages/workspaces/workspaces.spec
@@ -27,6 +27,7 @@ Source106: migrator.service
 Source107: host-containers@.service
 Source108: updog.timer
 Source109: updog.service
+Source110: mark-successful-boot.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -197,7 +198,8 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
-  %{S:100} %{S:101} %{S:102} %{S:103} %{S:104} %{S:105} %{S:106} %{S:107} %{S:108} %{S:109} \
+  %{S:100} %{S:101} %{S:102} %{S:103} %{S:104} %{S:105} \
+  %{S:106} %{S:107} %{S:108} %{S:109} %{S:110} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
@@ -263,6 +265,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.co
 
 %files -n %{_cross_os}signpost
 %{_cross_bindir}/signpost
+%{_cross_unitdir}/mark-successful-boot.service
 
 %files -n %{_cross_os}updog
 %{_cross_bindir}/updog


### PR DESCRIPTION
This implements a method to measure whether or not the host booted successfully, and then call signpost when that is achieved.  It consists of a new unit in the updater:

* mark-successful-boot.service - This unit will have dependencies injected into it by services that are required for a successful boot, by use of the RequiredBy= option in those services.

In addition to this new service, changes are required to services that we want to fail the boot if they can't start:
* The service must be of `Type=notify` to ensure that it does not transition to Active if it fails and systemd restarts it.  This could require patches for services that don't already support sd_notify.
* The service must include `RequiredBy=mark-successful-boot.service` in its [Install] section.

This change includes on-boarding kubelet.service to this way of boot measurement.

Fixes Issue #86 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
