### PR TITLE
build: remove direct support for fetching external files

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -63,19 +63,6 @@ docker run --rm \
 '''
 ]
 
-[tasks.fetch-external-files]
-dependencies = ["setup", "fetch-workspaces"]
-script = [
-'''
-export BUILDSYS_BUILD_FETCH_ONLY=true
-cargo build \
-  ${CARGO_BUILD_ARGS} \
-  ${CARGO_MAKE_CARGO_ARGS} \
-  --manifest-path packages/Cargo.toml \
-  --all
-'''
-]
-
 [tasks.build-packages]
 dependencies = ["setup", "fetch"]
 script = [

--- a/tools/buildsys/src/lib.rs
+++ b/tools/buildsys/src/lib.rs
@@ -51,19 +51,12 @@ pub mod error {
             var: String,
             source: std::env::VarError,
         },
-
-        #[snafu(display("Unable to write marker '{}'", marker.display()))]
-        Marker {
-            marker: std::path::PathBuf,
-            source: std::io::Error,
-        },
     }
 }
 
 pub type Result<T> = std::result::Result<T, error::Error>;
 
 pub fn build_package() -> Result<()> {
-    let out_dir: PathBuf = getenv("OUT_DIR")?.into();
     let manifest_dir: PathBuf = getenv("CARGO_MANIFEST_DIR")?.into();
     let manifest_file = "Cargo.toml";
     println!("cargo:rerun-if-changed={}", manifest_file);
@@ -73,21 +66,6 @@ pub fn build_package() -> Result<()> {
 
     if let Some(files) = manifest.external_files() {
         LookasideCache::fetch(&files).context(error::ExternalFileFetch)?;
-    }
-
-    let build_begin_marker = out_dir.join(".build-begin");
-    println!("cargo:rerun-if-changed={}", build_begin_marker.display());
-
-    if let Ok(val) = getenv("BUILDSYS_BUILD_FETCH_ONLY") {
-        if val == "true" {
-            return Ok(());
-        }
-    }
-
-    if !build_begin_marker.exists() {
-        std::fs::write(&build_begin_marker, vec![]).context(error::Marker {
-            marker: build_begin_marker,
-        })?;
     }
 
     if let Some(groups) = manifest.source_groups() {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Remove the remaining support for a separate build mode to retrieve external files.

*Testing done:*
`cargo make clean && cargo make world && cargo make world`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
