### PR TITLE
Fix docs for switch to --log-level args

### DIFF
--- a/workspaces/api/README.md
+++ b/workspaces/api/README.md
@@ -149,7 +149,7 @@ Now you can start the API server.
 From the `workspaces/api/apiserver` directory:
 
 ```
-cargo run -- --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock -v -v -v
+cargo run -- --datastore-path /tmp/data-store/current --socket-path /tmp/thar-api.sock --log-level debug
 ```
 
 You can leave that running in a terminal, or background it, whatever you like.

--- a/workspaces/api/apiserver/README.md
+++ b/workspaces/api/apiserver/README.md
@@ -68,9 +68,7 @@ The `datastore::deserialization` module provides code to deserialize datastore-a
 
 You can start the API server from the development workspace with a command like:
 
-`cargo run -- --datastore-path /tmp/thar/be/data --socket-path /tmp/thar/api.sock -v -v -v -v`
-
-(Add a few -v options to increase logging.)
+`cargo run -- --datastore-path /tmp/thar/be/data --socket-path /tmp/thar/api.sock --log-level debug`
 
 Then, from another shell, you can query or modify data.
 See `../../apiclient/README.md` for client examples.

--- a/workspaces/api/apiserver/src/lib.rs
+++ b/workspaces/api/apiserver/src/lib.rs
@@ -65,9 +65,7 @@ The `datastore::deserialization` module provides code to deserialize datastore-a
 
 You can start the API server from the development workspace with a command like:
 
-`cargo run -- --datastore-path /tmp/thar/be/data --socket-path /tmp/thar/api.sock -v -v -v -v`
-
-(Add a few -v options to increase logging.)
+`cargo run -- --datastore-path /tmp/thar/be/data --socket-path /tmp/thar/api.sock --log-level debug`
 
 Then, from another shell, you can query or modify data.
 See `../../apiclient/README.md` for client examples.


### PR DESCRIPTION
I forgot to update these after changing the logger to take `--log-level` instead of N `-v` args.