### PR TITLE
migrations: migration to add 'version-lock' & 'ignore-waves' settings

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -241,6 +241,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-version-lock-ignore-waves"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
 name = "adler32"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -19,6 +19,7 @@ members = [
 
     # "api/migration/migrations/vX.Y.Z/...
     "api/migration/migrations/v0.3.2/migrate-admin-container-v0-5-0",
+    "api/migration/migrations/v0.5.0/add-version-lock-ignore-waves",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v0.5.0/add-version-lock-ignore-waves/Cargo.toml
+++ b/sources/api/migration/migrations/v0.5.0/add-version-lock-ignore-waves/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "add-version-lock-ignore-waves"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.5.0/add-version-lock-ignore-waves/src/main.rs
+++ b/sources/api/migration/migrations/v0.5.0/add-version-lock-ignore-waves/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added two new settings, `updates.version-lock` and `updates.ignore-waves`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.updates.version-lock",
+        "settings.updates.ignore-waves",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jun 29 12:01:27 2020 -0700

    migrations: migration to add 'version-lock' & 'ignore-waves' settings
    
    Adds a migration for adding two new update settings: 'version-lock' and
    'ignore-waves'
```


**Testing done:**
Basically the same testing done in https://github.com/bottlerocket-os/bottlerocket/pull/958

The source datastore has the following content for update settings:
```
$ ls -al ds/current/live/settings/updates
total 32
drwxr-xr-x 2 etung domain^users 4096 Jun 25 14:05 .
drwxr-xr-x 6 etung domain^users 4096 Jun 25 14:05 ..
-rw-r--r-- 1 etung domain^users    5 Jun 25 14:05 ignore-waves
-rw-r--r-- 1 etung domain^users   46 Jun 25 14:01 metadata-base-url.setting-generator
-rw-r--r-- 1 etung domain^users   80 Jun 25 14:01 metadata-base-url.template
-rw-r--r-- 1 etung domain^users   11 Jun 25 14:01 seed.setting-generator
-rw-r--r-- 1 etung domain^users   43 Jun 25 14:05 targets-base-url
-rw-r--r-- 1 etung domain^users    8 Jun 25 14:05 version-lock
```

Forward migration:
```
     Running `add-version-lock-ignore-waves --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next --forward`
AddSettingsMigration(["settings.updates.version-lock", "settings.updates.version-lock"]) has no work to do on upgrade.
```

Observed that the temporary datastore created matches the source datastore, which is expected.

Backwards migration:
```
     Running `add-version-lock-ignore-waves --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next --backward`
Removed settings.updates.version-lock, which was set to '"latest"'
Removed settings.updates.ignore-waves, which was set to 'false'
```

Observed that the temporary datastore no longer has the `version-lock` and `ignore-waves` settings.
```
$ ls -al ds/next/live/settings/updates
total 24
drwxr-xr-x 2 etung domain^users 4096 Jun 29 11:50 .
drwxr-xr-x 6 etung domain^users 4096 Jun 29 11:50 ..
-rw-r--r-- 1 etung domain^users   46 Jun 29 11:50 metadata-base-url.setting-generator
-rw-r--r-- 1 etung domain^users   80 Jun 29 11:50 metadata-base-url.template
-rw-r--r-- 1 etung domain^users   11 Jun 29 11:50 seed.setting-generator
-rw-r--r-- 1 etung domain^users   43 Jun 29 11:50 targets-base-url
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
