### PR TITLE
tuf-repo-canary: replace hardcoded sns endpoint with CFN parameter

### DIFF
--- a/tools/infra/tuf-repo-canary/RepoCanary.template.yaml
+++ b/tools/infra/tuf-repo-canary/RepoCanary.template.yaml
@@ -2,6 +2,11 @@ Parameters:
   TaskName:
     Type: String
     Default: tuf-repo-canary
+  SNSSubscriptionEndpoint:
+    Type: String
+  SNSSubscriptionProtocol:
+    Type: String
+    Default: email
 Resources:
   VPC:
     Type: 'AWS::EC2::VPC'
@@ -59,8 +64,8 @@ Resources:
   TUFRepoCanarySNSSubscription:
     Type: 'AWS::SNS::Subscription'
     Properties:
-      Endpoint: etung@amazon.com
-      Protocol: email
+      Endpoint: !Sub '${SNSSubscriptionEndpoint}'
+      Protocol: !Sub '${SNSSubscriptionProtocol}'
       TopicArn: !Ref TUFRepoCanarySNSNotificationTopic
   TUFRepoCanaryImgRepo:
     Type: 'AWS::ECR::Repository'


### PR DESCRIPTION
Replaces the hardcoded testing SNS endpoint string with a CFN parameter

*Issue #, if available:* N/A

*Testing Done:*
CloudFormation stack gets created successfully


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
