### PR TITLE
aws-iam-authenticator: bump from v0.4.0 to v0.5.0

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.4.0/aws-iam-authenticator-0.4.0.tar.gz"
-sha512 = "2020ba908268d32bf5b0fa799052b26c37ea27fec6c41948bb090119a1963052b5f736da57a09390cc060bfa0b0717e8ed24d20ed01d828d5d27918117bbd7d0"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.5.0/aws-iam-authenticator-0.5.0.tar.gz"
+sha512 = "abe725b61e8c645ceabad28804c2687def541e6f6beb305fd49b624ab150b9c4a2dad169958ea13ae7d42cf417a6627a1459702d5451f34139a2b5f70c46d37a"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.4.0
+%global gover 0.5.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -14,6 +14,7 @@ Summary: AWS IAM authenticator
 License: Apache-2.0
 URL: https://%{goimport}
 Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
+Source1000: clarify.toml
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 
@@ -22,18 +23,17 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %prep
 %autosetup -Sgit -n %{gorepo}-%{gover} -p1
-%cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
 
 %build
-%cross_go_configure %{goimport}
+%set_cross_go_flags
 export BUILDTAGS="rpm_crashtraceback"
-go build -buildmode pie -tags="${BUILDTAGS}" -o aws-iam-authenticator %{goimport}/cmd/aws-iam-authenticator
+go build -buildmode pie -tags="${BUILDTAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-iam-authenticator %{buildroot}%{_cross_bindir}
 
-%cross_scan_attribution go-vendor vendor
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
 %license LICENSE

--- a/packages/aws-iam-authenticator/clarify.toml
+++ b/packages/aws-iam-authenticator/clarify.toml
@@ -1,0 +1,5 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xcdf3ae00 },
+]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Bumps aws-iam-authenticator from version v0.4.0 to v0.5.0. 
See v0.5.0 changelogs [here](https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/tag/v0.5.0)

This commits bumps the aws-iam-authenticator from version v0.4.0 to
v0.5.0.

aws-iam-authenticator migrated from using godep to using go modules
between these two versions.

Added license clarification file for license attribution scanning

Testing done:
Built new Thar image successfully.
Launched Thar worker node, joins my cluster without problems and run pods without problems.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
