### PR TITLE
defaults, migrations: host-containers default version bumps and migrations

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1315,6 +1315,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "migrate-admin-container-v0-5-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
+name = "migrate-control-container-v0-4-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
 name = "migration-helpers"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -22,6 +22,8 @@ members = [
     "api/migration/migrations/v0.3.2/migrate-admin-container-v0-5-0",
     "api/migration/migrations/v0.4.1/add-version-lock-ignore-waves",
     "api/migration/migrations/v0.4.1/pivot-repo-2020-07-07",
+    "api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-1",
+    "api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-1/Cargo.toml
+++ b/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "migrate-admin-container-v0-5-1"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-1/src/main.rs
+++ b/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-1/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.1";
+
+/// We bumped the version of the default admin container from v0.5.0 to v0.5.1
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1/Cargo.toml
+++ b/sources/api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "migrate-control-container-v0-4-1"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1/src/main.rs
+++ b/sources/api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.4.0";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.4.1";
+
+/// We bumped the version of the default control container from v0.4.0 to v0.4.1
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -60,7 +60,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0"
+template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.1"
 
 [settings.host-containers.control]
 enabled = true
@@ -68,7 +68,7 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.4.0"
+template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.4.1"
 
 [services.host-containers]
 configuration-files = []


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Aug 11 15:40:09 2020 -0700

    defaults: update default versions for host containers
    
    Set default admin container version to v0.5.1
    Set default control container version to v0.4.1
```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Aug 11 13:04:30 2020 -0700

    migrations: host-containers default version migrations
    
    Migrates default version for the admin container from v0.5.0 to v0.5.1
    Migrates default version for the control container from v0.4.0 to v0.4.1
```


**Testing done:**
Created a local datastore for testing purposes with `storewolf`.
For the admin container migration:

Initial `admin.source.template` and `admin.source`
```
$ cat ~/thar/testing/ds/current/live/settings/host-containers/admin/source
"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0"
$ cat ~/thar/testing/ds/current/live/settings/host-containers/admin/source.template 
"328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0"
```

Run the admin container forward migration:
```
     Running `migrate-admin-container-v0-5-1 --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next --forward`
Updating template and value of 'settings.host-containers.admin.source' on upgrade
Changing template of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0' to '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.1'
Changing value of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0' to '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.1'
Found no 'settings.host-containers.admin.source' to change on upgrade
```

See that the `admin.source.template` and `admin.source` got updated:
```
$ cat ~/thar/testing/ds/next/live/settings/host-containers/admin/source
"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.1"
$ cat ~/thar/testing/ds/next/live/settings/host-containers/admin/source.template "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.1"
```

Run the admin container backward migration:
```
$ VARIANT=aws-k8s-1.17 cargo run -- --source-datastore ~/thar/testing/ds/next --target-datastore ~/thar/testing/ds/next-backward --backward
Updating template and value of 'settings.host-containers.admin.source' on downgrade
Changing template of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.1' to '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0'
Changing value of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.1' to '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0'
Found no 'settings.host-containers.admin.source' to change on downgrade
```

See that the `admin.source.template` and `admin.source` are back to their original values:
```
$ cat ~/thar/testing/ds/next-backward/live/settings/host-containers/admin/source.template 
"328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0"
$ cat ~/thar/testing/ds/next-backward/live/settings/host-containers/admin/source 
"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0"
```

Same test results for the control container migration.


Will flip from draft mode once https://github.com/bottlerocket-os/bottlerocket-control-container/pull/5#pullrequestreview-465419930 and https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/12 are merged and ready.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
