### PR TITLE
migrator: remove unsigned migration support

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1392,7 +1392,6 @@ dependencies = [
  "bottlerocket-release 0.1.0",
  "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2784,7 +2783,6 @@ name = "update_metadata"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-datetime 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs"
 
 [dependencies]
 bottlerocket-release = { path = "../../../bottlerocket-release" }
-lazy_static = "1.2"
 log = "0.4"
 lz4 = "1.23.1"
 nix = "0.17"

--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -26,7 +26,6 @@ extern crate log;
 use args::Args;
 use direction::Direction;
 use error::Result;
-use lazy_static::lazy_static;
 use nix::{dir::Dir, fcntl::OFlag, sys::stat::Mode, unistd::fsync};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use semver::Version;
@@ -34,25 +33,20 @@ use simplelog::{Config as LogConfig, TermLogger, TerminalMode};
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashSet;
 use std::env;
-use std::fs::{self, File, Permissions};
-use std::os::unix::fs::{symlink, PermissionsExt};
+use std::fs::{self, File};
+use std::os::unix::fs::symlink;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::process::{self, Command};
+use std::process;
 use tempfile::TempDir;
 use tough::{ExpirationEnforcement, Limits};
-use update_metadata::{load_manifest, MIGRATION_FILENAME_RE};
+use update_metadata::load_manifest;
 
 mod args;
 mod direction;
 mod error;
 #[cfg(test)]
 mod test;
-
-lazy_static! {
-    /// This is the last version of Bottlerocket that supports *only* unsigned migrations.
-    static ref LAST_UNSIGNED_MIGRATIONS_VERSION: Version = Version::new(0, 3, 4);
-}
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
@@ -68,40 +62,6 @@ fn main() {
         eprintln!("{}", e);
         process::exit(1);
     }
-}
-
-fn are_migrations_signed(from_version: &Version) -> bool {
-    from_version.gt(&LAST_UNSIGNED_MIGRATIONS_VERSION)
-}
-
-fn find_and_run_unsigned_migrations<P1, P2>(
-    migrations_directory: P1,
-    datastore_path: P2,
-    current_version: &Version,
-    migrate_to_version: &Version,
-    direction: &Direction,
-) -> Result<()>
-where
-    P1: AsRef<Path>,
-    P2: AsRef<Path>,
-{
-    let migration_directories = vec![migrations_directory];
-    let migrations =
-        find_unsigned_migrations(&migration_directories, &current_version, migrate_to_version)?;
-
-    if migrations.is_empty() {
-        // Not all new OS versions need to change the data store format.  If there's been no
-        // change, we can just link to the last version rather than making a copy.
-        // (Note: we link to the fully resolved directory, args.datastore_path,  so we don't
-        // have a chain of symlinks that could go past the maximum depth.)
-        flip_to_new_version(migrate_to_version, datastore_path)?;
-    } else {
-        let copy_path =
-            run_unsigned_migrations(direction, &migrations, &datastore_path, &migrate_to_version)?;
-        flip_to_new_version(migrate_to_version, &copy_path)?;
-    }
-
-    Ok(())
 }
 
 fn get_current_version<P>(datastore_dir: P) -> Result<Version>
@@ -152,20 +112,6 @@ pub(crate) fn run(args: &Args) -> Result<()> {
             );
             process::exit(0);
         });
-
-    // DEPRECATED CODE BEGIN ///////////////////////////////////////////////////////////////////////
-    // check if the `from_version` supports signed migrations. if not, run the 'old'
-    // unsigned migrations code and return.
-    if !are_migrations_signed(&current_version) {
-        return find_and_run_unsigned_migrations(
-            &args.migration_directory,
-            &args.datastore_path, // TODO(brigmatt) make sure this is correct
-            &current_version,
-            &args.migrate_to_version,
-            &direction,
-        );
-    }
-    // DEPRECATED CODE END /////////////////////////////////////////////////////////////////////////
 
     // Prepare to load the locally cached TUF repository to obtain the manifest. Part of using a
     // `TempDir` is disabling timestamp checking, because we want an instance to still come up and
@@ -235,160 +181,6 @@ pub(crate) fn run(args: &Args) -> Result<()> {
 }
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
-
-/// Returns a list of all unsigned migrations found on disk.
-fn find_unsigned_migrations_on_disk<P>(dir: P) -> Result<Vec<PathBuf>>
-where
-    P: AsRef<Path>,
-{
-    let dir = dir.as_ref();
-    let mut result = Vec::new();
-
-    trace!("Looking for potential migrations in {}", dir.display());
-    let entries = fs::read_dir(dir).context(error::ListMigrations { dir })?;
-    for entry in entries {
-        let entry = entry.context(error::ReadMigrationEntry)?;
-        let path = entry.path();
-
-        // Just check that it's a file; other checks to determine whether we should actually run
-        // a file we find are done by select_migrations.
-        let file_type = entry
-            .file_type()
-            .context(error::PathMetadata { path: &path })?;
-        if !file_type.is_file() {
-            debug!(
-                "Skipping non-file in migration directory: {}",
-                path.display()
-            );
-            continue;
-        }
-
-        trace!("Found potential migration: {}", path.display());
-        result.push(path);
-    }
-
-    Ok(result)
-}
-
-/// Returns the sublist of the given migrations that should be run, in the returned order, to move
-/// from the 'from' version to the 'to' version.
-fn select_unsigned_migrations<P: AsRef<Path>>(
-    from: &Version,
-    to: &Version,
-    paths: &[P],
-) -> Result<Vec<PathBuf>> {
-    // Intermediate result where we also store the version and name, needed for sorting
-    let mut sortable: Vec<(Version, String, PathBuf)> = Vec::new();
-
-    for path in paths {
-        let path = path.as_ref();
-
-        // We pull the applicable version and the migration name out of the filename.
-        let file_name = path
-            .file_name()
-            .context(error::Internal {
-                msg: "Found '/' as migration",
-            })?
-            .to_str()
-            .context(error::MigrationNameNotUTF8 { path: &path })?;
-        // this will not match signed migrations because we used consistent snapshots and the signed
-        // files will have a sha prefix.
-        let captures = match MIGRATION_FILENAME_RE.captures(&file_name) {
-            Some(captures) => captures,
-            None => {
-                debug!(
-                    "Skipping non-migration (bad name) in migration directory: {}",
-                    path.display()
-                );
-                continue;
-            }
-        };
-
-        let version_match = captures.name("version").context(error::Internal {
-            msg: "Migration name matched regex but we don't have a 'version' capture",
-        })?;
-        let version = Version::parse(version_match.as_str())
-            .context(error::InvalidMigrationVersion { path: &path })?;
-
-        let name_match = captures.name("name").context(error::Internal {
-            msg: "Migration name matched regex but we don't have a 'name' capture",
-        })?;
-        let name = name_match.as_str().to_string();
-
-        // We don't want to include migrations for the "from" version we're already on.
-        // Note on possible confusion: when going backward it's the higher version that knows
-        // how to undo its changes and take you to the lower version.  For example, the v2
-        // migration knows what changes it made to go from v1 to v2 and therefore how to go
-        // back from v2 to v1.  See tests.
-        let applicable = if to > from && version > *from && version <= *to {
-            info!(
-                "Found applicable forward migration '{}': {} < ({}) <= {}",
-                file_name, from, version, to
-            );
-            true
-        } else if to < from && version > *to && version <= *from {
-            info!(
-                "Found applicable backward migration '{}': {} >= ({}) > {}",
-                file_name, from, version, to
-            );
-            true
-        } else {
-            debug!(
-                "Migration '{}' doesn't apply when going from {} to {}",
-                file_name, from, to
-            );
-            false
-        };
-
-        if applicable {
-            sortable.push((version, name, path.to_path_buf()));
-        }
-    }
-
-    // Sort the migrations using the metadata we stored -- version first, then name so that
-    // authors have some ordering control if necessary.
-    sortable.sort_unstable();
-
-    // For a Backward migration process, reverse the order.
-    if to < from {
-        sortable.reverse();
-    }
-
-    debug!(
-        "Sorted migrations: {:?}",
-        sortable
-            .iter()
-            // Want filename, which always applies for us, but fall back to name just in case
-            .map(|(_version, name, path)| path
-                .file_name()
-                .map(|osstr| osstr.to_string_lossy().into_owned())
-                .unwrap_or_else(|| name.to_string()))
-            .collect::<Vec<String>>()
-    );
-
-    // Get rid of the name; only needed it as a separate component for sorting
-    let result: Vec<PathBuf> = sortable
-        .into_iter()
-        .map(|(_version, _name, path)| path)
-        .collect();
-
-    Ok(result)
-}
-
-/// Given the versions we're migrating from and to, this will return an ordered list of paths to
-/// migration binaries we should run to complete the migration on a data store.
-/// This separation allows for easy testing of select_migrations.
-fn find_unsigned_migrations<P>(paths: &[P], from: &Version, to: &Version) -> Result<Vec<PathBuf>>
-where
-    P: AsRef<Path>,
-{
-    let mut candidates = Vec::new();
-    for path in paths {
-        candidates.extend(find_unsigned_migrations_on_disk(path)?);
-    }
-
-    select_unsigned_migrations(from, to, &candidates)
-}
 
 /// Generates a random ID, affectionately known as a 'rando', that can be used to avoid timing
 /// issues and identify unique migration attempts.
@@ -498,104 +290,6 @@ where
         }
 
         ensure!(output.status.success(), error::MigrationFailure { output });
-        source_datastore = &target_datastore;
-    }
-
-    // Remove the intermediate data stores
-    intermediate_datastores.remove(&target_datastore);
-    for intermediate_datastore in intermediate_datastores {
-        // Even if we fail to remove an intermediate data store, we've still migrated
-        // successfully, and we don't want to fail the upgrade - just let someone know for
-        // later cleanup.
-        trace!(
-            "Removing intermediate data store at {}",
-            intermediate_datastore.display()
-        );
-        if let Err(e) = fs::remove_dir_all(&intermediate_datastore) {
-            error!(
-                "Failed to remove intermediate data store at '{}': {}",
-                intermediate_datastore.display(),
-                e
-            );
-        }
-    }
-
-    Ok(target_datastore)
-}
-
-/// Runs the given migrations in their given order.  The given direction is passed to each
-/// migration so it knows which direction we're migrating.
-///
-/// The given data store is used as a starting point; each migration is given the output of the
-/// previous migration, and the final output becomes the new data store.
-fn run_unsigned_migrations<P1, P2>(
-    direction: &Direction,
-    migrations: &[P1],
-    source_datastore: P2,
-    new_version: &Version,
-) -> Result<PathBuf>
-where
-    P1: AsRef<Path>,
-    P2: AsRef<Path>,
-{
-    // We start with the given source_datastore, updating this after each migration to point to the
-    // output of the previous one.
-    let mut source_datastore = source_datastore.as_ref();
-    // We create a new data store (below) to serve as the target of each migration.  (Start at
-    // source just to have the right type; we know we have migrations at this point.)
-    let mut target_datastore = source_datastore.to_owned();
-    // Any data stores we create that aren't the final one, i.e. intermediate data stores, will be
-    // removed at the end.  (If we fail and return early, they're left for debugging purposes.)
-    let mut intermediate_datastores = HashSet::new();
-
-    for migration in migrations {
-        // Ensure the migration is executable.
-        fs::set_permissions(migration.as_ref(), Permissions::from_mode(0o755)).context(
-            error::SetPermissions {
-                path: migration.as_ref(),
-            },
-        )?;
-
-        let mut command = Command::new(migration.as_ref());
-
-        // Point each migration in the right direction, and at the given data store.
-        command.arg(direction.to_string());
-        command.args(&[
-            "--source-datastore".to_string(),
-            source_datastore.display().to_string(),
-        ]);
-
-        // Create a new output location for this migration.
-        target_datastore = new_datastore_location(&source_datastore, &new_version)?;
-        intermediate_datastores.insert(target_datastore.clone());
-
-        command.args(&[
-            "--target-datastore".to_string(),
-            target_datastore.display().to_string(),
-        ]);
-
-        info!("Running migration command: {:?}", command);
-
-        let output = command.output().context(error::StartMigration)?;
-
-        if !output.stdout.is_empty() {
-            debug!(
-                "Migration stdout: {}",
-                std::str::from_utf8(&output.stdout).unwrap_or("<invalid UTF-8>")
-            );
-        } else {
-            debug!("No migration stdout");
-        }
-        if !output.stderr.is_empty() {
-            let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<invalid UTF-8>");
-            // We want to see migration stderr on the console, so log at error level.
-            error!("Migration stderr: {}", stderr);
-        } else {
-            debug!("No migration stderr");
-        }
-
-        ensure!(output.status.success(), error::MigrationFailure { output });
-
         source_datastore = &target_datastore;
     }
 
@@ -779,62 +473,4 @@ where
     });
 
     Ok(())
-}
-
-// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
-
-#[cfg(test)]
-mod main_test {
-    use super::*;
-
-    #[test]
-    #[allow(unused_variables)]
-    fn select_migrations_works() {
-        // Migration paths for use in testing
-        let m00_1 = Path::new("migrate_v0.0.0_001");
-        let m01_1 = Path::new("migrate_v0.0.1_001");
-        let m01_2 = Path::new("migrate_v0.0.1_002");
-        let m02_1 = Path::new("migrate_v0.0.2_001");
-        let m03_1 = Path::new("migrate_v0.0.3_001");
-        let m04_1 = Path::new("migrate_v0.0.4_001");
-        let m04_2 = Path::new("migrate_v0.0.4_002");
-        let all_migrations = vec![&m00_1, &m01_1, &m01_2, &m02_1, &m03_1, &m04_1, &m04_2];
-
-        // Versions for use in testing
-        let v00 = Version::new(0, 0, 0);
-        let v01 = Version::new(0, 0, 1);
-        let v02 = Version::new(0, 0, 2);
-        let v03 = Version::new(0, 0, 3);
-        let v04 = Version::new(0, 0, 4);
-        let v05 = Version::new(0, 0, 5);
-
-        // Test going forward one minor version
-        assert_eq!(
-            select_unsigned_migrations(&v01, &v02, &all_migrations).unwrap(),
-            vec![m02_1]
-        );
-
-        // Test going backward one minor version
-        assert_eq!(
-            select_unsigned_migrations(&v02, &v01, &all_migrations).unwrap(),
-            vec![m02_1]
-        );
-
-        // Test going forward a few minor versions
-        assert_eq!(
-            select_unsigned_migrations(&v01, &v04, &all_migrations).unwrap(),
-            vec![m02_1, m03_1, m04_1, m04_2]
-        );
-
-        // Test going backward a few minor versions
-        assert_eq!(
-            select_unsigned_migrations(&v04, &v01, &all_migrations).unwrap(),
-            vec![m04_2, m04_1, m03_1, m02_1]
-        );
-
-        // Test no matching migrations
-        assert!(select_unsigned_migrations(&v04, &v05, &all_migrations)
-            .unwrap()
-            .is_empty());
-    }
 }

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 chrono = { version = "0.4.9", features = ["serde"] }
-lazy_static = "1.2"
 parse-datetime = { path = "../../parse-datetime" }
 rand = "0.7.0"
 regex = "1.1"

--- a/sources/updater/update_metadata/src/lib.rs
+++ b/sources/updater/update_metadata/src/lib.rs
@@ -6,10 +6,8 @@ mod se;
 
 use crate::error::Result;
 use chrono::{DateTime, Duration, Utc};
-use lazy_static::lazy_static;
 use parse_datetime::parse_offset;
 use rand::{thread_rng, Rng};
-use regex::Regex;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
@@ -21,29 +19,6 @@ use std::ops::Bound::{Excluded, Included};
 use std::path::Path;
 
 pub const MAX_SEED: u32 = 2048;
-
-// DEPRECATED CODE BEGIN ///////////////////////////////////////////////////////////////////////////
-// the use of this regex is deprecated and only used for backward compatibility with
-// unsigned migration
-lazy_static! {
-    /// Regular expression that will match migration file names and allow retrieving the
-    /// version and name components.
-    // Note: the version component is a simplified semver regex; we don't use any of the
-    // extensions, just a simple x.y.z, so this isn't as strict as it could be.
-    // Note: this regex will NOT match signed TUF targets because we use consistent snapshots in our
-    // TUF repository. We are relying on that behavior during the transition to signed migrations
-    // in which both signed an unsigned migrations are written in the same directory.
-    pub static ref MIGRATION_FILENAME_RE: Regex =
-        Regex::new(r"(?x)^
-                   migrate
-                   _
-                   v?  # optional 'v' prefix for humans
-                   (?P<version>[0-9]+\.[0-9]+\.[0-9]+[0-9a-zA-Z+-]*)
-                   _
-                   (?P<name>[a-zA-Z0-9-]+)
-                   $").unwrap();
-}
-// DEPRECATED CODE END /////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Wave {

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -245,27 +245,6 @@ fn retrieve_migrations(
     // find the list of migrations in the manifest based on our from and to versions.
     let mut targets = find_migrations(start, target, &manifest)?;
 
-    // DEPRECATED CODE BEGIN ///////////////////////////////////////////////////////////////////////
-    // write unsigned migrations for backward compatibility. note that signed migrations will have
-    // a sha prefix because we use consistent snapshots in our TUF repository. old versions of
-    // migrator will ignore signed migrations because they do not match the regex, and new versions
-    // of migrator will be unaffected by the presence of these unsigned migrations. this loop should
-    // be removed when we no longer support backward compatibility. signed migrations will remain
-    // lz4 compressed and will not be marked as executable, but unsigned migrations are uncompressed
-    // and marked as executable. original comment follows...
-    // download each migration, making sure they are executable and removing
-    // known extensions from our compression, e.g. .lz4
-    for name in &targets {
-        let mut destination = dir.join(&name);
-        if destination.extension() == Some("lz4".as_ref()) {
-            destination.set_extension("");
-        }
-        write_target_to_disk(repository, &name, &destination)?;
-        fs::set_permissions(&destination, Permissions::from_mode(0o755))
-            .context(error::SetPermissions { path: destination })?;
-    }
-    // DEPRECATED CODE END /////////////////////////////////////////////////////////////////////////
-
     // we need to store the manifest so that migrator can independently and securely determine the
     // migration list. this is true even if there are no migrations.
     targets.push("manifest.json".to_owned());


### PR DESCRIPTION
This is a redo of #966 which was reverted in #971, the text below is the same as what appeared in #966.

## Issue number:

Closes #972
Closes #954
Related to #961

## Description of changes:

Removes support for unsigned datastore migrations. CAUTION: this code is incompatible with versions less than 0.4.x. See #961 regarding strategy for ensuring hosts do not try to upgrade or downgrade to an incompatible version of Bottlerocket.

## Testing done:

Created a test migration that adds a setting "foo" with value "bar".
Ran an instance, upgraded to a higher version that included the test migration, downgrade back to original version. Along the way I verified that a pod could run, and that the migration actually ran (and affected the "foo" setting).


## Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
