### PR TITLE
build: don't drop 1 directory level in copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ WORKDIR /home/builder
 
 USER builder
 ENV PACKAGE=${PACKAGE} ARCH=${ARCH}
-COPY ./macros/${ARCH} ./macros/shared ./macros/rust ./macros/cargo ./packages/${PACKAGE}/* .
+COPY ./macros/${ARCH} ./macros/shared ./macros/rust ./macros/cargo ./packages/${PACKAGE}/ .
 RUN rpmdev-setuptree \
    && cat ${ARCH} shared rust cargo > .rpmmacros \
    && rm ${ARCH} shared rust cargo \


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

This prevents the `Dockerfile` from dropping a directory level when `COPY`-ing package contents in for build. 


```
With the splat, the directory structure is collapsed one level:

    ./this/pkg.spec

becomes:

    ./pkg.spec

This causes issues when an unpacked spec file is present in a
subdirectory as a later glob is used to install the spec's builddeps.
An error is raised by dnf specifically when the additional spec
specifies dependencies that are not installed in the SDK
container. This is the expected behavior and that remains unchanged;
the only thing this change fixes is the inclusion of an unexpected
spec which has unavailable build dependencies.

Signed-off-by: Jacob Vallejo <jakeev@amazon.com>
```

**Testing done:**

I built with an unpacked `kernel-*.src.rpm` in a subdirectory of the kernel package with an added `RUN find . -ls` in the `Dockerfile` to observe the structure. The structure was as expected and the build was able to succeed where it was not able to before. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
