### PR TITLE
Add migration to remove region on downgrade

### DIFF
--- a/RELEASE.toml
+++ b/RELEASE.toml
@@ -4,4 +4,4 @@ datastore_version = "0.2"
 [[migrations]]
 from = "0.2.0"
 to = "0.2.1"
-names = ["migrate_0.2_containerd-config-path"]
+names = ["migrate_0.2_containerd-config-path", "migrate_0.2_remove-region"]

--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -1987,6 +1987,15 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "remove-region"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "api/migration/migrations/v0.1/borkseed",
     "api/migration/migrations/v0.1/host-containers-version",
     "api/migration/migrations/v0.2/containerd-config-path",
+    "api/migration/migrations/v0.2/remove-region",
 
     "models",
 

--- a/workspaces/api/migration/migrations/v0.2/remove-region/Cargo.toml
+++ b/workspaces/api/migration/migrations/v0.2/remove-region/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "remove-region"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }
+serde_json = "1.0"
+snafu = "0.6"

--- a/workspaces/api/migration/migrations/v0.2/remove-region/src/main.rs
+++ b/workspaces/api/migration/migrations/v0.2/remove-region/src/main.rs
@@ -1,0 +1,41 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use std::process;
+
+/// We added a generated setting, "settings.aws.region", and want to make sure it's removed before
+/// we go back to old versions that don't understand it.
+struct RemoveRegionMigration;
+
+impl Migration for RemoveRegionMigration {
+    /// New versions will generate the setting, we don't need to do anything.
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("RemoveRegionMigration has no work to do on upgrade.");
+        Ok(input)
+    }
+
+    /// Older versions don't know about region; we remove it so that old versions don't see it and
+    /// fail deserialization.  (The setting is generated in new versions, and safe to remove.)
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(region) = input.data.remove("settings.aws.region") {
+            println!("Removed settings.aws.region, which was set to '{}'", region);
+        } else {
+            println!("Found no settings.aws.region to remove");
+        }
+        Ok(input)
+    }
+}
+
+fn run() -> Result<()> {
+    migrate(RemoveRegionMigration)
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
Older versions don't know about this setting and would fail to deserialize the
model if it's present.  (We currently need to write a migration for any
added/removed settings, but this will be automated away.)

Region is a generated setting, so we're not throwing away anything important.

---

Fixes #642.
Builds on #638 and #644.

**Testing done:**

Saved contents to make sure we write everything out:
```
$ find datastore-sample/current/ > v0.1-contents
```

Migrate to v0.2.  We can see the migration running and saying it has nothing to do.
```
$ cargo run -- --log-level trace --datastore-path datastore-sample/current --migration-directories ./migration-binaries --migrate-to-version 0.2
...
21:41:19 [DEBUG] (1) migrator: Sorted migrations: ["migrate_v0.2_remove-region"]
21:41:19 [ INFO] New data store is being built at work location /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2_Oq7CIMsaiEfnCNL3
21:41:19 [ INFO] Running migration command: "./migration-binaries/migrate_v0.2_remove-region" "--forward" "--source-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_AmdROiQykcX0vQRy" "--target-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2_Oq7CIMsaiEfnCNL3"
21:41:19 [DEBUG] (1) migrator: Migration stdout: RemoveRegionMigration has no work to do on upgrade.
RemoveRegionMigration has no work to do on upgrade.

21:41:19 [DEBUG] (1) migrator: Migration stderr: 
21:41:19 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2 to point to v0.2_Oq7CIMsaiEfnCNL3
21:41:19 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0 to point to v0.2
```

When v0.2 (of aws-k8s flavor) runs, it will set `settings.aws.region`:
```
$ mkdir datastore-sample/current/live/settings/aws && echo -n '"us-west-2"' > datastore-sample/current/live/settings/aws/region
```

Downgrade back to v0.1.  We can see the migration running and removing the region.  (It removes it from `live` settings; it wasn't set in `pending`, hence the second message.)
```
$ cargo run -- --log-level trace --datastore-path datastore-sample/current --migration-directories ./migration-binaries --migrate-to-version 0.1
...
21:42:30 [DEBUG] (1) migrator: Sorted migrations: ["migrate_v0.2_remove-region"]
21:42:30 [ INFO] New data store is being built at work location /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_kZNHRvDkARjcHinw
21:42:30 [ INFO] Running migration command: "./migration-binaries/migrate_v0.2_remove-region" "--backward" "--source-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2_Oq7CIMsaiEfnCNL3" "--target-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_kZNHRvDkARjcHinw"
21:42:30 [DEBUG] (1) migrator: Migration stdout: Removed settings.aws.region, which was set to '"us-west-2"'
Found no settings.aws.region to remove

21:42:30 [DEBUG] (1) migrator: Migration stderr: 
21:42:30 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1 to point to v0.1_kZNHRvDkARjcHinw
21:42:30 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0 to point to v0.1
```

Region was removed:
```
$ ll datastore-sample/current/live/settings/aws/region
ls: cannot access 'datastore-sample/current/live/settings/aws/region': No such file or directory
```

...and so the file list is the same as before:
```
$ find datastore-sample/current/ > v0.1-contents-after
$ diff v0.1-contents{,-after}
```