### PR TITLE
updog: Set permissions and extension of migrations

### DIFF
--- a/workspaces/updater/updog/src/error.rs
+++ b/workspaces/updater/updog/src/error.rs
@@ -222,6 +222,12 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failed setting permissions of '{}': {}", path.display(), source))]
+    SetPermissions {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
     #[snafu(display("Target not found: {}", target))]
     TargetNotFound {
         target: String,


### PR DESCRIPTION
*Issue #, if available:*
Fixes #558

*Description of changes:*
When downloading migrations don't include the '.lz4' extension in the resulting file, and make sure the file is executable.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Tested by checking the migration binaries after an update, before rebooting:
```
bash-5.0# updog check-update
aws-k8s-0.2.0 (v0.1)
bash-5.0# updog update-image
Starting update to 0.2.0
Update applied: aws-k8s-0.2.0
bash-5.0# ls -l /var/lib/thar/datastore/migrations/
total 1048
-rwxr-xr-x 1 root root 555720 Nov 25 21:30 borkseed-migration
-rwxr-xr-x 1 root root 514760 Nov 25 21:30 host-containers-version-migration
bash-5.0# /var/lib/thar/datastore/migrations/borkseed-migration
Usage: /var/lib/thar/datastore/migrations/borkseed-migration
            --datastore-path PATH
            ( --forward | --backward )
```