### PR TITLE
INSTALL: Update recommended CNI plugin version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,7 +121,7 @@ Now we can make a configuration change to use a CNI plugin that's compatible wit
 ```
 kubectl patch daemonset aws-node \
 -n kube-system \
--p '{"spec": {"template": {"spec": {"containers": [{"image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.0-rc3","name":"aws-node"}]}}}}'
+-p '{"spec": {"template": {"spec": {"containers": [{"image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.0-rc4","name":"aws-node"}]}}}}'
 ```
 
 ## Cluster info


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Updates the recommended CNI plugin version from `v1.6.0-rc3` to `v1.6.0-rc4`.
rc4 contains a fix for https://github.com/aws/amazon-vpc-cni-k8s/issues/641

We tested `v1.6.0-rc4` before and everything seems to be working fine. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
