### PR TITLE
Update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ The following settings are set for you automatically by [pluto](sources/api/) ba
 * `settings.updates.metadata-base-url`: The common portion of all URIs used to download update metadata.
 * `settings.updates.targets-base-url`: The common portion of all URIs used to download update files.
 * `settings.updates.seed`: A `u32` value that determines how far into in the update schedule this machine will accept an update.  We recommending leaving this at its default generated value so that updates can be somewhat randomized in your cluster.
+* `settings.updates.version-lock`: Controls the version that will be selected when you issue an update request.  Can be locked to a specific version like `v1.0.0`, or `latest` to take the latest available version.  Defaults to `latest`.
+* `settings.updates.ignore-waves`: Updates are rolled out in waves to reduce the impact of issues.  For testing purposes, you can set this to `true` to ignore those waves and update immediately.
 
 #### Time settings
 

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -28,6 +28,7 @@ Source110: mark-successful-boot.service
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
 Source201: host-containers-tmpfiles.conf
+Source202: thar-be-updates-tmpfiles.conf
 
 BuildRequires: %{_cross_os}glibc-devel
 
@@ -84,6 +85,12 @@ Summary: Dynamic setting generator for kubernetes
 Summary: Applies changed settings to a Bottlerocket system
 Requires: %{_cross_os}apiserver = %{version}-%{release}
 %description -n %{_cross_os}thar-be-settings
+%{summary}.
+
+%package -n %{_cross_os}thar-be-updates
+Summary: Dispatches Bottlerocket update commands
+Requires: %{_cross_os}apiserver = %{version}-%{release}
+%description -n %{_cross_os}thar-be-updates
 %{summary}.
 
 %package -n %{_cross_os}servicedog
@@ -160,6 +167,7 @@ mkdir bin
     -p pluto \
     -p bork \
     -p thar-be-settings \
+    -p thar-be-updates \
     -p servicedog \
     -p host-containers \
     -p storewolf \
@@ -186,7 +194,7 @@ install -d %{buildroot}%{_cross_bindir}
 for p in \
   apiserver \
   early-boot-config netdog sundog schnauzer pluto bork \
-  thar-be-settings servicedog host-containers \
+  thar-be-settings thar-be-updates servicedog host-containers \
   storewolf settings-committer \
   migrator \
   signpost updog logdog;
@@ -242,6 +250,7 @@ install -p -m 0644 \
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.conf
+install -p -m 0644 %{S:202} %{buildroot}%{_cross_tmpfilesdir}/thar-be-updates.conf
 
 %cross_scan_attribution --clarify %{_builddir}/sources/clarify.toml \
     cargo --offline --locked %{_builddir}/sources/Cargo.toml
@@ -283,6 +292,10 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.co
 %files -n %{_cross_os}thar-be-settings
 %{_cross_bindir}/thar-be-settings
 %{_cross_unitdir}/settings-applier.service
+
+%files -n %{_cross_os}thar-be-updates
+%{_cross_bindir}/thar-be-updates
+%{_cross_tmpfilesdir}/thar-be-updates.conf
 
 %files -n %{_cross_os}servicedog
 %{_cross_bindir}/servicedog

--- a/packages/os/thar-be-updates-tmpfiles.conf
+++ b/packages/os/thar-be-updates-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/cache/thar-be-updates 0755 root root -

--- a/packages/os/updog-toml
+++ b/packages/os/updog-toml
@@ -1,3 +1,5 @@
 metadata_base_url = "{{settings.updates.metadata-base-url}}"
 targets_base_url = "{{settings.updates.targets-base-url}}"
 seed = {{settings.updates.seed}}
+version_lock = "{{settings.updates.version-lock}}"
+ignore_waves = {{settings.updates.ignore-waves}}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -55,6 +55,7 @@ Requires: %{_cross_os}host-containers
 Requires: %{_cross_os}settings-committer
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}thar-be-settings
+Requires: %{_cross_os}thar-be-updates
 Requires: %{_cross_os}migration
 Requires: %{_cross_os}updog
 Requires: %{_cross_os}logdog

--- a/packages/systemd/run-tmpfiles.conf
+++ b/packages/systemd/run-tmpfiles.conf
@@ -2,6 +2,7 @@ d /run/cache 0755 root root -
 d /run/lib 0755 root root -
 d /run/log 0755 root root -
 d /run/spool 0755 root root -
+d /run/lock 0700 root root -
 
 d /run/cache/private 0700 root root -
 d /run/lib/private 0700 root root -

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "migrator 0.1.0",
+ "models 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -282,17 +282,22 @@ dependencies = [
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bottlerocket-release 0.1.0",
  "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "models 0.1.0",
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thar-be-updates 0.1.0",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -543,7 +548,7 @@ name = "chrono"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1565,6 +1570,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,10 +1612,31 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3147,8 +3204,13 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+"checksum num 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
+"checksum num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+"checksum num-complex 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
 "checksum num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
-"checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+"checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+"checksum num-iter 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+"checksum num-rational 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum olpc-cjson 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9409e2493366c8f19387c98c5189ab9c937541b5bf48f11390d038a59fdfd9c1"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1510,6 +1510,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "model-derive 0.1.0",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -93,7 +93,7 @@ dependencies = [
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -289,7 +289,7 @@ dependencies = [
  "models 0.1.0",
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -354,7 +354,7 @@ dependencies = [
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -395,7 +395,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -460,7 +460,7 @@ dependencies = [
  "envy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -511,8 +511,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -523,8 +523,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -544,8 +544,8 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -728,7 +728,7 @@ dependencies = [
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -764,7 +764,7 @@ name = "envy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -859,6 +859,15 @@ dependencies = [
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1006,8 +1015,8 @@ dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1048,7 +1057,7 @@ dependencies = [
  "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1099,7 +1108,7 @@ dependencies = [
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "models 0.1.0",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1239,7 +1248,7 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1400,7 +1409,7 @@ dependencies = [
  "apiserver 0.1.0",
  "handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnauzer 0.1.0",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1511,7 +1520,7 @@ dependencies = [
  "model-derive 0.1.0",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1538,7 +1547,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1556,17 +1565,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1586,7 +1605,7 @@ name = "olpc-cjson"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1937,7 +1956,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2056,7 +2075,7 @@ dependencies = [
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "models 0.1.0",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2102,7 +2121,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2112,15 +2131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2135,7 +2154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2143,7 +2162,7 @@ name = "serde_plain"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2153,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2167,7 +2186,7 @@ dependencies = [
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "models 0.1.0",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2181,7 +2200,7 @@ dependencies = [
  "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2234,7 +2253,7 @@ dependencies = [
  "block-party 0.1.0",
  "gptman 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2247,6 +2266,16 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2368,7 +2397,7 @@ dependencies = [
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "models 0.1.0",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2457,6 +2486,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,6 +2517,32 @@ dependencies = [
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thar-be-updates"
+version = "0.1.0"
+dependencies = [
+ "apiclient 0.1.0",
+ "bottlerocket-release 0.1.0",
+ "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "models 0.1.0",
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signpost 0.1.0",
+ "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "update_metadata 0.1.0",
 ]
 
 [[package]]
@@ -2571,7 +2634,7 @@ name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2585,7 +2648,7 @@ dependencies = [
  "pem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2705,7 +2768,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2725,7 +2788,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2795,7 +2858,7 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3019,6 +3082,7 @@ dependencies = [
 "checksum filetime 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f59efc38004c988e4201d11d263b8171f49a2e7ec0bdbb71773433f271504a5e"
 "checksum flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -3083,8 +3147,9 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+"checksum num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
-"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum olpc-cjson 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9409e2493366c8f19387c98c5189ab9c937541b5bf48f11390d038a59fdfd9c1"
 "checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
@@ -3142,8 +3207,8 @@ dependencies = [
 "checksum security-framework-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
-"checksum serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+"checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+"checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 "checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 "checksum serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "625fb0da2b006092b426a94acc1611bec52f2ec27bb27b266a9f93c29ee38eda"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
@@ -3153,6 +3218,7 @@ dependencies = [
 "checksum signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcacac97349a890d437921dfb23cbec52ab5b4752551cb637df2721371acd467"
+"checksum simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c"
 "checksum skeptic 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fb8ed853fdc19ce09752d63f3a2e5b5158aeb261520cd75eb618bd60305165"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
@@ -3172,6 +3238,7 @@ dependencies = [
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "api/host-containers",
     "api/storewolf",
     "api/thar-be-settings",
+    "api/thar-be-updates",
     "api/settings-committer",
     "api/migration/migrator",
     "api/migration/migration-helpers",

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -11,16 +11,21 @@ build = "build.rs"
 actix-rt = "1.0.0"
 actix-web = { version = "2.0.0", default-features = false }
 bottlerocket-release = { path = "../../bottlerocket-release" }
+fs2 = "0.4.3"
 futures = { version = "0.3", default-features = false }
+http = "0.2.1"
 libc = "0.2"
 log = "0.4"
 models = { path = "../../models" }
 nix = "0.17.0"
+num = "0.3.0"
 percent-encoding = "2.1"
+semver = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.7"
 snafu = "0.6"
+thar-be-updates = { path = "../thar-be-updates" }
 walkdir = "2.2"
 
 [build-dependencies]

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -120,8 +120,55 @@ pub enum Error {
     #[snafu(display("Unable to start shutdown: {}", source))]
     Shutdown { source: io::Error },
 
-    #[snafu(display("Failed to reboot, exit code: {}, stderr: {}", exit_code, String::from_utf8_lossy(stderr)))]
+    #[snafu(display(
+        "Failed to reboot, exit code: {}, stderr: {}",
+        exit_code,
+        String::from_utf8_lossy(stderr)
+    ))]
     Reboot { exit_code: i32, stderr: Vec<u8> },
+
+    // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    // Update related errors
+    #[snafu(display("Unable to start the update dispatcher: {} ", source))]
+    UpdateDispatcher { source: io::Error },
+
+    #[snafu(display("Unable to open update lock file: {}", source))]
+    UpdateLockOpen { source: io::Error },
+
+    #[snafu(display("Update lock held"))]
+    UpdateLockHeld,
+
+    #[snafu(display("Unable to obtain shared lock for reading update status: {}", source))]
+    UpdateShareLock { source: io::Error },
+
+    #[snafu(display("Previously chosen Update no longer exists"))]
+    UpdateDoesNotExist,
+
+    #[snafu(display("No update image applied to staging partition"))]
+    NoStagedImage,
+
+    #[snafu(display("Update action not allowed according to update state"))]
+    DisallowCommand,
+
+    #[snafu(display("Update dispatcher failed"))]
+    UpdateError,
+
+    #[snafu(display("Update status is uninitialized, refresh-updates to initialize it"))]
+    UninitializedUpdateStatus,
+
+    #[snafu(display("Failed to parse update status: {} ", source))]
+    UpdateStatusParse { source: serde_json::Error },
+
+    #[snafu(display(
+        "Failed to parse update information from '{}': {} ",
+        String::from_utf8_lossy(stdout),
+        source
+    ))]
+    UpdateInfoParse {
+        stdout: Vec<u8>,
+        source: serde_json::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -324,3 +324,79 @@ paths:
           description: "Reboot requested"
         500:
           description: "Server error"
+
+  /actions/refresh-updates:
+    post:
+      summary: "Query update repository and refresh list of updates"
+      operationId: "refresh_update"
+      responses:
+        204:
+          description: "Successful request"
+        500:
+          description: "Server error"
+        423:
+          description: "Update write lock held. Try again in a moment"
+
+  /actions/prepare-update:
+    post:
+      summary: "Download the chosen update and write the update image to the inactive partition"
+      operationId: "prepare_update"
+      responses:
+        204:
+          description: "Successful request"
+        404:
+          description: "Chosen update does not exist"
+        409:
+          description: "Action not allowed according to current update state"
+        500:
+          description: "Server error"
+        423:
+          description: "Update write lock held. Try again in a moment"
+
+  /actions/activate-update:
+    post:
+      summary: "Mark the partition with the prepared update as active so you can reboot into the chosen version"
+      operationId: "activate_update"
+      responses:
+        204:
+          description: "Successfully activated update"
+        404:
+          description: "No update image applied to staging partition, need to prepare-update first"
+        409:
+          description: "Action not allowed according to current update state"
+        500:
+          description: "Server error"
+        423:
+          description: "Update write lock held. Try again in a moment"
+
+  /actions/deactivate-update:
+    post:
+      summary: "Deactivate the update by marking the running partition as active again"
+      operationId: "deactivate-update"
+      responses:
+        204:
+          description: "Successfully deactivated update"
+        404:
+          description: "No update image applied to staging partition, need to prepare-update first"
+        409:
+          description: "Action not allowed according to current update state"
+        500:
+          description: "Server error"
+        423:
+          description: "Update write lock held. Try again in a moment"
+
+  /updates/status:
+    get:
+      summary: "Get update status"
+      operationId: "get_update_status"
+      responses:
+        200:
+          description: "Successful request"
+          content:
+            application/json:
+              schema:
+                $ref: "UpdateStatus"
+        500:
+          description: "Server error"
+        423:
+          description: "Update write lock held. Try again in a moment"

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "thar-be-updates"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[dependencies]
+apiclient = { path = "../apiclient" }
+bottlerocket-release = { path = "../../bottlerocket-release" }
+chrono = { version = "0.4.11", features = [ "serde" ] }
+fs2 = "0.4.3"
+http = "0.2.1"
+log = "0.4.8"
+models = { path = "../../models" }
+nix = "0.17.0"
+num-derive = "0.3.0"
+num-traits = "0.2.12"
+semver = { version = "0.9", features = [ "serde" ] }
+serde = { version = "1.0.111", features = [ "derive" ] }
+serde_json = "1.0.53"
+serde_plain = "0.3.0"
+signpost = { path = "../../updater/signpost" }
+simplelog = "0.8.0"
+snafu = "0.6.8"
+tempfile = "3.1.0"
+update_metadata = { path = "../../updater/update_metadata" }
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/api/thar-be-updates/README.md
+++ b/sources/api/thar-be-updates/README.md
@@ -1,0 +1,23 @@
+# thar-be-updates
+
+Current version: 0.1.0
+
+## Introduction
+
+thar-be-updates is a Bottlerocket update dispatcher that serves as an interface for the `apiserver` to issue update commands and monitor update status.
+
+It models the Bottlerocket update process after a state machine and provides several update commands that modifies the update state.
+It keeps track of the update state and other stateful update information in a update status file located at `/run/update-status`
+
+Upon receiving a command not allowed by the update state, thar-be-updates exits immediately with an exit status indicating so.
+Otherwise, thar-be-updates forks a child process to spawn the necessary process to do the work.
+The parent process immediately returns back to the caller with an exit status of `0`.
+The output and status of the command will be written to the update status file.
+This allows the caller to synchronously call thar-be-updates without having to wait for a result to come back.
+
+thar-be-updates uses a lockfile to control read/write access to the disks and the update status file.
+
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/thar-be-updates/README.tpl
+++ b/sources/api/thar-be-updates/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/thar-be-updates/build.rs
+++ b/sources/api/thar-be-updates/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/api/thar-be-updates/src/error.rs
+++ b/sources/api/thar-be-updates/src/error.rs
@@ -1,0 +1,161 @@
+use crate::status::{UpdateCommand, UpdateState};
+use http::StatusCode;
+use num_derive::{FromPrimitive, ToPrimitive};
+use snafu::Snafu;
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+pub enum Error {
+    #[snafu(display("Failed to create tempfile for writing status: {}", source))]
+    CreateTempfile { source: std::io::Error },
+
+    #[snafu(display("Failed to create update status file '{}': {}", path.display(), source))]
+    CreateStatusFile {
+        path: PathBuf,
+        source: tempfile::PathPersistError,
+    },
+
+    #[snafu(display("Failed to access update status file '{}': {}", path.display(), source))]
+    NoStatusFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse update status file '{}': {}", path.display(), source))]
+    StatusParse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Failed to write update status file '{}': {}", path.display(), source))]
+    StatusWrite {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Failed to deserialize update info: {}", source))]
+    UpdateInfo { source: serde_json::Error },
+
+    #[snafu(display("Unable to get OS version: {}", source))]
+    ReleaseVersion { source: bottlerocket_release::Error },
+
+    #[snafu(display("Failed to access lockfile '{}': {}",  path.display(),source))]
+    UpdateLockFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Unable to obtain lock on lockfile '{}': {}", path.display(), source))]
+    UpdateLockHeld {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Error sending {} to {}: {}", method, uri, source))]
+    APIRequest {
+        method: String,
+        uri: String,
+        source: apiclient::Error,
+    },
+
+    #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]
+    APIResponse {
+        method: String,
+        uri: String,
+        code: StatusCode,
+        response_body: String,
+    },
+
+    #[snafu(display("Error deserializing response as JSON from {}: {}", uri, source))]
+    ResponseJson {
+        uri: String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Failed to read OS disk partition table: {}", source))]
+    PartitionTableRead {
+        // signpost::Error triggers clippy::large_enum_variant
+        #[snafu(source(from(signpost::Error, Box::new)))]
+        source: Box<signpost::Error>,
+    },
+
+    #[snafu(display("Failed to modify OS disk partition table: {}", source))]
+    PartitionTableWrite {
+        // signpost::Error triggers clippy::large_enum_variant
+        #[snafu(source(from(signpost::Error, Box::new)))]
+        source: Box<signpost::Error>,
+    },
+
+    #[snafu(display("Could not mark inactive partition for boot: {}", source))]
+    InactivePartitionUpgrade { source: signpost::Error },
+
+    #[snafu(display("No partition set is set to boot next"))]
+    NoneSetToBoot,
+
+    #[snafu(display("Failed to fork process"))]
+    Fork {},
+
+    #[snafu(display("Failed to start updog: {}", source))]
+    Updog { source: std::io::Error },
+
+    #[snafu(display("Failed to prepare the update with updog"))]
+    PrepareUpdate,
+
+    #[snafu(display("Failed to activate the update with updog"))]
+    ActivateUpdate,
+
+    #[snafu(display("Failed to deactivate the update with updog"))]
+    DeactivateUpdate,
+
+    #[snafu(display("Failed to start signpost: {}", source))]
+    Signpost { source: std::io::Error },
+
+    #[snafu(display("Failed to get setting '{}': {}", setting, source))]
+    GetSetting {
+        setting: String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Failed to parse version string '{}' into semver version", version))]
+    SemVer {
+        version: String,
+        source: semver::SemVerError,
+    },
+
+    #[snafu(display("Invalid state transition from {:?} to {:?}", from, to))]
+    InvalidStateTransition { from: UpdateState, to: UpdateState },
+
+    #[snafu(display("Command '{:?}' not allowed when state is '{:?}'", command, state))]
+    DisallowCommand {
+        command: UpdateCommand,
+        state: UpdateState,
+    },
+
+    #[snafu(display("Chosen update does not exist"))]
+    UpdateDoesNotExist,
+
+    #[snafu(display("Update version to query is not specified"))]
+    UnspecifiedVersion,
+
+    #[snafu(display("No update image applied to the inactive partition set"))]
+    StagingPartition,
+
+    #[snafu(display("No image information for the active partition set"))]
+    ActivePartition,
+
+    #[snafu(display("Logger setup error: {}", source))]
+    Logger { source: simplelog::TermLogError },
+}
+
+/// Map errors to specific exit codes to return to caller
+#[derive(FromPrimitive, ToPrimitive)]
+pub enum TbuErrorStatus {
+    OtherError = 1,
+    UpdateLockHeld = 64,
+    DisallowCommand = 65,
+    UpdateDoesNotExist = 66,
+    NoStagedImage = 67,
+}

--- a/sources/api/thar-be-updates/src/lib.rs
+++ b/sources/api/thar-be-updates/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod status;

--- a/sources/api/thar-be-updates/src/main.rs
+++ b/sources/api/thar-be-updates/src/main.rs
@@ -1,0 +1,372 @@
+/*!
+# Introduction
+
+thar-be-updates is a Bottlerocket update dispatcher that serves as an interface for the `apiserver` to issue update commands and monitor update status.
+
+It models the Bottlerocket update process after a state machine and provides several update commands that modifies the update state.
+It keeps track of the update state and other stateful update information in a update status file located at `/run/update-status`
+
+Upon receiving a command not allowed by the update state, thar-be-updates exits immediately with an exit status indicating so.
+Otherwise, thar-be-updates forks a child process to spawn the necessary process to do the work.
+The parent process immediately returns back to the caller with an exit status of `0`.
+The output and status of the command will be written to the update status file.
+This allows the caller to synchronously call thar-be-updates without having to wait for a result to come back.
+
+thar-be-updates uses a lockfile to control read/write access to the disks and the update status file.
+
+*/
+
+use fs2::FileExt;
+use log::{debug, warn};
+use nix::unistd::{fork, ForkResult};
+use num_traits::cast::ToPrimitive;
+use simplelog::{Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
+use snafu::ensure;
+use snafu::{OptionExt, ResultExt};
+use std::fs::File;
+use std::path::Path;
+use std::process::{exit, Command};
+use std::str::FromStr;
+use std::{env, process};
+use tempfile::NamedTempFile;
+use thar_be_updates::error;
+use thar_be_updates::error::{Error, Result, TbuErrorStatus};
+use thar_be_updates::status::{
+    get_update_status, UpdateCommand, UpdateState, UpdateStatus, UPDATE_LOCKFILE,
+    UPDATE_STATUS_FILE,
+};
+
+// FIXME Get this from configuration in the future
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
+
+const UPDATE_STATUS_DIR: &str = "/run/cache/thar-be-updates";
+
+/// Stores the command line arguments
+struct Args {
+    subcommand: UpdateCommand,
+    log_level: LevelFilter,
+    socket_path: String,
+}
+
+/// Prints an usage message
+fn usage() -> ! {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            Subcommands:
+                refresh     Query update repository, store the list of available updates,
+                            and check if chosen version is available
+                prepare     Download the chosen update and write the update image to the
+                            inactive partition
+                activate    Marks the inactive partition for boot
+                deactivate  Reverts update activation by marking current active partition for boot
+
+            Global options:
+                    [ --socket-path PATH ]    Bottlerocket API socket path (default {})
+                    [ --log-level trace|debug|info|warn|error ]  (default info)",
+        program_name, DEFAULT_API_SOCKET,
+    );
+    process::exit(2);
+}
+
+/// Prints a more specific message before exiting through usage().
+fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
+    eprintln!("{}\n", msg.as_ref());
+    usage();
+}
+
+/// Parses the command line arguments
+fn parse_args(args: std::env::Args) -> Args {
+    let mut subcommand = None;
+    let mut log_level = None;
+    let mut socket_path = None;
+
+    let mut iter = args.skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--log-level" => {
+                let log_level_str = iter
+                    .next()
+                    .unwrap_or_else(|| usage_msg("Did not give argument to --log-level"));
+                log_level = Some(LevelFilter::from_str(&log_level_str).unwrap_or_else(|_| {
+                    usage_msg(format!("Invalid log level '{}'", log_level_str))
+                }));
+            }
+
+            "--socket-path" => {
+                socket_path = Some(
+                    iter.next()
+                        .unwrap_or_else(|| usage_msg("Did not give argument to --socket-path")),
+                )
+            }
+            // Assume any arguments not prefixed with '-' is a subcommand
+            s if !s.starts_with('-') => {
+                if subcommand.is_some() {
+                    usage();
+                }
+                subcommand =
+                    Some(serde_plain::from_str::<UpdateCommand>(s).unwrap_or_else(|_| usage()));
+            }
+            _ => usage(),
+        }
+    }
+
+    Args {
+        subcommand: subcommand.unwrap_or_else(|| usage()),
+        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+    }
+}
+
+// Simple wrapper for locking
+// Once we fork, the parent process and child process are going to have duplicate file descriptors
+// that refer to the same lock. Once the parent returns and closes its copy of the lockfile fd,
+// the child will still hold the lock. The lock is only released when all copies of the file descriptor are closed.
+fn lock_exclusive(lockfile: &File) -> Result<()> {
+    lockfile
+        .try_lock_exclusive()
+        .context(error::UpdateLockHeld {
+            path: UPDATE_LOCKFILE,
+        })?;
+    debug!("Obtained exclusive lock");
+    Ok(())
+}
+
+/// Initializes the update status and creates the update status file
+fn initialize_update_status() -> Result<()> {
+    let mut new_status = UpdateStatus::new();
+    // Initialize active partition set information
+    new_status.update_active_partition_info()?;
+    write_update_status(&new_status)
+}
+
+/// Atomically writes out the update status to disk
+fn write_update_status(update_status: &UpdateStatus) -> Result<()> {
+    // Create the status file as a temporary file first and finish writing to it
+    // before swapping the old status file out
+    let status_file_tempfile =
+        NamedTempFile::new_in(UPDATE_STATUS_DIR).context(error::CreateTempfile)?;
+    serde_json::to_writer_pretty(&status_file_tempfile, update_status).context(
+        error::StatusWrite {
+            path: status_file_tempfile.path(),
+        },
+    )?;
+    let tempfile_path = status_file_tempfile.into_temp_path();
+    debug!("Updating status file in '{}'", UPDATE_STATUS_FILE);
+    tempfile_path
+        .persist(UPDATE_STATUS_FILE)
+        .context(error::CreateStatusFile {
+            path: UPDATE_STATUS_FILE,
+        })?;
+    Ok(())
+}
+
+/// This macros encapsulates the boilerplate code for dispatching the update command in a forked process
+macro_rules! fork_and_return {
+    ($child_process:block) => {
+        match fork() {
+            Ok(ForkResult::Parent { child, .. }) => {
+                debug!("forked child pid: {}", child);
+                // Exit immediately as the parent
+                // Parent's lockfile fd will close but child will still have a duplicate fd
+                exit(0);
+            }
+            Ok(ForkResult::Child) => $child_process,
+            Err(e) => {
+                eprintln!("{}", e);
+                error::Fork.fail()
+            }
+        }
+    };
+}
+
+/// Spawns updog process to get list of updates and check if any of them can be updated to.
+/// Returns true if there is an available update, returns false otherwise.
+fn refresh(status: &mut UpdateStatus, socket_path: &str) -> Result<bool> {
+    fork_and_return!({
+        debug!("Spawning 'updog whats'");
+        let output = Command::new("updog")
+            .args(&["whats", "--all", "--json"])
+            .output()
+            .context(error::Updog)?;
+        status.set_recent_command_info(UpdateCommand::Refresh, &output);
+        if !output.status.success() {
+            warn!("Failed to check for updates with updog");
+            return Ok(false);
+        }
+        let update_info: Vec<update_metadata::Update> =
+            serde_json::from_slice(&output.stdout).context(error::UpdateInfo)?;
+        status.update_available_updates(socket_path, update_info)
+    })
+}
+
+/// Prepares the update by downloading and writing the update to the staging partition
+fn prepare(status: &mut UpdateStatus) -> Result<()> {
+    fork_and_return!({
+        debug!("Spawning 'updog update-image'");
+        let chosen_update = status
+            .chosen_update()
+            .context(error::UpdateDoesNotExist)?
+            .clone();
+        let output = Command::new("updog")
+            .arg("update-image")
+            .output()
+            .context(error::Updog)?;
+        status.set_recent_command_info(UpdateCommand::Prepare, &output);
+        if !output.status.success() {
+            warn!("Failed to prepare the update with updog");
+            return error::PrepareUpdate.fail();
+        }
+        status.set_staging_partition_image_info(chosen_update);
+        Ok(())
+    })
+}
+
+/// "Activates" the staged update by letting updog set up the appropriate boot flags
+fn activate(status: &mut UpdateStatus) -> Result<()> {
+    fork_and_return!({
+        debug!("Spawning 'updog update-apply'");
+        let output = Command::new("updog")
+            .arg("update-apply")
+            .output()
+            .context(error::Updog)?;
+        status.set_recent_command_info(UpdateCommand::Activate, &output);
+        if !output.status.success() {
+            warn!("Failed to activate the update with updog");
+            return error::ActivateUpdate.fail();
+        }
+        status.mark_staging_partition_next_to_boot()
+    })
+}
+
+/// "Deactivates" the staged update by rolling back actions done by `activate_update`
+fn deactivate(status: &mut UpdateStatus) -> Result<()> {
+    fork_and_return!({
+        debug!("Spawning 'updog update-revert'");
+        let output = Command::new("updog")
+            .arg("update-revert")
+            .output()
+            .context(error::Updog)?;
+        status.set_recent_command_info(UpdateCommand::Deactivate, &output);
+        if !output.status.success() {
+            warn!("Failed to deactivate the update with updog");
+            return error::DeactivateUpdate.fail();
+        }
+        status.unmark_staging_partition_next_to_boot()
+    })
+}
+
+/// Given the update command, this drives the update state machine.
+fn drive_state_machine(
+    update_status: &mut UpdateStatus,
+    operation: &UpdateCommand,
+    socket_path: &str,
+) -> Result<()> {
+    let new_state = match (operation, update_status.update_state()) {
+        (UpdateCommand::Refresh, UpdateState::Idle)
+        | (UpdateCommand::Refresh, UpdateState::Available) => {
+            if refresh(update_status, socket_path)? {
+                // Transitions state to `Available` if there is an available update
+                UpdateState::Available
+            } else {
+                // Go to Idle otherwise
+                UpdateState::Idle
+            }
+        }
+        // Refreshing the list of updates is allowed under every update state
+        (UpdateCommand::Refresh, _) => {
+            refresh(update_status, socket_path)?;
+            // No need to transition state here as we're already beyond `Available`
+            update_status.update_state().to_owned()
+        }
+        // Preparing the update is allowed when the state is either `Available` or `Staged`
+        (UpdateCommand::Prepare, UpdateState::Available)
+        | (UpdateCommand::Prepare, UpdateState::Staged) => {
+            // Make sure the chosen update exists
+            ensure!(
+                update_status.chosen_update().is_some(),
+                error::UpdateDoesNotExist
+            );
+            prepare(update_status)?;
+            // If we succeed in preparing the update, we transition to `Staged`
+            UpdateState::Staged
+        }
+        // Activating the update is only allowed when the state is `Staged`
+        (UpdateCommand::Activate, UpdateState::Staged) => {
+            // Make sure there's an update image written to the inactive partition
+            ensure!(
+                update_status.staging_partition().is_some(),
+                error::StagingPartition
+            );
+            activate(update_status)?;
+            // If we succeed in activating the update, we transition to `Ready`
+            UpdateState::Ready
+        }
+        // Deactivating the update is only allowed when the state is `Ready`
+        (UpdateCommand::Deactivate, UpdateState::Ready) => {
+            // Make sure there's an update image written to the inactive partition
+            ensure!(
+                update_status.staging_partition().is_some(),
+                error::StagingPartition
+            );
+            deactivate(update_status)?;
+            // If we succeed in deactivating the update, we transition to `Staged`
+            UpdateState::Staged
+        }
+        // Everything else is disallowed
+        _ => {
+            return error::DisallowCommand {
+                command: operation.clone(),
+                state: update_status.update_state().to_owned(),
+            }
+            .fail();
+        }
+    };
+    update_status.set_update_state(new_state);
+    Ok(())
+}
+
+fn run() -> Result<()> {
+    // Parse and store the args passed to the program
+    let args = parse_args(env::args());
+
+    // TerminalMode::Mixed will send errors to stderr and anything less to stdout.
+    TermLogger::init(args.log_level, LogConfig::default(), TerminalMode::Mixed)
+        .context(error::Logger)?;
+
+    // Open the lockfile for concurrency control, create it if it doesn't exist
+    let lockfile = File::create(UPDATE_LOCKFILE).context(error::UpdateLockFile {
+        path: UPDATE_LOCKFILE,
+    })?;
+    // Obtain an exclusive lock for upcoming operations to the status file
+    lock_exclusive(&lockfile)?;
+
+    // Check if the update status file exists. If it doesn't, create and initialize it.
+    if !Path::new(UPDATE_STATUS_FILE).is_file() {
+        // Get an exclusive lock for creating the update status file
+        initialize_update_status()?;
+    }
+    let mut update_status = get_update_status(&lockfile)?;
+    drive_state_machine(&mut update_status, &args.subcommand, &args.socket_path)?;
+    write_update_status(&update_status)?;
+    Ok(())
+}
+
+fn match_error_to_exit_status(err: Error) -> i32 {
+    match err {
+        Error::UpdateLockHeld { .. } => TbuErrorStatus::UpdateLockHeld,
+        Error::DisallowCommand { .. } => TbuErrorStatus::DisallowCommand,
+        Error::UpdateDoesNotExist { .. } => TbuErrorStatus::UpdateDoesNotExist,
+        Error::StagingPartition { .. } => TbuErrorStatus::NoStagedImage,
+        _ => TbuErrorStatus::OtherError,
+    }
+    .to_i32()
+    .unwrap_or(1)
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        std::process::exit(match_error_to_exit_status(e));
+    }
+}

--- a/sources/api/thar-be-updates/src/status.rs
+++ b/sources/api/thar-be-updates/src/status.rs
@@ -1,0 +1,306 @@
+use crate::error;
+use crate::error::Result;
+use bottlerocket_release::BottlerocketRelease;
+use chrono::{DateTime, Utc};
+use model::modeled_types::FriendlyVersion;
+use serde::{Deserialize, Serialize};
+use signpost::State;
+use snafu::{ensure, OptionExt, ResultExt};
+use std::convert::TryInto;
+use std::fs::File;
+use std::os::unix::process::ExitStatusExt;
+use std::process::Output;
+
+pub const UPDATE_LOCKFILE: &str = "/run/lock/thar-be-updates.lock";
+pub const UPDATE_STATUS_FILE: &str = "/run/cache/thar-be-updates/status.json";
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum UpdateState {
+    Idle,
+    Available,
+    Staged,
+    Ready,
+}
+
+/// UpdateImage represents a Bottlerocket update image
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UpdateImage {
+    arch: String,
+    version: semver::Version,
+    variant: String,
+}
+
+impl UpdateImage {
+    pub fn version(&self) -> &semver::Version {
+        &self.version
+    }
+}
+
+/// StagedImage represents a Bottlerocket image that is written to a partition set
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StagedImage {
+    image: UpdateImage,
+    /// Indicates whether this image is marked for next boot
+    next_to_boot: bool,
+}
+
+impl StagedImage {
+    pub(crate) fn set_next_to_boot(&mut self, next_to_boot: bool) {
+        self.next_to_boot = next_to_boot
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum CommandStatus {
+    Success,
+    Failed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UpdateCommand {
+    Refresh,
+    Prepare,
+    Activate,
+    Deactivate,
+}
+
+/// CommandResult represents the result of an issued command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CommandResult {
+    cmd_type: UpdateCommand,
+    cmd_status: CommandStatus,
+    timestamp: DateTime<Utc>,
+    exit_status: Option<i32>,
+    stderr: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UpdateStatus {
+    update_state: UpdateState,
+    available_updates: Vec<semver::Version>,
+    chosen_update: Option<UpdateImage>,
+    active_partition: Option<StagedImage>,
+    staging_partition: Option<StagedImage>,
+    most_recent_command: Option<CommandResult>,
+}
+
+impl Default for UpdateStatus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Loads and returns the update status from disk.
+/// This takes the update lock file as an parameter to signal to caller that the update
+/// lock needs to be obtained before calling this.
+pub fn get_update_status(_lockfile: &File) -> Result<UpdateStatus> {
+    let status_file = File::open(UPDATE_STATUS_FILE).context(error::NoStatusFile {
+        path: UPDATE_STATUS_FILE,
+    })?;
+    Ok(
+        serde_json::from_reader(status_file).context(error::StatusParse {
+            path: UPDATE_STATUS_FILE,
+        })?,
+    )
+}
+
+// This is how the UpdateStatus is stored on disk
+impl UpdateStatus {
+    /// Initializes the update status
+    pub fn new() -> Self {
+        Self {
+            update_state: UpdateState::Idle,
+            available_updates: vec![],
+            chosen_update: None,
+            active_partition: None,
+            staging_partition: None,
+            most_recent_command: None,
+        }
+    }
+
+    pub fn update_state(&self) -> &UpdateState {
+        &self.update_state
+    }
+
+    pub fn set_update_state(&mut self, state: UpdateState) {
+        self.update_state = state;
+    }
+
+    pub fn chosen_update(&self) -> Option<&UpdateImage> {
+        match &self.chosen_update {
+            Some(update) => Some(&update),
+            None => None,
+        }
+    }
+
+    pub fn staging_partition(&self) -> Option<&StagedImage> {
+        match &self.staging_partition {
+            Some(partition_info) => Some(&partition_info),
+            None => None,
+        }
+    }
+
+    /// Updates the active partition set information
+    pub fn update_active_partition_info(&mut self) -> Result<()> {
+        // Get current OS release info to determine active partition image information
+        let os_info = BottlerocketRelease::new().context(error::ReleaseVersion)?;
+        let active_image = UpdateImage {
+            arch: os_info.arch,
+            version: os_info.version_id,
+            variant: os_info.variant_id,
+        };
+
+        // Get partition set information. We can infer the version of the image in the active
+        // partition set by checking the os release information
+        let gpt_state = State::load().context(error::PartitionTableRead)?;
+        let active_set = gpt_state.active();
+        let next_set = gpt_state.next().context(error::NoneSetToBoot)?;
+        self.active_partition = Some(StagedImage {
+            image: active_image,
+            next_to_boot: active_set == next_set,
+        });
+        Ok(())
+    }
+
+    /// Sets the staging partition image information
+    pub fn set_staging_partition_image_info(&mut self, image: UpdateImage) {
+        self.staging_partition = Some(StagedImage {
+            image,
+            next_to_boot: false,
+        });
+    }
+
+    /// Mark staging partition as next to boot
+    pub fn mark_staging_partition_next_to_boot(&mut self) -> Result<()> {
+        if let Some(staging_partition) = &mut self.staging_partition {
+            staging_partition.set_next_to_boot(true);
+        } else {
+            return error::StagingPartition {}.fail();
+        }
+        if let Some(active_partition) = &mut self.active_partition {
+            active_partition.set_next_to_boot(false);
+        } else {
+            return error::ActivePartition {}.fail();
+        }
+        Ok(())
+    }
+
+    /// Unmark staging partition as next to boot
+    pub fn unmark_staging_partition_next_to_boot(&mut self) -> Result<()> {
+        if let Some(staging_partition) = &mut self.staging_partition {
+            staging_partition.set_next_to_boot(false);
+        } else {
+            return error::StagingPartition {}.fail();
+        }
+        if let Some(active_partition) = &mut self.active_partition {
+            active_partition.set_next_to_boot(true);
+        } else {
+            return error::ActivePartition {}.fail();
+        }
+        Ok(())
+    }
+
+    /// Sets information regarding the latest command invocation
+    /// Derive success/failure status from exit status when possible.
+    pub fn set_recent_command_info(&mut self, cmd_type: UpdateCommand, cmd_output: &Output) {
+        let exit_status = match cmd_output.status.code() {
+            Some(code) => code,
+            None => cmd_output.status.signal().unwrap_or(1),
+        };
+        let command_result = CommandResult {
+            cmd_type,
+            cmd_status: if exit_status == 0 {
+                CommandStatus::Success
+            } else {
+                CommandStatus::Failed
+            },
+            timestamp: Utc::now(),
+            exit_status: Some(exit_status),
+            stderr: Some(String::from_utf8_lossy(&cmd_output.stderr).to_string()),
+        };
+        self.most_recent_command = Some(command_result);
+    }
+
+    /// Returns the update information of the 'latest' available update
+    pub fn get_latest_update(
+        updates: Vec<update_metadata::Update>,
+    ) -> Result<Option<update_metadata::Update>> {
+        let os_info = BottlerocketRelease::new().context(error::ReleaseVersion)?;
+        for update in updates {
+            // If the current running version is greater than the max version ever published,
+            // or moves us to a valid version <= the maximum version, update.
+            // Updates are listed in descending order (in terms of versions) in the manifest,
+            // so the first picked out would be the latest update available.
+            if os_info.version_id < update.version || os_info.version_id > update.max_version {
+                return Ok(Some(update));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Checks the list of updates to for an available update.
+    /// If the 'version-lock'ed version is available returns true. Otherwise returns false
+    pub fn update_available_updates(
+        &mut self,
+        socket_path: &str,
+        updates: Vec<update_metadata::Update>,
+    ) -> Result<bool> {
+        // Extract the version to store
+        self.available_updates = updates.iter().map(|u| u.version.to_owned()).collect();
+        // Check if the 'version-lock'ed update is available as the 'chosen' update
+        // Retrieve the 'version-lock' setting
+        let uri = "/settings";
+        let method = "GET";
+        let (code, response_body) = apiclient::raw_request(&socket_path, uri, method, None)
+            .context(error::APIRequest { method, uri })?;
+        ensure!(
+            code.is_success(),
+            error::APIResponse {
+                method,
+                uri,
+                code,
+                response_body,
+            }
+        );
+        let settings: serde_json::Value =
+            serde_json::from_str(&response_body).context(error::ResponseJson { uri })?;
+        let locked_version: FriendlyVersion = serde_json::from_value(
+            settings["updates"]["version-lock"].to_owned(),
+        )
+        .context(error::GetSetting {
+            setting: "/settings/updates/version-lock",
+        })?;
+
+        if String::from(locked_version.to_owned()) == "latest" {
+            // Set chosen_update to the latest version available
+            if let Some(latest_update) = UpdateStatus::get_latest_update(updates)? {
+                self.chosen_update = Some(UpdateImage {
+                    arch: latest_update.arch,
+                    version: latest_update.version,
+                    variant: latest_update.variant,
+                });
+                return Ok(true);
+            }
+        } else {
+            let chosen_version =
+                FriendlyVersion::try_into(locked_version.to_owned()).context(error::SemVer {
+                    version: locked_version,
+                })?;
+            for update in &updates {
+                if update.version == chosen_version {
+                    self.chosen_update = Some(UpdateImage {
+                        arch: update.arch.clone(),
+                        version: chosen_version,
+                        variant: update.variant.clone(),
+                    });
+                    return Ok(true);
+                }
+            }
+        }
+        // 'version-lock'ed update is unavailable.
+        self.chosen_update = None;
+        Ok(false)
+    }
+}

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -13,6 +13,7 @@ bottlerocket-release = { path = "../bottlerocket-release" }
 lazy_static = "1.2"
 model-derive = { path = "model-derive" }
 regex = "1.1"
+semver = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 snafu = "0.6"
 toml = "0.5"

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -33,6 +33,8 @@ template-path = "/usr/share/templates/containerd-config-toml"
 
 [settings.updates]
 targets-base-url = "https://updates.bottlerocket.aws/targets/"
+version-lock = "latest"
+ignore-waves = false
 
 [metadata.settings.updates.metadata-base-url]
 setting-generator = "schnauzer settings.updates.metadata-base-url"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -71,8 +71,8 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    SingleLineString, Url, ValidBase64,
+    FriendlyVersion, KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue,
+    KubernetesTaintValue, SingleLineString, Url, ValidBase64,
 };
 
 // Kubernetes related settings. The dynamic settings are retrieved from
@@ -93,13 +93,16 @@ struct KubernetesSettings {
     pod_infra_container_image: SingleLineString,
 }
 
-// Updog settings. Taken from userdata. The 'seed' setting is generated
+// Update settings. Taken from userdata. The 'seed' setting is generated
 // by the "Bork" settings generator at runtime.
 #[model]
 struct UpdatesSettings {
     metadata_base_url: Url,
     targets_base_url: Url,
     seed: u32,
+    // Version to update to when updating via the API.
+    version_lock: FriendlyVersion,
+    ignore_waves: bool,
 }
 
 #[model]

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -28,6 +28,9 @@ pub mod error {
         #[snafu(display("Given invalid URL '{}'", input))]
         InvalidUrl { input: String },
 
+        #[snafu(display("Invalid version string '{}'", input))]
+        InvalidVersion { input: String },
+
         #[snafu(display("{} must match '{}', given: {}", thing, pattern, input))]
         Pattern {
             thing: String,

--- a/sources/updater/signpost/src/set.rs
+++ b/sources/updater/signpost/src/set.rs
@@ -30,8 +30,8 @@ impl fmt::Display for PartitionSet {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum SetSelect {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SetSelect {
     A,
     B,
 }

--- a/sources/updater/signpost/src/state.rs
+++ b/sources/updater/signpost/src/state.rs
@@ -149,11 +149,11 @@ impl State {
         self.table[self.boot_partition_nums[select.idx()]].attribute_bits = flags.into();
     }
 
-    pub(crate) fn active(&self) -> SetSelect {
+    pub fn active(&self) -> SetSelect {
         self.active
     }
 
-    pub(crate) fn inactive(&self) -> SetSelect {
+    pub fn inactive(&self) -> SetSelect {
         // resolve opposing set member
         !self.active
     }
@@ -166,7 +166,7 @@ impl State {
         &self.sets[self.inactive().idx()]
     }
 
-    pub(crate) fn next(&self) -> Option<SetSelect> {
+    pub fn next(&self) -> Option<SetSelect> {
         let gptprio_a = self.gptprio(SetSelect::A);
         let gptprio_b = self.gptprio(SetSelect::B);
         match (gptprio_a.will_boot(), gptprio_b.will_boot()) {

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -28,6 +28,7 @@ structopt = "0.3"
 migrator = { path = "../../api/migration/migrator" }
 url = "2.1.0"
 signal-hook = "0.1.13"
+models = { path = "../../models" }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -10,6 +10,22 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub(crate) enum Error {
+    #[snafu(display(
+        "Failed to convert '{}' from FriendlyVersion to semver::Version: {}",
+        version_str,
+        source
+    ))]
+    BadVersion {
+        version_str: String,
+        source: semver::SemVerError,
+    },
+
+    #[snafu(display("Bad version string '{}' in config: {}", version_str, source))]
+    BadVersionConfig {
+        version_str: String,
+        source: model::modeled_types::error::Error,
+    },
+
     #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]
     ConfigParse {
         path: PathBuf,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

Adds a set of API endpoints to `apiserver` that exposes OS update information and manages OS updates.
Adds a rust binary, `thar-be-updates` that `apiserver` uses to dispatch update commands.
Adds new updog changes to support the update API

`thar-be-updates` models the Bottlerocket update process after a state machine:
![update-api-states-mark2(6)](https://user-images.githubusercontent.com/52762042/84511521-7e693380-ac7b-11ea-951b-2bdc6be54885.png)

**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jun 8 14:30:21 2020 -0700

    models: new 'FriendlyVersion' model type
    
    Adds a new model type to represent versions that can optionally be
    prefixed with 'v' or represeted by "latest"
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jun 8 14:33:16 2020 -0700

    settings: add new 'version-lock' and 'ignore-waves' settings
    
    Adds a 'version-lock' setting for specifying the version to update to
    when updating via the API.
    
    Adds a 'ignore-waves' setting for specifying whether to respect update
    waves when updating via the API.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jun 11 09:14:08 2020 -0700

    signpost::State: make next(), active(), inactive() public
    
    Exposes 'next()', 'active()', 'inactive()' and consequently 'SetSelect' fo
r
    external crate use.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Jun 17 11:04:03 2020 -0700

    updog: new subcommand to revert 'update-apply'
    
    Adds a new subcommand for reverting actions done by 'update-apply'.
    Used to "deactivate" an update.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Jun 17 10:52:25 2020 -0700

    updog: use version-lock and ignore-wave setting for default behavior
    
    updog reads the 'version-lock' and 'ignore-wave' settings for
    determining default update behavior. Still allows overrides via the
    command line options.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jun 11 10:20:42 2020 -0700

    thar-be-updates: a Bottlerocket update dispatcher
    
    Adds a new crate 'thar-be-updates' that serves as the interface for
    `apiserver` to dispatch updates.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jun 11 13:52:40 2020 -0700

    apiserver: adds update actions API
    
    Extends the Bottlerocket API with endpoints to do updates.

    New action endpoints:

    * /actions/refresh-update
    * /actions/prepare-update
    * /actions/activate-update
    * /actions/deactivate-update
    * /updates/status

    'apiserver' uses 'thar-be-updates' to dispatch update commands.
```


**Testing done:**

### Testing the updog changes:

Build an image with release version set to 0.3.2, launched instance where `version-lock` is set to 0.3.3. Then tried the following:

<details>

Updog configuration generated properly.
```
bash-5.0# cat /etc/updog.toml 
metadata_base_url = "https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.15/x86_64/"
targets_base_url = "https://updates.bottlerocket.aws/targets/"
seed = 191
version_lock = "v0.3.3"
ignore_waves = false
bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
PRETTY_NAME="Bottlerocket OS 0.3.2"
VARIANT_ID=aws-k8s-1.15
VERSION_ID=0.3.2
BUILD_ID=7192d50a-dirty
```

Initiate update with `updog update-image` and see that by default, updog updates to the `version-lock`ed version (0.3.3 in this case).
```
bash-5.0# updog whats      
aws-k8s-1.15 0.3.3
bash-5.0# updog whats --all
aws-k8s-1.15 0.3.4
aws-k8s-1.15 0.3.3
aws-k8s-1.15 0.3.2
aws-k8s-1.15 0.3.1
aws-k8s-1.15 0.3.0
bash-5.0# updog update-image  
Starting update to 0.3.3
Update applied: aws-k8s-1.15 0.3.3
```

I could also update the boot flags and then revert it via `updog revert-update-apply`
```
bash-5.0# updog update-apply
bash-5.0# signpost status
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=2 tries_left=1 successful=false
Active:  Set A
Next:    Set B

bash-5.0# updog revert-update-apply   
bash-5.0# signpost status          
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=2 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=0 tries_left=1 successful=false
Active:  Set A
Next:    Set A

bash-5.0# updog update-apply       
bash-5.0# signpost status   
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=2 tries_left=1 successful=false
Active:  Set A
Next:    Set B
bash-5.0# 
```

</details>

### Testing the update API

Built custom image with a 0.3.2 version tag. Launched instance, tried the following (`version-lock` set to 'latest'):
(I pretty-printed the json output for clarity)
<details>


```
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
Status 404 when GETing unix://2f72756e2f6170692e736f636b:0/updates/status: Update status is uninitialized, refresh-updates to initialize it
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /actions/refresh-updates -m POST
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
{
  "update_state": "Available",
  "available_updates": [
    "0.4.0",
    "0.3.4",
    "0.3.3",
    "0.3.2",
    "0.3.1",
    "0.3.0"
  ],
  "chosen_update": {
    "arch": "x86_64",
    "version": "0.4.0",
    "variant": "aws-k8s-1.15"
  },
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "version": "0.3.4",
      "variant": "aws-k8s-1.15"
    },
    "next_to_boot": true
  },
  "staging_partition": null,
  "most_recent_command": {
    "cmd_type": "refresh",
    "cmd_status": "Success",
    "timestamp": "2020-07-10T06:42:52.284285751Z",
    "exit_status": 0,
    "stderr": ""
  }
}
[ec2-user@ip-192-168-0-240 ~]$ apiclient -v -u /actions/prepare-update -m POST
204 No Content
```

Here you can see `apiserver` trying to obtain the shareable lock to read the update status file. Caller gets 423 responses when the lock is held by `t-b-u`.

```
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
Status 423 when GETing unix://2f72756e2f6170692e736f636b:0/updates/status: Unable to obtain shared lock for reading update status: Resource temporarily unavailable (os error 11)
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
Status 423 when GETing unix://2f72756e2f6170692e736f636b:0/updates/status: Unable to obtain shared lock for reading update status: Resource temporarily unavailable (os error 11)
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
Status 423 when GETing unix://2f72756e2f6170692e736f636b:0/updates/status: Unable to obtain shared lock for reading update status: Resource temporarily unavailable (os error 11)
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
Status 423 when GETing unix://2f72756e2f6170692e736f636b:0/updates/status: Unable to obtain shared lock for reading update status: Resource temporarily unavailable (os error 11)
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
{
  "update_state": "Staged",
  "available_updates": [
    "0.4.0",
    "0.3.4",
    "0.3.3",
    "0.3.2",
    "0.3.1",
    "0.3.0"
  ],
  "chosen_update": {
    "arch": "x86_64",
    "version": "0.4.0",
    "variant": "aws-k8s-1.15"
  },
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "version": "0.3.4",
      "variant": "aws-k8s-1.15"
    },
    "next_to_boot": true
  },
  "staging_partition": {
    "image": {
      "arch": "x86_64",
      "version": "0.4.0",
      "variant": "aws-k8s-1.15"
    },
    "next_to_boot": false
  },
  "most_recent_command": {
    "cmd_type": "prepare",
    "cmd_status": "Success",
    "timestamp": "2020-07-10T06:44:27.982261529Z",
    "exit_status": 0,
    "stderr": "Starting update to 0.4.0\n"
  }
}
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /actions/activate-update -m POST
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
{
  "update_state": "Ready",
  "available_updates": [
    "0.4.0",
    "0.3.4",
    "0.3.3",
    "0.3.2",
    "0.3.1",
    "0.3.0"
  ],
  "chosen_update": {
    "arch": "x86_64",
    "version": "0.4.0",
    "variant": "aws-k8s-1.15"
  },
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "version": "0.3.4",
      "variant": "aws-k8s-1.15"
    },
    "next_to_boot": false
  },
  "staging_partition": {
    "image": {
      "arch": "x86_64",
      "version": "0.4.0",
      "variant": "aws-k8s-1.15"
    },
    "next_to_boot": true
  },
  "most_recent_command": {
    "cmd_type": "activate",
    "cmd_status": "Success",
    "timestamp": "2020-07-10T06:47:19.903337270Z",
    "exit_status": 0,
    "stderr": ""
  }
}
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /actions/deactivate-update -m POST
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
{"update_state":"Staged","available_updates":["0.4.0","0.3.4","0.3.3","0.3.2","0.3.1","0.3.0"],"chosen_update":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"active_partition":{"image":{"arch":"x86_64","version":"0.3.4","variant":"aws-k8s-1.15"},"next_to_boot":true},"staging_partition":{"image":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"next_to_boot":false},"most_recent_command":{"cmd_type":"deactivate","cmd_status":"Success","timestamp":"2020-07-10T15:55:09.238751262Z","exit_status":0,"stderr":""}}
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /actions/activate-update -m POST
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /updates/status
{"update_state":"Ready","available_updates":["0.4.0","0.3.4","0.3.3","0.3.2","0.3.1","0.3.0"],"chosen_update":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"active_partition":{"image":{"arch":"x86_64","version":"0.3.4","variant":"aws-k8s-1.15"},"next_to_boot":false},"staging_partition":{"image":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"next_to_boot":true},"most_recent_command":{"cmd_type":"activate","cmd_status":"Success","timestamp":"2020-07-10T15:55:51.310418363Z","exit_status":0,"stderr":""}}
[ec2-user@ip-192-168-0-240 ~]$ apiclient -u /actions/reboot -m POST
```

</details>

 Please let me know if there are any other scenarios you'd like me to run through.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
