### PR TITLE
build: exclude fetch-external-files

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -32,7 +32,7 @@ mkdir -p ${GO_MOD_CACHE}
 ]
 
 [tasks.fetch]
-dependencies = ["fetch-workspaces", "fetch-vendored", "fetch-external-files"]
+dependencies = ["fetch-workspaces", "fetch-vendored"]
 
 [tasks.fetch-workspaces]
 dependencies = ["setup"]


### PR DESCRIPTION

*Issue #, if available:*

#485 #484 

*Description of changes:*

The build step is causing Cargo to invalidate some portion of the
context that is used to facilitate incremental builds. Until we can
determine why and how to fix this issue the removal of the task from the
dependency graph should allow for incremental builds to work properly.

Signed-off-by: Jacob Vallejo <jakeev@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
