### PR TITLE
drop use of rpm_crashtraceback tag

### DIFF
--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -26,8 +26,7 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %build
 %set_cross_go_flags
-export BUILDTAGS="rpm_crashtraceback"
-go build -buildmode pie -tags="${BUILDTAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
+go build -buildmode pie -o aws-iam-authenticator ./cmd/aws-iam-authenticator
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -27,9 +27,8 @@ Requires: %{_cross_os}iptables
 
 %build
 %cross_go_configure %{goimport}
-export BUILDTAGS="rpm_crashtraceback"
 for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
-  go build -buildmode pie -tags="${BUILDTAGS}" -o "bin/${d##*/}" %{goimport}/${d}
+  go build -buildmode pie -o "bin/${d##*/}" %{goimport}/${d}
 done
 
 %install

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -27,8 +27,7 @@ Requires: %{_cross_os}iptables
 
 %build
 %cross_go_configure %{goimport}
-export BUILDTAGS="rpm_crashtraceback"
-go build -buildmode pie -tags="${BUILDTAGS}" -o "bin/cnitool" %{goimport}/cnitool
+go build -buildmode pie -o "bin/cnitool" %{goimport}/cnitool
 
 %install
 install -d %{buildroot}%{_cross_factorydir}/opt/cni/bin

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -37,7 +37,7 @@ Requires: %{_cross_os}systemd
 
 %build
 %cross_go_configure %{goimport}
-export BUILDTAGS="no_btrfs rpm_crashtraceback seccomp selinux"
+export BUILDTAGS="no_btrfs seccomp selinux"
 for bin in \
   containerd \
   containerd-shim \

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -27,8 +27,7 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %build
 %cross_go_configure %{goimport}
-export BUILDTAGS="rpm_crashtraceback"
-go build -buildmode pie -tags="${BUILDTAGS}" -o docker %{goimport}/cmd/docker
+go build -buildmode pie -o docker %{goimport}/cmd/docker
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -44,7 +44,7 @@ Requires: %{_cross_os}systemd
 
 %build
 %cross_go_configure %{doimport}
-BUILDTAGS="journald rpm_crashtraceback selinux seccomp"
+BUILDTAGS="journald selinux seccomp"
 BUILDTAGS+=" exclude_graphdriver_btrfs"
 BUILDTAGS+=" exclude_graphdriver_devicemapper"
 BUILDTAGS+=" exclude_graphdriver_vfs"

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -30,8 +30,7 @@ cp client/mflag/LICENSE LICENSE.mflag
 
 %build
 %cross_go_configure %{goimport}
-export BUILDTAGS="rpm_crashtraceback"
-go build -buildmode pie -tags="${BUILDTAGS}" -o docker-proxy %{goimport}/cmd/proxy
+go build -buildmode pie -o docker-proxy %{goimport}/cmd/proxy
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -22,8 +22,7 @@ cp -r %{_builddir}/sources/%{workspace_name}/cmd/host-ctr/* .
 
 %build
 %set_cross_go_flags
-export BUILDTAGS="rpm_crashtraceback"
-go build -buildmode=pie -tags="${BUILDTAGS}" -o host-ctr
+go build -buildmode=pie -o host-ctr
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -30,7 +30,7 @@ Requires: %{_cross_os}libseccomp
 
 %build
 %cross_go_configure %{goimport}
-export BUILDTAGS="rpm_crashtraceback ambient seccomp selinux"
+export BUILDTAGS="ambient seccomp selinux"
 go build -buildmode pie -tags="${BUILDTAGS}" -o bin/runc .
 
 %install


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Removes unused `rpm_crashtraceback` tag.


**Testing done:**
Rebuilt `aws-k8s` image, updated cluster, verified pods + containers worked.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
