### PR TITLE
Use github checkout v2 for faster fetch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: [self-hosted, linux, x64]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: cargo install --version 0.28.0 cargo-make
       - run: cargo install --version 0.6.6 cargo-deny --no-default-features
       - run: cargo make


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

As GHA checkout action release note says on https://github.com/actions/checkout/releases/tag/v2.0.0 v2 is faster at fetching the code.

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/854

**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
