### PR TITLE
repo-canary: more evaluation periods to alarms, minor fixes

### DIFF
--- a/tools/infra/tuf-repo-canary/RepoCanary.template.yaml
+++ b/tools/infra/tuf-repo-canary/RepoCanary.template.yaml
@@ -97,7 +97,7 @@ Resources:
             LogDriver: awslogs
             Options:
               awslogs-group: !Ref LogGroup
-              awslogs-region: us-west-2
+              awslogs-region: !Ref 'AWS::Region'
               awslogs-stream-prefix: 'ecs'
   TUFRepoCanaryTaskExecutionRole:
     Type: 'AWS::IAM::Role'
@@ -161,14 +161,15 @@ Resources:
       Threshold: 0
       TreatMissingData: notBreaching
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
+      EvaluationPeriods: 4
+      DatapointsToAlarm: 3
       ActionsEnabled: true
       AlarmActions:
         - !Ref TUFRepoCanarySNSNotificationTopic
   TUFRepoCanaryScheduledTask:
     Type: 'AWS::Events::Rule'
     Properties:
-      Description: !Sub 'Schedules ${TaskName} task to run every hour at 00 minutes'
+      Description: !Sub 'Schedules ${TaskName} task to run every 10 minutes'
       ScheduleExpression: cron(0/10 * * * ? *)
       State: ENABLED
       Targets:
@@ -202,7 +203,8 @@ Resources:
       Threshold: 0
       TreatMissingData: notBreaching
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
+      EvaluationPeriods: 4
+      DatapointsToAlarm: 3
       ActionsEnabled: true
       AlarmActions:
         - !Ref TUFRepoCanarySNSNotificationTopic
@@ -236,7 +238,8 @@ Resources:
       Threshold: 0
       TreatMissingData: notBreaching
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
+      EvaluationPeriods: 4
+      DatapointsToAlarm: 3
       ActionsEnabled: true
       AlarmActions:
         - !Ref TUFRepoCanarySNSNotificationTopic


### PR DESCRIPTION
Adds more evaluation periods to alarms and datapoints necessary to trigger TUF repo canary alarms.

Minor fixes to the Cloudformation template

*Issue #, if available:* N/A

*Testing done:*
Created Cloudformation stack with template and everything is set up correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
