### PR TITLE
updata add-update: don't create manifest, require 'init' first

### DIFF
--- a/sources/updater/update_metadata/src/error.rs
+++ b/sources/updater/update_metadata/src/error.rs
@@ -71,7 +71,7 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to read manifest file {}: {}", path.display(), source))]
+    #[snafu(display("Failed to read manifest file '{}' - do you need to `updata init`? ({})", path.display(), source))]
     ManifestRead {
         path: PathBuf,
         source: std::io::Error,

--- a/sources/updater/updog/src/bin/updata.rs
+++ b/sources/updater/updog/src/bin/updata.rs
@@ -59,11 +59,7 @@ struct AddUpdateArgs {
 
 impl AddUpdateArgs {
     fn run(self) -> Result<()> {
-        let mut manifest: Manifest = match update_metadata::load_file(&self.file) {
-            Ok(m) => m,
-            _ => Manifest::default(), // TODO only if EEXIST
-        };
-
+        let mut manifest: Manifest = update_metadata::load_file(&self.file)?;
         manifest.add_update(
             self.image_version,
             self.max_version,


### PR DESCRIPTION
Automatically creating a manifest during `add-update` can be problematic if you
thought the manifest path did exist.  You may create an empty repo instead of
adding to one as intended.

This change requires "init" to be run first, so you're showing your intention
to create a new repo.

---

This happened to us during the 0.4.1 release when making a test repo that we expected to include older versions as well.

**Testing done:**

Before, it runs regardless of whether the manifest ("not-a-file") exists:
```
$ cargo run --bin updata -- add-update not-a-file -a x86_64 -b README.md -h README.md -r README.md -v 0.0.1 -m 0.0.1 -f variant
```
It creates an empty manifest, then inserts the update, when I intended to add to an existing repo:
```
$ cat not-a-file
{
  "updates": [
     ...
```

After, it fails in the expected way when the file doesn't exist.  (Works as expected after `init`ing the file.)
```
$ cargo run --bin updata -- add-update not-a-file -a x86_64 -b README.md -h README.md -r README.md -v 0.0.1 -m 0.0.1 -f variant
23:05:52 [ERROR] Failed to read manifest file 'not-a-file' - do you need to `updata init`? (No such file or directory (os error 2))
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
