### PR TITLE
testing: initialize manifest before loading

### DIFF
--- a/sources/updater/updog/src/bin/updata.rs
+++ b/sources/updater/updog/src/bin/updata.rs
@@ -374,6 +374,7 @@ mod tests {
     #[test]
     fn max_versions() -> Result<()> {
         let tmpfd = NamedTempFile::new().context(error::TmpFileCreate)?;
+        update_metadata::write_file(tmpfd.path(), &Manifest::default()).unwrap();
         AddUpdateArgs {
             file: PathBuf::from(tmpfd.path()),
             variant: String::from("yum"),


### PR DESCRIPTION
Missed this when adding init requirement in https://github.com/bottlerocket-os/bottlerocket/pull/991

**Testing done:**

`tests::max_versions` now passes (along with all other unit tests)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
