### PR TITLE
updata/update_metadata: Adds ability to add waves using TOML files

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2646,6 +2646,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "migrator 0.1.0",
+ "parse-datetime 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/parse-datetime/README.md
+++ b/sources/parse-datetime/README.md
@@ -9,7 +9,7 @@ This library parses a `DateTime<Utc>` from a string.
 The string can be:
 
 * an `RFC3339` formatted date / time
-* a string with the form `"in <unsigned integer> <unit(s)>"` where
+* a string with the form `"[in] <unsigned integer> <unit(s)>"` where 'in' is optional
    * `<unsigned integer>` may be any unsigned integer and
    * `<unit(s)>` may be either the singular or plural form of the following: `hour | hours`, `day | days`, `week | weeks`
 
@@ -19,6 +19,8 @@ Examples:
 * `"in 2 hours"`
 * `"in 6 days"`
 * `"in 2 weeks"`
+* `"1 hour"`
+* `"7 days"`
 
 ## Colophon
 

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 chrono = { version = "0.4.9", features = ["serde"] }
+parse-datetime = { path = "../../parse-datetime" }
 rand = "0.7.0"
 regex = "1.1"
 semver = { version = "0.9.0", features = ["serde"] }

--- a/sources/updater/update_metadata/src/error.rs
+++ b/sources/updater/update_metadata/src/error.rs
@@ -46,6 +46,12 @@ pub enum Error {
     #[snafu(display("Migration {} matches regex but missing name", name))]
     BadRegexName { name: String },
 
+    #[snafu(display("Unable to parse datetime from string '{}': {}", datetime, source))]
+    BadDateTime {
+        datetime: String,
+        source: parse_datetime::Error,
+    },
+
     #[snafu(display("Duplicate key ID: {}", keyid))]
     DuplicateKeyId { backtrace: Backtrace, keyid: u32 },
 
@@ -103,6 +109,12 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Waves are not ordered: bound {} occurs before bound {}", next, wave))]
-    WavesUnordered { wave: u32, next: u32 },
+    #[snafu(display("Waves are not ordered; percentages and dates must be in ascending order"))]
+    WavesUnordered,
+
+    #[snafu(display(
+        "`fleet_percentage` must be a value between 1 - 100: value provided: {}",
+        provided
+    ))]
+    InvalidFleetPercentage { provided: u32 },
 }

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -177,9 +177,7 @@ pub(crate) enum Error {
     },
 
     #[snafu(display("Unable to get OS version: {}", source))]
-    ReleaseVersion {
-        source: bottlerocket_release::Error,
-    },
+    ReleaseVersion { source: bottlerocket_release::Error },
 
     #[snafu(display("Failed setting permissions of '{}': {}", path.display(), source))]
     SetPermissions {
@@ -229,8 +227,8 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("--start-time <time> required to add wave to update"))]
-    WaveStartArg { backtrace: Backtrace },
+    #[snafu(display("--wave-file <path> required to add waves to update"))]
+    WaveFileArg { backtrace: Backtrace },
 
     #[snafu(display("Failed writing update data to disk: {}", source))]
     WriteUpdate {

--- a/sources/updater/updog/tests/data/default_waves.toml
+++ b/sources/updater/updog/tests/data/default_waves.toml
@@ -1,0 +1,15 @@
+[[waves]]
+start_after = '12 hours'
+fleet_percentage = 1
+
+[[waves]]
+start_after = '1 day'
+fleet_percentage = 10
+
+[[waves]]
+start_after = '3 days'
+fleet_percentage = 25
+
+[[waves]]
+start_after = '6 days'
+fleet_percentage = 100


### PR DESCRIPTION
**Issue number:**
Fixes #596 


**Description of changes:**
This commit adds to updata the ability to use TOML-formatted files
to add waves to an existing update. The `--wave-file` flag for
the `add-wave` subcommand allows a user to specify the path to the
file where waves are defined.

Structs for deserializing the TOML have been added to `update_metadata`. A method on `add_waves` was also added `Manifest`. This allows us to update the `manifest.json` using other Rust code.

**Testing done:**
* All unit tests continue to pass
* An built image boots locally
* Calling `updata` with a waves file with an invalid `fleet_percentage` fails as expected.
```
$ cat ./waves 
[[waves]]
start_after = 'in 12 hours'
fleet_percentage = 1

[[waves]]
start_after = 'in 1 day'
fleet_percentage = 10

[[waves]]
start_after = 'in 3 days'
fleet_percentage = 0

[[waves]]
start_after = 'in 6 days'
fleet_percentage = 100

$ cargo run --bin updata -- set-waves foobar --arch x86_64 --version 0.3.1 --variant aws-k8s-1.15 --wave-file ./waves
...
15:31:56 [ERROR] `fleet_percentage` must be a value between 1 - 100

$ cat ./waves 
[[waves]]
start_after = 'in 12 hours'
fleet_percentage = 1

[[waves]]
start_after = 'in 1 day'
fleet_percentage = 10

[[waves]]
start_after = 'in 3 days'
fleet_percentage = 101

[[waves]]
start_after = 'in 6 days'
fleet_percentage = 100

$ cargo run --bin updata -- set-waves foobar --arch x86_64 --version 0.3.1 --variant aws-k8s-1.15 --wave-file ./waves
...
15:33:17 [ERROR] `fleet_percentage` must be a value between 1 - 100

```

* Calling `updata` with waves out of order fails as expected
```
$ cat ./waves 
[[waves]]
start_after = 'in 1 day'
fleet_percentage = 1

[[waves]]
start_after = 'in 12 hours'
fleet_percentage = 10

[[waves]]
start_after = 'in 3 days'
fleet_percentage = 25

[[waves]]
start_after = 'in 6 days'
fleet_percentage = 100

$ RUST_BACKTRACE=1 cargo run --bin updata -- set-waves foobar --arch x86_64 --version 0.3.1 --variant aws-k8s-1.15 --wave-file ./waves
...
15:35:59 [ERROR] Waves are not ordered: bound 20 occurs before bound 0
```

* Calling `updata` with a valid waves file usin a fake `manifest.json` works a treat:
```
$ cat foobar
{
  "updates": [
    {
      "variant": "aws-k8s-1.15",
      "arch": "x86_64",
      "version": "0.3.0",
      "max_version": "0.3.1",
      "waves": {},
      "images": {
        "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-boot.ext4.lz4",
        "root": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-root.ext4.lz4",
        "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-root.verity.lz4"
      }
    },
  ],
  "migrations": {}
}

$ cat ./waves
[[waves]]
start_after = 'in 12 hours'
fleet_percentage = 1

[[waves]]
start_after = 'in 1 day'
fleet_percentage = 10

[[waves]]
start_after = 'in 3 days'
fleet_percentage = 25

[[waves]]
start_after = 'in 6 days'
fleet_percentage = 100

$ cargo run --bin updata -- set-waves foobar --arch x86_64 --version 0.3.0 --variant aws-k8s-1.15 --wave-file ./waves
...

$ cat foobar
{
  "updates": [
    {
      "variant": "aws-k8s-1.15",
      "arch": "x86_64",
      "version": "0.3.0",
      "max_version": "0.3.1",
      "waves": {
        "0": "2020-04-03T11:08:59.483930025Z",
        "20": "2020-04-03T23:08:59.483949148Z",
        "204": "2020-04-05T23:08:59.483958597Z",
        "512": "2020-04-08T23:08:59.483967129Z"
      },
      "images": {
        "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-boot.ext4.lz4",
        "root": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-root.ext4.lz4",
        "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-root.verity.lz4"
      }
    },
  ],
  "migrations": {}
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
