### PR TITLE
make BUILDSYS_OUTPUT_DIR work with overrides

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,7 +12,6 @@ BUILDSYS_TIMESTAMP = { script = ["date +%s"] }
 BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*' || echo 00000000"] }
 BUILDSYS_VERSION_IMAGE = { script = ["awk -F '[ =\"]+' '$1 == \"version\" {print $2}' Release.toml"] }
 BUILDSYS_VARIANT = "aws-k8s-1.15"
-BUILDSYS_OUTPUT_DIR = "${BUILDSYS_BUILD_DIR}/images/${BUILDSYS_ARCH}-${BUILDSYS_VARIANT}"
 
 # Disallow pulling directly Upstream URLs when lookaside cache results in MISSes as a fallback.
 # To use the upstream source as fallback, override this on the command line and set it to 'true'
@@ -40,6 +39,9 @@ BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.11.0"
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"
+
+# Depends on ${BUILDSYS_ARCH} and ${BUILDSYS_VARIANT}.
+BUILDSYS_OUTPUT_DIR = "${BUILDSYS_BUILD_DIR}/images/${BUILDSYS_ARCH}-${BUILDSYS_VARIANT}"
 
 [tasks.setup]
 script = [


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
In 805bef2 we added a separate directory for images, but the component variables were not correctly expanded when overridden on the command line. Now they are.


**Testing done:**
```
$ cargo make -e BUILDSYS_VARIANT=aws-dev && cargo make -e BUILDSYS_VARIANT=aws-k8s-1.16
...

$ ls -1 build/images/
x86_64-aws-dev
x86_64-aws-k8s-1.16
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
