### PR TITLE
aws-ecs-1: add configurable logging drivers

### DIFF
--- a/sources/api/ecs-settings-applier/src/main.rs
+++ b/sources/api/ecs-settings-applier/src/main.rs
@@ -30,6 +30,9 @@ struct ECSConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     privileged_disabled: Option<bool>,
+
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    available_logging_drivers: Vec<String>,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -58,6 +61,12 @@ fn run() -> Result<()> {
     let mut config = ECSConfig {
         cluster: ecs.cluster,
         privileged_disabled: ecs.allow_privileged_containers.map(|s| !s),
+        available_logging_drivers: ecs
+            .logging_drivers
+            .unwrap_or_default()
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
         ..Default::default()
     };
     if let Some(os) = settings.os {

--- a/sources/models/src/aws-ecs-1/override-defaults.toml
+++ b/sources/models/src/aws-ecs-1/override-defaults.toml
@@ -12,3 +12,4 @@ affected-services = ["ecs"]
 
 [settings.ecs]
 allow-privileged-containers = false
+logging-drivers = ["json-file", "awslogs", "none"]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -111,6 +111,7 @@ struct ECSSettings {
     cluster: String,
     instance_attributes: HashMap<ECSAttributeKey, ECSAttributeValue>,
     allow_privileged_containers: bool,
+    logging_drivers: Vec<SingleLineString>,
 }
 
 // Update settings. Taken from userdata. The 'seed' setting is generated


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/815

**Description of changes:**

The new ecs.logging-drivers setting controls the list of logging drivers available for use with ECS.  The defaults are "json-file", "awslogs", and "none".  Other logging drivers (such as those installed via a plugin) can be enabled.  The default set of logging drivers can be reduced or removed to implement policy for allowable logging drivers in a cluster.

**Testing done:**

Launched an instance, saw it register with the appropriate capabilities.  Ran a task using the awslogs driver, validated that logs appeared in CloudWatch Logs with the correct group and stream.  Used apiclient to mutate the list of logging drivers, saw changes rendered in the ECS config file and reflected in DescribeContainerInstances.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
