### PR TITLE
Stuff /usr/share/licenses into a squashfs

### DIFF
--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -21,6 +21,7 @@ Source1007: var.mount
 Source1008: opt.mount
 Source1009: usr-src-kernels.mount.in
 Source1010: var-lib-thar.mount
+Source1011: usr-share-licenses.mount.in
 
 BuildArch: noarch
 Requires: %{_cross_os}acpid
@@ -90,6 +91,10 @@ KERNELPATH=$(systemd-escape --path %{_cross_usrsrc}/kernels)
 sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1009} > ${KERNELPATH}.mount
 install -p -m 0644 ${KERNELPATH}.mount %{buildroot}%{_cross_unitdir}
 
+LICENSEPATH=$(systemd-escape --path %{_cross_licensedir})
+sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1011} > ${LICENSEPATH}.mount
+install -p -m 0644 ${LICENSEPATH}.mount %{buildroot}%{_cross_unitdir}
+
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/hostname
 
@@ -105,6 +110,7 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/hostname
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/*-kernels.mount
+%{_cross_unitdir}/*-licenses.mount
 %{_cross_unitdir}/var-lib-thar.mount
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/hostname

--- a/packages/release/usr-share-licenses.mount.in
+++ b/packages/release/usr-share-licenses.mount.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=License files
+Conflicts=umount.target
+Before=local-fs.target umount.target
+
+[Mount]
+What=PREFIX/share/thar/licenses.squashfs
+Where=PREFIX/share/licenses
+Type=squashfs
+Options=defaults,ro,loop
+
+[Install]
+WantedBy=local-fs.target

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -75,7 +75,8 @@ sgdisk --clear \
    --sort --print "${DISK_IMAGE}"
 
 rpm -iv --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
-rm -rf "${ROOT_MOUNT}"/var/lib
+mksquashfs "${ROOT_MOUNT}"/usr/share/licenses "${ROOT_MOUNT}"/usr/share/thar/licenses.squashfs
+rm -rf "${ROOT_MOUNT}"/var/lib "${ROOT_MOUNT}"/usr/share/licenses/*
 
 if [[ "${ARCH}" == "x86_64" ]]; then
   SYS_ROOT="x86_64-thar-linux-gnu/sys-root"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Makes the contents of /usr/share/licenses a squashfs on disk that is auto-mounted at boot.

Tested on an aws-k8s AMI, including the changes from #719 — without hardlinking files:

```
bash-5.0# du -sh /usr/share/licenses/ 
6.9M    /usr/share/licenses/
```

After hardlinking:

```
bash-5.0# du -sh /usr/share/licenses/
4.4M    /usr/share/licenses/
```

Size of the squashfs:

```
bash-5.0# ls -lh /usr/share/thar/licenses.squashfs 
-rw-r--r-- 1 root root 320K Feb 12 16:47 /usr/share/thar/licenses.squashfs
```

(Hardlinking doesn't save any space in the squashfs, because there is already duplicate file detection. So it's not included here.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
