### PR TITLE
kubernetes: update to v1.15.10

### DIFF
--- a/packages/kubernetes/0002-do-not-omit-debug-info.patch
+++ b/packages/kubernetes/0002-do-not-omit-debug-info.patch
@@ -12,11 +12,11 @@ diff --git a/hack/lib/golang.sh b/hack/lib/golang.sh
 index a82880a5..5454e73f 100755
 --- a/hack/lib/golang.sh
 +++ b/hack/lib/golang.sh
-@@ -779,7 +779,7 @@ kube::golang::build_binaries() {
-     host_platform=$(kube::golang::host_platform)
- 
-     local goflags goldflags goasmflags gogcflags
--    goldflags="${GOLDFLAGS:-} -s -w $(kube::version::ldflags)"
+@@ -790,7 +790,7 @@ kube::golang::build_binaries() {
+     # Disable SC2153 for this, as it will throw a warning that the local
+     # variable goldflags will exist, and it suggest changing it to this.
+     # shellcheck disable=SC2153
+-    goldflags="${GOLDFLAGS=-s -w} $(kube::version::ldflags)"
 +    goldflags="${GOLDFLAGS:-} $(kube::version::ldflags)"
      goasmflags="-trimpath=${KUBE_ROOT}"
      gogcflags="${GOGCFLAGS:-} -trimpath=${KUBE_ROOT}"

--- a/packages/kubernetes/0003-enable-PIE-for-platform-binaries.patch
+++ b/packages/kubernetes/0003-enable-PIE-for-platform-binaries.patch
@@ -12,7 +12,7 @@ diff --git a/hack/lib/golang.sh b/hack/lib/golang.sh
 index 5454e73f..a146fc28 100755
 --- a/hack/lib/golang.sh
 +++ b/hack/lib/golang.sh
-@@ -709,6 +709,7 @@ kube::golang::build_binaries_for_platform() {
+@@ -715,6 +715,7 @@ kube::golang::build_binaries_for_platform() {
  
    if [[ "${#nonstatics[@]}" != 0 ]]; then
      build_args=(

--- a/packages/kubernetes/0004-opt-out-of-module-mode-for-builds.patch
+++ b/packages/kubernetes/0004-opt-out-of-module-mode-for-builds.patch
@@ -1,0 +1,408 @@
+From d40d5a759f518d788427b917ca30dfd4c6d701be Mon Sep 17 00:00:00 2001
+From: Jordan Liggitt <liggitt@google.com>
+Date: Wed, 12 Jun 2019 13:52:50 -0400
+Subject: [PATCH] opt out of module mode for builds
+
+Added with Go 1.13 support: kubernetes/kubernetes#82809
+https://github.com/kubernetes/kubernetes/pull/82809
+
+Go modules fixed with kubernetes/kubernetes@8618c09 (this patch)
+https://github.com/kubernetes/kubernetes/commit/8618c09
+
+---
+ hack/jenkins/benchmark-dockerized.sh |   9 ++-
+ hack/jenkins/test-dockerized.sh      |   7 +-
+ hack/lib/init.sh                     |  15 +++-
+ hack/make-rules/test.sh              | 115 +++++++++++----------------
+ 4 files changed, 71 insertions(+), 75 deletions(-)
+
+diff --git a/hack/jenkins/benchmark-dockerized.sh b/hack/jenkins/benchmark-dockerized.sh
+index 9e817a09e39..aa2d58deadc 100755
+--- a/hack/jenkins/benchmark-dockerized.sh
++++ b/hack/jenkins/benchmark-dockerized.sh
+@@ -38,8 +38,13 @@ retry() {
+ 
+ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
+ 
++# Until all GOPATH references are removed from all build scripts as well,
++# explicitly disable module mode to avoid picking up user-set GO111MODULE preferences.
++# As individual scripts make use of go modules, they can explicitly set GO111MODULE=on
++export GO111MODULE=off
++
+ go install k8s.io/kubernetes/vendor/github.com/cespare/prettybench
+-go install k8s.io/kubernetes/vendor/github.com/jstemmer/go-junit-report
++go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum
+ 
+ # Disable the Go race detector.
+ export KUBE_RACE=" "
+@@ -49,7 +54,7 @@ export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
+ export FULL_LOG="true"
+ 
+ mkdir -p "${ARTIFACTS}"
+-cd /go/src/k8s.io/kubernetes
++cd "${GOPATH}/src/k8s.io/kubernetes"
+ 
+ ./hack/install-etcd.sh
+ 
+diff --git a/hack/jenkins/test-dockerized.sh b/hack/jenkins/test-dockerized.sh
+index c1660289750..c55b55284bd 100755
+--- a/hack/jenkins/test-dockerized.sh
++++ b/hack/jenkins/test-dockerized.sh
+@@ -37,7 +37,12 @@ retry() {
+ 
+ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
+ 
+-go install k8s.io/kubernetes/vendor/github.com/jstemmer/go-junit-report
++# Until all GOPATH references are removed from all build scripts as well,
++# explicitly disable module mode to avoid picking up user-set GO111MODULE preferences.
++# As individual scripts make use of go modules, they can explicitly set GO111MODULE=on
++export GO111MODULE=off
++
++go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum
+ 
+ # Enable the Go race detector.
+ export KUBE_RACE=-race
+diff --git a/hack/lib/init.sh b/hack/lib/init.sh
+index 42f34567db9..dffbc01e113 100755
+--- a/hack/lib/init.sh
++++ b/hack/lib/init.sh
+@@ -23,13 +23,13 @@ set -o pipefail
+ unset CDPATH
+ 
+ # Until all GOPATH references are removed from all build scripts as well,
+-# explicitly reset to auto mode to avoid picking up user-set GO111MODULE preferences.
++# explicitly disable module mode to avoid picking up user-set GO111MODULE preferences.
+ # As individual scripts (like hack/update-vendor.sh) make use of go modules,
+ # they can explicitly set GO111MODULE=on
+-export GO111MODULE=auto
++export GO111MODULE=off
+ 
+ # The root of the build/dist directory
+-KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../.." && pwd -P)"
++KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+ 
+ KUBE_OUTPUT_SUBPATH="${KUBE_OUTPUT_SUBPATH:-_output/local}"
+ KUBE_OUTPUT="${KUBE_ROOT}/${KUBE_OUTPUT_SUBPATH}"
+@@ -44,7 +44,7 @@ KUBE_RSYNC_COMPRESS="${KUBE_RSYNC_COMPRESS:-0}"
+ export no_proxy=127.0.0.1,localhost
+ 
+ # This is a symlink to binaries for "this platform", e.g. build tools.
+-THIS_PLATFORM_BIN="${KUBE_ROOT}/_output/bin"
++export THIS_PLATFORM_BIN="${KUBE_ROOT}/_output/bin"
+ 
+ source "${KUBE_ROOT}/hack/lib/util.sh"
+ source "${KUBE_ROOT}/hack/lib/logging.sh"
+@@ -56,13 +56,16 @@ source "${KUBE_ROOT}/hack/lib/golang.sh"
+ source "${KUBE_ROOT}/hack/lib/etcd.sh"
+ 
+ KUBE_OUTPUT_HOSTBIN="${KUBE_OUTPUT_BINPATH}/$(kube::util::host_platform)"
++export KUBE_OUTPUT_HOSTBIN
+ 
+ # list of all available group versions.  This should be used when generated code
+ # or when starting an API server that you want to have everything.
+ # most preferred version for a group should appear first
+ KUBE_AVAILABLE_GROUP_VERSIONS="${KUBE_AVAILABLE_GROUP_VERSIONS:-\
+ v1 \
++admissionregistration.k8s.io/v1 \
+ admissionregistration.k8s.io/v1beta1 \
++admission.k8s.io/v1 \
+ admission.k8s.io/v1beta1 \
+ apps/v1 \
+ apps/v1beta1 \
+@@ -81,6 +84,7 @@ batch/v2alpha1 \
+ certificates.k8s.io/v1beta1 \
+ coordination.k8s.io/v1beta1 \
+ coordination.k8s.io/v1 \
++discovery.k8s.io/v1alpha1 \
+ extensions/v1beta1 \
+ events.k8s.io/v1beta1 \
+ imagepolicy.k8s.io/v1alpha1 \
+@@ -99,6 +103,7 @@ settings.k8s.io/v1alpha1 \
+ storage.k8s.io/v1beta1 \
+ storage.k8s.io/v1 \
+ storage.k8s.io/v1alpha1 \
++flowcontrol.apiserver.k8s.io/v1alpha1 \
+ }"
+ 
+ # not all group versions are exposed by the server.  This list contains those
+@@ -108,8 +113,10 @@ KUBE_NONSERVER_GROUP_VERSIONS="
+  abac.authorization.kubernetes.io/v1beta1 \
+  componentconfig/v1alpha1 \
+  imagepolicy.k8s.io/v1alpha1\
++ admission.k8s.io/v1\
+  admission.k8s.io/v1beta1\
+ "
++export KUBE_NONSERVER_GROUP_VERSIONS
+ 
+ # This emulates "readlink -f" which is not available on MacOS X.
+ # Test:
+diff --git a/hack/make-rules/test.sh b/hack/make-rules/test.sh
+index b215aa147ba..4dc755988df 100755
+--- a/hack/make-rules/test.sh
++++ b/hack/make-rules/test.sh
+@@ -18,7 +18,7 @@ set -o errexit
+ set -o nounset
+ set -o pipefail
+ 
+-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
++KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+ source "${KUBE_ROOT}/hack/lib/init.sh"
+ 
+ kube::golang::setup_env
+@@ -43,7 +43,7 @@ fi
+ 
+ kube::test::find_dirs() {
+   (
+-    cd ${KUBE_ROOT}
++    cd "${KUBE_ROOT}"
+     find -L . -not \( \
+         \( \
+           -path './_artifacts/*' \
+@@ -65,49 +65,16 @@ kube::test::find_dirs() {
+         \) -prune \
+       \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed "s|^\./|${KUBE_GO_PACKAGE}/|" | LC_ALL=C sort -u
+ 
+-    find -L . \
+-        -path './_output' -prune \
+-        -o -path './vendor/k8s.io/client-go/*' \
+-        -o -path './vendor/k8s.io/apiserver/*' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed "s|^\./|${KUBE_GO_PACKAGE}/|" | LC_ALL=C sort -u
+-
+-    # run tests for client-go
+-    find ./staging/src/k8s.io/client-go -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+-
+-    # run tests for apiserver
+-    find ./staging/src/k8s.io/apiserver -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+-
+-    # run tests for apimachinery
+-    find ./staging/src/k8s.io/apimachinery -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+-
+-    find ./staging/src/k8s.io/kube-aggregator -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+-
+-    find ./staging/src/k8s.io/apiextensions-apiserver -not \( \
+-        \( \
+-          -path '*/test/integration/*' \
+-        \) -prune \
+-      \) -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+-
+-    find ./staging/src/k8s.io/sample-apiserver -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+-
+-    find ./staging/src/k8s.io/cli-runtime -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+-
+-    # add legacy cloud providers tests 
+-    find ./staging/src/k8s.io/legacy-cloud-providers -name '*_test.go' \
+-      -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
++    find ./staging -name '*_test.go' -not -path '*/test/integration/*' -prune -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u
+   )
+ }
+ 
+-KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 120s}
++KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout=120s}
+ KUBE_COVER=${KUBE_COVER:-n} # set to 'y' to enable coverage collection
+ KUBE_COVERMODE=${KUBE_COVERMODE:-atomic}
++# The directory to save test coverage reports to, if generating them. If unset,
++# a semi-predictable temporary directory will be used.
++KUBE_COVER_REPORT_DIR="${KUBE_COVER_REPORT_DIR:-}"
+ # How many 'go test' instances to run simultaneously when running tests in
+ # coverage mode.
+ KUBE_COVERPROCS=${KUBE_COVERPROCS:-4}
+@@ -165,12 +132,12 @@ while getopts "hp:i:" opt ; do
+       kube::test::usage
+       exit 1
+       ;;
+-    ?)
++    :)
++      kube::log::usage "Option -${OPTARG} <value>"
+       kube::test::usage
+       exit 1
+       ;;
+-    :)
+-      kube::log::usage "Option -${OPTARG} <value>"
++    ?)
+       kube::test::usage
+       exit 1
+       ;;
+@@ -179,15 +146,17 @@ done
+ shift $((OPTIND - 1))
+ 
+ # Use eval to preserve embedded quoted strings.
++testargs=()
+ eval "testargs=(${KUBE_TEST_ARGS:-})"
+ 
+ # Used to filter verbose test output.
+ go_test_grep_pattern=".*"
+ 
+-# The go-junit-report tool needs full test case information to produce a
++# The junit report tool needs full test case information to produce a
+ # meaningful report.
+ if [[ -n "${KUBE_JUNIT_REPORT_DIR}" ]] ; then
+   goflags+=(-v)
++  goflags+=(-json)
+   # Show only summary lines by matching lines like "status package/test"
+   go_test_grep_pattern="^[^[:space:]]\+[[:space:]]\+[^[:space:]]\+/[^[[:space:]]\+"
+ fi
+@@ -206,10 +175,14 @@ for arg; do
+   fi
+ done
+ if [[ ${#testcases[@]} -eq 0 ]]; then
+-  testcases=($(kube::test::find_dirs))
++  while IFS='' read -r line; do testcases+=("$line"); done < <(kube::test::find_dirs)
+ fi
+ set -- "${testcases[@]+${testcases[@]}}"
+ 
++if [[ -n "${KUBE_RACE}" ]] ; then
++  goflags+=("${KUBE_RACE}")
++fi
++
+ junitFilenamePrefix() {
+   if [[ -z "${KUBE_JUNIT_REPORT_DIR}" ]]; then
+     echo ""
+@@ -221,7 +194,8 @@ junitFilenamePrefix() {
+   # barely fits there and in coverage mode test names are
+   # appended to generated file names, easily exceeding
+   # 255 chars in length. So let's just use a sha1 hash of it.
+-  local KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"| ${SHA1SUM} |awk '{print $1}')"
++  local KUBE_TEST_API_HASH
++  KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"| ${SHA1SUM} |awk '{print $1}')"
+   echo "${KUBE_JUNIT_REPORT_DIR}/junit_${KUBE_TEST_API_HASH}_$(kube::util::sortable_date)"
+ }
+ 
+@@ -239,7 +213,8 @@ verifyAndSuggestPackagePath() {
+     # Because k8s sets a localized $GOPATH for testing, seeing the actual
+     # directory can be confusing. Instead, just show $GOPATH if it exists in the
+     # $specified_package_path.
+-    local printable_package_path=$(echo "${specified_package_path}" | sed "s|${GOPATH}|\${GOPATH}|")
++    local printable_package_path
++    printable_package_path=${specified_package_path//${GOPATH}/\$\{GOPATH\}}
+     kube::log::error "specified test path '${printable_package_path}' does not exist"
+ 
+     if [ -d "${alternative_package_path}" ]; then
+@@ -250,7 +225,7 @@ verifyAndSuggestPackagePath() {
+ }
+ 
+ verifyPathsToPackagesUnderTest() {
+-  local packages_under_test=($@)
++  local packages_under_test=("$@")
+ 
+   for package_path in "${packages_under_test[@]}"; do
+     local local_package_path="${package_path}"
+@@ -270,19 +245,19 @@ produceJUnitXMLReport() {
+     return
+   fi
+ 
+-  local test_stdout_filenames
+   local junit_xml_filename
+-  test_stdout_filenames=$(ls ${junit_filename_prefix}*.stdout)
+   junit_xml_filename="${junit_filename_prefix}.xml"
+-  if ! command -v go-junit-report >/dev/null 2>&1; then
+-    kube::log::error "go-junit-report not found; please install with " \
+-      "go get -u github.com/jstemmer/go-junit-report"
++
++  if ! command -v gotestsum >/dev/null 2>&1; then
++    kube::log::error "gotestsum not found; please install with " \
++      "GO111MODULE=off go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum"
+     return
+   fi
+-  cat ${test_stdout_filenames} | go-junit-report > "${junit_xml_filename}"
++  gotestsum --junitfile "${junit_xml_filename}" --raw-command cat "${junit_filename_prefix}"*.stdout
+   if [[ ! ${KUBE_KEEP_VERBOSE_TEST_OUTPUT} =~ ^[yY]$ ]]; then
+-    rm ${test_stdout_filenames}
++    rm "${junit_filename_prefix}"*.stdout
+   fi
++
+   kube::log::status "Saved JUnit XML test report to ${junit_xml_filename}"
+ }
+ 
+@@ -297,7 +272,7 @@ runTests() {
+   if [[ ! ${KUBE_COVER} =~ ^[yY]$ ]]; then
+     kube::log::status "Running tests without code coverage"
+     go test "${goflags[@]:+${goflags[@]}}" \
+-      ${KUBE_RACE} ${KUBE_TIMEOUT} "${@}" \
++     "${KUBE_TIMEOUT}" "${@}" \
+      "${testargs[@]:+${testargs[@]}}" \
+      | tee ${junit_filename_prefix:+"${junit_filename_prefix}.stdout"} \
+      | grep --binary-files=text "${go_test_grep_pattern}" && rc=$? || rc=$?
+@@ -307,7 +282,11 @@ runTests() {
+ 
+   # Create coverage report directories.
+   KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"| ${SHA1SUM} |awk '{print $1}')"
+-  cover_report_dir="/tmp/k8s_coverage/${KUBE_TEST_API_HASH}/$(kube::util::sortable_date)"
++  if [[ -z "${KUBE_COVER_REPORT_DIR}" ]]; then
++    cover_report_dir="/tmp/k8s_coverage/${KUBE_TEST_API_HASH}/$(kube::util::sortable_date)"
++  else
++    cover_report_dir="${KUBE_COVER_REPORT_DIR}"
++  fi
+   cover_profile="coverage.out"  # Name for each individual coverage profile
+   kube::log::status "Saving coverage output in '${cover_report_dir}'"
+   mkdir -p "${@+${@/#/${cover_report_dir}/}}"
+@@ -328,21 +307,20 @@ runTests() {
+   # vendor/k8s.io/client-go/1.4/rest: causes cover internal errors
+   #                            https://github.com/golang/go/issues/16540
+   cover_ignore_dirs="vendor/k8s.io/code-generator/cmd/generator|vendor/k8s.io/client-go/1.4/rest"
+-  for path in $(echo ${cover_ignore_dirs} | sed 's/|/ /g'); do
++  for path in ${cover_ignore_dirs//|/ }; do
+       echo -e "skipped\tk8s.io/kubernetes/${path}"
+   done
+ 
+   printf "%s\n" "${@}" \
+     | grep -Ev ${cover_ignore_dirs} \
+-    | xargs -I{} -n 1 -P ${KUBE_COVERPROCS} \
++    | xargs -I{} -n 1 -P "${KUBE_COVERPROCS}" \
+     bash -c "set -o pipefail; _pkg=\"\$0\"; _pkg_out=\${_pkg//\//_}; \
+-      go test ${goflags[@]:+${goflags[@]}} \
+-        ${KUBE_RACE} \
++      go test ${goflags[*]:+${goflags[*]}} \
+         ${KUBE_TIMEOUT} \
+         -cover -covermode=\"${KUBE_COVERMODE}\" \
+         -coverprofile=\"${cover_report_dir}/\${_pkg}/${cover_profile}\" \
+         \"\${_pkg}\" \
+-        ${testargs[@]:+${testargs[@]}} \
++        ${testargs[*]:+${testargs[*]}} \
+       | tee ${junit_filename_prefix:+\"${junit_filename_prefix}-\$_pkg_out.stdout\"} \
+       | grep \"${go_test_grep_pattern}\"" \
+     {} \
+@@ -360,9 +338,9 @@ runTests() {
+ 
+     # Include all coverage reach data in the combined profile, but exclude the
+     # 'mode' lines, as there should be only one.
+-    for x in `find "${cover_report_dir}" -name "${cover_profile}"`; do
+-      cat ${x} | grep -h -v "^mode:" || true
+-    done
++    while IFS='' read -r x; do
++      grep -h -v "^mode:" < "${x}" || true
++    done < <(find "${cover_report_dir}" -name "${cover_profile}")
+   } >"${COMBINED_COVER_PROFILE}"
+ 
+   coverage_html_file="${cover_report_dir}/combined-coverage.html"
+@@ -385,7 +363,8 @@ reportCoverageToCoveralls() {
+ checkFDs() {
+   # several unittests panic when httptest cannot open more sockets
+   # due to the low default files limit on OS X.  Warn about low limit.
+-  local fileslimit="$(ulimit -n)"
++  local fileslimit
++  fileslimit="$(ulimit -n)"
+   if [[ ${fileslimit} -lt 1000 ]]; then
+     echo "WARNING: ulimit -n (files) should be at least 1000, is ${fileslimit}, may cause test failure";
+   fi
+@@ -395,9 +374,9 @@ checkFDs
+ 
+ 
+ # Convert the CSVs to arrays.
+-IFS=';' read -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
++IFS=';' read -r -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
+ apiVersionsCount=${#apiVersions[@]}
+-for (( i=0; i<${apiVersionsCount}; i++ )); do
++for (( i=0; i<apiVersionsCount; i++ )); do
+   apiVersion=${apiVersions[i]}
+   echo "Running tests for APIVersion: ${apiVersion}"
+   # KUBE_TEST_API sets the version of each group to be tested.
+-- 
+2.17.1
+

--- a/packages/kubernetes/Cargo.toml
+++ b/packages/kubernetes/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.14.10/kubernetes-1.14.10.tar.gz"
-sha512 = "25ecc7bf737e7cbac6405042ced98ccf824ee9a59f290906b76594ab8742028a5b783e892a5b3a03b59a758641f2fe3dfe6a83d72c603103ec7ab0696e406dfc"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.15.10/kubernetes-1.15.10.tar.gz"
+sha512 = "48c069d88a0111072ac02aed0760bc34ae44fbb5140489a837f089a6c944b5fa18f95f4bcc4286ca1fdfd6cd25e7bd0ff99c3b21373a1d70d3a0f70d352d4ed8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes/kubernetes.spec
+++ b/packages/kubernetes/kubernetes.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.14.10
+%global gover 1.15.10
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -24,6 +24,10 @@ Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 Patch2: 0002-do-not-omit-debug-info.patch
 Patch3: 0003-enable-PIE-for-platform-binaries.patch
+
+# Fix builds in $GOPATH when using Go 1.13 - drop when we catch up in v1.17.0
+# https://github.com/kubernetes/kubernetes/commit/8618c09
+Patch4: 0004-opt-out-of-module-mode-for-builds.patch 
 
 BuildRequires: git
 BuildRequires: rsync


### PR DESCRIPTION
*Issue*

N/A

*Description*

Update Kubernetes (`kubelet`) to `1.15.10`.

*Testing*

Built an AMI with this branch's parent being `ed05e4e - Merge pull request #632 from bottlerocket-os/bonus-metrics` (includes the kernel 5.4). Ran the AMI on 3 nodes in an EKS 1.14 cluster.

Ran Sonobuoy tests with success:

```
Plugin: e2e
Status: passed
Total: 3586
Passed: 204
Failed: 0
Skipped: 3382

Plugin: systemd-logs
Status: passed
Total: 3
Passed: 3
Failed: 0
Skipped: 0
```

Also ran `export VARIANT=aws-k8s && cargo make unit-tests` without any failures.