### PR TITLE
thar-control: pin amazon-ssm-agent to a version that supports imdsv2

### DIFF
--- a/extras/host-containers/thar-control/Dockerfile
+++ b/extras/host-containers/thar-control/Dockerfile
@@ -1,10 +1,12 @@
 FROM amazonlinux:2
 ARG IMAGE_VERSION
-# Make the container image version a mandatory build argument
+ARG SSM_AGENT_VERSION
+# Mandatory build arguments
 RUN test -n "$IMAGE_VERSION"
+RUN test -n "$SSM_AGENT_VERSION"
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 
-RUN yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm shadow-utils
+RUN yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/"$SSM_AGENT_VERSION"/linux_amd64/amazon-ssm-agent.rpm shadow-utils
 
 # Add motd explaining the control container.
 RUN rm -f /etc/motd /etc/issue

--- a/extras/host-containers/thar-control/Makefile
+++ b/extras/host-containers/thar-control/Makefile
@@ -1,5 +1,5 @@
 IMAGE_VERSION=`cat VERSION`
-
+SSM_AGENT_VERSION ?= 2.3.842.0
 DOCKER_IMAGE := thar-control
 DOCKER_IMAGE_REF_RELEASE := $(DOCKER_IMAGE):$(CONTROL_CTR_VERSION)
 SHORT_SHA ?= $(shell git rev-parse --short=8 HEAD)
@@ -9,6 +9,7 @@ container:
 	docker build --network=host \
 		--tag $(DOCKER_IMAGE_REF) \
 		--build-arg IMAGE_VERSION="$(IMAGE_VERSION)" \
+		--build-arg SSM_AGENT_VERSION="$(SSM_AGENT_VERSION)" \
 		--build-arg BUILD_LDFLAGS='' \
 		.
 


### PR DESCRIPTION
*Issue #, if available:* Partially addresses #685

*Description of changes:*
Instead of installing the latest version of `amazon-ssm-agent` every time when we build `thar-control`, it is now pinned to a default version (v2.3.842.0). See `amazon-ssm-agent` releases [here](https://github.com/aws/amazon-ssm-agent/releases)

*Testing done:*
Launched Thar instance with userdata that points to a `thar-control` container image with these changes:
`host-containers@control` starts and runs fine
```
bash-5.0# systemctl status host-containers@control
● host-containers@control.service - Host container: control
     Loaded: loaded (/x86_64-thar-linux-gnu/sys-root/usr/lib/systemd/system/host-containers@.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2020-02-04 00:13:31 UTC; 46s ago
    Process: 2636 ExecStartPre=/usr/bin/mkdir -m 1777 -p ${LOCAL_DIR}/host-containers/control (code=exited, status=0/SUCCESS)
   Main PID: 2717 (host-ctr)
      Tasks: 21 (limit: 4430)
     Memory: 42.7M
     CGroup: /system.slice/system-host\x2dcontainers.slice/host-containers@control.service
             └─2717 /usr/bin/host-ctr -ctr-id=control -source=SNIP.dkr.ecr.us-west-2.amazonaws.com/thar-control:latest -superpowered=false

Feb 04 00:14:09 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:09 INFO [StartupProcessor] Unable to open serial port /dev/ttyS0:
 open /dev/ttyS0: no such file or directory
Feb 04 00:14:09 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:09 INFO [StartupProcessor] Attempting to use different port (PV):
 /dev/hvc0
Feb 04 00:14:09 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:09 INFO [StartupProcessor] Unable to open serial port /dev/hvc0:
open /dev/hvc0: no such file or directory
Feb 04 00:14:09 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:09 ERROR [StartupProcessor] Error opening serial port: open /dev/
hvc0: no such file or directory
Feb 04 00:14:09 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:09 ERROR [StartupProcessor] Error opening serial port: open /dev/
hvc0: no such file or directory. Retrying in 5 seconds...
Feb 04 00:14:14 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:14 INFO [StartupProcessor] Unable to open serial port /dev/ttyS0:
 open /dev/ttyS0: no such file or directory
Feb 04 00:14:14 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:14 INFO [StartupProcessor] Attempting to use different port (PV):
 /dev/hvc0
Feb 04 00:14:14 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:14 INFO [StartupProcessor] Unable to open serial port /dev/hvc0:
open /dev/hvc0: no such file or directory
Feb 04 00:14:14 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:14 ERROR [StartupProcessor] Error opening serial port: open /dev/
hvc0: no such file or directory
Feb 04 00:14:14 ip-192-168-61-30.us-west-2.compute.internal host-ctr[2717]: 2020-02-04 00:14:14 ERROR [StartupProcessor] Error opening serial port: open /dev/
hvc0: no such file or directory. Retrying in 5 seconds...
```
*Note that the serial port error does not prevent us from starting ssm sessions. Being tracked here:  https://github.com/amazonlinux/PRIVATE-thar/issues/599

Can start SSM sessions with said instance
```
$ aws ssm start-session --target i-SNIP

Starting session with SessionId: SNIP
Welcome to Thar's control container!

This container gives you access to the Thar API, which in turn lets you inspect
and configure the system.  You'll probably want to use the `apiclient` tool for
that; for example, to inspect the system:

   apiclient -u /settings

You can run `apiclient --help` for usage details, and check the main Thar
documentation for descriptions of all settings and examples of changing them.

If you need to debug the system further, you can enable the admin container.
This enables SSH access to the system using the key you specified when you
launched the instance.  This environment has more debugging tools installed,
and allows you to get root access to the host.

To enable the admin container, run:

   enable-admin-container
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
