### PR TITLE
Build stable image paths using symlinks in build/latest/

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,8 +56,8 @@ First, decompress the images.
 (Note: these filenames assume an `x86_64` architecture and `aws-k8s` [variant](README.md).)
 
 ```
-lz4 -d build/bottlerocket-x86_64-aws-k8s.img.lz4 build/bottlerocket-x86_64-aws-k8s.img && \
-lz4 -d build/bottlerocket-x86_64-aws-k8s-data.img.lz4 build/bottlerocket-x86_64-aws-k8s-data.img
+lz4 -d build/latest/bottlerocket-x86_64-aws-k8s.img.lz4 && \
+lz4 -d build/latest/bottlerocket-x86_64-aws-k8s-data.img.lz4
 ```
 
 Next, register an AMI:
@@ -65,8 +65,8 @@ Next, register an AMI:
 ```
 bin/amiize.sh --name YOUR-AMI-NAME-HERE \
               --ssh-keypair YOUR-EC2-SSH-KEYPAIR-NAME-HERE \
-              --root-image build/bottlerocket-x86_64-aws-k8s.img \
-              --data-image build/bottlerocket-x86_64-aws-k8s-data.img \
+              --root-image build/latest/bottlerocket-x86_64-aws-k8s.img \
+              --data-image build/latest/bottlerocket-x86_64-aws-k8s-data.img \
               --region us-west-2 \
               --instance-type m3.xlarge \
               --arch x86_64 \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -166,10 +166,47 @@ script = [
 '''
 ]
 
+[tasks.link-clean]
+dependencies = ["fetch"]
+script = [
+'''
+PREFIX="bottlerocket-${BUILDSYS_ARCH}-${BUILDSYS_VARIANT}"
+for link in ${BUILDSYS_OUTPUT_DIR}/latest/${PREFIX}*; do
+  if [ -L "${link}" ]; then
+    rm ${link}
+  fi
+done
+'''
+]
+
+[tasks.link-variant]
+dependencies = ["build-variant"]
+script = [
+'''
+PREFIX="bottlerocket-${BUILDSYS_ARCH}-${BUILDSYS_VARIANT}"
+VERSIONED="${PREFIX}-${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
+mkdir -p ${BUILDSYS_OUTPUT_DIR}/latest
+ln -snf ../${VERSIONED}.img.lz4 \
+  ${BUILDSYS_OUTPUT_DIR}/latest/${PREFIX}.img.lz4
+ln -snf ../${VERSIONED}-data.img.lz4 \
+  ${BUILDSYS_OUTPUT_DIR}/latest/${PREFIX}-data.img.lz4
+ln -snf ../${VERSIONED}-boot.ext4.lz4 \
+  ${BUILDSYS_OUTPUT_DIR}/latest/${PREFIX}-boot.ext4.lz4
+ln -snf ../${VERSIONED}-root.ext4.lz4 \
+  ${BUILDSYS_OUTPUT_DIR}/latest/${PREFIX}-root.ext4.lz4
+ln -snf ../${VERSIONED}-root.verity.lz4 \
+  ${BUILDSYS_OUTPUT_DIR}/latest/${PREFIX}-root.verity.lz4
+ln -snf ../${VERSIONED}-migrations.tar \
+  ${BUILDSYS_OUTPUT_DIR}/latest/${PREFIX}-migrations.tar
+'''
+]
+
 [tasks.build]
 dependencies = [
+    "link-clean",
     "build-variant",
     "check-licenses",
+    "link-variant",
 ]
 
 [tasks.world]
@@ -188,6 +225,7 @@ rm -f ${BUILDSYS_TOOLS_DIR}/bin/buildsys
 for ext in rpm tar lz4 img ; do
   rm -f ${BUILDSYS_OUTPUT_DIR}/*.${ext}
 done
+rm -rf ${BUILDSYS_OUTPUT_DIR}/latest
 rm -rf html
 '''
 ]

--- a/bin/amiize.sh
+++ b/bin/amiize.sh
@@ -31,8 +31,8 @@
 # Tested with the Amazon Linux AMI as worker AMI.
 # Example call:
 #    bin/amiize.sh --region us-west-2 \
-#       --root-image build/bottlerocket-x86_64-aws-k8s.img \
-#       --data-image build/bottlerocket-x86_64-aws-k8s-data.img \
+#       --root-image build/latest/bottlerocket-x86_64-aws-k8s.img \
+#       --data-image build/latest/bottlerocket-x86_64-aws-k8s-data.img \
 #       --worker-ami ami-0f2176987ee50226e --ssh-keypair tjk \
 #       --instance-type m3.xlarge --name bottlerocket-20190918-01 --arch x86_64 \
 #       --user-data 'I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK'
@@ -356,8 +356,8 @@ if [ -n "${registered_ami}" ]; then
 fi
 
 # Determine the size of the images (in G, for EBS)
-# 2G      bottlerocket-x86_64.img
-# 8G      bottlerocket-x86_64-data.img
+# 2G      bottlerocket-x86_64-aws-k8s.img
+# 8G      bottlerocket-x86_64-aws-k8s-data.img
 # This is overridden by --root-volume-size and --data-volume-size if you pass those options.
 root_image_size=$(du --apparent-size --block-size=G "${ROOT_IMAGE}" | sed -r 's,^([0-9]+)G\t.*,\1,')
 if [ ! "${root_image_size}" -gt 0 ]; then


### PR DESCRIPTION
**Issue number:**

Fixes #725

**Description of changes:**

This adds stable paths for the most recently built artifacts of each arch/variant combination.  Stable paths make our builds easier for newcomers to understand, make the setup experience easier to document, and make it easier to do informal scripting around build processes.  The links are in a new directory to reduce the chance of using them accidentally.

**Testing done:**

I built aws-k8s and saw the links in place:

```
$ ll build/latest
total 80K
drwxr-xr-x 2 tjk domain^users 4.0K 02-21 12:13 ./
drwxr-xr-x 3 tjk domain^users  52K 02-21 12:13 ../
lrwxrwxrwx 1 tjk domain^users   65 02-21 12:13 bottlerocket-x86_64-aws-k8s-boot.ext4.lz4 -> ../bottlerocket-x86_64-aws-k8s-0.2.2-a1d831a5-dirty-boot.ext4.lz4
lrwxrwxrwx 1 tjk domain^users   64 02-21 12:13 bottlerocket-x86_64-aws-k8s-data.img.lz4 -> ../bottlerocket-x86_64-aws-k8s-0.2.2-a1d831a5-dirty-data.img.lz4
lrwxrwxrwx 1 tjk domain^users   59 02-21 12:13 bottlerocket-x86_64-aws-k8s.img.lz4 -> ../bottlerocket-x86_64-aws-k8s-0.2.2-a1d831a5-dirty.img.lz4
lrwxrwxrwx 1 tjk domain^users   66 02-21 12:13 bottlerocket-x86_64-aws-k8s-migrations.tar -> ../bottlerocket-x86_64-aws-k8s-0.2.2-a1d831a5-dirty-migrations.tar
lrwxrwxrwx 1 tjk domain^users   65 02-21 12:13 bottlerocket-x86_64-aws-k8s-root.ext4.lz4 -> ../bottlerocket-x86_64-aws-k8s-0.2.2-a1d831a5-dirty-root.ext4.lz4
lrwxrwxrwx 1 tjk domain^users   67 02-21 12:13 bottlerocket-x86_64-aws-k8s-root.verity.lz4 -> ../bottlerocket-x86_64-aws-k8s-0.2.2-a1d831a5-dirty-root.verity.lz4
```

I rebuilt aws-k8s and saw the links disappear during the build, then reappear at the end.

I built aws-dev and saw that the aws-k8s links were not touched, and aws-dev links were created at the end.