### PR TITLE
Migrations build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ USER root
 RUN --mount=target=/host \
     mkdir -p /local/rpms /local/migrations ./rpmbuild/RPMS \
     && ln -s /host/build/packages/*.rpm ./rpmbuild/RPMS \
-    && cp /host/build/packages/bottlerocket-${ARCH}-migrations-*.rpm /local/migrations \
+    && find /host/build/packages/ -maxdepth 1 -type f -name "bottlerocket-${ARCH}-migrations-*.rpm" -not -iname '*debuginfo*' -exec cp '{}' '/local/migrations/' ';' \
     && createrepo_c \
         -o ./rpmbuild/RPMS \
         -x '*-debuginfo-*.rpm' \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Updates the Dockerfile to limit the file being added for 'rpm2migration' to only the migrations rpm. This is to prevent the migrations-debuginfo rpm from being installed.

Reverts 3980e54 which broke `ReplaceTemplateMigration` migration helper.

**Testing done:**
Built migration from https://github.com/bottlerocket-os/bottlerocket/pull/903 fine, end up with correct migrations archive.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
