### PR TITLE
use SELinux to restrict datastore modifications

### DIFF
--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -43,6 +43,10 @@
 (filecon "/.*/usr/bin/containerd.*" file runtime_exec)
 (filecon "/.*/usr/bin/docker.*" file runtime_exec)
 (filecon "/.*/usr/sbin/runc" file runtime_exec)
+(filecon "/.*/usr/bin/apiserver" file api_exec)
+(filecon "/.*/usr/bin/early-boot-config" file api_exec)
+(filecon "/.*/usr/bin/migrator" file api_exec)
+(filecon "/.*/usr/bin/storewolf" file api_exec)
 
 ; Label local storage mounts.
 (filecon "/local" any local)

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -58,13 +58,9 @@
 (typeattribute ephemeral_o)
 (typeattributeset ephemeral_o (any_t))
 
-; Protected objects are certain files on local storage.
+; Protected objects are files on local storage with special rules.
 (typeattribute protected_o)
 (typeattributeset protected_o (cache_t private_t))
-
-; Unprotected objects are everything else on local storage.
-(typeattribute unprotected_o)
-(typeattributeset unprotected_o (local_t))
 
 ; Immutable objects reside on read-only storage.
 (typeattribute immutable_o)

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -26,6 +26,11 @@
 (allow init_t system_t (processes (transform)))
 (allow system_t os_t (file (entrypoint)))
 
+; PID 1 starts API components as "api_t".
+(typetransition init_t api_exec_t process api_t)
+(allow init_t api_t (processes (transform)))
+(allow api_t api_exec_t (file (entrypoint)))
+
 ; PID 1 starts container runtimes as "runtime_t".
 ; The level range is adjusted to span all categories at the same time,
 ; to support Docker's use of MCS labels.
@@ -66,17 +71,21 @@
 
 ; All subjects are allowed to write to, set watches for, and manage
 ; mounts for most files and directories on /local.
-(allow all_s unprotected_o (files (mutate watch mount)))
+(allow all_s local_t (files (mutate watch mount)))
 
 ; Trusted components are allowed to manage mounts everywhere.
 (allow trusted_s global (files (mount)))
 
-; Only trusted components can write to "cache_t" or "private_t", as
-; they provide a means to persist changes across container restarts
-; and reboots. We restrict the ability to set watches as this can
-; be used to block access for another process.
-(allow trusted_s protected_o (files (mutate watch)))
+; Trusted components can set watches on immutable files, since we
+; expect this behavior from systemd and dbus-broker.
 (allow trusted_s immutable_o (files (watch)))
+
+; Only specific components can write to "private_t" or "cache_t", as
+; they provide a means to persist changes across container restarts
+; and reboots. We also restrict the ability to set watches as this
+; can be used to block access for another process.
+(allow api_s private_t (files (mutate watch)))
+(allow runtime_s cache_t (files (mutate watch)))
 
 ; Untrusted processes should not be permitted to modify these files,
 ; set watches for them, or to manage mounts for these directories.

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -59,6 +59,10 @@
 (typeattribute host_s)
 (typeattributeset host_s (not container_s))
 
+; Subjects that are allowed to manage the API datastore.
+(typeattribute api_s)
+(typeattributeset api_s (api_t super_t))
+
 ; Subjects that are treated as container runtimes.
 (typeattribute runtime_s)
 (typeattributeset runtime_s (runtime_t super_t))

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -31,6 +31,7 @@ const TARGET_ARCH: &str = "aarch64";
 
 const TRUSTED_ROOT_PATH: &str = "/usr/share/updog/root.json";
 const MIGRATION_PATH: &str = "/var/lib/bottlerocket-migrations";
+const METADATA_PATH: &str = "/var/cache/bottlerocket-metadata";
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
@@ -104,14 +105,14 @@ fn load_repository<'a>(
     transport: &'a HttpQueryTransport,
     config: &'a Config,
 ) -> Result<HttpQueryRepo<'a>> {
-    fs::create_dir_all("/var/lib/bottlerocket/updog").context(error::CreateMetadataCache)?;
+    fs::create_dir_all(METADATA_PATH).context(error::CreateMetadataCache)?;
     Repository::load(
         transport,
         Settings {
             root: File::open(TRUSTED_ROOT_PATH).context(error::OpenRoot {
                 path: TRUSTED_ROOT_PATH,
             })?,
-            datastore: Path::new("/var/lib/bottlerocket/updog"),
+            datastore: Path::new(METADATA_PATH),
             metadata_base_url: &config.metadata_base_url,
             target_base_url: &config.targets_base_url,
             limits: Limits {


### PR DESCRIPTION
**Issue number:**
#764 


**Description of changes:**
Adds filesystem labels to the four components that we expect to modify the datastore. Extends the policy with rules to allow the transition to `api_t` and mutations for `private_t` objects. 

Changes `updog` to store its cached repo metadata outside the reserved filesystem.


**Testing done:**
Tested `aws-dev` in a local VM and `aws-k8s-1.15` in an EC2 instance. No SELinux denials observed.

Components had the expected label:
```
# find /usr/bin -context 'system_u:object_r:api_exec_t:s0'
/usr/bin/apiserver
/usr/bin/storewolf
/usr/bin/migrator
/usr/bin/early-boot-config
```

`apiserver` ran with the expected label:
```
$ cat /proc/$(pgrep apiserver)/attr/current
system_u:system_r:api_t:s0
```

`updog` worked and created the files in the expected path:
```
# updog check-update -a
aws-k8s-1.15 0.3.2
aws-k8s-1.15 0.3.1
aws-k8s-1.15 0.3.0

# ls -latrZ /var/cache/bottlerocket-metadata/
total 24
drwxr-xr-x. 3 root root system_u:object_r:local_t:s0 4096 Apr 22 21:01 ..
drwxr-xr-x. 2 root root system_u:object_r:local_t:s0 4096 Apr 22 21:01 .
-rw-r--r--. 1 root root system_u:object_r:local_t:s0 1279 Apr 22 21:02 timestamp.json
-rw-r--r--. 1 root root system_u:object_r:local_t:s0 1471 Apr 22 21:02 snapshot.json
-rw-r--r--. 1 root root system_u:object_r:local_t:s0 3497 Apr 22 21:02 targets.json
-rw-r--r--. 1 root root system_u:object_r:local_t:s0   32 Apr 22 21:02 latest_known_time.json
```

Policy blocked access from a different label:
```
# echo -n 'system_u:system_r:system_t:s0' > /proc/self/attr/current
# touch /var/lib/bottlerocket/stuff
[ 1090.055119] audit: type=1400 audit(1587590229.927:7): avc:  denied  { write } for  pid=13065 comm="touch" path="/var/lib/bottlerocket/stuff" dev=
"nvme0n1p10" ino=19 scontext=system_u:system_r:system_t:s0 tcontext=system_u:object_r:private_t:s0 tclass=file permissive=1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
