### PR TITLE
updog: Make check-update wave aware

### DIFF
--- a/workspaces/updater/updog/src/error.rs
+++ b/workspaces/updater/updog/src/error.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::default_trait_access)]
 
 use data_store_version::Version as DataVersion;
+use semver::Version as SemVer;
 use snafu::{Backtrace, Snafu};
 use std::path::PathBuf;
 use update_metadata::error::Error as update_metadata_error;
@@ -197,6 +198,17 @@ pub(crate) enum Error {
     TransportBorrow {
         backtrace: Backtrace,
         source: std::cell::BorrowMutError,
+    },
+
+    #[snafu(display("No update available"))]
+    UpdateNotAvailable {
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Update {} exists but wave in the future", version))]
+    UpdateNotReady {
+        backtrace: Backtrace,
+        version: SemVer,
     },
 
     #[snafu(display("Failed to serialize update information: {}", source))]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Change the behaviour of check-update to not return any update unless the
wave for the update that Updog is in is also ready.
If no update is available or ready, Updog will now also return an error
instead of succeeding silently.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
