### PR TITLE
README: add supported architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ For example, an `x86_64` build of the `aws-k8s-1.17` variant will produce an ima
 
 Our first supported variants, `aws-k8s-1.15`, `aws-k8s-1.16`, and `aws-k8s-1.17`, supports EKS as described above.
 
+## Architectures
+
+Our supported architectures include `x86_64` and `aarch64` (written as `arm64` in some contexts).
+
 ## Setup
 
 :walking: :running:


### PR DESCRIPTION
**Description of changes:**

The v0.5.0 release including ARM64 support is out; this change adds a note to the README.  There aren't too many places in the docs that need to mention / depend on arch, and this simple addition seemed clearest.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
