### PR TITLE
kernel: enable BTF debug info

### DIFF
--- a/packages/kernel/config-bottlerocket
+++ b/packages/kernel/config-bottlerocket
@@ -40,3 +40,6 @@ CONFIG_IKCONFIG_PROC=y
 
 # kernel headers at /sys/kernel/kheaders.tar.xz
 CONFIG_IKHEADERS=y
+
+# BTF debug info at /sys/kernel/btf/vmlinux
+CONFIG_DEBUG_INFO_BTF=y


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Adds BTF debug info at `/sys/kernel/btf/vmlinux` for BPF tools.


**Testing done:**
```
# ls -latr /sys/kernel/btf/vmlinux
-r--r--r--. 1 root root 1655968 Feb 27 21:12 /sys/kernel/btf/vmlinux
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
