### PR TITLE
signpost: `cancel-upgrade` behavior fix

### DIFF
--- a/sources/updater/signpost/src/state.rs
+++ b/sources/updater/signpost/src/state.rs
@@ -210,9 +210,9 @@ impl State {
     }
 
     /// Sets the inactive partition as a new upgrade partition, but **does not write to the disk**.
+    /// Ensures that the inactive partition is marked as valid beforehand
     ///
     /// * Sets the inactive partition's priority to 2 and the active partition's priority to 1.
-    /// * Sets the inactive partition's tries left to 1.
     /// * Sets the inactive partition as not successfully booted.
     /// * Returns an error if the partition has not been marked as potentially
     ///   valid or if it has already been marked for upgrade.
@@ -243,10 +243,12 @@ impl State {
 
     /// Reverts upgrade_to_inactive(), but **does not write to the disk**.
     ///
-    /// * Clears all bits of the inactive partition.
+    /// * Sets the inactive partition's priority to 0
     /// * Restores the active partition's priority to 2
     pub fn cancel_upgrade(&mut self) {
-        self.clear_inactive();
+        let mut inactive_flags = self.gptprio(self.inactive());
+        inactive_flags.set_priority(0);
+        self.set_gptprio(self.inactive(), inactive_flags);
 
         let mut active_flags = self.gptprio(self.active());
         active_flags.set_priority(2);


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** Fixes https://github.com/bottlerocket-os/bottlerocket/issues/949



**Description of changes:** 
```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Jun 19 11:55:10 2020 -0700

    signpost: `cancel-upgrade` behavior update
    
    Changes `cancel-upgrade` so that it only reverts actions done by
    `upgrade-to-inactive` as the usage information implies.
    `cancel-upgrade` now preserves the number of tries left on the
    inactive partition instead of just wiping all bits

```


**Testing done:**
Initial status:
```
bash-5.0# signpost status
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=0 tries_left=0 successful=false
Active:  Set A
Next:    Set A
```

Mark inactive partition as valid, see tries_left set to 1
```
bash-5.0# signpost mark-inactive-valid
bash-5.0# signpost status             
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=0 tries_left=1 successful=false
Active:  Set A
Next:    Set A
```

Make the inactive as next to boot, see priority bumped to 2
```
bash-5.0# signpost upgrade-to-inactive
bash-5.0# signpost status             
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=2 tries_left=1 successful=false
Active:  Set A
Next:    Set B
```

`cancel-upgrade` then properly rolls back `upgrade-to-inactive` by setting the priority back to 0 while keeping `tries_left` at 1
```
bash-5.0# signpost cancel-upgrade                                                                                                                                             
bash-5.0# signpost status        
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=2 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=0 tries_left=1 successful=false
Active:  Set A
Next:    Set A
```

Subsequent `upgrade-to-inactive` call is successful because the inactive partition is still marked valid (`tries_left` > 0)
```
bash-5.0# signpost upgrade-to-inactive
bash-5.0# signpost status             
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=2 tries_left=1 successful=false
Active:  Set A
Next:    Set B
```

`cancel-upgrade` then restores active partition as next to boot.
Another `clear-inactive` call then wipes the inactive partition priority bits.
```
bash-5.0# signpost cancel-upgrade     
bash-5.0# signpost status             
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=2 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=0 tries_left=1 successful=false
Active:  Set A
Next:    Set A
bash-5.0# signpost clear-inactive
bash-5.0# signpost status        
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p2 root=/dev/nvme0n1p3 hash=/dev/nvme0n1p4 priority=2 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p6 root=/dev/nvme0n1p7 hash=/dev/nvme0n1p8 priority=0 tries_left=0 successful=false
Active:  Set A
Next:    Set A
bash-5.0# 
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
