### PR TITLE
build: canonicalize to EC2 machine architecture

### DIFF
--- a/bin/amiize.sh
+++ b/bin/amiize.sh
@@ -118,7 +118,7 @@ Required:
    --ssh-keypair              The SSH keypair name that's registered with EC2, to connect to worker instance
    --instance-type            Instance type launched for worker instance
    --name                     The name under which to register the AMI
-   --arch                     The machine architecture of the AMI, e.g. x86_64
+   --arch                     The machine architecture of the AMI, e.g. x86_64, arm64
 
 Optional:
    --description              The description attached to the registered AMI (defaults to name)
@@ -186,6 +186,20 @@ parse_args() {
    required_arg "--instance-type" "${INSTANCE_TYPE}"
    required_arg "--name" "${NAME}"
    required_arg "--arch" "${ARCH}"
+
+   # Validate and canonicalize architecture identifier.
+   case "${ARCH,,}" in
+      arm64|aarch64)
+         ARCH=arm64
+         ;;
+      x86_64|amd64)
+         ARCH=x86_64
+         ;;
+      *)
+         echo "ERROR: Unsupported EC2 machine architecture: $ARCH" >&2
+         usage
+         exit 2
+   esac
 
    # Other argument checks
    if [ ! -r "${ROOT_IMAGE}" ] ; then


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

There are places in which architectures may/must be provided vary in which identifier should be provided, like `aarch64` and `arm64`. The `amiize.sh` script would get *very* far before an error is raised about an incorrect choice on the part of the caller. Instead of waiting until the `aws ec2 register-image` call, the script will now bail on invalid architectures and also will canonicalize the given value from a supported set (eg: `aarch64 -> arm64`).

```
This handles callers providing a mix of identifiers and maps to the
correct EC2 identifier.

Signed-off-by: Jacob Vallejo <jakeev@amazon.com>
```

**Testing done:**

I ran `./amiize.sh` with `--arch aarch64` and had a successful image on the other side.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
