### PR TITLE
aws-ecs-1: enable task IAM role support

### DIFF
--- a/sources/api/ecs-settings-applier/src/main.rs
+++ b/sources/api/ecs-settings-applier/src/main.rs
@@ -33,6 +33,12 @@ struct ECSConfig {
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     available_logging_drivers: Vec<String>,
+
+    #[serde(rename = "TaskIAMRoleEnabled")]
+    task_iam_role_enabled: bool,
+
+    #[serde(rename = "TaskIAMRoleEnabledForNetworkHost")]
+    task_iam_role_enabled_for_network_host: bool,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -67,6 +73,10 @@ fn run() -> Result<()> {
             .iter()
             .map(|s| s.to_string())
             .collect(),
+
+        // Task role support is always enabled
+        task_iam_role_enabled: true,
+        task_iam_role_enabled_for_network_host: true,
         ..Default::default()
     };
     if let Some(os) = settings.os {


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/815


**Description of changes:**
This change enables the task role capabilities so Bottlerocket instances become eligible for placement for tasks with roles.


**Testing done:**
Launched a new Bottlerocket instance.  Saw the following capabilities registered successfully:
* `com.amazonaws.ecs.capability.task-iam-role-network-host`
* `com.amazonaws.ecs.capability.task-iam-role`

Ran two tasks using task roles, one in the `bridge` (default) network mode and the other in `host` (requires the `task-iam-role-network-host` capability).  Observed that the containers were able to use the role and successfully make API calls requiring permissions that were not in the instance's role.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
