### PR TITLE
[storewolf] Improve default metadata representation

### DIFF
--- a/workspaces/api/storewolf/defaults.toml
+++ b/workspaces/api/storewolf/defaults.toml
@@ -17,10 +17,8 @@ restart-commands = []
 path = "/etc/hostname"
 template-path = "/usr/share/templates/hostname"
 
-[[metadata]]
-key = "settings.hostname"
-md = "affected-services"
-val = ["hostname"]
+[metadata.settings.hostname]
+affected-services = ["hostname"]
 
 # Kubernetes.
 
@@ -48,30 +46,12 @@ template-path = "/usr/share/templates/kubernetes-ca-crt"
 path = "/etc/containerd/config.toml"
 template-path = "/usr/share/templates/containerd-config-toml"
 
-[[metadata]]
-key = "settings.kubernetes.max-pods"
-md = "setting-generator"
-val = "pluto max-pods"
-
-[[metadata]]
-key = "settings.kubernetes.cluster-dns-ip"
-md = "setting-generator"
-val = "pluto cluster-dns-ip"
-
-[[metadata]]
-key = "settings.kubernetes.node-ip"
-md = "setting-generator"
-val = "pluto node-ip"
-
-[[metadata]]
-key = "settings.kubernetes.pod-infra-container-image"
-md = "setting-generator"
-val = "pluto pod-infra-container-image"
-
-[[metadata]]
-key = "settings.kubernetes"
-md = "affected-services"
-val = ["kubernetes"]
+[metadata.settings.kubernetes]
+max-pods.setting-generator = "pluto max-pods"
+cluster-dns-ip.setting-generator = "pluto cluster-dns-ip"
+node-ip.setting-generator = "pluto node-ip"
+pod-infra-container-image.setting-generator = "pluto pod-infra-container-image"
+affected-services = ["kubernetes"]
 
 # Updog.
 
@@ -83,15 +63,9 @@ restart-commands = []
 path = "/etc/updog.toml"
 template-path = "/usr/share/templates/updog-toml"
 
-[[metadata]]
-key = "settings.updates"
-md = "affected-services"
-val = ["updog"]
-
-[[metadata]]
-key = "settings.updates.seed"
-md = "setting-generator"
-val = "bork seed"
+[metadata.settings.updates]
+affected-services = ["updog"]
+seed.setting-generator = "bork seed"
 
 # HostContainers
 
@@ -109,10 +83,8 @@ superpowered = false
 configuration-files = []
 restart-commands = ["/usr/bin/host-containers"]
 
-[[metadata]]
-key = "settings.host-containers"
-md = "affected-services"
-val = ["host-containers"]
+[metadata.settings.host-containers]
+affected-services = ["host-containers"]
 
 # NTP
 
@@ -127,7 +99,5 @@ restart-commands = ["/bin/systemctl try-reload-or-restart chronyd.service"]
 path = "/etc/chrony.conf"
 template-path = "/usr/share/templates/chrony-conf"
 
-[[metadata]]
-key = "settings.ntp"
-md = "affected-services"
-val = "[chronyd]"
+[metadata.settings.ntp]
+affected-services = ["chronyd"]


### PR DESCRIPTION
This commit improves how metadata is represented in our defaults.toml.
Previously each metadata entry required a seperate 4 line declaration,
which is noisy and unpleasant. With this change, metadata for each
corresponding setting can be defined together in a single metadata
entry.

The commit adds a single function to translate this new defaults toml
format into a Vec<Metadata> which is processed in storewolf exactly
the same as we did previously.

**Please closely double check my edits of defaults.toml!*

*Issue #, if available:*
Fixes #135 

*Description of changes:*
* Update defaults.toml to new format
* Add function to parse new defaults.toml metadata format and convert to Vec<Metadata>

*Testing done*
* Datastore on an image created with this PR has identical structure with a prior Thar image.
* On my dev box I'm able to create a datastore that looks correct
```
[mrowicki@ip-10-0-60-75 api]$ ../target/debug/storewolf --data-store-base-path /tmp/mrowicki --version 1.0
20:03:09 [ INFO] Storewolf started
20:03:09 [ INFO] Deleting pending settings
20:03:09 [ INFO] Populating datastore at: /tmp/mrowicki
20:03:09 [ INFO] Creating datastore at: /tmp/mrowicki/current/live
20:03:09 [ INFO] Datastore populated

[mrowicki@ip-10-0-60-75 api]$ tree /tmp/mrowicki/
/tmp/mrowicki/
├── current -> v1
├── v1 -> v1.0
├── v1.0 -> v1.0_NLEMxi3UTTT7U6nH
└── v1.0_NLEMxi3UTTT7U6nH
    ├── live
    │   ├── configuration-files
    │   │   ├── chrony-conf
    │   │   │   ├── path
    │   │   │   └── template-path
    │   │   ├── containerd-config-toml
    │   │   │   ├── path
    │   │   │   └── template-path
    │   │   ├── hostname
    │   │   │   ├── path
    │   │   │   └── template-path
    │   │   ├── kubelet-config
    │   │   │   ├── path
    │   │   │   └── template-path
    │   │   ├── kubelet-env
    │   │   │   ├── path
    │   │   │   └── template-path
    │   │   ├── kubelet-kubeconfig
    │   │   │   ├── path
    │   │   │   └── template-path
    │   │   ├── kubernetes-ca-crt
    │   │   │   ├── path
    │   │   │   └── template-path
    │   │   └── updog-toml
    │   │       ├── path
    │   │       └── template-path
    │   ├── services
    │   │   ├── host-containers
    │   │   │   ├── configuration-files
    │   │   │   └── restart-commands
    │   │   ├── hostname
    │   │   │   ├── configuration-files
    │   │   │   └── restart-commands
    │   │   ├── kubernetes
    │   │   │   ├── configuration-files
    │   │   │   └── restart-commands
    │   │   ├── ntp
    │   │   │   ├── configuration-files
    │   │   │   └── restart-commands
    │   │   └── updog
    │   │       ├── configuration-files
    │   │       └── restart-commands
    │   └── settings
    │       ├── host-containers.affected-services
    │       ├── hostname.affected-services
    │       ├── kubernetes
    │       │   ├── cluster-dns-ip.setting-generator
    │       │   ├── max-pods.setting-generator
    │       │   ├── node-ip.setting-generator
    │       │   └── pod-infra-container-image.setting-generator
    │       ├── kubernetes.affected-services
    │       ├── ntp.affected-services
    │       ├── updates
    │       │   └── seed.setting-generator
    │       └── updates.affected-services
    └── pending
        └── settings
            ├── host-containers
            │   ├── admin
            │   │   ├── enabled
            │   │   ├── source
            │   │   └── superpowered
            │   └── control
            │       ├── enabled
            │       ├── source
            │       └── superpowered
            ├── hostname
            ├── ntp
            │   └── time-servers
            ├── timezone
            └── updates
                ├── metadata-base-url
                └── target-base-url
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
