### PR TITLE
ci: cd in script's shell instead of "if"s subshell

### DIFF
--- a/tools/infra/container/runtime/bin/write-build-meta
+++ b/tools/infra/container/runtime/bin/write-build-meta
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 #
-# write-build-meta - collect and write out build job details
+# write-build-meta - collect and write out build job & environment details
 #
-has_command() { type "$1" &>/dev/null; }
+
+# shellcheck source=../lib/lib.bash
+source "${RUNTIME_SCRIPT_LIB:-../lib}/lib.bash"
 
 write_common() {
     echo "${USER}" > build-user
@@ -24,10 +26,13 @@ write_codebuild() {
     echo "${CODEBUILD_BUILD_ARN}" > build-codebuild-arn
 }
 
-if ! { mkdir -p "build/meta" && cd "build/meta"; }; then
-    logger -s -t ERROR "could not create build/meta directory for writing"
+if ! mkdir -p "build/meta"; then
+    logger -t ERROR "could not create build/meta directory for writing"
     exit 1
 fi
+cd build/meta
+
+# Write build environment information to disk
 
 write_common
 
@@ -36,7 +41,7 @@ if [[ -n "${CODEBUILD_BUILD_ID}" ]]; then
 fi
 
 if [[ ! -s "build-service" ]]; then
-    logger -s -t WARN "unknown service, cannot write out CI build metadata"
+    logger -t WARN "unknown service, cannot write out CI build metadata"
     echo "unknown" > build-service
     exit 0
 fi

--- a/tools/infra/container/runtime/lib/lib.bash
+++ b/tools/infra/container/runtime/lib/lib.bash
@@ -49,3 +49,9 @@ logger() {
 
     return 0
 }
+
+# has_command returns true for present commands
+has_command() {
+    local name="${1:?has_command requires a name to check}"
+    command -v "$name" &>/dev/null
+}


### PR DESCRIPTION
*Issue #, if available:*

#657 

*Description of changes:*

The implicit subshell of the `if` prevented the `cd` from moving the scripts' working directory (causing issues where builds requires `write-build-meta` output in a specific location: #657).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
