### PR TITLE
logdog: support ecs variant

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1261,6 +1261,7 @@ name = "logdog"
 version = "0.1.0"
 dependencies = [
  "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-words 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
+cfg-if = "0.1"
 flate2 = "1.0"
 shell-words = "1.0.0"
 snafu = { version = "0.6", features = ["backtraces-impl-backtrace-crate"] }

--- a/sources/logdog/build.rs
+++ b/sources/logdog/build.rs
@@ -5,7 +5,20 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+const VARIANT_GROUPS: &[&str] = &["aws-k8s", "aws-ecs"];
+
 fn main() {
+    println!("cargo:rerun-if-env-changed=VARIANT");
+    if let Ok(variant) = env::var("VARIANT") {
+        println!("cargo:rustc-cfg=variant=\"{}\"", variant);
+        for &variant_group in VARIANT_GROUPS {
+            if variant.starts_with(variant_group) {
+                println!("cargo:rustc-cfg=variant_group=\"{}\"", variant_group);
+                break;
+            }
+        }
+    }
+
     // Check for environment variable "SKIP_README". If it is set,
     // skip README generation
     if env::var_os("SKIP_README").is_some() {

--- a/sources/logdog/src/log_request.rs
+++ b/sources/logdog/src/log_request.rs
@@ -6,24 +6,85 @@ pub(crate) struct LogRequest<'a> {
     pub(crate) command: &'a str,
 }
 
-/// Returns the standard list of `logdog` commands.
-pub(crate) fn log_requests<'a>() -> impl Iterator<Item = LogRequest<'static>> {
-    [
-        ("os-release", "cat /etc/os-release"),
-        ("journalctl-boots", "journalctl --list-boots --no-pager"),
-        ("journalctl.errors", "journalctl -p err -a --no-pager"),
-        ("journalctl.log", "journalctl -a --no-pager"),
-        ("signpost", "signpost status"),
-        ("settings.json", "apiclient --method GET --uri /"),
-        ("wicked", "wicked show all"),
-        ("containerd-config", "containerd config dump"),
-        ("kube-status", "systemctl status kube* -l --no-pager"),
-        ("dmesg", "dmesg --color=never --nopager"),
-        ("iptables-filter", "iptables -nvL -t filter"),
-        ("iptables-nat", "iptables -nvL -t nat"),
-        ("df", "df -h"),
-        ("df-inodes", "df -hi"),
-    ]
-    .iter()
-    .map(|(filename, command)| LogRequest { filename, command })
+cfg_if::cfg_if! {
+    if #[cfg(variant_group = "aws-k8s")] {
+        /// Returns the list of `logdog` commands for aws-k8s variants.
+        pub(crate) fn log_requests<'a>() -> impl Iterator<Item = LogRequest<'static>> {
+        [
+            ("containerd-config", "containerd config dump"),
+            ("df", "df -h"),
+            ("df-inodes", "df -hi"),
+            ("dmesg", "dmesg --color=never --nopager"),
+            ("etc-mtab", "cat /etc/mtab"),
+            ("iptables-filter", "iptables -nvL -t filter"),
+            ("iptables-nat", "iptables -nvL -t nat"),
+            ("journalctl-boots", "journalctl --list-boots --no-pager"),
+            ("journalctl.errors", "journalctl -p err -a --no-pager"),
+            ("journalctl.log", "journalctl -a --no-pager"),
+            ("kube-status", "systemctl status kube* -l --no-pager"),
+            ("os-release", "cat /etc/os-release"),
+            ("proc-mounts", "cat /proc/mounts"),
+            ("settings.json", "apiclient --method GET --uri /"),
+            ("signpost", "signpost status"),
+            ("wicked", "wicked show all"),
+        ]
+        .iter()
+        .map(|(filename, command)| LogRequest { filename, command })
+        }
+    } else if #[cfg(variant_group = "aws-ecs")] {
+        /// Returns the list of `logdog` commands for aws-ecs variants.
+        pub(crate) fn log_requests<'a>() -> impl Iterator<Item = LogRequest<'static>> {
+        [
+            ("containerd-config", "containerd config dump"),
+            ("df", "df -h"),
+            ("df-inodes", "df -hi"),
+            ("dmesg", "dmesg --color=never --nopager"),
+            ("docker-daemon.json", "cat /etc/docker/daemon.json"),
+            ("docker-info", "docker info"),
+            ("ecs-agent-state.json", "cat /var/lib/ecs/data/ecs_agent_data.json"),
+            ("ecs-config.json", "cat /etc/ecs/ecs.config.json"),
+            ("etc-mtab", "cat /etc/mtab"),
+            ("iptables-filter", "iptables -nvL -t filter"),
+            ("iptables-nat", "iptables -nvL -t nat"),
+            ("journalctl-boots", "journalctl --list-boots --no-pager"),
+            ("journalctl.errors", "journalctl -p err -a --no-pager"),
+            ("journalctl.log", "journalctl -a --no-pager"),
+            ("os-release", "cat /etc/os-release"),
+            ("proc-mounts", "cat /proc/mounts"),
+            ("settings.json", "apiclient --method GET --uri /"),
+            ("signpost", "signpost status"),
+            ("wicked", "wicked show all"),
+            // TODO - https://github.com/bottlerocket-os/bottlerocket/issues/1039
+            // ("ecs-tasks", "curl localhost:51678/v1/tasks"),
+        ]
+        .iter()
+        .map(|(filename, command)| LogRequest { filename, command })
+        }
+    }
+    else {
+        /// Returns the list of `logdog` commands for dev or unspecified variants.
+        pub(crate) fn log_requests<'a>() -> impl Iterator<Item = LogRequest<'static>> {
+        [
+            ("containerd-config", "containerd config dump"),
+            ("df", "df -h"),
+            ("df-inodes", "df -hi"),
+            ("dmesg", "dmesg --color=never --nopager"),
+            ("docker-daemon.json", "cat /etc/docker/daemon.json"),
+            ("docker-info", "docker info"),
+            ("etc-mtab", "cat /etc/mtab"),
+            ("iptables-filter", "iptables -nvL -t filter"),
+            ("iptables-nat", "iptables -nvL -t nat"),
+            ("journalctl-boots", "journalctl --list-boots --no-pager"),
+            ("journalctl.errors", "journalctl -p err -a --no-pager"),
+            ("journalctl.log", "journalctl -a --no-pager"),
+            ("os-release", "cat /etc/os-release"),
+            ("proc-mounts", "cat /proc/mounts"),
+            ("settings.json", "apiclient --method GET --uri /"),
+            ("signpost", "signpost status"),
+            ("wicked", "wicked show all"),
+        ]
+        .iter()
+        .map(|(filename, command)| LogRequest { filename, command })
+        }
+    }
 }


### PR DESCRIPTION

**Issue number:**

#815

**Description of changes:**

Conditionally compile a different set of `logdog` commands for ECS.

**Testing done:**

Ran an ECS variant, got the ECS logs.
Ran a k8s variant, got the k8s logs.

** More work to be Done **

I wanted to get the low hanging fruit handled now, but I still need to do #1039 which requires a more substantial change in `logdog`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
