### PR TITLE
Comment unused licenses in whitelist so we don't get warnings

### DIFF
--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -19,7 +19,7 @@ allow = [
     "MIT",
     "OpenSSL",
     "Unlicense",
-    "Zlib",
+    #"Zlib",  # OK but currently unused; commenting to prevent warning
 ]
 
 exceptions = [

--- a/tools/buildsys/deny.toml
+++ b/tools/buildsys/deny.toml
@@ -11,14 +11,14 @@ confidence-threshold = 0.93
 
 allow = [
     "Apache-2.0",
-    "BSD-2-Clause",
+    #"BSD-2-Clause",  # OK but currently unused; commenting to prevent warning
     "BSD-3-Clause",
     "BSL-1.0",
     "ISC",
     "MIT",
     "OpenSSL",
     "Unlicense",
-    "Zlib",
+    #"Zlib",  # OK but currently unused; commenting to prevent warning
 ]
 
 exceptions = [


### PR DESCRIPTION
**Testing done:**

Before, we'd always see this:
```
warning: license was not encountered

    ┌── /home/ANT.AMAZON.COM/tjk/work/thar/sources/deny.toml:22:5 ───
    │
 22 │     "Zlib",
    │     ^^^^^^ no crate used this license
    │

warning: license was not encountered

    ┌── /home/ANT.AMAZON.COM/tjk/work/thar/tools/buildsys/deny.toml:14:5 ───
    │
 14 │     "BSD-2-Clause",
    │     ^^^^^^^^^^^^^^ no crate used this license
    │

warning: license was not encountered

    ┌── /home/ANT.AMAZON.COM/tjk/work/thar/tools/buildsys/deny.toml:21:5 ───
    │
 21 │     "Zlib",
    │     ^^^^^^ no crate used this license
    │
```

After, no warnings.