### PR TITLE
updog: change heuristics for determining update availability

### DIFF
--- a/sources/updater/README.md
+++ b/sources/updater/README.md
@@ -41,8 +41,8 @@ Updog will ensure that appropriate migration files are available to safely trans
 
 ### Update wave
 Updates may include "wave" information which provides a way for updates to be scheduled over time for groups of Bottlerocket hosts.
-Updog will find the update wave the host belongs to and jitter its update time within that range.
-If the calculated time has not passed yet, Updog returns the update timestamp to the caller so it can be called again at the correct time.
+Updog will find the update wave the host belongs to and calculate the time position allocated to the host given its seed.
+If the calculated time has not passed, Updog will not report an update as being available.
 
 Assuming all the requirements are met, Updog requests the update images from the TUF repository and writes them to the "inactive" partition.
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Jul 14 15:58:23 2020 -0700

    updog: remove jitters, calculate wave position to determine availability
    
    This removes jittering in updog and instead use the seed to find a
    target time position within the wave to determine whether an update is
    available
```

This also removes the `--timestamp` option since it's no longer necessary without updog returning the jittered time.

As result of this change, updates will only be visible if they are available (host is past their defined update wave). To see all updates regardless of update waves, either `--ignore-waves` needs to be specified or `settings.updates.ignore-waves` needs to be set to true.

**Testing done:**
`updog` unit tests pass, newly created unit test for `update_metadata` passes.

Testing in an instance:

Confirmed that the seed value places the host in the last wave which starts on 7/19
```
bash-5.0# cat /etc/updog.toml 
metadata_base_url = "https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.15/x86_64/"
targets_base_url = "https://updates.bottlerocket.aws/targets/"
seed = 887
version_lock = "latest"
ignore_waves = false

```

Check update without ignoring waves, v0.4.1 does not show up since our wave hasn't started:
```
bash-5.0# updog check-update                                           aws-k8s-1.15 0.4.0
bash-5.0# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.15",
    "arch": "x86_64",
    "version": "0.4.0",
    "max_version": "0.4.1",
    "waves": {
      "0": "2020-06-29T20:00:00Z",
      "20": "2020-06-29T23:00:00Z",
      "102": "2020-06-30T19:00:00Z",
      "204": "2020-07-02T19:00:00Z",
      "512": "2020-07-05T19:00:00Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.4.0-7303622-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.15-x86_64-0.4.0-7303622-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.4.0-7303622-root.verity.lz4"
    }
  },
  {
    "variant": "aws-k8s-1.15",
    "arch": "x86_64",
    "version": "0.3.4",
    "max_version": "0.4.1",
    "waves": {
      "0": "2020-05-28T18:00:00Z",
      "20": "2020-05-28T21:00:00Z",
      "102": "2020-05-29T17:00:00Z",
      "204": "2020-05-31T17:00:00Z",
      "512": "2020-06-03T17:00:00Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.3.4-85d09a8-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.15-x86_64-0.3.4-85d09a8-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.3.4-85d09a8-root.verity.lz4"
    }
  },
  {
    "variant": "aws-k8s-1.15",
    "arch": "x86_64",
    "version": "0.3.3",
    "max_version": "0.4.1",
    "waves": {
      "0": "2020-05-14T21:02:06.101007479Z",
      "61": "2020-05-15T00:02:06.101016645Z",
      "245": "2020-05-15T04:02:06.101021535Z",
      "1024": "2020-05-15T20:02:06.101025162Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.3.3-b7d91846-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.15-x86_64-0.3.3-b7d91846-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.3.3-b7d91846-root.verity.lz4"
    }
  },
  {
    "variant": "aws-k8s-1.15",
    "arch": "x86_64",
    "version": "0.3.2",
    "max_version": "0.4.1",
    "waves": {
      "0": "2020-04-20T23:15:20.890251663Z",
      "20": "2020-04-21T02:15:20.890267117Z",
      "102": "2020-04-21T22:15:20.890276237Z",
      "204": "2020-04-23T22:15:20.890287476Z",
      "512": "2020-04-26T22:15:20.890299173Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.3.2-25aa08c-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.15-x86_64-0.3.2-25aa08c-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.3.2-25aa08c-root.verity.lz4"
    }
  },
  {
    "variant": "aws-k8s-1.15",
    "arch": "x86_64",
    "version": "0.3.1",
    "max_version": "0.4.1",
    "waves": {
      "0": "2020-03-10T19:00:00Z",
      "2048": "2020-03-12T19:00:00Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.3.1-8a0c0b3-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.15-x86_64-0.3.1-8a0c0b3-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.3.1-8a0c0b3-root.verity.lz4"
    }
  },
  {
    "variant": "aws-k8s-1.15",
    "arch": "x86_64",
    "version": "0.3.0",
    "max_version": "0.4.1",
    "waves": {
      "0": "2020-02-28T16:00:00Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.15-x86_64-0.3.0-faaec6e4-root.verity.lz4"
    }
  }
]
```

Calling `updog update` gives me 0.4.0:
```
bash-5.0# updog update
Starting update to 0.4.0
^C
```

With `--ignore-waves` set, 0.4.1 becomes visible

```
bash-5.0# updog check-update --ignore-waves
aws-k8s-1.15 0.4.1
bash-5.0# updog check-update -a --ignore-waves       
aws-k8s-1.15 0.4.1
aws-k8s-1.15 0.4.0
aws-k8s-1.15 0.3.4
aws-k8s-1.15 0.3.3
aws-k8s-1.15 0.3.2
aws-k8s-1.15 0.3.1
aws-k8s-1.15 0.3.0
```

Calling `updog update --ignore-waves` gives me v0.4.1:
```
bash-5.0# updog update --ignore-waves         
Starting update to 0.4.1

``` 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
