### PR TITLE
Remove hardcoded paths from repo canary

### DIFF
--- a/extras/repo-canary/Cargo.lock
+++ b/extras/repo-canary/Cargo.lock
@@ -1000,6 +1000,14 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "repo-canary"
 version = "0.1.0"
 dependencies = [
@@ -1008,6 +1016,7 @@ dependencies = [
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tough 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1275,6 +1284,19 @@ dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1836,6 +1858,7 @@ dependencies = [
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
@@ -1864,6 +1887,7 @@ dependencies = [
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "575be94ccb86e8da37efb894a87e2b660be299b41d8ef347f9d6d79fbe61b1ba"
+"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/extras/repo-canary/Cargo.toml
+++ b/extras/repo-canary/Cargo.toml
@@ -11,4 +11,5 @@ rand = "0.7.0"
 reqwest = { version = "0.9.17", default-features = false, features = ["rustls-tls"] }
 simplelog = "0.7"
 snafu = "0.5.0"
+tempfile = "3.1.0"
 tough = { version = "0.1.0", features = ["http"] }

--- a/extras/repo-canary/Dockerfile
+++ b/extras/repo-canary/Dockerfile
@@ -14,4 +14,4 @@ RUN mkdir -p /usr/share/repo-canary
 COPY root.json /usr/share/repo-canary/
 COPY --from=builder /opt/build/target/release/repo-canary /usr/bin/
 
-CMD /usr/bin/repo-canary --metadata-base-url $METADATA_BASE_URL --target-base-url $TARGET_BASE_URL --percentage-of-targets-to-retrieve 50
+CMD /usr/bin/repo-canary --metadata-base-url $METADATA_BASE_URL --target-base-url $TARGET_BASE_URL --trusted-root-path /usr/share/repo-canary/root.json --percentage-of-targets-to-retrieve 50


### PR DESCRIPTION
We can use a tempdir for the data store, since we don't use it persistently.

We can accept an argument for the trusted root path; local usage would probably
point to the root.json in the same directory, and container-based canary usage
can point to the root file in the directory it creates.

---

**Testing done:**

Can run locally with `cargo run` now:
```
$ cargo run -- --metadata-base-url "https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/metadata/" --target-base-url "https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/targets/" --log-level info --trusted-root-path root.json
18:52:00 [ INFO] Loading TUF repo
18:52:00 [ INFO] Loaded TUF repo
18:52:00 [ INFO] Downloading 100% of listed targets
18:52:00 [ INFO] Downloading target: thar-x86_64-0.1.4-root.verity.lz4
18:52:01 [ INFO] Downloading target: thar-x86_64-0.1.5-boot.ext4.lz4
18:52:02 [ INFO] Downloading target: thar-x86_64-0.2.1-root.verity.lz4
18:52:03 [ INFO] Downloading target: manifest.json
18:52:03 [ INFO] Downloading target: thar-x86_64-0.2.1-root.ext4.lz4
18:52:43 [ INFO] Downloading target: thar-x86_64-0.1.5-root.ext4.lz4
18:53:27 [ INFO] Downloading target: thar-x86_64-0.1.6-boot.ext4.lz4
18:53:29 [ INFO] Downloading target: thar-x86_64-root.verity.lz4
18:53:31 [ INFO] Downloading target: thar-x86_64-boot.ext4.lz4
18:53:34 [ INFO] Downloading target: thar-x86_64-0.2.1-boot.ext4.lz4
18:53:36 [ INFO] Downloading target: thar-x86_64-0.1.6-root.verity.lz4
18:53:38 [ INFO] Downloading target: thar-x86_64-0.1.4-boot.ext4.lz4
18:53:41 [ INFO] Downloading target: thar-x86_64-0.1.4-root.ext4.lz4
18:54:49 [ INFO] Downloading target: thar-x86_64-0.1.6-root.ext4.lz4
18:55:37 [ INFO] Downloading target: thar-x86_64-0.1.5-root.verity.lz4
18:55:38 [ INFO] Downloading target: thar-x86_64-root.ext4.lz4
cargo run -- --metadata-base-url  --target-base-url  --log-level info    172.28s user 7.92s system 65% cpu 4:36.19 total
```

Docker version still runs:
```
$ docker build . --build-arg METADATA_BASE_URL=https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/metadata/ --build-arg TARGET_BASE_URL=https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/targets/
Sending build context to Docker daemon  990.7MB
Step 1/14 : FROM rust:1.38.0 as builder
 ---> fc49eca6d556
 ...
Step 14/14 : CMD /usr/bin/repo-canary --metadata-base-url $METADATA_BASE_URL --target-base-url $TARGET_BASE_URL --trusted-root-path /usr/share/repo-canary/root.json --percentage-of-targets-to-retrieve 50
 ---> Running in 68b164f0bbc2
Removing intermediate container 68b164f0bbc2
 ---> 781e7c9df3d0
Successfully built 781e7c9df3d0
 
$ docker run 781e7c9df3d0
19:03:39 [ INFO] Loading TUF repo
19:03:39 [ INFO] Loaded TUF repo
19:03:39 [ INFO] Downloading 50% of listed targets
19:03:39 [ INFO] Downloading target: thar-x86_64-0.1.6-boot.ext4.lz4
19:03:40 [ INFO] Downloading target: thar-x86_64-0.2.1-boot.ext4.lz4
19:03:41 [ INFO] Downloading target: thar-x86_64-0.1.4-root.verity.lz4
19:03:41 [ INFO] Downloading target: thar-x86_64-root.verity.lz4
19:03:41 [ INFO] Downloading target: thar-x86_64-0.1.4-root.ext4.lz4
19:03:49 [ INFO] Downloading target: manifest.json
19:03:49 [ INFO] Downloading target: thar-x86_64-0.1.5-root.verity.lz4
19:03:49 [ INFO] Downloading target: thar-x86_64-0.2.1-root.ext4.lz4
```