### PR TITLE
fix aarch64 build failure for libcap

### DIFF
--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -34,7 +34,7 @@ make \
   LIBDIR=%{_cross_libdir} SBINDIR=%{_cross_sbindir} \
   INCDIR=%{_cross_includedir} MANDIR=%{_cross_mandir} \
   PKGCONFIGDIR=%{_cross_pkgconfigdir} \
-  RAISE_SETFCAP=no PAM_CAP=no \
+  GOLANG=no RAISE_SETFCAP=no PAM_CAP=no \
 
 %install
 make install \
@@ -45,7 +45,7 @@ make install \
   LIBDIR=%{_cross_libdir} SBINDIR=%{_cross_sbindir} \
   INCDIR=%{_cross_includedir} MANDIR=%{_cross_mandir} \
   PKGCONFIGDIR=%{_cross_pkgconfigdir} \
-  RAISE_SETFCAP=no PAM_CAP=no \
+  GOLANG=no RAISE_SETFCAP=no PAM_CAP=no \
 
 chmod +x %{buildroot}%{_cross_libdir}/*.so.*
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Disables building an unused Go module. This doesn't work properly when cross-compiling without some special effort to set up the Go build environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
