### PR TITLE
isolate host containers and limit access to API socket

### DIFF
--- a/packages/os/host-containers-tmpfiles.conf
+++ b/packages/os/host-containers-tmpfiles.conf
@@ -1,1 +1,3 @@
 d /etc/host-containers 0755 root root -
+d /local/host-containers 0700 root root -
+T /local/host-containers - - - - security.selinux=system_u:object_r:state_t:s0

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -62,6 +62,8 @@
 (filecon "/var/.*" any ())
 
 ; Label local state directories.
+(filecon "/local/host-containers" any state)
+(filecon "/local/host-containers/.*" any state)
 (filecon "/var/lib/chrony" any measure)
 (filecon "/var/lib/chrony/.*" any measure)
 (filecon "/var/lib/systemd" any state)

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -65,6 +65,11 @@
 (roletype object_r private_t)
 (context private (system_u object_r private_t s0))
 
+; Files that are the API socket.
+(type api_socket_t)
+(roletype object_r api_socket_t)
+(context api_socket (system_u object_r api_socket_t s0))
+
 ; Files for cached container layers.
 (type cache_t)
 (roletype object_r cache_t)
@@ -118,4 +123,5 @@
   network_exec_t bus_exec_t runtime_exec_t
   any_t etc_t unlabeled_t external_t
   local_t private_t cache_t
-  lease_t measure_t state_t))
+  lease_t measure_t state_t
+  api_socket_t))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -59,9 +59,11 @@
 ; objects on local storage.
 (typetransition runtime_t local_t process container_t)
 (typetransition runtime_t cache_t process container_t)
+(typetransition runtime_t state_t process container_t)
 (allow runtime_t container_s (processes (transform)))
 (allow container_s local_t (file (entrypoint)))
 (allow container_s cache_t (file (entrypoint)))
+(allow container_s state_t (file (entrypoint)))
 
 ; Allow containers to communicate with runtimes via pipes.
 (allow container_s runtime_t (files (mutate)))
@@ -81,6 +83,10 @@
 (typetransition runtime_t local_t dir "io.containerd.snapshotter.v1.overlayfs" cache_t)
 ; ... docker's image layers
 (typetransition runtime_t local_t dir "overlay2" cache_t)
+
+; If a system process creates a directory for host container state, it
+; receives the "state_t" label.
+(typetransition system_t local_t dir "host-containers" state_t)
 
 ; All subjects are allowed to write to objects with their own label.
 ; This includes files like the ones under /proc/self.
@@ -105,8 +111,19 @@
 ; mounts for "local" files and directories on /local.
 (allow unconfined_s local_t (files (mutate watch mount)))
 
-; Confined subjects cannot modify these "local" files.
+; Subjects that control the OS can write to, set watches for, and
+; manage mounts for "state" files and directories on /local. Our
+; runtimes also need to be able to perform these operations so that
+; they can launch host containers.
+(allow control_s state_t (files (mutate watch mount)))
+(allow runtime_s state_t (files (mutate watch mount)))
+
+; Untrusted subjects cannot modify the "state" files.
+(neverallow untrusted_s state_t (files (mutate watch mount)))
+
+; Confined subjects cannot modify either "state" or "local" files.
 (neverallow confined_s local_t (files (mutate watch mount)))
+(neverallow confined_s state_t (files (mutate watch mount)))
 
 ; Trusted components are allowed to manage mounts everywhere.
 (allow trusted_s global (files (mount)))
@@ -126,7 +143,6 @@
 (allow clock_s measure_t (files (mutate watch)))
 (allow network_s lease_t (files (mutate watch)))
 (allow runtime_s cache_t (files (mutate watch)))
-(allow system_s state_t (files (mutate watch)))
 
 ; Other components should not be permitted to modify these files,
 ; set watches for them, or to manage mounts for these directories.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -88,6 +88,9 @@
 ; receives the "state_t" label.
 (typetransition system_t local_t dir "host-containers" state_t)
 
+; The socket for the API server gets the "api_socket_t" label.
+(typetransition api_t any_t sock_file "api.sock" api_socket_t)
+
 ; All subjects are allowed to write to objects with their own label.
 ; This includes files like the ones under /proc/self.
 ; They can also set watches on those objects.
@@ -148,6 +151,15 @@
 ; set watches for them, or to manage mounts for these directories.
 (neverallow other_s protected_o (files (mutate watch mount)))
 (neverallow other_s immutable_o (files (watch)))
+
+; Only the API server and specific components can use the API
+; socket, as this provides a means to escalate privileges and
+; persist changes.
+(allow api_s api_socket_t (files (mutate watch)))
+(allow control_s api_socket_t (files (mutate watch)))
+
+; Untrusted components are not allowed to use the API socket.
+(neverallow untrusted_s api_socket_t (files (mutate watch)))
 
 ; Only trusted components are allowed to relabel files.
 (allow trusted_s global (files (relabel)))

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -48,6 +48,11 @@
 (roletype system_r container_t)
 (context container (system_u system_r container_t s0))
 
+; Processes that run inside containers that control the OS.
+(type control_t)
+(roletype system_r control_t)
+(context control (system_u system_r control_t s0))
+
 ; Processes that run inside highly privileged containers.
 (type super_t)
 (roletype system_r super_t)
@@ -58,7 +63,7 @@
 (typeattributeset all_s (
   kernel_t init_t system_t api_t
   network_t clock_t bus_t runtime_t
-  container_t super_t))
+  container_t control_t super_t))
 
 ; Subjects that are treated as a trusted part of the OS.
 (typeattribute trusted_s)
@@ -82,7 +87,7 @@
 
 ; Subjects that are started from containers.
 (typeattribute container_s)
-(typeattributeset container_s (container_t super_t))
+(typeattributeset container_s (container_t control_t super_t))
 
 ; Subjects that are shipped with the OS.
 (typeattribute host_s)
@@ -104,6 +109,6 @@
 (typeattribute network_s)
 (typeattributeset network_s (network_t system_t super_t))
 
-; Subjects that are allowed to manage system files.
-(typeattribute system_s)
-(typeattributeset system_s (system_t super_t))
+; Subjects that are allowed to control system files.
+(typeattribute control_s)
+(typeattributeset control_s (control_t system_t super_t))

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -207,7 +207,7 @@ func _main() int {
 				Source:      "/local/host-containers/" + containerID,
 			}}),
 		// Mount the rootfs with an SELinux label that makes it writable
-		withMountLabel("system_u:object_r:local_t:s0"),
+		withMountLabel("system_u:object_r:state_t:s0"),
 		// Include conditional options for superpowered containers.
 		withSuperpowered(superpowered),
 	)
@@ -375,8 +375,11 @@ func withMountLabel(label string) oci.SpecOpts {
 // when it's `superpowered`.
 func withSuperpowered(superpowered bool) oci.SpecOpts {
 	if !superpowered {
+		// Set the `control_t` process label so the host container can
+		// interact with the API and modify its local state files.
 		return oci.Compose(
 			seccomp.WithDefaultProfile(),
+			oci.WithSelinuxLabel("system_u:system_r:control_t:s0"),
 		)
 	}
 


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Create a distinction between host containers and orchestrated containers in the SELinux policy, and update host-ctr to match. Now host containers will run with one of two privileged labels, and the files they write will receive a different label. 

Limit access to the API socket to processes with one of the privileged labels. All host containers will have access to the API, but orchestrated containers will need to opt-in to its use by running as either `control_t` or `super_t`.


**Testing done:**
Confirmed that `apiclient` in the control container and admin container still works, and that the files they create are correctly labeled.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
