### PR TITLE
name tag the amiize worker

### DIFF
--- a/bin/amiize.sh
+++ b/bin/amiize.sh
@@ -419,6 +419,7 @@ while true; do
       --output json \
       --region "${REGION}" \
       --image-id "${WORKER_AMI}" \
+      --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=amiize-worker}]' \
       --instance-type "${INSTANCE_TYPE}" \
       ${SUBNET_ID:+--subnet-id "${SUBNET_ID}"} \
       ${USER_DATA:+--user-data "${USER_DATA}"} \


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

As I was working through Thar build and deploy for the first time, I found that I wished the amiize-worker EC2 instance had a name so that I could quickly see in the AWS console which machine(s) were the amiize workers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
