### PR TITLE
QUICKSTART: add easier setup instructions using new eksctl release

### DIFF
--- a/sample-eksctl-ssh.yaml
+++ b/sample-eksctl-ssh.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: bottlerocket
+  region: us-west-2
+  version: '1.15'
+
+nodeGroups:
+  - name: ng-bottlerocket
+    instanceType: m5.large
+    desiredCapacity: 4
+    amiFamily: Bottlerocket
+    iam:
+       attachPolicyARNs:
+          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    ssh:
+        allow: true
+        publicKeyName: YOUR_EC2_KEYPAIR_NAME
+    bottlerocket:
+      settings:
+        motd: "Hello from eksctl!"

--- a/sample-eksctl.yaml
+++ b/sample-eksctl.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: bottlerocket
+  region: us-west-2
+  version: '1.15'
+
+nodeGroups:
+  - name: ng-bottlerocket
+    instanceType: m5.large
+    desiredCapacity: 4
+    amiFamily: Bottlerocket
+    iam:
+       attachPolicyARNs:
+          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    bottlerocket:
+      settings:
+        motd: "Hello from eksctl!"


### PR DESCRIPTION
**Testing done:**

I created clusters with each of these configs and the new instructions, confirming they were able to run pods and connect via SSM.  I confirmed that the sample config with SSH was able to connect to the admin container via SSH, and the other was not.  The system seemed healthy.