### PR TITLE
aws-ecs-1: constrain ephemeral port range

### DIFF
--- a/packages/ecs-agent/ecs-sysctl.conf
+++ b/packages/ecs-agent/ecs-sysctl.conf
@@ -1,2 +1,6 @@
 # ECS task role endpoint
 net.ipv4.conf.all.route_localnet = 1
+
+# Constrain ephemeral ports to the range documented for ECS
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html
+net.ipv4.ip_local_port_range = 32768 60999


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/815


**Description of changes:**
ECS documents a smaller ephemeral port range than is default on Bottlerocket.  Constraining our range to the documented ECS range should avoid surprising customers who expect ECS's documented range and have configured their security groups accordingly.


**Testing done:**
* Ran containers with `docker run` locally and saw the correct ephemeral port range being used.
* Ran a task with `"portMappings": [{"containerPort": 80}]` and saw the correct ephemeral port range being used.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
