### PR TITLE
refresh-timestamp-lambda: invocation frequency specified in hours, adds `refesh-threshold`, allow for no-op executions

### DIFF
--- a/tools/refresh-timestamp-lambda/README.md
+++ b/tools/refresh-timestamp-lambda/README.md
@@ -6,7 +6,8 @@ Current version: 0.1.0
 
 This is a lambda function that periodically refreshes a TUF repository's `timestamp.json` metadata file's expiration date and version.
 
-Every time this lambda runs, the expiration date is pushed out by a custom number of days from the current date (defined by the lambda event).
+If the current date passes the defined refresh threshold, the expiration date is pushed out by a custom number of days from the current date (defined by the lambda event).
+Otherwise the lambda does not push out the updated and signed `timestamp.json` metadata file, which makes the execution equivalent to a no-op operation.
 
 ## Compiling & Building
 

--- a/tools/refresh-timestamp-lambda/TimestampRefreshLambda.yaml
+++ b/tools/refresh-timestamp-lambda/TimestampRefreshLambda.yaml
@@ -24,13 +24,23 @@ Parameters:
   MetadataPath:
     Description: 'The path where to find metadata files in the TUF repo S3 bucket (e.g. "0af132ea221/metadata")'
     Type: String
-  RefreshFrequencyDays:
-    Description: 'Defines how often to run the refresh lambda (in days).'
+  LambdaInvocationFrequency:
+    Description: 'Defines how often to run the refresh lambda (in hours).'
     MinValue: 1
-    MaxValue: 10
+    MaxValue: 72
     Type: Number
   RefreshValidityDays:
     Description: 'How many days to refresh the timestamp metadata for.'
+    MinValue: 1
+    MaxValue: 10
+    Default: 7
+    Type: Number
+  RefreshThresholdDays:
+    Description: >-
+      The threshold for pushing timestamp.json. The threshold is set to be the old expiration date of timestamp.json
+      subtract the value of this parameter. If current date passes the threshold, the lambda will push
+      out the updated and signed timestamp.json. Otherwise the lambda will only go through the motions of updating and
+      signing timestamp.json and not push anything out to the TUF repository.
     MinValue: 1
     MaxValue: 10
     Default: 7
@@ -88,6 +98,7 @@ Resources:
           KEY_PARAMETER_NAME: !Sub '${SigningKeyParameterName}'
           METADATA_PATH: !Sub '${MetadataPath}'
           REFRESH_VALIDITY_DAYS: !Sub '${RefreshValidityDays}'
+          REFRESH_THRESHOLD: !Sub '${RefreshThresholdDays}'
           METADATA_URL: !Sub '${MetadataBaseUrl}'
           TARGETS_URL: !Sub '${TargetBaseUrl}'
   LambdaFunctionSchedule:
@@ -95,7 +106,7 @@ Resources:
     Properties:
       Description: Schedules the refresh lambda
       Name: refresh-timestamp-lambda-schedule
-      ScheduleExpression: !Sub 'cron(0 0 */${RefreshFrequencyDays} * ? *)'
+      ScheduleExpression: !Sub 'rate(${LambdaInvocationFrequency} hours)'
       State: ENABLED
       Targets:
         - Arn: !GetAtt 'LambdaFunction.Arn'


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/amazonlinux/PRIVATE-thar/issues/666 :smiling_imp: 

*Description of changes:* 
* Lambda invocation frequency can now be specified in hours.
* Adds a new `refresh-threshold` parameter.  The threshold is set to be the old expiration date of timestamp.json subtract the value of this parameter.
  * If current date passes the threshold, the lambda will push out the updated and signed timestamp.json. Otherwise the lambda will only go through the motions of updating and signing timestamp.json and not push anything out to the TUF repository, which makes the execution equivalent to a no-op operation.

* Moves the signing of timestamp.json into a separate function.

*Testing*:
##### If `refresh-threshold` is set to `4` days, and the old expiration date of `timestamp.json` is `2020-01-29T23:45:01.052668236+00:00` (not within 4 days as of testing).
```
{
  "message": "new version = 1579911019, 
                      new expiration date = 2020-02-01 00:10:19.714376261 UTC, 
                      pushed timestamp = false"
}
```
The timestamp.json is not pushed out to the TUF repository.
##### If `refresh-threshold` is set to `7` days, and the old expiration date of `timestamp.json` is `2020-01-29T23:45:01.052668236+00:00` (within 7 days as of testing).
```
{
  "message": "new version = 1579911235, 
                       new expiration date = 2020-02-01 00:13:55.886453687 UTC, 
                       pushed timestamp = true"
}
```
The timestamp.json is pushed out to the TUF repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
