### PR TITLE
Add systemd.log_color=0 to remove ANSI color escapes from console log

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -162,8 +162,8 @@ set timeout="0"
 menuentry "Bottlerocket OS ${VERSION_ID}" {
    linux (\$root)/vmlinuz root=/dev/dm-0 rootwait ro init=/sbin/preinit \\
        console=tty0 console=ttyS0 random.trust_cpu=on selinux=1 enforcing=1 \\
-       systemd.log_target=journal-or-kmsg net.ifnames=0 biosdevname=0 \\
-       dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\
+       systemd.log_target=journal-or-kmsg systemd.log_color=0 net.ifnames=0 \\
+       biosdevname=0 dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\
        dm-mod.create="root,,,ro,0 $VERITY_DATA_512B_BLOCKS verity $VERITY_VERSION PARTUUID=\$boot_uuid/PARTNROFF=1 PARTUUID=\$boot_uuid/PARTNROFF=2 \\
        $VERITY_DATA_BLOCK_SIZE $VERITY_HASH_BLOCK_SIZE $VERITY_DATA_4K_BLOCKS 1 $VERITY_HASH_ALGORITHM $VERITY_ROOT_HASH $VERITY_SALT 1 restart_on_corruption"
 }


### PR DESCRIPTION
**Issue number:**

Partially addresses #385

**Testing done:**

Ran an instance, it ran a pod OK.

I checked the EC2 web console and the system log showed no ANSI color escapes; lines look as you'd expect, like:
```
[  239.362950] host-ctr[2978]: Accepted publickey for ec2-user from ...
```