### PR TITLE
kernel: Enable access to /proc/config.gz

### DIFF
--- a/packages/kernel/config-thar
+++ b/packages/kernel/config-thar
@@ -24,3 +24,7 @@ CONFIG_DM_VERITY=y
 
 # yama LSM for ptrace restrictions
 CONFIG_SECURITY_YAMA=y
+
+# enable /proc/config.gz
+CONFIG_IKCONFIG=y
+CONFIG_IKCONFIG_PROC=y


### PR DESCRIPTION
*Issue #, if available:*
Related to https://github.com/amazonlinux/PRIVATE-thar/issues/454

*Description of changes:*
Tools such as [sysdig] have the ability to deploy BPF probes across a
Kubernetes cluster. However part of the setup scripts for this require
access to the kernel config and on Thar this isn't available in any of
the common locations. CONFIG_IKCONFIG makes the config available
regardless of where the setup is being run and is a well known source,
so switch it on for Thar.

In particular for sysdig, the config is required to determine the expected
name of the precompiled probe, without which it will refuse to load.

[sysdig]: https://github.com/draios/sysdig

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
