### PR TITLE
build: Update cargo deny configs to v0.6.2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ To get these, run:
 
 ```
 cargo install cargo-make
-cargo install cargo-deny --version 0.2.6
+cargo install cargo-deny --version 0.6.2
 ```
 
 #### Docker

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -159,9 +159,9 @@ alias = "build-variant"
 dependencies = ["fetch"]
 script = [
 '''
-(cd workspaces && cargo deny check)
-(cd tools/buildsys && cargo deny check)
-(cd extras/sdk-container/license-scan && cargo deny check)
+(cd workspaces && cargo deny check --disable-fetch licenses)
+(cd tools/buildsys && cargo deny check --disable-fetch licenses)
+(cd extras/sdk-container/license-scan && cargo deny check --disable-fetch licenses)
 '''
 ]
 

--- a/extras/sdk-container/license-scan/deny.toml
+++ b/extras/sdk-container/license-scan/deny.toml
@@ -1,44 +1,22 @@
 [licenses]
 unlicensed = "deny"
-unknown = "deny"
+
+# Deny licenses unless they are specifically listed here
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+
 # We want really high confidence when inferring licenses from text
-confidence_threshold = 0.93
+confidence-threshold = 0.93
 
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
-    "BSD-2-Clause-FreeBSD",
-    "BSD-3-Clause",
-    "CC0-1.0",
-    "ISC",
-    "MIT",
-    "Openssl",
-    "Unlicense",
-    "Zlib",
-
-    # cargo-deny currently parses out exceptions as separate licenses, which may not be the correct thing to do
-    # example: `wasi` crate uses "Apache-2.0 WITH LLVM-exception" as on of the licenses
-    # tracked in https://github.com/EmbarkStudios/cargo-deny/issues/22
-    "LLVM-exception",
-
-    # pending review
     "BSL-1.0",
+    "MIT",
+    "Unlicense",
 ]
 
-skip = [
-    # first-party code, license pending
-    { name = "thar-license-scan", licenses = [] },
-]
-
-ignore = [
-    # crossbeam-queue:
-    # - Bounded MPMC queue: BSD-2-Clause-FreeBSD
-    { name = "crossbeam-queue", license_files = [{ path = "LICENSE-THIRD-PARTY", hash = 0x7e40bc60 }] },
-
-    # crossbeam-channel:
-    # - Bounded MPMC queue: BSD-2-Clause-FreeBSD
-    # - matching.go: CC-BY-3.0
-    # - Go: BSD-3-Clause
-    # - Rust: Apache-2.0 OR MIT
-    { name = "crossbeam-channel", license_files = [{ path = "LICENSE-THIRD-PARTY", hash = 0xc6242648 }] },
-]
+# FIXME: Remove this when a license is assigned for first-party packages
+[licenses.private]
+ignore = true

--- a/tools/buildsys/deny.toml
+++ b/tools/buildsys/deny.toml
@@ -1,61 +1,44 @@
 [licenses]
 unlicensed = "deny"
-unknown = "deny"
+
+# Deny licenses unless they are specifically listed here
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+
 # We want really high confidence when inferring licenses from text
-confidence_threshold = 0.93
+confidence-threshold = 0.93
 
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
-    "BSD-2-Clause-FreeBSD",
     "BSD-3-Clause",
-    "CC0-1.0",
+    "BSL-1.0",
     "ISC",
     "MIT",
-    "Openssl",
+    "OpenSSL",
     "Unlicense",
     "Zlib",
-
-    # cargo-deny currently parses out exceptions as separate licenses, which may not be the correct thing to do
-    # example: `wasi` crate uses "Apache-2.0 WITH LLVM-exception" as on of the licenses
-    # tracked in https://github.com/EmbarkStudios/cargo-deny/issues/22
-    "LLVM-exception",
-
-    # pending review
-    "BSL-1.0",
 ]
 
-skip = [
-    # first-party code, license pending
-    { name = "buildsys", licenses = [] },
-
-    # ring: ISC AND Openssl
-    { name = "ring", licenses = [] },
-
-    # webpki: ISC AND BSD-3-Clause
-    { name = "webpki", licenses = [] },
-
-    # pending review
-    { name = "webpki-roots", licenses = ["MPL-2.0"] },
+exceptions = [
+    { name = "webpki-roots", allow = ["MPL-2.0"], version = "*" },
 ]
 
-ignore = [
-    # standard rustls "any of Apache-2.0/ISC/MIT" files
-    { name = "ct-logs", license_files = [{ path = "LICENSE", hash = 0xe567c411 }] },
-    { name = "hyper-rustls", license_files = [{ path = "LICENSE", hash = 0x3154a1c7 }] },
-    { name = "rustls", license_files = [{ path = "LICENSE", hash = 0xe567c411 }] },
-    { name = "sct", license_files = [{ path = "LICENSE", hash = 0xb7619ae7 }] },
+# FIXME: Remove this when a license is assigned for first-party packages
+[licenses.private]
+ignore = true
 
-    # adler32: two Zlib notices
-    { name = "adler32", license_files = [{ path = "LICENSE", hash = 0x1e225da6 }] },
-    # crossbeam-queue: source information at top of LICENSE-THIRD-PARTY file (BSD-2-Clause-FreeBSD)
-    { name = "crossbeam-queue", license_files = [{ path = "LICENSE-THIRD-PARTY", hash = 0x7e40bc60 }] },
-    # ring: ISC AND Openssl
-    # pending review
-    { name = "ring", license_files = [{ path = "LICENSE", hash = 0xbd0eed23 }] },
-    # webpki: first-party ISC, third-party/chromium BSD-3-Clause
-    { name = "webpki", license_files = [{ path = "LICENSE", hash = 0x001c7e6c }] },
-    # webpki-roots: describes provenance from ca-bundle.crt and MPL-2.0
-    # pending review
-    { name = "webpki-roots", license_files = [{ path = "LICENSE", hash = 0x6c919c48 }] },
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
 ]

--- a/tools/infra/container/scripts/install-crates
+++ b/tools/infra/container/scripts/install-crates
@@ -21,5 +21,5 @@ cargo_dep() {
 
 # Install build tooling dependencies
 cargo_dep --version 0.23.0 cargo-make
-cargo_dep --version 0.2.6  cargo-deny
+cargo_dep --version 0.6.2  cargo-deny
 

--- a/workspaces/api/data_store_version/Cargo.toml
+++ b/workspaces/api/data_store_version/Cargo.toml
@@ -3,6 +3,7 @@ name = "data_store_version"
 version = "0.1.0"
 authors = ["mrowicki <mrowicki@amazon.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 lazy_static = "1.2"

--- a/workspaces/deny.toml
+++ b/workspaces/deny.toml
@@ -1,93 +1,45 @@
 [licenses]
 unlicensed = "deny"
-unknown = "deny"
+
+# Deny licenses unless they are specifically listed here
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+
 # We want really high confidence when inferring licenses from text
-confidence_threshold = 0.93
+confidence-threshold = 0.93
 
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
-    "BSD-2-Clause-FreeBSD",
     "BSD-3-Clause",
+    "BSL-1.0",
     "CC0-1.0",
     "ISC",
     "MIT",
-    "Openssl",
+    "OpenSSL",
     "Unlicense",
     "Zlib",
-
-    # cargo-deny currently parses out exceptions as separate licenses, which may not be the correct thing to do
-    # example: `wasi` crate uses "Apache-2.0 WITH LLVM-exception" as on of the licenses
-    # tracked in https://github.com/EmbarkStudios/cargo-deny/issues/22
-    "LLVM-exception",
-
-    # pending review
-    "BSL-1.0",
 ]
 
-skip = [
-    # first-party code, license pending
-    { name = "apiclient", licenses = [] },
-    { name = "apiserver", licenses = [] },
-    { name = "block-party", licenses = [] },
-    { name = "bork", licenses = [] },
-    { name = "borkseed-migration", licenses = [] },
-    { name = "containerd-config-path", licenses = [] },
-    { name = "data_store_version", licenses = [] },
-    { name = "growpart", licenses = [] },
-    { name = "host-containers", licenses = [] },
-    { name = "host-containers-version-migration", licenses = [] },
-    { name = "laika", licenses = [] },
-    { name = "migration-helpers", licenses = [] },
-    { name = "migrator", licenses = [] },
-    { name = "model-derive", licenses = [] },
-    { name = "models", licenses = [] },
-    { name = "moondog", licenses = [] },
-    { name = "netdog", licenses = [] },
-    { name = "pluto", licenses = [] },
-    { name = "servicedog", licenses = [] },
-    { name = "settings-committer", licenses = [] },
-    { name = "signpost", licenses = [] },
-    { name = "storewolf", licenses = [] },
-    { name = "sundog", licenses = [] },
-    { name = "testmigration", licenses = [] },
-    { name = "thar-be-settings", licenses = [] },
-    { name = "update_metadata", licenses = [] },
-    { name = "updog", licenses = [] },
-    { name = "webpki-roots", licenses = [] },
-
-    # ring: ISC AND Openssl
-    { name = "ring", licenses = [] },
-
-    # webpki: ISC AND BSD-3-Clause
-    { name = "webpki", licenses = [] },
-
-    # pending review
-    { name = "copyless", licenses = ["MPL-2.0"] },
-    { name = "libsystemd-sys", licenses = ["LGPL-2.1"] },
-    { name = "systemd", licenses = ["LGPL-2.1"] },
+exceptions = [
+    { name = "copyless", allow = ["MPL-2.0"], version = "*" },
 ]
 
-ignore = [
-    # standard rustls "any of Apache-2.0/ISC/MIT" files
-    { name = "ct-logs", license_files = [{ path = "LICENSE", hash = 0xe567c411 }] },
-    { name = "hyper-rustls", license_files = [{ path = "LICENSE", hash = 0x3154a1c7 }] },
-    { name = "rustls", license_files = [{ path = "LICENSE", hash = 0xe567c411 }] },
-    { name = "sct", license_files = [{ path = "LICENSE", hash = 0xb7619ae7 }] },
+# FIXME: Remove this when a license is assigned for first-party packages
+[licenses.private]
+ignore = true
 
-    # adler32: two Zlib notices
-    { name = "adler32", license_files = [{ path = "LICENSE", hash = 0x1e225da6 }] },
-    # crossbeam-queue: source information at top of LICENSE-THIRD-PARTY file (BSD-2-Clause-FreeBSD)
-    { name = "crossbeam-queue", license_files = [{ path = "LICENSE-THIRD-PARTY", hash = 0x7e40bc60 }] },
-    # dns-lookup: MIT license file includes prelude about code copyrighted by The Rust Project Developers
-    { name = "dns-lookup", license_files = [{ path = "LICENSE-MIT", hash = 0x7ea99b1f }] },
-    # err-derive: license file simply points to LICENSE-APACHE and LICENSE-MIT
-    { name = "err-derive", license_files = [{ path = "LICENSE", hash = 0x847b2dc3 }] },
-    # md5: fancy markdown!
-    { name = "md5", license_files = [{ path = "LICENSE.md", hash = 0xa7154852 }] },
-    # ring: ISC AND Openssl
-    # pending review
-    { name = "ring", license_files = [{ path = "LICENSE", hash = 0xbd0eed23 }] },
-    # webpki: first-party ISC, third-party/chromium BSD-3-Clause
-    { name = "webpki", license_files = [{ path = "LICENSE", hash = 0x001c7e6c }] },
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
 ]

--- a/workspaces/growpart/Cargo.toml
+++ b/workspaces/growpart/Cargo.toml
@@ -3,6 +3,7 @@ name = "growpart"
 version = "0.1.0"
 authors = ["Ben Cressey <bcressey@amazon.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 gptman = { version = "0.5.0", default-features = false }


### PR DESCRIPTION
*Issue #, if available:* Closes #531

*Description of changes:*
Moving to the most recent cargo-deny, which simplifies these configs significantly. :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
