### PR TITLE
Address feedback about `cargo make ami`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -181,7 +181,13 @@ cargo install \
   --root tools \
   --force \
   --quiet
+'''
+]
 
+[tasks.publish-tools]
+dependencies = ["setup", "fetch-sources"]
+script = [
+'''
 cargo install \
   ${CARGO_MAKE_CARGO_ARGS} \
   --path tools/pubsys \
@@ -281,7 +287,10 @@ alias = "build"
 # to create a repo under /build/repos, named after the arch/variant/version,
 # containing subdirectories for the repo metadata and targets.
 [tasks.repo]
-dependencies = ["build"]
+# Rather than depend on "build", which currently rebuilds images each run, we
+# check for the image files below to save time.  This does mean that `cargo
+# make` must be run before `cargo make repo`.
+dependencies = ["publish-tools"]
 script_runner = "bash"
 script = [
 '''
@@ -293,6 +302,14 @@ cleanup() {
 trap 'cleanup' EXIT
 
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+bootlz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-boot.ext4.lz4"
+rootlz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-root.ext4.lz4"
+hashlz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-root.verity.lz4"
+if [ ! -s "${bootlz4}" ] || [ ! -s "${rootlz4}" ] || [ ! -s "${hashlz4}" ]; then
+   echo "Image files don't exist for the current version/commit - ${BUILDSYS_VERSION_FULL} - please run 'cargo make'" >&2
+   exit 1
+fi
 
 # TODO: only add migrations from Release.toml, not all
 MIGRATIONS_DIR="$(mktemp -d)"
@@ -313,9 +330,9 @@ pubsys \
    --version "${BUILDSYS_VERSION_IMAGE}" \
    --variant "${BUILDSYS_VARIANT}" \
    \
-   --boot-image "${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-boot.ext4.lz4" \
-   --root-image "${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-root.ext4.lz4" \
-   --hash-image "${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-root.verity.lz4" \
+   --boot-image "${bootlz4}" \
+   --root-image "${rootlz4}" \
+   --hash-image "${hashlz4}" \
    ${ADD_MIGRATION_TARGETS[*]} \
    \
    --repo-expiration-policy-path "${PUBLISH_EXPIRATION_POLICY_PATH}" \
@@ -332,11 +349,16 @@ ln -sfn "${PUBLISH_REPO_OUTPUT_DIR##*/}" "${PUBLISH_REPO_BASE_DIR}/latest"
 ]
 
 [tasks.ami]
-dependencies = ["build"]
+# Rather than depend on "build", which currently rebuilds images each run, we
+# depend on publish-tools and check for the image files below to save time.
+# This does mean that `cargo make` must be run before `cargo make ami`.
+dependencies = ["publish-tools"]
 script_runner = "bash"
 script = [
 '''
 set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
 
 cleanup() {
    [ -f "${root_image}" ] && rm -f "${root_image}"
@@ -344,7 +366,17 @@ cleanup() {
 }
 trap 'cleanup' EXIT
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+# Unlz4 the root / data images
+rootlz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.img.lz4"
+root_image="${rootlz4%.lz4}"
+datalz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-data.img.lz4"
+data_image="${datalz4%.lz4}"
+if [ ! -s "${rootlz4}" ] || [ ! -s "${datalz4}" ]; then
+   echo "Image files don't exist for the current version/commit - ${BUILDSYS_VERSION_FULL} - please run 'cargo make'" >&2
+   exit 1
+fi
+lz4 -df "${rootlz4}" "${root_image}"
+lz4 -df "${datalz4}" "${data_image}"
 
 # Canonicalize architecture identifier to the value recognized by EC2.
 case "${BUILDSYS_ARCH,,}" in
@@ -355,15 +387,6 @@ case "${BUILDSYS_ARCH,,}" in
    *)
       arch="${BUILDSYS_ARCH}" ;;
 esac
-
-# Unlz4 the root / data images
-rootlz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.img.lz4"
-root_image="${rootlz4%.lz4}"
-lz4 -df "${rootlz4}" "${root_image}"
-
-datalz4="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-data.img.lz4"
-data_image="${datalz4%.lz4}"
-lz4 -df "${datalz4}" "${data_image}"
 
 pubsys \
    --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -71,9 +71,7 @@ pub(crate) async fn run(args: &Args, ami_args: &AmiArgs) -> Result<()> {
     let infra_config = InfraConfig::from_path(&args.infra_config_path).context(error::Config)?;
     trace!("Parsed infra config: {:?}", infra_config);
 
-    let aws = infra_config.aws.context(error::MissingConfig {
-        missing: "aws section",
-    })?;
+    let aws = infra_config.aws.unwrap_or_else(|| Default::default());
 
     // If the user gave an override list of regions, use that, otherwise use what's in the config.
     let mut regions = if !ami_args.regions.is_empty() {

--- a/tools/pubsys/src/config.rs
+++ b/tools/pubsys/src/config.rs
@@ -34,11 +34,13 @@ impl InfraConfig {
 }
 
 /// AWS-specific infrastructure configuration
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub(crate) struct AwsConfig {
+    #[serde(default)]
     pub(crate) regions: VecDeque<String>,
     pub(crate) role: Option<String>,
     pub(crate) profile: Option<String>,
+    #[serde(default)]
     pub(crate) region: HashMap<String, AwsRegionConfig>,
 }
 


### PR DESCRIPTION
```
commit 89e2a37afafb7d2b088572bed723971467cb8730
Author: Zac Mrowicki <mrowicki@amazon.com>
Date:   Tue Aug 11 17:41:16 2020 +0000

    pubsys: default AwsConfig so it's not required

    Have serde default `aws.region` so the user does not have to have an empty
    `aws.region` table if they have no region-specific configuration.

    Have serde default `aws.regions` in case the user only wants to specify regions
    on the command line with `PUBLISH_REGIONS`.

    Derive Default on AwsConfig now that all sections of `aws` in Infra.toml are
    optional, so the user doesn't need an empty `[aws]` section if they intend to
    use default credential mechanisms and specify `PUBLISH_REGIONS`.
```

```
commit b69d2a218178914d8081c7e0694318da98a439ae
Author: Zac Mrowicki <mrowicki@amazon.com>
Date:   Tue Aug 11 17:19:42 2020 +0000

    Separate publish tasks

    If you just want to build images, you don't need to build the pubsys tool
    first, only buildsys.  This change splits the tasks so that builds only need to
    depend on buildsys.

    Similarly, AMI builds only need to depend on pubsys, not buildsys.  `cargo
    make` currently rebuilds images each run.  If you want to build or copy AMIs
    based on a previous image build, you don't want to wait for image rebuilds, and
    you don't want to use different files - you want to use the same image files
    you had.  This change makes the ami task depend only on pubsys and sources, and
    checks for image file existence internally.  (The image file names include
    version and commit, so you can't accidentally use an old build.)

    This will also apply for `cargo make ssm`, where timing is even more critical.
```

**Testing done:**

Before: `cargo make` built pubsys unnecessarily.
After: `cargo make` does not build pubsys; `cargo make ami` still does.

Before: images rebuilt every time before `cargo make ami` when it should use existing images.
After: `cargo make ami` fails appropriately if no images exist, and runs quickly and correctly when they do.

Before: aws.region was required in Infra.toml even when you don't have region-specific config.
Before: aws.regions was required in Infra.toml even if you wanted to override with PUBLISH_REGIONS.
After: `cargo make ami -e PUBLISH_REGIONS=bla1,bla2` works, even with no `aws` section in Infra.toml.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
