### PR TITLE
chrony: Update seccomp filter to work with glibc 2.31

### DIFF
--- a/packages/chrony/0001-sys_linux-add-support-for-TCP-sockets.patch
+++ b/packages/chrony/0001-sys_linux-add-support-for-TCP-sockets.patch
@@ -1,0 +1,40 @@
+From 1e3925f7a62765d271cfad4eb371c6e555911746 Mon Sep 17 00:00:00 2001
+From: Jamie Anderson <jamieand@amazon.com>
+Date: Wed, 26 Feb 2020 20:29:00 +0000
+Subject: [PATCH] sys_linux: add support for TCP sockets
+
+This patch was reworked from an upstream patch to only apply changes to
+the seccomp filter, to allow later patches to the seccomp filter to
+apply cleanly.  The upstream patch message is preserved below:
+
+From 02ada36838e48942dd1ecd0513c3449fcf9135df Mon Sep 17 00:00:00 2001
+From: Miroslav Lichvar <mlichvar@redhat.com>
+Date: Tue, 6 Aug 2019 18:33:06 +0200
+Subject: socket: add support for TCP sockets
+
+TCP sockets will be needed for NTS key establishment.
+---
+ sys_linux.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/sys_linux.c b/sys_linux.c
+index 898dc7a..1f36696 100644
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -496,9 +496,10 @@ SYS_Linux_EnableSystemCallFilter(int level)
+     SCMP_SYS(stat), SCMP_SYS(stat64), SCMP_SYS(statfs), SCMP_SYS(statfs64),
+     SCMP_SYS(unlink), SCMP_SYS(unlinkat),
+     /* Socket */
+-    SCMP_SYS(bind), SCMP_SYS(connect), SCMP_SYS(getsockname), SCMP_SYS(getsockopt),
+-    SCMP_SYS(recv), SCMP_SYS(recvfrom), SCMP_SYS(recvmmsg), SCMP_SYS(recvmsg),
+-    SCMP_SYS(send), SCMP_SYS(sendmmsg), SCMP_SYS(sendmsg), SCMP_SYS(sendto),
++    SCMP_SYS(accept), SCMP_SYS(bind), SCMP_SYS(connect), SCMP_SYS(getsockname),
++    SCMP_SYS(getsockopt), SCMP_SYS(recv), SCMP_SYS(recvfrom),
++    SCMP_SYS(recvmmsg), SCMP_SYS(recvmsg), SCMP_SYS(send), SCMP_SYS(sendmmsg),
++    SCMP_SYS(sendmsg), SCMP_SYS(sendto), SCMP_SYS(shutdown),
+     /* TODO: check socketcall arguments */
+     SCMP_SYS(socketcall),
+     /* General I/O */
+-- 
+2.25.0.191.gde93cc14ab
+

--- a/packages/chrony/0002-sys_linux-allow-F_GETFL-in-seccomp-filter.patch
+++ b/packages/chrony/0002-sys_linux-allow-F_GETFL-in-seccomp-filter.patch
@@ -1,0 +1,23 @@
+From 429c4468b0058d9c2e2fffbf6660b0f1581af6af Mon Sep 17 00:00:00 2001
+From: Miroslav Lichvar <mlichvar@redhat.com>
+Date: Thu, 24 Oct 2019 12:42:02 +0200
+Subject: sys_linux: allow F_GETFL in seccomp filter
+
+This is needed for fdopen().
+
+diff --git a/sys_linux.c b/sys_linux.c
+index 1f36696..63eb8f1 100644
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -529,7 +529,7 @@ SYS_Linux_EnableSystemCallFilter(int level)
+ #endif
+   };
+ 
+-  const static int fcntls[] = { F_GETFD, F_SETFD, F_SETFL };
++  const static int fcntls[] = { F_GETFD, F_SETFD, F_GETFL, F_SETFL };
+ 
+   const static unsigned long ioctls[] = {
+     FIONREAD, TCGETS,
+-- 
+cgit v0.10.2
+

--- a/packages/chrony/0003-sys_linux-allow-clock_adjtime-in-seccomp-filter.patch
+++ b/packages/chrony/0003-sys_linux-allow-clock_adjtime-in-seccomp-filter.patch
@@ -1,0 +1,26 @@
+From 0cf506c92967c84f9ed83ba9e1be946a7fda6425 Mon Sep 17 00:00:00 2001
+From: Miroslav Lichvar <mlichvar@redhat.com>
+Date: Mon, 2 Dec 2019 12:47:13 +0100
+Subject: sys_linux: allow clock_adjtime in seccomp filter
+
+The adjtimex() function in glibc was switched to the clock_adjtime
+system call.
+
+diff --git a/sys_linux.c b/sys_linux.c
+index 63eb8f1..fcf89c2 100644
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -478,8 +478,8 @@ SYS_Linux_EnableSystemCallFilter(int level)
+ {
+   const int syscalls[] = {
+     /* Clock */
+-    SCMP_SYS(adjtimex), SCMP_SYS(clock_gettime), SCMP_SYS(gettimeofday),
+-    SCMP_SYS(settimeofday), SCMP_SYS(time),
++    SCMP_SYS(adjtimex), SCMP_SYS(clock_adjtime), SCMP_SYS(clock_gettime),
++    SCMP_SYS(gettimeofday), SCMP_SYS(settimeofday), SCMP_SYS(time),
+     /* Process */
+     SCMP_SYS(clone), SCMP_SYS(exit), SCMP_SYS(exit_group), SCMP_SYS(getpid),
+     SCMP_SYS(getrlimit), SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
+-- 
+cgit v0.10.2
+

--- a/packages/chrony/0004-sys_linux-allow-renameat2-in-seccomp-filter.patch
+++ b/packages/chrony/0004-sys_linux-allow-renameat2-in-seccomp-filter.patch
@@ -1,0 +1,26 @@
+From 994409a03697b8df68115342dc8d1e7ceeeb40bd Mon Sep 17 00:00:00 2001
+From: Vincent Blut <vincent.debian@free.fr>
+Date: Thu, 16 Jan 2020 17:04:35 +0100
+Subject: sys_linux: allow renameat2 in seccomp filter
+
+This is needed for architectures that support neither rename() nor
+renameat() (e.g. riscv64)
+
+diff --git a/sys_linux.c b/sys_linux.c
+index fcf89c2..d2dc908 100644
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -493,8 +493,8 @@ SYS_Linux_EnableSystemCallFilter(int level)
+     SCMP_SYS(chown32), SCMP_SYS(faccessat), SCMP_SYS(fchmodat), SCMP_SYS(fchownat),
+     SCMP_SYS(fstat), SCMP_SYS(fstat64), SCMP_SYS(getdents), SCMP_SYS(getdents64),
+     SCMP_SYS(lseek), SCMP_SYS(newfstatat), SCMP_SYS(rename), SCMP_SYS(renameat),
+-    SCMP_SYS(stat), SCMP_SYS(stat64), SCMP_SYS(statfs), SCMP_SYS(statfs64),
+-    SCMP_SYS(unlink), SCMP_SYS(unlinkat),
++    SCMP_SYS(renameat2), SCMP_SYS(stat), SCMP_SYS(stat64), SCMP_SYS(statfs),
++    SCMP_SYS(statfs64), SCMP_SYS(unlink), SCMP_SYS(unlinkat),
+     /* Socket */
+     SCMP_SYS(accept), SCMP_SYS(bind), SCMP_SYS(connect), SCMP_SYS(getsockname),
+     SCMP_SYS(getsockopt), SCMP_SYS(recv), SCMP_SYS(recvfrom),
+-- 
+cgit v0.10.2
+

--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -16,6 +16,19 @@ BuildRequires: %{_cross_os}readline-devel
 Requires: %{_cross_os}libcap
 Requires: %{_cross_os}libseccomp
 
+# Patches taken from upstream
+
+# Update seccomp filter to work with glibc 2.31
+# Reworked version of
+# https://git.tuxfamily.org/chrony/chrony.git/patch/sys_linux.c?id=02ada36838e48942dd1ecd0513c3449fcf9135df
+Patch0: 0001-sys_linux-add-support-for-TCP-sockets.patch
+# https://git.tuxfamily.org/chrony/chrony.git/patch/sys_linux.c?id=429c4468b0058d9c2e2fffbf6660b0f1581af6af
+Patch1: 0002-sys_linux-allow-F_GETFL-in-seccomp-filter.patch
+# https://git.tuxfamily.org/chrony/chrony.git/patch/sys_linux.c?id=0cf506c92967c84f9ed83ba9e1be946a7fda6425
+Patch2: 0003-sys_linux-allow-clock_adjtime-in-seccomp-filter.patch
+# https://git.tuxfamily.org/chrony/chrony.git/patch/sys_linux.c?id=994409a03697b8df68115342dc8d1e7ceeeb40bd
+Patch3: 0004-sys_linux-allow-renameat2-in-seccomp-filter.patch
+
 %description
 %{summary}.
 


### PR DESCRIPTION
**Description of changes:**

This is a series of additive patches taken from upstream.

Signed-off-by: Jamie Anderson <jamieand@amazon.com>

**Testing done:**

Built an image and verified that chronyd started and found a time source:

```
# journalctl -x -u chronyd.service
-- Logs begin at Wed 2020-02-26 21:01:17 UTC, end at Wed 2020-02-26 21:02:44 UTC. --
Feb 26 21:01:20 ip-192-168-97-15.us-west-2.compute.internal systemd[1]: Started A versatile implementation of the Network Time Protocol.
-- Subject: A start job for unit chronyd.service has finished successfully
-- Defined-By: systemd
-- Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- A start job for unit chronyd.service has finished successfully.
-- 
-- The job identifier is 58.
Feb 26 21:01:20 ip-192-168-97-15.us-west-2.compute.internal chronyd[2916]: 2020-02-26T21:01:20Z chronyd version 3.5 starting (+CMDMON +NTP +REFCLOCK +RTC +P
RIVDROP +SCFILTER -SIGND +ASYNCDNS -SECHASH +IPV6 -DEBUG)
Feb 26 21:01:20 ip-192-168-97-15.us-west-2.compute.internal chronyd[2916]: 2020-02-26T21:01:20Z Loaded seccomp filter
Feb 26 21:01:26 ip-192-168-97-15.us-west-2.compute.internal chronyd[2916]: 2020-02-26T21:01:25Z Selected source 169.254.169.123
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
