### PR TITLE
Exclude README.md from cargo change tracking

### DIFF
--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 futures = "0.3"

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 actix-rt = "1.0.0"

--- a/sources/api/bork/Cargo.toml
+++ b/sources/api/bork/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Samuel Mendoza-Jonas <samjonas@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 rand = "0.7.0"

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiserver = { path = "../../apiserver" }

--- a/sources/api/migration/migrations/v0.3.2/migrate-admin-container-v0-5-0/Cargo.toml
+++ b/sources/api/migration/migrations/v0.3.2/migrate-admin-container-v0-5-0/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Erikson Tung <etung@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.4.1/add-version-lock-ignore-waves/Cargo.toml
+++ b/sources/api/migration/migrations/v0.4.1/add-version-lock-ignore-waves/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Erikson Tung <etung@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.4.1/pivot-repo-2020-07-07/Cargo.toml
+++ b/sources/api/migration/migrations/v0.4.1/pivot-repo-2020-07-07/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Jamie Anderson <jamieand@amazon.com"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 bottlerocket-release = { path = "../../../bottlerocket-release" }

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 dns-lookup = "1.0"

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 reqwest = { version = "0.10", default-features = false, features = ["blocking"]}

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/api/servicedog/Cargo.toml
+++ b/sources/api/servicedog/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiserver = { path = "../apiserver" }

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }

--- a/sources/bottlerocket-release/Cargo.toml
+++ b/sources/bottlerocket-release/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 envy = "0.4"

--- a/sources/growpart/Cargo.toml
+++ b/sources/growpart/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 gptman = { version = "0.6.1", default-features = false }

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Matt Briggs <brigmatt@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 flate2 = "1.0"

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 base64 = "0.12"

--- a/sources/models/model-derive/Cargo.toml
+++ b/sources/models/model-derive/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [lib]
 path = "src/lib.rs"

--- a/sources/parse-datetime/Cargo.toml
+++ b/sources/parse-datetime/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 chrono = "0.4.11"

--- a/sources/updater/block-party/Cargo.toml
+++ b/sources/updater/block-party/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 snafu = "0.6.0"

--- a/sources/updater/signpost/Cargo.toml
+++ b/sources/updater/signpost/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 bit_field = "0.10.0"

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Samuel Mendoza-Jonas <samjonas@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 chrono = { version = "0.4.9", features = ["serde"] }

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 bottlerocket-release = { path = "../../bottlerocket-release" }

--- a/sources/webpki-roots-shim/Cargo.toml
+++ b/sources/webpki-roots-shim/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/tools/buildsys/Cargo.toml
+++ b/tools/buildsys/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [dependencies]
 duct = "0.13.0"

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.15/Cargo.toml
+++ b/variants/aws-k8s-1.15/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.16/Cargo.toml
+++ b/variants/aws-k8s-1.16/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.17/Cargo.toml
+++ b/variants/aws-k8s-1.17/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
 
 [package.metadata.build-variant]
 included-packages = [


### PR DESCRIPTION
In packages using cargo-readme, README.md files are touched by build.rs, which
triggers cargo's change tracking in the next build.  This means cargo is
rebuilding the package every time.

This change adds README.md to the exclude list in Cargo.toml files so that
cargo doesn't think a README change requires a rebuild.  Most of our packages
use cargo-readme to generate README.md, and for packages that don't, this still
isn't harmful; manual updates to README.md don't need a Rust build.  (Special
cases can just remove this exclude line.)

The downside is that accidental changes to README.md, like removing it, won't
be automatically corrected with a rebuild if you haven't touched anything else.
This should be rare, and will correct itself upon any other change.  (And a
developer is unlikely to commit such an accidental change.)

---

Thanks to @bcressey for finding this!

**Testing done:**

Without this, I observed crates with cargo-readme (and their local dependencies) rebuilding every `cargo build`.

With this, `cargo build` finishes immediately in successive attempts.

Also, at least for me and Zac, `cargo make` was rebuilding the `os` package every time, which is not a quick one.  With this change, the `build-packages` step finishes very quickly and the only work we're redoing is image builds.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
