### PR TITLE
migrator: fix unit test to use new tough 0.8 interface

### DIFF
--- a/sources/api/migration/migrator/src/test.rs
+++ b/sources/api/migration/migrator/src/test.rs
@@ -162,7 +162,13 @@ fn create_test_repo() -> TestRepo {
     let signed_repo = editor
         .sign(&[Box::new(tough::key_source::LocalKeySource { path: pem() })])
         .unwrap();
-    signed_repo.link_targets(tuf_indir, &targets_path).unwrap();
+    signed_repo
+        .link_targets(
+            tuf_indir,
+            &targets_path,
+            tough::editor::signed::PathExists::Fail,
+        )
+        .unwrap();
     signed_repo.write(&metadata_path).unwrap();
 
     TestRepo {


### PR DESCRIPTION
**Description of changes:**

Sorry, I missed this in #1019; the update to tough 0.8 changed the interface of this function used in a migrator test.

**Testing done:**

All unit tests in `sources/` now pass.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
