### PR TITLE
Admin container v0.5.0 migration

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1387,6 +1387,13 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "migrate-admin-container-v0_5_0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
 name = "migration-helpers"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "api/migration/migration-helpers",
 
     # "api/migration/migrations/vX.Y.Z/...
+    "api/migration/migrations/v0.3.2/migrate-admin-container-v0_5_0",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v0.3.2/migrate-admin-container-v0_5_0/Cargo.toml
+++ b/sources/api/migration/migrations/v0.3.2/migrate-admin-container-v0_5_0/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "migrate-admin-container-v0_5_0"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.3.2/migrate-admin-container-v0_5_0/src/main.rs
+++ b/sources/api/migration/migrations/v0.3.2/migrate-admin-container-v0_5_0/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.4.0";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0";
+
+/// We bumped the version of the default admin container from v0.4.0 to v0.5.0
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -58,7 +58,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.4.0"
+template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0"
 
 [settings.host-containers.control]
 enabled = true


### PR DESCRIPTION
```
commit 8c0aadfbb39461bf41da9e2a8511d1f084f355ba
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Apr 14 14:52:31 2020 -0700

    migrations: add migration to migrate admin container version

    Adds a new migration to migrate the default admin host-container version
    from v0.4.0 to v0.5.0.
```

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses https://github.com/bottlerocket-os/bottlerocket/issues/890


**Testing done:**
Created a datastore locally using `storewolf` and manually populated `settings.aws.region` with `"us-west-2"`
Forward migration:
```
     Running `migrate-admin-container --source-datastore /tmp/ds/next --target-datastore /tmp/ds/current --forward`
Updating template and value of 'settings.host-containers.admin.source' on upgrade
Changing template of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.4.0' to '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0'
Changing value of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.4.0' to '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0'

$ cat /tmp/ds/current/live/settings/host-containers/admin/source.template
"328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0"
$ cat /tmp/ds/current/live/settings/host-containers/admin/source
"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0"
```

Backwards migration:
```
     Running `migrate-admin-container --source-datastore /tmp/ds/current --target-datastore /tmp/ds/next --backward`
Updating template and value of 'settings.host-containers.admin.source' on downgrade
Changing template of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0' to '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.4.0'
Changing value of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0' to '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.4.0'

$ cat /tmp/ds/next/live/settings/host-containers/admin/source.template 
"328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.4.0"
$ cat /tmp/ds/next/live/settings/host-containers/admin/source
"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.4.0"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
