### PR TITLE
update_metadata: Include space in datastore tuple

### DIFF
--- a/workspaces/updater/update_metadata/src/se.rs
+++ b/workspaces/updater/update_metadata/src/se.rs
@@ -12,8 +12,9 @@ where
 {
     let mut map = BTreeMap::new();
     for ((from, to), val) in value {
+        // NOTE: The space in this tuple is required for versions of Thar < 0.2.0
         let key = format!(
-            "({},{})",
+            "({}, {})",
             serde_plain::to_string(&from).map_err(|e| S::Error::custom(format!(
                 "Could not serialize 'from' version: {}",
                 e


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazonlinux/PRIVATE-thar/issues/572

*Description of changes:*
Current Updog can deserialise the datastore version tuple either way,
however older versions used a regex that requires at least one space in
between the versions. These versions will upgrade using a manifest
written by the new version, so the space is required while they exist.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

Tested by writing a manifest and making sure Updog on a 0.1.6 instance could read it.
