### PR TITLE
metricdog: anonymous bottlerocket metrics

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -14,6 +14,8 @@
   Used for system maintenance and connectivity.
 * [**host-ctr**](sources/host-ctr): The program started by `host-containers@.service` for each host container.
   Its job is to start the specified host container on the “host” instance of containerd, which is separate from the “user” instance of containerd used for Kubernetes pods.
+* [**logdog**](sources/logdog): A program that one can use to collect logs when things go wrong. 
+* [**metricdog**](sources/metricdog): A program that sends anonymous health pings.
 * [**model**](sources/models): The API system has a data model defined for each variant, and this model is used by other programs to serialize and deserialize requests while maintaining safety around data types.
 * [**netdog**](sources/api/netdog): A program called by wicked to retrieve and write out network configuration from DHCP.
 * [**pluto**](sources/api/pluto): A setting generator called by sundog to find networking settings required by Kubernetes.

--- a/Release.toml
+++ b/Release.toml
@@ -20,3 +20,5 @@ version = "1.0.5"
     "migrate_v1.0.5_add-proxy-restart.lz4",
     "migrate_v1.0.5_add-proxy-services.lz4"
 ]
+"(1.0.5, 1.0.6)" = ["migrate_v1.0.6_metricdog-init.lz4"]
+

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -10,6 +10,7 @@ variant-sensitive = true
 source-groups = [
     "api",
     "bottlerocket-release",
+    "metricdog",
     "parse-datetime",
     "ghostdog",
     "growpart",

--- a/packages/os/mark-successful-boot.service
+++ b/packages/os/mark-successful-boot.service
@@ -8,6 +8,7 @@ After=multi-user.target
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/bin/signpost mark-successful-boot
+ExecStartPost=-/usr/bin/metricdog send-boot-success
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/os/metricdog-toml
+++ b/packages/os/metricdog-toml
@@ -1,0 +1,7 @@
+metrics_url = "{{settings.metrics.metrics-url}}"
+send_metrics = {{settings.metrics.send-metrics}}
+service_checks = [{{join_array ", " settings.metrics.service-checks}}]
+region = "{{settings.aws.region}}"
+seed = {{settings.updates.seed}}
+version_lock = "{{settings.updates.version-lock}}"
+ignore_waves = {{settings.updates.ignore-waves}}

--- a/packages/os/metricdog.service
+++ b/packages/os/metricdog.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Send a Metricdog Ping
+
+[Service]
+Type=oneshot
+RemainAfterExit=false
+StandardError=journal+console
+ExecStart=/usr/bin/metricdog send-health-ping
+TimeoutStartSec=30s

--- a/packages/os/metricdog.timer
+++ b/packages/os/metricdog.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Scheduled Metricdog Pings
+
+[Timer]
+# Don't run missed executions
+Persistent=false
+# Run 120 seconds after startup
+OnStartupSec=120
+# Run every 6 hours thereafter
+OnUnitActiveSec=21600
+# Don't fire at exactly the same second across machines started together.
+RandomizedDelaySec=3600
+# We don't want to extend the startup report too long after the requested time.
+AccuracySec=10
+# File describing job to execute
+Unit=metricdog.service
+
+[Install]
+WantedBy=timers.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -20,6 +20,7 @@ Source3: eni-max-pods
 #SourceX: root.json
 
 Source5: updog-toml
+Source6: metricdog-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -30,6 +31,8 @@ Source105: settings-applier.service
 Source106: migrator.service
 Source107: host-containers@.service
 Source110: mark-successful-boot.service
+Source111: metricdog.service
+Source112: metricdog.timer
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -157,6 +160,11 @@ Summary: Bottlerocket updater CLI
 %description -n %{_cross_os}updog
 not much what's up with you
 
+%package -n %{_cross_os}metricdog
+Summary: Bottlerocket health metrics sender
+%description -n %{_cross_os}metricdog
+%{summary}.
+
 %package -n %{_cross_os}logdog
 Summary: Bottlerocket log extractor
 %description -n %{_cross_os}logdog
@@ -198,6 +206,7 @@ mkdir bin
     -p signpost \
     -p updog \
     -p logdog \
+    -p metricdog \
     -p ghostdog \
     -p growpart \
     -p corndog \
@@ -229,7 +238,7 @@ for p in \
   thar-be-settings thar-be-updates servicedog host-containers \
   storewolf settings-committer \
   migrator \
-  signpost updog logdog \
+  signpost updog metricdog logdog \
   ghostdog \
 %if "%{_cross_variant}" == "aws-ecs-1"
   ecs-settings-applier \
@@ -275,12 +284,12 @@ install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:5} %{S:6} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:100} %{S:101} %{S:102} %{S:103} %{S:105} \
-  %{S:106} %{S:107} %{S:110} \
+  %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
@@ -378,6 +387,13 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %{_cross_datadir}/updog
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/updog-toml
+
+%files -n %{_cross_os}metricdog
+%{_cross_bindir}/metricdog
+%dir %{_cross_templatedir}
+%{_cross_templatedir}/metricdog-toml
+%{_cross_unitdir}/metricdog.service
+%{_cross_unitdir}/metricdog.timer
 
 %files -n %{_cross_os}logdog
 %{_cross_bindir}/logdog

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -72,6 +72,7 @@ Requires: %{_cross_os}thar-be-settings
 Requires: %{_cross_os}thar-be-updates
 Requires: %{_cross_os}migration
 Requires: %{_cross_os}updog
+Requires: %{_cross_os}metricdog
 Requires: %{_cross_os}logdog
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}wicked

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -606,7 +606,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -777,6 +779,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -1066,6 +1089,7 @@ checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1087,6 +1111,17 @@ name = "futures-core"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1381,6 +1416,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "httptest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1bd96bf54054746b39c93f5e43822e5fa29fb081190d1f24d8f51d2fb800577"
+dependencies = [
+ "bstr",
+ "bytes 0.5.6",
+ "crossbeam-channel",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
+
+[[package]]
 name = "hyper"
 version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1735,31 @@ version = "0.1.0"
 dependencies = [
  "snafu",
  "toml",
+]
+
+[[package]]
+name = "metricdog"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-release",
+ "cargo-readme",
+ "httptest",
+ "log",
+ "reqwest",
+ "serde",
+ "simplelog",
+ "snafu",
+ "structopt",
+ "tempfile",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "metricdog-init"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]
@@ -2366,6 +2454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,9 +2975,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2889,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -37,12 +37,15 @@ members = [
     "api/migration/migrations/v1.0.5/add-network-settings",
     "api/migration/migrations/v1.0.5/add-proxy-restart",
     "api/migration/migrations/v1.0.5/add-proxy-services",
+    "api/migration/migrations/v1.0.6/metricdog-init",
 
     "bottlerocket-release",
 
     "ghostdog",
 
     "growpart",
+
+    "metricdog",
 
     "logdog",
 

--- a/sources/api/migration/migrations/v1.0.6/metricdog-init/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.6/metricdog-init/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "metricdog-init"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.6/metricdog-init/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.6/metricdog-init/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// Add settings for the new `metricdog` program.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.metrics",
+        "services.metricdog",
+        "configuration-files.metricdog",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -1,5 +1,5 @@
 // This module contains helpers for rendering templates. These helpers can
-// be registerd with the Handlebars library to assist in manipulating
+// be registered with the Handlebars library to assist in manipulating
 // text at render time.
 
 use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError};
@@ -91,6 +91,18 @@ mod error {
         ))]
         InvalidTemplateValue {
             expected: &'static str,
+            value: handlebars::JsonValue,
+            template: String,
+        },
+
+        #[snafu(display(
+            "The join_array helper expected type '{}' while processing '{}' for template '{}'",
+            expected_type,
+            value,
+            template
+        ))]
+        JoinStringsWrongType {
+            expected_type: &'static str,
             value: handlebars::JsonValue,
             template: String,
         },
@@ -507,6 +519,73 @@ pub fn host(
 
     // write it to the template
     out.write(&url_host).with_context(|| error::TemplateWrite {
+        template: template_name.to_owned(),
+    })?;
+
+    Ok(())
+}
+
+/// `join_array` is used to join an array of scalar strings into an array of
+/// quoted, delimited strings. The delimiter must be specified.
+///
+/// # Example
+///
+/// Consider an array of values: `[ "a", "b", "c" ]` stored in a setting such as
+/// `settings.somewhere.foo-list`. In our template we can write:
+/// `{{ join_array ", " settings.somewhere.foo-list }}`
+///
+/// This will render `"a", "b", "c"`.
+pub fn join_array(
+    helper: &Helper<'_, '_>,
+    _: &Handlebars,
+    _: &Context,
+    renderctx: &mut RenderContext<'_, '_>,
+    out: &mut dyn Output,
+) -> Result<(), RenderError> {
+    trace!("Starting join_array helper");
+    let template_name = template_name(renderctx);
+    check_param_count(helper, template_name, 2)?;
+
+    // get the delimiter
+    let delimiter_param = get_param(helper, 0)?;
+    let delimiter = delimiter_param
+        .as_str()
+        .with_context(|| error::JoinStringsWrongType {
+            expected_type: "string",
+            value: delimiter_param.to_owned(),
+            template: template_name,
+        })?;
+
+    // get the array
+    let array_param = get_param(helper, 1)?;
+    let array = array_param
+        .as_array()
+        .with_context(|| error::JoinStringsWrongType {
+            expected_type: "array",
+            value: array_param.to_owned(),
+            template: template_name,
+        })?;
+
+    let mut result = String::new();
+    for (i, value) in array.iter().enumerate() {
+        if i > 0 {
+            result.push_str(delimiter);
+        }
+        result.push_str(
+            format!(
+                "\"{}\"",
+                value.as_str().context(error::JoinStringsWrongType {
+                    expected_type: "string",
+                    value: array.to_owned(),
+                    template: template_name,
+                })?
+            )
+            .as_str(),
+        );
+    }
+
+    // write it to the template
+    out.write(&result).with_context(|| error::TemplateWrite {
         template: template_name.to_owned(),
     })?;
 
@@ -930,5 +1009,73 @@ mod test_host {
         )
         .unwrap();
         assert_eq!(result, "example.com");
+    }
+}
+
+#[cfg(test)]
+mod test_join_array {
+    use super::*;
+    use handlebars::TemplateRenderError;
+    use serde::Serialize;
+    use serde_json::json;
+
+    // A thin wrapper around the handlebars render_template method that includes
+    // setup and registration of helpers
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    where
+        T: Serialize,
+    {
+        let mut registry = Handlebars::new();
+        registry.register_helper("join_array", Box::new(join_array));
+
+        registry.render_template(tmpl, data)
+    }
+
+    const TEMPLATE: &str = r#"{{join_array ", " settings.foo-list}}"#;
+
+    #[test]
+    fn join_array_empty() {
+        let result =
+            setup_and_render_template(TEMPLATE, &json!({"settings": {"foo-list": []}})).unwrap();
+        let expected = "";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn join_array_one_item() {
+        let result =
+            setup_and_render_template(TEMPLATE, &json!({"settings": {"foo-list": ["a"]}})).unwrap();
+        let expected = r#""a""#;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn join_array_two_items() {
+        let result =
+            setup_and_render_template(TEMPLATE, &json!({"settings": {"foo-list": ["a", "b"]}}))
+                .unwrap();
+        let expected = r#""a", "b""#;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn join_array_two_delimiter() {
+        let template = r#"{{join_array "~ " settings.foo-list}}"#;
+        let result = setup_and_render_template(
+            template,
+            &json!({"settings": {"foo-list": ["a", "b", "c"]}}),
+        )
+        .unwrap();
+        let expected = r#""a"~ "b"~ "c""#;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn join_array_empty_item() {
+        let result =
+            setup_and_render_template(TEMPLATE, &json!({"settings": {"foo-list": ["a", "", "c"]}}))
+                .unwrap();
+        let expected = r#""a", "", "c""#;
+        assert_eq!(result, expected);
     }
 }

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -123,6 +123,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("default", Box::new(helpers::default));
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
     template_registry.register_helper("host", Box::new(helpers::host));
+    template_registry.register_helper("join_array", Box::new(helpers::join_array));
 
     Ok(template_registry)
 }

--- a/sources/bottlerocket-release/src/lib.rs
+++ b/sources/bottlerocket-release/src/lib.rs
@@ -54,7 +54,7 @@ impl BottlerocketRelease {
         Self::from_file(DEFAULT_RELEASE_FILE)
     }
 
-    fn from_file<P>(path: P) -> Result<Self>
+    pub fn from_file<P>(path: P) -> Result<Self>
     where
         P: AsRef<Path>,
     {
@@ -67,7 +67,7 @@ impl BottlerocketRelease {
             .lines()
             .filter_map(|line| {
                 // Allow for comments
-                if line.starts_with("#") {
+                if line.starts_with('#') {
                     return None;
                 }
 

--- a/sources/clarify.toml
+++ b/sources/clarify.toml
@@ -31,6 +31,14 @@ license-files = [
     { path = "LICENSE-THIRD-PARTY", hash = 0x7e40bc60 },
 ]
 
+[clarify.crossbeam-channel]
+expression = "(MIT OR Apache-2.0) AND BSD-2-Clause-FreeBSD"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0xbc436f08 },
+    { path = "LICENSE-THIRD-PARTY", hash = 0xc6242648 },
+]
+
 [clarify.lz4-sys]
 # The lz4-sys crate's license is listed as MIT.
 #
@@ -73,6 +81,18 @@ license-files = [
 ]
 skip-files = [
     "src/testdata/LICENSE", # we aren't using the test data
+]
+
+[clarify.regex-automata]
+expression = "Unlicense OR MIT"
+license-files = [
+    { path = "COPYING", hash = 0x969f37d8 },
+    { path = "LICENSE-MIT", hash = 0x616d8a83 },
+    { path = "UNLICENSE", hash = 0x87b84020 },
+]
+skip-files = [
+    "data/fowler-tests/LICENSE", # we aren't using the test data
+    "data/tests/fowler/LICENSE",
 ]
 
 [clarify.regex-syntax]

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "metricdog"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+bottlerocket-release = { path = "../bottlerocket-release"}
+log = "0.4"
+reqwest = { version = "0.10.1", default-features = false, features = ["blocking", "rustls-tls"] }
+serde = { version = "1.0.100", features = ["derive"] }
+simplelog = "0.9"
+snafu = { version = "0.6" }
+structopt = "0.3.17"
+toml = "0.5.1"
+url = "2.1.1"
+
+[build-dependencies]
+cargo-readme = "3.1"
+
+[dev-dependencies]
+httptest = "0.13.1"
+tempfile = { version = "3.1.0", default-features = false }

--- a/sources/metricdog/README.md
+++ b/sources/metricdog/README.md
@@ -1,0 +1,55 @@
+# metricdog
+
+Current version: 0.1.0
+
+## Introduction
+
+Metricdog sends anonymous information about the health of a Bottlerocket host.
+It does so by sending key-value pairs as query params in an HTTP GET request.
+
+Metricdog also has the ability to check that a list of critical services is running.
+It does so using `systemctl` and reports services that are not healthy.
+
+## What it Sends
+
+#### The standard set of metrics:
+
+* `sender`: the application sending the report.
+* `event`: the event that invoked the report.
+* `version`: the Bottlerocket version.
+* `variant`: the Bottlerocket variant.
+* `arch`: the machine architecture, e.g.'x86_64' or 'aarch64'.
+* `region`: the region the machine is running in.
+* `seed`: the seed value used to roll-out updates.
+* `version_lock`: the optional setting that controls Bottlerocket update selection.
+* `ignore_waves`: an update setting that allows hosts to update before their seed is reached.
+
+#### Additionally, when `metricdog` sends a 'health ping', it adds:
+
+* `is_healthy`: true or false based on whether critical services are running.
+* `failed_services`: a list of critical services that have failed, if any.
+
+## Configuration
+
+Configuration is read from a TOML file, which is generated from Bottlerocket settings:
+
+```toml
+# the url to which metricdog will send metrics information
+metrics_url = "https://example.com/metrics"
+# whether or not metricdog will send metrics. opt-out by setting this to false
+send_metrics = true
+# a list of systemd service names that will be checked
+service_checks = ["apiserver", "containerd", "kubelet"]
+# the region
+region = "us-west-2"
+# the update wave seed
+seed = 1234
+# what version bottlerocket should stay on
+version_lock = "latest"
+# whether bottlerocket should ignore update roll-out timing
+ignore_waves = false
+```
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/metricdog/README.tpl
+++ b/sources/metricdog/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/metricdog/build.rs
+++ b/sources/metricdog/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/metricdog/src/args.rs
+++ b/sources/metricdog/src/args.rs
@@ -1,0 +1,27 @@
+use log::LevelFilter;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Command line arguments for the metricdog program.
+#[derive(StructOpt)]
+pub(crate) struct Arguments {
+    /// Path to the TOML config file [default: /etc/metricdog]
+    #[structopt(short = "c", long = "config")]
+    pub(crate) config: Option<PathBuf>,
+    /// Logging verbosity [trace|debug|info|warn|error]
+    #[structopt(short = "l", long = "log-level", default_value = "info")]
+    pub(crate) log_level: LevelFilter,
+    /// Path to the os-release file [default: /etc/os-release]
+    #[structopt(short = "o", long = "os-release")]
+    pub(crate) os_release: Option<PathBuf>,
+    #[structopt(subcommand)]
+    pub(crate) command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+pub(crate) enum Command {
+    /// report a successful boot.
+    SendBootSuccess,
+    /// check services and report their health.
+    SendHealthPing,
+}

--- a/sources/metricdog/src/config.rs
+++ b/sources/metricdog/src/config.rs
@@ -1,0 +1,95 @@
+use crate::error::{self, Result};
+use serde::Deserialize;
+use snafu::ResultExt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_CONFIG_PATH: &str = "/etc/metricdog.toml";
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Config {
+    pub(crate) metrics_url: String,
+    pub(crate) send_metrics: bool,
+    pub(crate) service_checks: Vec<String>,
+    pub(crate) region: String,
+    pub(crate) seed: u32,
+    pub(crate) version_lock: String,
+    pub(crate) ignore_waves: bool,
+}
+
+impl Config {
+    pub(crate) fn new() -> Result<Self> {
+        Self::from_file(PathBuf::from(DEFAULT_CONFIG_PATH))
+    }
+
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let s = fs::read_to_string(path).context(error::ConfigRead { path })?;
+        let config: Config = toml::from_str(&s).context(error::ConfigParse { path })?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::config::Config;
+    use tempfile::TempDir;
+
+    // This is what most configs will look like.
+    const STANDARD_CONFIG: &str = r#"
+    metrics_url = "https://example.com"
+    send_metrics = true
+    service_checks = ["a", "b", "c",]
+    region = "us-west-2"
+    seed = 1234
+    version_lock = "v0.1.2"
+    ignore_waves = false
+    "#;
+
+    // This is what a config might look like if the user opts out of metrics collection.
+    const OPT_OUT_CONFIG: &str = r#"
+    metrics_url = ""
+    send_metrics = false
+    service_checks = ["a", "b", "c",]
+    region = "us-west-2"
+    seed = 1234
+    version_lock = "v0.1.2"
+    ignore_waves = false
+    "#;
+
+    #[test]
+    fn standard_config() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, STANDARD_CONFIG).unwrap();
+        let config = Config::from_file(&path).unwrap();
+        assert_eq!("https://example.com", config.metrics_url.as_str());
+        assert!(config.send_metrics);
+        assert_eq!(3, config.service_checks.len());
+        assert_eq!("a", config.service_checks.get(0).unwrap());
+        assert_eq!("b", config.service_checks.get(1).unwrap());
+        assert_eq!("c", config.service_checks.get(2).unwrap());
+        assert_eq!("us-west-2", config.region);
+        assert_eq!(1234, config.seed);
+        assert_eq!("v0.1.2", config.version_lock);
+        assert!(!config.ignore_waves);
+    }
+
+    #[test]
+    fn opt_out_config() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, OPT_OUT_CONFIG).unwrap();
+        let config = Config::from_file(&path).unwrap();
+        assert_eq!("", config.metrics_url.as_str());
+        assert!(!config.send_metrics);
+        assert_eq!(3, config.service_checks.len());
+        assert_eq!("a", config.service_checks.get(0).unwrap());
+        assert_eq!("b", config.service_checks.get(1).unwrap());
+        assert_eq!("c", config.service_checks.get(2).unwrap());
+        assert_eq!("us-west-2", config.region);
+        assert_eq!(1234, config.seed);
+        assert_eq!("v0.1.2", config.version_lock);
+        assert!(!config.ignore_waves);
+    }
+}

--- a/sources/metricdog/src/error.rs
+++ b/sources/metricdog/src/error.rs
@@ -1,0 +1,48 @@
+//! Provides the list of errors for `metricdog`.
+
+use snafu::Snafu;
+use std::path::PathBuf;
+use url::Url;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub(crate) enum Error {
+    #[snafu(display("Unable to load Bottlerocket release info: '{}'", source))]
+    BottlerocketRelease { source: bottlerocket_release::Error },
+
+    #[snafu(display("Command '{}' with args '{:?}' failed: {}", command, args, source))]
+    Command {
+        command: String,
+        args: Vec<String>,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]
+    ConfigParse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[snafu(display("Failed to read config file {}: {}", path.display(), source))]
+    ConfigRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Error building HTTP client for {}: {}", url.as_str(), source))]
+    HttpClient { url: Url, source: reqwest::Error },
+
+    #[snafu(display("Error sending HTTP request to {}: {}", url.as_str(), source))]
+    HttpSend { url: Url, source: reqwest::Error },
+
+    #[snafu(display("Error receiving HTTP response {}: {}", url.as_str(), source))]
+    HttpResponse { url: Url, source: reqwest::Error },
+
+    #[snafu(display("Unable to parse URL {}: {}", url, source))]
+    UrlParse {
+        url: String,
+        source: url::ParseError,
+    },
+}
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sources/metricdog/src/main.rs
+++ b/sources/metricdog/src/main.rs
@@ -1,0 +1,127 @@
+#![deny(rust_2018_idioms, unused_imports)]
+
+/*!
+# Introduction
+
+Metricdog sends anonymous information about the health of a Bottlerocket host.
+It does so by sending key-value pairs as query params in an HTTP GET request.
+
+Metricdog also has the ability to check that a list of critical services is running.
+It does so using `systemctl` and reports services that are not healthy.
+
+# What it Sends
+
+### The standard set of metrics:
+
+* `sender`: the application sending the report.
+* `event`: the event that invoked the report.
+* `version`: the Bottlerocket version.
+* `variant`: the Bottlerocket variant.
+* `arch`: the machine architecture, e.g.'x86_64' or 'aarch64'.
+* `region`: the region the machine is running in.
+* `seed`: the seed value used to roll-out updates.
+* `version_lock`: the optional setting that controls Bottlerocket update selection.
+* `ignore_waves`: an update setting that allows hosts to update before their seed is reached.
+
+### Additionally, when `metricdog` sends a 'health ping', it adds:
+
+* `is_healthy`: true or false based on whether critical services are running.
+* `failed_services`: a list of critical services that have failed, if any.
+
+# Configuration
+
+Configuration is read from a TOML file, which is generated from Bottlerocket settings:
+
+```toml
+# the url to which metricdog will send metrics information
+metrics_url = "https://example.com/metrics"
+# whether or not metricdog will send metrics. opt-out by setting this to false
+send_metrics = true
+# a list of systemd service names that will be checked
+service_checks = ["apiserver", "containerd", "kubelet"]
+# the region
+region = "us-west-2"
+# the update wave seed
+seed = 1234
+# what version bottlerocket should stay on
+version_lock = "latest"
+# whether bottlerocket should ignore update roll-out timing
+ignore_waves = false
+```
+*/
+
+#![deny(rust_2018_idioms)]
+
+mod args;
+mod config;
+mod error;
+#[cfg(test)]
+mod main_test;
+mod metricdog;
+#[cfg(test)]
+mod metricdog_test;
+mod service_check;
+
+use crate::args::{Arguments, Command};
+use crate::config::Config;
+use crate::error::Result;
+use crate::metricdog::Metricdog;
+use crate::service_check::{ServiceCheck, SystemdCheck};
+use bottlerocket_release::BottlerocketRelease;
+use log::error;
+use simplelog::{Config as LogConfig, SimpleLogger};
+use snafu::ResultExt;
+use std::process;
+use structopt::StructOpt;
+
+fn main() -> ! {
+    let args = Arguments::from_args();
+    SimpleLogger::init(args.log_level, LogConfig::default()).expect("unable to configure logger");
+    process::exit(match main_inner(args, Box::new(SystemdCheck {})) {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!("{}", err);
+            1
+        }
+    })
+}
+
+/// pub(crate) for testing.
+pub(crate) fn main_inner(arguments: Arguments, service_check: Box<dyn ServiceCheck>) -> Result<()> {
+    // load the metricdog config file
+    let config = match &arguments.config {
+        None => Config::new()?,
+        Some(filepath) => Config::from_file(filepath)?,
+    };
+
+    // exit early with no error if the opt-out flag is set
+    if !config.send_metrics {
+        return Ok(());
+    }
+
+    // load bottlerocket release info
+    let os_release = if let Some(os_release_path) = &arguments.os_release {
+        BottlerocketRelease::from_file(os_release_path)
+    } else {
+        BottlerocketRelease::new()
+    }
+    .context(error::BottlerocketRelease)?;
+
+    // instantiate the metricdog object
+    let metricdog = Metricdog::from_parts(config, os_release, service_check)?;
+
+    // execute the specified command
+    match arguments.command {
+        Command::SendBootSuccess => {
+            if let Err(err) = metricdog.send_boot_success() {
+                // we don't want to fail the boot if there is a failure to send this message, so
+                // we log the error and return Ok(())
+                error!("Error while reporting boot success: {}", err);
+            }
+        }
+        Command::SendHealthPing => {
+            metricdog.send_health_ping()?;
+        }
+    }
+    Ok(())
+}

--- a/sources/metricdog/src/main_test.rs
+++ b/sources/metricdog/src/main_test.rs
@@ -1,0 +1,175 @@
+use crate::args::{Arguments, Command};
+use crate::error::Result;
+use crate::main_inner;
+use crate::service_check::{ServiceCheck, ServiceHealth};
+use httptest::responders::status_code;
+use httptest::{matchers::*, Expectation, Server};
+use log::LevelFilter;
+use std::fs::write;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+const OS_RELEASE: &str = r#"PRETTY_NAME=Bottlerocket
+VARIANT_ID=myvariant
+VERSION_ID=1.2.3
+BUILD_ID=abcdef0
+"#;
+
+struct MockCheck {}
+
+impl ServiceCheck for MockCheck {
+    fn check(&self, service_name: &str) -> Result<ServiceHealth> {
+        if service_name.ends_with("failed") {
+            Ok(ServiceHealth {
+                is_healthy: false,
+                exit_code: Some(1),
+            })
+        } else {
+            Ok(ServiceHealth {
+                is_healthy: true,
+                exit_code: None,
+            })
+        }
+    }
+}
+
+// dynamically create a config file where we can set server port, list of services, and send_metrics
+fn create_config_file_contents(port: u16, services: &[&str], send_metrics: bool) -> String {
+    let svcs = services
+        .iter()
+        .map(|&s| format!("\"{}\"", s))
+        .collect::<Vec<String>>()
+        .join(", ");
+    format!(
+        r#"
+    metrics_url = "http://localhost:{}/metrics"
+    send_metrics = {}
+    service_checks = [{}]
+    region = "us-west-2"
+    seed = 1234
+    version_lock = "v0.1.2"
+    ignore_waves = false
+    "#,
+        port, send_metrics, svcs
+    )
+}
+
+// create the config and os-release files in a tempdir and return the tempdir
+fn create_test_files(port: u16, services: &[&str], send_metrics: bool) -> TempDir {
+    let t = TempDir::new().unwrap();
+    write(
+        PathBuf::from(config_path(&t)),
+        create_config_file_contents(port, services, send_metrics),
+    )
+    .unwrap();
+    write(PathBuf::from(os_release_path(&t)), OS_RELEASE).unwrap();
+    t
+}
+
+// create the path to the config in the tempdir
+fn config_path(tempdir: &TempDir) -> PathBuf {
+    tempdir
+        .path()
+        .join("metricdog.toml")
+        .to_str()
+        .unwrap()
+        .into()
+}
+
+// create the path to os-release in the tempdir
+fn os_release_path(tempdir: &TempDir) -> PathBuf {
+    tempdir.path().join("os-release").to_str().unwrap().into()
+}
+
+#[test]
+fn send_boot_success() {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/metrics"))
+            .respond_with(status_code(200)),
+    );
+    let port = server.addr().port();
+    let tempdir = create_test_files(port, &["a", "b"], true);
+    let args = Arguments {
+        config: Some(config_path(&tempdir)),
+        log_level: LevelFilter::Off,
+        os_release: Some(os_release_path(&tempdir)),
+        command: Command::SendBootSuccess,
+    };
+    main_inner(args, Box::new(MockCheck {})).unwrap();
+}
+
+#[test]
+/// assert that a request is NOT sent to the server when the user sets `send_metrics` to false
+fn opt_out() {
+    let server = Server::run();
+    // expect the get request zero times
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/metrics"))
+            .times(0)
+            .respond_with(status_code(200)),
+    );
+    let port = server.addr().port();
+    let tempdir = create_test_files(port, &[], false);
+    let args = Arguments {
+        config: Some(config_path(&tempdir)),
+        log_level: LevelFilter::Off,
+        os_release: Some(os_release_path(&tempdir)),
+        command: Command::SendBootSuccess,
+    };
+    main_inner(args, Box::new(MockCheck {})).unwrap();
+}
+
+#[test]
+/// assert that send-boot-success exits without error even when there is no HTTP server
+fn send_boot_success_no_server() {
+    let port = 0;
+    let tempdir = create_test_files(port, &[], true);
+    let args = Arguments {
+        config: Some(config_path(&tempdir)),
+        log_level: LevelFilter::Off,
+        os_release: Some(os_release_path(&tempdir)),
+        command: Command::SendBootSuccess,
+    };
+    main_inner(args, Box::new(MockCheck {})).unwrap();
+}
+
+#[test]
+/// assert that send-boot-success exits without error even if the server sends a 404
+fn send_boot_success_404() {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/metrics"))
+            .respond_with(status_code(404)),
+    );
+    let port = server.addr().port();
+    let tempdir = create_test_files(port, &[], true);
+    let args = Arguments {
+        config: Some(config_path(&tempdir)),
+        log_level: LevelFilter::Off,
+        os_release: Some(os_release_path(&tempdir)),
+        command: Command::SendBootSuccess,
+    };
+    main_inner(args, Box::new(MockCheck {})).unwrap();
+}
+
+#[test]
+/// assert that send-health-ping works as expected using a mock `ServiceCheck`
+fn send_health_ping() {
+    let server = Server::run();
+    let matcher = all_of![
+        request::method_path("GET", "/metrics"),
+        request::query(url_decoded(contains(("is_healthy", "false")))),
+        request::query(url_decoded(contains(("failed_services", "afailed:1")))),
+    ];
+    server.expect(Expectation::matching(matcher).respond_with(status_code(200)));
+    let port = server.addr().port();
+    let tempdir = create_test_files(port, &["afailed", "b"], true);
+    let args = Arguments {
+        config: Some(config_path(&tempdir)),
+        log_level: LevelFilter::Off,
+        os_release: Some(os_release_path(&tempdir)),
+        command: Command::SendHealthPing,
+    };
+    main_inner(args, Box::new(MockCheck {})).unwrap();
+}

--- a/sources/metricdog/src/metricdog.rs
+++ b/sources/metricdog/src/metricdog.rs
@@ -1,0 +1,158 @@
+use crate::config::Config;
+use crate::error::{self, Result};
+use crate::service_check::ServiceCheck;
+use bottlerocket_release::BottlerocketRelease;
+use log::debug;
+use reqwest::blocking::Client;
+use snafu::ResultExt;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::Duration;
+use url::Url;
+
+/// The send function optionally takes a timeout parameter so that we can have a short timeout for
+/// `boot_success`. When `None` is passed, the default timeout is used. 20 seconds was arbitrarily
+/// chosen and can be changed if the need arises.
+const DEFAULT_TIMEOUT_SECONDS: u64 = 20;
+
+/// Sends key-value pairs as query params to a URL configured in `config`. Also provides the ability
+/// to check the health of a list of services and send information about whether or not the services
+/// are running.
+pub(crate) struct Metricdog {
+    /// The `Metricdog` configuration, e.g. from `/etc/metricdog.toml`
+    config: Config,
+    /// Information about the Bottlerocket release, e.g. from `os-release`
+    os_release: BottlerocketRelease,
+    /// A trait object that checks if a service (listed in `config`) is healthy. This can be passed-
+    /// in, but defaults to an object that uses `systemctl` to check services.
+    healthcheck: Box<dyn ServiceCheck>,
+    /// The metrics_url, having been parsed during construction of the `Metricdog` object.
+    metrics_url: Url,
+}
+
+impl Metricdog {
+    /// Create a new instance by passing in the `Config`, `BottlerocketRelease`, and `ServiceCheck`
+    /// objects.
+    pub(crate) fn from_parts(
+        config: Config,
+        os_release: BottlerocketRelease,
+        healthcheck: Box<dyn ServiceCheck>,
+    ) -> Result<Self> {
+        let metrics_url = Url::from_str(&config.metrics_url).context(error::UrlParse {
+            url: &config.metrics_url,
+        })?;
+        Ok(Self {
+            config,
+            os_release,
+            healthcheck,
+            metrics_url,
+        })
+    }
+
+    /// # Description
+    ///
+    /// Sends key-value pairs as query parameters in a GET request to the URL in `config`. A
+    /// standard set of key-value pairs are added first, and appended by any additional parameters
+    /// passed in to this function.
+    ///
+    /// # Parameters
+    ///
+    /// * `sender`:          This is the name of the application sending the metrics e.g.
+    ///                      `metricdog` or `updog`.
+    /// * `event`:           The name of the type of metrics event that is being sent. For example
+    ///                      `boot_success` or `health_ping`.
+    /// * `values`:          The key-value pairs that you want to send. These will be sorted by key
+    ///                      before sending to ensure consistency of key-value ordering.
+    /// * `timeout_seconds`: The timeout setting for the HTTP client. Defaults to
+    ///                      `DEFAULT_TIMEOUT_SECONDS` when `None` is passed.
+    pub(crate) fn send<S1, S2>(
+        &self,
+        sender: S1,
+        event: S2,
+        values: Option<&HashMap<String, String>>,
+        timeout_seconds: Option<u64>,
+    ) -> Result<()>
+    where
+        S1: AsRef<str>,
+        S2: AsRef<str>,
+    {
+        let mut url = self.metrics_url.clone();
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("sender", sender.as_ref());
+            q.append_pair("event", event.as_ref());
+            q.append_pair("version", &self.os_release.version_id.to_string());
+            q.append_pair("variant", &self.os_release.variant_id);
+            q.append_pair("arch", &self.os_release.arch);
+            q.append_pair("region", &self.config.region);
+            q.append_pair("seed", &self.config.seed.to_string());
+            q.append_pair("version_lock", &self.config.version_lock);
+            q.append_pair("ignore_waves", &self.config.ignore_waves.to_string());
+            if let Some(map) = values {
+                let mut keys: Vec<&String> = map.keys().collect();
+                // sorted for consistency
+                keys.sort();
+                for key in keys {
+                    if let Some(val) = map.get(key) {
+                        q.append_pair(key, val);
+                    }
+                }
+            }
+        }
+        Self::send_get_request(url, timeout_seconds)?;
+        Ok(())
+    }
+
+    /// Sends a notification to the metrics url that boot succeeded.
+    pub(crate) fn send_boot_success(&self) -> Result<()> {
+        // timeout of 3 seconds to prevent blocking the completion of mark-boot-success
+        self.send("metricdog", "boot_success", None, Some(3))?;
+        Ok(())
+    }
+
+    /// Checks the services listed in `config.service_checks` using `healthcheck`. Sends a
+    /// notification to the metrics url reporting `is_healthy=true&failed_services=` if all services
+    /// are healthy, or `is_healthy=false&failed_services=a:1,b:2` where `a` and `b` are the failed
+    /// services, and `1` and `2` are exit codes of the failed services.
+    pub(crate) fn send_health_ping(&self) -> Result<()> {
+        let mut is_healthy = true;
+        let mut failed_services = Vec::new();
+        for service in &self.config.service_checks {
+            let service_status = self.healthcheck.check(service)?;
+            if !service_status.is_healthy {
+                is_healthy = false;
+                match service_status.exit_code {
+                    None => failed_services.push(service.clone()),
+                    Some(exit_code) => {
+                        failed_services.push(format!("{}:{}", service.as_str(), exit_code))
+                    }
+                }
+            }
+        }
+        let mut values = HashMap::new();
+        values.insert(String::from("is_healthy"), format!("{}", is_healthy));
+        // consistent ordering of failed services could be helpful when viewing raw records.
+        failed_services.sort();
+        values.insert(String::from("failed_services"), failed_services.join(","));
+        self.send("metricdog", "health_ping", Some(&values), None)?;
+        Ok(())
+    }
+
+    fn send_get_request(url: Url, timeout_sec: Option<u64>) -> Result<()> {
+        debug!("sending: {}", url.as_str());
+        let client = Client::builder()
+            .timeout(Duration::from_secs(
+                timeout_sec.unwrap_or(DEFAULT_TIMEOUT_SECONDS),
+            ))
+            .build()
+            .context(error::HttpClient { url: url.clone() })?;
+        let response = client
+            .get(url.clone())
+            .send()
+            .context(error::HttpSend { url: url.clone() })?;
+        response
+            .error_for_status()
+            .context(error::HttpResponse { url })?;
+        Ok(())
+    }
+}

--- a/sources/metricdog/src/metricdog_test.rs
+++ b/sources/metricdog/src/metricdog_test.rs
@@ -1,0 +1,162 @@
+use crate::config::Config;
+use crate::error::Result;
+use crate::metricdog::Metricdog;
+use crate::service_check::{ServiceCheck, ServiceHealth};
+use bottlerocket_release::BottlerocketRelease;
+use httptest::{matchers::*, responders::*, Expectation, Server};
+use tempfile::TempDir;
+
+const OS_RELEASE: &str = r#"NAME=Bottlerocket
+ID=bottlerocket
+PRETTY_NAME="Bottlerocket OS 0.4.0"
+VARIANT_ID=aws-k8s-1.16
+VERSION_ID=0.4.0
+BUILD_ID=7303622
+"#;
+
+fn os_release() -> BottlerocketRelease {
+    let td = TempDir::new().unwrap();
+    let path = td.path().join("os-release");
+    std::fs::write(&path, OS_RELEASE).unwrap();
+    BottlerocketRelease::from_file(&path).unwrap()
+}
+
+struct MockCheck {}
+
+impl ServiceCheck for MockCheck {
+    fn check(&self, service_name: &str) -> Result<ServiceHealth> {
+        if service_name.ends_with("fail1") {
+            Ok(ServiceHealth {
+                is_healthy: false,
+                exit_code: Some(1),
+            })
+        } else if service_name.ends_with("fail2") {
+            Ok(ServiceHealth {
+                is_healthy: false,
+                exit_code: Some(2),
+            })
+        } else {
+            Ok(ServiceHealth {
+                is_healthy: true,
+                exit_code: None,
+            })
+        }
+    }
+}
+
+#[test]
+fn send_healthy_ping() {
+    let server = Server::run();
+    let matcher = all_of![
+        request::method_path("GET", "/metrics"),
+        request::query(url_decoded(contains(("sender", "metricdog")))),
+        request::query(url_decoded(contains(("event", "health_ping")))),
+        request::query(url_decoded(contains(("version", "0.4.0")))),
+        request::query(url_decoded(contains(("variant", "aws-k8s-1.16")))),
+        request::query(url_decoded(contains(("arch", "x86_64")))),
+        request::query(url_decoded(contains(("region", "us-east-1")))),
+        request::query(url_decoded(contains(("seed", "2041")))),
+        request::query(url_decoded(contains(("failed_services", "")))),
+        request::query(url_decoded(contains(("is_healthy", "true")))),
+    ];
+    server.expect(Expectation::matching(matcher).respond_with(status_code(200)));
+    let port = server.addr().port();
+    let metricdog = Metricdog::from_parts(
+        Config {
+            metrics_url: format!("http://localhost:{}/metrics", port),
+            send_metrics: true,
+            service_checks: vec![
+                String::from("service_a"),
+                String::from("service_b"),
+                String::from("service_c"),
+            ],
+            region: String::from("us-east-1"),
+            seed: 2041,
+            version_lock: String::from("latest"),
+            ignore_waves: false,
+        },
+        os_release(),
+        Box::new(MockCheck {}),
+    )
+    .unwrap();
+    metricdog.send_health_ping().unwrap();
+}
+
+#[test]
+fn send_unhealthy_ping() {
+    let server = Server::run();
+    let matcher = all_of![
+        request::method_path("GET", "/metrics"),
+        request::query(url_decoded(contains(("sender", "metricdog")))),
+        request::query(url_decoded(contains(("event", "health_ping")))),
+        request::query(url_decoded(contains(("version", "0.4.0")))),
+        request::query(url_decoded(contains(("variant", "aws-k8s-1.16")))),
+        request::query(url_decoded(contains(("arch", "x86_64")))),
+        request::query(url_decoded(contains(("region", "us-east-1")))),
+        request::query(url_decoded(contains(("seed", "2041")))),
+        request::query(url_decoded(contains((
+            "failed_services",
+            "service_afail2:2,service_cfail1:1"
+        )))),
+        request::query(url_decoded(contains(("is_healthy", "false")))),
+    ];
+    server.expect(Expectation::matching(matcher).respond_with(status_code(200)));
+    let port = server.addr().port();
+    let metricdog = Metricdog::from_parts(
+        Config {
+            metrics_url: format!("http://localhost:{}/metrics", port),
+            send_metrics: true,
+            // note that these are out-of-order sort order to ensure that failed services are sorted
+            // in the url.
+            service_checks: vec![
+                String::from("service_cfail1"),
+                String::from("service_afail2"),
+                String::from("service_b"),
+            ],
+            region: String::from("us-east-1"),
+            seed: 2041,
+            version_lock: String::from("latest"),
+            ignore_waves: false,
+        },
+        os_release(),
+        Box::new(MockCheck {}),
+    )
+    .unwrap();
+    metricdog.send_health_ping().unwrap();
+}
+
+#[test]
+fn send_boot_success() {
+    let server = Server::run();
+    let matcher = all_of![
+        request::method_path("GET", "/metrics"),
+        request::query(url_decoded(contains(("sender", "metricdog")))),
+        request::query(url_decoded(contains(("event", "boot_success")))),
+        request::query(url_decoded(contains(("version", "0.4.0")))),
+        request::query(url_decoded(contains(("variant", "aws-k8s-1.16")))),
+        request::query(url_decoded(contains(("arch", "x86_64")))),
+        request::query(url_decoded(contains(("region", "us-east-1")))),
+        request::query(url_decoded(contains(("seed", "2041")))),
+    ];
+    server.expect(Expectation::matching(matcher).respond_with(status_code(200)));
+    let port = server.addr().port();
+    let metricdog = Metricdog::from_parts(
+        Config {
+            metrics_url: format!("http://localhost:{}/metrics", port),
+            send_metrics: true,
+            service_checks: vec![
+                String::from("service_afail2"),
+                String::from("service_b"),
+                String::from("service_cfail1"),
+            ],
+            region: String::from("us-east-1"),
+            seed: 2041,
+            version_lock: String::from("latest"),
+            ignore_waves: false,
+        },
+        os_release(),
+        Box::new(MockCheck {}),
+    )
+    .unwrap();
+    metricdog.send_boot_success().unwrap();
+}

--- a/sources/metricdog/src/service_check.rs
+++ b/sources/metricdog/src/service_check.rs
@@ -1,0 +1,164 @@
+use crate::error::{self, Result};
+use log::trace;
+use snafu::ResultExt;
+use std::process::Command;
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct ServiceHealth {
+    /// Whether or not the service is healthy.
+    pub(crate) is_healthy: bool,
+    /// In the event of an unhealthy service, the service's exit code (if found).
+    pub(crate) exit_code: Option<i32>,
+}
+
+pub(crate) trait ServiceCheck {
+    /// Checks the given service to see if it is healthy.
+    fn check(&self, service_name: &str) -> Result<ServiceHealth>;
+}
+
+pub(crate) struct SystemdCheck {}
+
+impl ServiceCheck for SystemdCheck {
+    fn check(&self, service_name: &str) -> Result<ServiceHealth> {
+        if is_ok(service_name)? {
+            return Ok(ServiceHealth {
+                is_healthy: true,
+                exit_code: None,
+            });
+        }
+        Ok(ServiceHealth {
+            is_healthy: false,
+            exit_code: parse_service_exit_code(service_name)?,
+        })
+    }
+}
+
+struct Outcome {
+    exit: i32,
+    stdout: String,
+}
+
+impl Outcome {
+    fn is_exit_true(&self) -> bool {
+        self.exit == 0
+    }
+}
+
+fn systemctl(args: &[&str]) -> Result<Outcome> {
+    trace!("calling systemctl with '{:?}'", args);
+    let output = Command::new("systemctl")
+        .args(args)
+        .output()
+        .with_context(|| error::Command {
+            command: "systemctl",
+            args: args.iter().map(|&s| s.to_owned()).collect::<Vec<String>>(),
+        })?;
+    Ok(Outcome {
+        exit: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(output.stdout.as_slice()).into(),
+    })
+}
+
+fn is_active(service: &str) -> Result<bool> {
+    let outcome = systemctl(&["is-active", service])?;
+    Ok(outcome.is_exit_true())
+}
+
+fn is_failed(service: &str) -> Result<bool> {
+    let outcome = systemctl(&["is-failed", service])?;
+    Ok(outcome.is_exit_true())
+}
+
+fn is_ok(service: &str) -> Result<bool> {
+    Ok(!is_failed(service)? && is_active(service)?)
+}
+
+const STATUS_PROPERTY: &str = "ExecMainStatus";
+
+fn parse_service_exit_code(service: &str) -> Result<Option<i32>> {
+    // we don't check the command's exit code because systemctl returns non-zero codes for various
+    // non-exceptional execution outcomes.
+    let outcome = systemctl(&["show", "--property", STATUS_PROPERTY, service])?;
+    Ok(parse_stdout(&outcome.stdout))
+}
+
+fn parse_stdout(stdout: &str) -> Option<i32> {
+    trace!(
+        "parsing stdout from 'systemctl show --property {}':\n{}",
+        STATUS_PROPERTY,
+        stdout
+    );
+
+    // we expect the response to be formatted like this: ExecMainStatus=1\n
+    // we will split this at the equals sign, verify the left side and parse the right side.
+    let mut split = stdout.splitn(2, '=');
+
+    // verify that the returned property matches the expected/desired property
+    if split.next().unwrap_or("") != STATUS_PROPERTY {
+        return None;
+    }
+
+    // the iterator should now give us the exit code. if it does, we remove the trailing newline
+    // and parse it into an int. if we cannot parse it into an int, then we return None.
+    split
+        .next()
+        .and_then(|exit_code| exit_code.trim_end().parse::<i32>().ok())
+}
+
+#[test]
+fn parse_stdout_exit_0() {
+    let got = parse_stdout(format!("{}=0", STATUS_PROPERTY).as_str()).unwrap();
+    let want = 0;
+    assert_eq!(got, want);
+}
+
+#[test]
+fn parse_stdout_exit_255() {
+    let got = parse_stdout(format!("{}=255", STATUS_PROPERTY).as_str()).unwrap();
+    let want = 255;
+    assert_eq!(got, want);
+}
+
+#[test]
+fn parse_stdout_exit_0_with_newline() {
+    let got = parse_stdout(format!("{}=0\n", STATUS_PROPERTY).as_str()).unwrap();
+    let want = 0;
+    assert_eq!(got, want);
+}
+
+#[test]
+fn parse_stdout_exit_255_with_newline() {
+    let got = parse_stdout(format!("{}=255\n", STATUS_PROPERTY).as_str()).unwrap();
+    let want = 255;
+    assert_eq!(got, want);
+}
+
+#[test]
+fn parse_stdout_exit_extra_chars() {
+    let got = parse_stdout(format!("{}=255foo", STATUS_PROPERTY).as_str());
+    assert!(got.is_none());
+}
+
+#[test]
+fn parse_stdout_malformed() {
+    let got = parse_stdout(format!("{} = 123", STATUS_PROPERTY).as_str());
+    assert!(got.is_none());
+}
+
+#[test]
+fn parse_stdout_empty_string() {
+    let got = parse_stdout("");
+    assert!(got.is_none());
+}
+
+#[test]
+fn parse_stdout_property_only() {
+    let got = parse_stdout(STATUS_PROPERTY);
+    assert!(got.is_none());
+}
+
+#[test]
+fn parse_stdout_property_and_equals_only() {
+    let got = parse_stdout(format!("{}=", STATUS_PROPERTY).as_str());
+    assert!(got.is_none());
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -58,6 +58,25 @@ template-path = "/usr/share/templates/updog-toml"
 affected-services = ["updog"]
 seed.setting-generator = "bork seed"
 
+# Metrics
+
+[settings.metrics]
+# the URL to which anonymous health metrics will be sent
+metrics-url = "https://metrics.bottlerocket.aws/v1/metrics"
+# whether or not health metrics will be sent. set to false to opt-out
+send-metrics = true
+# the list of services that are checked to determine if a host is healthy,
+# overridden in each variant to list services critical to that variant
+service-checks = ["apiserver", "chronyd", "containerd", "host-containerd"]
+
+[services.metricdog]
+configuration-files = ["metricdog-toml"]
+restart-commands = []
+
+[configuration-files.metricdog-toml]
+path = "/etc/metricdog.toml"
+template-path = "/usr/share/templates/metricdog-toml"
+
 # HostContainers
 
 [services.host-containers]

--- a/sources/models/src/aws-dev/defaults.d/50-aws-dev.toml
+++ b/sources/models/src/aws-dev/defaults.d/50-aws-dev.toml
@@ -7,6 +7,11 @@ template-path = "/usr/share/templates/containerd-config-toml_aws-dev"
 restart-commands = ["/bin/systemctl try-restart docker.service"]
 configuration-files = ["proxy-env"]
 
+# Metrics
+[settings.metrics]
+send-metrics = false
+service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "docker"]
+
 # Network
 [metadata.settings.network]
 affected-services = ["containerd", "docker", "host-containerd"]

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, KernelSettings, NetworkSettings, NtpSettings, UpdatesSettings,
+    AwsSettings, ContainerImage, KernelSettings, MetricsSettings, NetworkSettings, NtpSettings,
+    UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -18,4 +19,5 @@ struct Settings {
     network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,
+    metrics: MetricsSettings,
 }

--- a/sources/models/src/aws-ecs-1/defaults.d/50-aws-ecs-1.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/50-aws-ecs-1.toml
@@ -24,6 +24,10 @@ allow-privileged-containers = false
 logging-drivers = ["json-file", "awslogs", "none"]
 loglevel = "info"
 
+# Metrics
+[settings.metrics]
+service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "docker", "ecs"]
+
 # Network
 [metadata.settings.network]
 affected-services = ["containerd", "docker", "ecs", "host-containerd"]

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, ECSSettings, KernelSettings, NetworkSettings, NtpSettings, UpdatesSettings,
+    AwsSettings, ContainerImage, ECSSettings, KernelSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -19,4 +20,5 @@ struct Settings {
     kernel: KernelSettings,
     aws: AwsSettings,
     ecs: ECSSettings,
+    metrics: MetricsSettings,
 }

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -37,6 +37,9 @@ affected-services = ["kubernetes", "containerd"]
 [settings.kubernetes]
 cluster-domain = "cluster.local"
 
+# Metrics
+[settings.metrics]
+service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kubelet"]
 
 # Network
 [metadata.settings.network]

--- a/sources/models/src/aws-k8s-1.15/mod.rs
+++ b/sources/models/src/aws-k8s-1.15/mod.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, KernelSettings, KubernetesSettings, NetworkSettings, NtpSettings,
-    UpdatesSettings,
+    AwsSettings, ContainerImage, KernelSettings, KubernetesSettings, MetricsSettings,
+    NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -20,4 +20,5 @@ struct Settings {
     network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,
+    metrics: MetricsSettings,
 }

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -176,6 +176,14 @@ struct AwsSettings {
     region: SingleLineString,
 }
 
+// Metrics settings
+#[model]
+struct MetricsSettings {
+    metrics_url: Url,
+    send_metrics: bool,
+    service_checks: Vec<String>,
+}
+
 ///// Internal services
 
 // Note: Top-level objects that get returned from the API should have a "rename" attribute


### PR DESCRIPTION
## Issue Number

Closes #1000 

## Description

Adds a program and systemd service that checks whether certain critical services are running. Reports this to a URL via GET request.

## Testing

### Unit Testing

I organized the code in such a way as to facilitate unit testing everything except the calls to systemctl. 

### Happy Integ

I set up an S3 bucket and confirmed that metricdog requests are working. I ran metricdog manually from the command line under various scenarious and traced the URL that was produced.

#### Healthy Health Ping

```sh
metricdog --log-level trace send-health-ping
```

Result:

```text
https://somedomain.com/metricstest?sender=metricdog&event=health-ping&version=0.4.1&variant=aws-k8s-1.15&arch=x86_64&region=us-west-2&seed=1712&version-lock=latest&ignore-waves=false&failed_services=&is_healthy=true
```

#### Boot Success

```sh
metricdog --log-level trace send-boot-success
```

```text
https://somedomain.com/metricstest?sender=metricdog&event=boot-success&version=0.4.1&variant=aws-k8s-1.15&arch=x86_64&region=us-west-2&seed=1712&version-lock=latest&ignore-waves=false
```

#### One Failed Service

I 'broke' kubelet and ran a health ping, and received:

```text
https://somedomain.com/metricstest?sender=metricdog&event=health-ping&version=0.4.1&variant=aws-k8s-1.15&arch=x86_64&region=us-west-2&seed=1712&version-lock=latest&ignore-waves=false&failed_services=kubelet%3A255&is_healthy=false
```

The failed services list de-escapes to `kubelet:255`

#### Two Failed Services

I 'broke' an additional service:

```text
https://somedomain.com/metricstest?sender=metricdog&event=health-ping&version=0.4.1&variant=aws-k8s-1.15&arch=x86_64&region=us-west-2&seed=1605&version-lock=latest&ignore-waves=false&failed_services=containerd%3A1%2Ckubelet%3A255&is_healthy=false
```

The failed services list de-escapes to `containerd:1,kubelet:255`.

### Bad URL Integ

To make sure that a bad URL doesn't cause problems, I ran an instance with a fake URL. I found that that, send-boot-success and send-health-ping each caused an error to be reported in the system journal, but no other ill affects were observed.

### Systemd

I ran hosts and observed that the systemd unit and timer work as expected.

**Edit 8/28/2020**: I tested an ECS variant with `ab6930c` and found the the URLs are still being constructed properly, including the reporting of failed services.

### Migration

I tested the migration through upgrade and downgrade, confirming that settings were added/removed and the system was healthy at all three waypoints.

## Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
