### PR TITLE
migrator: Set migrations executable before running

### DIFF
--- a/workspaces/api/migration/migrator/src/error.rs
+++ b/workspaces/api/migration/migrator/src/error.rs
@@ -74,6 +74,9 @@ pub(crate) enum Error {
     #[snafu(display("Failed reading metadata of '{}': {}", path.display(), source))]
     PathMetadata { path: PathBuf, source: io::Error },
 
+    #[snafu(display("Failed setting permissions of '{}': {}", path.display(), source))]
+    SetPermissions { path: PathBuf, source: io::Error },
+
     #[snafu(display("Migration path '{}' contains invalid UTF-8", path.display()))]
     MigrationNameNotUTF8 { path: PathBuf },
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #558 

*Description of changes:* 
Make migration binaries executable before migrator runs them.

*Testing done*:
On a live Thar instance, copied over migration binaries. They are initially not executable. Ran migrator, migrations got applied and confirmed that the migration binaries are now executable.
```
bash-5.0# ls -al
total 1048
drwxr-xr-x 2 root root   4096 Nov 22 22:05 .
drwxr-xr-x 7 root root   4096 Nov 22 22:04 ..
-rw-rw-r-- 1 1000 1000 547296 Nov 22 22:05 migrate_v0.1_borkseed
-rw-rw-r-- 1 1000 1000 514528 Nov 22 21:58 migrate_v0.1_host-containers
bash-5.0# migrator --datastore-path /var/lib/thar/datastore/current --log-level debug --migrate-to-version 0.1 --migration-directories /var/lib/thar/datasto>
22:06:12 [ INFO] Found applicable forward migration 'migrate_v0.1_host-containers': v0.0 < (v0.1) <= v0.1
22:06:12 [ INFO] Found applicable forward migration 'migrate_v0.1_borkseed': v0.0 < (v0.1) <= v0.1
22:06:12 [DEBUG] (1) migrator: Sorted migrations: ["migrate_v0.1_borkseed", "migrate_v0.1_host-containers"]
22:06:12 [ INFO] Copying datastore from /var/lib/thar/datastore/v0.0_RRzPF5ak52eVHa3B to work location /var/lib/thar/datastore/v0.1_qwNcks1TZIf5ideX
22:06:12 [ INFO] Running migration command: "/var/lib/thar/datastore/migrations/migrate_v0.1_borkseed" "--forward" "--datastore-path" "/var/lib/thar/datastore/v0.1_qwNcks1TZIf5ideX"
22:06:12 [ INFO] Running migration command: "/var/lib/thar/datastore/migrations/migrate_v0.1_host-containers" "--forward" "--datastore-path" "/var/lib/thar/datastore/v0.1_qwNcks1TZIf5ideX"
22:06:12 [ INFO] Flipping /var/lib/thar/datastore/v0.1 to point to v0.1_qwNcks1TZIf5ideX
22:06:12 [ INFO] Flipping /var/lib/thar/datastore/v0 to point to v0.1
bash-5.0# cat /var/lib/thar/datastore/current/live/settings/updates/seed
1808
bash-5.0# migrator --datastore-path /var/lib/thar/datastore/current --log-level debug --migrate-to-version 0.0 --migration-directories /var/lib/thar/datasto>
22:06:21 [ INFO] Found applicable backward migration 'migrate_v0.1_host-containers': v0.1 >= (v0.1) > v0.0
22:06:21 [ INFO] Found applicable backward migration 'migrate_v0.1_borkseed': v0.1 >= (v0.1) > v0.0
22:06:21 [DEBUG] (1) migrator: Sorted migrations: ["migrate_v0.1_host-containers", "migrate_v0.1_borkseed"]
22:06:21 [ INFO] Copying datastore from /var/lib/thar/datastore/v0.1_qwNcks1TZIf5ideX to work location /var/lib/thar/datastore/v0.0_KTsOCeOXcFzeoVYl
22:06:21 [ INFO] Running migration command: "/var/lib/thar/datastore/migrations/migrate_v0.1_host-containers" "--backward" "--datastore-path" "/var/lib/thar/datastore/v0.0_KTsOCeOXcFzeoVYl"
22:06:21 [ INFO] Running migration command: "/var/lib/thar/datastore/migrations/migrate_v0.1_borkseed" "--backward" "--datastore-path" "/var/lib/thar/datastore/v0.0_KTsOCeOXcFzeoVYl"
22:06:21 [ INFO] Flipping /var/lib/thar/datastore/v0.0 to point to v0.0_KTsOCeOXcFzeoVYl
22:06:21 [ INFO] Flipping /var/lib/thar/datastore/v0 to point to v0.0
bash-5.0# cat /var/lib/thar/datastore/current/live/settings/updates/seed
"1808"
bash-5.0# ls -al
total 1048
drwxr-xr-x 2 root root   4096 Nov 22 22:05 .
drwxr-xr-x 9 root root   4096 Nov 22 22:06 ..
-rwxr-xr-x 1 1000 1000 547296 Nov 22 22:05 migrate_v0.1_borkseed
-rwxr-xr-x 1 1000 1000 514528 Nov 22 21:58 migrate_v0.1_host-containers
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
