### PR TITLE
Switch to new update URIs

### DIFF
--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -32,8 +32,11 @@ template-path = "/usr/share/templates/containerd-config-toml"
 # Updates.
 
 [settings.updates]
-metadata-base-url = "https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/metadata/"
-target-base-url = "https://d25d9m6x9pxh9h.cloudfront.net/45efedef4afe/targets/"
+target-base-url = "https://updates.bottlerocket.aws/targets/"
+
+[metadata.settings.updates.metadata-base-url]
+setting-generator = "schnauzer settings.updates.metadata-base-url"
+template = "https://updates.bottlerocket.aws/2020-02-02/{{ os.variant_id }}/{{ os.arch }}/"
 
 [services.updog]
 configuration-files = ["updog-toml"]


### PR DESCRIPTION
**Description of changes:**

This uses the new OS information made available in #777 to switch us to our new updates URIs that include variant and arch.

**Testing done:**

Basic tests done with #777.

The new URI values show up:
```
  "updates": {
    "metadata-base-url": "https://updates.bottlerocket.aws/2020-02-20/aws-k8s/x86_64/",
    "target-base-url": "https://updates.bottlerocket.aws/targets/",
```