### PR TITLE
kernel: Include objtool in kernel-devel

### DIFF
--- a/packages/kernel/kernel.spec
+++ b/packages/kernel/kernel.spec
@@ -107,6 +107,11 @@ mkdir src_squashfs
 for file in $(cat kernel_devel_files); do
   install -D ${file} src_squashfs/%{version}/${file}
 done
+# if we have it, include objtool (not all arches support it yet)
+if [ "%{_cross_karch}" == "x86"  ]; then
+  install -D tools/objtool/objtool src_squashfs/%{version}/tools/objtool/objtool
+fi
+
 mksquashfs src_squashfs kernel-devel.squashfs
 install -D kernel-devel.squashfs %{buildroot}%{_cross_datadir}/bottlerocket/kernel-devel.squashfs
 install -d %{buildroot}%{kernel_sourcedir}


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/819


**Description of changes:**
objtool is a requirement for compiling external modules, particularly if
stack validation is enabled at build time.

**Testing done:**
Built an image and compiled a module against the installed kernel headers from within the SDK container:
```
# docker run -it --net host --mount type=bind,source=/home/ANT.AMAZON.COM/samjonas/workbench/thar/module/mod,target=/tmp/mod --mount type=bind,source=/home/ANT.AMAZON.COM/samjonas/workbench/thar/module/kernels,target=/usr/src/kernels --mount type=bind,source=/home/ANT.AMAZON.COM/samjonas/workbench/thar/module/modules,target=/lib/modules bottlerocket/sdk-x86_64:v0.10.0
[builder@u87e72aa3c6c25c /]$ cd /tmp/mod
[builder@u87e72aa3c6c25c mod]$ make -C /lib/modules/5.4.16/build/ M=`pwd` modules
make: Entering directory '/usr/src/kernels/5.4.16'
  CC [M]  /tmp/mod/KMOD_XXX.o
  AS [M]  /tmp/mod/KMOD_YYY.o
  LD [M]  /tmp/mod/KMOD_ZZZ.o
  Building modules, stage 2.
  MODPOST 1 modules
  CC [M]  /tmp/mod/KMOD_ZZZ.mod.o
  LD [M]  /tmp/mod/KMOD_ZZZ.ko
make: Leaving directory '/usr/src/kernels/5.4.16'
[builder@u87e72aa3c6c25c mod]$ echo $?
0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.

Signed-off-by: Samuel Mendoza-Jonas <samjonas@amazon.com>

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
