### PR TITLE
aws-ecs-1: remove unsupported capabilities

### DIFF
--- a/packages/ecs-agent/0003-bottlerocket-remove-unsupported-capabilities.patch
+++ b/packages/ecs-agent/0003-bottlerocket-remove-unsupported-capabilities.patch
@@ -1,0 +1,59 @@
+From 5d5517422621691341d0f3c9ecee2f314d0adc02 Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Wed, 19 Aug 2020 00:44:07 -0700
+Subject: [PATCH 3/3] bottlerocket: remove unsupported capabilities
+
+---
+ agent/app/agent_capability.go | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/agent/app/agent_capability.go b/agent/app/agent_capability.go
+index 09e01825..a7c36cfd 100644
+--- a/agent/app/agent_capability.go
++++ b/agent/app/agent_capability.go
+@@ -186,33 +186,33 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
+ 	capabilities = agent.appendPIDAndIPCNamespaceSharingCapabilities(capabilities)
+ 
+ 	// ecs agent version 1.26.0 supports aws-appmesh cni plugin
+-	capabilities = agent.appendAppMeshCapabilities(capabilities)
++	// capabilities = agent.appendAppMeshCapabilities(capabilities)
+ 
+ 	// support elastic inference in agent
+-	capabilities = agent.appendTaskEIACapabilities(capabilities)
++	// capabilities = agent.appendTaskEIACapabilities(capabilities)
+ 
+ 	// support aws router capabilities for fluentd
+-	capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
++	// capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
+ 
+ 	// support aws router capabilities for fluentbit
+-	capabilities = agent.appendFirelensFluentbitCapabilities(capabilities)
++	// capabilities = agent.appendFirelensFluentbitCapabilities(capabilities)
+ 
+ 	// support aws router capabilities for log driver router
+-	capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
++	// capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
+ 
+ 	// support efs on ecs capabilities
+ 	capabilities = agent.appendEFSCapabilities(capabilities)
+ 
+ 	// support external firelens config
+-	capabilities = agent.appendFirelensConfigCapabilities(capabilities)
++	// capabilities = agent.appendFirelensConfigCapabilities(capabilities)
+ 
+ 	// support GMSA capabilities
+ 	capabilities = agent.appendGMSACapabilities(capabilities)
+ 
+ 	// support efs auth on ecs capabilities
+-	for _, cap := range agent.cfg.VolumePluginCapabilities {
+-		capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
+-	}
++	// for _, cap := range agent.cfg.VolumePluginCapabilities {
++	//	capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
++	// }
+ 
+ 	return capabilities, nil
+ }
+-- 
+2.28.0
+

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -32,6 +32,9 @@ Patch0001: 0001-bottlerocket-default-filesystem-locations.patch
 # Bottlerocket-specific - version data can be set with linker options
 Patch0002: 0002-bottlerocket-version-values-settable-with-linker.patch
 
+# Bottlerocket-specific - remove unsupported capabilities
+Patch0003: 0003-bottlerocket-remove-unsupported-capabilities.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 
 Requires: %{_cross_os}docker-engine


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/815


**Description of changes:**
By default, the ECS agent adds several capabilities for features that are non-functional on Bottlerocket.  This patch removes those capabilities until we add support for the associated features.


**Testing done:**
Built an AMI.  Examined the list of capabilities with `amazon-ecs-agent -ecs-attributes` (through sheltie) and by calling the DescribeContainerInstances API.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
