### PR TITLE
Add bottlerocket-release library for getting /etc/os-release data

### DIFF
--- a/workspaces/Cargo.lock
+++ b/workspaces/Cargo.lock
@@ -425,6 +425,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bottlerocket-release"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "envy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -25,6 +25,10 @@ members = [
     "api/migration/migrations/v0.2/migrate-remove-region",
     "api/migration/migrations/v0.2/migrate-host-containers-v03",
 
+    "bottlerocket-release",
+
+    "growpart",
+
     "models",
 
     "preinit/laika",
@@ -35,8 +39,6 @@ members = [
     "updater/updog",
 
     "webpki-roots-shim",
-
-    "growpart",
 ]
 
 [profile.release]

--- a/workspaces/bottlerocket-release/Cargo.toml
+++ b/workspaces/bottlerocket-release/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bottlerocket-release"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+envy = "0.4"
+log = "0.4"
+semver = { version = "0.9", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+snafu = "0.6"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/workspaces/bottlerocket-release/README.md
+++ b/workspaces/bottlerocket-release/README.md
@@ -1,0 +1,12 @@
+# bottlerocket-release
+
+Current version: 0.1.0
+
+## Background
+
+This library lets you get a BottlerocketRelease struct that represents the data in the /etc/os-release file, or another file you point to.
+The VERSION_ID is returned as a semver::Version for convenience.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/workspaces/bottlerocket-release/README.tpl
+++ b/workspaces/bottlerocket-release/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/workspaces/bottlerocket-release/build.rs
+++ b/workspaces/bottlerocket-release/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/lib.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/workspaces/bottlerocket-release/src/lib.rs
+++ b/workspaces/bottlerocket-release/src/lib.rs
@@ -1,0 +1,89 @@
+/*!
+# Background
+
+This library lets you get a BottlerocketRelease struct that represents the data in the /etc/os-release file, or another file you point to.
+The VERSION_ID is returned as a semver::Version for convenience.
+*/
+
+const DEFAULT_RELEASE_FILE: &str = "/etc/os-release";
+
+use log::debug;
+use semver::Version;
+use serde::Deserialize;
+use snafu::ResultExt;
+use std::fs;
+use std::path::Path;
+
+/// BottlerocketRelease represents the data found in the release file.
+#[derive(Debug, Deserialize, Clone)]
+pub struct BottlerocketRelease {
+    pub pretty_name: String,
+    pub variant_id: String,
+    pub version_id: Version,
+    pub build_id: String,
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::io;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub enum Error {
+        #[snafu(display("Unable to read release file '{}': {}", path.display(), source))]
+        ReadReleaseFile { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Unable to load release data from file '{}': {}", path.display(), source))]
+        LoadReleaseData { path: PathBuf, source: envy::Error },
+    }
+}
+pub use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;
+
+impl BottlerocketRelease {
+    pub fn new() -> Result<Self> {
+        Self::from_file(DEFAULT_RELEASE_FILE)
+    }
+
+    fn from_file<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+
+        let release_data = fs::read_to_string(path).context(error::ReadReleaseFile { path })?;
+
+        // Split and process each line
+        let pairs: Vec<(String, String)> = release_data
+            .lines()
+            .filter_map(|line| {
+                // Allow for comments
+                if line.starts_with("#") {
+                    return None;
+                }
+
+                // Split out KEY=VALUE; if there is no "=" we skip the line
+                let mut parts = line.splitn(2, '=');
+                let key = parts.next().expect("split returned zero parts");
+                let mut value = match parts.next() {
+                    Some(part) => part,
+                    None => return None,
+                };
+                debug!("Found os-release value {}={}", key, value);
+
+                // If the value was quoted (unnecessary in this file) then remove the quotes
+                if value.starts_with('"') {
+                    value = &value[1..];
+                }
+                if value.ends_with('"') {
+                    value = &value[..value.len() - 1];
+                }
+
+                Some((key.to_owned(), value.to_owned()))
+            })
+            .collect();
+
+        envy::from_iter(pairs).context(error::LoadReleaseData { path })
+    }
+}


### PR DESCRIPTION
**Testing done:**

Made a one-line `main.rs`:
```
dbg!(bottlerocket_release::BottlerocketRelease::from_file("home/br-release").unwrap());
```
...and the referenced br-release file:
```
PRETTY_NAME="Bottlerocket OS 0.2.1"
VARIANT_ID=aws-k8s
VERSION_ID=0.2.1
BUILD_ID=build
# hi there
EXTRA=stuff
```
...and it worked:
```
[bottlerocket-release/src/main.rs:2] bottlerocket_release::BottlerocketRelease::from_file("home/br-release").unwrap() = BottlerocketRelease {
    pretty_name: "Bottlerocket OS 0.2.1",
    variant_id: "aws-k8s",
    version_id: Version {
        major: 0,
        minor: 2,
        patch: 1,
        pre: [],
        build: [],
    },
    build_id: "build",
}
```