### PR TITLE
Add version to PRETTY_NAME

### DIFF
--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -75,7 +75,7 @@ install -p -m 0644 %{S:99} %{buildroot}%{_cross_tmpfilesdir}/release.conf
 
 cat >%{buildroot}%{_cross_libdir}/os-release <<EOF
 NAME=Thar
-PRETTY_NAME="Thar, The Operating System"
+PRETTY_NAME="Thar, The Operating System (%{version})"
 ID=thar
 VERSION_ID=%{version}
 EOF


### PR DESCRIPTION
This makes it more obvious what version you've booted into; the console now
shows something like "Welcome to Thar, The Operating System (0.2.1)!"

---

**Testing done:**

Saw it in the console, it helped debugging.