### PR TITLE
chrony: Split chronyc into a subpackage

### DIFF
--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -15,10 +15,17 @@ BuildRequires: %{_cross_os}ncurses-devel
 BuildRequires: %{_cross_os}readline-devel
 Requires: %{_cross_os}libcap
 Requires: %{_cross_os}libseccomp
-Requires: %{_cross_os}ncurses
-Requires: %{_cross_os}readline
 
 %description
+%{summary}.
+
+%package tools
+Summary: Command-line interface for chrony daemon
+Requires: %{_cross_os}chrony
+Requires: %{_cross_os}readline
+Requires: %{_cross_os}ncurses
+
+%description tools
 %{summary}.
 
 %prep
@@ -48,11 +55,13 @@ install -p -m 0644 %{SOURCE3} %{buildroot}%{_cross_sysusersdir}/chrony.conf
 %license COPYING
 %{_cross_attribution_file}
 %dir %{_cross_templatedir}
-%{_cross_bindir}/chronyc
 %{_cross_sbindir}/chronyd
 %{_cross_templatedir}/chrony-conf
 %{_cross_unitdir}/chronyd.service
 %{_cross_sysusersdir}/chrony.conf
 %exclude %{_cross_mandir}
+
+%files tools
+%{_cross_bindir}/chronyc
 
 %changelog

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -21,6 +21,7 @@ included-packages = [
     "procps",
     "strace",
     "tcpdump",
+    "chrony-tools",
 ]
 
 [lib]


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Splits the chronyc binary into a `chrony-tools` subpackage, excluded in the aws-k8s variant and included in the aws-dev variant.

This drops the dependency on readline for the aws-k8s variant.

*Testing done:*
Built both variants. It and readline are now excluded from aws-k8s, and are still included in aws-dev.

Ran instances in a cluster, enabled the admin container on one and `systemctl status chronyd` shows chrony running, with `Selected source 169.254.169.123`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
