### PR TITLE
Add preliminary signing role and corresponding assume role stack

### DIFF
--- a/tools/infra/stacks/signing-cross-account-assume-role.yml
+++ b/tools/infra/stacks/signing-cross-account-assume-role.yml
@@ -1,0 +1,21 @@
+# This is expected to be used by the account that owns the CodeBuild projects
+# for pipeline automation and should be stood up with those resources.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: 'A policy that can be added to an existing role, allowing it to assume a role that allows access to signing keys'
+Parameters:
+  SigningRoleArn:
+    Description: 'The ARN of the role that allows access to the signing keys'
+    Type: String
+
+Resources:
+  AssumeSigningRolePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: 'Allows assume role access to read-only signing keys'
+      ManagedPolicyName: SigningKeyAssumeRolePolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !Sub '${SigningRoleArn}'

--- a/tools/infra/stacks/signing-cross-account-read-role.yml
+++ b/tools/infra/stacks/signing-cross-account-read-role.yml
@@ -1,0 +1,47 @@
+# This is expected to be used by the account that owns the keys
+# for TUF repo signing and should be stood up with those resources.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: 'A role that allows read-only access to signing keys'
+Parameters:
+  AllowedAccountIds:
+    Description: 'The AWS accounts that require access to the signing key'
+    # A comma separated list of account ids, i.e "1234, 5678"
+    Type: CommaDelimitedList
+  KMSKeyArn:
+    Description: "ARN of the KMS key required to decrypt the signing key in the SSM Parameter's SecureString"
+    Type: String
+  SigningKeyArn:
+    Description: 'The ARN of the signing key SSM parameter'
+    Type: String
+
+Resources:
+  SigningAutomationAccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: 'Role allowing access to the signing key'
+      Path: !Sub '/${AWS::StackName}/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Join [ ',' , [!Ref AllowedAccountIds]]
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: 'SigningKeyReadOnlyAccess'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:Get*
+                Resource: !Sub '${SigningKeyArn}'
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: !Sub '${KMSKeyArn}'
+Outputs:
+  Role:
+    Description: 'The ARN of the signing key read-only role'
+    Value: !GetAtt SigningAutomationAccessRole.Arn


### PR DESCRIPTION
*Issue #, if available:*
Related to #608 

*Description of changes:*
Add two small CloudFormation templates containing IAM roles: one to provide access to the signing keys in a given account, and one to allow CodeBuild to assume the aforementioned role.

These will eventually roll up into larger stacks that deploy infrastructure but for now they're here for documentation and review purposes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
