### PR TITLE
fix growpart to avoid race in partition table reload

### DIFF
--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -12,19 +12,17 @@ Environment=BOTTLEROCKET_DATA=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
 Environment=LOCAL_DIR=/local
 Environment=CONTEXT="system_u:object_r:local_t:s0"
 
-# To "grow" the partition, we delete it and recreate it at the larger size, which
-# causes the udev links to be deleted and then recreated. We have to wait for the
-# links to return before continuing.
+# To "grow" the partition, we delete it and recreate it at the larger size, then
+# write it back to the device. udevd observes the write via inotify, and tells
+# the kernel to reload the partition table. This causes the partition link to be
+# deleted and then recreated.
 ExecStart=/usr/sbin/growpart ${BOTTLEROCKET_DATA}
-ExecStart=/usr/bin/udevadm settle -E ${BOTTLEROCKET_DATA}
 
-# HACK: If the GPT label was not already at the end of the disk, the first pass
-# will write it there, but any additional sectors beyond the original position
-# were not included in the resized partition. Now that the kernel has reloaded
-# the partition table, the second pass can find and use those sectors. This
-# avoids the need to synchronize with the kernel (and udev) inside `growpart`.
+# If the GPT label was not already at the end of the disk, the first pass will
+# write it there, but any additional sectors beyond the original position were
+# not included in the resized partition. Now that the kernel has reloaded the
+# partition table, the second pass can find and use those sectors.
 ExecStart=/usr/sbin/growpart ${BOTTLEROCKET_DATA}
-ExecStart=/usr/bin/udevadm settle -E ${BOTTLEROCKET_DATA}
 
 # The above note means we can't have a "normal" mount unit here, because it would
 # depend on the link, and would immediately transition to the failed state when the

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "block-party 0.1.0",
  "cargo-readme 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gptman 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1170,6 +1171,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inotify"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2990,6 +3012,8 @@ dependencies = [
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+"checksum inotify 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "46dd0a94b393c730779ccfd2a872b67b1eb67be3fc33082e733bdb38b5fde4d4"
+"checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum instant 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum ipconfig 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"

--- a/sources/growpart/Cargo.toml
+++ b/sources/growpart/Cargo.toml
@@ -13,6 +13,7 @@ gptman = { version = "0.6.1", default-features = false }
 snafu = "0.6"
 libc = "0.2"
 block-party = { path = "../updater/block-party" }
+inotify = "0.8.3"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/growpart/src/diskpart/error.rs
+++ b/sources/growpart/src/diskpart/error.rs
@@ -30,12 +30,6 @@ pub enum Error {
         source: std::io::Error,
     },
 
-    #[snafu(display("Failed to stat '{}': {}", path.display(), source))]
-    DeviceStat {
-        path: std::path::PathBuf,
-        source: std::io::Error,
-    },
-
     #[snafu(display("Failed to read partition table from '{}': {}", path.display(), source))]
     ReadPartitionTable {
         path: std::path::PathBuf,
@@ -54,12 +48,6 @@ pub enum Error {
         source: gptman::Error,
     },
 
-    #[snafu(display("Failed to reload partition table from '{}': {}", path.display(), source))]
-    ReloadPartitionTable {
-        path: std::path::PathBuf,
-        source: gptman::linux::BlockError,
-    },
-
     #[snafu(display("Failed to remove partition {} from '{}': {}", part, path.display(), source))]
     RemovePartition {
         part: u32,
@@ -72,6 +60,21 @@ pub enum Error {
         path: std::path::PathBuf,
         source: gptman::Error,
     },
+
+    #[snafu(display("Failed to initialize inotify: {}", source))]
+    InitInotify { source: std::io::Error },
+
+    #[snafu(display("Failed to add inotify watch: {}", source))]
+    AddInotifyWatch { source: std::io::Error },
+
+    #[snafu(display("Failed to read inotify events: {}", source))]
+    ReadInotifyEvents { source: std::io::Error },
+
+    #[snafu(display("Failed to find parent directory for '{}'", path.display()))]
+    FindParentDirectory { path: std::path::PathBuf },
+
+    #[snafu(display("Failed to find file name for '{}'", path.display()))]
+    FindFileName { path: std::path::PathBuf },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/sources/growpart/src/main.rs
+++ b/sources/growpart/src/main.rs
@@ -44,6 +44,7 @@ fn run() -> Result<()> {
     let mut diskpart = DiskPart::new(args.partition)?;
     diskpart.grow()?;
     diskpart.write()?;
+    diskpart.sync()?;
     Ok(())
 }
 


### PR DESCRIPTION
**Issue number:**
#845 


**Description of changes:**
udevd watches files in /dev via inotify, and when a block disk device is closed after writing, it tells the kernel to reload the partition table.

This was racing with the reload code in growpart; if we were unlucky in our timing, the kernel would be busy with udevd's reload and our call would fail.

To fix this, we stop reloading the partition table in growpart, and use inotify to determine when udevd has deleted and recreated the partition links.


**Testing done:**
Tested launches and reboots of 250 instances in a cluster. All came up successfully and resized the partition to the expected 20 GiB size.

```
# systemctl status prepare-local
● prepare-local.service - Prepare Local Directory (/local)
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/prepare-local.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2020-08-21 19:05:08 UTC; 22min ago
   Main PID: 2049 (code=exited, status=0/SUCCESS)
      Tasks: 0 (limit: 9185)
     Memory: 0B
     CGroup: /system.slice/prepare-local.service

Aug 21 19:05:07 localhost growpart[1911]: read partition table from nvme1n1
Aug 21 19:05:07 localhost growpart[1911]: wrote partition table to /dev/nvme1n1
Aug 21 19:05:07 localhost growpart[1911]: saw BOTTLEROCKET-DATA link deleted
Aug 21 19:05:07 localhost growpart[1911]: saw BOTTLEROCKET-DATA link created
Aug 21 19:05:07 localhost growpart[2008]: read partition table from nvme1n1
Aug 21 19:05:07 localhost growpart[2008]: wrote partition table to /dev/nvme1n1
Aug 21 19:05:07 localhost growpart[2008]: saw BOTTLEROCKET-DATA link deleted
Aug 21 19:05:07 localhost growpart[2008]: saw BOTTLEROCKET-DATA link created
Aug 21 19:05:08 localhost systemd-growfs[2026]: Successfully resized "/local" to 19.9G bytes.
Aug 21 19:05:08 localhost systemd[1]: Finished Prepare Local Directory (/local).
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
