### PR TITLE
Change remaining 'flavor' references to 'variant'

### DIFF
--- a/extras/dogswatch/pkg/platform/updog/host.go
+++ b/extras/dogswatch/pkg/platform/updog/host.go
@@ -63,7 +63,7 @@ var _ platform.Update = (*availableUpdate)(nil)
 type availableUpdate struct {
 	ID         UpdateID `json:"id"`
 	Applicable bool     `json:"applicable"`
-	Flavor     string   `json:"flavor"`
+	Variant    string   `json:"variant"`
 	Arch       string   `json:"arch"`
 	Version    string   `json:"version"`
 	Status     string   `json:"status"`

--- a/tools/update_sign_tuf_repo/src/main.rs
+++ b/tools/update_sign_tuf_repo/src/main.rs
@@ -15,7 +15,7 @@ In order the run this code, you must have:
 Currently the code expects the following environment variables to be set:
 * `CODEBUILD_SRC_DIR` (subject to change) This is the directory where your `Bottlerocket` repository lives
 * `ARCH` : architecture for your current set of images (i.e. `x86_64`)
-* `FLAVOR` : Variant of Bottlerocket for your current set of images (i.e. `aws-k8s`)
+* `VARIANT` : Variant of Bottlerocket for your current set of images (i.e. `aws-k8s`)
 * `INPUT_BUILDSYS_ARTIFACTS` : A directory containing the built Bottlerocket images
 * `METADATA_URL` : Metadata URL for your existing TUF repo
 * `TARGET_URL` : Target URL for your existing TUF repo
@@ -221,7 +221,7 @@ type Result<T> = std::result::Result<T, error::Error>;
 struct EnvVars {
     codebuild_src_dir: String,
     arch: String,
-    flavor: String,
+    variant: String,
     input_buildsys_artifacts: String,
     metadata_url: String,
     refresh_days: i64,
@@ -326,7 +326,7 @@ fn build_target_names(env: &EnvVars, release: &ReleaseInfo) -> Result<HashMap<St
     let mut map = HashMap::new();
     let name_stub = format!(
         "{}-{}-{}-v{}",
-        OS_NAME, env.arch, env.flavor, release.version
+        OS_NAME, env.arch, env.variant, release.version
     );
     for file in FILES_TO_SIGN {
         let name = match file.as_ref() {
@@ -597,7 +597,7 @@ fn run() -> Result<()> {
             Some(release_semver.clone()),
             datastore_version,
             env_vars.arch.clone(),
-            env_vars.flavor.clone(),
+            env_vars.variant.clone(),
             images,
         )
         .context(error::ManifestUpdate)?;
@@ -611,7 +611,7 @@ fn run() -> Result<()> {
     // First wave starts today
     manifest
         .add_wave(
-            env_vars.flavor.clone(),
+            env_vars.variant.clone(),
             env_vars.arch.clone(),
             release_semver.clone(),
             512,
@@ -621,7 +621,7 @@ fn run() -> Result<()> {
     // Second wave starts tomorrow
     manifest
         .add_wave(
-            env_vars.flavor.clone(),
+            env_vars.variant.clone(),
             env_vars.arch.clone(),
             release_semver.clone(),
             1024,
@@ -631,7 +631,7 @@ fn run() -> Result<()> {
     // Third wave starts the day after tomorrow
     manifest
         .add_wave(
-            env_vars.flavor.clone(),
+            env_vars.variant.clone(),
             env_vars.arch.clone(),
             release_semver.clone(),
             1576,

--- a/workspaces/updater/update_metadata/src/lib.rs
+++ b/workspaces/updater/update_metadata/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Images {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Update {
-    pub flavor: String,
+    pub variant: String,
     pub arch: String,
     pub version: SemVer,
     pub max_version: SemVer,
@@ -140,7 +140,7 @@ impl Manifest {
         max_version: Option<SemVer>,
         datastore_version: DataVersion,
         arch: String,
-        flavor: String,
+        variant: String,
         images: Images,
     ) -> Result<()> {
         let max_version = if let Some(version) = max_version {
@@ -154,7 +154,7 @@ impl Manifest {
             }
         };
         let update = Update {
-            flavor,
+            variant,
             arch,
             version: image_version.clone(),
             max_version: max_version.clone(),
@@ -166,27 +166,27 @@ impl Manifest {
         self.update_max_version(
             &update.max_version,
             Some(&update.arch),
-            Some(&update.flavor),
+            Some(&update.variant),
         );
         self.updates.push(update);
         Ok(())
     }
 
     /// Update the maximum version for all updates that optionally match the
-    /// architecture and flavor of some new update.
+    /// architecture and variant of some new update.
     pub fn update_max_version(
         &mut self,
         version: &SemVer,
         arch: Option<&str>,
-        flavor: Option<&str>,
+        variant: Option<&str>,
     ) {
         let matching: Vec<&mut Update> = self
             .updates
             .iter_mut()
-            .filter(|update| match (arch, flavor) {
-                (Some(arch), Some(flavor)) => update.arch == arch && update.flavor == flavor,
+            .filter(|update| match (arch, variant) {
+                (Some(arch), Some(variant)) => update.arch == arch && update.variant == variant,
                 (Some(arch), None) => update.arch == arch,
-                (None, Some(flavor)) => update.flavor == flavor,
+                (None, Some(variant)) => update.variant == variant,
                 _ => true,
             })
             .collect();
@@ -216,7 +216,7 @@ impl Manifest {
     /// Adds a wave to update, returns number of matching updates for wave
     pub fn add_wave(
         &mut self,
-        flavor: String,
+        variant: String,
         arch: String,
         image_version: SemVer,
         bound: u32,
@@ -227,7 +227,7 @@ impl Manifest {
             .iter_mut()
             // Find the update that exactly matches the specified update
             .filter(|update| {
-                update.arch == arch && update.flavor == flavor && update.version == image_version
+                update.arch == arch && update.variant == variant && update.version == image_version
             })
             .collect();
         let num_matching = matching.len();
@@ -240,7 +240,7 @@ impl Manifest {
 
     pub fn remove_wave(
         &mut self,
-        flavor: String,
+        variant: String,
         arch: String,
         image_version: SemVer,
         bound: u32,
@@ -249,7 +249,7 @@ impl Manifest {
             .updates
             .iter_mut()
             .filter(|update| {
-                update.arch == arch && update.flavor == flavor && update.version == image_version
+                update.arch == arch && update.variant == variant && update.version == image_version
             })
             .collect();
         for update in matching {

--- a/workspaces/updater/updog/README.md
+++ b/workspaces/updater/updog/README.md
@@ -25,7 +25,7 @@ aws-k8s-0.1.1 (v0.0)
 ### Specify JSON output
 ```
 # updog check-update --json
-[{"flavor":"aws-k8s","arch":"x86_64","version":"0.1.4","max_version":"0.1.4","waves":{"512":"2019-10-03T20:45:52Z","1024":"2019-10-03T21:00:52Z","1536":"2019-10-03T22:00:52Z","2048":"2019-10-03T23:00:52Z"},"images":{"boot":"bottlerocket-x86_64-aws-k8s-v0.1.4-boot.ext4.lz4","root":"bottlerocket-x86_64-aws-k8s-v0.1.4-root.ext4.lz4","hash":"bottlerocket-x86_64-aws-k8s-v0.1.4-root.verity.lz4"}}]
+[{"variant":"aws-k8s","arch":"x86_64","version":"0.1.4","max_version":"0.1.4","waves":{"512":"2019-10-03T20:45:52Z","1024":"2019-10-03T21:00:52Z","1536":"2019-10-03T22:00:52Z","2048":"2019-10-03T23:00:52Z"},"images":{"boot":"bottlerocket-x86_64-aws-k8s-v0.1.4-boot.ext4.lz4","root":"bottlerocket-x86_64-aws-k8s-v0.1.4-root.ext4.lz4","hash":"bottlerocket-x86_64-aws-k8s-v0.1.4-root.verity.lz4"}}]
 ```
 
 ### Try to update with wave information

--- a/workspaces/updater/updog/tests/data/bad-bound.json
+++ b/workspaces/updater/updog/tests/data/bad-bound.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.13.0",
       "status": "Ready",

--- a/workspaces/updater/updog/tests/data/duplicate-bound.json
+++ b/workspaces/updater/updog/tests/data/duplicate-bound.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.13.0",
       "status": "Ready",

--- a/workspaces/updater/updog/tests/data/example.json
+++ b/workspaces/updater/updog/tests/data/example.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.13.0",
       "status": "Ready",

--- a/workspaces/updater/updog/tests/data/example_2.json
+++ b/workspaces/updater/updog/tests/data/example_2.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.1.0",
       "status": "Ready",

--- a/workspaces/updater/updog/tests/data/example_3.json
+++ b/workspaces/updater/updog/tests/data/example_3.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "aws-k8s",
+      "variant": "aws-k8s",
       "arch": "x86_64",
       "version": "0.1.1",
       "max_version": "0.1.2",
@@ -16,7 +16,7 @@
       }
     },
     {
-      "flavor": "aws-k8s",
+      "variant": "aws-k8s",
       "arch": "x86_64",
       "version": "0.1.2",
       "max_version": "0.1.2",

--- a/workspaces/updater/updog/tests/data/migrations.json
+++ b/workspaces/updater/updog/tests/data/migrations.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.5.0",
       "status": "Ready",

--- a/workspaces/updater/updog/tests/data/multiple.json
+++ b/workspaces/updater/updog/tests/data/multiple.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.13.0",
       "status": "Ready",
@@ -17,7 +17,7 @@
       }
     },
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.25.0",
       "status": "Ready",
@@ -33,7 +33,7 @@
     }
     },
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.15.0",
       "status": "Ready",
@@ -49,7 +49,7 @@
     }
     },
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "aarch64",
       "version": "1.16.0",
       "status": "Ready",

--- a/workspaces/updater/updog/tests/data/regret.json
+++ b/workspaces/updater/updog/tests/data/regret.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.25.0",
       "status": "Ready",

--- a/workspaces/updater/updog/tests/data/single_wave.json
+++ b/workspaces/updater/updog/tests/data/single_wave.json
@@ -1,7 +1,7 @@
 {
   "updates": [
     {
-      "flavor": "bottlerocket-aws-eks",
+      "variant": "bottlerocket-aws-eks",
       "arch": "x86_64",
       "version": "1.13.0",
       "status": "Ready",


### PR DESCRIPTION
**NOTE: This is a breaking change not to be merged until corresponding fixes have been made to TUF metadata and `manifest.json`!!**

*Issue #, if available:*
Related to #587 

*Description of changes:*
Any remaining references to 'flavor' in the 'updater' workspace
have been changed to 'variant'. This will require a corresponding
change the the 'manifest.json' but that will be handled separately.

*Testing done:*
* Build completes successfully
* All unit tests pass
* Booted image appropriately fails to parse our existing metadata:
```
[   62.787905] updog[3792]: Failed to parse updates manifest: missing field `variant` at line 17 column 5
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
