### PR TITLE
Fix docs for variant defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ timezone = "America/Thunder_Bay"
 
 Here we'll describe each setting you can change.
 
-**Note:** You can see the default values (for any settings that have defaults) by looking at the `defaults.toml` for your Thar variant under [models](workspaces/models/).
+**Note:** You can see the default values (for any settings that are not generated at runtime) by looking at [defaults.toml](workspaces/models/defaults.toml).
 
 When you're sending settings to the API, or receiving settings from the API, they're in a structured JSON format.
 This allows allow modification of any number of keys at once.

--- a/workspaces/api/README.md
+++ b/workspaces/api/README.md
@@ -49,7 +49,7 @@ On first boot, [storewolf](#storewolf) hasn’t run yet, so there’s no data st
 
 storewolf owns the creation and initial population of the data store.
 
-storewolf ensures the default values (defined in the `defaults.toml` for [your variant](../models)) are populated in the data store.
+storewolf ensures the default values (defined in [defaults.toml](../models/defaults.toml)) are populated in the data store.
 First, it has to create the data store directories and symlinks if they don’t exist.
 Then, it goes key-by-key through the defaults, and if a key isn’t already set, sets it with the default value.
 
@@ -107,7 +107,7 @@ This service sends a commit request to the API, which moves all the pending sett
 
 Further docs:
 * [thar-be-settings](thar-be-settings/), the tool settings-applier uses
-* The `defaults.toml` files for each [variant](../models), which define our configuration files and services
+* [defaults.toml](../models/defaults.toml), which defines our configuration files and services
 
 This is a simple startup service that runs `thar-be-settings --all` to write out all of the configuration files that are based on our settings.
 

--- a/workspaces/models/README.md
+++ b/workspaces/models/README.md
@@ -16,17 +16,19 @@ This `Settings` essentially becomes the schema for the variant's data store.
 
 At the field level, standard Rust types can be used, or ["modeled types"](src/modeled_types) that add input validation.
 
+Default values are specified in [defaults.toml](defaults.toml) and can be overridden by each variant.
+
 The `#[model]` attribute on Settings and its sub-structs reduces duplication and adds some required metadata; see [its docs](model-derive/) for details.
 
 ### aws-k8s: Kubernetes
 
 * [Model](src/aws-k8s/mod.rs)
-* [Defaults](src/aws-k8s/defaults.toml)
+* [Overridden defaults](src/aws-k8s/override-defaults.toml)
 
 ### aws-dev: Development build
 
 * [Model](src/aws-dev/mod.rs)
-* [Defaults](src/aws-dev/defaults.toml)
+* [Overridden defaults](src/aws-dev/override-defaults.toml)
 
 ## This directory
 

--- a/workspaces/models/src/lib.rs
+++ b/workspaces/models/src/lib.rs
@@ -13,17 +13,19 @@ This `Settings` essentially becomes the schema for the variant's data store.
 
 At the field level, standard Rust types can be used, or ["modeled types"](src/modeled_types) that add input validation.
 
+Default values are specified in [defaults.toml](defaults.toml) and can be overridden by each variant.
+
 The `#[model]` attribute on Settings and its sub-structs reduces duplication and adds some required metadata; see [its docs](model-derive/) for details.
 
 ## aws-k8s: Kubernetes
 
 * [Model](src/aws-k8s/mod.rs)
-* [Defaults](src/aws-k8s/defaults.toml)
+* [Overridden defaults](src/aws-k8s/override-defaults.toml)
 
 ## aws-dev: Development build
 
 * [Model](src/aws-dev/mod.rs)
-* [Defaults](src/aws-dev/defaults.toml)
+* [Overridden defaults](src/aws-dev/override-defaults.toml)
 
 # This directory
 


### PR DESCRIPTION
Sorry, forgot to do this in #613.

(The main defaults.toml explains the variant overrides, so we don't need to point to all of them all the time.)