### PR TITLE
Update tough to v0.7.1

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "storewolf 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tough 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "update_metadata 0.1.0",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2838,7 +2838,7 @@ dependencies = [
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tough 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2864,7 +2864,7 @@ dependencies = [
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tough 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "update_metadata 0.1.0",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3319,7 +3319,7 @@ dependencies = [
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum tough 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399281f099d94187b40b97aa14f850258918ed56e3628621095984c69bfdd96b"
+"checksum tough 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bbb6b9c013f32b9fc52a70268c17b5ffb0562323b9213921f22f1b755cf2c4ad"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum trust-dns-proto 0.18.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2a7f3a2ab8a919f5eca52a468866a67ed7d3efa265d48a652a9a3452272b413f"
 "checksum trust-dns-resolver 0.18.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6f90b1502b226f8b2514c6d5b37bafa8c200d7ca4102d57dc36ee0f3b7a04a2f"

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -20,7 +20,7 @@ semver = "0.9"
 simplelog = "0.7"
 snafu = "0.6"
 tempfile = "3.1.0"
-tough = "0.6.0"
+tough = "0.7.1"
 update_metadata = { path = "../../../updater/update_metadata" }
 url = "2.1.1"
 

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.100", features = ["derive"] }
 serde_json = "1.0.40"
 serde_plain = "0.3.0"
 snafu = "0.6.0"
-tough = "0.6.0"
+tough = "0.7.1"
 
 [lib]
 name = "update_metadata"

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -22,7 +22,7 @@ simplelog = "0.7"
 snafu = "0.6.0"
 tempfile = "3.1.0"
 toml = "0.5.1"
-tough = { version = "0.6.0", features = ["http"] }
+tough = { version = "0.7.1", features = ["http"] }
 update_metadata = { path = "../update_metadata" }
 structopt = "0.3"
 migrator = { path = "../../api/migration/migrator" }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Updates tough from v0.6.0 to v0.7.1 tree-wide for [CVE-2020-15093](https://github.com/awslabs/tough/security/advisories/GHSA-5q2r-92f9-4m49).

**Testing done:**

Built an AMI, it boots.

```
[ec2-user@ip-172-31-43-128 ~]$ sudo sheltie
bash-5.0# updog check-update -a
aws-k8s-1.16 0.4.0
aws-k8s-1.16 0.3.4
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
