### PR TITLE
migration-helpers: AddSettingsMigration, RemoveSettingsMigration for migrating multiple settings at once

### DIFF
--- a/sources/api/migration/README.md
+++ b/sources/api/migration/README.md
@@ -156,7 +156,7 @@ If we're confident no user configuration has changed, or if the user wants to di
 Say we add a new open-source application, like rngd.
 We can add data regarding settings, services, and configuration-files of the application to our data model.
 
-In this case, we can use the existing helper `AddSettingMigration`.
+In this case, we can use the existing helper `AddSettingsMigration`.
 It doesn't need to do anything on upgrade, because the new key will be populated by its default value.
 On downgrade, it removes the setting, so that the old data store model doesn't see an unexpected key and reject the data.
 
@@ -164,7 +164,7 @@ On downgrade, it removes the setting, so that the old data store model doesn't s
 
 If we upgrade an important application, its available and required settings may change.
 This means we'd have to update the data model to include any new or changed settings, and we'd write migrations to transform data from the old settings to the new.
-This can likely be handled by existing helpers `AddSettingMigration`, `RemoveSettingMigration`, `ReplaceStringMigration`, and `ReplaceTemplateMigration`.
+This can likely be handled by existing helpers `AddSettingsMigration`, `RemoveSettingMigration`, `ReplaceStringMigration`, and `ReplaceTemplateMigration`.
 
 ### Data store implementation change
 

--- a/sources/api/migration/README.md
+++ b/sources/api/migration/README.md
@@ -164,7 +164,7 @@ On downgrade, it removes the setting, so that the old data store model doesn't s
 
 If we upgrade an important application, its available and required settings may change.
 This means we'd have to update the data model to include any new or changed settings, and we'd write migrations to transform data from the old settings to the new.
-This can likely be handled by existing helpers `AddSettingsMigration`, `RemoveSettingMigration`, `ReplaceStringMigration`, and `ReplaceTemplateMigration`.
+This can likely be handled by existing helpers `AddSettingsMigration`, `RemoveSettingsMigration`, `ReplaceStringMigration`, and `ReplaceTemplateMigration`.
 
 ### Data store implementation change
 

--- a/sources/api/migration/migration-helpers/src/common_migrations.rs
+++ b/sources/api/migration/migration-helpers/src/common_migrations.rs
@@ -4,28 +4,50 @@ use serde::Serialize;
 use snafu::{OptionExt, ResultExt};
 use std::collections::HashMap;
 
-/// We use this migration when we add a setting and want to make sure it's removed before we go
-/// back to old versions that don't understand it.
-pub struct AddSettingMigration(pub &'static str);
+/// We use this migration when we add settings and want to make sure they're removed before we go
+/// back to old versions that don't understand them.
+pub struct AddSettingsMigration<'a> (pub &'a [&'static str]);
 
-impl Migration for AddSettingMigration {
-    /// New versions must either have a default for the setting or generate it; we don't need to
+impl Migration for AddSettingsMigration<'_> {
+    /// New versions must either have a default for the settings or generate them; we don't need to
     /// do anything.
     fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
-        println!("AddSettingMigration({}) has no work to do on upgrade.", self.0);
+        println!(
+            "AddSettingsMigration({:?}) has no work to do on upgrade.",
+            self.0
+        );
         Ok(input)
     }
 
-    /// Older versions don't know about the setting; we remove it so that old versions don't see
-    /// it and fail deserialization.  (The setting must be defaulted or generated in new versions,
+    /// Older versions don't know about the settings; we remove them so that old versions don't see
+    /// them and fail deserialization.  (The settings must be defaulted or generated in new versions,
     /// and safe to remove.)
     fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
-        if let Some(data) = input.data.remove(self.0) {
-            println!("Removed {}, which was set to '{}'", self.0, data);
-        } else {
-            println!("Found no {} to remove", self.0);
+        for setting in self.0 {
+            if let Some(data) = input.data.remove(*setting) {
+                println!("Removed {}, which was set to '{}'", setting, data);
+            } else {
+                println!("Found no {} to remove", setting);
+            }
         }
         Ok(input)
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// Similar to the above, this migration is for when we add a single setting.
+/// We are retaining this migration helper in case there are migrations already using it.
+#[deprecated(note = "Please use `AddSettingsMigration` instead")]
+pub struct AddSettingMigration(pub &'static str);
+
+impl Migration for AddSettingMigration {
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        AddSettingsMigration(&[self.0]).forward(input)
+    }
+
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        AddSettingsMigration(&[self.0]).backward(input)
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jun 25 17:05:41 2020 -0700

    migration-helpers: `RemoveSettingsMigration` to remove multiple settings at once
    
    Adds new migration helper `RemoveSettingsMigration` to remove multiple
    settings at once.
    
    Original `RemoveSettingMigration` now wraps `RemoveSettingsMigration`
    and is now deprecated.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jun 25 13:42:16 2020 -0700

    migration-helpers: AddSettingsMigration handle more than one setting
    
    Adds new migration helper `AddSettingsMigration`.
    `AddSettingsMigration` handles migrating more than one setting.
    
    Original `AddSettingMigration` now wraps `AddSettingsMigration` and is
    now deprecated

```

**Testing done:**
Created my own datastore locally with `storewolf`.
Running `apiserver` locally, committed initial `bottlerocket-launch` transaction with `settings-commiter`.
The source datastore has the following content for update settings:
```
$ ls -al ds/current/live/settings/updates
total 32
drwxr-xr-x 2 etung domain^users 4096 Jun 25 14:05 .
drwxr-xr-x 6 etung domain^users 4096 Jun 25 14:05 ..
-rw-r--r-- 1 etung domain^users    5 Jun 25 14:05 ignore-waves
-rw-r--r-- 1 etung domain^users   46 Jun 25 14:01 metadata-base-url.setting-generator
-rw-r--r-- 1 etung domain^users   80 Jun 25 14:01 metadata-base-url.template
-rw-r--r-- 1 etung domain^users   11 Jun 25 14:01 seed.setting-generator
-rw-r--r-- 1 etung domain^users   43 Jun 25 14:05 targets-base-url
-rw-r--r-- 1 etung domain^users    8 Jun 25 14:05 version-lock
```

Tried the following with a migration using this helper:
Forward migration:
```
Running `add-version-lock-ignore-waves --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next --forward`
AddSettingsMigration(["settings.updates.version-lock", "settings.updates.ignore-waves"]) has no work to do on upgrade.
```
Observed that the temporary datastore created matches the source datastore. Which is expected

Backward migration:
```
     Running `add-version-lock-ignore-waves --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next --backward`
Removed settings.updates.version-lock, which was set to '"latest"'
Removed settings.updates.ignore-waves, which was set to 'false'
```
Observed that the temporary datastore no longer has the `version-lock` and `ignore-waves` settings.
```
$ ls -al ds/next/live/settings/updates
total 24
drwxr-xr-x 2 etung domain^users 4096 Jun 25 15:03 .
drwxr-xr-x 6 etung domain^users 4096 Jun 25 15:03 ..
-rw-r--r-- 1 etung domain^users   46 Jun 25 15:03 metadata-base-url.setting-generator
-rw-r--r-- 1 etung domain^users   80 Jun 25 15:03 metadata-base-url.template
-rw-r--r-- 1 etung domain^users   11 Jun 25 15:03 seed.setting-generator
-rw-r--r-- 1 etung domain^users   43 Jun 25 15:03 targets-base-url
```

#### Testing the original `AddSettingMigration` (singular setting)
Backwards migration to remove a single `version-lock` setting:
```     
Running `add-version-lock-ignore-waves --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next --backward`
Removed settings.updates.version-lock, which was set to '"latest"'
```
Resultant temporary datastore where `version-lock` no longer exists.
```
$ ls -al ds/next/live/settings/updates
total 28
drwxr-xr-x 2 etung domain^users 4096 Jun 25 15:07 .
drwxr-xr-x 6 etung domain^users 4096 Jun 25 15:07 ..
-rw-r--r-- 1 etung domain^users    5 Jun 25 15:07 ignore-waves
-rw-r--r-- 1 etung domain^users   46 Jun 25 15:07 metadata-base-url.setting-generator
-rw-r--r-- 1 etung domain^users   80 Jun 25 15:07 metadata-base-url.template
-rw-r--r-- 1 etung domain^users   11 Jun 25 15:07 seed.setting-generator
-rw-r--r-- 1 etung domain^users   43 Jun 25 15:07 targets-base-url
```

For `RemoveSettingsMigration`, I inverted the forward/backward testing from the steps above and they work as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
