### PR TITLE
Makefile: remove 'preview-docs' task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -231,9 +231,6 @@ dependencies = [
 [tasks.world]
 alias = "build"
 
-[tasks.preview-docs]
-script = ['tools/gen-docs.sh']
-
 [tasks.clean]
 script = [
 '''


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Removes 'preview-docs' task from the Makefile targets.
'gen-docs.sh' no longer exists.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
