### PR TITLE
Check licenses before building rather than after

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,6 +14,11 @@ BUILDSYS_VARIANT = "aws-k8s"
 # Disallow pulling directly Upstream URLs when lookaside cache results in MISSes as a fallback.
 # To use the upstream source as fallback, override this on the command line and set it to 'true'
 BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"
+# We require license checks to pass to build an image.  If you're working on a
+# local change and don't have license information yet, you can run with `-e
+# BUILDSYS_ALLOW_FAILED_LICENSE_CHECK=true` to allow the build to continue even
+# if the license check fails.
+BUILDSYS_ALLOW_FAILED_LICENSE_CHECK = "false"
 
 CARGO_HOME = "${BUILDSYS_ROOT_DIR}/.cargo"
 CARGO_MAKE_CARGO_ARGS = "--jobs 8 --offline --locked"
@@ -161,8 +166,10 @@ alias = "build-variant"
 dependencies = ["fetch"]
 script = [
 '''
+[ "${BUILDSYS_ALLOW_FAILED_LICENSE_CHECK}" = "true" ] && set +e
 (cd sources && cargo deny check --disable-fetch licenses)
 (cd tools/buildsys && cargo deny check --disable-fetch licenses)
+set -e
 '''
 ]
 
@@ -204,8 +211,8 @@ ln -snf ../${VERSIONED}-migrations.tar \
 [tasks.build]
 dependencies = [
     "link-clean",
-    "build-variant",
     "check-licenses",
+    "build-variant",
     "link-variant",
 ]
 


### PR DESCRIPTION
If a license is incorrect and will be rejected, it's good to know that before
you've spent time building the project.

As an example, if the license in a Cargo.toml file is wrong and will be
rejected, but we check after the build, you have to rebuild that package even
though none of the source has changed.

---

**Testing done:**

I ran a build and check-licenses passed.

I then changed apiserver's Cargo.toml to have `license = "Very-Bad-License"` and saw it fail immediately, rather than building the whole OS, failing, and then requiring me to rebuild apiserver and the OS images.

I then built with `cargo make -e BUILDSYS_ALLOW_FAILED_LICENSE_CHECK=true` and saw the license error, but saw the build continue anyway.