### PR TITLE
Specify cargo-deny version in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,8 @@ We also use [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) during the
 To get these, run:
 
 ```
-cargo install cargo-make cargo-deny
+cargo install cargo-make
+cargo install cargo-deny --version 0.2.6
 ```
 
 #### Docker


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Specify the version of `cargo-deny` that needs to be installed to make everything work. Trying to `cargo make world` with the latest version of `cargo-deny` from crates.io doesn't work.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
