### PR TITLE
Add pivot migration to move to 2020-07-07 repos

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1419,6 +1419,7 @@ name = "migration-helpers"
 version = "0.1.0"
 dependencies = [
  "apiserver 0.1.0",
+ "bottlerocket-release 0.1.0",
  "handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnauzer 0.1.0",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1814,6 +1814,13 @@ version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pivot-repo-2020-07-07"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
 name = "pluto"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     # "api/migration/migrations/vX.Y.Z/...
     "api/migration/migrations/v0.3.2/migrate-admin-container-v0-5-0",
     "api/migration/migrations/v0.4.1/add-version-lock-ignore-waves",
+    "api/migration/migrations/v0.4.1/pivot-repo-2020-07-07",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 apiserver = { path = "../../apiserver" }
+bottlerocket-release = { path = "../../../bottlerocket-release" }
 schnauzer = { path = "../../schnauzer" }
 handlebars = "3.0.1"
 snafu = "0.6"

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -8,6 +8,11 @@ use apiserver::datastore;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub")]
 pub enum Error {
+    #[snafu(display("Unable to get system release data: {}", source))]
+    BottlerocketRelease {
+        source: bottlerocket_release::Error,
+    },
+
     #[snafu(display("Unable to get {:?} data for migration: {}", committed, source))]
     GetData {
         committed: datastore::Committed,
@@ -25,6 +30,9 @@ pub enum Error {
 
     #[snafu(display("Unable to serialize Value: {}", source))]
     Serialize { source: datastore::ScalarError },
+
+    #[snafu(display("Unable to serialize release data: {}", source))]
+    SerializeRelease { source: datastore::serialization::Error },
 
     #[snafu(display("Unable to write to data store: {}", source))]
     DataStoreWrite { source: datastore::Error },

--- a/sources/api/migration/migrations/v0.4.1/pivot-repo-2020-07-07/Cargo.toml
+++ b/sources/api/migration/migrations/v0.4.1/pivot-repo-2020-07-07/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pivot-repo-2020-07-07"
+version = "0.1.0"
+authors = ["Jamie Anderson <jamieand@amazon.com"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.4.1/pivot-repo-2020-07-07/src/main.rs
+++ b/sources/api/migration/migrations/v0.4.1/pivot-repo-2020-07-07/src/main.rs
@@ -1,0 +1,30 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const BEFORE_PIVOT_REPO_URL: &str =
+    "https://updates.bottlerocket.aws/2020-02-02/{{ os.variant_id }}/{{ os.arch }}/";
+const AFTER_PIVOT_REPO_URL: &str =
+    "https://updates.bottlerocket.aws/2020-07-07/{{ os.variant_id }}/{{ os.arch }}/";
+
+/// Starting with v0.4.1 we use a new set of repos that does not contain
+/// unsigned migrations
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.updates.metadata-base-url",
+        old_template: BEFORE_PIVOT_REPO_URL,
+        new_template: AFTER_PIVOT_REPO_URL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -38,7 +38,7 @@ ignore-waves = false
 
 [metadata.settings.updates.metadata-base-url]
 setting-generator = "schnauzer settings.updates.metadata-base-url"
-template = "https://updates.bottlerocket.aws/2020-02-02/{{ os.variant_id }}/{{ os.arch }}/"
+template = "https://updates.bottlerocket.aws/2020-07-07/{{ os.variant_id }}/{{ os.arch }}/"
 
 [services.updog]
 configuration-files = ["updog-toml"]


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/961

**Description of changes:**

* Allow migrations access to "os.*" settings
* Add pivot migration for changing repo URL from 2020-02-02 to 2020-07-07

**Testing done:**

Local testing runs the migration OK:
```
Updating template and value of 'settings.updates.metadata-base-url' on upgrade
Changing template of 'settings.updates.metadata-base-url' from 'https://updates.bottlerocket.aws/2020-02-02/{{ os.variant_id }}/{{ os.arch }}/' to 'https://updates.bottlerocket.aws/2020-07-07/{{ os.variant_id }}/{{ os.arch }}/'
Changing value of 'settings.updates.metadata-base-url' from 'https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.15/x86_64/' to 'https://updates.bottlerocket.aws/2020-07-07/aws-k8s-1.15/x86_64/'
```

Instance testing also worked OK.  Since we need to update to a test image to run the migrations, and the test image is obviously not in production repos, and because the migration requires that you're pointing at production repos, we needed a bit of a workaround -- rather than changing the metadata URL setting in the API, we changed updog's config file directly to point at our test repo.  That way we could initiate the update and the migration could still see the production URL in the setting that it expects to change.

After doing so, we updated, reconnected, and saw that both v0.4.1 migrations ran successfully - this one, to change the metadata_base_url, and @etungsten's, adding version_lock and ignore_waves.
```
bash-5.0# cat /etc/updog.toml 
metadata_base_url = "https://updates.bottlerocket.aws/2020-07-07/aws-k8s-1.15/x86_64/"
targets_base_url = "https://updates.bottlerocket.aws/targets/"
seed = 1340
version_lock = "latest"
ignore_waves = false
```
Obviously, further usage of updog failed because it couldn't retrieve this new metadata URL yet; that will be put in place during the 0.4.1 release.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
