### PR TITLE
repo-canary: fixes arguments to repo-canary for check expire task

### DIFF
--- a/tools/infra/stacks/canaries/repo-canaries.yml
+++ b/tools/infra/stacks/canaries/repo-canaries.yml
@@ -114,7 +114,7 @@ Resources:
             - !Sub '${RepoTargetBaseUrl}'
             - '--trusted-root-path'
             - '/usr/share/repo-canary/root.json'
-            - '--check-upcoming-expiration'
+            - '--check-upcoming-expiration-days'
             - '3'
             - '--percentage-targets-to-retrieve'
             - '0'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Missed adding `-days` to the end of `--check-upcoming-expiration` in the
repo-canary stack.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
