### PR TITLE
apiserver: new `/actions/reboot` endpoint

### DIFF
--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -3,6 +3,7 @@ use nix::unistd::Gid;
 use snafu::Snafu;
 use std::io;
 use std::path::PathBuf;
+use std::string::String;
 
 // We want server (router/handler) and controller errors together so it's easy to define response
 // error codes for all the high-level types of errors that could happen during a request.
@@ -115,6 +116,12 @@ pub enum Error {
 
     #[snafu(display("Unable to send input to config applier: {}", source))]
     ConfigApplierWrite { source: io::Error },
+
+    #[snafu(display("Unable to start shutdown: {}", source))]
+    Shutdown { source: io::Error },
+
+    #[snafu(display("Failed to reboot, exit code: {}, stderr: {}", exit_code, String::from_utf8_lossy(stderr)))]
+    Reboot { exit_code: i32, stderr: Vec<u8> },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -314,3 +314,13 @@ paths:
                 $ref: "ConfigurationFiles"
         500:
           description: "Server error"
+
+  /actions/reboot:
+    post:
+      summary: "Reboot"
+      operationId: "reboot"
+      responses:
+        204:
+          description: "Reboot requested"
+        500:
+          description: "Server error"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Adds new API path: `/actions/reboot` for initiating reboots.



**Testing done:**
Built images, created AMI, launched instance with said AMI
Was able to reboot the machine from both the control container and admin container with:
`apiclient -v -u /actions/reboot -m POST`. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
