### PR TITLE
update SELinux userspace to 3.1

### DIFF
--- a/macros/shared
+++ b/macros/shared
@@ -5,8 +5,15 @@
 %_cross_target %{_cross_triple}-%{_cross_libc}
 %dist %{nil}
 
-%_cross_cflags -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-clash-protection
-%_cross_c_args '-O2', '-g', '-pipe', '-Wall', '-Werror=format-security', '-Wp,-D_FORTIFY_SOURCE=2', '-Wp,-D_GLIBCXX_ASSERTIONS', '-fexceptions', '-fstack-clash-protection'
+%_cross_cflags %{shrink: \
+  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS \
+  -fexceptions -fstack-clash-protection -fno-semantic-interposition \
+  %{nil}}
+%_cross_c_args %{shrink: \
+  '-O2', '-g', '-pipe', '-Wall', '-Werror=format-security', \
+  '-Wp,-D_FORTIFY_SOURCE=2', '-Wp,-D_GLIBCXX_ASSERTIONS', \
+  '-fexceptions', '-fstack-clash-protection', '-fno-semantic-interposition' \
+  %{nil}}
 %_cross_cxxflags %_cross_cflags
 %_cross_ldflags -Wl,-z,relro -Wl,-z,now
 %_cross_c_link_args '-Wl,-z,relro', '-Wl,-z,now'

--- a/packages/libselinux/Cargo.toml
+++ b/packages/libselinux/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20191204/libselinux-3.0.tar.gz"
-sha512 = "6fd8c3711e25cb1363232e484268609b71d823975537b3863e403836222eba026abce8ca198f64dba6f4c1ea4deb7ecef68a0397b9656a67b363e4d74409cd95"
+url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/libselinux-3.1.tar.gz"
+sha512 = "57730cddd2d4751556d9e1f207c0f85119c81848f0620c16239e997150989e3f9a586a8c23861fd51ed89f7e084ad441190a58a288258a49a95f7beef7dbbb13"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libselinux/libselinux.spec
+++ b/packages/libselinux/libselinux.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}libselinux
-Version: 3.0
+Version: 3.1
 Release: 1%{?dist}
 Summary: Library for SELinux
 License: LicenseRef-SELinux-PD
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20191204/libselinux-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/libselinux-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libpcre-devel
 BuildRequires: %{_cross_os}libsepol-devel

--- a/packages/libsemanage/Cargo.toml
+++ b/packages/libsemanage/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20191204/libsemanage-3.0.tar.gz"
-sha512 = "f960e1bd6815d3c9f000efa7ae717bc7937e742af5a7fea4aa865cf1aee49486e34897d83dbdb9cf77975a09a5ad77e5512d47690a74512a468a89432b72a42c"
+url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/libsemanage-3.1.tar.gz"
+sha512 = "8609ca7d13b5c603677740f2b14558fea3922624af182d20d618237ba11fcf2559fab82fc68d1efa6ff118f064d426f005138521652c761de92cd66150102197"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libsemanage/libsemanage.spec
+++ b/packages/libsemanage/libsemanage.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}libsemanage
-Version: 3.0
+Version: 3.1
 Release: 1%{?dist}
 Summary: Library for SELinux binary policy manipulation
 License: LGPL-2.1-or-later
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20191204/libsemanage-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/libsemanage-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libaudit-devel
 BuildRequires: %{_cross_os}libbzip2-devel

--- a/packages/libsepol/Cargo.toml
+++ b/packages/libsepol/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20191204/libsepol-3.0.tar.gz"
-sha512 = "82a5bae0afd9ae53b55ddcfc9f6dd61724a55e45aef1d9cd0122d1814adf2abe63c816a7ac63b64b401f5c67acb910dd8e0574eec546bed04da7842ab6c3bb55"
+url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/libsepol-3.1.tar.gz"
+sha512 = "4b5f4e82853ff3e9b4fac2dbdea5c2fc3bb7b508af912217ac4b75da6540fbcd77aa314ab95cd9dfa94fbc4a885000656a663c1a152f65b4cf6970ea0b6034ab"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libsepol/libsepol.spec
+++ b/packages/libsepol/libsepol.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}libsepol
-Version: 3.0
+Version: 3.1
 Release: 1%{?dist}
 Summary: Library for SELinux policy manipulation
 License: LGPL-2.1-or-later
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20191204/libsepol-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/libsepol-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 
 %description

--- a/packages/policycoreutils/Cargo.toml
+++ b/packages/policycoreutils/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20191204/policycoreutils-3.0.tar.gz"
-sha512 = "d8d25db48c1caef69228e87d7ebb2c0f075e44e4ff6bf18a26af341d948b81375b33945128cd0410ffebc64ca478fd19a207295189c716c95e6a3c586e9f053d"
+url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/policycoreutils-3.1.tar.gz"
+sha512 = "0592f218563a99ba95d2cfd07fdc3761b61c1cc3c01a17ab89ad840169e1a7d4083521d5cacc72d1b76911d516bf592db7a3f90d9ef0cc11ceed007e4580e140"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/policycoreutils/policycoreutils.spec
+++ b/packages/policycoreutils/policycoreutils.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}policycoreutils
-Version: 3.0
+Version: 3.1
 Release: 1%{?dist}
 Summary: A set of SELinux policy tools
 License: GPL-2.0-only
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20191204/policycoreutils-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/policycoreutils-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libselinux-devel
 BuildRequires: %{_cross_os}libsemanage-devel


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Update to the 3.1 release of the SELinux packages.

Add `-fno-semantic-interposition` to default CFLAGS. This is required by the newer SELinux packages, but fine for other shared libraries on the host since we don't expect any use of `LD_PRELOAD`.


**Testing done:**
Built `aws-dev` and tested locally. Built `aws-k8s-1.17` and verified that the nodes joined the cluster.

Confirmed that processes and files were labeled correctly and that `semodule` works.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
