### PR TITLE
mount debugfs in superpowered containers

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -321,6 +321,11 @@ func withSuperpowered(superpowered bool) oci.SpecOpts {
 				Options:     []string{"rbind", "ro"},
 				Destination: "/usr/src/kernels",
 				Source:      "/usr/src/kernels",
+			},
+			{
+				Options:     []string{"rbind"},
+				Destination: "/sys/kernel/debug",
+				Source:      "/sys/kernel/debug",
 			}}),
 	)
 }


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Mount debugfs in superpowered containers.

Tools like `bcc` and `bpftrace` interact with various files in debugfs and tracefs, for example to read the list of invalid probe addresses from `/sys/kernel/debug/kprobes/blacklist`.


**Testing done:**
Built a custom admin container with `bpftrace` and `bcc` installed.

Confirmed that the tools under `/usr/share/bcc/tools` and `/usr/share/bpftrace/tools` ran OK.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
