### PR TITLE
updog, thar-be-updates: prevent updating into the same version

### DIFF
--- a/sources/api/thar-be-updates/src/status.rs
+++ b/sources/api/thar-be-updates/src/status.rs
@@ -288,14 +288,17 @@ impl UpdateStatus {
                 FriendlyVersion::try_into(locked_version.to_owned()).context(error::SemVer {
                     version: locked_version,
                 })?;
-            for update in &updates {
-                if update.version == chosen_version {
-                    self.chosen_update = Some(UpdateImage {
-                        arch: update.arch.clone(),
-                        version: chosen_version,
-                        variant: update.variant.clone(),
-                    });
-                    return Ok(true);
+            let os_info = BottlerocketRelease::new().context(error::ReleaseVersion)?;
+            if chosen_version != os_info.version_id {
+                for update in &updates {
+                    if update.version == chosen_version {
+                        self.chosen_update = Some(UpdateImage {
+                            arch: update.arch.clone(),
+                            version: chosen_version,
+                            variant: update.variant.clone(),
+                        });
+                        return Ok(true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Prevents updating into the same version if version-lock == current version.


**Testing done:**
Build an image with release version set to v0.3.4. `version-lock` is set to `v0.3.4`
<details>

`version-lock` is set to v0.3.4, same as the current running OS version
```
bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
PRETTY_NAME="Bottlerocket OS 0.3.4"
VARIANT_ID=aws-k8s-1.15
VERSION_ID=0.3.4
BUILD_ID=2c7c8dcf-dirty
bash-5.0# apiclient -u /settings
{"motd":"Welcome to Bottlerocket!","kubernetes":{"... ,"version-lock":"v0.3.4"..."aws":{"region":"us-west-2"}}
```

Update API reports there is no available update since the `version-lock` == current OS version
```

bash-5.0# apiclient -u /actions/refresh-updates -m POST
bash-5.0# apiclient -u /updates/status
{"update_state":"Idle","available_updates":["0.4.0","0.3.4","0.3.3","0.3.2","0.3.1","0.3.0"],"chosen_update":null,"active_partition":{"image":{"arch":"x86_64","version":"0.3.4","variant":"aws-k8s-1.15"},"next_to_boot":true},"staging_partition":null,"most_recent_command":{"cmd_type":"refresh","cmd_status":"Success","timestamp":"2020-07-10T17:51:52.128956235Z","exit_status":0,"stderr":""}}
```

Updog does see an available update either
```
bash-5.0# apiclient -u /actions/prepare-update -m POST
Status 409 when POSTing unix://2f72756e2f6170692e736f636b:0/actions/prepare-update: Update action not allowed according to update state
bash-5.0# updog update
No update required
bash-5.0# updog whats   
No update available
```

Change `version-lock` to `"latest"`, updog and the update API updates to the latest version (v0.4.0 in this case) successfully through the standard process
```
bash-5.0# apiclient -X PATCH -u /settings -d '{"updates":{"version-lock":"latest"}}' 
bash-5.0# apiclient -m POST -u /tx/commit_and_apply
["settings.updates.version-lock"]
bash-5.0# apiclient -u /settings                                                    
{"motd":"Welcome to Bottlerocket!","kubernetes":{"... ,"version-lock":"latest"..."aws":{"region":"us-west-2"}}
bash-5.0# apiclient -u /actions/refresh-updates -m POST                             
bash-5.0# apiclient -u /updates/status                                              
{"update_state":"Available","available_updates":["0.4.0","0.3.4","0.3.3","0.3.2","0.3.1","0.3.0"],"chosen_update":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"active_partition":{"image":{"arch":"x86_64","version":"0.3.4","variant":"aws-k8s-1.15"},"next_to_boot":true},"staging_partition":null,"most_recent_command":{"cmd_type":"refresh","cmd_status":"Success","timestamp":"2020-07-10T17:54:56.212080653Z","exit_status":0,"stderr":""}}
bash-5.0# apiclient -u /actions/prepare-update -m POST                              
bash-5.0# apiclient -u /updates/status                
Status 423 when GETing unix://2f72756e2f6170692e736f636b:0/updates/status: Unable to obtain shared lock for reading update status: Resource temporarily unavailable (os error 11)
bash-5.0# apiclient -u /updates/status                
{"update_state":"Staged","available_updates":["0.4.0","0.3.4","0.3.3","0.3.2","0.3.1","0.3.0"],"chosen_update":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"active_partition":{"image":{"arch":"x86_64","version":"0.3.4","variant":"aws-k8s-1.15"},"next_to_boot":true},"staging_partition":{"image":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"next_to_boot":false},"most_recent_command":{"cmd_type":"prepare","cmd_status":"Success","timestamp":"2020-07-10T17:55:14.218717904Z","exit_status":0,"stderr":"Starting update to 0.4.0\n"}}
bash-5.0# updog whats
aws-k8s-1.15 0.4.0
bash-5.0# updog update
Starting update to 0.4.0
Update applied: aws-k8s-1.15 0.4.0
bash-5.0# 
```

Verified that updog can override (force) the update even if the version is the same as the current OS version.
```
bash-5.0# apiclient -X PATCH -u /settings -d '{"updates":{"version-lock":"v0.3.4"}}'
bash-5.0# apiclient -m POST -u /tx/commit_and_apply
["settings.updates.version-lock"]
bash-5.0# updog update -i 0.3.4                                                     
Starting update to 0.3.4
Update applied: aws-k8s-1.15 0.3.4
```
</details>

Built image with release set to 0.4.0 (latest in the current repository), update API and updog reports no update available when checking for updates which is expected:
```
bash-5.0# cat /etc/os-release                                      
NAME=Bottlerocket               
ID=bottlerocket
PRETTY_NAME="Bottlerocket OS 0.4.0"
VARIANT_ID=aws-k8s-1.15
VERSION_ID=0.4.0
BUILD_ID=2c7c8dcf-dirty
bash-5.0# apiclient -u /settings                                                    
{"motd":"Welcome to Bottlerocket!","kubernetes":{...,"version-lock":"latest"...,"aws":{"region":"us-west-2"}}
bash-5.0# apiclient -u /actions/refresh-updates -m POST                             
bash-5.0# apiclient -u /updates/status                                              
{"update_state":"Idle","available_updates":["0.4.0","0.3.4","0.3.3","0.3.2","0.3.1","0.3.0"],"chosen_update":null,"active_partition":{"image":{"arch":"x86_64","version":"0.4.0","variant":"aws-k8s-1.15"},"next_to_boot":true},"staging_partition":null,"most_recent_command":{"cmd_type":"refresh","cmd_status":"Success","timestamp":"2020-07-10T18:45:02.463864056Z","exit_status":0,"stderr":""}}
bash-5.0# updog whats
No update available
bash-5.0# 
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
