### PR TITLE
Add attributions and license files for non-Rust upstream packages

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -179,9 +179,11 @@ CROSS_COMPILATION_CONF_EOF\
 
 %_cross_attribution_file %{_cross_licensedir}/%{name}/attribution.txt
 %cross_generate_attribution \
-  mkdir -p %{buildroot}%{_cross_licensedir}/%{name} \
-  echo "%{name} - %{url}" >> %{buildroot}%{_cross_attribution_file} \
-  echo "SPDX-License-Identifier: %{license}" >> %{buildroot}%{_cross_attribution_file}
+  if [ 0%{?_cross_first_party} -eq 0 ]; then \
+    mkdir -p %{buildroot}%{_cross_licensedir}/%{name} \
+    echo "%{name} - %{url}" >> %{buildroot}%{_cross_attribution_file} \
+    echo "SPDX-License-Identifier: %{license}" >> %{buildroot}%{_cross_attribution_file} \
+  fi
 %_cross_attribution_vendor_dir %{_cross_licensedir}/%{name}/vendor
 %cross_scan_attribution \
   thar-license-scan --spdx-data /usr/libexec/tools/spdx-data --out-dir %{buildroot}%{_cross_attribution_vendor_dir}
@@ -210,5 +212,6 @@ CROSS_COMPILATION_CONF_EOF\
 %__brp_mangle_shebangs /bin/true
 
 %__arch_install_post \
-/usr/lib/rpm/check-rpaths \
-/usr/lib/rpm/check-buildroot
+  /usr/lib/rpm/check-rpaths \
+  /usr/lib/rpm/check-buildroot \
+  %cross_generate_attribution

--- a/packages/acpid/acpid.spec
+++ b/packages/acpid/acpid.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}acpid
 Version: 2.0.32
 Release: 1%{?dist}
 Summary: ACPI event daemon
-License: GPLv2+
+License: GPL-2.0-or-later
 URL: http://sourceforge.net/projects/acpid2/
 Source0: http://downloads.sourceforge.net/acpid2/acpid-%{version}.tar.xz
 Source1: acpid.service
@@ -30,6 +30,8 @@ install -d %{buildroot}%{_cross_libdir}/acpid/events
 install -p -m 0644 %{S:2} %{buildroot}%{_cross_libdir}/acpid/events/power
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_sbindir}/acpid
 %{_cross_unitdir}/acpid.service
 %{_cross_libdir}/acpid/

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -33,7 +33,6 @@ go build -buildmode pie -tags="${BUILDTAGS}" -o aws-iam-authenticator %{goimport
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-iam-authenticator %{buildroot}%{_cross_bindir}
 
-%cross_generate_attribution
 %cross_scan_attribution go-vendor vendor
 
 %files

--- a/packages/bash/bash.spec
+++ b/packages/bash/bash.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}bash
 Version: 5.0
 Release: 1%{?dist}
 Summary: The GNU Bourne Again shell
-License: GPLv3+
+License: GPL-3.0-or-later
 URL: https://www.gnu.org/software/bash
 Source0: https://ftp.gnu.org/gnu/bash/bash-%{version}.tar.gz
 
@@ -78,6 +78,8 @@ make "CPPFLAGS=-D_GNU_SOURCE -DRECYCLES_PIDS -DDEFAULT_PATH_VALUE='\"/usr/local/
 ln -s bash %{buildroot}%{_cross_bindir}/sh
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_bindir}/bash
 %{_cross_bindir}/sh
 %exclude %{_cross_bindir}/bashbug

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}ca-certificates
 Version: 2019.11.27
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
-License: MPL 2.0
+License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
@@ -24,6 +24,7 @@ install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/ca-certificates.conf
 
 %files
+%{_cross_attribution_file}
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/pki
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/pki/tls
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/pki/tls/certs

--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}chrony
 Version: 3.5
 Release: 1%{?dist}
 Summary: A versatile implementation of the Network Time Protocol
-License: GPLv2
+License: GPL-2.0-only
 URL: https://chrony.tuxfamily.org
 Source0: https://download.tuxfamily.org/chrony/chrony-3.5.tar.gz
 Source1: chronyd.service
@@ -45,6 +45,8 @@ install -d %{buildroot}%{_cross_sysusersdir}
 install -p -m 0644 %{SOURCE3} %{buildroot}%{_cross_sysusersdir}/chrony.conf
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %dir %{_cross_templatedir}
 %{_cross_bindir}/chronyc
 %{_cross_sbindir}/chronyd

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -36,7 +36,6 @@ done
 install -d %{buildroot}%{_cross_factorydir}/opt/cni/bin
 install -p -m 0755 bin/* %{buildroot}%{_cross_factorydir}/opt/cni/bin
 
-%cross_generate_attribution
 %cross_scan_attribution go-vendor vendor
 
 %files

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -11,7 +11,7 @@ Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
 Summary: Plugins for container networking
-License: ASL 2.0
+License: Apache-2.0
 URL: https://%{goimport}
 Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
 BuildRequires: git
@@ -35,6 +35,8 @@ install -d %{buildroot}%{_cross_factorydir}/opt/cni/bin
 install -p -m 0755 bin/cnitool %{buildroot}%{_cross_factorydir}/opt/cni/bin
 
 %files
+%license LICENSE
+%{_cross_attribution_file}
 %dir %{_cross_factorydir}/opt/cni/bin
 %{_cross_factorydir}/opt/cni/bin/cnitool
 

--- a/packages/conntrack-tools/conntrack-tools.spec
+++ b/packages/conntrack-tools/conntrack-tools.spec
@@ -2,7 +2,8 @@ Name: %{_cross_os}conntrack-tools
 Version: 1.4.5
 Release: 1%{?dist}
 Summary: Tools for managing Linux kernel connection tracking
-License: GPLv2
+# src/utils.c contains GPLv2-only code from linux
+License: GPL-2.0-or-later AND GPL-2.0-only
 URL: http://conntrack-tools.netfilter.org/
 Source0: https://www.netfilter.org/projects/conntrack-tools/files/conntrack-tools-%{version}.tar.bz2
 Patch1: 0001-disable-RPC-helper.patch
@@ -44,6 +45,8 @@ autoreconf -fi
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_sbindir}/conntrack
 %exclude %{_cross_sbindir}/conntrackd
 %exclude %{_cross_sbindir}/nfct

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -70,7 +70,6 @@ install -p -m 0644 %{S:2} %{S:3} %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
 
-%cross_generate_attribution
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files

--- a/packages/coreutils/coreutils.spec
+++ b/packages/coreutils/coreutils.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}coreutils
 Version: 8.31
 Release: 1%{?dist}
 Summary: A set of basic GNU tools
-License: GPLv3+
+License: GPL-3.0-or-later
 URL: https://www.gnu.org/software/coreutils/
 Source0: https://ftp.gnu.org/gnu/coreutils/coreutils-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
@@ -39,6 +39,8 @@ Requires: %{_cross_os}libxcrypt
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_bindir}/[
 %{_cross_bindir}/b2sum
 %{_cross_bindir}/base32

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}dbus-broker
 Version: 21
 Release: 1%{?dist}
 Summary: D-BUS message broker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/bus1/dbus-broker
 Source0: https://github.com/bus1/dbus-broker/releases/download/v%{version}/dbus-broker-%{version}.tar.xz
 Source1: dbus.socket
@@ -49,6 +49,8 @@ install -d %{buildroot}%{_cross_sysusersdir}
 install -p -m 0644 %{S:3} %{buildroot}%{_cross_sysusersdir}/dbus.conf
 
 %files
+%license LICENSE
+%{_cross_attribution_file}
 %{_cross_bindir}/dbus-broker
 %{_cross_bindir}/dbus-broker-launch
 %dir %{_cross_datadir}/dbus-1

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -34,7 +34,6 @@ go build -buildmode pie -tags="${BUILDTAGS}" -o docker %{goimport}/cmd/docker
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker %{buildroot}%{_cross_bindir}
 
-%cross_generate_attribution
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -69,7 +69,6 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/d
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/docker.conf
 
-%cross_generate_attribution
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files

--- a/packages/docker-init/docker-init.spec
+++ b/packages/docker-init/docker-init.spec
@@ -27,6 +27,8 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 tini-static %{buildroot}%{_cross_bindir}/docker-init
 
 %files
+%license LICENSE
+%{_cross_attribution_file}
 %{_cross_bindir}/docker-init
 
 %changelog

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -37,7 +37,6 @@ go build -buildmode pie -tags="${BUILDTAGS}" -o docker-proxy %{goimport}/cmd/pro
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker-proxy %{buildroot}%{_cross_bindir}
 
-%cross_generate_attribution
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files

--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -1,3 +1,5 @@
+%global _cross_first_party 1
+
 Name: %{_cross_os}filesystem
 Version: 1.0
 Release: 1%{?dist}

--- a/packages/findutils/findutils.spec
+++ b/packages/findutils/findutils.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}findutils
 Version: 4.7.0
 Release: 1%{?dist}
 Summary: A set of GNU tools for finding
-License: GPLv3+
+License: GPL-3.0-or-later
 URL: http://www.gnu.org/software/findutils/
 Source0: https://ftp.gnu.org/pub/gnu/findutils/findutils-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
@@ -23,6 +23,8 @@ Requires: %{_cross_os}libselinux
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_bindir}/find
 %{_cross_bindir}/xargs
 %exclude %{_cross_bindir}/locate

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}glibc
 Version: 2.30
 Release: 1%{?dist}
 Summary: The GNU libc libraries
-License: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
+License: LGPL-2.1-or-later AND (LGPL-2.1-or-later WITH GCC-exception-2.0) AND GPL-2.0-or-later AND (GPL-2.0-or-later WITH GCC-exception-2.0) AND BSD-3-Clause AND ISC
 URL: http://www.gnu.org/software/glibc/
 Source0: https://ftp.gnu.org/gnu/glibc/glibc-%{version}.tar.xz
 Source1: glibc-tmpfiles.conf
@@ -73,6 +73,8 @@ truncate -s 0 %{buildroot}%{_cross_datadir}/locale/locale.alias
 chmod 644 %{buildroot}%{_cross_datadir}/locale/locale.alias
 
 %files
+%license COPYING COPYING.LIB LICENSES
+%{_cross_attribution_file}
 %{_cross_tmpfilesdir}/glibc.conf
 %exclude %{_cross_sysconfdir}/rpc
 

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -4,7 +4,7 @@ Name: %{_cross_os}grub
 Version: 2.04
 Release: 1%{?dist}
 Summary: Bootloader with support for Linux and more
-License: GPLv3+
+License: GPL-3.0-or-later AND Unicode-DFS-2015
 URL: https://www.gnu.org/software/grub/
 Source0: https://ftp.gnu.org/gnu/grub/grub-%{version}.tar.xz
 Source1: core.cfg
@@ -75,6 +75,7 @@ Summary: Tools for the bootloader with support for Linux and more
 
 %prep
 %autosetup -n grub-%{version} -p1
+cp unicode/COPYING COPYING.unicode
 
 %global grub_cflags -pipe -fno-stack-protector -fno-strict-aliasing
 %global grub_ldflags -static
@@ -129,6 +130,8 @@ install -m 0644 ./grub-core/boot.img \
 %endif
 
 %files
+%license COPYING COPYING.unicode
+%{_cross_attribution_file}
 %dir %{_cross_grubdir}
 %if %{_cross_arch} == x86_64
 %{_cross_grubdir}/boot.img

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -1,3 +1,4 @@
+%global _cross_first_party 1
 %global workspace_name host-ctr
 
 Name: %{_cross_os}%{workspace_name}

--- a/packages/iproute/iproute.spec
+++ b/packages/iproute/iproute.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}iproute
 Version: 4.19.0
 Release: 1%{?dist}
 Summary: Tools for advanced IP routing and network device configuration
-License: GPLv2+ and Public Domain
+License: GPL-2.0-or-later AND GPL-2.0-only
 URL: http://kernel.org/pub/linux/utils/net/iproute2/
 Source0: http://kernel.org/pub/linux/utils/net/iproute2/iproute2-%{version}.tar.xz
 Patch1: 0001-skip-libelf-check.patch
@@ -54,6 +54,8 @@ for f in %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/iproute2/* ; do
 done
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_sbindir}/bridge
 %{_cross_sbindir}/ctstat
 %{_cross_sbindir}/devlink

--- a/packages/iptables/iptables.spec
+++ b/packages/iptables/iptables.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}iptables
 Version: 1.8.4
 Release: 1%{?dist}
 Summary: Tools for managing Linux kernel packet filtering capabilities
-License: GPLv2
+License: GPL-2.0-or-later AND GPL-2.0-only
 URL: http://www.netfilter.org/
 Source0: http://www.netfilter.org/projects/iptables/files/iptables-%{version}.tar.bz2
 Patch1: 0001-iptables-apply-Use-mktemp-instead-of-tempfile.patch
@@ -51,6 +51,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_sbindir}/xtables-legacy-multi
 %{_cross_sbindir}/iptables
 %{_cross_sbindir}/iptables-legacy

--- a/packages/iputils/iputils.spec
+++ b/packages/iputils/iputils.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}iputils
 Version: 20190709
 Release: 1%{?dist}
 Summary: A set of network monitoring tools
-License: BSD and GPLv2+
+License: GPL-2.0-or-later AND BSD-3-Clause
 URL: https://github.com/iputils/iputils
 Source0: https://github.com/iputils/iputils/archive/s%{version}.tar.gz#/iputils-s%{version}.tar.gz
 
@@ -15,6 +15,7 @@ Requires: %{_cross_os}libcap
 
 %prep
 %autosetup -n iputils-s%{version} -p1
+cp ninfod/COPYING COPYING.ninfod
 
 %build
 CONFIGURE_OPTS=(
@@ -45,6 +46,8 @@ CONFIGURE_OPTS=(
 %cross_meson_install
 
 %files
+%license LICENSE Documentation/LICENSE.GPL2 Documentation/LICENSE.BSD3 COPYING.ninfod
+%{_cross_attribution_file}
 %attr(0755,root,root) %caps(cap_net_raw=p) %{_cross_bindir}/arping
 %attr(0755,root,root) %caps(cap_net_raw=p cap_net_admin=p) %{_cross_bindir}/ping
 %{_cross_bindir}/tracepath

--- a/packages/kernel/kernel.spec
+++ b/packages/kernel/kernel.spec
@@ -95,8 +95,6 @@ find %{buildroot}%{_cross_prefix} \
    \( -name .install -o -name .check -o \
       -name ..install.cmd -o -name ..check.cmd \) -delete
 
-%cross_generate_attribution
-
 # files for external module compilation
 (
   find * -name Kbuild\* -type f -print  \

--- a/packages/kmod/kmod.spec
+++ b/packages/kmod/kmod.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}kmod
 Version: 26
 Release: 1%{?dist}
 Summary: Tools for kernel module loading and unloading
-License: LGPLv2+
+License: GPL-2.0-or-later AND LGPL-2.1-or-later
 URL: http://git.kernel.org/?p=utils/kernel/kmod/kmod.git;a=summary
 Source0: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
@@ -19,6 +19,8 @@ Requires: %{name}
 
 %prep
 %autosetup -n kmod-%{version} -p1
+cp COPYING COPYING.LGPL
+cp tools/COPYING COPYING.GPL
 
 %build
 %cross_configure \
@@ -39,6 +41,8 @@ install -d %{buildroot}%{_cross_sbindir}
 ln -s ../bin/kmod %{buildroot}%{_cross_sbindir}/modprobe
 
 %files
+%license COPYING.LGPL COPYING.GPL
+%{_cross_attribution_file}
 %{_cross_bindir}/kmod
 %{_cross_bindir}/depmod
 %{_cross_bindir}/insmod

--- a/packages/kubernetes/kubernetes.spec
+++ b/packages/kubernetes/kubernetes.spec
@@ -73,7 +73,6 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 
-%cross_generate_attribution
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet

--- a/packages/libacl/libacl.spec
+++ b/packages/libacl/libacl.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libacl
 Version: 2.2.53
 Release: 1%{?dist}
 Summary: Library for access control list support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 URL: https://savannah.nongnu.org/projects/acl
 Source0: https://download-mirror.savannah.gnu.org/releases/acl/acl-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -36,6 +36,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %make_install
 
 %files
+%license doc/COPYING.LGPL
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_bindir}
 %exclude %{_cross_docdir}

--- a/packages/libattr/libattr.spec
+++ b/packages/libattr/libattr.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libattr
 Version: 2.4.48
 Release: 1%{?dist}
 Summary: Library for extended attribute support
-License: LGPLv2+
+License: LGPL-2.1-or-later
 URL: https://savannah.nongnu.org/projects/attr
 Source0: https://download-mirror.savannah.gnu.org/releases/attr/attr-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -31,6 +31,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %make_install
 
 %files
+%license doc/COPYING.LGPL
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_sysconfdir}/xattr.conf
 %exclude %{_cross_bindir}

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libcap
 Version: 2.28
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
-License: GPLv2
+License: GPL-2.0-only OR BSD-3-Clause
 URL: https://sites.google.com/site/fullycapable/
 Source0: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-%{version}.tar.gz
 BuildRequires: libcap-devel
@@ -50,6 +50,8 @@ make install \
 chmod +x %{buildroot}%{_cross_libdir}/*.so.*
 
 %files
+%license License
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}
 %exclude %{_cross_sbindir}

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libdbus
 Version: 1.12.16
 Release: 1%{?dist}
 Summary: Library for a message bus
-License: (GPLv2+ or AFL) and GPLv2+
+License: AFL-2.1 OR GPL-2.0-or-later
 URL: http://www.freedesktop.org/Software/dbus/
 Source0: https://dbus.freedesktop.org/releases/dbus/dbus-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -45,6 +45,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 rm -rf %{buildroot}%{_cross_docdir}/dbus/examples
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_bindir}
 %exclude %{_cross_datadir}

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -34,6 +34,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_docdir}
 

--- a/packages/libgcc/libgcc.spec
+++ b/packages/libgcc/libgcc.spec
@@ -7,7 +7,7 @@ Name: %{_cross_os}libgcc
 Version: 0.0
 Release: 1%{?dist}
 Summary: GCC runtime library
-License: GPL-2.0+ WITH GCC-exception-2.0
+License: GPL-3.0-or-later WITH GCC-exception-3.1
 URL: https://gcc.gnu.org/
 
 %description
@@ -15,6 +15,7 @@ URL: https://gcc.gnu.org/
 
 %prep
 %setup -T -c
+cp %{_cross_licensedir}/%{name}/* .
 
 %build
 install -p -m0755 %{_cross_libdir}/libgcc_s.so.1 .
@@ -24,6 +25,8 @@ mkdir -p %{buildroot}%{_cross_libdir}
 install -p -m0755 libgcc_s.so.1 %{buildroot}%{_cross_libdir}
 
 %files
+%license COPYING3 COPYING.RUNTIME
+%{_cross_attribution_file}
 %{_cross_libdir}/libgcc_s.so.1
 
 %changelog

--- a/packages/libiw/libiw.spec
+++ b/packages/libiw/libiw.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libiw
 Version: 29
 Release: 1%{?dist}
 Summary: Library for wireless
-License: GPLv2+
+License: GPL-2.0-or-later
 URL: https://hewlettpackard.github.io/wireless-tools/
 Source0: https://hewlettpackard.github.io/wireless-tools/wireless_tools.%{version}.tar.gz
 Patch1: wireless-tools-29-makefile.patch
@@ -36,6 +36,8 @@ make \
   install-dynamic install-hdr
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libmnl/libmnl.spec
+++ b/packages/libmnl/libmnl.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libmnl
 Version: 1.0.4
 Release: 1%{?dist}
 Summary: Library for netlink
-License: LGPLv2+
+License: LGPL-2.1-or-later
 URL: http://netfilter.org/projects/libmnl
 Source0: http://netfilter.org/projects/libmnl/files/libmnl-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
@@ -30,6 +30,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
+++ b/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libnetfilter_conntrack
 Version: 1.0.7
 Release: 1%{?dist}
 Summary: Library for netfilter conntrack
-License: GPLv2+
+License: GPL-2.0-or-later
 URL: http://netfilter.org
 Source0: https://netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
@@ -35,6 +35,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libnetfilter_cthelper/libnetfilter_cthelper.spec
+++ b/packages/libnetfilter_cthelper/libnetfilter_cthelper.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libnetfilter_cthelper
 Version: 1.0.0
 Release: 1%{?dist}
 Summary: Library for netfilter cthelper
-License: GPLv2
+License: GPL-2.0-or-later
 URL: http://netfilter.org
 Source0: https://netfilter.org/projects/libnetfilter_cthelper/files/libnetfilter_cthelper-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
@@ -32,6 +32,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libnetfilter_cttimeout/libnetfilter_cttimeout.spec
+++ b/packages/libnetfilter_cttimeout/libnetfilter_cttimeout.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libnetfilter_cttimeout
 Version: 1.0.0
 Release: 1%{?dist}
 Summary: Library for netfilter cttimeout
-License: GPLv2+
+License: GPL-2.0-or-later
 URL: http://netfilter.org
 Source0: https://netfilter.org/projects/libnetfilter_cttimeout/files/libnetfilter_cttimeout-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
@@ -32,6 +32,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libnetfilter_queue/libnetfilter_queue.spec
+++ b/packages/libnetfilter_queue/libnetfilter_queue.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libnetfilter_queue
 Version: 1.0.3
 Release: 1%{?dist}
 Summary: Library for netfilter queue
-License: GPLv2
+License: GPL-2.0-or-later
 URL: http://netfilter.org
 Source0: https://netfilter.org/projects/libnetfilter_queue/files/libnetfilter_queue-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
@@ -34,6 +34,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libnfnetlink/libnfnetlink.spec
+++ b/packages/libnfnetlink/libnfnetlink.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libnfnetlink
 Version: 1.0.1
 Release: 1%{?dist}
 Summary: Library for netfilter netlink
-License: GPLv2+
+License: GPL-2.0-only
 URL: http://netfilter.org
 Source0: http://netfilter.org/projects/libnfnetlink/files/libnfnetlink-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
@@ -30,6 +30,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libnftnl/libnftnl.spec
+++ b/packages/libnftnl/libnftnl.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libnftnl
 Version: 1.1.5
 Release: 1%{?dist}
 Summary: Library for nftables netlink
-License: GPLv2+
+License: GPL-2.0-or-later AND GPL-2.0-only
 URL: http://netfilter.org/projects/libnftnl/
 Source0: http://netfilter.org/projects/libnftnl/files/libnftnl-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
@@ -34,6 +34,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 
 %files devel

--- a/packages/libnl/libnl.spec
+++ b/packages/libnl/libnl.spec
@@ -5,7 +5,7 @@ Name: %{_cross_os}libnl
 Version: %{rpmver}
 Release: 1%{?dist}
 Summary: Convenience library for netlink
-License: LGPLv2+
+License: LGPL-2.1-only
 URL: https://github.com/thom311/libnl
 Source0: https://github.com/thom311/libnl/archive/libnl%{srcver}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -38,6 +38,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}
 %exclude %{_cross_sysconfdir}

--- a/packages/libpcap/libpcap.spec
+++ b/packages/libpcap/libpcap.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libpcap
 Version: 1.9.1
 Release: 1%{?dist}
 Summary: Library for packet capture
-License: BSD with advertising
+License: BSD-3-Clause
 URL: http://www.tcpdump.org
 Source0: http://www.tcpdump.org/release/libpcap-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -30,6 +30,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license LICENSE
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_bindir}/*
 %exclude %{_cross_mandir}/*

--- a/packages/libpcre/libpcre.spec
+++ b/packages/libpcre/libpcre.spec
@@ -48,6 +48,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %make_install
 
 %files
+%license LICENCE
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_bindir}
 %exclude %{_cross_docdir}

--- a/packages/libseccomp/libseccomp.spec
+++ b/packages/libseccomp/libseccomp.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libseccomp
 Version: 2.4.2
 Release: 1%{?dist}
 Summary: Library for enhanced seccomp
-License: LGPLv2
+License: LGPL-2.1-only
 URL: https://github.com/seccomp/libseccomp
 Source0: https://github.com/seccomp/libseccomp/releases/download/v%{version}/libseccomp-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -32,6 +32,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license LICENSE
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_bindir}/scmp_sys_resolver
 %exclude %{_cross_mandir}

--- a/packages/libselinux/libselinux.spec
+++ b/packages/libselinux/libselinux.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libselinux
 Version: 3.0
 Release: 1%{?dist}
 Summary: Library for SELinux
-License: Public Domain
+License: LicenseRef-SELinux-PD
 URL: https://github.com/SELinuxProject/
 Source0: https://github.com/SELinuxProject/selinux/releases/download/20191204/libselinux-%{version}.tar.gz
 Patch1: 0001-adjust-default-selinux-directory.patch
@@ -45,6 +45,8 @@ export USE_PCRE2='y' \\\
 %make_install
 
 %files
+%license LICENSE
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_sbindir}
 %exclude %{_cross_mandir}

--- a/packages/libsepol/libsepol.spec
+++ b/packages/libsepol/libsepol.spec
@@ -37,6 +37,8 @@ export SHLIBDIR='%{_cross_libdir}' \\\
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_bindir}
 %exclude %{_cross_mandir}

--- a/packages/libstd-rust/libstd-rust.spec
+++ b/packages/libstd-rust/libstd-rust.spec
@@ -15,6 +15,7 @@ URL: https://www.rust-lang.org/
 
 %prep
 %setup -T -c
+cp %{_cross_licensedir}/%{name}/* .
 
 %build
 %define _rust_target %{_cross_arch}-unknown-linux-%{_cross_libc}
@@ -25,6 +26,8 @@ mkdir -p %{buildroot}%{_cross_libdir}
 install -p -m0755 libstd-*.so %{buildroot}%{_cross_libdir}
 
 %files
+%license COPYRIGHT LICENSE-APACHE LICENSE-MIT
+%{_cross_attribution_file}
 %{_cross_libdir}/libstd-*.so
 
 %changelog

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}libxcrypt
 Version: 4.4.10
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
-License: LGPLv2+ and BSD and Public Domain
+License: LGPL-2.1-or-later
 URL: https://github.com/besser82/libxcrypt
 Source0: https://github.com/besser82/libxcrypt/archive/v%{version}/libxcrypt-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -39,6 +39,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license LICENSING COPYING.LIB
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}
 

--- a/packages/login/login.spec
+++ b/packages/login/login.spec
@@ -1,3 +1,5 @@
+%global _cross_first_party 1
+
 Name: %{_cross_os}login
 Version: 0.0.1
 Release: 1%{?dist}

--- a/packages/ncurses/ncurses.spec
+++ b/packages/ncurses/ncurses.spec
@@ -3,7 +3,7 @@ Name: %{_cross_os}ncurses
 Version: 6.1
 Release: 10.%{revision}%{?dist}
 Summary: Ncurses libraries
-License: MIT
+License: X11
 URL: https://invisible-island.net/ncurses/ncurses.html
 Source0: https://invisible-mirror.net/archives/ncurses/current/ncurses-%{version}-%{revision}.tgz
 Patch1: ncurses-config.patch
@@ -94,6 +94,8 @@ done
 rm -rf "%{buildroot}%{_cross_datadir}/terminfo.bak"
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/lib*.so.6*
 %dir %{_cross_datadir}/terminfo
 %{_cross_datadir}/terminfo/*

--- a/packages/procps/procps.spec
+++ b/packages/procps/procps.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}procps
 Version: 3.3.16
 Release: 1%{?dist}
 Summary: A set of process monitoring tools
-License: GPL+ and GPLv2 and GPLv2+ and GPLv3+ and LGPLv2+
+License: GPL-2.0-or-later AND LGPL-2.1-or-later
 URL: https://gitlab.com/procps-ng/procps
 Source0: https://gitlab.com/procps-ng/procps/-/archive/v%{version}/procps-v%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -42,6 +42,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %make_install
 
 %files
+%license COPYING COPYING.LIB
+%{_cross_attribution_file}
 %{_cross_bindir}/free
 %{_cross_bindir}/pgrep
 %{_cross_bindir}/pidof

--- a/packages/readline/readline.spec
+++ b/packages/readline/readline.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}readline
 Version: 8.0
 Release: 1%{?dist}
 Summary: A library for editing typed command lines
-License: GPLv3+
+License: GPL-3.0-or-later
 URL: https://tiswww.case.edu/php/chet/readline/rltop.html
 Source0: https://ftp.gnu.org/gnu/readline/readline-%{version}.tar.gz
 Patch1: readline-8.0-shlib.patch
@@ -31,6 +31,8 @@ Requires: %{name}
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_infodir}
 %exclude %{_cross_mandir}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -1,3 +1,5 @@
+%global _cross_first_party 1
+
 Name: %{_cross_os}release
 Version: 0.2.1
 Release: 1%{?dist}

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -37,7 +37,6 @@ go build -buildmode pie -tags="${BUILDTAGS}" -o bin/runc .
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 bin/runc %{buildroot}%{_cross_bindir}
 
-%cross_generate_attribution
 %cross_scan_attribution go-vendor vendor
 
 %files

--- a/packages/socat/socat.spec
+++ b/packages/socat/socat.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}socat
 Version: 1.7.3.3
 Release: 1%{?dist}
 Summary: Transfer data between two channels
-License: GPLv2
+License: GPL-2.0-only
 URL: http://www.dest-unreach.org/socat/
 Source0: http://www.dest-unreach.org/socat/download/socat-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -57,6 +57,8 @@ BuildRequires: %{_cross_os}glibc-devel
 %make_install
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_bindir}/socat
 %exclude %{_cross_bindir}/filan
 %exclude %{_cross_bindir}/procan

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}strace
 Version: 5.4
 Release: 1%{?dist}
 Summary: Linux syscall tracer
-License: LGPLv2.1+
+License: LGPL-2.1-or-later
 URL: https://strace.io/
 Source0: https://strace.io/files/%{version}/strace-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
@@ -23,6 +23,8 @@ BuildRequires: %{_cross_os}glibc-devel
 %make_install
 
 %files
+%license COPYING LGPL-2.1-or-later
+%{_cross_attribution_file}
 %{_cross_bindir}/strace
 %exclude %{_cross_bindir}/strace-graph
 %exclude %{_cross_bindir}/strace-log-merge

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -1,11 +1,13 @@
 # Skip check-rpaths since we expect them for systemd.
-%global __arch_install_post /usr/lib/rpm/check-buildroot
+%global __arch_install_post \
+  /usr/lib/rpm/check-buildroot \
+  %cross_generate_attribution
 
 Name: %{_cross_os}systemd
 Version: 244
 Release: 1%{?dist}
 Summary: System and Service Manager
-License: LGPLv2+ and MIT and GPLv2+
+License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later
 URL: https://www.freedesktop.org/wiki/Software/systemd
 Source0: https://github.com/systemd/systemd/archive/v%{version}/systemd-%{version}.tar.gz
 Source1: run-tmpfiles.conf
@@ -178,6 +180,8 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_libdir}/modules-load.d/nf_conntra
 rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 
 %files
+%license LICENSE.GPL2 LICENSE.LGPL2.1
+%{_cross_attribution_file}
 %{_cross_bindir}/busctl
 %{_cross_bindir}/journalctl
 %{_cross_bindir}/systemctl

--- a/packages/tcpdump/tcpdump.spec
+++ b/packages/tcpdump/tcpdump.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}tcpdump
 Version: 4.9.3
 Release: 1%{?dist}
 Summary: Network monitoring tool
-License: BSD with advertising
+License: BSD-3-Clause
 URL: http://www.tcpdump.org
 Source0: http://www.tcpdump.org/release/tcpdump-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
@@ -25,6 +25,8 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 tcpdump %{buildroot}%{_cross_bindir}
 
 %files
+%license LICENSE
+%{_cross_attribution_file}
 %{_cross_bindir}/tcpdump
 
 %changelog

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}util-linux
 Version: 2.34
 Release: 1%{?dist}
 Summary: A collection of basic system utilities
-License: GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain
+License: BSD-3-Clause AND BSD-4-Clause-UC AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
 URL: http://en.wikipedia.org/wiki/Util-linux
 Source0: https://www.kernel.org/pub/linux/utils/util-linux/v2.34/util-linux-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
@@ -24,14 +24,14 @@ Requires: %{_cross_os}libuuid
 
 %package -n %{_cross_os}libblkid
 Summary: Block device ID library
-License: LGPLv2+
+License: LGPL-2.1-or-later
 
 %description -n %{_cross_os}libblkid
 %{summary}.
 
 %package -n %{_cross_os}libblkid-devel
 Summary: Files for development using the block device ID library
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: %{_cross_os}libblkid
 
 %description -n %{_cross_os}libblkid-devel
@@ -39,7 +39,7 @@ Requires: %{_cross_os}libblkid
 
 %package -n %{_cross_os}libmount
 Summary: Device mounting library
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: %{_cross_os}libselinux
 
 %description -n %{_cross_os}libmount
@@ -47,7 +47,7 @@ Requires: %{_cross_os}libselinux
 
 %package -n %{_cross_os}libmount-devel
 Summary: Files for development using the device mounting library
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: %{_cross_os}libmount
 
 %description -n %{_cross_os}libmount-devel
@@ -55,14 +55,14 @@ Requires: %{_cross_os}libmount
 
 %package -n %{_cross_os}libsmartcols
 Summary: Formatting library for ls-like programs
-License: LGPLv2+
+License: LGPL-2.1-or-later
 
 %description -n %{_cross_os}libsmartcols
 %{summary}.
 
 %package -n %{_cross_os}libsmartcols-devel
 Summary: Files for development using the formatting library for ls-like programs
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Requires: %{_cross_os}libsmartcols
 
 %description -n %{_cross_os}libsmartcols-devel
@@ -70,14 +70,14 @@ Requires: %{_cross_os}libsmartcols
 
 %package -n %{_cross_os}libuuid
 Summary: Universally unique ID library
-License: BSD
+License: BSD-3-Clause
 
 %description -n %{_cross_os}libuuid
 %{summary}.
 
 %package -n %{_cross_os}libuuid-devel
 Summary: Files for development using the universally unique ID library
-License: BSD
+License: BSD-3-Clause
 Requires: %{_cross_os}libuuid
 
 %description -n %{_cross_os}libuuid-devel
@@ -85,6 +85,8 @@ Requires: %{_cross_os}libuuid
 
 %prep
 %autosetup -n util-linux-%{version} -p1
+
+cp Documentation/licenses/COPYING.* .
 
 %build
 %cross_configure \
@@ -114,7 +116,18 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %install
 %make_install
 
+# add attribution.txt files for lib subpackages that need them, since the
+# default macro only generates attribution.txt for the main package
+for lib in lib{blkid,mount,smartcols,uuid}; do
+    mkdir -p %{buildroot}%{_cross_licensedir}/$lib
+    echo "$lib - %{url}" >> %{buildroot}%{_cross_licensedir}/$lib/attribution.txt
+done
+echo "SPDX-License-Identifier: LGPL-2.1-or-later" | tee -a %{buildroot}%{_cross_licensedir}/lib{blkid,mount,smartcols}/attribution.txt >/dev/null
+echo "SPDX-License-Identifier: BSD-3-Clause" | tee -a %{buildroot}%{_cross_licensedir}/libuuid/attribution.txt
+
 %files
+%license COPYING.BSD-3-Clause COPYING.BSD-4-Clause-UC COPYING.GPL-2.0-or-later COPYING.LGPL-2.1-or-later
+%{_cross_attribution_file}
 %{_cross_bindir}/chmem
 %{_cross_bindir}/choom
 %{_cross_bindir}/chrt
@@ -234,6 +247,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %exclude %{_cross_mandir}
 
 %files -n %{_cross_os}libblkid
+%license COPYING.LGPL-2.1-or-later
+%{_licensedir}/libblkid/attribution.txt
 %{_cross_libdir}/libblkid.so.*
 
 %files -n %{_cross_os}libblkid-devel
@@ -245,6 +260,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %exclude %{_cross_libdir}/libblkid.la
 
 %files -n %{_cross_os}libmount
+%license COPYING.LGPL-2.1-or-later
+%{_licensedir}/libmount/attribution.txt
 %{_cross_libdir}/libmount.so.*
 
 %files -n %{_cross_os}libmount-devel
@@ -256,6 +273,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %exclude %{_cross_libdir}/libmount.la
 
 %files -n %{_cross_os}libsmartcols
+%license COPYING.LGPL-2.1-or-later
+%{_licensedir}/libsmartcols/attribution.txt
 %{_cross_libdir}/libsmartcols.so.*
 
 %files -n %{_cross_os}libsmartcols-devel
@@ -267,6 +286,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %exclude %{_cross_libdir}/libsmartcols.la
 
 %files -n %{_cross_os}libuuid
+%license COPYING.BSD-3-Clause
+%{_licensedir}/libuuid/attribution.txt
 %{_cross_libdir}/libuuid.so.*
 
 %files -n %{_cross_os}libuuid-devel

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -14,7 +14,7 @@ Name: %{_cross_os}wicked
 Version: 0.6.54
 Release: 1%{?dist}
 Summary: Network configuration infrastructure
-License: GPLv2+
+License: GPL-2.0-or-later AND (GPL-2.0-only OR BSD-3-Clause)
 URL: https://github.com/openSUSE/wicked
 Source0: https://github.com/openSUSE/wicked/archive/version-%{version}.tar.gz
 
@@ -96,6 +96,8 @@ install -p -m 0644 %{S:99} %{buildroot}%{_cross_datadir}/wicked/schema/constants
 %endif
 
 %files
+%license COPYING
+%{_cross_attribution_file}
 %{_cross_sbindir}/wicked
 %{_cross_sbindir}/wickedd
 %{_cross_sbindir}/wickedd-nanny

--- a/packages/workspaces/workspaces.spec
+++ b/packages/workspaces/workspaces.spec
@@ -1,4 +1,5 @@
 %global migration_dir %{_cross_factorydir}%{_cross_sharedstatedir}/thar/datastore/migrations
+%global _cross_first_party 1
 %undefine _debugsource_packages
 
 Name: %{_cross_os}workspaces


### PR DESCRIPTION
This adds attribution.txt and relevant license files to /usr/share/licenses for all remaining packages (other than workspaces).

libgcc and libstd-rust don't have copies of their licenses in /usr/share/licenses yet, as I'll want to plumb that through the SDK container.

If folks want me to squash the per-package attribution commits I will do so.

Testing done: Thar builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
