### PR TITLE
buildsys: exclude README.md from change tracking

### DIFF
--- a/tools/buildsys/src/project.rs
+++ b/tools/buildsys/src/project.rs
@@ -45,7 +45,7 @@ impl ProjectInfo {
         entry
             .file_name()
             .to_str()
-            .map(|s| s.starts_with('.') || s == "target" || s == "vendor")
+            .map(|s| s.starts_with('.') || s == "target" || s == "vendor" || s == "README.md")
             .unwrap_or(false)
     }
 }


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This is a follow-up to cd7e66db that also excludes `README.md` from change tracking for buildsys.


**Testing done:**
Confirmed that the `os` package is not rebuilt after changing the mtime of `sources/api/README.md`, but is rebuilt after changing other sources.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
