### PR TITLE
containerd: specify killmode=mixed

### DIFF
--- a/packages/containerd/containerd.service
+++ b/packages/containerd/containerd.service
@@ -7,7 +7,7 @@ Wants=network-online.target configured.target
 [Service]
 ExecStart=/usr/bin/containerd
 Delegate=yes
-KillMode=process
+KillMode=mixed
 TimeoutSec=0
 RestartSec=2
 Restart=always


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazonlinux/PRIVATE-thar/issues/289

*Description of changes:*
Changes `containerd.service`'s `KillMode` from `process` to `mixed`.

`KillMode=mixed` is needed because when containerd.service shuts down, systemd also needs to send termination signals to its child `containerd-shim` processes. 
Otherwise the system gets stuck on waiting for `containerd-shim` processes to stop when trying to reboot


*Testing*:
With `KillMode=process` (before this change):
```
.....
[[0;32m  OK  [0m] Stopped [0;1;39mlibcontainer conta���e386221259872faea0a9e9c6a912d[0m.
[K[[0;32m  OK  [0m] Removed slice [0;1;39mlibcontainer���_11ea_a850_02fe0b2a3c5c.slice[0m.
[[0;32m  OK  [0m] Removed slice [0;1;39mlibcontainer���iner kubepods-burstable.slice[0m.
[[0;32m  OK  [0m] Removed slice [0;1;39mlibcontainer container kubepods.slice[0m.
[[0;32m  OK  [0m] Reached target [0;1;39mShutdown[0m.
[[0;32m  OK  [0m] Reached target [0;1;39mFinal Step[0m.
[[0;32m  OK  [0m] Started [0;1;39mReboot[0m.
[[0;32m  OK  [0m] Reached target [0;1;39mReboot[0m.
[  240.313308] systemd-shutdow: 43 output lines suppressed due to ratelimiting
[  240.322923] systemd-shutdown[1]: Syncing filesystems and block devices.
[  240.325975] systemd-shutdown[1]: Sending SIGTERM to remaining processes...
[  240.330833] systemd-journald[838]: Received SIGTERM from PID 1 (systemd-shutdow).
[  250.332130] systemd-shutdown[1]: Waiting for process: containerd-shim, containerd-shim, containerd-shim
[  330.334825] systemd-shutdown[1]: Sending SIGKILL to remaining processes...
[  330.338875] systemd-shutdown[1]: Sending SIGKILL to PID 3059 (containerd-shim).
[  330.342323] systemd-shutdown[1]: Sending SIGKILL to PID 3060 (containerd-shim).
[  330.345780] systemd-shutdown[1]: Sending SIGKILL to PID 3903 (containerd-shim).
[  330.350285] systemd-shutdown[1]: Unmounting file systems.
```

With `KillMode=mixed`:
```
[K[[0;32m  OK  [0m] Stopped [0;1;39mlibcontainer conta���19ba2b79b2277925b84c855a2830e[0m.
[K[[0;32m  OK  [0m] Removed slice [0;1;39mlibcontainer���_11ea_a850_02fe0b2a3c5c.slice[0m.
[[0;32m  OK  [0m] Removed slice [0;1;39mlibcontainer���iner kubepods-burstable.slice[0m.
[[0;32m  OK  [0m] Removed slice [0;1;39mlibcontainer container kubepods.slice[0m.
[[0;32m  OK  [0m] Reached target [0;1;39mShutdown[0m.
[[0;32m  OK  [0m] Reached target [0;1;39mFinal Step[0m.
[[0;32m  OK  [0m] Started [0;1;39mReboot[0m.
[[0;32m  OK  [0m] Reached target [0;1;39mReboot[0m.
[  146.934703] systemd-shutdown[1]: Syncing filesystems and block devices.
[  146.939223] systemd-shutdown[1]: Sending SIGTERM to remaining processes...
[  146.945179] systemd-journald[864]: Received SIGTERM from PID 1 (systemd-shutdow).
[  146.980919] systemd-shutdown[1]: Sending SIGKILL to remaining processes...
[  146.986548] systemd-shutdown[1]: Unmounting file systems.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
