### PR TITLE
migrations: Adds new migration for bumping host container versions

### DIFF
--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -1021,6 +1021,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "host-containers-version-migration"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     # Migrations will be listed here.  They won't need to be listed as a
     # workspace member when we add cross-workspace dependencies.
     "api/migration/migrations/v0.1/borkseed",
+    "api/migration/migrations/v0.1/host-containers-version",
 
     "preinit/laika",
 

--- a/workspaces/api/migration/migrations/v0.1/host-containers-version/Cargo.toml
+++ b/workspaces/api/migration/migrations/v0.1/host-containers-version/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "host-containers-version-migration"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }
+serde_json = "1.0"
+snafu = "0.5"

--- a/workspaces/api/migration/migrations/v0.1/host-containers-version/src/main.rs
+++ b/workspaces/api/migration/migrations/v0.1/host-containers-version/src/main.rs
@@ -1,0 +1,63 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+
+/// We bumped the versions of the default admin container and the default control container from v0.1 to v0.2
+struct HostContainersVersionMigration;
+const DEFAULT_ADMIN_CTR_IMG_OLD: &str =
+    "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.1";
+const DEFAULT_ADMIN_CTR_IMG_NEW: &str =
+    "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.2";
+const DEFAULT_CONTROL_CTR_IMG_OLD: &str =
+    "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.1";
+const DEFAULT_CONTROL_CTR_IMG_NEW: &str =
+    "328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.2";
+
+impl Migration for HostContainersVersionMigration {
+    fn forward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(admin_ctr_source) = input.data.get_mut("settings.host-containers.admin.source")
+        {
+            // Need to bump versions if the default admin container version source matches its older version
+            if admin_ctr_source.as_str() == Some(DEFAULT_ADMIN_CTR_IMG_OLD) {
+                *admin_ctr_source =
+                    serde_json::Value::String(DEFAULT_ADMIN_CTR_IMG_NEW.to_string());
+            }
+        }
+        if let Some(control_ctr_source) = input
+            .data
+            .get_mut("settings.host-containers.control.source")
+        {
+            // Need to bump versions if the default control container version source matches its older version
+            if control_ctr_source.as_str() == Some(DEFAULT_CONTROL_CTR_IMG_OLD) {
+                *control_ctr_source =
+                    serde_json::Value::String(DEFAULT_CONTROL_CTR_IMG_NEW.to_string());
+            }
+        }
+        Ok(input)
+    }
+
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(admin_ctr_source) = input.data.get_mut("settings.host-containers.admin.source")
+        {
+            // The default admin container v0.2 image needs OS changes adding persistent host container storage
+            if admin_ctr_source.as_str() == Some(DEFAULT_ADMIN_CTR_IMG_NEW) {
+                *admin_ctr_source =
+                    serde_json::Value::String(DEFAULT_ADMIN_CTR_IMG_OLD.to_string());
+            }
+        }
+        if let Some(control_ctr_source) = input
+            .data
+            .get_mut("settings.host-containers.control.source")
+        {
+            if control_ctr_source.as_str() == Some(DEFAULT_CONTROL_CTR_IMG_NEW) {
+                *control_ctr_source =
+                    serde_json::Value::String(DEFAULT_CONTROL_CTR_IMG_OLD.to_string());
+            }
+        }
+        Ok(input)
+    }
+}
+
+fn main() -> Result<()> {
+    migrate(HostContainersVersionMigration)
+}

--- a/workspaces/deny.toml
+++ b/workspaces/deny.toml
@@ -35,6 +35,7 @@ skip = [
     { name = "data_store_version", licenses = [] },
     { name = "growpart", licenses = [] },
     { name = "host-containers", licenses = [] },
+    { name = "host-containers-version-migration", licenses = [] },
     { name = "laika", licenses = [] },
     { name = "migration-helpers", licenses = [] },
     { name = "migrator", licenses = [] },


### PR DESCRIPTION
Adds migration for the default admin and control container versions v0.1 <-> v0.2

*Issue #, if available:* https://github.com/amazonlinux/PRIVATE-thar/issues/534

*Description of changes:*

*Testing done:*
Locally testing forward migration,  and it bumps version correctly from v0.1 to v0.2:
```
$ echo '"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.1"' > ds/live/settings/host-containers/admin/source
$ cargo run -- --datastore-path ds --forward
    SNIP
     Running `/home/ANT.AMAZON.COM/etung/thar/PRIVATE-thar/workspaces/target/debug/host-containers-version-migration --datastore-path ds --forward`
$ cat ds/live/settings/host-containers/admin/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.2"
```
Run again:
```
$ cargo run -- --datastore-path ds --forward
$ cat ds/live/settings/host-containers/admin/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.2"
```

If the admin container is a custom container, no modification is made:
```
$ echo '"super-cool-custom-admin-containerv123"' > ds/live/settings/host-containers/admin/source
$ cargo run -- --datastore-path ds --forward
$ cat ds/live/settings/host-containers/admin/source 
"super-cool-custom-admin-containerv123"
```

For control container, same, bumps version correctly from v0.1 to v0.2:
```
$ echo '"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.1"' > ds/live/settings/host-containers/control/source
$ cargo run -- --datastore-path ds --forward
$ cat ds/live/settings/host-containers/control/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.2"
```

For backwards migration, admin downgrades from v0.2 to v0.1:
```
$ cat ds/live/settings/host-containers/admin/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.2"
$ cargo run -- --datastore-path ds --backward
$ cat ds/live/settings/host-containers/admin/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.1"
```

Backwards control container version migration:
```
$ cat ds/live/settings/host-containers/control/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.2"
$ cargo run -- --datastore-path ds --backward
$ cat ds/live/settings/host-containers/control/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.1"
```

Tested in live Thar instance, launched Thar v0.1.6 (datastore version v0.0), loaded new image into side B using `dd`, loaded migrations, ran updates and verified that default image versions got bumped:
```
bash-5.0# signpost status                                                                                                                   min/source
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=2 tries_left=0 successful=true
Active:  Set B
Next:    Set B
bash-5.0# cat /var/lib/thar/datastore/current/live/settings/host-containers/admin/source                                                    
"328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-admin:v0.2"
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
