### PR TITLE
pubsys: add AMI registration/copying

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -33,6 +33,14 @@ PUBLISH_REPO = "default"
 # Default signing key to use from PUBLISH_INFRA_CONFIG_PATH
 PUBLISH_KEY = "default"
 
+# The size in GiB of the data volume in the block device mapping of registered
+# AMIs.  (You can also specify PUBLISH_ROOT_VOLUME_SIZE to override the root
+# volume size; by default it's the image size, rounded up.)
+PUBLISH_DATA_VOLUME_SIZE = "20"
+# You can also set PUBLISH_REGIONS to override the list of regions for AMIs
+# from Infra.toml; it's a comma-separated list like "us-west-2,us-east-1".
+# You can also set NO_PROGRESS to not print progress bars during snapshot upload.
+
 # Disallow pulling directly Upstream URLs when lookaside cache results in MISSes as a fallback.
 # To use the upstream source as fallback, override this on the command line and set it to 'true'
 BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"
@@ -72,6 +80,8 @@ BUILDSYS_NAME_FULL="${BUILDSYS_NAME_VARIANT}-${BUILDSYS_VERSION_FULL}"
 # Repo directories have subdirectories for variant/arch, so we only want version here.
 PUBLISH_REPO_BASE_DIR = "${BUILDSYS_BUILD_DIR}/repos"
 PUBLISH_REPO_OUTPUT_DIR = "${PUBLISH_REPO_BASE_DIR}/${BUILDSYS_NAME_VERSION}"
+# The name of registered AMIs.
+PUBLISH_AMI_NAME = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
 
 [tasks.setup]
 script = [
@@ -318,6 +328,58 @@ pubsys \
    --outdir "${PUBLISH_REPO_OUTPUT_DIR}"
 
 ln -sfn "${PUBLISH_REPO_OUTPUT_DIR##*/}" "${PUBLISH_REPO_BASE_DIR}/latest"
+'''
+]
+
+[tasks.ami]
+dependencies = ["build"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+cleanup() {
+   [ -f "${root_image}" ] && rm -f "${root_image}"
+   [ -f "${data_image}" ] && rm -f "${data_image}"
+}
+trap 'cleanup' EXIT
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+# Canonicalize architecture identifier to the value recognized by EC2.
+case "${BUILDSYS_ARCH,,}" in
+   arm64|aarch64)
+      arch=arm64 ;;
+   x86_64|amd64)
+      arch=x86_64 ;;
+   *)
+      arch="${BUILDSYS_ARCH}" ;;
+esac
+
+# Unlz4 the root / data images
+rootlz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.img.lz4"
+root_image="${rootlz4%.lz4}"
+lz4 -df "${rootlz4}" "${root_image}"
+
+datalz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-data.img.lz4"
+data_image="${datalz4%.lz4}"
+lz4 -df "${datalz4}" "${data_image}"
+
+pubsys \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   \
+   ami \
+   \
+   --root-image "${root_image}" \
+   --data-image "${data_image}" \
+   ${PUBLISH_ROOT_VOLUME_SIZE:+--root-volume-size "${PUBLISH_ROOT_VOLUME_SIZE}"} \
+   --data-volume-size "${PUBLISH_DATA_VOLUME_SIZE}" \
+   \
+   --arch "${arch}" \
+   --name "${PUBLISH_AMI_NAME}" \
+   --description "${PUBLISH_AMI_DESCRIPTION:-${PUBLISH_AMI_NAME}}" \
+   ${NO_PROGRESS:+--no-progress} \
+   ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"}
 '''
 ]
 

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -40,6 +40,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
+name = "argh"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1877e24cecacd700d469066e0160c4f8497cc5635367163f50c8beec820154"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e742194e0f43fc932bcb801708c2b279d3ec8f527e3acda05a6a9f342c5ef764"
+dependencies = [
+ "argh_shared",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ba68f4276a778591e36a0c348a269888f3a177c8d2054969389e3b59611ff5"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +293,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "coldsnap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89fd66a760caaf8647b3e60a068a03f4adee0091338c69b05a46d263e9efa3bd"
+dependencies = [
+ "argh",
+ "base64 0.12.3",
+ "bytes",
+ "futures",
+ "indicatif",
+ "rusoto_core 0.45.0",
+ "rusoto_credential 0.45.0",
+ "rusoto_ebs",
+ "rusoto_ec2",
+ "rusoto_signature 0.45.0",
+ "sha2 0.9.1",
+ "snafu",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "console"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "termios",
+ "unicode-width",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,7 +386,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
- "subtle",
+ "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -391,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +503,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -629,8 +737,18 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.7.0",
  "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -719,6 +837,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +868,18 @@ checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
 ]
 
 [[package]]
@@ -908,6 +1051,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+
+[[package]]
 name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,10 +1156,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_pipe"
@@ -1063,6 +1257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,12 +1317,22 @@ dependencies = [
 name = "pubsys"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
+ "coldsnap",
+ "futures",
+ "indicatif",
  "lazy_static",
  "log",
  "parse-datetime",
  "reqwest",
+ "rusoto_core 0.45.0",
+ "rusoto_credential 0.45.0",
+ "rusoto_ebs",
+ "rusoto_ec2",
+ "rusoto_signature 0.45.0",
+ "rusoto_sts",
  "semver 0.10.0",
  "serde",
  "serde_json",
@@ -1130,6 +1340,7 @@ dependencies = [
  "snafu",
  "structopt",
  "tempfile",
+ "tokio",
  "toml",
  "tough",
  "tough-ssm",
@@ -1292,7 +1503,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes",
  "futures",
- "hmac",
+ "hmac 0.7.1",
  "http",
  "hyper",
  "hyper-rustls 0.20.0",
@@ -1301,12 +1512,40 @@ dependencies = [
  "md5",
  "percent-encoding",
  "pin-project",
- "rusoto_credential",
- "rusoto_signature",
+ "rusoto_credential 0.44.0",
+ "rusoto_signature 0.44.0",
  "rustc_version",
  "serde",
  "serde_json",
  "sha2 0.8.2",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_core"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e977941ee0658df96fca7291ecc6fc9a754600b21ad84b959eb1dbbc9d5abcc7"
+dependencies = [
+ "async-trait",
+ "base64 0.12.3",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "lazy_static",
+ "log",
+ "md5",
+ "percent-encoding",
+ "pin-project",
+ "rusoto_credential 0.45.0",
+ "rusoto_signature 0.45.0",
+ "rustc_version",
+ "serde",
+ "serde_json",
  "tokio",
  "xml-rs",
 ]
@@ -1332,6 +1571,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_credential"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac05563f83489b19b4d413607a30821ab08bbd9007d14fa05618da3ef09d8b"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs",
+ "futures",
+ "hyper",
+ "pin-project",
+ "regex",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "rusoto_ebs"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4b9c1321c10ac639bb285e46bc558d24937b1744183c0da17f1acc752fe01c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core 0.45.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "rusoto_ec2"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5145366791ba9097d917330944ef460e1ebd67da871a8e04ad9f51cecc64375f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core 0.45.0",
+ "serde_urlencoded",
+ "xml-rs",
+]
+
+[[package]]
 name = "rusoto_signature"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,17 +1629,42 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.7.1",
  "http",
  "hyper",
  "log",
  "md5",
  "percent-encoding",
  "pin-project",
- "rusoto_credential",
+ "rusoto_credential 0.44.0",
  "rustc_version",
  "serde",
  "sha2 0.8.2",
+ "time 0.2.16",
+ "tokio",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a740a88dde8ded81b6f2cff9cd5e054a5a2e38a38397260f7acdd2c85d17dd"
+dependencies = [
+ "base64 0.12.3",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac 0.8.1",
+ "http",
+ "hyper",
+ "log",
+ "md5",
+ "percent-encoding",
+ "pin-project",
+ "rusoto_credential 0.45.0",
+ "rustc_version",
+ "serde",
+ "sha2 0.9.1",
  "time 0.2.16",
  "tokio",
 ]
@@ -1365,9 +1678,25 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "rusoto_core",
+ "rusoto_core 0.44.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3815b8c0fc1c50caf9e87603f23daadfedb18d854de287b361c69f68dc9d49e0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "rusoto_core 0.45.0",
+ "serde_urlencoded",
+ "tempfile",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1779,6 +2108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
+name = "subtle"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+
+[[package]]
 name = "syn"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +2145,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1944,6 +2298,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,8 +2359,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e670640f67e719671a87fac948eabba0fd33633aa8be7804b38a1a1d2da32b"
 dependencies = [
- "rusoto_core",
- "rusoto_credential",
+ "rusoto_core 0.44.0",
+ "rusoto_credential 0.44.0",
  "rusoto_ssm",
  "serde",
  "serde_json",
@@ -2122,6 +2486,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -7,19 +7,30 @@ edition = "2018"
 publish = false
 
 [dependencies]
+async-trait = "0.1.36"
 chrono = "0.4"
 clap = "2.33"
+coldsnap = "0.1"
+futures = "0.3.5"
+indicatif = "0.15.0"
 lazy_static = "1.4"
 log = "0.4"
 parse-datetime = { path = "../../sources/parse-datetime" }
 # Need to bring in reqwest with a TLS feature so tough can support TLS repos.
 reqwest = { version = "0.10.1", default-features = false, features = ["rustls-tls", "blocking"] }
+rusoto_core = "0.45.0"
+rusoto_credential = "0.45.0"
+rusoto_ebs = "0.45.0"
+rusoto_ec2 = "0.45.0"
+rusoto_signature = "0.45.0"
+rusoto_sts = "0.45.0"
 simplelog = "0.8"
 snafu = "0.6"
 semver = "0.10.0"
 serde = { version = "1.0", features = ["derive"]  }
 serde_json = "1.0"
 structopt = { version = "0.3", default-features = false  }
+tokio = "0.2.21"
 toml = "0.5"
 tough = { version = "0.8", features = ["http"] }
 tough-ssm = "0.3"

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -26,3 +26,20 @@ signing_keys = { default = { file = { path = "/home/user/key.pem" } } }
 [repo.default]
 # metadata_base_url = "https://example.com/metadata/"
 # targets_url = "https://example.com/targets/"
+
+[aws]
+# The list of regions in which you want to publish AMIs. We register an AMI in
+# the first region and copy it to all other regions.
+regions = ["us-west-2", "us-east-1", "us-east-2"]
+# If specified, we use this named profile from ~/.aws/credentials, rather than
+# the default path of trying credentials from the environment, from a
+# credential process, from the default profile, and then from an IAM instance
+# profile.
+profile = "my-profile"
+# If specified, we assume this role before making any API calls.
+role = "arn:aws:iam::012345678901:role/assume-global"
+
+[aws.region.us-west-2]
+# If specified, we assume this role before making any API calls in this region.
+# (This is assumed after the "global" aws.role, if that is also specified.)
+role = "arn:aws:iam::012345678901:role/assume-regional"

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -1,0 +1,324 @@
+//! The ami module owns the 'ami' subcommand and controls the process of registering and copying
+//! EC2 AMIs.
+
+mod register;
+mod snapshot;
+mod wait;
+
+use crate::aws::client::build_client;
+use crate::config::{AwsConfig, InfraConfig};
+use crate::Args;
+use futures::future::{join, lazy, ready, FutureExt};
+use futures::stream::{self, StreamExt};
+use log::{error, info, trace};
+use register::{get_ami_id, register_image};
+use rusoto_core::{Region, RusotoError};
+use rusoto_ebs::EbsClient;
+use rusoto_ec2::{CopyImageError, CopyImageRequest, CopyImageResult, Ec2, Ec2Client};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
+use structopt::StructOpt;
+use wait::wait_for_ami;
+
+/// Builds Bottlerocket AMIs using latest build artifacts
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct AmiArgs {
+    /// Path to the image containing the root volume
+    #[structopt(short = "r", long, parse(from_os_str))]
+    root_image: PathBuf,
+
+    /// Path to the image containing the data volume
+    #[structopt(short = "d", long, parse(from_os_str))]
+    data_image: PathBuf,
+
+    /// Desired root volume size in gibibytes
+    #[structopt(long)]
+    root_volume_size: Option<i64>,
+
+    /// Desired data volume size in gibibytes
+    #[structopt(long)]
+    data_volume_size: i64,
+
+    /// The architecture of the machine image
+    #[structopt(short = "a", long)]
+    arch: String,
+
+    /// The desired AMI name
+    #[structopt(short = "n", long)]
+    name: String,
+
+    /// The desired AMI description
+    #[structopt(long)]
+    description: Option<String>,
+
+    /// Don't display progress bars
+    #[structopt(long)]
+    no_progress: bool,
+
+    /// Regions where you want the AMI, the first will be used as the base for copying
+    #[structopt(long, use_delimiter = true)]
+    regions: Vec<String>,
+}
+
+/// Common entrypoint from main()
+pub(crate) async fn run(args: &Args, ami_args: &AmiArgs) -> Result<()> {
+    info!(
+        "Using infra config from path: {}",
+        args.infra_config_path.display()
+    );
+    let infra_config = InfraConfig::from_path(&args.infra_config_path).context(error::Config)?;
+    trace!("Parsed infra config: {:?}", infra_config);
+
+    let aws = infra_config.aws.context(error::MissingConfig {
+        missing: "aws section",
+    })?;
+
+    // If the user gave an override list of regions, use that, otherwise use what's in the config.
+    let mut regions = if !ami_args.regions.is_empty() {
+        VecDeque::from(ami_args.regions.clone())
+    } else {
+        aws.regions.clone()
+    }
+    .into_iter()
+    .map(|name| region_from_string(&name, &aws))
+    .collect::<Result<VecDeque<Region>>>()?;
+
+    // We register in this base region first, then copy from there to any other regions.
+    let base_region = regions.pop_front().context(error::MissingConfig {
+        missing: "aws.regions",
+    })?;
+
+    // Build EBS client for snapshot management, and EC2 client for registration
+    let ebs_client = build_client::<EbsClient>(&base_region, &aws).context(error::Client {
+        client_type: "EBS",
+        region: base_region.name(),
+    })?;
+    let ec2_client = build_client::<Ec2Client>(&base_region, &aws).context(error::Client {
+        client_type: "EC2",
+        region: base_region.name(),
+    })?;
+
+    // Check if the AMI already exists, in which case we can use the existing ID, otherwise we
+    // register a new one.
+    let maybe_id = get_ami_id(
+        &ami_args.name,
+        &ami_args.arch,
+        base_region.name(),
+        &ec2_client,
+    )
+    .await
+    .context(error::GetAmiId {
+        name: &ami_args.name,
+        arch: &ami_args.arch,
+        region: base_region.name(),
+    })?;
+
+    let (image_id, already_registered) = if let Some(found_id) = maybe_id {
+        info!(
+            "Found '{}' already registered in {}: {}",
+            ami_args.name,
+            base_region.name(),
+            found_id
+        );
+        (found_id, true)
+    } else {
+        let new_id = register_image(ami_args, base_region.name(), ebs_client, &ec2_client)
+            .await
+            .context(error::RegisterImage {
+                name: &ami_args.name,
+                arch: &ami_args.arch,
+                region: base_region.name(),
+            })?;
+        info!(
+            "Registered AMI '{}' in {}: {}",
+            ami_args.name,
+            base_region.name(),
+            new_id
+        );
+        (new_id, false)
+    };
+
+    // If we don't need to copy AMIs, we're done.
+    if regions.is_empty() {
+        return Ok(());
+    }
+
+    // Wait for AMI to be available so it can be copied
+    let successes_required = if already_registered { 1 } else { 3 };
+    wait_for_ami(
+        &image_id,
+        &base_region,
+        "available",
+        successes_required,
+        &aws,
+    )
+    .await
+    .context(error::WaitAmi {
+        id: &image_id,
+        region: base_region.name(),
+    })?;
+
+    // For every other region, initiate copy-image calls.
+    // We make a map storing our regional clients because they're used in a future and need to
+    // live until the future is resolved.
+    let mut ec2_clients = HashMap::with_capacity(regions.len());
+    for region in regions.iter() {
+        let ec2_client = build_client::<Ec2Client>(&region, &aws).context(error::Client {
+            client_type: "EC2",
+            region: base_region.name(),
+        })?;
+        ec2_clients.insert(region.clone(), ec2_client);
+    }
+
+    let mut copy_requests = Vec::with_capacity(regions.len());
+    for region in regions.iter() {
+        let ec2_client = &ec2_clients[region];
+        if let Some(id) = get_ami_id(&ami_args.name, &ami_args.arch, region.name(), ec2_client)
+            .await
+            .context(error::GetAmiId {
+                name: &ami_args.name,
+                arch: &ami_args.arch,
+                region: base_region.name(),
+            })?
+        {
+            info!(
+                "Found '{}' already registered in {}: {}",
+                ami_args.name,
+                region.name(),
+                id
+            );
+            continue;
+        }
+        let request = CopyImageRequest {
+            description: ami_args.description.clone(),
+            name: ami_args.name.clone(),
+            source_image_id: image_id.clone(),
+            source_region: base_region.name().to_string(),
+            ..Default::default()
+        };
+        let response_future = ec2_client.copy_image(request);
+
+        let base_region_name = base_region.name();
+        // Store the region so we can output it to the user
+        let region_future = ready(region.clone());
+        // Let the user know the copy is starting, when this future goes to run
+        let message_future = lazy(move |_| {
+            info!(
+                "Starting copy from {} to {}",
+                base_region_name,
+                region.name()
+            )
+        });
+        copy_requests.push(message_future.then(|_| join(region_future, response_future)));
+    }
+
+    // If all target regions already have the AMI, we're done.
+    if copy_requests.is_empty() {
+        return Ok(());
+    }
+
+    // Start requests; they return almost immediately and the copying work is done by the service
+    // afterward.  You should wait for the AMI status to be "available" before launching it.
+    // (We still use buffer_unordered, rather than something like join_all, to retain some control
+    // over the number of requests going out in case we need it later, but this will effectively
+    // spin through all regions quickly because the requests return before any copying is done.)
+    let request_stream = stream::iter(copy_requests).buffer_unordered(4);
+    // Run through the stream and collect results into a list.
+    let copy_responses: Vec<(
+        Region,
+        std::result::Result<CopyImageResult, RusotoError<CopyImageError>>,
+    )> = request_stream.collect().await;
+
+    // Report on successes and errors; don't fail immediately if we see an error so we can report
+    // all successful IDs.
+    let mut saw_error = false;
+    for (region, copy_response) in copy_responses {
+        match copy_response {
+            Ok(success) => info!(
+                "Registered AMI '{}' in region {}: {}",
+                ami_args.name,
+                region.name(),
+                success.image_id.unwrap_or_else(|| "<missing>".to_string())
+            ),
+            Err(e) => {
+                saw_error = true;
+                error!("Copy to {} failed: {}", region.name(), e);
+            }
+        }
+    }
+
+    ensure!(!saw_error, error::AmiCopy);
+
+    Ok(())
+}
+
+/// Builds a Region from the given region name, and uses the custom endpoint from the AWS config,
+/// if specified in aws.region.REGION.endpoint.
+fn region_from_string(name: &str, aws: &AwsConfig) -> Result<Region> {
+    let maybe_endpoint = aws.region.get(name).and_then(|r| r.endpoint.clone());
+    Ok(match maybe_endpoint {
+        Some(endpoint) => Region::Custom {
+            name: name.to_string(),
+            endpoint,
+        },
+        None => name.parse().context(error::ParseRegion { name })?,
+    })
+}
+
+mod error {
+    use crate::aws::{self, ami};
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Some AMIs failed to copy, see above"))]
+        AmiCopy,
+
+        #[snafu(display("Error creating {} client in {}: {}", client_type, region, source))]
+        Client {
+            client_type: String,
+            region: String,
+            source: aws::client::Error,
+        },
+
+        #[snafu(display("Error reading config: {}", source))]
+        Config { source: crate::config::Error },
+
+        #[snafu(display("Error getting AMI ID for {} {} in {}: {}", arch, name, region, source))]
+        GetAmiId {
+            name: String,
+            arch: String,
+            region: String,
+            source: ami::register::Error,
+        },
+
+        #[snafu(display("Infra.toml is missing {}", missing))]
+        MissingConfig { missing: String },
+
+        #[snafu(display("Failed to parse region '{}': {}", name, source))]
+        ParseRegion {
+            name: String,
+            source: rusoto_signature::region::ParseRegionError,
+        },
+
+        #[snafu(display("Error registering {} {} in {}: {}", arch, name, region, source))]
+        RegisterImage {
+            name: String,
+            arch: String,
+            region: String,
+            source: ami::register::Error,
+        },
+
+        #[snafu(display("AMI '{}' in {} did not become available: {}", id, region, source))]
+        WaitAmi {
+            id: String,
+            region: String,
+            source: ami::wait::Error,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ami/register.rs
+++ b/tools/pubsys/src/aws/ami/register.rs
@@ -1,0 +1,256 @@
+use super::{snapshot::snapshot_from_image, AmiArgs};
+use coldsnap::{SnapshotUploader, SnapshotWaiter};
+use log::{debug, info, warn};
+use rusoto_ebs::EbsClient;
+use rusoto_ec2::{
+    BlockDeviceMapping, DeleteSnapshotRequest, DescribeImagesRequest, EbsBlockDevice, Ec2,
+    Ec2Client, Filter, RegisterImageRequest,
+};
+use snafu::{ensure, OptionExt, ResultExt};
+
+const ROOT_DEVICE_NAME: &str = "/dev/xvda";
+const DATA_DEVICE_NAME: &str = "/dev/xvdb";
+
+// Features we assume/enable for the images.
+const VIRT_TYPE: &str = "hvm";
+const VOLUME_TYPE: &str = "gp2";
+const SRIOV: &str = "simple";
+const ENA: bool = true;
+
+/// Helper for `register_image`.  Inserts registered snapshot IDs into `cleanup_snapshot_ids` so
+/// they can be cleaned up on failure if desired.
+async fn _register_image(
+    ami_args: &AmiArgs,
+    region: &str,
+    ebs_client: EbsClient,
+    ec2_client: &Ec2Client,
+    cleanup_snapshot_ids: &mut Vec<String>,
+) -> Result<String> {
+    debug!(
+        "Uploading root and data images into EBS snapshots in {}",
+        region
+    );
+    let uploader = SnapshotUploader::new(ebs_client);
+    let root_snapshot = snapshot_from_image(
+        &ami_args.root_image,
+        &uploader,
+        ami_args.root_volume_size,
+        ami_args.no_progress,
+    )
+    .await
+    .context(error::Snapshot {
+        path: &ami_args.root_image,
+        region,
+    })?;
+    cleanup_snapshot_ids.push(root_snapshot.clone());
+
+    let data_snapshot = snapshot_from_image(
+        &ami_args.data_image,
+        &uploader,
+        Some(ami_args.data_volume_size),
+        ami_args.no_progress,
+    )
+    .await
+    .context(error::Snapshot {
+        path: &ami_args.root_image,
+        region,
+    })?;
+    cleanup_snapshot_ids.push(data_snapshot.clone());
+
+    debug!(
+        "Waiting for root and data snapshots to become available in {}",
+        region
+    );
+    let waiter = SnapshotWaiter::new(ec2_client.clone());
+    waiter
+        .wait(&root_snapshot, Default::default())
+        .await
+        .context(error::WaitSnapshot {
+            snapshot_type: "root",
+        })?;
+    waiter
+        .wait(&data_snapshot, Default::default())
+        .await
+        .context(error::WaitSnapshot {
+            snapshot_type: "data",
+        })?;
+
+    // Prepare parameters for AMI registration request
+    let root_bdm = BlockDeviceMapping {
+        device_name: Some(ROOT_DEVICE_NAME.to_string()),
+        ebs: Some(EbsBlockDevice {
+            delete_on_termination: Some(true),
+            snapshot_id: Some(root_snapshot),
+            volume_type: Some(VOLUME_TYPE.to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let mut data_bdm = root_bdm.clone();
+    data_bdm.device_name = Some(DATA_DEVICE_NAME.to_string());
+    if let Some(ebs) = data_bdm.ebs.as_mut() {
+        ebs.snapshot_id = Some(data_snapshot);
+    }
+
+    let register_request = RegisterImageRequest {
+        architecture: Some(ami_args.arch.clone()),
+        block_device_mappings: Some(vec![root_bdm, data_bdm]),
+        description: ami_args.description.clone(),
+        ena_support: Some(ENA),
+        name: ami_args.name.clone(),
+        root_device_name: Some(ROOT_DEVICE_NAME.to_string()),
+        sriov_net_support: Some(SRIOV.to_string()),
+        virtualization_type: Some(VIRT_TYPE.to_string()),
+        ..Default::default()
+    };
+
+    debug!("Registering AMI in {}", region);
+    let register_response = ec2_client
+        .register_image(register_request)
+        .await
+        .context(error::RegisterImage { region })?;
+
+    register_response
+        .image_id
+        .context(error::MissingImageId { region })
+}
+
+/// Uploads the given images into snapshots and registers an AMI using them as its block device
+/// mapping.  Deletes snapshots on failure.
+pub(crate) async fn register_image(
+    ami_args: &AmiArgs,
+    region: &str,
+    ebs_client: EbsClient,
+    ec2_client: &Ec2Client,
+) -> Result<String> {
+    info!("Registering '{}' in {}", ami_args.name, region);
+    let mut cleanup_snapshot_ids = Vec::new();
+    let register_result = _register_image(
+        ami_args,
+        region,
+        ebs_client,
+        ec2_client,
+        &mut cleanup_snapshot_ids,
+    )
+    .await;
+
+    if let Err(_) = register_result {
+        for snapshot_id in cleanup_snapshot_ids {
+            let delete_request = DeleteSnapshotRequest {
+                snapshot_id: snapshot_id.clone(),
+                ..Default::default()
+            };
+            if let Err(e) = ec2_client.delete_snapshot(delete_request).await {
+                warn!(
+                    "While cleaning up, failed to delete snapshot {}: {}",
+                    snapshot_id, e
+                );
+            }
+        }
+    }
+    register_result
+}
+
+/// Queries EC2 for the given AMI name. If found, returns Ok(Some(id)), if not returns Ok(None).
+pub(crate) async fn get_ami_id<S1, S2>(
+    name: S1,
+    arch: S2,
+    region: &str,
+    ec2_client: &Ec2Client,
+) -> Result<Option<String>>
+where
+    S1: Into<String>,
+    S2: Into<String>,
+{
+    let describe_request = DescribeImagesRequest {
+        owners: Some(vec!["self".to_string()]),
+        filters: Some(vec![
+            Filter {
+                name: Some("name".to_string()),
+                values: Some(vec![name.into()]),
+            },
+            Filter {
+                name: Some("architecture".to_string()),
+                values: Some(vec![arch.into()]),
+            },
+            Filter {
+                name: Some("image-type".to_string()),
+                values: Some(vec!["machine".to_string()]),
+            },
+            Filter {
+                name: Some("virtualization-type".to_string()),
+                values: Some(vec![VIRT_TYPE.to_string()]),
+            },
+        ]),
+        ..Default::default()
+    };
+    let describe_response = ec2_client
+        .describe_images(describe_request)
+        .await
+        .context(error::DescribeImages { region })?;
+    if let Some(mut images) = describe_response.images {
+        if images.is_empty() {
+            return Ok(None);
+        }
+        ensure!(
+            images.len() == 1,
+            error::MultipleImages {
+                images: images
+                    .into_iter()
+                    .map(|i| i.image_id.unwrap_or_else(|| "<missing>".to_string()))
+                    .collect::<Vec<_>>()
+            }
+        );
+        let image = images.remove(0);
+        // If there is an image but we couldn't find the ID of it, fail rather than returning None,
+        // which would indicate no image.
+        let id = image.image_id.context(error::MissingImageId { region })?;
+        Ok(Some(id))
+    } else {
+        Ok(None)
+    }
+}
+
+mod error {
+    use crate::aws::ami;
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Failed to describe images in {}: {}", region, source))]
+        DescribeImages {
+            region: String,
+            source: rusoto_core::RusotoError<rusoto_ec2::DescribeImagesError>,
+        },
+
+        #[snafu(display("Image response in {} did not include image ID", region))]
+        MissingImageId { region: String },
+
+        #[snafu(display("DescribeImages with unique filters returned multiple results: {}", images.join(", ")))]
+        MultipleImages { images: Vec<String> },
+
+        #[snafu(display("Failed to register image in {}: {}", region, source))]
+        RegisterImage {
+            region: String,
+            source: rusoto_core::RusotoError<rusoto_ec2::RegisterImageError>,
+        },
+
+        #[snafu(display("Failed to upload snapshot from {} in {}: {}", path.display(),region, source))]
+        Snapshot {
+            path: PathBuf,
+            region: String,
+            source: ami::snapshot::Error,
+        },
+
+        #[snafu(display("{} snapshot did not become available: {}", snapshot_type, source))]
+        WaitSnapshot {
+            snapshot_type: String,
+            source: coldsnap::WaitError,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ami/snapshot.rs
+++ b/tools/pubsys/src/aws/ami/snapshot.rs
@@ -1,0 +1,58 @@
+use coldsnap::SnapshotUploader;
+use indicatif::{ProgressBar, ProgressStyle};
+use snafu::{OptionExt, ResultExt};
+use std::path::Path;
+
+/// Create a progress bar to show status of snapshot blocks, if wanted.
+fn build_progress_bar(no_progress: bool, verb: &str) -> Option<ProgressBar> {
+    if no_progress {
+        return None;
+    }
+    let progress_bar = ProgressBar::new(0);
+    progress_bar.set_style(
+        ProgressStyle::default_bar()
+            .template(&["  ", verb, "  [{bar:50.white/black}] {pos}/{len} ({eta})"].concat())
+            .progress_chars("=> "),
+    );
+    Some(progress_bar)
+}
+
+/// Uploads the given path into a snapshot.
+pub(crate) async fn snapshot_from_image<P>(
+    path: P,
+    uploader: &SnapshotUploader,
+    desired_size: Option<i64>,
+    no_progress: bool,
+) -> Result<String>
+where
+    P: AsRef<Path>,
+{
+    let path = path.as_ref();
+    let progress_bar = build_progress_bar(no_progress, "Uploading snapshot");
+    let filename = path
+        .file_name()
+        .context(error::InvalidImagePath { path })?
+        .to_string_lossy();
+
+    uploader
+        .upload_from_file(path, desired_size, Some(&filename), progress_bar)
+        .await
+        .context(error::UploadSnapshot)
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Invalid image path '{}'", path.display()))]
+        InvalidImagePath { path: PathBuf },
+
+        #[snafu(display("Failed to upload snapshot: {}", source))]
+        UploadSnapshot { source: coldsnap::UploadError },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ami/wait.rs
+++ b/tools/pubsys/src/aws/ami/wait.rs
@@ -1,0 +1,149 @@
+use crate::aws::client::build_client;
+use crate::config::AwsConfig;
+use log::info;
+use rusoto_core::Region;
+use rusoto_ec2::{DescribeImagesRequest, Ec2, Ec2Client};
+use snafu::{ensure, ResultExt};
+use std::thread::sleep;
+use std::time::Duration;
+
+/// Waits for the given AMI ID to reach the given state, requiring it be in that state for
+/// `success_required` checks in a row.
+pub(crate) async fn wait_for_ami(
+    id: &str,
+    region: &Region,
+    state: &str,
+    successes_required: u8,
+    aws: &AwsConfig,
+) -> Result<()> {
+    let mut successes = 0;
+    let max_attempts = 90;
+    let mut attempts = 0;
+    let seconds_between_attempts = 2;
+
+    loop {
+        attempts += 1;
+        // Stop if we're over max, unless we're on a success streak, then give it some wiggle room.
+        ensure!(
+            (attempts - successes) <= max_attempts,
+            error::MaxAttempts {
+                id,
+                max_attempts,
+                region: region.name()
+            }
+        );
+        if attempts % 5 == 1 {
+            info!(
+                "Waiting for {} in {} to be {}... (attempt {} of {})",
+                id,
+                region.name(),
+                state,
+                attempts,
+                max_attempts
+            );
+        }
+
+        let describe_request = DescribeImagesRequest {
+            image_ids: Some(vec![id.to_string()]),
+            ..Default::default()
+        };
+        // Use a new client each time so we have more confidence that different endpoints can see
+        // the new AMI.
+        let ec2_client = build_client::<Ec2Client>(&region, &aws).context(error::Client {
+            client_type: "EC2",
+            region: region.name(),
+        })?;
+        let describe_response =
+            ec2_client
+                .describe_images(describe_request)
+                .await
+                .context(error::DescribeImages {
+                    region: region.name(),
+                })?;
+        // The response contains an Option<Vec<Image>>, so we have to check that we got a
+        // list at all, and then that the list contains the ID in question.
+        if let Some(images) = describe_response.images {
+            let mut saw_it = false;
+            for image in images {
+                if let Some(ref found_id) = image.image_id {
+                    if let Some(ref found_state) = image.state {
+                        if id == found_id && state == found_state {
+                            // Success; check if we have enough to declare victory.
+                            saw_it = true;
+                            successes += 1;
+                            if successes >= successes_required {
+                                info!("Found {} {} in {}", id, state, region.name());
+                                return Ok(());
+                            }
+                            break;
+                        }
+                        // If the state shows us the AMI failed, we know we'll never hit the
+                        // desired state.  (Unless they desired "error", which will be caught
+                        // above.)
+                        ensure!(
+                            !["invalid", "deregistered", "failed", "error"]
+                                .iter()
+                                .any(|e| e == found_state),
+                            error::State {
+                                id,
+                                state: found_state,
+                                region: region.name()
+                            }
+                        );
+                    }
+                }
+            }
+            if !saw_it {
+                // Did not find image in list; reset success count and try again (if we have spare attempts)
+                successes = 0;
+            }
+        } else {
+            // Did not receive list; reset success count and try again (if we have spare attempts)
+            successes = 0;
+        };
+        sleep(Duration::from_secs(seconds_between_attempts));
+    }
+}
+
+mod error {
+    use crate::aws;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Error creating {} client in {}: {}", client_type, region, source))]
+        Client {
+            client_type: String,
+            region: String,
+            source: aws::client::Error,
+        },
+
+        #[snafu(display("Failed to describe images in {}: {}", region, source))]
+        DescribeImages {
+            region: String,
+            source: rusoto_core::RusotoError<rusoto_ec2::DescribeImagesError>,
+        },
+
+        #[snafu(display(
+            "Failed to reach desired state within {} attempts for {} in {}",
+            max_attempts,
+            id,
+            region
+        ))]
+        MaxAttempts {
+            max_attempts: u8,
+            id: String,
+            region: String,
+        },
+
+        #[snafu(display("Image '{}' went to '{}' state in {}", id, state, region))]
+        State {
+            id: String,
+            state: String,
+            region: String,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/client.rs
+++ b/tools/pubsys/src/aws/client.rs
@@ -1,0 +1,127 @@
+use async_trait::async_trait;
+use crate::config::AwsConfig;
+use rusoto_core::{request::DispatchSignedRequest, HttpClient, Region};
+use rusoto_credential::{
+    AutoRefreshingProvider, AwsCredentials, CredentialsError, DefaultCredentialsProvider,
+    ProfileProvider, ProvideAwsCredentials,
+};
+use rusoto_ebs::EbsClient;
+use rusoto_ec2::Ec2Client;
+use rusoto_sts::{StsAssumeRoleSessionCredentialsProvider, StsClient};
+use snafu::ResultExt;
+
+pub(crate) trait NewWith {
+    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+        D: DispatchSignedRequest + Send + Sync + 'static;
+}
+
+impl NewWith for EbsClient {
+    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+        D: DispatchSignedRequest + Send + Sync + 'static,
+        {
+            Self::new_with(request_dispatcher, credentials_provider, region)
+        }
+}
+
+impl NewWith for Ec2Client {
+    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+        D: DispatchSignedRequest + Send + Sync + 'static,
+        {
+            Self::new_with(request_dispatcher, credentials_provider, region)
+        }
+}
+
+/// Create a rusoto client of the given type using the given region and configuration.
+pub(crate) fn build_client<T: NewWith>(region: &Region, aws: &AwsConfig) -> Result<T> {
+    let maybe_regional_role = aws.region.get(region.name()).and_then(|r| r.role.clone());
+    let assume_roles = aws.role.iter().chain(maybe_regional_role.iter()).cloned();
+    let provider = build_provider(&region, assume_roles.clone(), base_provider(&aws.profile)?)?;
+    Ok(T::new_with(
+        rusoto_core::HttpClient::new().context(error::HttpClient)?,
+        provider,
+        region.clone(),
+    ))
+}
+
+/// Wrapper for trait object that implements ProvideAwsCredentials to simplify return values.
+/// Might be able to remove if rusoto implements ProvideAwsCredentials for
+/// Box<ProvideAwsCredentials>.
+struct CredentialsProvider(Box<dyn ProvideAwsCredentials + Send + Sync + 'static>);
+#[async_trait]
+impl ProvideAwsCredentials for CredentialsProvider {
+    async fn credentials(&self) -> std::result::Result<AwsCredentials, CredentialsError> {
+        self.0.credentials().await
+    }
+}
+
+/// Chains credentials providers to assume the given roles in order.
+fn build_provider<P>(
+    region: &Region,
+    assume_roles: impl Iterator<Item = String>,
+    base_provider: P,
+) -> Result<CredentialsProvider>
+where
+    P: ProvideAwsCredentials + Send + Sync + 'static,
+{
+    let mut provider = CredentialsProvider(Box::new(base_provider));
+    for assume_role in assume_roles {
+        let sts = StsClient::new_with(
+            HttpClient::new().context(error::HttpClient)?,
+            provider,
+            region.clone(),
+        );
+        let expiring_provider = StsAssumeRoleSessionCredentialsProvider::new(
+            sts,
+            assume_role,
+            "pubsys".to_string(), // session name
+            None,                 // external ID
+            None,                 // session duration
+            None,                 // scope down policy
+            None,                 // MFA serial
+        );
+        provider = CredentialsProvider(Box::new(
+            AutoRefreshingProvider::new(expiring_provider).context(error::Provider)?,
+        ));
+    }
+    Ok(provider)
+}
+
+/// If the user specified a profile, have rusoto use that, otherwise use Rusoto's default
+/// credentials mechanisms.
+fn base_provider(maybe_profile: &Option<String>) -> Result<CredentialsProvider> {
+    if let Some(profile) = maybe_profile {
+        let mut p = ProfileProvider::new().context(error::Provider)?;
+        p.set_profile(profile);
+        Ok(CredentialsProvider(Box::new(p)))
+    } else {
+        Ok(CredentialsProvider(Box::new(
+            DefaultCredentialsProvider::new().context(error::Provider)?,
+        )))
+    }
+}
+
+pub(crate) mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Failed to create HTTP client: {}", source))]
+        HttpClient {
+            source: rusoto_core::request::TlsError,
+        },
+
+        #[snafu(display("Failed to create AWS credentials provider: {}", source))]
+        Provider {
+            source: rusoto_credential::CredentialsError,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/mod.rs
+++ b/tools/pubsys/src/aws/mod.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+pub(crate) mod client;
+
+pub(crate) mod ami;

--- a/tools/pubsys/src/config.rs
+++ b/tools/pubsys/src/config.rs
@@ -12,9 +12,9 @@ use url::Url;
 /// Configuration needed to load and create repos
 #[derive(Debug, Deserialize)]
 pub(crate) struct InfraConfig {
-    pub(crate) root_role_path: PathBuf,
-    pub(crate) signing_keys: HashMap<String, SigningKeyConfig>,
-    pub(crate) repo: HashMap<String, RepoConfig>,
+    pub(crate) root_role_path: Option<PathBuf>,
+    pub(crate) signing_keys: Option<HashMap<String, SigningKeyConfig>>,
+    pub(crate) repo: Option<HashMap<String, RepoConfig>>,
 }
 
 impl InfraConfig {


### PR DESCRIPTION
**Description of changes:**

```
commit fdffc56bb4a7eaae368d16b5ca974c65b0063dcc
Author: Zac Mrowicki <mrowicki@amazon.com>
Date:   Thu Jul 30 23:30:39 2020 +0000

    Add the "ami" subcommand to pubsys

    This lets you register an AMI from the latest build and copy it to a list of
    regions.

commit 659fe384c7f2990294080f712efbb28a4aaf2fcd
Author: Zac Mrowicki <mrowicki@amazon.com>
Date:   Tue Jul 28 23:25:43 2020 +0000

    Make all fields of Infra.toml optional

    Pubsys subcommands do not use the same parts of Infra.toml, so they have
    to be optional if we want to have a common config file.  The subcommands
    will confirm that the necessary fields are present.
```

`Infra.toml.example` was updated with the configuration needed for building AMIs; only a region list is necessary, and that can be overridden by specifying `-e PUBLISH_REGIONS` if desired.  You can also override the AMI name and volume sizes, if desired.

**Testing done:**

Used `cargo make ami` to register single AMIs, register/copy AMIs in multiple regions, register with global and regional roles.  A registered Bottlerocket aws-k8s-1.17 AMI ran/connected OK.  Also reran `cargo make repo` to ensure existing functionality wasn't affected by config change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
