### PR TITLE
Add version to dogswatch.

### DIFF
--- a/extras/dogswatch/Makefile
+++ b/extras/dogswatch/Makefile
@@ -1,8 +1,12 @@
+
+DOGSWATCH_VERSION=v0.1.0
+
 GOPKG = github.com/amazonlinux/thar/dogswatch
 GOPKGS = $(GOPKG) $(GOPKG)/pkg/... $(GOPKG)/cmd/...
 GOBIN = ./bin/
 DOCKER_IMAGE := dogswatch
-DOCKER_IMAGE_REF := $(DOCKER_IMAGE):$(shell git describe --always --dirty)
+DOCKER_IMAGE_REF_RELEASE := $(DOCKER_IMAGE):$(DOGSWATCH_VERSION)
+DOCKER_IMAGE_REF := $(DOCKER_IMAGE):$(shell git rev-parse --short=8 HEAD)
 
 build: $(GOBIN)
 	cd $(GOBIN) && \
@@ -17,6 +21,9 @@ test:
 
 container: vendor
 	docker build --network=host -t $(DOCKER_IMAGE_REF) .
+
+release-container: container
+	docker tag $(DOCKER_IMAGE_REF) $(DOCKER_IMAGE_REF_RELEASE)
 
 load: container
 	kind load docker-image $(DOCKER_IMAGE)


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Add a version variable to Dogswatch's Makefile. By default `make container` will tag the image with the version and append a short SHA of the current commit. `make release-container` will tag the container without the SHA.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
