### PR TITLE
Update SDK to 0.12.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -55,7 +55,7 @@ DOCKER_BUILDKIT = "1"
 # on the command line.
 
 # Depends on ${BUILDSYS_ARCH}.
-BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.11.0"
+BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.12.0"
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"

--- a/macros/cargo
+++ b/macros/cargo
@@ -18,7 +18,7 @@
 %__cargo_env CARGO_TARGET_DIR="${HOME}/.cache" SKIP_README="true"
 %__cargo_cross_pkg_config PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" PKG_CONFIG_ALLOW_CROSS=1
 %__cargo_cross_env %{__cargo_env} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-gnu-gcc"
-%__cargo_cross_env_static %{__cargo_env} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-musl-gcc"
+%__cargo_cross_env_static %{__cargo_env} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-musl-gcc" CARGO_PROFILE_RELEASE_LTO=thin
 
 %cargo_prep (\
 %{__mkdir} -p %{_builddir}/.cargo \

--- a/macros/rust
+++ b/macros/rust
@@ -15,7 +15,7 @@
 %__global_rustflags_shared -Cprefer-dynamic %__global_rustflags
 
 # Enable LTO and static C runtime.
-%__global_rustflags_static -Clto=thin -Ctarget-feature=+crt-static -Clink-arg=-lgcc %__global_rustflags
+%__global_rustflags_static -Ctarget-feature=+crt-static -Clink-arg=-lgcc %__global_rustflags
 
 %__global_rustflags_shared_toml [%{lua:
     for arg in string.gmatch(rpm.expand("%{__global_rustflags_shared}"), "%S+") do


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Move to SDK v0.12.0 (https://github.com/bottlerocket-os/bottlerocket-sdk/pull/30). Two changes on the Bottlerocket side:

* [The new `embed-bitcode` flag](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1450-2020-07-16) conflicts with `-C lto`. https://github.com/rust-lang/rust/issues/71848 suggests using Cargo-specific environment variables to get correct behavior, as "Cargo has much more intrusive knowledge of LTO now for compile time speedups".
* ~~Updated to glibc 2.32 in this PR, otherwise our Rust code doesn't build on aarch64 due to missing symbol versions. This will probably conflict with @tjkirch's version-bumps-in-progress, and I can cherry-pick his commit over here to replace mine to get rid of the conflict (I think).~~ Looks like glibc updates need to be lockstep across the SDK and the OS.

**Testing done:**

It builds, need to do a boot test.

CI will fail until I actually perform an SDK release.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
