### PR TITLE
Add platform-specific settings to API model

### DIFF
--- a/workspaces/api/moondog/README.md
+++ b/workspaces/api/moondog/README.md
@@ -4,13 +4,13 @@ Current version: 0.1.0
 
 ## Introduction
 
-moondog is a minimal user data agent.
+moondog sends provider-specific platform data to the Thar API.
 
-It accepts TOML-formatted settings from a user data provider such as an instance metadata service.
-These are sent to a known Thar API server endpoint.
+For most providers this means configuration from user data and platform metadata, taken from
+something like an instance metadata service.
 
-Currently, Amazon EC2 user data support is implemented.
-User data can also be retrieved from a file for testing.
+Currently, Amazon EC2 is supported through the IMDSv1 HTTP API.  Data will be taken from files in
+/etc/moondog instead, if available, for testing purposes.
 
 ## Colophon
 

--- a/workspaces/models/src/aws-dev/mod.rs
+++ b/workspaces/models/src/aws-dev/mod.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::modeled_types::{Identifier, SingleLineString};
-use crate::{ContainerImage, NtpSettings, UpdatesSettings};
+use crate::{AwsSettings, ContainerImage, NtpSettings, UpdatesSettings};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -14,4 +14,5 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
     ntp: NtpSettings,
+    aws: AwsSettings,
 }

--- a/workspaces/models/src/aws-k8s/mod.rs
+++ b/workspaces/models/src/aws-k8s/mod.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::modeled_types::{Identifier, SingleLineString};
-use crate::{ContainerImage, KubernetesSettings, NtpSettings, UpdatesSettings};
+use crate::{AwsSettings, ContainerImage, KubernetesSettings, NtpSettings, UpdatesSettings};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -15,4 +15,5 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
     ntp: NtpSettings,
+    aws: AwsSettings,
 }

--- a/workspaces/models/src/lib.rs
+++ b/workspaces/models/src/lib.rs
@@ -108,6 +108,12 @@ struct NtpSettings {
     time_servers: Vec<Url>,
 }
 
+// Platform-specific settings
+#[model]
+struct AwsSettings {
+    region: SingleLineString,
+}
+
 ///// Internal services
 
 // Note: Top-level objects that get returned from the API should have a "rename" attribute


### PR DESCRIPTION
Initially, this means setting "region" for the AWS platform.

The first use case is 'region' so we can regionalize container addresses; usage
will be controlled by variant-specific (and therefore platform-specific)
metadata, so a platform-specific setting path doesn't hurt.  In the near
future, we will likely want to use region in other places, like telemetry,
where we don't want applications to have to understand platform; in this case,
we can abstract usage through a sundog generator that translates platform
specifics to application-specific settings.

Implementation is mostly in moondog.  Previously, we only read user data, so it
needed some restructuring to handle other data in IMDS.  Now, each platform
implements PlatformDataProvider.  Its sole method can read user data or other
metadata however it likes, and just has to return a list of Settings-like
objects that it wants to be sent to the API.

---

**Testing done:**

The system is healthy, pods launch OK, moondog had no errors, and the new setting shows up:
```
[ec2-user@ip-192-168-33-74 ~]$ apiclient -u /settings
{
...
  "aws": {
    "region": "us-east-1"
  }
}
```