### PR TITLE
Fix warnings for use of deprecated items in common_migrations

### DIFF
--- a/sources/api/migration/migration-helpers/src/common_migrations.rs
+++ b/sources/api/migration/migration-helpers/src/common_migrations.rs
@@ -41,6 +41,7 @@ impl Migration for AddSettingsMigration<'_> {
 #[deprecated(note = "Please use `AddSettingsMigration` instead")]
 pub struct AddSettingMigration(pub &'static str);
 
+#[allow(deprecated)]
 impl Migration for AddSettingMigration {
     fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
         AddSettingsMigration(&[self.0]).forward(input)
@@ -90,6 +91,7 @@ impl Migration for RemoveSettingsMigration<'_> {
 #[deprecated(note = "Please use `RemoveSettingsMigration` instead")]
 pub struct RemoveSettingMigration(pub &'static str);
 
+#[allow(deprecated)]
 impl Migration for RemoveSettingMigration {
     fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
         RemoveSettingsMigration(&[self.0]).forward(input)


### PR DESCRIPTION
The singular `AddSettingMigration` and `RemoveSettingMigration` exist for
backward compatibility and are marked deprecated.  The trait implementations on
those items have to reference the deprecated items, of course, but this
triggers compiler warnings about use of the deprecated items.  We only want
warnings when people are actively using these types outside of the module that
defines them; we don't want to see the warnings on every build.

**Testing done:**

Build no longer shows the warnings.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
