### PR TITLE
v0.3.2 release

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,3 +1,4 @@
-version = "0.3.1"
+version = "0.3.2"
 
 [migrations]
+"(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0_5_0"]


### PR DESCRIPTION
Bumps version to v0.3.2
Includes one migration for changing the default admin container version.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
