### PR TITLE
docker: upgrade to 19.03.12

### DIFF
--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v18.09.9/cli-18.09.9.tar.gz"
-sha512 = "bc06dbbe8da1d9eaab509eadb6d6af3b2a603176c5c6b8432641dc0f2843a90f14b16455331540c30fd9b0039cc7936c334da3bdc957afebcf0b5a4caf312b7e"
+url = "https://github.com/docker/cli/archive/v19.03.12/cli-19.03.12.tar.gz"
+sha512 = "3114ba5134d8606393c526d9d780cae4ca8584017c734a49250be43eb84ab9c716c30735d04b33a1ef47475b06b31f269f4a020ac1b6647b58504acb9fed8be6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/clarify.toml
+++ b/packages/docker-cli/clarify.toml
@@ -5,8 +5,8 @@ license-files = [
 ]
 skip-files = ["license.go", "model/license.go"]
 
-[clarify."github.com/ghodss/yaml"]
+[clarify."sigs.k8s.io/yaml"]
 expression = "MIT AND BSD-3-Clause"
 license-files = [
-    { path = "LICENSE", hash = 0xcdf3ae00 },
+    { path = "LICENSE", hash = 0xcdf3ae00},
 ]

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,8 +2,11 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 18.09.9
+%global gover 19.03.12
 %global rpmver %{gover}
+%global gitrev 0ed913b885c8919944a2e4c8d0b80a318a8dd48b
+
+%global source_date_epoch 1492525740
 
 %global _dwz_low_mem_die_limit 0
 
@@ -27,7 +30,16 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %build
 %cross_go_configure %{goimport}
-go build -buildmode pie -o docker %{goimport}/cmd/docker
+LD_VERSION="-X github.com/docker/cli/cli/version.Version=%{gover}"
+LD_GIT_REV="-X github.com/docker/cli/cli/version.GitCommit=%{gitrev}"
+LD_PLATFORM="-X \"github.com/docker/cli/cli/version.PlatformName=Docker Engine - Community\""
+BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
+LD_BUILDTIME="-X github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}"
+go build \
+  -buildmode pie \
+  -ldflags "${LD_VERSION} ${LD_GIT_REV} ${LD_PLATFORM} ${LD_BUILDTIME}" \
+  -o docker \
+  %{goimport}/cmd/docker
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/engine/archive/v18.09.9/engine-18.09.9.tar.gz"
-sha512 = "070700e5b9dac439fd494ae52824ebbd0a8dbc4bf0351c4173c47f585ab81a0fb39470c4d566a7dc69481b03e04f073727062872d2550505ae67a5d1bb30132e"
+url = "https://github.com/docker/engine/archive/v19.03.12/engine-19.03.12.tar.gz"
+sha512 = "51632ca8cff03440e3b76ad3e7f06b9c6275c776f4c4f9dc88cd7f5aa9b8aa8cb16ce2b3702426cb93f3714265a6cd28d4ba31612db37199e2915821b9ee8fd4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine/clarify.toml
+++ b/packages/docker-engine/clarify.toml
@@ -1,8 +1,3 @@
-[clarify."github.com/gogo/googleapis"]
-# license file was added later, see https://github.com/gogo/googleapis/commit/b23578765ee54ff6bceff57f397d833bf4ca6869
-expression = "Apache-2.0"
-license-files = []
-
 [clarify."github.com/sean-/seed"]
 expression = "MIT AND BSD-3-Clause"
 license-files = [

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -7,8 +7,11 @@
 %global dorepo docker
 %global doimport %{goproject}/%{dorepo}
 
-%global gover 18.09.9
+%global gover 19.03.12
 %global rpmver %{gover}
+%global gitrev 9dc6525e6118a25fab2be322d1914740ea842495
+
+%global source_date_epoch 1363394400
 
 %global _dwz_low_mem_die_limit 0
 
@@ -48,12 +51,18 @@ Requires: %{_cross_os}systemd
 
 %build
 %cross_go_configure %{doimport}
-BUILDTAGS="journald selinux seccomp"
+BUILDTAGS="autogen journald selinux seccomp"
 BUILDTAGS+=" exclude_graphdriver_btrfs"
 BUILDTAGS+=" exclude_graphdriver_devicemapper"
 BUILDTAGS+=" exclude_graphdriver_vfs"
 BUILDTAGS+=" exclude_graphdriver_zfs"
 export BUILDTAGS
+export VERSION=%{gover}
+export GITCOMMIT=%{gitrev}
+export BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
+export PLATFORM="Docker Engine - Community"
+chmod +x ./hack/make/.go-autogen
+./hack/make/.go-autogen
 go build -buildmode pie -tags="${BUILDTAGS}" -o dockerd %{doimport}/cmd/dockerd
 
 %install


### PR DESCRIPTION
**Description of changes:**
Upgrade docker-engine and docker-cli to 19.03.12.


**Testing done:**
Built and ran both the `aws-dev` and `aws-ecs-1` variants.  Both variants are able to run containers.  `docker version` output looks reasonable.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
