### PR TITLE
updog and migrator: signed migrations

### DIFF
--- a/packages/os/migrator.service
+++ b/packages/os/migrator.service
@@ -3,7 +3,7 @@ Description=Bottlerocket data store migrator
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/migrator --datastore-path /var/lib/bottlerocket/datastore/current --migration-directories /var/lib/bottlerocket-migrations --migrate-to-version-from-os-release
+ExecStart=/usr/bin/migrator --datastore-path /var/lib/bottlerocket/datastore/current --migration-directory /var/lib/bottlerocket-migrations --root-path /usr/share/updog/root.json --metadata-directory /var/cache/bottlerocket-metadata --migrate-to-version-from-os-release
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1414,13 +1414,18 @@ dependencies = [
  "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pentacle 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tough 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "update_metadata 0.1.0",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1639,6 +1644,15 @@ dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pentacle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2707,7 +2721,6 @@ dependencies = [
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "migrator 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3078,6 +3091,7 @@ dependencies = [
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum pem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1581760c757a756a41f0ee3ff01256227bdf64cb752839779b95ffb01c59793"
+"checksum pentacle 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a68bcd5f6f87e5afcae276a85b759446e3dddaceedde1583b85f1a3e32dbe638"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -11,13 +11,18 @@ build = "build.rs"
 bottlerocket-release = { path = "../../../bottlerocket-release" }
 lazy_static = "1.2"
 log = "0.4"
+lz4 = "1.23.1"
 nix = "0.17"
+pentacle = "0.1.1"
 rand = { version = "0.7", default-features = false, features = ["std"] }
 regex = "1.1"
 semver = "0.9"
 simplelog = "0.7"
 snafu = "0.6"
+tempfile = "3.1.0"
+tough = "0.6.0"
 update_metadata = { path = "../../../updater/update_metadata" }
+url = "2.1.1"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/migration/migrator/src/direction.rs
+++ b/sources/api/migration/migrator/src/direction.rs
@@ -2,7 +2,7 @@
 //! is moving forward to a new version or rolling back to a previous version.
 
 use semver::Version;
-use std::cmp::Ordering;
+use std::cmp::{Ord, Ordering};
 use std::fmt;
 
 /// Direction represents whether we're moving forward toward a newer version, or rolling back to
@@ -45,14 +45,20 @@ mod test {
         let v02 = Version::new(0, 0, 2);
         let v10 = Version::new(0, 1, 0);
 
-        assert_eq!(Direction::from_versions(&v01, &v02), Some(Direction::Forward));
+        assert_eq!(
+            Direction::from_versions(&v01, &v02),
+            Some(Direction::Forward)
+        );
         assert_eq!(
             Direction::from_versions(&v02, &v01),
             Some(Direction::Backward)
         );
         assert_eq!(Direction::from_versions(&v01, &v01), None);
 
-        assert_eq!(Direction::from_versions(&v02, &v10), Some(Direction::Forward));
+        assert_eq!(
+            Direction::from_versions(&v02, &v10),
+            Some(Direction::Forward)
+        );
         assert_eq!(
             Direction::from_versions(&v10, &v02),
             Some(Direction::Backward)

--- a/sources/updater/update_metadata/src/lib.rs
+++ b/sources/updater/update_metadata/src/lib.rs
@@ -13,21 +13,26 @@ use regex::Regex;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fs;
 use std::fs::File;
 use std::ops::Bound::{Excluded, Included};
 use std::path::Path;
-use std::str::FromStr;
-use tough;
 
 pub const MAX_SEED: u32 = 2048;
 
+// DEPRECATED CODE BEGIN ///////////////////////////////////////////////////////////////////////////
+// the use of this regex is deprecated and only used for backward compatibility with
+// unsigned migration
 lazy_static! {
     /// Regular expression that will match migration file names and allow retrieving the
     /// version and name components.
     // Note: the version component is a simplified semver regex; we don't use any of the
     // extensions, just a simple x.y.z, so this isn't as strict as it could be.
+    // Note: this regex will NOT match signed TUF targets because we use consistent snapshots in our
+    // TUF repository. We are relying on that behavior during the transition to signed migrations
+    // in which both signed an unsigned migrations are written in the same directory.
     pub static ref MIGRATION_FILENAME_RE: Regex =
         Regex::new(r"(?x)^
                    migrate
@@ -38,6 +43,7 @@ lazy_static! {
                    (?P<name>[a-zA-Z0-9-]+)
                    $").unwrap();
 }
+// DEPRECATED CODE END /////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Wave {
@@ -132,48 +138,6 @@ pub fn write_file(path: &Path, manifest: &Manifest) -> Result<()> {
 }
 
 impl Manifest {
-    pub fn add_migration(
-        &mut self,
-        append: bool,
-        from: Version,
-        to: Version,
-        migration_list: Vec<String>,
-    ) -> Result<()> {
-        // Check each migration matches the filename conventions used by the migrator
-        for name in &migration_list {
-            let captures = MIGRATION_FILENAME_RE
-                .captures(&name)
-                .context(error::MigrationNaming)?;
-
-            let version_match = captures
-                .name("version")
-                .context(error::BadRegexVersion { name })?;
-            let version = Version::from_str(version_match.as_str())
-                .context(error::BadVersion { key: name })?;
-            ensure!(
-                version == to,
-                error::MigrationInvalidTarget { name, to, version }
-            );
-
-            let _ = captures
-                .name("name")
-                .context(error::BadRegexName { name })?;
-        }
-
-        // If append is true, append the new migrations to the existing vec.
-        if append && self.migrations.contains_key(&(from.clone(), to.clone())) {
-            let migrations = self
-                .migrations
-                .get_mut(&(from.clone(), to.clone()))
-                .context(error::MigrationMutable { from, to })?;
-            migrations.extend_from_slice(&migration_list);
-        // Otherwise just overwrite the existing migrations
-        } else {
-            self.migrations.insert((from, to), migration_list);
-        }
-        Ok(())
-    }
-
     pub fn add_update(
         &mut self,
         image_version: Version,
@@ -387,7 +351,32 @@ impl Update {
     }
 }
 
-pub fn migration_targets(from: &Version, to: &Version, manifest: &Manifest) -> Result<Vec<String>> {
+pub fn find_migrations(from: &Version, to: &Version, manifest: &Manifest) -> Result<Vec<String>> {
+    // early exit if there is no work to do.
+    if from == to {
+        return Ok(Vec::new());
+    }
+    // express the versions in ascending order
+    let (lower, higher, is_reversed) = match from.cmp(to) {
+        Ordering::Less | Ordering::Equal => (from, to, false),
+        Ordering::Greater => (to, from, true),
+    };
+    let mut migrations = find_migrations_forward(&lower, &higher, manifest)?;
+    // if the direction is backward, reverse the order of the migration list.
+    if is_reversed {
+        migrations = migrations.into_iter().rev().collect();
+    }
+    Ok(migrations)
+}
+
+/// Finds the migration from one version to another. The migration direction must be forward, that
+/// is, `from` must be less than or equal to `to`. The caller may reverse the Vec returned by this
+/// function to migrate backward.
+fn find_migrations_forward(
+    from: &Version,
+    to: &Version,
+    manifest: &Manifest,
+) -> Result<Vec<String>> {
     let mut targets = Vec::new();
     let mut version = from;
     while version != to {
@@ -431,18 +420,34 @@ pub fn load_manifest<T: tough::Transport>(repository: &tough::Repository<T>) -> 
 }
 
 #[test]
-fn test_migrations() {
+fn test_migrations_forward() {
     // A manifest with four migration tuples starting at 1.0 and ending at 1.3.
     // There is a shortcut from 1.1 to 1.3, skipping 1.2
     let path = "./tests/data/migrations.json";
     let manifest: Manifest = serde_json::from_reader(File::open(path).unwrap()).unwrap();
     let from = Version::parse("1.0.0").unwrap();
     let to = Version::parse("1.5.0").unwrap();
-    let targets = migration_targets(&from, &to, &manifest).unwrap();
+    let targets = find_migrations(&from, &to, &manifest).unwrap();
 
     assert!(targets.len() == 3);
     let mut i = targets.iter();
     assert!(i.next().unwrap() == "migration_1.1.0_a");
     assert!(i.next().unwrap() == "migration_1.1.0_b");
     assert!(i.next().unwrap() == "migration_1.5.0_shortcut");
+}
+
+#[test]
+fn test_migrations_backward() {
+    // The same manifest as `test_migrations_forward` but this time we will migrate backward.
+    let path = "./tests/data/migrations.json";
+    let manifest: Manifest = serde_json::from_reader(File::open(path).unwrap()).unwrap();
+    let from = Version::parse("1.5.0").unwrap();
+    let to = Version::parse("1.0.0").unwrap();
+    let targets = find_migrations(&from, &to, &manifest).unwrap();
+
+    assert!(targets.len() == 3);
+    let mut i = targets.iter();
+    assert!(i.next().unwrap() == "migration_1.5.0_shortcut");
+    assert!(i.next().unwrap() == "migration_1.1.0_b");
+    assert!(i.next().unwrap() == "migration_1.1.0_a");
 }

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -12,7 +12,6 @@ chrono = "0.4.9"
 log = "0.4"
 lz4 = "1.23.1"
 rand = "0.7.0"
-regex = "1.1"
 reqwest = { version = "0.10.1", default-features = false, features = ["rustls-tls", "blocking"] }
 semver = "0.9.0"
 serde = { version = "1.0.100", features = ["derive"] }
@@ -21,6 +20,7 @@ serde_plain = "0.3.0"
 signpost = { path = "../signpost" }
 simplelog = "0.7"
 snafu = "0.6.0"
+tempfile = "3.1.0"
 toml = "0.5.1"
 tough = { version = "0.6.0", features = ["http"] }
 update_metadata = { path = "../update_metadata" }

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -31,8 +31,15 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to create metadata cache directory: {}", source))]
+    #[snafu(display("Failed to create metadata cache directory '{}': {}", path, source))]
     CreateMetadataCache {
+        path: &'static str,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to create a tempdir for tough datastore: {}", source))]
+    CreateTempDir {
         source: std::io::Error,
         backtrace: Backtrace,
     },
@@ -235,6 +242,9 @@ pub(crate) enum Error {
         source: std::io::Error,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Failed to store manifest and migrations: {}", source))]
+    RepoCacheMigrations { source: tough::error::Error },
 }
 
 impl std::convert::From<update_metadata::error::Error> for Error {


### PR DESCRIPTION
## Issue number:

Closes #91
Closes #905 

## Description of changes:

Implements all changes necessary for migrator to load a locally cached tuf repo and obtain migrations from there. See #905 for a detailed explanation of the aigned migrations design.

Additionally, we decided to maintain compatibility so that instances can be upgraded into signed migrations. To facilitate this, in the current version, `upog` writes both signed and unsigned migrations. `migrator` checks the from version. If it's less than `0.3.5`, migrator executes unsigned migrations, otherwise it executes signed migrations.

In a future version, we can create a breaking change in which unsigned migrations are no-longer read. At that point, versions less than 0.3.5 must pass through a version that supports both signed and unsigned migrations (such as this one) in order to upgrade into signed migrations.

There is one behavioral change about signed migrations. Previously we used a `sort` of the migration names to provide stability to their order of execution (when more than one migration existed for a single version pair). With signed migrations, this is no longer necessary and the migrations will run in the order that they are listed in the manifest.

## Testing done:

The testing procedure is extensive. Note: a trace was added so that `migrator` announces in the system journal whether it is running signed or unsigned migrations. Also note, v0.3.1 was used as a starting point because a migration exists for v0.3.2 (which changes the host container version). Thus upgrading from v0.3.1 presents an actual unsigned migration.

### Test Setup
  
  * Create an AMI of v0.3.1, but with my non-production `root.json`.
  * Create matching image binaries for v0.3.1 with my non-production `root.json` and add them to a TUF repo (replacing the prod images).
  * Create a version of the code in this PR, naming the version 0.99.0, create an AMI of this and add the update binaries to the TUF repo/manifest.
  * Create a version of the code in this PR, along with a migration that adds a `foo` setting and sets its value to `bar`. Call this v0.99.1 and add it to the TUF repo/manifest.

### Test Execution

Starting from the v0.3.1 AMI, perform the following sequence of upgrades and downgrades.

  * Start at v0.3.1 via AMI
  * Upgrade v0.3.1 -> v0.99.0
  * Upgrade v0.99.0 -> v0.99.1
  * Downgrade v0.99.1 -> v0.99.0
  * Downgrade v0.99.0 -> v0.3.1

At each step along the way.

  * Ensure that Kubernetes is working by running a busybox pod.
  * Copy the system journal and Bottlerocket API settings to local storage.

At the end of the cycle, diff the system journals to observe that migrator annouced:

  * Upgrade v0.3.1 -> v0.99.0 'running unsigned migrations'
  * Upgrade v0.99.0 -> v0.99.1 'running signed migrations'
  * Downgrade v0.99.1 -> v0.99.0 'running signed migrations'
  * Downgrade v0.99.0 -> v0.3.1: older version of migrator made no announcement

Diff the API settings to observe the following setting changes:

  * Upgrade v0.3.1 -> v0.99.0: host container changed from v0.4.0 to v0.5.0
  * Upgrade v0.99.0 -> v0.99.1: "foo": "bar" was added
  * Downgrade v0.99.1 -> v0.99.0: "foo": "bar" was removed
  * Downgrade v0.99.0 -> v0.3.1: host container changed from v0.5.0 to v0.4.0

### Additional Testing

Additional testing has been performed with v0.99.0 AMI -> v0.99.1 -> v0.99.0, though this has not been repeated at every testing cycle.

## TODO

  * [x] Use `pentacle`
  * [x] Use `tough::RepoEditor` to create the `migrator` unit test repo on the fly.  ([pushed](https://github.com/bottlerocket-os/bottlerocket/compare/f481a2dba97732110a08896f8ad009a2c49284ea..44434413686ee190eeba8a65cef0a1f315c027fe))
  * [x] Use a single migration script for testing instead of two different migration scripts, and compress the migration script on the fly instead of checking in a compressed version of it. ([pushed](https://github.com/bottlerocket-os/bottlerocket/compare/f481a2dba97732110a08896f8ad009a2c49284ea..44434413686ee190eeba8a65cef0a1f315c027fe))
  * [x] Set repo expiration to 1970-01-01 to make it obvious that it is expired. Also make a note about this in the test. ([pushed](https://github.com/bottlerocket-os/bottlerocket/compare/f481a2dba97732110a08896f8ad009a2c49284ea..44434413686ee190eeba8a65cef0a1f315c027fe))
  
## Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
