### PR TITLE
Add 'set-migrations' subcommand to updata

### DIFF
--- a/workspaces/updater/update_metadata/src/lib.rs
+++ b/workspaces/updater/update_metadata/src/lib.rs
@@ -80,6 +80,17 @@ pub struct Manifest {
     pub datastore_versions: BTreeMap<SemVer, DataVersion>,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Release {
+    pub version: String,
+    /// For now, this matches the Manifest struct, but having a separate struct gives us the
+    /// flexibility to have a different, human-oriented representation in the release TOML compared
+    /// to the machine-oriented representation in the manifest.
+    #[serde(deserialize_with = "de::deserialize_migration")]
+    #[serde(serialize_with = "se::serialize_migration")]
+    pub migrations: BTreeMap<(DataVersion, DataVersion), Vec<String>>,
+}
+
 pub fn load_file(path: &Path) -> Result<Manifest> {
     let file = File::open(path).context(error::ManifestRead { path })?;
     serde_json::from_reader(file).context(error::ManifestParse)

--- a/workspaces/updater/updog/src/error.rs
+++ b/workspaces/updater/updog/src/error.rs
@@ -176,6 +176,13 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failed to parse release metadata file '{}': {}", path.display(), source))]
+    ReleaseParse {
+        path: PathBuf,
+        source: toml::de::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Failed setting permissions of '{}': {}", path.display(), source))]
     SetPermissions {
         path: PathBuf,
@@ -201,9 +208,7 @@ pub(crate) enum Error {
     },
 
     #[snafu(display("No update available"))]
-    UpdateNotAvailable {
-        backtrace: Backtrace,
-    },
+    UpdateNotAvailable { backtrace: Backtrace },
 
     #[snafu(display("Update {} exists but wave in the future", version))]
     UpdateNotReady {

--- a/workspaces/updater/updog/tests/data/release.toml
+++ b/workspaces/updater/updog/tests/data/release.toml
@@ -1,0 +1,6 @@
+version = "0.2.2"
+
+[migrations]
+"(0.0, 0.2)" = ["migrate_0.1_foo", "migrate_0.1_baz", "migrate_0.2_bar"]
+"(0.2, 0.3)" = ["migrate_0.3_foobar"]
+"(0.0, 0.1)" = ["migrate_0.1_foo", "migrate_0.1_baz"]


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
This commit adds a 'set-migrations' subcommand to updata that will
copy the migrations section from a file to another file. This
subcommand replaces the `add-migration` and `remove-migration`
subcommands. It is meant to be used to take migrations data from
`Release.toml` and copy it to `manifest.json`.

**Testing done:**
* Added new unit tests for new functionality
* All unit tests continue to pass
* Built image boots successfully

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
