### PR TITLE
updata: allow specifying a start time for waves

### DIFF
--- a/sources/parse-datetime/src/lib.rs
+++ b/sources/parse-datetime/src/lib.rs
@@ -47,7 +47,7 @@ pub use error::Error;
 type Result<T> = std::result::Result<T, error::Error>;
 
 /// Parses a user-specified datetime, either in full RFC 3339 format, or a shorthand like "in 7
-/// days"
+/// days" that's taken as an offset from the time the function is run.
 pub fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
     // If the user gave an absolute date in a standard format, accept it.
     let try_dt: std::result::Result<DateTime<FixedOffset>, chrono::format::ParseError> =
@@ -57,6 +57,15 @@ pub fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
         return Ok(utc);
     }
 
+    let offset = parse_offset(input)?;
+
+    let now = Utc::now();
+    let then = now + offset;
+    Ok(then)
+}
+
+/// Parses a user-specified datetime offset in the form of a shorthand like "in 7 days".
+pub fn parse_offset(input: &str) -> Result<Duration> {
     // Otherwise, pull apart a request like "in 5 days" to get an exact datetime.
     let mut parts: Vec<&str> = input.split_whitespace().collect();
     ensure!(
@@ -95,9 +104,7 @@ pub fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
         }
     };
 
-    let now = Utc::now();
-    let then = now + duration;
-    Ok(then)
+    Ok(duration)
 }
 
 #[cfg(test)]

--- a/sources/updater/update_metadata/src/error.rs
+++ b/sources/updater/update_metadata/src/error.rs
@@ -46,9 +46,13 @@ pub enum Error {
     #[snafu(display("Migration {} matches regex but missing name", name))]
     BadRegexName { name: String },
 
-    #[snafu(display("Unable to parse datetime from string '{}': {}", datetime, source))]
-    BadDateTime {
-        datetime: String,
+    #[snafu(display(
+        "Unable to parse 'start_after' offset from string '{}': {}",
+        offset,
+        source
+    ))]
+    BadOffset {
+        offset: String,
         source: parse_datetime::Error,
     },
 

--- a/sources/updater/update_metadata/src/lib.rs
+++ b/sources/updater/update_metadata/src/lib.rs
@@ -7,7 +7,7 @@ mod se;
 use crate::error::Result;
 use chrono::{DateTime, Duration, Utc};
 use lazy_static::lazy_static;
-use parse_datetime::parse_datetime;
+use parse_datetime::parse_offset;
 use rand::{thread_rng, Rng};
 use regex::Regex;
 use semver::Version;
@@ -293,6 +293,7 @@ impl Manifest {
         variant: String,
         arch: String,
         image_version: Version,
+        start_at: DateTime<Utc>,
         waves: &UpdateWaves,
     ) -> Result<usize> {
         let matching = self.get_matching_updates(variant, arch, image_version);
@@ -311,10 +312,10 @@ impl Manifest {
                     }
                 );
 
-                let start_time = parse_datetime(&wave.start_after).context(error::BadDateTime {
-                    datetime: &wave.start_after,
+                let offset = parse_offset(&wave.start_after).context(error::BadOffset {
+                    offset: &wave.start_after,
                 })?;
-                update.waves.insert(seed, start_time);
+                update.waves.insert(seed, start_at + offset);
 
                 // Get the appropriate seed from the percentage given
                 // First get the percentage as a decimal,


### PR DESCRIPTION
Previously, wave start times would always be relative to when you ran updata,
meaning you'd have to hold off on running updata until you were ready to start
a release process.  This lets you (optionally) pick any start time for the
start of the waves, and the given start_after offsets will be relative to that
time.

To keep the code and the deployment process simple, this also requires
specifying relative offsets in wave definition files, rather than absolute
times; we only used relative offsets anyway so that the files were reusable and
it was easier to understand the delays between waves, but this codifies that
behavior.

---

This caused pain in the 0.3.3 release, requiring rework and a changed deployment plan, so I wanted to fix it before the next release.

**Testing done:**

Start with no waves:
```
$ jq '.updates[].waves' manifest.json
{}
```
Add waves with no `start-at` argument, as we have before:
```
$ cargo run --bin updata -- set-waves manifest.json --arch x86_64 --version 0.3.3 --variant aws-k8s-1.15 --wave-file ../waves/accelerated-waves.toml
```
We see the waves are relative to when I ran the command, as before.
```
$ jq '.updates[].waves' manifest.json
{
  "0": "2020-05-14T23:06:11.364246960Z",
  "61": "2020-05-15T02:06:11.364246960Z",
  "245": "2020-05-15T06:06:11.364246960Z",
  "1024": "2020-05-15T22:06:11.364246960Z"
}

$ date -u
Thu May 14 22:06:18 UTC 2020
```

Now run with a `start-at` next month, and we see the waves start next month as expected:
```
$ cargo run --bin updata -- set-waves manifest.json --arch x86_64 --version 0.3.3 --variant aws-k8s-1.15 --wave-file ../waves/accelerated-waves.toml --start-at '2020-06-01T00:00:00Z'

$ jq '.updates[].waves' manifest.json
{
  "0": "2020-06-01T01:00:00Z",
  "61": "2020-06-01T04:00:00Z",
  "245": "2020-06-01T08:00:00Z",
  "1024": "2020-06-02T00:00:00Z"
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.