### PR TITLE
migrations: migrate new `cluster-domain` setting

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -243,6 +243,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-cluster-domain"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
 name = "add-version-lock-ignore-waves"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "api/migration/migrations/v0.4.1/pivot-repo-2020-07-07",
     "api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-1",
     "api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1",
+    "api/migration/migrations/v0.5.0/add-cluster-domain",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v0.5.0/add-cluster-domain/Cargo.toml
+++ b/sources/api/migration/migrations/v0.5.0/add-cluster-domain/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-cluster-domain"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v0.5.0/add-cluster-domain/src/main.rs
+++ b/sources/api/migration/migrations/v0.5.0/add-cluster-domain/src/main.rs
@@ -1,0 +1,22 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting, `kubernetes.cluster-domain`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.cluster-domain",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
Add a migration for migrating the new `cluster-domain` setting

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Aug 13 09:32:04 2020 -0700

    migrations: add `cluster-domain` setting
    
    Add a migration for migrating the new `cluster-domain` setting

```


**Testing done:**
With a local datastore:
Backward migration from 0.5.0 datastore
```
$ VARIANT=aws-k8s-1.17 cargo run -- --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next-backward --backward
...
Found no settings.kubernetes.cluster-domain to remove
Removed settings.kubernetes.cluster-domain, which was set to '"cluster.local"'
etung in migrations/v0.5.0/add-cluster-domain on 🌱 develop [⇡$!?] via 🦀 v1.45.2 took 9s
```

Forward migration from there:
```
$ VARIANT=aws-k8s-1.17 cargo run -- --source-datastore ~/thar/testing/ds/next-backward --target-datastore ~/thar/testing/ds/next-forward --forward
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `/home/ANT.AMAZON.COM/etung/thar/PRIVATE-thar/sources/target/debug/add-cluster-domain --source-datastore /home/ANT.AMAZON.COM/etung/thar/testing/ds/next-backward --target-datastore /home/ANT.AMAZON.COM/etung/thar/testing/ds/next-forward --forward`
AddSettingsMigration(["settings.kubernetes.cluster-domain"]) has no work to do on upgrade.
AddSettingsMigration(["settings.kubernetes.cluster-domain"]) has no work to do on upgrade.
```
No work done as expected on upgrade.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
