### PR TITLE
fix delay on reboot or power off

### DIFF
--- a/packages/containerd/containerd.service
+++ b/packages/containerd/containerd.service
@@ -7,7 +7,7 @@ Wants=network-online.target configured.target
 [Service]
 ExecStart=/usr/bin/containerd
 Delegate=yes
-KillMode=mixed
+KillMode=process
 TimeoutSec=0
 RestartSec=2
 Restart=always

--- a/packages/release/release-systemd-system.conf
+++ b/packages/release/release-systemd-system.conf
@@ -1,0 +1,3 @@
+[Manager]
+DefaultTimeoutStartSec=10s
+DefaultTimeoutStopSec=10s

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -8,7 +8,8 @@ License: Apache-2.0 OR MIT
 
 Source10: hosts
 Source11: nsswitch.conf
-Source98: release-sysctl.conf
+Source97: release-sysctl.conf
+Source98: release-systemd-system.conf
 Source99: release-tmpfiles.conf
 
 Source200: motd.template
@@ -76,7 +77,10 @@ install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/wicked/ifconfig
 install -p -m 0644 %{S:1000} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/wicked/ifconfig
 
 install -d %{buildroot}%{_cross_sysctldir}
-install -p -m 0644 %{S:98} %{buildroot}%{_cross_sysctldir}/80-release.conf
+install -p -m 0644 %{S:97} %{buildroot}%{_cross_sysctldir}/80-release.conf
+
+install -d %{buildroot}%{_cross_libdir}/systemd/system.conf.d
+install -p -m 0644 %{S:98} %{buildroot}%{_cross_libdir}/systemd/system.conf.d/80-release.conf
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:99} %{buildroot}%{_cross_tmpfilesdir}/release.conf
@@ -107,6 +111,7 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 %{_cross_sysctldir}/80-release.conf
 %{_cross_tmpfilesdir}/release.conf
 %{_cross_libdir}/os-release
+%{_cross_libdir}/systemd/system.conf.d/80-release.conf
 %{_cross_unitdir}/configured.target
 %{_cross_unitdir}/prepare-local.service
 %{_cross_unitdir}/var.mount

--- a/packages/systemd/9001-move-stateful-paths-to-ephemeral-storage.patch
+++ b/packages/systemd/9001-move-stateful-paths-to-ephemeral-storage.patch
@@ -1,7 +1,7 @@
-From 8189d4f9604c4e37eee6db75e2cea2a3e3935f34 Mon Sep 17 00:00:00 2001
+From 8862df96457fa790bb2dea414f89d1fe0a704716 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sun, 15 Sep 2019 00:21:26 +0000
-Subject: [PATCH 9001/9003] move stateful paths to ephemeral storage
+Subject: [PATCH 9001/9004] move stateful paths to ephemeral storage
 
 We reserve most of /var for persistent local storage controlled by
 the administrator, and want to avoid depending on it for our own
@@ -13,10 +13,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/src/libsystemd/sd-path/sd-path.c b/src/libsystemd/sd-path/sd-path.c
-index ad56ddb..36cd0b4 100644
+index 95d6551..ac3e6fc 100644
 --- a/src/libsystemd/sd-path/sd-path.c
 +++ b/src/libsystemd/sd-path/sd-path.c
-@@ -252,19 +252,19 @@ static int get_path(uint64_t type, char **buffer, const char **ret) {
+@@ -251,19 +251,19 @@ static int get_path(uint64_t type, char **buffer, const char **ret) {
                  return 0;
  
          case SD_PATH_SYSTEM_STATE_PRIVATE:

--- a/packages/systemd/9002-do-not-create-unused-state-directories.patch
+++ b/packages/systemd/9002-do-not-create-unused-state-directories.patch
@@ -1,7 +1,7 @@
-From 1be1595d5d43f05481d5fbf08f3e75a5eec2873c Mon Sep 17 00:00:00 2001
+From 1b3b7345d19a7877026690ef05852dbb4fb0efe8 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sun, 15 Sep 2019 00:51:25 +0000
-Subject: [PATCH 9002/9003] do not create unused state directories
+Subject: [PATCH 9002/9004] do not create unused state directories
 
 We do not use the coredump handler, and the private directories have
 been relocated to `/run`.
@@ -12,10 +12,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 7 deletions(-)
 
 diff --git a/tmpfiles.d/systemd.conf.m4 b/tmpfiles.d/systemd.conf.m4
-index d39c9cb..5d7d420 100644
+index 9c57d3b..30a9bd9 100644
 --- a/tmpfiles.d/systemd.conf.m4
 +++ b/tmpfiles.d/systemd.conf.m4
-@@ -68,10 +68,3 @@ a+ /var/log/journal/%m - - - - d:group:wheel:r-x
+@@ -70,10 +70,3 @@ a+ /var/log/journal/%m - - - - d:group:wheel:r-x
  a+ /var/log/journal/%m - - - - group:wheel:r-x
  a+ /var/log/journal/%m/system.journal - - - - group:wheel:r--
  '')')')m4_dnl

--- a/packages/systemd/9003-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9003-use-absolute-path-for-var-run-symlink.patch
@@ -1,7 +1,7 @@
-From ce9b01ee7a39bfed3e96be6b4547188d4b49bed3 Mon Sep 17 00:00:00 2001
+From 6c298326187075878688ac06f7d99e5b9822aaec Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 17 Sep 2019 01:35:51 +0000
-Subject: [PATCH 9003/9003] use absolute path for /var/run symlink
+Subject: [PATCH 9003/9004] use absolute path for /var/run symlink
 
 Otherwise the symlink may be broken if /var is a bind mount from
 somewhere else.

--- a/packages/systemd/9004-core-add-separate-timeout-for-system-shutdown.patch
+++ b/packages/systemd/9004-core-add-separate-timeout-for-system-shutdown.patch
@@ -1,0 +1,66 @@
+From 4d11f5d502ca4a61c491681cdfd99ebe24e3f58c Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 10 Mar 2020 20:30:10 +0000
+Subject: [PATCH 9004/9004] core: add separate timeout for system shutdown
+
+There is an existing setting for this (DefaultTimeoutStopUSec), but
+changing it has no effect because `reset_arguments()` is called just
+before `become_shutdown()`, which sets everything back to the stock
+values.
+
+It's also awkward to use a single timeout value for stopping normal
+services, and for cleaning up stray processes after most of userspace
+has gone away.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ src/basic/def.h | 3 +++
+ src/core/main.c | 4 +++-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/basic/def.h b/src/basic/def.h
+index 970654a..b02f6f0 100644
+--- a/src/basic/def.h
++++ b/src/basic/def.h
+@@ -13,6 +13,9 @@
+  * the watchdog pings will keep the loop busy. */
+ #define DEFAULT_EXIT_USEC (30*USEC_PER_SEC)
+ 
++/* The default time after which processes are killed on shutdown. */
++#define DEFAULT_TIMEOUT_SHUTDOWN_USEC (10*USEC_PER_SEC)
++
+ /* The default value for the net.unix.max_dgram_qlen sysctl */
+ #define DEFAULT_UNIX_MAX_DGRAM_QLEN 512UL
+ 
+diff --git a/src/core/main.c b/src/core/main.c
+index c24b696..8ffa09f 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -114,6 +114,7 @@ static ExecOutput arg_default_std_error;
+ static usec_t arg_default_restart_usec;
+ static usec_t arg_default_timeout_start_usec;
+ static usec_t arg_default_timeout_stop_usec;
++static usec_t arg_default_timeout_shutdown_usec;
+ static usec_t arg_default_timeout_abort_usec;
+ static bool arg_default_timeout_abort_set;
+ static usec_t arg_default_start_limit_interval;
+@@ -1389,7 +1390,7 @@ static int become_shutdown(
+         env_block = strv_copy(environ);
+ 
+         xsprintf(log_level, "%d", log_get_max_level());
+-        xsprintf(timeout, "%" PRI_USEC "us", arg_default_timeout_stop_usec);
++        xsprintf(timeout, "%" PRI_USEC "us", arg_default_timeout_shutdown_usec);
+ 
+         switch (log_get_target()) {
+ 
+@@ -2124,6 +2125,7 @@ static void reset_arguments(void) {
+         arg_default_restart_usec = DEFAULT_RESTART_USEC;
+         arg_default_timeout_start_usec = DEFAULT_TIMEOUT_USEC;
+         arg_default_timeout_stop_usec = DEFAULT_TIMEOUT_USEC;
++        arg_default_timeout_shutdown_usec = DEFAULT_TIMEOUT_SHUTDOWN_USEC;
+         arg_default_timeout_abort_usec = DEFAULT_TIMEOUT_USEC;
+         arg_default_timeout_abort_set = false;
+         arg_default_start_limit_interval = DEFAULT_START_LIMIT_INTERVAL;
+-- 
+2.21.0
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -16,6 +16,10 @@ Patch9001: 9001-move-stateful-paths-to-ephemeral-storage.patch
 Patch9002: 9002-do-not-create-unused-state-directories.patch
 Patch9003: 9003-use-absolute-path-for-var-run-symlink.patch
 
+# TODO: this could potentially be submitted upstream, but needs a better
+# way to be configured at build time or during execution first.
+Patch9004: 9004-core-add-separate-timeout-for-system-shutdown.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**
#858 

**Description of changes:**
This reverts the `KillMode=mixed` change from 75125f6, and replaces it with lower timeouts for starting and stopping services.


**Testing done:**
Terminated an instance through the API.

New settings are applied:
```
# systemctl show
...
DefaultTimeoutStartUSec=10s
DefaultTimeoutStopUSec=10s
```

Relevant console output during shutdown from an instance with running pods and host containers:
```
[ 9655.638443] systemd-shutdown[1]: Syncing filesystems and block devices.
[ 9655.643105] systemd-shutdown[1]: Sending SIGTERM to remaining processes...
[ 9655.649976] systemd-journald[1026]: Received SIGTERM from PID 1 (systemd-shutdow).
[ 9665.650617] systemd-shutdown[1]: Waiting for process: containerd-shim, containerd-shim, containerd-shim, containerd-shim, containerd-shim, containerd-shim
[ 9665.659807] systemd-shutdown[1]: Sending SIGKILL to remaining processes...
[ 9665.665462] systemd-shutdown[1]: Sending SIGKILL to PID 3536 (containerd-shim).
[ 9665.671968] systemd-shutdown[1]: Sending SIGKILL to PID 3537 (containerd-shim).
[ 9665.678394] systemd-shutdown[1]: Sending SIGKILL to PID 4389 (containerd-shim).
[ 9665.684806] systemd-shutdown[1]: Sending SIGKILL to PID 4512 (containerd-shim).
[ 9665.691255] systemd-shutdown[1]: Sending SIGKILL to PID 4548 (containerd-shim).
[ 9665.697675] systemd-shutdown[1]: Sending SIGKILL to PID 4744 (containerd-shim).
[ 9665.705557] systemd-shutdown[1]: Unmounting file systems.
...
[ 9665.777562] systemd-shutdown[1]: Powering off.
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
