### PR TITLE
Add helpers for common add/remove setting migrations

### DIFF
--- a/workspaces/api/migration/migration-helpers/src/common_migrations.rs
+++ b/workspaces/api/migration/migration-helpers/src/common_migrations.rs
@@ -1,0 +1,53 @@
+use crate::{Migration, MigrationData, Result};
+
+/// We use this migration when we add a setting and want to make sure it's removed before we go
+/// back to old versions that don't understand it.
+pub struct AddSettingMigration(pub &'static str);
+
+impl Migration for AddSettingMigration {
+    /// New versions must either have a default for the setting or generate it; we don't need to
+    /// do anything.
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("AddSettingMigration({}) has no work to do on upgrade.", self.0);
+        Ok(input)
+    }
+
+    /// Older versions don't know about the setting; we remove it so that old versions don't see
+    /// it and fail deserialization.  (The setting must be defaulted or generated in new versions,
+    /// and safe to remove.)
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(data) = input.data.remove(self.0) {
+            println!("Removed {}, which was set to '{}'", self.0, data);
+        } else {
+            println!("Found no {} to remove", self.0);
+        }
+        Ok(input)
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// We use this migration when we remove a setting from the model, so the new version doesn't see
+/// it and error.
+pub struct RemoveSettingMigration(String);
+
+impl Migration for RemoveSettingMigration {
+    /// Newer versions don't know about the setting; we remove it so that new versions don't see
+    /// it and fail deserialization.  (The setting must be defaulted or generated in old versions,
+    /// and safe to remove.)
+    fn forward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(data) = input.data.remove(&self.0) {
+            println!("Removed {}, which was set to '{}'", self.0, data);
+        } else {
+            println!("Found no {} to remove", self.0);
+        }
+        Ok(input)
+    }
+
+    /// Old versions must either have a default for the setting or generate it; we don't need to
+    /// do anything.
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("RemoveSettingMigration({}) has no work to do on downgrade.", self.0);
+        Ok(input)
+    }
+}

--- a/workspaces/api/migration/migration-helpers/src/lib.rs
+++ b/workspaces/api/migration/migration-helpers/src/lib.rs
@@ -12,6 +12,7 @@
 #![deny(rust_2018_idioms)]
 
 mod args;
+pub mod common_migrations;
 mod datastore;
 pub mod error;
 mod workarounds;

--- a/workspaces/api/migration/migrations/v0.2/remove-region/src/main.rs
+++ b/workspaces/api/migration/migrations/v0.2/remove-region/src/main.rs
@@ -1,33 +1,13 @@
 #![deny(rust_2018_idioms)]
 
-use migration_helpers::{migrate, Migration, MigrationData, Result};
+use migration_helpers::{migrate, Result};
+use migration_helpers::common_migrations::AddSettingMigration;
 use std::process;
 
 /// We added a generated setting, "settings.aws.region", and want to make sure it's removed before
 /// we go back to old versions that don't understand it.
-struct RemoveRegionMigration;
-
-impl Migration for RemoveRegionMigration {
-    /// New versions will generate the setting, we don't need to do anything.
-    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
-        println!("RemoveRegionMigration has no work to do on upgrade.");
-        Ok(input)
-    }
-
-    /// Older versions don't know about region; we remove it so that old versions don't see it and
-    /// fail deserialization.  (The setting is generated in new versions, and safe to remove.)
-    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
-        if let Some(region) = input.data.remove("settings.aws.region") {
-            println!("Removed settings.aws.region, which was set to '{}'", region);
-        } else {
-            println!("Found no settings.aws.region to remove");
-        }
-        Ok(input)
-    }
-}
-
 fn run() -> Result<()> {
-    migrate(RemoveRegionMigration)
+    migrate(AddSettingMigration("settings.aws.region"))
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu


### PR DESCRIPTION
I'm still thinking about how we could automate away the need for common migrations, but this at least makes adding or removing a setting a one-liner that you barely have to think about, rather than copy/paste or new code each time.

**Testing done:**

Rebuild and ran the remove-region migration forward and backward.  It has no work to do on upgrade:
```
$ cargo run -- --log-level trace --datastore-path datastore-sample/current --migration-directories ./migration-binaries --migrate-to-version 0.2
...
19:59:08 [DEBUG] (1) migrator: Sorted migrations: ["migrate_v0.2_remove-region"]
19:59:08 [ INFO] New data store is being built at work location /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2_AqZorFmcnAhXpUNF
19:59:08 [ INFO] Running migration command: "./migration-binaries/migrate_v0.2_remove-region" "--forward" "--source-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_j52ioMoTEFBcHM0Z" "--target-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2_AqZorFmcnAhXpUNF"
19:59:08 [DEBUG] (1) migrator: Migration stdout: AddSettingMigration(settings.aws.region) has no work to do on upgrade.
AddSettingMigration(settings.aws.region) has no work to do on upgrade.

19:59:08 [DEBUG] (1) migrator: Migration stderr: 
19:59:08 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2 to point to v0.2_AqZorFmcnAhXpUNF
19:59:08 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0 to point to v0.2
```

On downgrade it did its job:
```
$ cargo run -- --log-level trace --datastore-path datastore-sample/current --migration-directories ./migration-binaries --migrate-to-version 0.1
...
19:59:23 [DEBUG] (1) migrator: Sorted migrations: ["migrate_v0.2_remove-region"]
19:59:23 [ INFO] New data store is being built at work location /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_lm9HzZmqysxr94CJ
19:59:23 [ INFO] Running migration command: "./migration-binaries/migrate_v0.2_remove-region" "--backward" "--source-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.2_AqZorFmcnAhXpUNF" "--target-datastore" "/home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1_lm9HzZmqysxr94CJ"
19:59:23 [DEBUG] (1) migrator: Migration stdout: Removed settings.aws.region, which was set to '"us-west-2"'
Found no settings.aws.region to remove

19:59:23 [DEBUG] (1) migrator: Migration stderr: 
19:59:23 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0.1 to point to v0.1_lm9HzZmqysxr94CJ
19:59:23 [ INFO] Flipping /home/ANT.AMAZON.COM/tjk/work/thar/workspaces/api/migration/migrator/datastore-sample/v0 to point to v0.1
```