### PR TITLE
updog: Add a standalone messenger dog to send query parameters

### DIFF
--- a/packages/workspaces/workspaces.spec
+++ b/packages/workspaces/workspaces.spec
@@ -177,7 +177,7 @@ for p in \
   thar-be-settings servicedog host-containers \
   storewolf settings-committer \
   migrator \
-  signpost updog ;
+  signpost updog smoky ;
 do
   install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/${p} %{buildroot}%{_cross_bindir}
 done
@@ -283,6 +283,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.co
 
 %files -n %{_cross_os}updog
 %{_cross_bindir}/updog
+%{_cross_bindir}/smoky
 %{_cross_datadir}/updog
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/updog-toml

--- a/workspaces/updater/updog/src/bin/smoky.rs
+++ b/workspaces/updater/updog/src/bin/smoky.rs
@@ -1,0 +1,185 @@
+#![deny(rust_2018_idioms)]
+#![warn(clippy::pedantic)]
+
+#[path = "../error.rs"]
+mod error;
+#[path = "../transport.rs"]
+mod transport;
+
+use crate::error::Result;
+use crate::transport::HttpQueryTransport;
+use semver::Version as SemVer;
+use simplelog::{Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
+use snafu::{ErrorCompat, ResultExt};
+use std::str::FromStr;
+use tough::Transport;
+use url::Url;
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
+    eprintln!("{}\n", msg.as_ref());
+    usage();
+}
+
+fn usage() -> ! {
+    #[rustfmt::skip]
+    eprintln!("\
+USAGE:
+    smoky <QUERY OPTIONS> --target <target url> [--log-level <level>]
+
+QUERY OPTIONS:
+    [ --boot-success | --boot-failure ] Signal whether the boot succeeed or not
+    [ -v | --current-version ]          Version of currently running image
+    [ -p | --previous-version ]         Version of last booted image
+
+    [ --target ]                        URL of the telemetry target file
+    [ --log-level trace|debug|info|warn|error ]  Set logging verbosity");
+    std::process::exit(1)
+}
+
+/// Struct to hold the specified command line argument values
+struct Arguments {
+    boot_success: Option<bool>,
+    current_version: Option<SemVer>,
+    previous_version: Option<SemVer>,
+
+    target_url: String,
+
+    log_level: LevelFilter,
+}
+
+/// Parse the command line arguments to get the user-specified values
+fn parse_args(args: std::env::Args) -> Arguments {
+    let mut mark_success = false;
+    let mut mark_failure = false;
+    let mut target_url = None;
+    let mut current_version = None;
+    let mut previous_version = None;
+    let mut log_level = None;
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--log-level" => {
+                let log_level_str = iter
+                    .next()
+                    .unwrap_or_else(|| usage_msg("Did not give argument to --log-level"));
+                log_level = Some(LevelFilter::from_str(&log_level_str).unwrap_or_else(|_| {
+                    usage_msg(format!("Invalid log level '{}'", log_level_str))
+                }));
+            }
+            "--boot-success" => {
+                mark_success = true;
+            }
+            "--boot-failure" => {
+                mark_failure = true;
+            }
+            "-v" | "--current-version" => match iter.next() {
+                Some(v) => {
+                    if let Ok(version) = SemVer::parse(&v) {
+                        current_version = Some(version);
+                    } else {
+                        usage();
+                    }
+                }
+                _ => usage(),
+            },
+            "-p" | "--previous-version" => match iter.next() {
+                Some(v) => {
+                    if let Ok(version) = SemVer::parse(&v) {
+                        previous_version = Some(version);
+                    } else {
+                        usage();
+                    }
+                }
+                _ => usage(),
+            },
+            "--target" => match iter.next() {
+                Some(u) => target_url = Some(u),
+                _ => usage(),
+            },
+            _ => usage(),
+        }
+    }
+
+    if mark_success && mark_failure {
+        // Must specify success xor failure
+        usage();
+    }
+
+    // Exit if no queries were specified
+    if !(mark_success || mark_failure) && current_version.is_none() && previous_version.is_none() {
+        usage_msg("No queries to send");
+    }
+
+    Arguments {
+        boot_success: if mark_success || mark_failure {
+            Some(mark_success)
+        } else {
+            None
+        },
+        current_version,
+        previous_version,
+        target_url: target_url.unwrap_or_else(|| usage()),
+        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+    }
+}
+
+fn main_inner() -> Result<()> {
+    let arguments = parse_args(std::env::args());
+
+    // TerminalMode::Mixed will send errors to stderr and anything less to stdout.
+    TermLogger::init(
+        arguments.log_level,
+        LogConfig::default(),
+        TerminalMode::Mixed,
+    )
+    .context(error::Logger)?;
+
+    let transport = HttpQueryTransport::new();
+    let query_target = Url::parse(&arguments.target_url).context(error::UrlParse)?;
+
+    if let Some(boot_success) = arguments.boot_success {
+        let status = if boot_success {
+            String::from("success")
+        } else {
+            String::from("failure")
+        };
+        transport
+            .queries_get_mut()
+            .context(error::TransportBorrow)?
+            .push((String::from("boot-status"), status));
+    }
+    if let Some(current_version) = arguments.current_version {
+        transport
+            .queries_get_mut()
+            .context(error::TransportBorrow)?
+            .push((String::from("version"), current_version.to_string()));
+    }
+    if let Some(previous_version) = arguments.previous_version {
+        transport
+            .queries_get_mut()
+            .context(error::TransportBorrow)?
+            .push((String::from("fallback"), previous_version.to_string()));
+    }
+
+    transport.fetch(query_target).context(error::FetchFailure)?;
+    Ok(())
+}
+
+fn main() -> ! {
+    std::process::exit(match main_inner() {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!("{}", err);
+            if let Some(var) = std::env::var_os("RUST_BACKTRACE") {
+                if var != "0" {
+                    if let Some(backtrace) = err.backtrace() {
+                        eprintln!("\n{:?}", backtrace);
+                    }
+                }
+            }
+            1
+        }
+    })
+}

--- a/workspaces/updater/updog/src/error.rs
+++ b/workspaces/updater/updog/src/error.rs
@@ -44,6 +44,12 @@ pub(crate) enum Error {
         path: PathBuf,
     },
 
+    #[snafu(display("Failed to fetch URL via transport: {}", source))]
+    FetchFailure {
+        backtrace: Backtrace,
+        source: reqwest::Error,
+    },
+
     #[snafu(display("Logger setup error: {}", source))]
     Logger { source: simplelog::TermLogError },
 
@@ -243,6 +249,12 @@ pub(crate) enum Error {
     UpdateMetadata {
         source: update_metadata::error::Error,
     },
+
+    #[snafu(display("Unable to parse URL: {}", source))]
+    UrlParse { source: url::ParseError },
+
+    #[snafu(display("Unable to join URL: {}", source))]
+    UrlJoin { source: url::ParseError },
 }
 
 impl std::convert::From<update_metadata::error::Error> for Error {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add the ['smoky'](https://en.wikipedia.org/wiki/Smoky_(dog)) utility to send query parameters outside of the
normal update process, and without otherwise interacting with the TUF
repository.

Smoky uses the HttpQueryTransport already used by Updog to add query
parameters to some URL, and then invokes the default fetch method. By
default the URL points to the timestamp.json in the default repository,
and can be changed to another prefix or target that has access logs.

Since this doesn't require the tough repository it can be used on boot
to mark boot success or failure, without depending on the rest of the
system being available.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

Example:
```
bash-5.0# smoky --boot-success --current-version 0.2.0 --previous-version 0.1.6 --log-level debug
...
00:38:43 [DEBUG] (2) reqwest::async_impl::response: Response: '200 OK' for https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/metadata/timestamp.json?boot-status=success&version=0.2.0&fallback=0.1.6
```
