### PR TITLE
logdog: a tool for aggregating logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,28 @@ We use it for the control container because it needs to be available early to gi
 
 Be careful, and make sure you have a similar low-level use case before reaching for host containers.
 
+### Logs
+
+You can use `logdog` through the [admin container](#admin-container) to obtain an archive of log files from your Bottlerocket host.
+SSH to the Bottlerocket host, then run:
+
+```bash
+sudo sheltie
+logdog
+```
+
+This will write an archive of the logs to `/tmp/bottlerocket-logs.tar.gz`.
+You can use SSH to retrieve the file.
+Once you have exited from the Bottlerocket host, run a command like:
+
+```bash
+ssh -i YOUR_KEY_FILE \
+    ec2-user@YOUR_HOST \
+    "cat /.bottlerocket/rootfs/tmp/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
+```
+
+For a list of what is collected, see the logdog [command list](sources/logdog/src/log_request.rs).
+
 ## Details
 
 ### Security

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -14,6 +14,7 @@ source-groups = [
     "growpart",
     "updater",
     "webpki-roots-shim",
+    "logdog",
     "models",
     "preinit",
 ]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -130,6 +130,11 @@ Summary: Bottlerocket updater CLI
 %description -n %{_cross_os}updog
 not much what's up with you
 
+%package -n %{_cross_os}logdog
+Summary: Bottlerocket log extractor
+%description -n %{_cross_os}logdog
+use logdog to extract logs from the Bottlerocket host
+
 %package -n %{_cross_os}preinit
 Summary: Bottlerocket pre-init system setup
 %description -n %{_cross_os}preinit
@@ -162,6 +167,7 @@ mkdir bin
     -p migrator \
     -p signpost \
     -p updog \
+    -p logdog \
     -p growpart \
     -p laika \
     %{nil}
@@ -183,7 +189,7 @@ for p in \
   thar-be-settings servicedog host-containers \
   storewolf settings-committer \
   migrator \
-  signpost updog ;
+  signpost updog logdog;
 do
   install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/${p} %{buildroot}%{_cross_bindir}
 done
@@ -313,6 +319,9 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.co
 %{_cross_datadir}/updog
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/updog-toml
+
+%files -n %{_cross_os}logdog
+%{_cross_bindir}/logdog
 
 %files -n %{_cross_os}preinit
 %{_cross_sbindir}/preinit

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -57,6 +57,7 @@ Requires: %{_cross_os}systemd
 Requires: %{_cross_os}thar-be-settings
 Requires: %{_cross_os}migration
 Requires: %{_cross_os}updog
+Requires: %{_cross_os}logdog
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}preinit
 Requires: %{_cross_os}wicked

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -241,6 +241,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler32"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +612,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +850,17 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1302,6 +1326,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "logdog"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell-words 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "loopdev"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1430,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2165,6 +2209,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "shell-words"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "signal-hook"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2423,16 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "loopdev 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2935,6 +2994,7 @@ dependencies = [
 "checksum actix-utils 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf8f5631bf01adec2267808f00e228b761c60c0584cc9fa0b5364f41d147f4e"
 "checksum actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3158e822461040822f0dbf1735b9c2ce1f95f93b651d7a7aded00b1efbb1f635"
 "checksum actix-web-codegen 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f00371942083469785f7e28c540164af1913ee7c96a4534acb9cea92c39f057"
+"checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
@@ -2974,6 +3034,7 @@ dependencies = [
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
@@ -2998,6 +3059,7 @@ dependencies = [
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+"checksum flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -3056,6 +3118,7 @@ dependencies = [
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+"checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
@@ -3128,6 +3191,7 @@ dependencies = [
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+"checksum shell-words 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39acde55a154c4cd3ae048ac78cc21c25f3a0145e44111b523279113dce0d94a"
 "checksum signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "05a3e303ace6adb0a60a9e9e2fbc6a33e1749d1e43587e2125f7efa9c5e107c5"
@@ -3147,6 +3211,7 @@ dependencies = [
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum sys-mount 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "62f5703caf67c45ad3450104001b4620a605e9def0cef13dde3c9add23f73cee"
+"checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -22,6 +22,8 @@ members = [
 
     "growpart",
 
+    "logdog",
+
     "models",
 
     "parse-datetime",

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -19,7 +19,7 @@ allow = [
     "MIT",
     "OpenSSL",
     "Unlicense",
-    #"Zlib",  # OK but currently unused; commenting to prevent warning
+    "Zlib"
 ]
 
 exceptions = [

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "logdog"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+flate2 = "1.0"
+shell-words = "0.1.0"
+snafu = { version = "0.6", features = ["backtraces-impl-backtrace-crate"] }
+tar = { version = "0.4", default-features = false }
+tempfile = { version = "3.1.0", default-features = false }
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/logdog/README.md
+++ b/sources/logdog/README.md
@@ -1,0 +1,23 @@
+# logdog
+
+Current version: 0.1.0
+
+## Introduction
+
+`logdog` is a program that gathers logs from various places on a Bottlerocket host and combines them
+into a tarball for easy export.
+
+Usage example:
+```rust
+$ logdog
+logs are at: /tmp/bottlerocket-logs.tar.gz
+```
+
+## Logs
+
+For the commands used to gather logs, please see [log_request](src/log_request.rs).
+
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/logdog/README.tpl
+++ b/sources/logdog/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/logdog/build.rs
+++ b/sources/logdog/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/logdog/src/create_tarball.rs
+++ b/sources/logdog/src/create_tarball.rs
@@ -1,0 +1,87 @@
+//! Provides a function for compressing a directory's contents into a tarball.
+
+use crate::error::{self, Result};
+use std::fs::{self, File};
+use std::path::Path;
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use snafu::{ensure, OptionExt, ResultExt};
+
+/// Creates a tarball with all the contents of directory `dir`.
+pub(crate) fn create_tarball<P1, P2>(indir: P1, outfile: P2) -> Result<()>
+where
+    P1: AsRef<Path>,
+    P2: AsRef<Path>,
+{
+    let indir = indir.as_ref();
+    let outfile = outfile.as_ref();
+
+    // ensure the output directory exists.
+    let outdir = outfile.parent().context(error::RootAsFile)?;
+    fs::create_dir_all(outdir).context(error::CreateOutputDirectory { path: outdir })?;
+
+    // ensure the outfile will not be written to the input dir.
+    ensure!(
+        indir != outdir,
+        error::TarballOutputIsInInputDir { indir, outfile }
+    );
+
+    // compress files and create the tarball.
+    let tarfile = File::create(outfile).context(error::TarballFileCreate { path: outfile })?;
+    let encoder = GzEncoder::new(tarfile, Compression::default());
+    let mut tarball = tar::Builder::new(encoder);
+    tarball
+        .append_dir_all(crate::TARBALL_DIRNAME, indir)
+        .context(error::TarballWrite { path: outfile })?;
+    tarball
+        .finish()
+        .context(error::TarballClose { path: indir })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+    use tempfile::TempDir;
+
+    #[test]
+    fn tarball_test() {
+        // create an input directory with one file in it.
+        let indir = TempDir::new().unwrap();
+        let mut file = File::create(indir.path().to_path_buf().join("hello.txt")).unwrap();
+        file.write_all(b"Hello World!").unwrap();
+        drop(file);
+
+        // create an output directory into which our function will produce a tarball.
+        let outdir = TempDir::new().unwrap();
+        let outfilepath = outdir.path().join("somefile.tar.gz");
+
+        // run the function under test.
+        create_tarball(&indir.path().to_path_buf(), &outfilepath).unwrap();
+
+        // assert that the output tarball exists.
+        assert!(Path::new(&outfilepath).is_file());
+
+        // open the output tarball and check that it has the expected top level directory in it.
+        let tar_gz = File::open(outfilepath).unwrap();
+        let tar = GzDecoder::new(tar_gz);
+        let mut archive = Archive::new(tar);
+        let mut entries = archive.entries().unwrap();
+        let entry = entries.next().unwrap().unwrap();
+        let actual_path = PathBuf::from(entry.path().unwrap());
+        let expected_path = PathBuf::from(crate::TARBALL_DIRNAME);
+        assert!(actual_path == expected_path);
+
+        // check that the tarball also contains our hello.txt file.
+        let entry = entries.next().unwrap().unwrap();
+        let actual_path = PathBuf::from(entry.path().unwrap());
+        let expected_path = PathBuf::from(crate::TARBALL_DIRNAME).join("hello.txt");
+        assert!(actual_path == expected_path);
+    }
+}

--- a/sources/logdog/src/error.rs
+++ b/sources/logdog/src/error.rs
@@ -1,0 +1,94 @@
+//! Provides the list of errors for `logdog`.
+
+use std::io;
+use std::path::PathBuf;
+
+use snafu::{Backtrace, Snafu};
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub(crate) enum Error {
+    #[snafu(display("Encountered an empty command."))]
+    EmptyCommand { backtrace: Backtrace },
+    #[snafu(display("Error creating the tarball file '{}': {}", path.display(), source))]
+    TarballFileCreate {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error writing to the tarball '{}': {}", path.display(), source))]
+    TarballWrite {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error closing the tarball '{}': {}", path.display(), source))]
+    TarballClose {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("The output directory '{}' could not be created: {}.", path.display(), source))]
+    CreateOutputDirectory {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Output file '{}' can not be written to the directory that is being compressed '{}'.", outfile.display(), indir.display()))]
+    TarballOutputIsInInputDir {
+        indir: PathBuf,
+        outfile: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error creating the command stdout file '{}': {}", path.display(), source))]
+    CommandOutputFile {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error parsing command '{}': {}", command, source))]
+    CommandParse {
+        source: shell_words::ParseError,
+        command: String,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error creating the command stderr file '{}': {}", path.display(), source))]
+    CommandErrFile {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error creating the error file '{}': {}", path.display(), source))]
+    ErrorFile {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error writing to the error file '{}': {}", path.display(), source))]
+    ErrorWrite {
+        source: io::Error,
+        path: PathBuf,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error starting command '{}': {}", command, source))]
+    CommandSpawn {
+        command: String,
+        source: io::Error,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Error completing command '{}': {}", command, source))]
+    CommandFinish {
+        command: String,
+        source: io::Error,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Cannot write to / as a file."))]
+    RootAsFile { backtrace: Backtrace },
+    #[snafu(display("Error creating tempdir: {}", source))]
+    TempDirCreate {
+        source: io::Error,
+        backtrace: Backtrace,
+    },
+}
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sources/logdog/src/log_request.rs
+++ b/sources/logdog/src/log_request.rs
@@ -1,0 +1,29 @@
+//! Provides the list of commands that `logdog` will run.
+
+/// `LogRequest` holds a command to run to retrieve log information and the filename for its output.
+pub(crate) struct LogRequest<'a> {
+    pub(crate) filename: &'a str,
+    pub(crate) command: &'a str,
+}
+
+/// Returns the standard list of `logdog` commands.
+pub(crate) fn log_requests<'a>() -> impl Iterator<Item = LogRequest<'static>> {
+    [
+        ("os-release", "cat /etc/os-release"),
+        ("journalctl-boots", "journalctl --list-boots --no-pager"),
+        ("journalctl.errors", "journalctl -p err -a --no-pager"),
+        ("journalctl.log", "journalctl -a --no-pager"),
+        ("signpost", "signpost status"),
+        ("settings.json", "apiclient --method GET --uri /"),
+        ("wicked", "wicked show all"),
+        ("containerd-config", "containerd config dump"),
+        ("kube-status", "systemctl status kube* -l --no-pager"),
+        ("dmesg", "dmesg --color=never --nopager"),
+        ("iptables-filter", "iptables -nvL -t filter"),
+        ("iptables-nat", "iptables -nvL -t nat"),
+        ("df", "df -h"),
+        ("df-inodes", "df -hi"),
+    ]
+    .iter()
+    .map(|(filename, command)| LogRequest { filename, command })
+}

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -1,0 +1,215 @@
+/*!
+# Introduction
+
+`logdog` is a program that gathers logs from various places on a Bottlerocket host and combines them
+into a tarball for easy export.
+
+Usage example:
+```
+$ logdog
+logs are at: /tmp/bottlerocket-logs.tar.gz
+```
+
+# Logs
+
+For the commands used to gather logs, please see [log_request](src/log_request.rs).
+
+*/
+
+#![deny(rust_2018_idioms)]
+
+mod create_tarball;
+mod error;
+mod log_request;
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::{env, process};
+
+use create_tarball::create_tarball;
+use error::Result;
+use log_request::{log_requests, LogRequest};
+use snafu::{ErrorCompat, OptionExt, ResultExt};
+use tempfile::TempDir;
+
+const ERROR_FILENAME: &str = "logdog.errors";
+const OUTPUT_FILENAME: &str = "bottlerocket-logs.tar.gz";
+const TARBALL_DIRNAME: &str = "bottlerocket-logs";
+
+/// Prints a usage message in the event a bad arg is passed.
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            [ --output PATH ]       where to write archived logs
+",
+        program_name,
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg(msg: &str) -> ! {
+    eprintln!("{}\n", msg);
+    usage();
+}
+
+/// Parses the command line arguments.
+fn parse_args(args: env::Args) -> PathBuf {
+    let mut output_arg = None;
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--output" => {
+                output_arg = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to --output")),
+                )
+            }
+            _ => usage(),
+        }
+    }
+
+    match output_arg {
+        Some(path) => PathBuf::from(path),
+        None => env::temp_dir().as_path().join(OUTPUT_FILENAME),
+    }
+}
+
+/// Runs a command and writes its output to a file.
+pub(crate) fn run_command<P: AsRef<Path>>(output_filepath: P, command: &str) -> Result<()> {
+    let output_filepath = output_filepath.as_ref();
+    let mut args: VecDeque<String> = shell_words::split(command)
+        .context(error::CommandParse { command })?
+        .into();
+    let command = args.pop_front().context(error::EmptyCommand)?;
+    let ofile = File::create(output_filepath).context(error::CommandOutputFile {
+        path: output_filepath,
+    })?;
+    let stderr_file = ofile.try_clone().context(error::CommandErrFile {
+        path: output_filepath,
+    })?;
+    Command::new(command.as_str())
+        .args(&args)
+        .stdout(Stdio::from(ofile))
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .context(error::CommandSpawn {
+            command: command.clone(),
+        })?
+        .wait_with_output()
+        .context(error::CommandFinish {
+            command: command.clone(),
+        })?;
+    Ok(())
+}
+
+/// Runs a list of commands and writes all of their output into files in the same `outdir`.  Any
+/// failures are noted in the file named by ERROR_FILENAME.  This function ignores the commands'
+/// return status and only fails if we can't save our own errors.
+pub(crate) fn collect_logs<P: AsRef<Path>>(
+    log_requests: impl Iterator<Item = LogRequest<'static>>,
+    outdir: P,
+) -> Result<()> {
+    // if a command fails, we will pipe its error here and continue.
+    let outdir = outdir.as_ref();
+    let error_path = outdir.join(crate::ERROR_FILENAME);
+    let mut error_file = File::create(&error_path).context(error::ErrorFile {
+        path: error_path.clone(),
+    })?;
+
+    for log_request in log_requests {
+        // show the user what command we are running
+        println!("Running: {}", log_request.command);
+        if let Err(e) = run_command(outdir.join(&log_request.filename), &log_request.command) {
+            // ignore the error, but make note of it in the error file.
+            write!(
+                &mut error_file,
+                "Error running command '{}': '{}'\n",
+                log_request.command, e
+            )
+            .context(error::ErrorWrite {
+                path: error_path.clone(),
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Runs the bulk of the program's logic, main wraps this.
+fn run(log_requests: impl Iterator<Item = LogRequest<'static>>, output: &PathBuf) -> Result<()> {
+    let temp_dir = TempDir::new().context(error::TempDirCreate)?;
+    collect_logs(log_requests, &temp_dir.path().to_path_buf())?;
+    create_tarball(&temp_dir.path().to_path_buf(), &output)?;
+    println!("logs are at: {}", output.display());
+    Ok(())
+}
+
+fn main() -> ! {
+    let output = parse_args(env::args());
+    process::exit(match run(log_requests(), &output) {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!("{}", err);
+            if let Some(var) = env::var_os("RUST_BACKTRACE") {
+                if var != "0" {
+                    if let Some(backtrace) = err.backtrace() {
+                        eprintln!("\n{:?}", backtrace);
+                    }
+                }
+            }
+            1
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::read::GzDecoder;
+    use std::fs::File;
+    use tar::Archive;
+
+    #[test]
+    fn test_program() {
+        let output_tempdir = TempDir::new().unwrap();
+        let output_filepath = output_tempdir.path().join("logstest");
+
+        // we assume that `echo` will not do something unexpected on the machine running this test.
+        run(
+            [("hello.txt", "echo hello")]
+                .iter()
+                .map(|&item| LogRequest {
+                    filename: item.0,
+                    command: item.1,
+                }),
+            &output_filepath,
+        )
+        .unwrap();
+
+        // open the file and check that its contents are as expected.
+
+        // this function will panic if the path is not found in the tarball.
+        let find = |path_to_find: &PathBuf| {
+            let tar_gz = File::open(&output_filepath).unwrap();
+            let tar = GzDecoder::new(tar_gz);
+            let mut archive = Archive::new(tar);
+            let mut entries = archive.entries().unwrap();
+            let _found = entries
+                .find(|item| {
+                    let entry = item.as_ref().clone().unwrap();
+                    let path = entry.path().unwrap();
+                    PathBuf::from(path) == PathBuf::from(path_to_find)
+                })
+                .unwrap()
+                .unwrap();
+        };
+
+        // these assert that the provided paths exist in the tarball
+        find(&PathBuf::from(TARBALL_DIRNAME));
+        find(&PathBuf::from(TARBALL_DIRNAME).join("hello.txt"));
+    }
+}


### PR DESCRIPTION
### Issue number:

Closes #452

### Description of changes:

A rust executable that shells out to multiple programs writing logs into an aggregation tempdir, then tars these and deletes the tempdir.

### Testing done:

I built a Bottlerocket AMI and ran `logdog` on it.
I used SSH to bring the tar to my local machine and inspected the logs.
(The Bottlerocket host joined the EKS cluster as a node.)

The size of the executable on the Bottlerocket host is `173K`.
The size of the tarball✻ `138K`.
The size of the same tarball when inflated is `1.5M`.

✻ on a host that's been running idle for about an hour.

### Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
