### PR TITLE
refresh-timestamp-lambda: fixes the expiration date logging

### DIFF
--- a/tools/refresh-timestamp-lambda/src/main.rs
+++ b/tools/refresh-timestamp-lambda/src/main.rs
@@ -196,11 +196,13 @@ fn refresh_timestamp() -> failure::Fallible<CustomOutput> {
     );
     timestamp.signed.version = new_version;
 
+    let new_expiration = now + Duration::days(env_vars.refresh_validity_days.parse::<i64>()?);
     info!(
         "Updating expiration date from {} to {}",
-        timestamp.signed.version, new_version
+        timestamp.signed.expires.to_rfc3339(),
+        new_expiration.to_rfc3339()
     );
-    timestamp.signed.expires = now + Duration::days(env_vars.refresh_validity_days.parse::<i64>()?);
+    timestamp.signed.expires = new_expiration;
 
     let signed_root = repo.root();
     let key_id = if let Some(key) = signed_root


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Was incorrectly logging with the current unix timestamp for the expiration dates.
Now logging the expiration date and the new expiration date in RFC3339.

*Testing*:
Before the change:
```
2020-01-21 23:59:20,402 INFO  [bootstrap] Updating version from 1579303298 to 1579651160
2020-01-21 23:59:20,402 INFO  [bootstrap] Updating expiration date from 1579651160 to 1579651160
```

After the change:
```
2020-01-22 00:24:51,696 INFO  [bootstrap] Updating version from 1579651234 to 1579652691
2020-01-22 00:24:51,696 INFO  [bootstrap] Updating expiration date from 2020-01-29T00:00:34.861880614+00:00 to 2020-01-29T00:24:51.696956543+00:00
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
