### PR TITLE
infra: Stacks for S3 log processing and access

### DIFF
--- a/tools/infra/stacks/update-logs-cross-account-athena-role.yml
+++ b/tools/infra/stacks/update-logs-cross-account-athena-role.yml
@@ -1,0 +1,79 @@
+# Role for the Athena user / Glue crawler in the consuming Telemetry account
+AWSTemplateFormatVersion: "2010-09-09"
+Description: 'A role that allows access to a Glue catalog in a separate account'
+Parameters:
+  SourceBucketName:
+    Description: "Name of the S3 bucket that Glue will crawl"
+    AllowedPattern: '[a-z0-9\-]+'
+    ConstraintDescription: "Must follow normal S3 bucket naming rules"
+    Type: String
+  DatabaseName:
+    Description: "Name of database to store metrics in"
+    AllowedPattern: '[a-z0-9_]+'
+    ConstraintDescription: "Lowercase names only, no special characters bar _"
+    Type: String
+
+Resources:
+  MetricsAccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "AWSGlueServiceRole-log-processing-${AWS::Region}"
+      Description: 'Role allowing access to the S3 bucket and Glue/Athena services'
+      Path: !Sub "/${AWS::StackName}/"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: glue.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+      Policies:
+        - PolicyName: 'S3LogsReadOnlyAccess'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject*
+                Resource: 
+                  - !Sub "arn:aws:s3:::${SourceBucketName}/*"
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !Sub "arn:aws:s3:::${SourceBucketName}"
+
+  MetricsDatabase:
+    Type: AWS::Glue::Database
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseInput:
+        Name: !Ref DatabaseName
+        Description: "Telemetry derived metrics"
+
+  GlueResultCrawler:
+    Type: AWS::Glue::Crawler
+    Properties:
+      Role: !GetAtt MetricsAccessRole.Arn
+      Description: "Processed telemetry metrics collector"
+      #Schedule: none for now (on-demand)
+      DatabaseName: !Ref DatabaseName
+      Targets:
+        S3Targets:
+          - Path: !Sub 's3://${SourceBucketName}'
+      SchemaChangePolicy:
+        UpdateBehavior: "UPDATE_IN_DATABASE"
+        DeleteBehavior: "LOG"
+      Configuration: "{\"Version\":1.0,\"CrawlerOutput\":{\"Partitions\":{\"AddOrUpdateBehavior\":\"InheritFromTable\"},\"Tables\":{\"AddOrUpdateBehavior\":\"MergeNewColumns\"}}}"
+
+Outputs:
+  MetricsAccessRole:
+    Description: 'The ARN of the metrics user role'
+    Value: !GetAtt MetricsAccessRole.Arn
+  MetricsDatabase:
+    Description: 'The database to store metrics and run queries against'
+    Value: !Ref MetricsDatabase
+  GlueResultCrawler:
+    Description: 'The Glue crawler which reads processed S3 logs'
+    Value: !Ref GlueResultCrawler

--- a/tools/infra/stacks/update-logs-glue-role.yml
+++ b/tools/infra/stacks/update-logs-glue-role.yml
@@ -1,0 +1,172 @@
+# This stack is intended for use in the main repository account. It allows the
+# AWS Glue service to process raw S3 access logs and store them in a resulting
+# bucket which a separate "Telemetry" account will have access to.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: 'A role that gives a Glue job permissions to process a bucket of raw s3 logs'
+Parameters:
+  LogBucketArn:
+    Description: "ARN of the S3 bucket Glue will read raw logs from"
+    AllowedPattern: 'arn:aws:s3:::[a-z\-]+'
+    ConstraintDescription: "Must follow normal S3 bucket naming rules"
+    Type: String
+  CrawlerAccount:
+    Description: "Account ID of the user which will crawl the converted logs bucket"
+    AllowedPattern: '[0-9]+'
+    Type: String
+
+Resources:
+  # Bucket that glue results are stored in
+  GlueResultBucket:
+    Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+
+  # Bucket policy to give permissions to reader of glue results
+  GlueResultBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref GlueResultBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - s3:GetObject*
+              - s3:ListMultipartUploadParts
+              - s3:GetBucketAcl
+              - s3:GetBucketLocation
+              - s3:ListBucket
+              - s3:ListBucketVersions
+              - s3:ListBucketMultipartUploads
+            Effect: Allow
+            Resource:
+              - !GetAtt GlueResultBucket.Arn
+              - !Sub "${GlueResultBucket.Arn}/*"
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${CrawlerAccount}:root'
+
+  GlueJobRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub 'AWSGlueServiceRole-metrics-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: glue.amazonaws.com
+
+  GlueJobRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+        - !Ref GlueJobRole
+      PolicyName: GlueJobRolePolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: 'glueServiceRawBucketAccess'
+            Action:
+              - s3:GetObject*
+            Effect: Allow
+            Resource:
+              - !Ref LogBucketArn
+              - !Sub '${LogBucketArn}/*'
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Resource:
+              - !Ref LogBucketArn
+          - Sid: 'glueServiceResultBucketAccess'
+            Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:DeleteObject
+              - s3:ListBucket
+            Effect: Allow
+            Resource:
+              - !GetAtt GlueResultBucket.Arn
+              - !Sub "${GlueResultBucket.Arn}/*"
+          - Action:
+              - s3:ListAllMyBuckets
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::*"
+          - Sid: 'glueServiceGeneralAccess'
+            Action:
+              - glue:BatchCreatePartition
+              - glue:BatchGetCrawlers
+              - glue:BatchGetJobs
+              - glue:BatchGetPartition
+              - glue:BatchGetTriggers
+              - glue:BatchStopJobRun
+              - glue:CreateDatabase
+              - glue:CreatePartition
+              - glue:CreateTable
+              - glue:GetDatabase
+              - glue:GetDatabases
+              - glue:GetJob
+              - glue:GetJobBookmark
+              - glue:GetJobRun
+              - glue:GetJobRuns
+              - glue:GetJobs
+              - glue:GetPartition
+              - glue:GetPartitions
+              - glue:GetResourcePolicy
+              - glue:GetTable
+              - glue:GetTableVersion
+              - glue:GetTableVersions
+              - glue:GetTables
+              - glue:GetTags
+              - glue:GetTrigger
+              - glue:GetTriggers
+              - glue:ListJobs
+              - glue:ListTriggers
+              - glue:ResetJobBookmark
+              - glue:SearchTables
+              - glue:StartJobRun
+              - glue:StartTrigger
+              - glue:StopTrigger
+              - glue:TagResource
+              - glue:UntagResource
+              - glue:UpdateDatabase
+              - glue:UpdateJob
+              - glue:UpdatePartition
+              - glue:UpdateTable
+              - glue:UpdateTrigger
+              - cloudwatch:PutMetricData
+            Effect: Allow
+            Resource:
+              - "*"
+          - Action:
+                  - s3:CreateBucket
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::aws-glue-*"
+          - Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::aws-glue-*/*"
+              - "arn:aws:s3:::*/*aws-glue-*/*"
+          - Action:
+                  - s3:GetObject
+            Effect: Allow
+            Resource:
+              - "arn:aws:s3:::aws-glue-*"
+              - "arn:aws:s3:::crawler-public*"
+          - Action:
+                  - logs:*
+            Effect: Allow
+            Resource:
+              - "arn:aws:logs:*:*:/aws-glue/*"
+
+Outputs:
+  GlueResultBucket:
+    Description: 'S3 bucket containing converted S3 access logs'
+    Value: !Ref GlueResultBucket
+  GlueJobRole:
+    Description: 'Role for the Glue job processing access logs'
+    Value: !GetAtt GlueJobRole.Arn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Define two Cloudformation stacks, one intended for the account owning
the TUF repository, and the other for an account intended for telemetry
purposes.

The first stack, "update-logs-glue-role", defines resources to allow an
AWS Glue job to process raw S3 access logs into a more consumable
format, and give the telemetry account access to the results. In
particular this is intended to use the Glue job defined by the scripts
in https://github.com/awslabs/athena-glue-service-logs.

The second stack, "update-logs-cross-account-athena-role", defines a
role which has access to the resulting bucket, and permissions required
for the Glue and Athena services to operate on it.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

Tested by creating both stacks in a "repo" and "telemetry" account, adding & running the Glue job in the repo account, and making sure the Glue crawler & Athena in the telemetry account can see the results.
