### PR TITLE
host-ctr: bumps aws-sdk-go and amazon-ecr-containerd-resolver version

### DIFF
--- a/workspaces/host-ctr/cmd/host-ctr/go.mod
+++ b/workspaces/host-ctr/cmd/host-ctr/go.mod
@@ -3,8 +3,8 @@ module host-ctr
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.23.22
-	github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20190912214810-5bbc33959a5c
+	github.com/aws/aws-sdk-go v1.28.9
+	github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20200131205711-bda55ee680cd
 	github.com/containerd/containerd v1.2.9
 	github.com/opencontainers/runc v1.0.0-rc8
 	github.com/opencontainers/runtime-spec v1.0.1

--- a/workspaces/host-ctr/cmd/host-ctr/go.sum
+++ b/workspaces/host-ctr/cmd/host-ctr/go.sum
@@ -8,8 +8,12 @@ github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXn
 github.com/aws/aws-sdk-go v1.22.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.22 h1:6zwCJ9X8NMizf4wMEGQjqTUV+otsB+NwyJftt2Ua9Oo=
 github.com/aws/aws-sdk-go v1.23.22/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.28.9 h1:grIuBQc+p3dTRXerh5+2OxSuWFi0iXuxbFdTSg0jaW0=
+github.com/aws/aws-sdk-go v1.28.9/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20190912214810-5bbc33959a5c h1:jczRvUAPu6J5o+W2HLmlR/iQDCWl4MMFVl7aUTOWlbo=
 github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20190912214810-5bbc33959a5c/go.mod h1:Ax5zrFys+l3QCaIGTlQv7AG19364kGStlE46QR0HPQk=
+github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20200131205711-bda55ee680cd h1:nliop6zhgm6tjBc1zhsyBXGV/292pmEwzKKSRyThs94=
+github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20200131205711-bda55ee680cd/go.mod h1:I/mO5gP5VnbDlRDkjtXD9FueZzLbrVfdpjnutZheAW4=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601 h1:6xW3ogNpFIly0umJGEKzFfGDNUk5rXFE1lJ3/gBmz3U=
 github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601/go.mod h1:X9rLEHIqSf/wfK8NsPqxJmeZgW4pcfzdXITDrUSJ6uI=
@@ -49,6 +53,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/htcat/htcat v1.0.2 h1:zro95dGwkKDeZOgq9ei+9szd5qurGxBGfHY8hRehA7k=
+github.com/htcat/htcat v1.0.2/go.mod h1:i8ViQbjSi2+lJzM6Lx20FIxHENCz6mzJglK3HH06W3s=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
*Issue #, if available:* Partially addresses #685

*Description of changes:*
Bumps the version of `aws-sdk-go`
Bumps the version of `amazon-ecr-containerd-resolver`
Now `host-ctr` supports pulling images from ECR when IMDSv2 is enforced

*Testing done:*
Built new image with changes. Launched Thar instance with new image.
`host-containers` all still start fine.
```
bash-5.0# systemctl status host-containers@admin
● host-containers@admin.service - Host container: admin
     Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/host-containers@.service; enabled; vendor preset: enabled)
     Active: active (running) since Sat 2020-02-01 00:04:37 UTC; 2 days ago
    Process: 2601 ExecStartPre=/usr/bin/mkdir -m 1777 -p ${LOCAL_DIR}/host-containers/admin (code=exited, status=0/SUCCESS)
   Main PID: 2689 (host-ctr)
      Tasks: 26 (limit: 4430)
     Memory: 37.7M
     CGroup: /system.slice/system-host\x2dcontainers.slice/host-containers@admin.service
             └─2689 /usr/bin/host-ctr -ctr-id=admin -source=722737851570.dkr.ecr.us-west-2.amazonaws.com/thar-admin:latest -superpowered=true
....
bash-5.0# systemctl status host-containers@control
● host-containers@control.service - Host container: control
     Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/host-containers@.service; enabled; vendor preset: enabled)
     Active: active (running) since Sat 2020-02-01 00:04:37 UTC; 2 days ago
    Process: 2641 ExecStartPre=/usr/bin/mkdir -m 1777 -p ${LOCAL_DIR}/host-containers/control (code=exited, status=0/SUCCESS)
   Main PID: 2723 (host-ctr)
      Tasks: 20 (limit: 4430)
     Memory: 38.1M
     CGroup: /system.slice/system-host\x2dcontainers.slice/host-containers@control.service
             └─2723 /usr/bin/host-ctr -ctr-id=control -source=328549459982.dkr.ecr.us-west-2.amazonaws.com/thar-control:v0.2 -superpowered=false
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
