### PR TITLE
Add pipeline tooling for signing tool

### DIFF
--- a/tools/infra/buildspec/thar-develop-pipeline-sign.yml
+++ b/tools/infra/buildspec/thar-develop-pipeline-sign.yml
@@ -1,0 +1,20 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - environment-report
+      - write-build-meta
+  build:
+    commands:
+      - sign-tuf-repo
+
+artifacts:
+  base-directory: '/tmp/tuf_out'
+  files:
+    - '*'
+  secondary-artifacts:
+    meta:
+      base-directory: 'build/meta'
+      files:
+        - '*'

--- a/tools/infra/container/Dockerfile.builder
+++ b/tools/infra/container/Dockerfile.builder
@@ -10,7 +10,7 @@
 FROM amazonlinux:2 as base
 RUN yum update -y \
 	&& yum groupinstall -y 'Development Tools' \
-	&& yum install -y socat procps-ng awscli jq openssh rsync systemd-devel \
+	&& yum install -y socat procps-ng awscli jq openssh rsync systemd-devel openssl-devel \
 	&& amazon-linux-extras enable docker \
 	&& yum install -y docker amazon-ecr-credential-helper \
 	&& yum clean all \
@@ -18,19 +18,22 @@ RUN yum update -y \
 RUN install -D /dev/null /root/.docker/config.json \
 	&& echo '{ "credsStore": "ecr-login" }' >> /root/.docker/config.json
 
-FROM base
+FROM base as buildenv
 ENV PATH="$PATH:/build/runtime/bin:/build/scripts:/build/.cargo/bin"
 ENV CARGO_HOME="/build/.cargo"
 ENV RUNTIME_SCRIPT_LIB="/build/runtime/lib"
-
-COPY scripts /build/scripts
-COPY runtime /build/runtime
-WORKDIR /build
-
+COPY tools/infra/container/scripts /build/scripts
+COPY tools/infra/container/runtime /build/runtime
 RUN install-rust && configure-rust && install-crates
 
-COPY builder/entrypoint.sh /build/entrypoint.sh
+FROM buildenv as signing-tool
+COPY . /build/src
+RUN cd /build/src/tools/update_sign_tuf_repo && \
+  cargo build --release
 
+FROM buildenv
+COPY --from=signing-tool /build/src/tools/update_sign_tuf_repo/target/release/update_sign_tuf_repo /build/runtime/bin/update_sign_tuf_repo
+WORKDIR /build
+COPY tools/infra/container/builder/entrypoint.sh /build/entrypoint.sh
 ENTRYPOINT ["/build/entrypoint.sh"]
-
 CMD [ "bash" ]

--- a/tools/infra/container/Makefile
+++ b/tools/infra/container/Makefile
@@ -25,6 +25,13 @@ ECR_URI_PREFIX = $(shell aws ssm get-parameter --name /infra/container/infra/bui
 # conventional across automations' consumed images.
 ECR_NAME_PREFIX ?= infra/
 
+# This is a reference to the root of the Thar repo (relative to the current path)
+# so later we can run `docker build` with this path. This allows us to
+# more easily copy the Thar repo into a container, which in turn makes it simpler
+# to build Rust code that has dependencies on other code in the repo.
+# FIXME: when we split this code out we will need to handle this differently
+THAR_SRC = ../../../
+
 .DEFAULT: all
 .PHONY: force all release $(NAMES)
 force:
@@ -34,7 +41,7 @@ all: $(if $(NAME),$(NAME),$(NAMES))
 $(NAMES) : NAME = $@
 $(NAMES): force
 	@echo "Building container image for '$(NAME)'"
-	docker build -t $(IMAGE_NAME) -f Dockerfile.$(NAME) .
+	docker build -t $(IMAGE_NAME) -f Dockerfile.$(NAME) $(THAR_SRC)
 
 # Push images (must explicitly provide IMAGE_TAG=release to be pulled
 # by consumers).

--- a/tools/infra/container/runtime/bin/sign-tuf-repo
+++ b/tools/infra/container/runtime/bin/sign-tuf-repo
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# sign-tuf-repo - wrapper for the Rust binary that signs a tuf repo
+#
+# usage:
+#
+#   sign-tuf-repo
+#
+
+# shellcheck source=../lib/lib.bash
+source "${RUNTIME_SCRIPT_LIB:-../lib}/lib.bash"
+
+# $INPUT_BUILDSYS_ARTIFACTS_VAR comes from CodePipelines and is a reference to a
+# CODEBUILD provided variable that points to artifacts. We remap them in
+# order to remove references to CodeBuild.
+if [[ -z "${INPUT_BUILDSYS_ARTIFACTS}" ]] && [[ -n "${INPUT_BUILDSYS_ARTIFACTS_VAR}" ]]; then
+    export INPUT_BUILDSYS_ARTIFACTS="${!INPUT_BUILDSYS_ARTIFACTS_VAR}"
+fi
+
+if [[ -z "${INPUT_BUILDSYS_ARTIFACTS}" ]]; then
+    logger -t ERROR "unable to resolve expected environment variable 'INPUT_BUILDSYS_ARTIFACTS'"
+    exit 1
+fi
+
+if [[ -d "${INPUT_BUILDSYS_ARTIFACTS}" ]]; then
+    logger -t ERROR "provided path to artifacts is not present (provided: ${INPUT_BUILDSYS_ARTIFACTS})"
+    exit 1
+fi
+
+
+if !update_sign_tuf_repo; then
+    logger -t ERROR "signing failed"
+    exit 1
+fi


### PR DESCRIPTION
*Issue #, if available:*
Related to #592 and #608 

*Description of changes:*
* Add the buildspec for the "signing" stage in the pipeline
* Update the Dockerfile for the "builder" container to include the signing tool
* Include a wrapper script for the signing tool
* Update the Makefile to build with the root of the Thar repo as its base context.

*Testing done:*
Once the container finishes building I can test the tooling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
