### PR TITLE
updog changes to support the Update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ The following settings are set for you automatically by [pluto](sources/api/) ba
 * `settings.updates.metadata-base-url`: The common portion of all URIs used to download update metadata.
 * `settings.updates.targets-base-url`: The common portion of all URIs used to download update files.
 * `settings.updates.seed`: A `u32` value that determines how far into in the update schedule this machine will accept an update.  We recommending leaving this at its default generated value so that updates can be somewhat randomized in your cluster.
+* `settings.updates.version-lock`: Controls the version that will be selected when you issue an update request.  Can be locked to a specific version like `v1.0.0`, or `latest` to take the latest available version.  Defaults to `latest`.
+* `settings.updates.ignore-waves`: Updates are rolled out in waves to reduce the impact of issues.  For testing purposes, you can set this to `true` to ignore those waves and update immediately.
 
 #### Time settings
 

--- a/packages/os/updog-toml
+++ b/packages/os/updog-toml
@@ -1,3 +1,5 @@
 metadata_base_url = "{{settings.updates.metadata-base-url}}"
 targets_base_url = "{{settings.updates.targets-base-url}}"
 seed = {{settings.updates.seed}}
+version_lock = "{{settings.updates.version-lock}}"
+ignore_waves = {{settings.updates.ignore-waves}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1505,6 +1505,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "model-derive 0.1.0",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2706,6 +2706,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "migrator 0.1.0",
+ "models 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 snafu = "0.6"
 toml = "0.5"
 url = "2.1"
+semver = "0.9.0"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -33,6 +33,8 @@ template-path = "/usr/share/templates/containerd-config-toml"
 
 [settings.updates]
 targets-base-url = "https://updates.bottlerocket.aws/targets/"
+version-lock = "latest"
+ignore-waves = false
 
 [metadata.settings.updates.metadata-base-url]
 setting-generator = "schnauzer settings.updates.metadata-base-url"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -71,8 +71,8 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    SingleLineString, Url, ValidBase64,
+    FriendlyVersion, KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue,
+    KubernetesTaintValue, SingleLineString, Url, ValidBase64,
 };
 
 // Kubernetes related settings. The dynamic settings are retrieved from
@@ -93,13 +93,16 @@ struct KubernetesSettings {
     pod_infra_container_image: SingleLineString,
 }
 
-// Updog settings. Taken from userdata. The 'seed' setting is generated
+// Update settings. Taken from userdata. The 'seed' setting is generated
 // by the "Bork" settings generator at runtime.
 #[model]
 struct UpdatesSettings {
     metadata_base_url: Url,
     targets_base_url: Url,
     seed: u32,
+    // Version to update to when updating via the API.
+    version_lock: FriendlyVersion,
+    ignore_waves: bool,
 }
 
 #[model]

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -28,6 +28,9 @@ pub mod error {
         #[snafu(display("Given invalid URL '{}'", input))]
         InvalidUrl { input: String },
 
+        #[snafu(display("Invalid version string '{}'", input))]
+        InvalidVersion { input: String },
+
         #[snafu(display("{} must match '{}', given: {}", thing, pattern, input))]
         Pattern {
             thing: String,

--- a/sources/models/src/modeled_types/shared.rs
+++ b/sources/models/src/modeled_types/shared.rs
@@ -1,12 +1,14 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 // Just need serde's Error in scope to get its trait methods
+use super::error;
+use semver::Version;
 use serde::de::Error as _;
 use snafu::{ensure, ResultExt};
 use std::borrow::Borrow;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
-use super::error;
+use std::str::FromStr;
 
 /// ValidBase64 can only be created by deserializing from valid base64 text.  It stores the
 /// original text, not the decoded form.  Its purpose is input validation, namely being used as a
@@ -247,6 +249,103 @@ mod test_url {
             "weird@",
         ] {
             Url::try_from(*err).unwrap_err();
+        }
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// FriendlyVersion represents a version string that can optionally be prefixed with 'v'.
+/// It can also be set to 'latest' to represent the latest version. It stores the original string
+/// and makes it accessible through standard traits.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct FriendlyVersion {
+    inner: String,
+}
+
+impl TryFrom<&str> for FriendlyVersion {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        if input == "latest" {
+            return Ok(FriendlyVersion {
+                inner: input.to_string(),
+            });
+        }
+        // If the string begins with a 'v', skip it before checking if it is valid semver.
+        let version = if input.starts_with('v') {
+            &input[1..]
+        } else {
+            input
+        };
+
+        if version.parse::<semver::Version>().is_ok() {
+            return Ok(FriendlyVersion {
+                inner: input.to_string(),
+            });
+        }
+        error::InvalidVersion { input }.fail()
+    }
+}
+
+impl TryFrom<FriendlyVersion> for semver::Version {
+    type Error = semver::SemVerError;
+
+    fn try_from(input: FriendlyVersion) -> Result<semver::Version, Self::Error> {
+        // If the string begins with a 'v', skip it before conversion
+        let version = if input.inner.starts_with('v') {
+            &input.inner[1..]
+        } else {
+            &input.inner
+        };
+        Version::from_str(version)
+    }
+}
+
+string_impls_for!(FriendlyVersion, "FriendlyVersion");
+
+#[cfg(test)]
+mod test_version {
+    use super::FriendlyVersion;
+    use semver::{SemVerError, Version};
+    use std::convert::TryFrom;
+    use std::convert::TryInto;
+
+    #[test]
+    fn good_version_strings() {
+        for ok in &[
+            "1.0.0",
+            "v1.0.0",
+            "1.0.1-alpha",
+            "v1.0.1-alpha",
+            "1.0.2-alpha+1.0",
+            "v1.0.2-alpha+1.0",
+            "1.0.3-beta.1.01",
+            "v1.0.3-beta.1.01",
+            "1.1.0-rc.1.1",
+            "v1.1.0-rc.1.1",
+            "latest",
+        ] {
+            FriendlyVersion::try_from(*ok).unwrap();
+            // Test conversion to semver::Version
+            if *ok != "latest" {
+                let _: Version = FriendlyVersion {
+                    inner: ok.to_string(),
+                }
+                .try_into()
+                .unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn bad_version_string() {
+        for err in &["hi", "1.0", "1", "v", "v1", "v1.0", "vv1.1.0"] {
+            FriendlyVersion::try_from(*err).unwrap_err();
+            let res: Result<Version, SemVerError> = FriendlyVersion::try_into(FriendlyVersion {
+                inner: err.to_string(),
+            });
+            res.unwrap_err();
         }
     }
 }

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -28,6 +28,7 @@ structopt = "0.3"
 migrator = { path = "../../api/migration/migrator" }
 url = "2.1.0"
 signal-hook = "0.1.13"
+models = { path = "../../models" }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -10,6 +10,9 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub(crate) enum Error {
+    #[snafu(display("Failed to get convert between version types: {}", source))]
+    BadVersion { source: semver::SemVerError },
+
     #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]
     ConfigParse {
         path: PathBuf,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** https://github.com/bottlerocket-os/bottlerocket/pull/942#discussion_r441153501 and https://github.com/bottlerocket-os/bottlerocket/pull/942#discussion_r441041593



**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Jun 17 11:04:03 2020 -0700

    updog: new subcommand to revert 'update-apply'
    
    Adds a new subcommand for reverting actions done by 'update-apply'.
    Used to "deactivate" an update.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Jun 17 10:52:25 2020 -0700

    updog: use version-lock and ignore-wave setting for default behavior
    
    updog reads the 'version-lock' and 'ignore-wave' settings for
    determining default update behavior. Still allows overrides via the
    command line options.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jun 8 14:33:16 2020 -0700

    settings: add new 'version-lock' and 'ignore-waves' settings
    
    Adds a 'version-lock' setting for specifying the version to update to
    when updating.
    
    Adds a 'ignore-waves' setting for specifying whether to respect update
    waves when updating.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jun 8 14:30:21 2020 -0700

    models: new 'FriendlyVersion' model type
    
    Adds a new model type to represent versions that can optionally be
    prefixed with 'v' or represeted by "latest"
```


**Testing done:**
Build an image with release version set to 0.3.2, launched instance where `version-lock` is set to 0.3.3. Then tried the following:

<details>

Updog configuration generated properly.
```
bash-5.0# cat /etc/updog.toml 
metadata_base_url = "https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.15/x86_64/"
targets_base_url = "https://updates.bottlerocket.aws/targets/"
seed = 191
version_lock = "v0.3.3"
ignore_waves = false
bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
PRETTY_NAME="Bottlerocket OS 0.3.2"
VARIANT_ID=aws-k8s-1.15
VERSION_ID=0.3.2
BUILD_ID=7192d50a-dirty
```

Initiate update with `updog update-image` and see that by default, updog updates to the `version-lock`ed version (0.3.3 in this case).
```
bash-5.0# updog whats      
aws-k8s-1.15 0.3.3
bash-5.0# updog whats --all
aws-k8s-1.15 0.3.4
aws-k8s-1.15 0.3.3
aws-k8s-1.15 0.3.2
aws-k8s-1.15 0.3.1
aws-k8s-1.15 0.3.0
bash-5.0# updog update-image  
Starting update to 0.3.3
Update applied: aws-k8s-1.15 0.3.3
```

I could also update the boot flags and then revert it via `updog revert-update-apply`
```
bash-5.0# updog update-apply
bash-5.0# signpost status
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=2 tries_left=1 successful=false
Active:  Set A
Next:    Set B

bash-5.0# updog revert-update-apply   
bash-5.0# signpost status          
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=2 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=0 tries_left=1 successful=false
Active:  Set A
Next:    Set A

bash-5.0# updog update-apply       
bash-5.0# signpost status   
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=2 tries_left=1 successful=false
Active:  Set A
Next:    Set B
bash-5.0# 
```

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
