### PR TITLE
schnauzer: add a helper for ecr repos

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -7,3 +7,5 @@ version = "0.5.0"
 "(0.3.4, 0.4.0)" = []
 "(0.4.0, 0.4.1)" = ["migrate_v0.4.1_add-version-lock-ignore-waves.lz4", "migrate_v0.4.1_pivot-repo-2020-07-07.lz4"]
 "(0.4.1, 0.5.0)" = ["migrate_v0.5.0_add-cluster-domain.lz4", "migrate_v0.5.0_admin-container-v0-5-2.lz4", "migrate_v0.5.0_control-container-v0-4-1.lz4"]
+# TODO - add ecr-helper-admin and ecr-helper-control migrations to next release.
+# NOTE - these expect container versions v0.5.2 and v0.4.1

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -672,6 +672,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecr-helper-admin"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
+name = "ecr-helper-control"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
 name = "ecs-settings-applier"
 version = "0.1.0"
 dependencies = [
@@ -1996,6 +2010,7 @@ dependencies = [
  "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "models 0.1.0",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -25,6 +25,8 @@ members = [
     "api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-2",
     "api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1",
     "api/migration/migrations/v0.5.0/add-cluster-domain",
+    "api/migration/migrations/v0.5.1/ecr-helper-admin",
+    "api/migration/migrations/v0.5.1/ecr-helper-control",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v0.5.1/ecr-helper-admin/Cargo.toml
+++ b/sources/api/migration/migrations/v0.5.1/ecr-helper-admin/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ecr-helper-admin"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.5.1/ecr-helper-admin/src/main.rs
+++ b/sources/api/migration/migrations/v0.5.1/ecr-helper-admin/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.2";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.5.2";
+
+/// We added a helper to lookup an ECR registry number by region.
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v0.5.1/ecr-helper-control/Cargo.toml
+++ b/sources/api/migration/migrations/v0.5.1/ecr-helper-control/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ecr-helper-control"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.5.1/ecr-helper-control/src/main.rs
+++ b/sources/api/migration/migrations/v0.5.1/ecr-helper-control/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.4.1";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.4.1";
+
+/// We added a helper to lookup an ECR registry number by region.
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "metadata.settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.12"
 bottlerocket-release = { path = "../../bottlerocket-release" }
 handlebars = "3.0"
 http = "0.2"
+lazy_static = "1.4"
 log = "0.4"
 models = { path = "../../models" }
 serde = { version = "1.0", features = ["derive"] }

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -98,8 +98,7 @@ where
     P: AsRef<Path>,
 {
     debug!("Querying API for settings data");
-    let settings: model::Model =
-        get_json(&socket_path, "/", None as Option<(String, String)>)?;
+    let settings: model::Model = get_json(&socket_path, "/", None as Option<(String, String)>)?;
     trace!("Model values: {:?}", settings);
 
     Ok(settings)
@@ -115,6 +114,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("base64_decode", Box::new(helpers::base64_decode));
     template_registry.register_helper("join_map", Box::new(helpers::join_map));
     template_registry.register_helper("default", Box::new(helpers::default));
+    template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
 
     Ok(template_registry)
 }

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -60,7 +60,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.5.2"
 
 [settings.host-containers.control]
 enabled = true
@@ -68,7 +68,7 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-control:v0.4.1"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.4.1"
 
 [services.host-containers]
 configuration-files = []


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

In order to expand Bottlerocket to certain AWS regions, we need to change the way the ECR URL is constructed. Initially we intended to use a single ECR registry ID. For some regions this will not work. So we added a helper function and a map to Schnauzer so that we can look up the registry ID from a map.

Additionally, this allows us to introduce the concept of a fallback ID/region pair. This will prove useful if a new region is added and, for example, an older version of Bottlerocket tries to run on it.

*NOTE* we need to update the migration versionized-directrory and the container tag versions that it hard-codes based on where things stand when we release these changes.

**Testing done:**

Ran an instance in me-south-1, the admin container worked, and I found these container URLs in the settings:

```
509306038620.dkr.ecr.me-south-1.amazonaws.com/bottlerocket-control:v0.4.1
509306038620.dkr.ecr.me-south-1.amazonaws.com/bottlerocket-admin:v0.5.2
```

Created a fake future version of Bottlerocket and ran an upgrade in us-west-2. Observed that the migrations ran and the URLs were still good.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
