### PR TITLE
aws-ecs-1: enable SELinux capability

### DIFF
--- a/sources/api/ecs-settings-applier/README.md
+++ b/sources/api/ecs-settings-applier/README.md
@@ -7,7 +7,8 @@ Current version: 0.1.0
 ecs-settings-applier generates a configuration file for the ECS agent from Bottlerocket settings.
 
 The configuration file for ECS is a JSON-formatted document with conditionally-defined keys and
-embedded lists.
+embedded lists.  The structure and names of fields in the document can be found
+[here](https://github.com/aws/amazon-ecs-agent/blob/a250409cf5eb4ad84a7b889023f1e4d2e274b7ab/agent/config/types.go).
 
 ## Colophon
 

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -4,7 +4,8 @@
 ecs-settings-applier generates a configuration file for the ECS agent from Bottlerocket settings.
 
 The configuration file for ECS is a JSON-formatted document with conditionally-defined keys and
-embedded lists.
+embedded lists.  The structure and names of fields in the document can be found
+[here](https://github.com/aws/amazon-ecs-agent/blob/a250409cf5eb4ad84a7b889023f1e4d2e274b7ab/agent/config/types.go).
 */
 use log::debug;
 use serde::Serialize;

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -38,6 +38,9 @@ struct ECSConfig {
 
     #[serde(rename = "TaskIAMRoleEnabledForNetworkHost")]
     task_iam_role_enabled_for_network_host: bool,
+
+    #[serde(rename = "SELinuxCapable")]
+    selinux_capable: bool,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -76,6 +79,9 @@ fn run() -> Result<()> {
         // Task role support is always enabled
         task_iam_role_enabled: true,
         task_iam_role_enabled_for_network_host: true,
+
+        // SELinux is always available
+        selinux_capable: true,
         ..Default::default()
     };
     if let Some(os) = settings.os {


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/815


**Description of changes:**
Configure the ECS agent to register the SELinux capability so SELinux options can be set in the task definition:

```
"dockerSecurityOptions": [
    "label:type:super_t"
]
```


**Testing done:**
* Ran a task through ECS with a restricted host path (`/etc`) mounted and no explicit SELinux options.  Observed that the container received the default `container_t` label and that it cannot write to the `/etc` bind-mount.
* Ran a task through ECS with a restricted host path (`/etc`) mounted and the `super_t` label assigned in the task definition.  Observed that the container received the `super_t` label and that it can write to the `/etc` bind-mount.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
