### PR TITLE
Add .crates2.json to .gitignore

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,2 +1,3 @@
 /bin/buildsys
 /.crates.toml
+/.crates2.json


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Looks like `cargo install` writes a new metadata file to whatever directory you ask it to install into.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
