### PR TITLE
remove permissive types from SELinux policy

### DIFF
--- a/SECURITY_FEATURES.md
+++ b/SECURITY_FEATURES.md
@@ -137,7 +137,5 @@ The policy in Bottlerocket has the following objectives:
 2) Block most components from modifying the container archives saved on disk.
 3) Stop containers from directly modifying the layers for other running containers.
 
-The policy is currently **incomplete**.
-Notably, all domains are marked as "permissive", which means that actions denied by the policy will be logged but not blocked.
-This is a temporary measure to allow us to evaluate compatibility with common use cases.
-Additional work is tracked in #764.
+The policy is currently aimed at hardening the OS against persistent threats.
+Future enhancements to the policy will focus on mitigating the impact of OS vulnerabilities, and protecting containers from other containers.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -147,13 +147,3 @@
 
 ; Untrusted processes cannot use systems-level management functions.
 (neverallow untrusted_s global (systems (manage)))
-
-; TODO: remove once we're confident that we aren't generating AVC
-; denials for the majority of workloads.
-(typepermissive kernel_t)
-(typepermissive init_t)
-(typepermissive system_t)
-(typepermissive api_t)
-(typepermissive runtime_t)
-(typepermissive container_t)
-(typepermissive super_t)


### PR DESCRIPTION
**Issue number:**
#764

**Description of changes:**
This removes all permissive types from the policy, meaning that actions will be denied and not simply logged, as they are today.

**Testing done:**

Ran `sonobuoy` on a k8s 1.16 cluster.

```
$ sonobuoy run --kube-conformance-image-version v1.16.8 --mode certified-conformance
$ sonobuoy results $(sonobuoy retrieve)
Plugin: e2e
Status: passed
Total: 4731
Passed: 276
Failed: 0
Skipped: 4455
```

Confirmed that the policy is enforced.
```
# echo -n 'system_u:system_r:container_t:s0' > /proc/self/attr/current
bash: echo: write error: Permission denied

[  289.111027] audit: type=1400 audit(1591976578.536:3): avc:  denied  { dyntransition } for  pid=8105 comm="bash" scontext=system_u:system_r:super_t:s0 tcontext=system_u:system_r:container_t:s0 tclass=process permissive=0

# cat /proc/self/attr/current
system_u:system_r:super_t:s0
```

Verified that the operator can upgrade the system when the policy is enforced.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
