### PR TITLE
quickstart: add ap-south-1

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -111,6 +111,7 @@ The currently supported regions are:
 
 ```
 ap-northeast-1
+ap-south-1
 eu-central-1
 us-east-1
 us-west-2


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#847 

**Description of changes:**

Add `ap-south-1` to the list of supported regions.

**Testing done:**

Ran both public AMIs in `ap-south-1`. Both were able to run pods and I was able to ssh to the respective admin containers and see the correct updates with updog.

* aws-k8s-1.15: ami-00c86d202f9882966
* aws-k8s-1.16: ami-0a8aa754409828926

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
