### PR TITLE
Update RELEASE.toml for next release

### DIFF
--- a/RELEASE.toml
+++ b/RELEASE.toml
@@ -1,7 +1,13 @@
-version = "0.2.1"
-datastore_version = "0.2"
+version = "0.2.2"
+datastore_version = "0.3"
 
-[[migrations]]
-from = "0.2.0"
-to = "0.2.1"
-names = ["migrate_0.2_containerd-config-path", "migrate_0.2_remove-region"]
+[migrations]
+# Happy path - skip over 0.1, which had an issue with compressed migrations.  Normal new migrations go here.
+"(0.0, 0.2)" = ["migrate_0.1_borkseed", "migrate_0.1_host-containers-version-migration", "migrate_0.2_containerd-config-path"]
+"(0.2, 0.3)" = ["migrate_0.3_remove-region"]
+# We don't want to block updating into 0.1 if a user specifically wants the related OS version...
+"(0.0, 0.1)" = ["migrate_0.1_borkseed", "migrate_0.1_host-containers-version-migration"]
+# ...but to migrate out of the OS with version 0.1 we have to have copies of the migration with the lz4 extension.
+# (These filenames are also supported by newer OS versions.)
+"(0.1, 0.2)" = ["migrate_0.2_containerd-config-path.lz4"]
+"(0.1, 0.3)" = ["migrate_0.2_containerd-config-path.lz4", "migrate_0.3_remove-region.lz4"]


### PR DESCRIPTION
This adds the remove-region migration needed to downgrade after adding
platform-specific settings.

This updates the migration syntax to match manifest.json from the TUF repo,
both for simplicity of updating the manifest and because we have a lot of
information and the increased density makes it easier for humans to see the
various migration paths.

---

We don't use this migration list yet, but it took me a bit to figure out the correct paths, so I wanted it represented here - either a tool will start to use it, or a human can copy/paste it into our next manifest.json.

I think our future process could be to add migrations to this file in the same PR that creates the migration.