### PR TITLE
Update charter wording based on feedback

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -5,25 +5,25 @@
 These tenets guide Bottlerocket's development.
 They let you know what we value and what we're working toward, even if not every feature is ready yet.
 
-### Open
-
-Bottlerocket is **open** because the best OS can only be built through collaboration.
-It is developed in full view of the world using open source tools and public infrastructure services.
-It is not a Kubernetes distro, nor an Amazon distro.
-We obsess over shared components like the kernel, but we are willing to accept support for other orchestrators or platforms.
-
-### Small
-
-Bottlerocket is **small** because a few big ideas scale better than many small ones.
-It includes only the core set of components needed for development and for use at runtime.
-Anything we ship, we must be prepared to fix, so our goal is to ship as little as possible while staying useful.
-
 ### Secure
 
 Bottlerocket is **secure** so it can become a quiet piece of a platform you trust.
 It uses a variety of mechanisms to provide defense-in-depth, and enables automatic updates by default.
 It protects itself from persistent threats.
 It enables kernel features that allow users to assert their own policies for locking down workloads.
+
+### Open
+
+Bottlerocket is **open** because the best OS can only be built through collaboration.
+It is developed in full view of the world using open source tools and public infrastructure services.
+It is not a Kubernetes distro, nor an Amazon distro.
+We obsess over shared components like the kernel, and work within the community to support new orchestrators and platforms.
+
+### Small
+
+Bottlerocket is **small** because a few big ideas scale better than many small ones.
+It includes only the core set of components needed for development and for use at runtime.
+Anything we ship, we must be prepared to fix, so our goal is to ship as little as possible while staying useful.
 
 ### Simple
 


### PR DESCRIPTION
We got some feedback on the wording of our charter.
* "Secure", as always, should be first.
* "Platform" raised a question, but was later approved; we thought about these phrases when writing the charter and thought it was the best option, so I left it as-is.
* The "obsess" sentence was taken as a bit negative / unclear, so I reworded it.