### PR TITLE
updater: exposes updata functions to add migrations and updates, add/remove waves

### DIFF
--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -2828,6 +2828,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "data_store_version 0.1.0",
+ "migrator 0.1.0",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/workspaces/updater/update_metadata/Cargo.toml
+++ b/workspaces/updater/update_metadata/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0.100", features = ["derive"] }
 serde_json = "1.0.40"
 serde_plain = "0.3.0"
 snafu = "0.5.0"
+migrator = { path = "../../api/migration/migrator" }
 
 [lib]
 name = "update_metadata"

--- a/workspaces/updater/update_metadata/src/de.rs
+++ b/workspaces/updater/update_metadata/src/de.rs
@@ -72,7 +72,7 @@ where
                 }
             }
         }
-        error::BadDataVersion { key }.fail()
+        error::BadDataVersionsFromTo { key }.fail()
     }
 
     fn parse_tuple_key(
@@ -88,7 +88,7 @@ where
                 error::DuplicateVersionKey { key }
             );
         } else {
-            return error::BadDataVersion {
+            return error::BadDataVersionsFromTo {
                 key: format!("{}, {}", from, to),
             }
             .fail();

--- a/workspaces/updater/update_metadata/src/lib.rs
+++ b/workspaces/updater/update_metadata/src/lib.rs
@@ -6,11 +6,19 @@ mod se;
 
 use chrono::{DateTime, Duration, Utc};
 use data_store_version::Version as DataVersion;
+use migrator::MIGRATION_FILENAME_RE;
 use rand::{thread_rng, Rng};
 use semver::Version as SemVer;
 use serde::{Deserialize, Serialize};
+use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::BTreeMap;
+use std::fs;
+use std::fs::File;
 use std::ops::Bound::{Excluded, Included};
+use std::path::Path;
+use std::str::FromStr;
+
+use crate::error::Result;
 
 pub const MAX_SEED: u32 = 2048;
 
@@ -39,6 +47,185 @@ pub struct Manifest {
     #[serde(serialize_with = "se::serialize_migration")]
     pub migrations: BTreeMap<(DataVersion, DataVersion), Vec<String>>,
     pub datastore_versions: BTreeMap<SemVer, DataVersion>,
+}
+
+pub fn load_file(path: &Path) -> Result<Manifest> {
+    let file = File::open(path).context(error::ManifestRead { path })?;
+    serde_json::from_reader(file).context(error::ManifestParse)
+}
+
+pub fn write_file(path: &Path, manifest: &Manifest) -> Result<()> {
+    let manifest = serde_json::to_string_pretty(&manifest).context(error::UpdateSerialize)?;
+    fs::write(path, &manifest).context(error::ManifestWrite { path })?;
+    Ok(())
+}
+
+impl Manifest {
+    pub fn add_migration(
+        &mut self,
+        append: bool,
+        from: DataVersion,
+        to: DataVersion,
+        migration_list: Vec<String>,
+    ) -> Result<()> {
+        // Check each migration matches the filename conventions used by the migrator
+        for name in &migration_list {
+            let captures = MIGRATION_FILENAME_RE
+                .captures(&name)
+                .context(error::MigrationNaming)?;
+
+            let version_match = captures
+                .name("version")
+                .context(error::BadRegexVersion { name })?;
+            let version = DataVersion::from_str(version_match.as_str())
+                .context(error::BadDataVersion { key: name })?;
+            ensure!(
+                version == to,
+                error::MigrationInvalidTarget { name, to, version }
+            );
+
+            let _ = captures
+                .name("name")
+                .context(error::BadRegexName { name })?;
+        }
+
+        // If append is true, append the new migrations to the existing vec.
+        if append && self.migrations.contains_key(&(from, to)) {
+            let migrations = self
+                .migrations
+                .get_mut(&(from, to))
+                .context(error::MigrationMutable { from: from, to: to })?;
+            migrations.extend_from_slice(&migration_list);
+        // Otherwise just overwrite the existing migrations
+        } else {
+            self.migrations.insert((from, to), migration_list);
+        }
+        Ok(())
+    }
+
+    pub fn add_update(
+        &mut self,
+        image_version: SemVer,
+        max_version: Option<SemVer>,
+        datastore_version: DataVersion,
+        arch: String,
+        flavor: String,
+        images: Images,
+    ) -> Result<()> {
+        let max_version = if let Some(version) = max_version {
+            version
+        } else {
+            // Default to greater of the current max version and this version
+            if let Some(update) = self.updates.first() {
+                std::cmp::max(&image_version, &update.max_version).clone()
+            } else {
+                image_version.clone()
+            }
+        };
+        let update = Update {
+            flavor,
+            arch,
+            version: image_version.clone(),
+            max_version: max_version.clone(),
+            images,
+            waves: BTreeMap::new(),
+        };
+        self.datastore_versions
+            .insert(image_version, datastore_version);
+        self.update_max_version(
+            &update.max_version,
+            Some(&update.arch),
+            Some(&update.flavor),
+        );
+        self.updates.push(update);
+        Ok(())
+    }
+
+    /// Update the maximum version for all updates that optionally match the
+    /// architecture and flavor of some new update.
+    pub fn update_max_version(
+        &mut self,
+        version: &SemVer,
+        arch: Option<&str>,
+        flavor: Option<&str>,
+    ) {
+        let matching: Vec<&mut Update> = self
+            .updates
+            .iter_mut()
+            .filter(|update| match (arch, flavor) {
+                (Some(arch), Some(flavor)) => update.arch == arch && update.flavor == flavor,
+                (Some(arch), None) => update.arch == arch,
+                (None, Some(flavor)) => update.flavor == flavor,
+                _ => true,
+            })
+            .collect();
+        for u in matching {
+            u.max_version = version.clone();
+        }
+    }
+
+    fn validate_updates(updates: &[Update]) -> Result<()> {
+        for update in updates {
+            let mut waves = update.waves.iter().peekable();
+            while let Some(wave) = waves.next() {
+                if let Some(next) = waves.peek() {
+                    ensure!(
+                        wave.1 < next.1,
+                        error::WavesUnordered {
+                            wave: *wave.0,
+                            next: *next.0
+                        }
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Adds a wave to update, returns number of matching updates for wave
+    pub fn add_wave(
+        &mut self,
+        flavor: String,
+        arch: String,
+        image_version: SemVer,
+        bound: u32,
+        start: DateTime<Utc>,
+    ) -> Result<usize> {
+        let matching: Vec<&mut Update> = self
+            .updates
+            .iter_mut()
+            // Find the update that exactly matches the specified update
+            .filter(|update| {
+                update.arch == arch && update.flavor == flavor && update.version == image_version
+            })
+            .collect();
+        let num_matching = matching.len();
+        for update in matching {
+            update.waves.insert(bound, start);
+        }
+        Self::validate_updates(&self.updates)?;
+        Ok(num_matching)
+    }
+
+    pub fn remove_wave(
+        &mut self,
+        flavor: String,
+        arch: String,
+        image_version: SemVer,
+        bound: u32,
+    ) -> Result<()> {
+        let matching: Vec<&mut Update> = self
+            .updates
+            .iter_mut()
+            .filter(|update| {
+                update.arch == arch && update.flavor == flavor && update.version == image_version
+            })
+            .collect();
+        for update in matching {
+            update.waves.remove(&bound);
+        }
+        Ok(())
+    }
 }
 
 impl Update {

--- a/workspaces/updater/updog/src/error.rs
+++ b/workspaces/updater/updog/src/error.rs
@@ -3,46 +3,13 @@
 use data_store_version::Version as DataVersion;
 use snafu::{Backtrace, Snafu};
 use std::path::PathBuf;
+use update_metadata::error::Error as update_metadata_error;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub(crate) enum Error {
-    #[snafu(display("Bad bound field: {}", bound_str))]
-    BadBound {
-        backtrace: Backtrace,
-        source: std::num::ParseIntError,
-        bound_str: String,
-    },
-
-    #[snafu(display("Invalid bound start: {}", key))]
-    BadBoundKey {
-        source: std::num::ParseIntError,
-        key: String,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Could not parse datastore version: {}", key))]
-    BadDataVersion {
-        backtrace: Backtrace,
-        key: String,
-        source: data_store_version::error::Error,
-    },
-
-    #[snafu(display("Could not parse image version: {} - {}", key, value))]
-    BadMapVersion {
-        backtrace: Backtrace,
-        key: String,
-        value: String,
-    },
-
-    #[snafu(display("Migration {} matches regex but missing version", name))]
-    BadRegexVersion { name: String },
-
-    #[snafu(display("Migration {} matches regex but missing name", name))]
-    BadRegexName { name: String },
-
     #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]
     ConfigParse {
         path: PathBuf,
@@ -64,13 +31,6 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to write config file {}: {}", path.display(), source))]
-    ConfigWrite {
-        path: PathBuf,
-        source: std::io::Error,
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Failed to create metadata cache directory: {}", source))]
     CreateMetadataCache {
         source: std::io::Error,
@@ -82,18 +42,6 @@ pub(crate) enum Error {
         backtrace: Backtrace,
         source: std::io::Error,
         path: PathBuf,
-    },
-
-    #[snafu(display("Duplicate key ID: {}", keyid))]
-    DuplicateKeyId { backtrace: Backtrace, keyid: u32 },
-
-    #[snafu(display("Duplicate version key: {}", key))]
-    DuplicateVersionKey { backtrace: Backtrace, key: String },
-
-    #[snafu(display("Migration '{}' contains invalid version: {}", name, source))]
-    InvalidMigrationVersion {
-        name: String,
-        source: data_store_version::error::Error,
     },
 
     #[snafu(display("Logger setup error: {}", source))]
@@ -133,13 +81,6 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to read manifest file {}: {}", path.display(), source))]
-    ManifestRead {
-        path: PathBuf,
-        source: std::io::Error,
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Metadata error: {}", source))]
     Metadata {
         source: tough::error::Error,
@@ -153,33 +94,8 @@ pub(crate) enum Error {
         name: String,
     },
 
-    #[snafu(display(
-        "Migration {} given for {} but name implies it is for {}",
-        name,
-        to,
-        version
-    ))]
-    MigrationInvalidTarget {
-        backtrace: Backtrace,
-        name: String,
-        to: DataVersion,
-        version: DataVersion,
-    },
-
-    #[snafu(display(
-        "Migration name invalid; must follow format 'migrate_${{TO_VERSION}}_${{NAME}}'"
-    ))]
-    MigrationNaming { backtrace: Backtrace },
-
     #[snafu(display("Migration not found in image: {:?}", name))]
     MigrationNotLocal { backtrace: Backtrace, name: PathBuf },
-
-    #[snafu(display("Unable to get mutable reference to ({},{}) migrations", from, to))]
-    MigrationMutable {
-        backtrace: Backtrace,
-        from: DataVersion,
-        to: DataVersion,
-    },
 
     #[snafu(display("Migration ({},{}) not present in manifest", from, to))]
     MigrationNotPresent {
@@ -308,12 +224,20 @@ pub(crate) enum Error {
     #[snafu(display("--start-time <time> required to add wave to update"))]
     WaveStartArg { backtrace: Backtrace },
 
-    #[snafu(display("Waves are not ordered: bound {} occurs before bound {}", next, wave))]
-    WavesUnordered { wave: u32, next: u32 },
-
     #[snafu(display("Failed writing update data to disk: {}", source))]
     WriteUpdate {
         source: std::io::Error,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("{}", source))]
+    UpdateMetadata {
+        source: update_metadata::error::Error,
+    },
+}
+
+impl std::convert::From<update_metadata::error::Error> for Error {
+    fn from(e: update_metadata_error) -> Self {
+        Error::UpdateMetadata { source: e }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/amazonlinux/PRIVATE-thar/issues/574

*Description of changes:*

Exposes `updata`'s `add_migration`, `add_update`, `add_wave`, `remove_wave` functionality as `Manifest` methods in the `update_metadata` library.

Also tries to reconcile some duplicate errors between `updog/error.rs` and `update_metadata/error.rs`

*Testing:*

`updog` and `updata` unit tests pass

Running updata:
```
$ updata init test-manifest
$ ls
debug  test-manifest
$ updata add-migration test-manifest --from 0.0.1 --to 0.0.2
$ cat test-manifest 
{
  "updates": [],
  "migrations": {
    "(0.0,0.0)": []
  },
  "datastore_versions": {}
}
$ updata add-migration test-manifest --from 0.1.1 --to 0.2.0
$ cat test-manifest 
{
  "updates": [],
  "migrations": {
    "(0.0,0.0)": [],
    "(0.1,0.2)": []
  },
  "datastore_versions": {}
}
$ updata add-update test-manifest --arch x86_64 --boot ~/thar/PRIVATE-thar/build/thar-x86_64-boot.ext4 --data-version 0.1 --flavor eks --hash blah --version 0.1.6 --root ~/thar/PRIVATE-thar/build/thar-x86_64-root.ext4
19:15:50 [ INFO] Maximum version set to 0.1.6
$ cat test-manifest 
{
  "updates": [
    {
      "flavor": "eks",
      "arch": "x86_64",
      "version": "0.1.6",
      "max_version": "0.1.6",
      "waves": {},
      "images": {
        "boot": "/home/ANT.AMAZON.COM/etung/thar/PRIVATE-thar/build/thar-x86_64-boot.ext4",
        "root": "/home/ANT.AMAZON.COM/etung/thar/PRIVATE-thar/build/thar-x86_64-root.ext4",
        "hash": "blah"
      }
    }
  ],
  "migrations": {
    "(0.0,0.0)": [],
    "(0.1,0.2)": []
  },
  "datastore_versions": {
    "0.1.6": "0.1"
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
