### PR TITLE
update to chrony 3.5.1

### DIFF
--- a/packages/chrony/Cargo.toml
+++ b/packages/chrony/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download.tuxfamily.org/chrony/chrony-3.5.tar.gz"
-sha512 = "c4f6376a44d71b6ac2b6d86e3d6fb4348642faeef7f3f3a4d6431627b5645efcc868b005cc398c8292bc3b63a1161fbd1a042c6ac2a0595843f908fe32eed90c"
+url = "https://download.tuxfamily.org/chrony/chrony-3.5.1.tar.gz"
+sha512 = "489cf614bfb2c1e024343af1316c339b287ed5c7b6cec15b44ef3d90512036fb1da3fd627d291a193c59d9c5c095afa66c529eeb6fd0c1bbc8256ed8873b7984"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}chrony
-Version: 3.5
+Version: 3.5.1
 Release: 1%{?dist}
 Summary: A versatile implementation of the Network Time Protocol
 License: GPL-2.0-only
 URL: https://chrony.tuxfamily.org
-Source0: https://download.tuxfamily.org/chrony/chrony-3.5.tar.gz
+Source0: https://download.tuxfamily.org/chrony/chrony-%{version}.tar.gz
 Source1: chronyd.service
 Source2: chrony-conf
 Source3: chrony-sysusers.conf


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This includes the fix for CVE-2020-14367.


**Testing done:**
Built the `aws-k8s-1.17` variant and confirmed that chronyd starts & restarts successfully.

```
# journalctl -t chronyd
-- Logs begin at Fri 2020-08-21 19:05:07 UTC, end at Fri 2020-08-21 19:11:49 UTC. --
Aug 21 19:05:40 chronyd[2920]: 2020-08-21T19:05:40Z chronyd version 3.5.1 starting (+CMDMON +NTP +REFCLOCK +
RTC +PRIVDROP +SCFILTER -SIGND +ASYNCDNS -SECHASH +IPV6 -DEBUG)
Aug 21 19:05:40 chronyd[2920]: 2020-08-21T19:05:40Z Loaded seccomp filter
Aug 21 19:05:46 chronyd[2920]: 2020-08-21T19:05:46Z Selected source 169.254.169.123
Aug 21 19:11:43 chronyd[2920]: 2020-08-21T19:11:43Z chronyd exiting
Aug 21 19:11:43 chronyd[6629]: 2020-08-21T19:11:43Z chronyd version 3.5.1 starting (+CMDMON +NTP +REFCLOCK +
RTC +PRIVDROP +SCFILTER -SIGND +ASYNCDNS -SECHASH +IPV6 -DEBUG)
Aug 21 19:11:43 chronyd[6629]: 2020-08-21T19:11:43Z Frequency 2.456 +/- 0.117 ppm read from /var/lib/chrony/drift
Aug 21 19:11:43 chronyd[6629]: 2020-08-21T19:11:43Z Loaded seccomp filter
Aug 21 19:11:49 chronyd[6629]: 2020-08-21T19:11:49Z Selected source 169.254.169.123
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
