### PR TITLE
kubelet: specify `--containerd` flag to specify containerd socket path

### DIFF
--- a/packages/kubernetes/kubelet.service
+++ b/packages/kubernetes/kubelet.service
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/kubelet \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \
+    --containerd=/run/dockershim.sock \
     --network-plugin cni \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Partially addresses https://github.com/bottlerocket-os/bottlerocket/issues/867


**Description of changes:**
We changed the containerd socket path to be `/run/dockershim.sock` in https://github.com/bottlerocket-os/bottlerocket/pull/796. cAdvisor assumes the containerd socket to be located at `/run/containerd/containerd.sock`.

Pass `--containerd` to kubelet to specify containerd socket path so cAdvisor can make calls to containerd for gathering metric metadata information.


**Testing done:**
Built bottlerocket image, ran in an EKS 1.15 cluster. Kubelet starts up fine, mark-successful-boot.service is OK. Node registers with the cluster successfully, pods run fine.
Most metrics now have metadata information, whereas before none of the metrics had any metadata information.
```
...
container_cpu_usage_seconds_total{container="kube-proxy",container_name="kube-proxy",cpu="total",id="/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf4bc1d43_e098_4f73_885e_36d6a678d0f3.slice/cri-containerd-c16e87d1b666e2909bebe42db582087b1f1edd2613535eeee0c49ca09a09e8f7.scope",image="sha256:f107a8632d08a7d7061a07b7110d630d4917856070ddd3136828da976ba51c7c",name="c16e87d1b666e2909bebe42db582087b1f1edd2613535eeee0c49ca09a09e8f7",namespace="kube-system",pod="kube-proxy-5hbpb",pod_name="kube-proxy-5hbpb"} 0.401646411 1585002411967
container_cpu_usage_seconds_total{container="kube-rbac-proxy",container_name="kube-rbac-proxy",cpu="total",id="/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podcd9426e7_bc4b_4616_bbf9_5562beed33e0.slice/cri-containerd-b68c12ffba18588b822956a2c496bada9f9b475783921d3bffeec9ca78137185.scope",image="sha256:685a73a3c754b9c143e9c91c4e7a7989c4be667707d4c1ec67acc8eb917bd749",name="b68c12ffba18588b822956a2c496bada9f9b475783921d3bffeec9ca78137185",namespace="monitoring",pod="node-exporter-kqzz2",pod_name="node-exporter-kqzz2"} 0.522531731 1585002414645
container_cpu_usage_seconds_total{container="node-exporter",container_name="node-exporter",cpu="total",id="/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podcd9426e7_bc4b_4616_bbf9_5562beed33e0.slice/cri-containerd-463e72e5406d8cd4ebbd64963a0b64ae803d7d339a3de124d7ce48ce27af3b98.scope",image="quay.io/prometheus/node-exporter:v0.18.1",name="463e72e5406d8cd4ebbd64963a0b64ae803d7d339a3de124d7ce48ce27af3b98",namespace="monitoring",pod="node-exporter-kqzz2",pod_name="node-exporter-kqzz2"} 0.143221556 1585002414216
...
```

Note that some metrics are still missing metadata information, e.g. most filesystem related metrics have missing metadata information.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
