### PR TITLE
Fix reference to parameter in signing keys cf stack

### DIFF
--- a/tools/infra/stacks/signing-cross-account-read-role.yml
+++ b/tools/infra/stacks/signing-cross-account-read-role.yml
@@ -25,7 +25,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Join [ ',' , [!Ref AllowedAccountIds]]
+              AWS: !Ref AllowedAccountIds
             Action:
               - 'sts:AssumeRole'
       Policies:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The reference to `AllowedAccountIds` needed to be a `!Ref`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
