### PR TITLE
ecs-agent: don't start if not configured

### DIFF
--- a/packages/ecs-agent/ecs.service
+++ b/packages/ecs-agent/ecs.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Amazon Elastic Container Service - container agent
 Documentation=https://aws.amazon.com/documentation/ecs/
-Requires=docker.service
+Requires=docker.service configured.target
 After=docker.service configured.target
 Wants=network-online.target configured.target
 

--- a/packages/release/configured.target
+++ b/packages/release/configured.target
@@ -1,5 +1,5 @@
 [Unit]
 Description=Bottlerocket user and dynamic configuration complete
 After=settings-applier.service
-Requires=settings-applier.service
+Requires=settings-applier.service early-boot-config.service
 AllowIsolate=yes


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/815


**Description of changes:**
Configuration errors can manifest in one of two ways:

1. configured.target can fail if settings-applier.service fails (which can happen if user-data is garbage/invalid TOML)
2. early-boot-config.service can fail if user-data includes validly-structured TOML with invalid fields or data

If configuration fails, the ECS agent should not start automatically.


**Testing done:**
Built an `aws-ecs-1` AMI.  Launched three instances:

1. an instance with well-structured, valid user-data - everything started normally
2. an instance with well-structured, invalid user-data - default host containers (control container) started.  After enabling the admin container, I could verify that `systemctl status` showed the host in a `degraded` state and both `ecs.service` and `chronyd.service` were marked `inactive (dead)` with a note that this was due to a failed dependency
3. an instance with garbage user-data - no host containers started, the console output showed a failure to construct the host container image names, and the console output showed `[FAILED] Failed to start Bottlerocket userdata configuration system.`, `[DEPEND] Dependency failed for Amazon Elasti…ntainer Service - container agent.`, and `[DEPEND] Dependency failed for A versatile i…tion of the Network Time Protocol.`

Built an `aws-dev` AMI.  Launched three instances:
1. an instance with well-structured, valid user-data - everything started normally
2. an instance with well-structured, invalid user-data - default host containers (control container) started.  After enabling the admin container, I could verify that `systemctl status` showed the host in a `degraded` state and `chronyd.service` was marked `inactive (dead)` with a note that this was due to a failed dependency
3. an instance with garbage user-data - no host containers started, the console output showed a failure to construct the host container image names, and the console output showed `[FAILED] Failed to start Bottlerocket userdata configuration system.` and `[DEPEND] Dependency failed for A versatile i…tion of the Network Time Protocol.`

Built an `aws-k8s-1.16` AMI.  Launched three instances:
1. an instance with well-structured, valid user-data - everything started normally
2. an instance with well-structured, invalid user-data - default host containers (control container) started.  After enabling the admin container, I could verify that `systemctl status` showed the host in a `degraded` state and `chronyd.service` was marked `inactive (dead)` with a note that this was due to a failed dependency
3. an instance with garbage user-data - no host containers started, the console output showed a failure to construct the host container image names, and the console output showed `[FAILED] Failed to start Bottlerocket userdata configuration system.` and `[DEPEND] Dependency failed for A versatile i…tion of the Network Time Protocol.`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
