### PR TITLE
build: Pass proxy environment variables through to docker containers.

### DIFF
--- a/tools/docker-go
+++ b/tools/docker-go
@@ -54,10 +54,19 @@ DOCKER_RUN_ARGS="--network=host"
 
 parse_args "${@}"
 
+# Go accepts both lower and uppercase proxy variables, pass both through.
+proxy_env=( )
+for i in http_proxy https_proxy no_proxy HTTP_PROXY HTTPS_PROXY NO_PROXY; do
+   if [ -n "${!i}" ]; then
+      proxy_env[${#proxy_env[@]}]="--env=$i=${!i}"
+   fi
+done
+
 docker run --rm \
   -e GOPRIVATE='*' \
   -e GOCACHE='/tmp/.cache' \
   -e GOPATH='/tmp/go' \
+  "${proxy_env[@]}" \
   --user "$(id -u):$(id -g)" \
   ${DOCKER_RUN_ARGS} \
   -v "${GO_MOD_CACHE}":/tmp/go/pkg/mod \


### PR DESCRIPTION
**Issue number:** none

**Description of changes:**
When building behind a proxy, build via 'cargo make' worked up to
the point of 'running Task: fetch-vendored' where it hung.

The reason was because necessary proxy environment variables
were not passed into the docker container's environment.

The fix here is to add these variables to the environment of the
docker container if they are set outside the container:
  http_proxy, https_proxy, no_proxy

**Testing done:** build with `cargo make`

**Terms of contribution:**
By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
