### PR TITLE
Configurable cluster domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ The following settings can be optionally set to customize the node labels and ta
 The following settings are set for you automatically by [pluto](sources/api/) based on runtime instance information, but you can override them if you know what you're doing!
 * `settings.kubernetes.max-pods`: The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)
 * `settings.kubernetes.cluster-dns-ip`: The CIDR block of the primary network interface.
+* `settings.kubernetes.cluster-domain`: The cluster domain is set to `cluster.local` by default.
 * `settings.kubernetes.node-ip`: The IPv4 address of this node.
 * `settings.kubernetes.pod-infra-container-image`: The URI of the "pause" container.
 

--- a/README.md
+++ b/README.md
@@ -347,10 +347,12 @@ The following settings can be optionally set to customize the node labels and ta
     special = "true:NoSchedule"
     ```
 
+The following settings are optional and allow you to further configure your cluster.
+* `settings.kubernetes.cluster-domain`: The DNS domain for this cluster, allowing all Kubernetes-run containers to search this domain before the host's search domains.  Defaults to `cluster.local`.
+
 The following settings are set for you automatically by [pluto](sources/api/) based on runtime instance information, but you can override them if you know what you're doing!
 * `settings.kubernetes.max-pods`: The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)
 * `settings.kubernetes.cluster-dns-ip`: The CIDR block of the primary network interface.
-* `settings.kubernetes.cluster-domain`: The cluster domain is set to `cluster.local` by default.
 * `settings.kubernetes.node-ip`: The IPv4 address of this node.
 * `settings.kubernetes.pod-infra-container-image`: The URI of the "pause" container.
 

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -15,7 +15,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-clusterDomain: cluster.local
+clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
 resolvConf: "/etc/resolv.conf"

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -15,7 +15,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-clusterDomain: cluster.local
+clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
 resolvConf: "/etc/resolv.conf"

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -15,7 +15,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-clusterDomain: cluster.local
+clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
 resolvConf: "/etc/resolv.conf"

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -92,8 +92,3 @@ template-path = "/usr/share/templates/chrony-conf"
 
 [metadata.settings.ntp]
 affected-services = ["chronyd"]
-
-# Kubernetes
-
-[settings.kubernetes]
-cluster-domain = "cluster.local"

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -92,3 +92,8 @@ template-path = "/usr/share/templates/chrony-conf"
 
 [metadata.settings.ntp]
 affected-services = ["chronyd"]
+
+# Kubernetes
+
+[settings.kubernetes]
+cluster-domain = "cluster.local"

--- a/sources/models/src/aws-k8s-1.15/override-defaults.toml
+++ b/sources/models/src/aws-k8s-1.15/override-defaults.toml
@@ -33,3 +33,6 @@ affected-services = ["kubernetes"]
 [metadata.settings.kubernetes.pod-infra-container-image]
 setting-generator = "pluto pod-infra-container-image"
 affected-services = ["kubernetes", "containerd"]
+
+[settings.kubernetes]
+cluster-domain = "cluster.local"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -76,7 +76,7 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    FriendlyVersion, KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue,
+    DNSDomain, FriendlyVersion, KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue,
     KubernetesTaintValue, SingleLineString, Url, ValidBase64,
 };
 
@@ -94,6 +94,7 @@ struct KubernetesSettings {
     // Dynamic settings.
     max_pods: u32,
     cluster_dns_ip: Ipv4Addr,
+    cluster_domain: DNSDomain,
     node_ip: Ipv4Addr,
     pod_infra_container_image: SingleLineString,
 }

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -44,6 +44,9 @@ pub mod error {
 
         #[snafu(display("Given invalid cluster name '{}': {}", name, msg))]
         InvalidClusterName { name: String, msg: String },
+
+        #[snafu(display("Invalid domain name '{}'", input))]
+        InvalidDomainName { input: String },
     }
 }
 

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -45,8 +45,8 @@ pub mod error {
         #[snafu(display("Given invalid cluster name '{}': {}", name, msg))]
         InvalidClusterName { name: String, msg: String },
 
-        #[snafu(display("Invalid domain name '{}'", input))]
-        InvalidDomainName { input: String },
+        #[snafu(display("Invalid domain name '{}': {}", input, msg))]
+        InvalidDomainName { input: String, msg: String },
     }
 }
 


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
This change allows users to set the value for the kubelet's clusterDomain setting. By default the clusterDomain is set to `cluster.local`, but users can set it to any valid domain. A description of the clusterDomain setting can be found [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L288-L295).

We have multiple EKS clusters and each uses a different clusterDomain. We'd prefer not to have all our EKS clusters using `cluster.local`.

**Testing done:**
Tested using the aws-k8s-1.15 variant on our EKS clusters. If no value is set for `settings.kubernetes.cluster-domain` in the user data, the kubelet will be configured to use `cluster.local` for the clusterDomain. This is the current behaviour. By default this PR doesn't change the current behaviour. If there is a value for `settings.kubernetes.cluster-domain`, the kubelet will be configure to use that value for the clusterDomain.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
