### PR TITLE
Fix rust build caching and tune rpm compression

### DIFF
--- a/macros/cargo
+++ b/macros/cargo
@@ -16,9 +16,10 @@
 %__cargo_cross_opts %{__cargo_common_opts} --target %{__cargo_target}
 %__cargo_cross_opts_static %{__cargo_common_opts} --target %{__cargo_target_static}
 %__cargo_env CARGO_TARGET_DIR="${HOME}/.cache" SKIP_README="true"
+%__cargo_env_static CARGO_TARGET_DIR="${HOME}/.cache/.static" SKIP_README="true"
 %__cargo_cross_pkg_config PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" PKG_CONFIG_ALLOW_CROSS=1
 %__cargo_cross_env %{__cargo_env} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-gnu-gcc"
-%__cargo_cross_env_static %{__cargo_env} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-musl-gcc" CARGO_PROFILE_RELEASE_LTO=thin
+%__cargo_cross_env_static %{__cargo_env_static} %{__cargo_cross_pkg_config} TARGET_CC="%{_cross_triple}-musl-gcc"
 
 %cargo_prep (\
 %{__mkdir} -p %{_builddir}/.cargo \

--- a/macros/rust
+++ b/macros/rust
@@ -15,7 +15,7 @@
 %__global_rustflags_shared -Cprefer-dynamic %__global_rustflags
 
 # Enable LTO and static C runtime.
-%__global_rustflags_static -Ctarget-feature=+crt-static -Clink-arg=-lgcc %__global_rustflags
+%__global_rustflags_static -Clto=thin -Cembed-bitcode=yes -Ctarget-feature=+crt-static -Clink-arg=-lgcc %__global_rustflags
 
 %__global_rustflags_shared_toml [%{lua:
     for arg in string.gmatch(rpm.expand("%{__global_rustflags_shared}"), "%S+") do

--- a/macros/shared
+++ b/macros/shared
@@ -222,6 +222,13 @@ CROSS_COMPILATION_CONF_EOF\
 # failures when rewriting "shebangs" in crate files.
 %__brp_mangle_shebangs /bin/true
 
+# Do not compress debuginfo.
+%_find_debuginfo_dwz_opts %{nil}
+
+# Compress RPM payloads with zstd level 1 in single-threaded mode.
+%_source_payload w1T0.zstdio
+%_binary_payload w1T0.zstdio
+
 %__arch_install_post \
   %{?!_cross_allow_rpath:/usr/lib/rpm/check-rpaths} \
   /usr/lib/rpm/check-buildroot \

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -210,7 +210,7 @@ for p in \
 done
 
 for p in apiclient ; do
-  install -p -m 0755 ${HOME}/.cache/%{__cargo_target_static}/release/${p} %{buildroot}%{_cross_bindir}
+  install -p -m 0755 ${HOME}/.cache/.static/%{__cargo_target_static}/release/${p} %{buildroot}%{_cross_bindir}
 done
 
 install -d %{buildroot}%{_cross_sbindir}
@@ -227,7 +227,7 @@ for version_path in %{_builddir}/sources/api/migration/migrations/*; do
     version="${version_path##*/}"
     crate_name="${migration_path##*/}"
     migration_binary_name="migrate_${version}_${crate_name#migrate-}"
-    built_path="${HOME}/.cache/%{__cargo_target_static}/release/${crate_name}"
+    built_path="${HOME}/.cache/.static/%{__cargo_target_static}/release/${crate_name}"
     target_path="%{buildroot}%{_cross_datadir}/migrations/${migration_binary_name}"
 
     install -m 0555 "${built_path}" "${target_path}"


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Use a separate cache for gnu and musl targets, so that they don't overwrite each other. Use fixed `rustc` flags to avoid letting `cargo` pick, which can invalidate the musl cache between builds.

Disable debuginfo compression since we don't need it. Optimize the compression of the cpio archive inside the rpms for our use case.

**Testing done:**
While hacking on `growpart` I noticed that each build was taking over five minutes which was pretty painful for iterative testing.

Changing the Rust macros to better preserve the cache dropped the time to two minutes, while adjusting the compression for debuginfo and cpio archives dropped it to one minute. I verified that all crates are marked as "fresh" in the output for subsequent runs.

Rebuild time when switching variants is now around five minutes. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
