### PR TITLE
Build ecs-settings-applier in same cargo_build

### DIFF
--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -179,18 +179,14 @@ mkdir bin
     -p updog \
     -p logdog \
     -p growpart \
+%if "%{_cross_variant}" == "aws-ecs-1"
+    -p ecs-settings-applier \
+%endif
     %{nil}
 
 %cargo_build_static --manifest-path %{_builddir}/sources/Cargo.toml \
     -p apiclient \
     %{nil}
-
-# Build conditional ECS component
-%if "%{_cross_variant}" == "aws-ecs-1"
-%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
-    -p ecs-settings-applier \
-    %{nil}
-%endif
 
 # Build the migrations
 for crate in $(find %{_builddir}/sources/api/migration/migrations -name 'Cargo.toml'); do
@@ -205,20 +201,13 @@ for p in \
   thar-be-settings thar-be-updates servicedog host-containers \
   storewolf settings-committer \
   migrator \
-  signpost updog logdog;
-do
-  install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/${p} %{buildroot}%{_cross_bindir}
-done
-
-
+  signpost updog logdog \
 %if "%{_cross_variant}" == "aws-ecs-1"
-for p in \
-  ecs-settings-applier;
-do
+  ecs-settings-applier \
+%endif
+; do
   install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/${p} %{buildroot}%{_cross_bindir}
 done
-%endif
-
 
 for p in apiclient ; do
   install -p -m 0755 ${HOME}/.cache/%{__cargo_target_static}/release/${p} %{buildroot}%{_cross_bindir}


### PR DESCRIPTION
We were rebuilding common dependencies.  With the conditional in the same build
block, ecs-settings-applier doesn't need to build dependencies from scratch.

With the same technique, we can also simplify/deduplicate the copying of the
resulting binary.

**Testing done:**

*Before:* saw 5+ minute delay from separate cargo build cycle for ecs-settings-applier.

*After:* Built aws-k8s-1.15, saw no change in behavior, it doesn't try to build ecs-settings-applier.  Built aws-ecs-1, saw ecs-settings-applier get built in the same cycle as our other os crates.  Confirmed ecs-settings-applier still shows up in the RPM.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
