### PR TITLE
tough: Add locking around datastore write operations

### DIFF
--- a/workspaces/updater/tough/src/datastore.rs
+++ b/workspaces/updater/tough/src/datastore.rs
@@ -4,13 +4,29 @@ use snafu::ResultExt;
 use std::fs::{self, File};
 use std::io::{ErrorKind, Read};
 use std::path::Path;
+use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Debug, Clone)]
-pub(crate) struct Datastore<'a>(pub(crate) &'a Path);
+pub(crate) struct Datastore<'a>(Arc<RwLock<&'a Path>>);
 
 impl<'a> Datastore<'a> {
+    pub(crate) fn new(path: &'a Path) -> Self {
+        Self(Arc::new(RwLock::new(path)))
+    }
+
+    // Because we are not actually changing the underlying data in the lock, we can ignore when a
+    // lock is poisoned.
+
+    fn read(&self) -> RwLockReadGuard<'_, &'a Path> {
+        self.0.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, &'a Path> {
+        self.0.write().unwrap_or_else(PoisonError::into_inner)
+    }
+
     pub(crate) fn reader(&self, file: &str) -> Result<Option<impl Read>> {
-        let path = self.0.join(file);
+        let path = self.read().join(file);
         match File::open(&path) {
             Ok(file) => Ok(Some(file)),
             Err(err) => match err.kind() {
@@ -21,7 +37,7 @@ impl<'a> Datastore<'a> {
     }
 
     pub(crate) fn create<T: Serialize>(&self, file: &str, value: &T) -> Result<()> {
-        let path = self.0.join(file);
+        let path = self.write().join(file);
         serde_json::to_writer_pretty(
             File::create(&path).context(error::DatastoreCreate { path: &path })?,
             value,
@@ -32,7 +48,7 @@ impl<'a> Datastore<'a> {
     }
 
     pub(crate) fn remove(&self, file: &str) -> Result<()> {
-        let path = self.0.join(file);
+        let path = self.write().join(file);
         match fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(err) => match err.kind() {

--- a/workspaces/updater/tough/src/lib.rs
+++ b/workspaces/updater/tough/src/lib.rs
@@ -140,7 +140,7 @@ impl<'a, T: Transport> Repository<'a, T> {
         let metadata_base_url = parse_url(settings.metadata_base_url)?;
         let target_base_url = parse_url(settings.target_base_url)?;
 
-        let datastore = Datastore(settings.datastore);
+        let datastore = Datastore::new(settings.datastore);
 
         // 0. Load the trusted root metadata file + 1. Update the root metadata file
         let root = load_root(


### PR DESCRIPTION
*Issue #, if available:* #117 (kinda)

*Description of changes:*
We don't want separate threads using tough to end up writing to its datastore and reading at the same time. #117 suggested making those operations take `&mut self`, but that bubbles up to requiring most methods on `Repository` to also take `&mut self`.

This adds a [`RwLock`](https://doc.rust-lang.org/std/sync/struct.RwLock.html) to `Datastore`, allowing "any number of readers to acquire the lock as long as a writer is not holding the lock".

The difference between this and `&mut self` is that this is ensured at runtime, which may cause a deadlock (I'm not aware of a way this is possible, because the guard drops out of scope before a reader is even returned), as opposed to ensuring against a data race at compile time, which may just cause borrowck to yell politely at you.

I've tested that this does not, in fact, cause a deadlock in updog.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
