### PR TITLE
INSTALL: Fix kube-proxy option formatting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -221,8 +221,8 @@ Add `--conntrack-max-per-core` and `--conntrack-min` to the kube-proxy arguments
         - kube-proxy
         - --v=2
         - --config=/var/lib/kube-proxy-config/config
-        - --conntrack-max-per-core 0
-        - --conntrack-min 0
+        - --conntrack-max-per-core=0
+        - --conntrack-min=0
 
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
kube-proxy doesn't seem to like the "--option value" format anymore,
but "--option=value" appears to work fine. Update the install section
about conntrack options to match.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Tested by starting an instance with the following daemonset config:
```
     - command:
        - kube-proxy
        - --v=2
        - --config=/var/lib/kube-proxy-config/config
        - --conntrack-max-per-core=0
        - --conntrack-min=0

```
and making sure kube-proxy starts and the node reaches Ready state.