### PR TITLE
build: ignore go module cache for docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /.git
+/.gomodcache
 /build/*.img
 /build/*.lz4
 /build/*.tar


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Removes an extraneous directory from Docker's view of the build context.

*Testing done:*
`cargo make clean && cargo make world`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
