### PR TITLE
build: use larger block size for dd ops

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -97,12 +97,12 @@ else
 
   # The 'recommended' size for the EFI partition is 100MB but our aarch64.efi
   # only takes up around 700KB, so this will suffice for now.
-  dd if=/dev/zero of=${EFI_IMAGE} bs=512 count=$((4*2048))
+  dd if=/dev/zero of=${EFI_IMAGE} bs=1M count=4
   mkfs.vfat -I -S 512 "${EFI_IMAGE}" $((4*2048))
   mmd -i ${EFI_IMAGE} ::/EFI
   mmd -i ${EFI_IMAGE} ::/EFI/BOOT
   mcopy -i ${EFI_IMAGE} ${EFI_MOUNT}/EFI/BOOT/bootaa64.efi ::/EFI/BOOT
-  dd if="${EFI_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((1*2048))
+  dd if="${EFI_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=1
 
   # Create the grub directory which grub-bios-setup would have otherwise done.
   mkdir -p ${ROOT_MOUNT}/boot/grub
@@ -117,7 +117,7 @@ echo "VARIANT_ID=${VARIANT}" >> ${ROOT_MOUNT}/${SYS_ROOT}/usr/lib/os-release
 # THAR-ROOT-A
 mkfs.ext4 -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" 920M
 resize2fs -M "${ROOT_IMAGE}"
-dd if="${ROOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((45*2048))
+dd if="${ROOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=45
 
 # THAR-VERITY-A
 truncate -s 8M "${VERITY_IMAGE}"
@@ -137,7 +137,7 @@ VERITY_DATA_512B_BLOCKS="$(($VERITY_DATA_4K_BLOCKS * 8))"
 VERITY_ROOT_HASH="$(grep '^Root hash:' <<<$veritysetup_output | awk '{ print $NF }')"
 VERITY_SALT="$(grep '^Salt:' <<<$veritysetup_output | awk '{ print $NF }')"
 veritysetup verify "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${VERITY_ROOT_HASH}"
-dd if="${VERITY_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((965*2048))
+dd if="${VERITY_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=965
 
 # write GRUB config
 cat <<EOF > ${BOOT_MOUNT}/grub/grub.cfg
@@ -157,7 +157,7 @@ EOF
 # THAR-BOOT-A
 mkfs.ext4 -O ^has_journal -d "${BOOT_MOUNT}" "${BOOT_IMAGE}" 40M
 resize2fs -M "${BOOT_IMAGE}"
-dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((5*2048))
+dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=5
 
 # THAR-PRIVATE
 
@@ -167,7 +167,7 @@ dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((5*2048))
 # - retain the inode size to allow most settings to be stored inline
 # - retain the block size to handle worse-case alignment for hardware
 mkfs.ext4 -L "THAR-PRIVATE" -b 4096 -i 4096 -I 256 "${PRIVATE_IMAGE}" 42M
-dd if="${PRIVATE_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=512 seek=$((2005*2048))
+dd if="${PRIVATE_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=2005
 
 # THAR-DATA
 truncate -s 1G "${DATA_IMAGE}"
@@ -176,7 +176,7 @@ sgdisk --clear \
    --sort --print "${DATA_IMAGE}"
 mkdir -p "${DATA_MOUNT}/var/"{cache,lib,log,spool}
 mkfs.ext4 -L "THAR-DATA" -d "${DATA_MOUNT}" "${THAR_DATA}" 1022M
-dd if="${THAR_DATA}" of="${DATA_IMAGE}" conv=notrunc bs=512 seek=$((1*2048))
+dd if="${THAR_DATA}" of="${DATA_IMAGE}" conv=notrunc bs=1M seek=1
 
 sgdisk -v "${DISK_IMAGE}"
 sgdisk -v "${DATA_IMAGE}"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This reduces the time for these operations from multiple seconds to under one second.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
