### PR TITLE
update systemd to v245

### DIFF
--- a/packages/login/login.spec
+++ b/packages/login/login.spec
@@ -21,7 +21,11 @@ Requires: %{_cross_os}systemd-console
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 %{S:0} %{buildroot}%{_cross_bindir}/login
 
+install -d %{buildroot}%{_cross_sbindir}
+ln -s ../bin/login %{buildroot}%{_cross_sbindir}/sulogin
+
 %files
 %{_cross_bindir}/login
+%{_cross_sbindir}/sulogin
 
 %changelog

--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -38,7 +38,7 @@ ExecStart=/usr/bin/mount \
 ExecStart=/usr/lib/systemd/systemd-growfs ${LOCAL_DIR}
 ExecStart=/usr/bin/mkdir -p ${LOCAL_DIR}/var ${LOCAL_DIR}/opt
 
-RemainAfterExit=false
+RemainAfterExit=true
 StandardError=journal+console
 
 [Install]

--- a/packages/systemd/9001-move-stateful-paths-to-ephemeral-storage.patch
+++ b/packages/systemd/9001-move-stateful-paths-to-ephemeral-storage.patch
@@ -1,7 +1,7 @@
-From 8862df96457fa790bb2dea414f89d1fe0a704716 Mon Sep 17 00:00:00 2001
+From 4f14d52fb6951f3870bfbe6789471cd75a87c341 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sun, 15 Sep 2019 00:21:26 +0000
-Subject: [PATCH 9001/9004] move stateful paths to ephemeral storage
+Subject: [PATCH 9001/9005] move stateful paths to ephemeral storage
 
 We reserve most of /var for persistent local storage controlled by
 the administrator, and want to avoid depending on it for our own

--- a/packages/systemd/9002-do-not-create-unused-state-directories.patch
+++ b/packages/systemd/9002-do-not-create-unused-state-directories.patch
@@ -1,7 +1,7 @@
-From 1b3b7345d19a7877026690ef05852dbb4fb0efe8 Mon Sep 17 00:00:00 2001
+From 8711db616a17523abcea9615c56233c68cf6a1e5 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sun, 15 Sep 2019 00:51:25 +0000
-Subject: [PATCH 9002/9004] do not create unused state directories
+Subject: [PATCH 9002/9005] do not create unused state directories
 
 We do not use the coredump handler, and the private directories have
 been relocated to `/run`.
@@ -12,11 +12,11 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 7 deletions(-)
 
 diff --git a/tmpfiles.d/systemd.conf.m4 b/tmpfiles.d/systemd.conf.m4
-index 9c57d3b..30a9bd9 100644
+index 11d87d2..c8fb51a 100644
 --- a/tmpfiles.d/systemd.conf.m4
 +++ b/tmpfiles.d/systemd.conf.m4
-@@ -70,10 +70,3 @@ a+ /var/log/journal/%m - - - - d:group:wheel:r-x
- a+ /var/log/journal/%m - - - - group:wheel:r-x
+@@ -65,10 +65,3 @@ a+ /var/log/journal    - - - - d:group::r-x,d:group:wheel:r-x,group::r-x,group:w
+ a+ /var/log/journal/%m - - - - d:group:wheel:r-x,group:wheel:r-x
  a+ /var/log/journal/%m/system.journal - - - - group:wheel:r--
  '')')')m4_dnl
 -

--- a/packages/systemd/9003-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9003-use-absolute-path-for-var-run-symlink.patch
@@ -1,7 +1,7 @@
-From 6c298326187075878688ac06f7d99e5b9822aaec Mon Sep 17 00:00:00 2001
+From 3cb32d73e064c2f5a6fde71c279b0cfe99e1c6ec Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 17 Sep 2019 01:35:51 +0000
-Subject: [PATCH 9003/9004] use absolute path for /var/run symlink
+Subject: [PATCH 9003/9005] use absolute path for /var/run symlink
 
 Otherwise the symlink may be broken if /var is a bind mount from
 somewhere else.

--- a/packages/systemd/9004-core-add-separate-timeout-for-system-shutdown.patch
+++ b/packages/systemd/9004-core-add-separate-timeout-for-system-shutdown.patch
@@ -1,7 +1,7 @@
-From 4d11f5d502ca4a61c491681cdfd99ebe24e3f58c Mon Sep 17 00:00:00 2001
+From 2feddea6cbee14216e26a4312f5cb0e546a472ff Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 10 Mar 2020 20:30:10 +0000
-Subject: [PATCH 9004/9004] core: add separate timeout for system shutdown
+Subject: [PATCH 9004/9005] core: add separate timeout for system shutdown
 
 There is an existing setting for this (DefaultTimeoutStopUSec), but
 changing it has no effect because `reset_arguments()` is called just
@@ -19,7 +19,7 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  2 files changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/src/basic/def.h b/src/basic/def.h
-index 970654a..b02f6f0 100644
+index 970654a..9251bb9 100644
 --- a/src/basic/def.h
 +++ b/src/basic/def.h
 @@ -13,6 +13,9 @@
@@ -33,7 +33,7 @@ index 970654a..b02f6f0 100644
  #define DEFAULT_UNIX_MAX_DGRAM_QLEN 512UL
  
 diff --git a/src/core/main.c b/src/core/main.c
-index c24b696..8ffa09f 100644
+index 3c6b66e..f2e9776 100644
 --- a/src/core/main.c
 +++ b/src/core/main.c
 @@ -114,6 +114,7 @@ static ExecOutput arg_default_std_error;
@@ -44,7 +44,7 @@ index c24b696..8ffa09f 100644
  static usec_t arg_default_timeout_abort_usec;
  static bool arg_default_timeout_abort_set;
  static usec_t arg_default_start_limit_interval;
-@@ -1389,7 +1390,7 @@ static int become_shutdown(
+@@ -1398,7 +1399,7 @@ static int become_shutdown(
          env_block = strv_copy(environ);
  
          xsprintf(log_level, "%d", log_get_max_level());
@@ -53,7 +53,7 @@ index c24b696..8ffa09f 100644
  
          switch (log_get_target()) {
  
-@@ -2124,6 +2125,7 @@ static void reset_arguments(void) {
+@@ -2151,6 +2152,7 @@ static void reset_arguments(void) {
          arg_default_restart_usec = DEFAULT_RESTART_USEC;
          arg_default_timeout_start_usec = DEFAULT_TIMEOUT_USEC;
          arg_default_timeout_stop_usec = DEFAULT_TIMEOUT_USEC;

--- a/packages/systemd/9005-repart-always-use-random-UUIDs.patch
+++ b/packages/systemd/9005-repart-always-use-random-UUIDs.patch
@@ -1,0 +1,178 @@
+From b96a0d9b2449719a7152f4b3c2871fd3b18a8ebf Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 16 Apr 2020 15:10:41 +0000
+Subject: [PATCH 9005/9005] repart: always use random UUIDs
+
+We would like to avoid adding OpenSSL to the base OS, and for our use
+case we do not need the UUIDs assigned to disks or partitions to be
+reproducible.
+
+The upstream implementation keys off machine ID, and we will almost
+always be resizing the local data partition on first boot, when the
+machine ID will be freshly generated and therefore also random.
+
+This takes the fallback case of generating a random UUID in the event
+of a collision and makes it the default behavior for both partition
+and disk UUIDs.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ meson.build            |   3 +-
+ src/partition/repart.c | 101 ++++++-----------------------------------
+ 2 files changed, 14 insertions(+), 90 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index fc216d2..eb28daa 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1305,8 +1305,7 @@ substs.set('DEFAULT_DNS_OVER_TLS_MODE', default_dns_over_tls)
+ 
+ want_repart = get_option('repart')
+ if want_repart != 'false'
+-        have = (conf.get('HAVE_OPENSSL') == 1 and
+-                conf.get('HAVE_LIBFDISK') == 1)
++        have = (conf.get('HAVE_LIBFDISK') == 1)
+         if want_repart == 'true' and not have
+                 error('repart support was requested, but dependencies are not available')
+         endif
+diff --git a/src/partition/repart.c b/src/partition/repart.c
+index 3e52f26..93f6834 100644
+--- a/src/partition/repart.c
++++ b/src/partition/repart.c
+@@ -13,9 +13,6 @@
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ 
+-#include <openssl/hmac.h>
+-#include <openssl/sha.h>
+-
+ #include "sd-id128.h"
+ 
+ #include "alloc-util.h"
+@@ -1143,26 +1140,18 @@ static int fdisk_set_disklabel_id_by_uuid(struct fdisk_context *c, sd_id128_t id
+ #define DISK_UUID_TOKEN "disk-uuid"
+ 
+ static int disk_acquire_uuid(Context *context, sd_id128_t *ret) {
+-        union {
+-                unsigned char md[SHA256_DIGEST_LENGTH];
+-                sd_id128_t id;
+-        } result;
++        sd_id128_t id;
++        int r;
+ 
+         assert(context);
+         assert(ret);
+ 
+-        /* Calculate the HMAC-SHA256 of the string "disk-uuid", keyed off the machine ID. We use the machine
+-         * ID as key (and not as cleartext!) since it's the machine ID we don't want to leak. */
+-
+-        if (!HMAC(EVP_sha256(),
+-                  &context->seed, sizeof(context->seed),
+-                  (const unsigned char*) DISK_UUID_TOKEN, strlen(DISK_UUID_TOKEN),
+-                  result.md, NULL))
+-                return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE), "HMAC-SHA256 calculation failed.");
++        /* Calculate a random UUID for the indicated disk. */
++        r = sd_id128_randomize(&id);
++        if (r < 0)
++            return log_error_errno(r, "Failed to generate randomized UUID: %m");
+ 
+-        /* Take the first half, mark it as v4 UUID */
+-        assert_cc(sizeof(result.md) == sizeof(result.id) * 2);
+-        *ret = id128_make_v4_uuid(result.id);
++        *ret = id;
+         return 0;
+ }
+ 
+@@ -2073,83 +2062,19 @@ static int context_wipe_and_discard(Context *context, bool from_scratch) {
+ }
+ 
+ static int partition_acquire_uuid(Context *context, Partition *p, sd_id128_t *ret) {
+-        struct {
+-                sd_id128_t type_uuid;
+-                uint64_t counter;
+-        } _packed_  plaintext = {};
+-        union {
+-                unsigned char md[SHA256_DIGEST_LENGTH];
+-                sd_id128_t id;
+-        } result;
+-
+-        uint64_t k = 0;
+-        Partition *q;
++        sd_id128_t id;
+         int r;
+ 
+         assert(context);
+         assert(p);
+         assert(ret);
+ 
+-        /* Calculate a good UUID for the indicated partition. We want a certain degree of reproducibility,
+-         * hence we won't generate the UUIDs randomly. Instead we use a cryptographic hash (precisely:
+-         * HMAC-SHA256) to derive them from a single seed. The seed is generally the machine ID of the
+-         * installation we are processing, but if random behaviour is desired can be random, too. We use the
+-         * seed value as key for the HMAC (since the machine ID is something we generally don't want to leak)
+-         * and the partition type as plaintext. The partition type is suffixed with a counter (only for the
+-         * second and later partition of the same type) if we have more than one partition of the same
+-         * time. Or in other words:
+-         *
+-         * With:
+-         *     SEED := /etc/machine-id
+-         *
+-         * If first partition instance of type TYPE_UUID:
+-         *     PARTITION_UUID := HMAC-SHA256(SEED, TYPE_UUID)
+-         *
+-         * For all later partition instances of type TYPE_UUID with INSTANCE being the LE64 encoded instance number:
+-         *     PARTITION_UUID := HMAC-SHA256(SEED, TYPE_UUID || INSTANCE)
+-         */
+-
+-        LIST_FOREACH(partitions, q, context->partitions) {
+-                if (p == q)
+-                        break;
+-
+-                if (!sd_id128_equal(p->type_uuid, q->type_uuid))
+-                        continue;
+-
+-                k++;
+-        }
+-
+-        plaintext.type_uuid = p->type_uuid;
+-        plaintext.counter = htole64(k);
+-
+-        if (!HMAC(EVP_sha256(),
+-                  &context->seed, sizeof(context->seed),
+-                  (const unsigned char*) &plaintext, k == 0 ? sizeof(sd_id128_t) : sizeof(plaintext),
+-                  result.md, NULL))
+-                return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE), "SHA256 calculation failed.");
+-
+-        /* Take the first half, mark it as v4 UUID */
+-        assert_cc(sizeof(result.md) == sizeof(result.id) * 2);
+-        result.id = id128_make_v4_uuid(result.id);
+-
+-        /* Ensure this partition UUID is actually unique, and there's no remaining partition from an earlier run? */
+-        LIST_FOREACH(partitions, q, context->partitions) {
+-                if (p == q)
+-                        continue;
+-
+-                if (sd_id128_equal(q->current_uuid, result.id) ||
+-                    sd_id128_equal(q->new_uuid, result.id)) {
+-                        log_warning("Partition UUID calculated from seed for partition %" PRIu64 " exists already, reverting to randomized UUID.", p->partno);
+-
+-                        r = sd_id128_randomize(&result.id);
+-                        if (r < 0)
+-                                return log_error_errno(r, "Failed to generate randomized UUID: %m");
+-
+-                        break;
+-                }
+-        }
++        /* Calculate a random UUID for the indicated partition. */
++        r = sd_id128_randomize(&id);
++        if (r < 0)
++                return log_error_errno(r, "Failed to generate randomized UUID: %m");
+ 
+-        *ret = result.id;
++        *ret = id;
+         return 0;
+ }
+ 
+-- 
+2.21.0
+

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd/archive/v244/systemd-244.tar.gz"
-sha512 = "08f260fb15b5eb273faafda826dd9154e9a02841b4c5911cc1c7e1445072ad51389f8cced7b9acf112737c20fd56b2fbf48b3f914733c934c774d38a23b616fb"
+url = "https://github.com/systemd/systemd/archive/v245/systemd-245.tar.gz"
+sha512 = "1b80d0e02472dfc4197f11dab4f56cf90e8a6e105ce19f837cb11335b6d8577ed49031dad94cdb41aa9bdc06ec8eec62c8e9246272b83935e7bb9dcd3cd8c012"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -276,18 +276,48 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 %exclude %{_cross_localstatedir}/log/README
 %exclude %{_cross_rundir}
 
+%exclude %{_cross_bindir}/systemd-ask-password
+%exclude %{_cross_bindir}/systemd-tty-ask-password-agent
+%exclude %{_cross_libdir}/systemd/systemd-sulogin-shell
+%exclude %{_cross_libdir}/systemd/systemd-reply-password
+%exclude %{_cross_systemdgeneratordir}/systemd-debug-generator
 %exclude %{_cross_systemdgeneratordir}/systemd-getty-generator
 %exclude %{_cross_unitdir}/console-getty.service
 %exclude %{_cross_unitdir}/container-getty@.service
+%exclude %{_cross_unitdir}/debug-shell.service
+%exclude %{_cross_unitdir}/emergency.service
+%exclude %{_cross_unitdir}/emergency.target
 %exclude %{_cross_unitdir}/getty@.service
+%exclude %{_cross_unitdir}/rescue.service
+%exclude %{_cross_unitdir}/rescue.target
 %exclude %{_cross_unitdir}/serial-getty@.service
+%exclude %{_cross_unitdir}/systemd-ask-password-console.service
+%exclude %{_cross_unitdir}/systemd-ask-password-console.path
+%exclude %{_cross_unitdir}/systemd-ask-password-wall.path
+%exclude %{_cross_unitdir}/sysinit.target.wants/systemd-ask-password-console.path
+%exclude %{_cross_unitdir}/multi-user.target.wants/systemd-ask-password-wall.path
 
 %files console
+%{_cross_bindir}/systemd-ask-password
+%{_cross_bindir}/systemd-tty-ask-password-agent
+%{_cross_libdir}/systemd/systemd-sulogin-shell
+%{_cross_libdir}/systemd/systemd-reply-password
+%{_cross_systemdgeneratordir}/systemd-debug-generator
 %{_cross_systemdgeneratordir}/systemd-getty-generator
 %{_cross_unitdir}/console-getty.service
 %{_cross_unitdir}/container-getty@.service
+%{_cross_unitdir}/debug-shell.service
+%{_cross_unitdir}/emergency.service
+%{_cross_unitdir}/emergency.target
 %{_cross_unitdir}/getty@.service
+%{_cross_unitdir}/rescue.service
+%{_cross_unitdir}/rescue.target
 %{_cross_unitdir}/serial-getty@.service
+%{_cross_unitdir}/systemd-ask-password-console.service
+%{_cross_unitdir}/systemd-ask-password-console.path
+%{_cross_unitdir}/systemd-ask-password-wall.path
+%{_cross_unitdir}/sysinit.target.wants/systemd-ask-password-console.path
+%{_cross_unitdir}/multi-user.target.wants/systemd-ask-password-wall.path
 
 %files devel
 %{_cross_libdir}/libsystemd.so

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -37,6 +37,21 @@ Requires: %{_cross_os}libblkid
 %description -n %{_cross_os}libblkid-devel
 %{summary}.
 
+%package -n %{_cross_os}libfdisk
+Summary: Partition table library
+License: LGPL-2.1-or-later
+
+%description -n %{_cross_os}libfdisk
+%{summary}.
+
+%package -n %{_cross_os}libfdisk-devel
+Summary: Files for development using the partition table library
+License: LGPL-2.1-or-later
+Requires: %{_cross_os}libfdisk
+
+%description -n %{_cross_os}libfdisk-devel
+%{summary}.
+
 %package -n %{_cross_os}libmount
 Summary: Device mounting library
 License: LGPL-2.1-or-later
@@ -90,12 +105,12 @@ cp Documentation/licenses/COPYING.* .
 
 %build
 %cross_configure \
-  --disable-libfdisk \
   --disable-makeinstall-chown \
   --disable-nls \
   --disable-rpath \
   --enable-all-programs \
   --enable-libblkid \
+  --enable-libfdisk \
   --enable-libmount \
   --enable-libsmartcols \
   --enable-libuuid \
@@ -118,12 +133,14 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 
 # add attribution.txt files for lib subpackages that need them, since the
 # default macro only generates attribution.txt for the main package
-for lib in lib{blkid,mount,smartcols,uuid}; do
+for lib in lib{blkid,fdisk,mount,smartcols,uuid}; do
     mkdir -p %{buildroot}%{_cross_licensedir}/$lib
     echo "$lib - %{url}" >> %{buildroot}%{_cross_licensedir}/$lib/attribution.txt
 done
-echo "SPDX-License-Identifier: LGPL-2.1-or-later" | tee -a %{buildroot}%{_cross_licensedir}/lib{blkid,mount,smartcols}/attribution.txt >/dev/null
-echo "SPDX-License-Identifier: BSD-3-Clause" | tee -a %{buildroot}%{_cross_licensedir}/libuuid/attribution.txt
+echo "SPDX-License-Identifier: LGPL-2.1-or-later" \
+  | tee -a %{buildroot}%{_cross_licensedir}/lib{blkid,fdisk,mount,smartcols}/attribution.txt >/dev/null
+echo "SPDX-License-Identifier: BSD-3-Clause" \
+  | tee -a %{buildroot}%{_cross_licensedir}/libuuid/attribution.txt
 
 %files
 %license COPYING.BSD-3-Clause COPYING.BSD-4-Clause-UC COPYING.GPL-2.0-or-later COPYING.LGPL-2.1-or-later
@@ -221,8 +238,10 @@ echo "SPDX-License-Identifier: BSD-3-Clause" | tee -a %{buildroot}%{_cross_licen
 %{_cross_sbindir}/switch_root
 %{_cross_sbindir}/wipefs
 %exclude %{_cross_sbindir}/hwclock
+%exclude %{_cross_sbindir}/cfdisk
 %exclude %{_cross_sbindir}/ctrlaltdel
 %exclude %{_cross_sbindir}/fdformat
+%exclude %{_cross_sbindir}/fdisk
 %exclude %{_cross_sbindir}/fsck.minix
 %exclude %{_cross_sbindir}/ldattach
 %exclude %{_cross_sbindir}/mkfs.bfs
@@ -232,6 +251,7 @@ echo "SPDX-License-Identifier: BSD-3-Clause" | tee -a %{buildroot}%{_cross_licen
 %exclude %{_cross_sbindir}/readprofile
 %exclude %{_cross_sbindir}/rfkill
 %exclude %{_cross_sbindir}/rtcwake
+%exclude %{_cross_sbindir}/sfdisk
 %exclude %{_cross_sbindir}/sulogin
 %exclude %{_cross_sbindir}/swaplabel
 %exclude %{_cross_sbindir}/swapoff
@@ -258,6 +278,19 @@ echo "SPDX-License-Identifier: BSD-3-Clause" | tee -a %{buildroot}%{_cross_licen
 %{_cross_includedir}/blkid/blkid.h
 %{_cross_pkgconfigdir}/blkid.pc
 %exclude %{_cross_libdir}/libblkid.la
+
+%files -n %{_cross_os}libfdisk
+%license COPYING.LGPL-2.1-or-later
+%{_licensedir}/libfdisk/attribution.txt
+%{_cross_libdir}/libfdisk.so.*
+
+%files -n %{_cross_os}libfdisk-devel
+%{_cross_libdir}/libfdisk.a
+%{_cross_libdir}/libfdisk.so
+%dir %{_cross_includedir}/libfdisk
+%{_cross_includedir}/libfdisk/libfdisk.h
+%{_cross_pkgconfigdir}/fdisk.pc
+%exclude %{_cross_libdir}/libfdisk.la
 
 %files -n %{_cross_os}libmount
 %license COPYING.LGPL-2.1-or-later

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -134,13 +134,23 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 # add attribution.txt files for lib subpackages that need them, since the
 # default macro only generates attribution.txt for the main package
 for lib in lib{blkid,fdisk,mount,smartcols,uuid}; do
-    mkdir -p %{buildroot}%{_cross_licensedir}/$lib
-    echo "$lib - %{url}" >> %{buildroot}%{_cross_licensedir}/$lib/attribution.txt
+    mkdir -p %{buildroot}%{_cross_licensedir}/${lib}
+    echo "${lib} - %{url}" >> %{buildroot}%{_cross_licensedir}/${lib}/attribution.txt
 done
-echo "SPDX-License-Identifier: LGPL-2.1-or-later" \
-  | tee -a %{buildroot}%{_cross_licensedir}/lib{blkid,fdisk,mount,smartcols}/attribution.txt >/dev/null
-echo "SPDX-License-Identifier: BSD-3-Clause" \
-  | tee -a %{buildroot}%{_cross_licensedir}/libuuid/attribution.txt
+
+# most lib subpackages are LGPL-2.1-or-later
+for lib in lib{blkid,fdisk,mount,smartcols}; do
+    echo "SPDX-License-Identifier: LGPL-2.1-or-later" \
+      | tee -a %{buildroot}%{_cross_licensedir}/${lib}/attribution.txt >/dev/null
+    cp -a COPYING.LGPL-2.1-or-later %{buildroot}%{_cross_licensedir}/${lib}
+done
+
+# libuuid is BSD-3-Clause
+for lib in libuuid; do
+    echo "SPDX-License-Identifier: BSD-3-Clause" \
+      | tee -a %{buildroot}%{_cross_licensedir}/${lib}/attribution.txt >/dev/null
+    cp -a COPYING.BSD-3-Clause %{buildroot}%{_cross_licensedir}/${lib}
+done
 
 %files
 %license COPYING.BSD-3-Clause COPYING.BSD-4-Clause-UC COPYING.GPL-2.0-or-later COPYING.LGPL-2.1-or-later
@@ -267,8 +277,8 @@ echo "SPDX-License-Identifier: BSD-3-Clause" \
 %exclude %{_cross_mandir}
 
 %files -n %{_cross_os}libblkid
-%license COPYING.LGPL-2.1-or-later
-%{_licensedir}/libblkid/attribution.txt
+%license %{_cross_licensedir}/libblkid/COPYING.LGPL-2.1-or-later
+%license %{_cross_licensedir}/libblkid/attribution.txt
 %{_cross_libdir}/libblkid.so.*
 
 %files -n %{_cross_os}libblkid-devel
@@ -280,8 +290,8 @@ echo "SPDX-License-Identifier: BSD-3-Clause" \
 %exclude %{_cross_libdir}/libblkid.la
 
 %files -n %{_cross_os}libfdisk
-%license COPYING.LGPL-2.1-or-later
-%{_licensedir}/libfdisk/attribution.txt
+%license %{_cross_licensedir}/libfdisk/COPYING.LGPL-2.1-or-later
+%license %{_cross_licensedir}/libfdisk/attribution.txt
 %{_cross_libdir}/libfdisk.so.*
 
 %files -n %{_cross_os}libfdisk-devel
@@ -293,8 +303,8 @@ echo "SPDX-License-Identifier: BSD-3-Clause" \
 %exclude %{_cross_libdir}/libfdisk.la
 
 %files -n %{_cross_os}libmount
-%license COPYING.LGPL-2.1-or-later
-%{_licensedir}/libmount/attribution.txt
+%license %{_cross_licensedir}/libmount/COPYING.LGPL-2.1-or-later
+%license %{_cross_licensedir}/libmount/attribution.txt
 %{_cross_libdir}/libmount.so.*
 
 %files -n %{_cross_os}libmount-devel
@@ -306,8 +316,8 @@ echo "SPDX-License-Identifier: BSD-3-Clause" \
 %exclude %{_cross_libdir}/libmount.la
 
 %files -n %{_cross_os}libsmartcols
-%license COPYING.LGPL-2.1-or-later
-%{_licensedir}/libsmartcols/attribution.txt
+%license %{_cross_licensedir}/libsmartcols/COPYING.LGPL-2.1-or-later
+%license %{_cross_licensedir}/libsmartcols/attribution.txt
 %{_cross_libdir}/libsmartcols.so.*
 
 %files -n %{_cross_os}libsmartcols-devel
@@ -319,8 +329,8 @@ echo "SPDX-License-Identifier: BSD-3-Clause" \
 %exclude %{_cross_libdir}/libsmartcols.la
 
 %files -n %{_cross_os}libuuid
-%license COPYING.BSD-3-Clause
-%{_licensedir}/libuuid/attribution.txt
+%license %{_cross_licensedir}/libuuid/COPYING.BSD-3-Clause
+%license %{_cross_licensedir}/libuuid/attribution.txt
 %{_cross_libdir}/libuuid.so.*
 
 %files -n %{_cross_os}libuuid-devel

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -52,6 +52,7 @@ BOTTLEROCKET_ROOT_TYPECODE="5526016a-1a97-4ea4-b39a-b7c8c6ca4502"
 BOTTLEROCKET_HASH_TYPECODE="598f10af-c955-4456-6a99-7720068a6cea"
 BOTTLEROCKET_RESERVED_TYPECODE="0c5d99a5-d331-4147-baef-08e2b855bdc9"
 BOTTLEROCKET_PRIVATE_TYPECODE="440408bb-eb0b-4328-a6e5-a29038fad706"
+BOTTLEROCKET_DATA_TYPECODE="626f7474-6c65-6474-6861-726d61726b73"
 
 if [[ "${ARCH}" == "x86_64" ]]; then
   FIRM_NAME="BIOS-BOOT"
@@ -187,7 +188,7 @@ dd if="${PRIVATE_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=2005
 # BOTTLEROCKET-DATA
 truncate -s 1G "${DATA_IMAGE}"
 sgdisk --clear \
-   -n 0:1M:1023M -c 0:"BOTTLEROCKET-DATA" -t 0:8300 \
+   -n 0:1M:1023M -c 0:"BOTTLEROCKET-DATA" -t 0:"${BOTTLEROCKET_DATA_TYPECODE}" \
    --sort --print "${DATA_IMAGE}"
 # If we build on a host with SELinux enabled, we could end up with labels that
 # do not match our policy. Since we allow replacing the data volume at runtime,


### PR DESCRIPTION
**Issue number:**
#865


**Description of changes:**
Updates systemd to v245. Enables the `repart` tool for declarative repartitioning. Syncs build options. Shifts relevant files into the `console` subpackage.

Adds `libfdisk` package to `util-linux`, needed as a dependency for `repart`. Fixes license files.

Minor tweak to `release` to fix an upgrade issue with `prepare-local`. Minor tweak to `rpm2img` to assign a fixed UUID to the data partition. 

**Testing done:**
Built `aws-dev` variant and tested locally.

Confirmed that:
* `/usr/lib/systemd/systemd-sulogin-shell debug` works to start a debug shell
* `systemd-repart` can add or grow a partition on the root device
* license files are in the expected directories under `/usr/share/licenses` for `util-linux` subpackages.

Built `aws-k8s-1.15` variant and tested in a cluster. Confirmed that `sonobuoy` tests pass.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
