### PR TITLE
ci: polyfill logger in edge cases for #541

### DIFF
--- a/tools/infra/container/runtime/lib/lib.bash
+++ b/tools/infra/container/runtime/lib/lib.bash
@@ -2,5 +2,50 @@
 
 # Logger provides the corrected interface to log to stderr.
 logger() {
-    command logger --no-act -s "$@"
+    # Use logger if its usable
+    if test -S /dev/log; then
+        command logger --no-act -s "$@"
+        return 0
+    fi
+
+    # Otherwise, use a simple polyfill implementation that provides a similar
+    # enough interface to be used across scripts.
+    local tag
+    local message
+    local format
+
+    # polyfill in a logger that writes to stderr
+    while [ "$#" -ne 0 ]; do
+        case "$1" in
+            -t )
+                tag="$2"
+                shift 1
+                ;;
+            -*|-- )
+                # drop options
+                ;;
+            * )
+                # message
+                message=( "$@" )
+                break
+                ;;
+        esac
+        shift 1
+    done
+
+    # Message printer format
+    format="${tag:+"$tag: "}%s\n"
+
+    # Single message in function call
+    if [[ "${#message[@]}" -ne 0 ]]; then
+        printf "$format" "${message[*]}" >&2
+        return 0
+    fi
+
+    # Stream of messages sent to function as input
+    while read msg; do
+        printf "$format" "${msg}" >&2
+    done
+
+    return 0
 }


### PR DESCRIPTION
*Issue #, if available:*

#541

*Description of changes:*

This polyfill implementation of `logger` handles scenarios where the
environment isn't fully initialized or where the logger stub isn't able
to be run. Falling back to `printf` eliminates logged errors from these
places and in their place prints the expected messages.

This helps reach full coverage for #541 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
