### PR TITLE
Log migration errors at error level so they show on console

### DIFF
--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -380,14 +380,21 @@ where
             .output()
             .context(error::StartMigration { command })?;
 
-        debug!(
-            "Migration stdout: {}",
-            std::str::from_utf8(&output.stdout).unwrap_or("<invalid UTF-8>")
-        );
-        debug!(
-            "Migration stderr: {}",
-            std::str::from_utf8(&output.stderr).unwrap_or("<invalid UTF-8>")
-        );
+        if !output.stdout.is_empty() {
+            debug!(
+                "Migration stdout: {}",
+                std::str::from_utf8(&output.stdout).unwrap_or("<invalid UTF-8>")
+            );
+        } else {
+            debug!("No migration stdout");
+        }
+        if !output.stderr.is_empty() {
+            let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<invalid UTF-8>");
+            // We want to see migration stderr on the console, so log at error level.
+            error!("Migration stderr: {}", stderr);
+        } else {
+            debug!("No migration stderr");
+        }
 
         ensure!(output.status.success(), error::MigrationFailure { output });
 


### PR DESCRIPTION
**Description of changes:**

Pipes through the stderr from migrations so it's easier to debug upgrade/downgrade failures from using the console.

**Testing done:**

Normal:
```
20:48:23 [DEBUG] (1) migrator: Migration stdout: Found no settings.added to remove
20:48:23 [DEBUG] (1) migrator: No migration stderr
```

With a `dbg!` in a migration so it has stderr:
```
20:48:36 [DEBUG] (1) migrator: Migration stdout: Found no settings.timezone to remove
20:48:36 [ERROR] Migration stderr: [api/migration/migration-helpers/src/lib.rs:93] &args.source_datastore = "/home/ANT.AMAZON.COM/tjk/work/thar/sources/api/migration/migrator/datastore-sample/v0.2.3_Ntp8bK3jHO8fkuRr"
```