### PR TITLE
updog: Add support for query parameters in TUF requests

### DIFF
--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -2862,6 +2862,7 @@ dependencies = [
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tough 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "update_metadata 0.1.0",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/workspaces/updater/updog/Cargo.toml
+++ b/workspaces/updater/updog/Cargo.toml
@@ -26,6 +26,7 @@ tough = { version = "0.1.0", features = ["http"] }
 update_metadata = { path = "../update_metadata" }
 structopt = "0.3"
 migrator = { path = "../../api/migration/migrator" }
+url = "2.1.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/workspaces/updater/updog/src/error.rs
+++ b/workspaces/updater/updog/src/error.rs
@@ -274,6 +274,12 @@ pub(crate) enum Error {
         source: std::io::Error,
     },
 
+    #[snafu(display("2Borrow2Fast"))]
+    TransportBorrow {
+        backtrace: Backtrace,
+        source: std::cell::BorrowMutError,
+    },
+
     #[snafu(display("Failed to serialize update information: {}", source))]
     UpdateSerialize {
         source: serde_json::Error,

--- a/workspaces/updater/updog/src/transport.rs
+++ b/workspaces/updater/updog/src/transport.rs
@@ -1,0 +1,45 @@
+use std::cell::{BorrowMutError, RefCell};
+use tough::{HttpTransport, Repository, Transport};
+use url::Url;
+
+#[derive(Debug)]
+#[allow(clippy::module_name_repetitions)]
+pub struct HttpQueryTransport {
+    pub inner: HttpTransport,
+    parameters: RefCell<Vec<(String, String)>>,
+}
+
+impl HttpQueryTransport {
+    pub fn new() -> Self {
+        Self {
+            inner: HttpTransport::new(),
+            parameters: RefCell::new(vec![]),
+        }
+    }
+
+    /// Try to borrow a mutable reference to parameters; returns an error if
+    /// a borrow is already active
+    pub fn queries_get_mut(
+        &self,
+    ) -> Result<std::cell::RefMut<'_, Vec<(String, String)>>, BorrowMutError> {
+        self.parameters.try_borrow_mut()
+    }
+
+    fn set_query_string(&self, mut url: Url) -> Url {
+        for (key, val) in self.parameters.borrow().iter() {
+            url.query_pairs_mut().append_pair(&key, &val);
+        }
+        url
+    }
+}
+
+pub type HttpQueryRepo<'a> = Repository<'a, HttpQueryTransport>;
+
+impl Transport for HttpQueryTransport {
+    type Stream = reqwest::Response;
+    type Error = reqwest::Error;
+
+    fn fetch(&self, url: Url) -> Result<Self::Stream, Self::Error> {
+        self.inner.fetch(self.set_query_string(url))
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazonlinux/PRIVATE-thar/issues/459

*Description of changes:*
Implement a new tough transport 'Bark', which allows Updog to add extra
query parameters to requests to the TUF repository.

Updog now uses this to append the current image version to all requests.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Tested by launching an instance, performing Updog commands, and observing the extra query parameters in the TUF repository access logs.
