### PR TITLE
buildsys, Makefile: disallow upstream source fallback by default

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,6 +11,9 @@ BUILDSYS_TIMESTAMP = { script = ["date +%s"] }
 BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*' || echo 00000000"] }
 BUILDSYS_VERSION_IMAGE = { script = ["awk -F '[ =\"]+' '$1 == \"version\" {print $2}' Release.toml"] }
 BUILDSYS_VARIANT = "aws-k8s"
+# Disallow pulling directly Upstream URLs when lookaside cache results in MISSes as a fallback.
+# To use the upstream source as fallback, override this on the command line and set it to 'true'
+BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"
 
 CARGO_HOME = "${BUILDSYS_ROOT_DIR}/.cargo"
 CARGO_MAKE_CARGO_ARGS = "--jobs 8 --offline --locked"
@@ -21,8 +24,6 @@ DOCKER_BUILDKIT = "1"
 [env.development]
 # Defined here to allow us to override ${BUILDSYS_ARCH} on the command line.
 BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.8"
-# Permit pulling directly Upstream URLs when lookaside cache results in MISSes.
-BUILDSYS_ALLOW_UPSTREAM_SOURCE_URL = "true"
 # Extra flags used when spawning containers.
 #
 # ex: BUILDSYS_DOCKER_RUN_ARGS="--network=host --dns=127.0.0.53"

--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -16,7 +16,6 @@ use error::Result;
 use super::manifest;
 use sha2::{Digest, Sha512};
 use snafu::{ensure, OptionExt, ResultExt};
-use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufWriter};
 use std::path::{Path, PathBuf};
@@ -63,7 +62,8 @@ impl LookasideCache {
             }
 
             // next check with upstream, if permitted
-            if env::var_os("BUILDSYS_ALLOW_UPSTREAM_SOURCE_URL").is_some() {
+            if std::env::var("BUILDSYS_UPSTREAM_SOURCE_FALLBACK") == Ok("true".to_string()) {
+                println!("Fetching {:?} from upstream source", url_file_name);
                 Self::fetch_file(&f.url, &tmp, hash)?;
                 fs::rename(&tmp, path).context(error::ExternalFileRename { path: &tmp })?;
             }


### PR DESCRIPTION
*Issue #, if available:* Related to https://github.com/amazonlinux/PRIVATE-thar/issues/540

*Description of changes:*
`buildsys` now checks environment variable `BUILDSYS_UPSTREAM_SOURCE_FALLBACK` to see whether to use upstream source as fallback if fetching from the lookaside cache fails for whatever reason.

Makefile updated to set `BUILDSYS_UPSTREAM_SOURCE_FALLBACK` to `false`, overridable from the command line by passing `-e BUILDSYS_UPSTREAM_SOURCE_FALLBACK=true` to `cargo make`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
