### PR TITLE
build: enable cargo make on macos

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -91,7 +91,7 @@ for ws in sources packages variants/* tools/buildsys ; do
   [ -d "${ws}" ] || continue
   cargo fetch --locked --manifest-path ${ws}/Cargo.toml
 done
-chmod o+r -R ${CARGO_HOME}
+chmod -R o+r ${CARGO_HOME}
 '''
 ]
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A, though I recognized the error in an issue discussion here: https://github.com/bottlerocket-os/bottlerocket/issues/940#issuecomment-643821815

**Description of changes:**

Change one line in `Makefile.toml` to make a `chmod` command compatible with macOS.

**Testing done:**

Ran `cargo make` on both macOS and Linux. Both worked as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
