### PR TITLE
v0.3.1

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,3 +1,3 @@
-version = "0.3.0"
+version = "0.3.1"
 
 [migrations]


### PR DESCRIPTION
Bumped version, no migrations (yet, but pretty unlikely).

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.