### PR TITLE
QUICKSTART: Clarify which setup is optional

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -50,14 +50,14 @@ eksctl create cluster --config-file ./my-eksctl.yaml
 
 This will take a few minutes to create the EKS cluster and spin up your Bottlerocket worker nodes.
 
-#### Remaining cluster configuration
-
 ##### CNI plugin
 
 Now we can make a configuration change to use a CNI plugin that's compatible with Bottlerocket.
 ```
 kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6/config/v1.6/aws-k8s-cni.yaml
 ```
+
+#### Optional cluster configuration
 
 ##### CSI plugin
 


### PR DESCRIPTION
**Issue number:**

Fixes #901

**Description of changes:**

Updates the headers in the cluster creation section of the quickstart guide to clarify what's required versus optional, now that we have more optional steps.

**Testing done:**

Rendered, looks OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.