### PR TITLE
apiserver: fix link to openapi.yaml in README

### DIFF
--- a/sources/api/apiserver/README.md
+++ b/sources/api/apiserver/README.md
@@ -16,7 +16,7 @@ Remote access should only be allowed through an authenticated control channel su
 ### API
 
 We present an HTTP interface to configurable settings and other state.
-The interface is documented in [OpenAPI format](https://swagger.io/docs/specification/about/) in [openapi.yaml](openapi.yaml).
+The interface is documented in [OpenAPI format](https://swagger.io/docs/specification/about/) in [openapi.yaml](../openapi.yaml).
 
 The Settings APIs are particularly important.
 You can GET settings from the `/settings` endpoint.

--- a/sources/api/apiserver/src/lib.rs
+++ b/sources/api/apiserver/src/lib.rs
@@ -13,7 +13,7 @@ Remote access should only be allowed through an authenticated control channel su
 ## API
 
 We present an HTTP interface to configurable settings and other state.
-The interface is documented in [OpenAPI format](https://swagger.io/docs/specification/about/) in [openapi.yaml](openapi.yaml).
+The interface is documented in [OpenAPI format](https://swagger.io/docs/specification/about/) in [openapi.yaml](../openapi.yaml).
 
 The Settings APIs are particularly important.
 You can GET settings from the `/settings` endpoint.


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Fixes the link to the OpenAPI spec that documents all of apiserver's endpoints.


**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
