### PR TITLE
defaults, migrations: update default admin-container version migration

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "migrate-admin-container-v0-5-1"
+name = "migrate-admin-container-v0-5-2"
 version = "0.1.0"
 dependencies = [
  "migration-helpers 0.1.0",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -22,7 +22,7 @@ members = [
     "api/migration/migrations/v0.3.2/migrate-admin-container-v0-5-0",
     "api/migration/migrations/v0.4.1/add-version-lock-ignore-waves",
     "api/migration/migrations/v0.4.1/pivot-repo-2020-07-07",
-    "api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-1",
+    "api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-2",
     "api/migration/migrations/v0.5.0/migrate-control-container-v0-4-1",
     "api/migration/migrations/v0.5.0/add-cluster-domain",
 

--- a/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-2/Cargo.toml
+++ b/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-2/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "migrate-admin-container-v0-5-1"
+name = "migrate-admin-container-v0-5-2"
 version = "0.1.0"
 authors = ["Erikson Tung <etung@amazon.com>"]
 license = "Apache-2.0 OR MIT"

--- a/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-2/src/main.rs
+++ b/sources/api/migration/migrations/v0.5.0/migrate-admin-container-v0-5-2/src/main.rs
@@ -7,9 +7,9 @@ use std::process;
 const OLD_ADMIN_CTR_TEMPLATE: &str =
     "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0";
 const NEW_ADMIN_CTR_TEMPLATE: &str =
-    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.1";
+    "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.2";
 
-/// We bumped the version of the default admin container from v0.5.0 to v0.5.1
+/// We bumped the version of the default admin container from v0.5.0 to v0.5.2
 fn run() -> Result<()> {
     migrate(ReplaceTemplateMigration {
         setting: "settings.host-containers.admin.source",

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -60,7 +60,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.1"
+template = "328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.2"
 
 [settings.host-containers.control]
 enabled = true


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Aug 13 13:19:53 2020 -0700

    defaults: update default admin container version to v0.5.2
    
    Changes default admin container version from v0.5.1 to v0.5.2
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Aug 13 13:17:59 2020 -0700

    migrations: update default admin-container migration to migrate to v0.5.2
    
    Updates default admin container version migration to migrate to v0.5.2 instead of v0.5.1

```


**Testing done:**
From a local datastore:

Forward migration:
```
$ VARIANT=aws-k8s-1.17 cargo run -- --source-datastore ~/thar/testing/ds/current --target-datastore ~/thar/testing/ds/next --forward
 ...
Updating template and value of 'settings.host-containers.admin.source' on upgrade
Changing template of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0' to '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.2'
Changing value of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0' to '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.2'
Found no 'settings.host-containers.admin.source' to change on upgrade
```

Backwards migration:
```
$ VARIANT=aws-k8s-1.17 cargo run -- --source-datastore ~/thar/testing/ds/next --target-datastore ~/thar/testing/ds/next-backwards --backward
    Finished dev [unoptimized + debuginfo] target(s) in 0.45s
 ...
Updating template and value of 'settings.host-containers.admin.source' on downgrade
Changing template of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.2' to '328549459982.dkr.ecr.{{ settings.aws.region }}.amazonaws.com/bottlerocket-admin:v0.5.0'
Changing value of 'settings.host-containers.admin.source' from '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.2' to '328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.0'
Found no 'settings.host-containers.admin.source' to change on downgrade
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
