### PR TITLE
rename target-base-url to targets-base-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The following settings are set for you automatically by [pluto](sources/api/) ba
 #### Updates settings
 
 * `settings.updates.metadata-base-url`: The common portion of all URIs used to download update metadata.
-* `settings.updates.target-base-url`: The common portion of all URIs used to download update files.
+* `settings.updates.targets-base-url`: The common portion of all URIs used to download update files.
 * `settings.updates.seed`: A `u32` value that determines how far into in the update schedule this machine will accept an update.  We recommending leaving this at its default generated value so that updates can be somewhat randomized in your cluster.
 
 #### Time settings

--- a/packages/os/updog-toml
+++ b/packages/os/updog-toml
@@ -1,3 +1,3 @@
 metadata_base_url = "{{settings.updates.metadata-base-url}}"
-target_base_url = "{{settings.updates.target-base-url}}"
+targets_base_url = "{{settings.updates.targets-base-url}}"
 seed = {{settings.updates.seed}}

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -32,7 +32,7 @@ template-path = "/usr/share/templates/containerd-config-toml"
 # Updates.
 
 [settings.updates]
-target-base-url = "https://updates.bottlerocket.aws/targets/"
+targets-base-url = "https://updates.bottlerocket.aws/targets/"
 
 [metadata.settings.updates.metadata-base-url]
 setting-generator = "schnauzer settings.updates.metadata-base-url"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -93,7 +93,7 @@ struct KubernetesSettings {
 #[model]
 struct UpdatesSettings {
     metadata_base_url: Url,
-    target_base_url: Url,
+    targets_base_url: Url,
     seed: u32,
 }
 

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -44,7 +44,7 @@ enum Command {
 #[derive(Debug, Deserialize)]
 struct Config {
     metadata_base_url: String,
-    target_base_url: String,
+    targets_base_url: String,
     seed: u32,
     // TODO API sourced configuration, eg.
     // blacklist: Option<Vec<Version>>,
@@ -111,7 +111,7 @@ fn load_repository<'a>(
             })?,
             datastore: Path::new("/var/lib/bottlerocket/updog"),
             metadata_base_url: &config.metadata_base_url,
-            target_base_url: &config.target_base_url,
+            target_base_url: &config.targets_base_url,
             limits: Limits {
                 max_root_size: 1024 * 1024,         // 1 MiB
                 max_targets_size: 1024 * 1024 * 10, // 10 MiB
@@ -701,7 +701,7 @@ mod tests {
         let manifest: Manifest = serde_json::from_reader(File::open(path).unwrap()).unwrap();
         let config = Config {
             metadata_base_url: String::from("foo"),
-            target_base_url: String::from("bar"),
+            targets_base_url: String::from("bar"),
             seed: 123,
         };
         let version = Version::parse("1.18.0").unwrap();
@@ -720,7 +720,7 @@ mod tests {
         let manifest: Manifest = serde_json::from_reader(File::open(path).unwrap()).unwrap();
         let config = Config {
             metadata_base_url: String::from("foo"),
-            target_base_url: String::from("bar"),
+            targets_base_url: String::from("bar"),
             seed: 1487,
         };
 
@@ -745,7 +745,7 @@ mod tests {
         let manifest: Manifest = serde_json::from_reader(File::open(path).unwrap()).unwrap();
         let config = Config {
             metadata_base_url: String::from("foo"),
-            target_base_url: String::from("bar"),
+            targets_base_url: String::from("bar"),
             seed: 123,
         };
 
@@ -774,7 +774,7 @@ mod tests {
         let manifest: Manifest = serde_json::from_reader(File::open(path).unwrap()).unwrap();
         let config = Config {
             metadata_base_url: String::from("foo"),
-            target_base_url: String::from("bar"),
+            targets_base_url: String::from("bar"),
             seed: 123,
         };
 
@@ -927,7 +927,7 @@ mod tests {
         let variant = String::from("aws-k8s");
         let config = Config {
             metadata_base_url: String::from("foo"),
-            target_base_url: String::from("bar"),
+            targets_base_url: String::from("bar"),
             seed: 512,
         };
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

For consistency, rename `target-base-url` to `targets-base-url` throughout. This will match the TUF spec and the urls that will end with `/targets`.

**Testing done:**

`cargo make`
`cargo make unit-tests`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
