### PR TITLE
update to SDK v0.11.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ DOCKER_BUILDKIT = "1"
 
 [env.development]
 # Defined here to allow us to override ${BUILDSYS_ARCH} on the command line.
-BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.10.1"
+BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.11.0"
 # Extra flags used when spawning containers.
 #
 # ex: BUILDSYS_DOCKER_RUN_ARGS="--network=host --dns=127.0.0.53"

--- a/macros/shared
+++ b/macros/shared
@@ -93,6 +93,7 @@ pkgconfig = '/usr/bin/pkg-config'\
 [properties]\
 c_args = [%{_cross_c_args}]\
 c_link_args = [%{_cross_c_link_args}]\
+pkg_config_libdir = '%{_cross_pkgconfigdir}'\
 [host_machine]\
 system = 'linux'\
 cpu_family ='%{_cross_cpu_family}'\

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -37,7 +37,7 @@ CFLAGS="${BUILDFLAGS}" CPPFLAGS="" CXXFLAGS="${BUILDFLAGS}" \
   --build="%{_build}" \
   --with-headers="%{_cross_includedir}" \
   --enable-bind-now \
-  --enable-kernel="4.19" \
+  --enable-kernel="5.4.0" \
   --enable-shared \
   --enable-stack-protector=strong \
   --enable-static-pie \

--- a/packages/selinux-policy/files.cil
+++ b/packages/selinux-policy/files.cil
@@ -89,7 +89,7 @@
 (classpermissionset relabel_fifo_file (
   fifo_file (relabelfrom relabelto)))
 (classpermissionset relabel_filesystem (
-  filesystem (associate relabelfrom relabelto transition)))
+  filesystem (associate relabelfrom relabelto)))
 (classpermissionset relabel_kernel_service (
   kernel_service (create_files_as)))
 
@@ -103,19 +103,19 @@
 (classpermission mount_fifo_file)
 (classpermission mount_filesystem)
 (classpermissionset mount_file (
-  file (mounton quotaon swapon)))
+  file (mounton quotaon)))
 (classpermissionset mount_dir (
-  dir (mounton quotaon swapon)))
+  dir (mounton quotaon)))
 (classpermissionset mount_lnk_file (
-  lnk_file (mounton quotaon swapon)))
+  lnk_file (mounton quotaon)))
 (classpermissionset mount_chr_file (
-  chr_file (mounton quotaon swapon)))
+  chr_file (mounton quotaon)))
 (classpermissionset mount_blk_file (
-  blk_file (mounton quotaon swapon)))
+  blk_file (mounton quotaon)))
 (classpermissionset mount_sock_file (
-  sock_file (mounton quotaon swapon)))
+  sock_file (mounton quotaon)))
 (classpermissionset mount_fifo_file (
-  fifo_file (mounton quotaon swapon)))
+  fifo_file (mounton quotaon)))
 (classpermissionset mount_filesystem (
   filesystem (mount quotamod remount unmount)))
 
@@ -216,36 +216,36 @@
   file (not (
     entrypoint execute_no_trans
     execute ioctl getattr map open read execmod
-    relabelfrom relabelto mounton quotaon swapon
+    relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))
 (classpermissionset mutate_dir (
   dir (not (
     search
     execute ioctl getattr map open read execmod
-    relabelfrom relabelto mounton quotaon swapon
+    relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))
 (classpermissionset mutate_lnk_file (
   lnk_file (not (
     execute ioctl getattr map open read execmod
-    relabelfrom relabelto mounton quotaon swapon
+    relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))
 (classpermissionset mutate_chr_file (
   chr_file (not (
     execute ioctl getattr map open read execmod
-    relabelfrom relabelto mounton quotaon swapon
+    relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))
 (classpermissionset mutate_blk_file (
   blk_file (not (
     execute ioctl getattr map open read execmod
-    relabelfrom relabelto mounton quotaon swapon
+    relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))
 (classpermissionset mutate_sock_file (
   sock_file (not (
     execute ioctl getattr map open read execmod
-    relabelfrom relabelto mounton quotaon swapon
+    relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))
 (classpermissionset mutate_fifo_file (
   fifo_file (not (
     execute ioctl getattr map open read execmod
-    relabelfrom relabelto mounton quotaon swapon
+    relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))

--- a/tools/docker-go
+++ b/tools/docker-go
@@ -68,6 +68,7 @@ docker run --rm \
   -e GOPATH='/tmp/go' \
   "${proxy_env[@]}" \
   --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
   ${DOCKER_RUN_ARGS} \
   -v "${GO_MOD_CACHE}":/tmp/go/pkg/mod \
   -v "${GO_MODULE_PATH}":/usr/src/host-ctr \


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Update to SDK v0.11.0.

Specify minimum kernel version for glibc, which should be safe because our update process ensures that they move in lockstep.

Drop undefined SELinux permissions which were removed in 7125a10; these were flagged as an error by the newer `secilc`.

Fix `cross-compilation.conf` to work with meson 0.54. 


**Testing done:**
Built all variants for both x86_64 and aarch64.

Built an AMI for the k8s-1.15 variant; refreshed cluster node; verified conformance test passed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
