### PR TITLE
kubernetes: Apply patches for CVE-2020-8558

### DIFF
--- a/packages/kubernetes-1.15/0006-kubelet-block-non-forwarded-packets.patch
+++ b/packages/kubernetes-1.15/0006-kubelet-block-non-forwarded-packets.patch
@@ -1,0 +1,45 @@
+From: Casey Callendrello <cdc@redhat.com>
+Date: Fri, 29 May 2020 13:03:37 +0200
+Subject: [PATCH] kubelet: block non-forwarded packets from crossing the
+ localhost boundary
+
+We set route_localnet so that host-network processes can connect to
+<127.0.0.1:NodePort> and it still works. This, however, is too
+permissive.
+
+So, block martians that are not already in conntrack.
+
+See: #90259
+Signed-off-by: Casey Callendrello <cdc@redhat.com>
+---
+ pkg/kubelet/kubelet_network_linux.go | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/pkg/kubelet/kubelet_network_linux.go b/pkg/kubelet/kubelet_network_linux.go
+index ec7d41d9557..136c18716d8 100644
+--- a/pkg/kubelet/kubelet_network_linux.go
++++ b/pkg/kubelet/kubelet_network_linux.go
+@@ -68,6 +68,20 @@ func (kl *Kubelet) syncNetworkUtil() {
+ 		klog.Errorf("Failed to ensure rule to drop packet marked by %v in %v chain %v: %v", KubeMarkDropChain, utiliptables.TableFilter, KubeFirewallChain, err)
+ 		return
+ 	}
++
++	// drop all non-local packets to localhost if they're not part of an existing
++	// forwarded connection. See #90259
++	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
++		"-m", "comment", "--comment", "block incoming localnet connections",
++		"--dst", "127.0.0.0/8",
++		"!", "--src", "127.0.0.0/8",
++		"-m", "conntrack",
++		"!", "--ctstate", "RELATED,ESTABLISHED,DNAT",
++		"-j", "DROP"); err != nil {
++		klog.Errorf("Failed to ensure rule to drop invalid localhost packets in %v chain %v: %v", utiliptables.TableFilter, KubeFirewallChain, err)
++		return
++	}
++
+ 	if _, err := kl.iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainOutput, "-j", string(KubeFirewallChain)); err != nil {
+ 		klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", utiliptables.TableFilter, utiliptables.ChainOutput, KubeFirewallChain, err)
+ 		return
+-- 
+2.27.0
+

--- a/packages/kubernetes-1.15/kubernetes-1.15.spec
+++ b/packages/kubernetes-1.15/kubernetes-1.15.spec
@@ -30,6 +30,8 @@ Patch4: 0004-override-SELinux-label-for-kubelet-plugins.patch
 # https://github.com/kubernetes/kubernetes/commit/8618c09
 Patch5: 0005-opt-out-of-module-mode-for-builds.patch
 
+Patch6: 0006-kubelet-block-non-forwarded-packets.patch
+
 BuildRequires: git
 BuildRequires: rsync
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/kubernetes-1.16/0005-kubelet-block-non-forwarded-packets.patch
+++ b/packages/kubernetes-1.16/0005-kubelet-block-non-forwarded-packets.patch
@@ -1,0 +1,48 @@
+From d22a61e21d677f7527bc8a4aeb3288c5e11dd49b Mon Sep 17 00:00:00 2001
+From: Casey Callendrello <cdc@redhat.com>
+Date: Fri, 29 May 2020 13:03:37 +0200
+Subject: [PATCH] kubelet: block non-forwarded packets from crossing the
+ localhost boundary
+
+We set route_localnet so that host-network processes can connect to
+<127.0.0.1:NodePort> and it still works. This, however, is too
+permissive.
+
+So, block martians that are not already in conntrack.
+
+See: #90259
+Signed-off-by: Casey Callendrello <cdc@redhat.com>
+---
+ pkg/kubelet/kubelet_network_linux.go | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/pkg/kubelet/kubelet_network_linux.go b/pkg/kubelet/kubelet_network_linux.go
+index 1c9ad46b989..d18ab75a053 100644
+--- a/pkg/kubelet/kubelet_network_linux.go
++++ b/pkg/kubelet/kubelet_network_linux.go
+@@ -68,6 +68,22 @@ func (kl *Kubelet) syncNetworkUtil() {
+ 		klog.Errorf("Failed to ensure rule to drop packet marked by %v in %v chain %v: %v", KubeMarkDropChain, utiliptables.TableFilter, KubeFirewallChain, err)
+ 		return
+ 	}
++
++	// drop all non-local packets to localhost if they're not part of an existing
++	// forwarded connection. See #90259
++	if !kl.iptClient.IsIpv6() { // ipv6 doesn't have this issue
++		if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
++			"-m", "comment", "--comment", "block incoming localnet connections",
++			"--dst", "127.0.0.0/8",
++			"!", "--src", "127.0.0.0/8",
++			"-m", "conntrack",
++			"!", "--ctstate", "RELATED,ESTABLISHED,DNAT",
++			"-j", "DROP"); err != nil {
++			klog.Errorf("Failed to ensure rule to drop invalid localhost packets in %v chain %v: %v", utiliptables.TableFilter, KubeFirewallChain, err)
++			return
++		}
++	}
++
+ 	if _, err := kl.iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainOutput, "-j", string(KubeFirewallChain)); err != nil {
+ 		klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", utiliptables.TableFilter, utiliptables.ChainOutput, KubeFirewallChain, err)
+ 		return
+-- 
+2.27.0
+

--- a/packages/kubernetes-1.16/kubernetes-1.16.spec
+++ b/packages/kubernetes-1.16/kubernetes-1.16.spec
@@ -25,6 +25,7 @@ Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 Patch2: 0002-do-not-omit-debug-info.patch
 Patch3: 0003-enable-PIE-for-platform-binaries.patch
 Patch4: 0004-override-SELinux-label-for-kubelet-plugins.patch
+Patch5: 0005-kubelet-block-non-forwarded-packets.patch
 
 # Update aws-sdk-go for IMDSv2 support
 Patch100: aws-sdk-go-1.28.2.patch.bz2


### PR DESCRIPTION
**Description of changes:**
Apply patches for CVE-2020-8558


**Testing done:**
Built both aws-k8s-1.15 and aws-k8s-1.16 variants.  Have not yet run Sonobuoy tests.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
