### PR TITLE
Update Go in SDK container to 1.13.8

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,7 +18,7 @@ BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"
 CARGO_HOME = "${BUILDSYS_ROOT_DIR}/.cargo"
 CARGO_MAKE_CARGO_ARGS = "--jobs 8 --offline --locked"
 GO_MOD_CACHE = "${BUILDSYS_ROOT_DIR}/.gomodcache"
-GO_VERSION = "1.12.5"
+GO_VERSION = "1.13.8"
 DOCKER_BUILDKIT = "1"
 
 [env.development]


### PR DESCRIPTION
*Description of changes:*
Update Go in SDK container to 1.13.8

*Testing done:*
- Rebuilt the SDK container with `make`
- Built Bottlerocket with `cargo make`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
