### PR TITLE
Remove instructions to manually apply aws-vpc-cni

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -50,13 +50,6 @@ eksctl create cluster --config-file ./my-eksctl.yaml
 
 This will take a few minutes to create the EKS cluster and spin up your Bottlerocket worker nodes.
 
-##### CNI plugin
-
-Now we can make a configuration change to use a CNI plugin that's compatible with Bottlerocket.
-```
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6/config/v1.6/aws-k8s-cni.yaml
-```
-
 #### Optional cluster configuration
 
 ##### CSI plugin
@@ -151,11 +144,6 @@ eksctl create cluster --region us-west-2 --name bottlerocket
 Now that the cluster is created, we can have `eksctl` create the configuration for `kubectl`:
 ```
 eksctl utils write-kubeconfig --region us-west-2 --name bottlerocket
-```
-
-Now we can make a configuration change to use a CNI plugin that's compatible with Bottlerocket.
-```
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6/config/v1.6/aws-k8s-cni.yaml
 ```
 
 ### Cluster info


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Aug 11 11:48:55 2020 -0700

    Remove instructions to manually apply aws-vpc-cni
    
    Creating new EKS clusters from scratch gives us a compatible aws-vpc-cni
    DaemonSet by default now.

```


**Testing done:**
Creating a fresh cluster from scratch lets me run Bottlerocket nodes in them without problems without having to manually apply these manifests.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
