### PR TITLE
exclude more paths in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
 /.git
 /.gomodcache
-/build/*.img
-/build/*.lz4
-/build/*.tar
-/build/*-debuginfo-*.rpm
-/build/*-debugsource-*.rpm
+/build/**/*.img
+/build/**/*.lz4
+/build/**/*.tar
+/build/**/*-debuginfo-*.rpm
+/build/**/*-debugsource-*.rpm
 **/target/*


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Update `.dockerignore` to account for the revamp of the build output directory structure.


**Testing done:**
Verified that `selinux-policy` no longer shows 30 GB of context transferred for every build. Build time reduced from 3 minutes to 20 seconds.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
