### PR TITLE
Update admin and control containers to v0.4.0

### DIFF
--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -58,7 +58,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.3"
+template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.4.0"
 
 [settings.host-containers.control]
 enabled = true
@@ -66,7 +66,7 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.3"
+template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.4.0"
 
 [services.host-containers]
 configuration-files = []


### PR DESCRIPTION
**Issue number:**

n/a

**Description of changes:**

Updates the admin and control containers to the newly-published v0.4.0.

**Testing done:**

Built AMIs, ran in ASG, they run new SSM agents and the settings look right. :)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
