### PR TITLE
ci: add /bin/sh dispatcher to use bash in builds

### DIFF
--- a/tools/infra/container/Dockerfile.builder
+++ b/tools/infra/container/Dockerfile.builder
@@ -34,3 +34,5 @@ COPY builder/entrypoint.sh /build/entrypoint.sh
 ENTRYPOINT ["/build/entrypoint.sh"]
 
 CMD [ "bash" ]
+
+RUN ln -snfv /build/runtime/bin/sh-dispatcher /bin/sh

--- a/tools/infra/container/runtime/bin/sh-dispatcher
+++ b/tools/infra/container/runtime/bin/sh-dispatcher
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# sh-dispatcher - dispatch to bash or sh based on call
+#
+# sh-dispatcher always execs bash on the first call to it and exports the PID in
+# the environment before exec-ing to use a determining factor of "first call",
+# or, put another way, the "entrypoint call".
+#
+# This shape works well for environments such as CodeBuild as the spec's
+# commands are executed in a new shell process for each command or each section
+# (depending on the buildspec version used or how you interpret the docs).
+# Therefore, the anticipated use of this script is to place at /bin/sh (under
+# the guise of being /bin/sh) to be executed as the script or command "runner"
+# shell.
+#
+# Within the interpretation and execution of the running script, any calls made
+# to run /bin/sh will be redirected to /bin/sh - which is likely what the caller
+# intended. This, however, assumes that there are no interposing processes that
+# clear environment variables or use a fresh environment altogether as this
+# would be clean of the signaling variable set before exec-ing and cause
+# false-negative calls to use bash.
+#
+
+real_bash="$(command -v bash)"
+# Check to see if the call is for the origin shell or for a caller within
+# origin's run.
+if [[ -n "$__INFRA_CONTAINER_SH_PID" ]] && [[ -d "/proc/$__INFRA_CONTAINER_SH_PID" ]]; then
+	exec -a "/bin/sh" "$real_bash" "$@"
+fi
+# Originating call, set the signaling environment variable to dispatch to sh.
+export __INFRA_CONTAINER_SH_PID="$$"
+exec -a "$real_bash" "$real_bash" "$@"


### PR DESCRIPTION
*Issue #, if available:*

#633 

*Description of changes:*

- Add `sh-dispatcher` and wire it up to be used as `/bin/sh`.

`sh-dispatcher` always execs bash on the first call to it and exports the PID in the environment before exec-ing to use a determining factor of "first call", or, put another way, the "entrypoint call".

This shape works well for environments such as CodeBuild as the spec's commands are executed in a new shell process for each command or each section (depending on the buildspec version used or how you interpret the docs). Therefore, the anticipated use of this script is to place at `/bin/sh` (under the guise of being `/bin/sh`) to be executed as the script or command "runner" shell.

Within the interpretation and execution of the running script, any calls made to run /bin/sh will be redirected to /bin/sh - which is likely what the caller intended. This, however, assumes that there are no interposing processes that clear environment variables or use a fresh environment altogether as this would be clean of the signaling variable set before exec-ing and cause false-negative calls to use bash.

For example, here's the container image built with `/bin/sh` symlinked to our `sh-dispatcher` script. Each level shows descending below a parent "origin" shell process and tracking through into other shell invocations - which allows for calling sh per usual (bash put into its `/bin/sh` POSIX mode).
```bash
# Indented by nested shell depth
host> docker run -ti --rm --entrypoint /bin/sh infra/builder:develop
cont> bash-4.2# sh
cont>   sh-4.2# sh
cont>     sh-4.2# exit
cont>     exit
cont>   sh-4.2# exit
cont>   exit
cont> bash-4.2# echo $__INFRA_CONTAINER_SH_PID
cont> 1
cont> bash-4.2# unset __INFRA_CONTAINER_SH_PID
cont> bash-4.2# sh
cont>   bash-4.2# echo $$
cont>   11
cont>   bash-4.2# echo $__INFRA_CONTAINER_SH_PID
cont>   11
cont>   bash-4.2# sh
cont>     sh-4.2# sh
cont>       sh-4.2# exit
cont>       exit
cont>     sh-4.2# exit
cont>     exit
cont>   bash-4.2# __INFRA_CONTAINER_SH_PID=9001
cont>   bash-4.2# stat /proc/9001
cont>   stat: cannot stat '/proc/9001': No such file or directory
cont>   bash-4.2# sh
cont>     bash-4.2#
```

Or, more succinctly, an example with shells calling shells:

```bash
# docker run -ti --rm --entrypoint /bin/sh infra/builder:develop \
#    -c 'ps auxwww; echo "hi from bash"; env | grep INFRA; echo; sh -c "ps auxwww ; echo hi from sh" ; env | grep INFRA'
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0  11572  2516 pts/0    Ss+  22:39   0:00 /usr/bin/bash -c ps auxwww; echo "hi from bash"; env | grep INFRA; echo; sh -c "ps auxwww ; echo hi from sh" ; env | grep INFRA
root         7  0.0  0.0  51864  3472 pts/0    R+   22:39   0:00 ps auxwww
hi from bash
__INFRA_CONTAINER_SH_PID=1

USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0  11572  2596 pts/0    Ss+  22:39   0:00 /usr/bin/bash -c ps auxwww; echo "hi from bash"; env | grep INFRA; echo; sh -c "ps auxwww ; echo hi from sh" ; env | grep INFRA
root        10  0.0  0.0  11572  2568 pts/0    S+   22:39   0:00 /bin/sh -c ps auxwww ; echo hi from sh
root        12  0.0  0.0  51864  3444 pts/0    R+   22:39   0:00 ps auxwww
hi from sh
__INFRA_CONTAINER_SH_PID=1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
