### PR TITLE
Update rpm2migrations process for Bottlerocket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ USER root
 RUN --mount=target=/host \
     mkdir -p /local/rpms /local/migrations ./rpmbuild/RPMS \
     && ln -s /host/build/*.rpm ./rpmbuild/RPMS \
-    && cp /host/build/thar-${ARCH}-migrations-*.rpm /local/migrations \
+    && cp /host/build/bottlerocket-${ARCH}-migrations-*.rpm /local/migrations \
     && createrepo_c \
         -o ./rpmbuild/RPMS \
         -x '*-debuginfo-*.rpm' \

--- a/tools/rpm2migrations
+++ b/tools/rpm2migrations
@@ -14,9 +14,9 @@ done
 
 mkdir -p "${OUTPUT_DIR}"
 
-MIGRATIONS_ARCHIVE="thar-${ARCH}-${VARIANT}-${VERSION_ID}-${BUILD_ID}-migrations.tar"
+MIGRATIONS_ARCHIVE="bottlerocket-${ARCH}-${VARIANT}-${VERSION_ID}-${BUILD_ID}-migrations.tar"
 ROOT_TEMP="$(mktemp -d)"
-SYS_ROOT="${ARCH}-thar-linux-gnu/sys-root"
+SYS_ROOT="${ARCH}-bottlerocket-linux-gnu/sys-root"
 MIGRATIONS_DIR="${ROOT_TEMP}/${SYS_ROOT}/usr/share/migrations"
 
 # "Install" the migrations (just puts them in $MIGRATIONS_DIR)


### PR DESCRIPTION
Due to merge timing, #716 didn't have the Bottlerocket naming.

**Testing done:**

Did a build, saw that it finished and migrations were produced correctly:

```
build/bottlerocket-x86_64-aws-k8s-0.2.2-735fedf8-dirty-migrations.tar
build/bottlerocket-x86_64-migrations-0.0-0.x86_64.rpm
```
```
$ tar tf build/bottlerocket-x86_64-aws-k8s-0.2.2-735fedf8-dirty-migrations.tar
migrate_v0.1_borkseed.lz4
migrate_v0.1_host-containers-version.lz4
migrate_v0.2_containerd-config-path.lz4
migrate_v0.2_host-containers-v03.lz4
migrate_v0.2_remove-region.lz4
```