### PR TITLE
api: add license information to openapi document

### DIFF
--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -3,10 +3,9 @@ info:
   version: "0.1.0"
   title: "Bottlerocket API"
   description: "The API for the Bottlerocket OS"
-  # TODO Get the right license in here
   license:
-    name: ""
-    url: ""
+    name: "Apache-2.0 OR MIT"
+    url: "https://github.com/bottlerocket-os/bottlerocket/blob/develop/COPYRIGHT"
 
 servers:
 - url: file:///run/api.sock


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** N/A



**Description of changes:**
Adds license information for apiserver's openapi specification document.


**Testing done:** N/A



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
