### PR TITLE
set containerd verbosity to warn

### DIFF
--- a/packages/containerd/containerd.service
+++ b/packages/containerd/containerd.service
@@ -5,7 +5,7 @@ After=network-online.target configured.target
 Wants=network-online.target configured.target
 
 [Service]
-ExecStart=/usr/bin/containerd
+ExecStart=/usr/bin/containerd --log-level=warn
 Delegate=yes
 KillMode=process
 TimeoutSec=0


### PR DESCRIPTION
**Issue number:**

Closes #872 

**Description of changes:**

The logs that are blowing up the system journal come from here (thanks @samuelkarp)

* https://github.com/containerd/containerd/blob/e5fc99107a210a5070561bd8126c0467eb91847f/vendor/github.com/containerd/cri/pkg/server/instrumented_service.go#L250
* https://github.com/containerd/containerd/blob/e5fc99107a210a5070561bd8126c0467eb91847f/vendor/github.com/containerd/cri/pkg/server/container_execsync.go#L174
* https://github.com/containerd/containerd/blob/e5fc99107a210a5070561bd8126c0467eb91847f/vendor/github.com/containerd/cri/pkg/server/io/exec_io.go#L102

These are logrus `info` level log statements that look like this:

```text
containerd[3062]: time="2020-03-26T16:32:10.954615655Z" level=info msg="ExecSync for \"8f76a5ea2288727801a8fe780dabb06ce70f5490eb74c25a2207f25b1e91f905\" with command [/app/grpc-health-probe -addr=:50051] and timeout 1 (s)"
containerd[3062]: time="2020-03-26T16:32:11.023213140Z" level=info msg="Finish piping \"stdout\" of container exec \"7ca0ac98f8e733cbeedea4d7a6cce81885e9782c0f1b1b0830d4b43422b27117\""
containerd[3062]: time="2020-03-26T16:32:11.023213284Z" level=info msg="Finish piping \"stderr\" of container exec \"7ca0ac98f8e733cbeedea4d7a6cce81885e9782c0f1b1b0830d4b43422b27117\""
containerd[3062]: time="2020-03-26T16:32:11.023405191Z" level=info msg="Exec process \"7ca0ac98f8e733cbeedea4d7a6cce81885e9782c0f1b1b0830d4b43422b27117\" exits with exit code 0 and error <nil>"
containerd[3062]: time="2020-03-26T16:32:11.024190117Z" level=info msg="ExecSync for \"8f76a5ea2288727801a8fe780dabb06ce70f5490eb74c25a2207f25b1e91f905\" returns with exit code 0"
```

These are triggered by the AWS VPC CNI plugin health check.

To prevent these 5 log lines from occurring every 30 seconds I set the containerd logging verbosity level to `warn` in `containerd.service`.  (Note: I don't think this can be done in the config file https://github.com/containerd/cri/blob/master/docs/config.md)

It's hard to know if some future investigation would be easier with a higher level of verbosity (and thus would be impeded by this change). But this seems to be the only way to eliminate these log lines short of patching cri-containerd.

**Testing done:**

I built and ran an AMI and confirmed that the nuisance logs were gone. I then rand a busybox pod to ensure that the AMI can run pods.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
