### PR TITLE
waves: fix example wave files 'wave'

### DIFF
--- a/sources/updater/waves/README.md
+++ b/sources/updater/waves/README.md
@@ -22,7 +22,7 @@ All waves include the seeds of the prior wave, so if a node misses its wave for 
 
 ## Writing wave files
 
-Wave files must be [valid TOML](https://github.com/toml-lang/toml) containing a list of `[[wave]]` entries.
+Wave files must be [valid TOML](https://github.com/toml-lang/toml) containing a list of `[[waves]]` entries.
 Waves defined in these files must contain two keys, `start_after` and `fleet_percentage`.
 
 `start_after` must be:

--- a/sources/updater/waves/accelerated-waves.toml
+++ b/sources/updater/waves/accelerated-waves.toml
@@ -1,18 +1,18 @@
 # The following represents an "accelerated" set of update waves for a much
 # quicker deployment. The deployment lasts for 1 day, and quickly increases the
 # nodes updated at once.
-[[wave]]
+[[waves]]
 start_after = '1 hour'
 fleet_percentage = 3
 
-[[wave]]
+[[waves]]
 start_after = '4 hours'
 fleet_percentage = 12
 
-[[wave]]
+[[waves]]
 start_after = '8 hours'
 fleet_percentage = 50
 
-[[wave]]
+[[waves]]
 start_after = '1 day'
 fleet_percentage = 100

--- a/sources/updater/waves/default-waves.toml
+++ b/sources/updater/waves/default-waves.toml
@@ -1,22 +1,22 @@
 # The following represents a "normal" set of update waves for a typical
 # deployment. The deployment lasts for 6 days, and gradually increases the
 # nodes updated at once.
-[[wave]]
+[[waves]]
 start_after = '1 hour'
 fleet_percentage = 1
 
-[[wave]]
+[[waves]]
 start_after = '4 hours'
 fleet_percentage = 5
 
-[[wave]]
+[[waves]]
 start_after = '1 day'
 fleet_percentage = 10
 
-[[wave]]
+[[waves]]
 start_after = '3 days'
 fleet_percentage = 25
 
-[[wave]]
+[[waves]]
 start_after = '6 days'
 fleet_percentage = 100

--- a/sources/updater/waves/ohno.toml
+++ b/sources/updater/waves/ohno.toml
@@ -1,14 +1,14 @@
 # The following represents an "emergency" set of update waves for a rapid
 # deployment. The deployment lasts for 3 hours, with a small initial wave,
 # and then all nodes will be updated after the first hour.
-[[wave]]
+[[waves]]
 start_after = '1 hour'
 fleet_percentage = 5
 
-[[wave]]
+[[waves]]
 start_after = '2 hours'
 fleet_percentage = 25
 
-[[wave]]
+[[waves]]
 start_after = '3 hours'
 fleet_percentage = 100


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Updata `UpdateWaves` expects `waves` but the example wave files were specifying waves with `wave`. 
https://github.com/bottlerocket-os/bottlerocket/blob/f18913f6ba27c16d3bd295b959f00ccf06fa1abc/sources/updater/update_metadata/src/lib.rs#L56-L61
This commit fixes all references of `wave` to `waves`.



**Testing done:**
Updata successfully updates a `manifest.toml` with `default-waves.toml` and adds the correct waves.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
