### PR TITLE
aws-ecs-1: enable awslogs execution role support

### DIFF
--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -42,6 +42,9 @@ struct ECSConfig {
 
     #[serde(rename = "SELinuxCapable")]
     selinux_capable: bool,
+
+    #[serde(rename = "OverrideAWSLogsExecutionRole")]
+    override_awslogs_execution_role: bool,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -83,6 +86,10 @@ fn run() -> Result<()> {
 
         // SELinux is always available
         selinux_capable: true,
+
+        // Always supported with Docker newer than v17.11.0
+        // See https://github.com/docker/engine/commit/c7cc9d67590dd11343336c121e3629924a9894e9
+        override_awslogs_execution_role: true,
         ..Default::default()
     };
     if let Some(os) = settings.os {


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/815


**Description of changes:**
The ECS agent does not currently auto-detect whether a new-enough Docker version is installed for the awslogs execution role capability to be registered.  This commit forces the capability to be registered, as we include a new-enough Docker in Bottlerocket.

**Testing done:**
Launched an instance, ran tasks that depend on the awslogs execution role functionality and validated that the tasks worked.

A number of ECS's automated test cases rely on this functionality.  Previously those tests would not run, now they are able to run and pass.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
