### PR TITLE
storewolf: version argument expects semver value

### DIFF
--- a/sources/api/README.md
+++ b/sources/api/README.md
@@ -143,7 +143,7 @@ These commands create one in `/tmp`, but you can create it in a more permanent l
 From the `sources/api/storewolf` directory:
 
 ```
-cargo run -- --data-store-base-path /tmp/data-store --version 0.1
+cargo run -- --data-store-base-path /tmp/data-store --version 0.0.1
 ```
 
 Now you can start the API server.

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -538,7 +538,7 @@ fn usage() -> ! {
     eprintln!(
         r"Usage: {}
             --data-store-base-path PATH
-            [ --version X.Y ]
+            [ --version X.Y.Z ]
             [ --log-level trace|debug|info|warn|error ]
 
         If --version is not given, the version will be pulled from /etc/os-release.


### PR DESCRIPTION
**Issue number:**
None


**Description of changes:**
The --version argument expects a valid semver value as input.  Version numbers without three parts fail with a message saying "Expected dot".  This commit updates the documentation to match the behavior of storewolf.


**Testing done:**
Created a local datastore with a semver version.  Attempting to create a datastore with "0.1" as the version failed with the following error:

```
Invalid version: Expected dot

Usage: ./storewolf
            --data-store-base-path PATH
            [ --version X.Y ]
            [ --log-level trace|debug|info|warn|error ]

        If --version is not given, the version will be pulled from /etc/os-release.
        This is used to set up versioned symlinks in the data store base path.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
