### PR TITLE
pubsys: add SSM parameter publishing

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,9 +37,17 @@ PUBLISH_KEY = "default"
 # AMIs.  (You can also specify PUBLISH_ROOT_VOLUME_SIZE to override the root
 # volume size; by default it's the image size, rounded up.)
 PUBLISH_DATA_VOLUME_SIZE = "20"
-# You can also set PUBLISH_REGIONS to override the list of regions for AMIs
-# from Infra.toml; it's a comma-separated list like "us-west-2,us-east-1".
-# You can also set NO_PROGRESS to not print progress bars during snapshot upload.
+# This can be overridden with -e to change the path to the directory containing
+# SSM parameter template files.  These files determine the parameter names and
+# values that will be published to SSM when you run `cargo make ssm`.
+PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm"
+
+# You can also set PUBLISH_REGIONS to override the list of regions from
+# Infra.toml for AMI and SSM commands; it's a comma-separated list like
+# "us-west-2,us-east-1".
+# You can set NO_PROGRESS=true to not print progress bars during snapshot upload.
+# You can use ALLOW_CLOBBER=true with the `ssm` task to make it overwrite existing values.
+# (This is not required with `promote-ssm` because the intent of promotion is overwriting.)
 
 # Disallow pulling directly Upstream URLs when lookaside cache results in MISSes as a fallback.
 # To use the upstream source as fallback, override this on the command line and set it to 'true'
@@ -468,6 +476,71 @@ pubsys \
    --make-private \
    \
    --ami-input "${ami_input}" \
+   ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"}
+'''
+]
+
+[tasks.ssm]
+# Rather than depend on "build", which currently rebuilds images each run, we
+# depend on publish-tools and check for the input file below to save time.
+# This does mean that `cargo make ami` must be run before `cargo make ssm`.
+dependencies = ["publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+ami_input="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-amis.json"
+if [ ! -s "${ami_input}" ]; then
+   echo "AMI input file doesn't exist for the current version/commit - ${BUILDSYS_VERSION_FULL} - please run 'cargo make ami'" >&2
+   exit 1
+fi
+
+pubsys \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   \
+   ssm \
+   \
+   --ami-input "${ami_input}" \
+   --arch "${BUILDSYS_ARCH}" \
+   --variant "${BUILDSYS_VARIANT}" \
+   --version "${BUILDSYS_VERSION_FULL}" \
+   --template-dir "${PUBLISH_SSM_TEMPLATES_PATH}" \
+   \
+   ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"} \
+   ${ALLOW_CLOBBER:+--allow-clobber}
+'''
+]
+
+[tasks.promote-ssm]
+dependencies = ["publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+source="${SSM_SOURCE:-${BUILDSYS_VERSION_FULL}}"
+target="${SSM_TARGET}"
+if [ -z "${target}" ]; then
+   echo "SSM_TARGET is mandatory for promote-ssm; please give the version (or pointer like "latest") to which you want to promote ${source}" >&2
+   exit 1
+fi
+
+pubsys \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   \
+   promote-ssm \
+   \
+   --arch "${BUILDSYS_ARCH}" \
+   --variant "${BUILDSYS_VARIANT}" \
+   --source "${source}" \
+   --target "${target}" \
+   --template-dir "${PUBLISH_SSM_TEMPLATES_PATH}" \
+   \
    ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"}
 '''
 ]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1332,6 +1332,7 @@ dependencies = [
  "rusoto_ebs",
  "rusoto_ec2",
  "rusoto_signature 0.45.0",
+ "rusoto_ssm 0.45.0",
  "rusoto_sts",
  "semver 0.10.0",
  "serde",
@@ -1340,6 +1341,7 @@ dependencies = [
  "snafu",
  "structopt",
  "tempfile",
+ "tinytemplate",
  "tokio",
  "toml",
  "tough",
@@ -1679,6 +1681,20 @@ dependencies = [
  "bytes",
  "futures",
  "rusoto_core 0.44.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rusoto_ssm"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4950a5600f4aab2eeb1f525d7843acbfbc7a720275d26c2afcddbb112ffd17"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core 0.45.0",
  "serde",
  "serde_json",
 ]
@@ -2233,6 +2249,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,7 +2387,7 @@ checksum = "54e670640f67e719671a87fac948eabba0fd33633aa8be7804b38a1a1d2da32b"
 dependencies = [
  "rusoto_core 0.44.0",
  "rusoto_credential 0.44.0",
- "rusoto_ssm",
+ "rusoto_ssm 0.44.0",
  "serde",
  "serde_json",
  "snafu",

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -23,6 +23,7 @@ rusoto_credential = "0.45.0"
 rusoto_ebs = "0.45.0"
 rusoto_ec2 = "0.45.0"
 rusoto_signature = "0.45.0"
+rusoto_ssm = "0.45.0"
 rusoto_sts = "0.45.0"
 simplelog = "0.8"
 snafu = "0.6"
@@ -30,7 +31,8 @@ semver = "0.10.0"
 serde = { version = "1.0", features = ["derive"]  }
 serde_json = "1.0"
 structopt = { version = "0.3", default-features = false  }
-tokio = "0.2.21"
+tinytemplate = "1.1"
+tokio = { version = "0.2.21", features = ["time"] }
 toml = "0.5"
 tough = { version = "0.8", features = ["http"] }
 tough-ssm = "0.3"

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -38,6 +38,8 @@ regions = ["us-west-2", "us-east-1", "us-east-2"]
 profile = "my-profile"
 # If specified, we assume this role before making any API calls.
 role = "arn:aws:iam::012345678901:role/assume-global"
+# If specified, this string will be prefixed on all parameter names published to SSM.
+ssm_prefix = "/your/prefix/here"
 
 [aws.region.us-west-2]
 # If specified, we assume this role before making any API calls in this region.

--- a/tools/pubsys/policies/ssm/README.md
+++ b/tools/pubsys/policies/ssm/README.md
@@ -1,0 +1,30 @@
+# Parameter templates
+
+Files in this directory contain template strings that are used to generate SSM parameter names and values.
+You can pass a different directory to `pubsys` to use a different set of parameters.
+
+The directory is expected to contain a file named `defaults.toml` with a table entry per parameter, like this:
+
+```
+[[parameter]]
+name = "{variant}/{arch}/{image_version}/image_id"
+value = "{image_id}"
+```
+
+The `name` and `value` can contain template variables that will be replaced with information from the current build and from the AMI registered from that build.
+
+The available variables include:
+* `variant`, for example "aws-k8s-1.17"
+* `arch`, for example "x86_64"
+* `image_id`, for example "ami-0123456789abcdef0"
+* `image_name`, for example "bottlerocket-aws-k8s-1.17-x86_64-v0.5.0-e0ddf1b"
+* `image_version`, for example "0.5.0-e0ddf1b"
+* `region`, for example "us-west-2"
+
+# Overrides
+
+You can also add or override parameters that are specific to `variant` or `arch`.
+To do so, create a directory named "variant" or "arch" inside parameters directory, and create a file named after the specific variant or arch for which you want overrides.
+
+For example, to add extra parameters just for the "aarch64" architecture, create `arch/aarch64.toml`.
+Inside you can put the same types of `[[parameter]]` declarations that you see in `defaults.toml`, but they'll only be applied for `aarch64` builds.

--- a/tools/pubsys/policies/ssm/defaults.toml
+++ b/tools/pubsys/policies/ssm/defaults.toml
@@ -1,0 +1,7 @@
+[[parameter]]
+name = "{variant}/{arch}/{image_version}/image_id"
+value = "{image_id}"
+
+[[parameter]]
+name = "{variant}/{arch}/{image_version}/image_version"
+value = "{image_version}"

--- a/tools/pubsys/src/aws/client.rs
+++ b/tools/pubsys/src/aws/client.rs
@@ -7,6 +7,7 @@ use rusoto_credential::{
 };
 use rusoto_ebs::EbsClient;
 use rusoto_ec2::Ec2Client;
+use rusoto_ssm::SsmClient;
 use rusoto_sts::{StsAssumeRoleSessionCredentialsProvider, StsClient};
 use snafu::ResultExt;
 
@@ -28,6 +29,16 @@ impl NewWith for EbsClient {
 }
 
 impl NewWith for Ec2Client {
+    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+        D: DispatchSignedRequest + Send + Sync + 'static,
+    {
+        Self::new_with(request_dispatcher, credentials_provider, region)
+    }
+}
+
+impl NewWith for SsmClient {
     fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,

--- a/tools/pubsys/src/aws/mod.rs
+++ b/tools/pubsys/src/aws/mod.rs
@@ -6,7 +6,9 @@ use snafu::ResultExt;
 pub(crate) mod client;
 
 pub(crate) mod ami;
+pub(crate) mod promote_ssm;
 pub(crate) mod publish_ami;
+pub(crate) mod ssm;
 
 /// Builds a Region from the given region name, and uses the custom endpoint from the AWS config,
 /// if specified in aws.region.REGION.endpoint.

--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -1,0 +1,269 @@
+//! The promote_ssm module owns the 'promote-ssm' subcommand and controls the process of copying
+//! SSM parameters from one version to another
+
+use crate::aws::client::build_client;
+use crate::aws::region_from_string;
+use crate::aws::ssm::{key_difference, ssm, template, BuildContext, SsmKey};
+use crate::config::InfraConfig;
+use crate::Args;
+use log::{info, trace};
+use rusoto_core::Region;
+use rusoto_ssm::SsmClient;
+use snafu::{ensure, ResultExt};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Copies sets of SSM parameters
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct PromoteArgs {
+    /// The architecture of the machine image
+    #[structopt(long)]
+    arch: String,
+
+    /// The variant name for the current build
+    #[structopt(long)]
+    variant: String,
+
+    /// Version number (or string) to copy from
+    #[structopt(long)]
+    source: String,
+
+    /// Version number (or string) to copy to
+    #[structopt(long)]
+    target: String,
+
+    /// Comma-separated list of regions to promote in, overriding Infra.toml
+    #[structopt(long, use_delimiter = true)]
+    regions: Vec<String>,
+
+    /// Directory holding the parameter template files
+    #[structopt(long)]
+    template_dir: PathBuf,
+}
+
+/// Common entrypoint from main()
+pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
+    info!(
+        "Promoting SSM parameters from {} to {}",
+        promote_args.source, promote_args.target
+    );
+
+    // Setup   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    info!(
+        "Using infra config from path: {}",
+        args.infra_config_path.display()
+    );
+    let infra_config = InfraConfig::from_path(&args.infra_config_path).context(error::Config)?;
+    trace!("Parsed infra config: {:#?}", infra_config);
+    let aws = infra_config.aws.unwrap_or_else(Default::default);
+    let ssm_prefix = aws.ssm_prefix.as_deref().unwrap_or_else(|| "");
+
+    // If the user gave an override list of regions, use that, otherwise use what's in the config.
+    let regions = if !promote_args.regions.is_empty() {
+        promote_args.regions.clone()
+    } else {
+        aws.regions.clone().into()
+    }
+    .into_iter()
+    .map(|name| region_from_string(&name, &aws).context(error::ParseRegion))
+    .collect::<Result<Vec<Region>>>()?;
+
+    ensure!(!regions.is_empty(), error::MissingConfig { missing: "aws.regions" });
+    let base_region = &regions[0];
+
+    let mut ssm_clients = HashMap::with_capacity(regions.len());
+    for region in &regions {
+        let ssm_client = build_client::<SsmClient>(region, &base_region, &aws).context(error::Client {
+            client_type: "SSM",
+            region: region.name(),
+        })?;
+        ssm_clients.insert(region.clone(), ssm_client);
+    }
+
+    // Template setup   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    // Non-image-specific context for building and rendering templates
+    let source_build_context = BuildContext {
+        variant: &promote_args.variant,
+        arch: &promote_args.arch,
+        image_version: &promote_args.source,
+    };
+
+    let target_build_context = BuildContext {
+        variant: &promote_args.variant,
+        arch: &promote_args.arch,
+        image_version: &promote_args.target,
+    };
+
+    info!(
+        "Parsing SSM parameter templates from {}",
+        promote_args.template_dir.display()
+    );
+    // Doesn't matter which build context we use to find template files because version isn't used
+    // in their naming
+    let template_parameters =
+        template::get_parameters(&promote_args.template_dir, &source_build_context)
+            .context(error::FindTemplates)?;
+
+    // Render parameter names into maps of {template string => rendered value}.  We need the
+    // template strings so we can associate source parameters with target parameters that came
+    // from the same template, so we know what to copy.
+    let source_parameter_map =
+        template::render_parameter_names(&template_parameters, ssm_prefix, &source_build_context)
+            .context(error::RenderTemplates)?;
+    let target_parameter_map =
+        template::render_parameter_names(&template_parameters, ssm_prefix, &target_build_context)
+            .context(error::RenderTemplates)?;
+
+    // Parameters are the same in each region, so we need to associate each region with each of
+    // the parameter names so we can fetch them.
+    let source_keys: Vec<SsmKey> = regions
+        .iter()
+        .flat_map(|region| {
+            source_parameter_map
+                .values()
+                .map(move |name| SsmKey::new(region.clone(), name.clone()))
+        })
+        .collect();
+    let target_keys: Vec<SsmKey> = regions
+        .iter()
+        .flat_map(|region| {
+            target_parameter_map
+                .values()
+                .map(move |name| SsmKey::new(region.clone(), name.clone()))
+        })
+        .collect();
+
+    // SSM get/compare   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    info!("Getting current SSM parameters for source and target names");
+    let current_source_parameters = ssm::get_parameters(&source_keys, &ssm_clients)
+        .await
+        .context(error::FetchSsm)?;
+    trace!(
+        "Current source SSM parameters: {:#?}",
+        current_source_parameters
+    );
+    ensure!(
+        !current_source_parameters.is_empty(),
+        error::EmptySource {
+            version: &promote_args.source
+        }
+    );
+
+    let current_target_parameters = ssm::get_parameters(&target_keys, &ssm_clients)
+        .await
+        .context(error::FetchSsm)?;
+    trace!(
+        "Current target SSM parameters: {:#?}",
+        current_target_parameters
+    );
+
+    // Build a map of rendered source parameter names to rendered target parameter names.  This
+    // will let us find which target parameters to set based on the source parameter names we get
+    // back from SSM.
+    let source_target_map: HashMap<&String, &String> = source_parameter_map
+        .iter()
+        .map(|(k, v)| (v, &target_parameter_map[k]))
+        .collect();
+
+    // Show the difference between source and target parameters in SSM.  We use the
+    // source_target_map we built above to map source keys to target keys (generated from the same
+    // template) so that the diff code has common keys to compare.
+    let set_parameters = key_difference(
+        &current_source_parameters
+            .into_iter()
+            .map(|(key, value)| {
+                (
+                    SsmKey::new(key.region, source_target_map[&key.name].to_string()),
+                    value,
+                )
+            })
+            .collect(),
+        &current_target_parameters,
+    );
+    if set_parameters.is_empty() {
+        info!("No changes necessary.");
+        return Ok(());
+    }
+
+    // SSM set   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    info!("Setting updated SSM parameters.");
+    ssm::set_parameters(&set_parameters, &ssm_clients)
+        .await
+        .context(error::SetSsm)?;
+
+    info!("Validating whether live parameters in SSM reflect changes.");
+    ssm::validate_parameters(&set_parameters, &ssm_clients)
+        .await
+        .context(error::ValidateSsm)?;
+
+    info!("All parameters match requested values.");
+    Ok(())
+}
+
+mod error {
+    use crate::aws;
+    use crate::aws::ssm::{ssm, template};
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Error creating {} client in {}: {}", client_type, region, source))]
+        Client {
+            client_type: String,
+            region: String,
+            source: aws::client::Error,
+        },
+
+        #[snafu(display("Error reading config: {}", source))]
+        Config {
+            source: crate::config::Error,
+        },
+
+        #[snafu(display("Found no parameters in source version {}", version))]
+        EmptySource {
+            version: String,
+        },
+
+        #[snafu(display("Failed to fetch parameters from SSM: {}", source))]
+        FetchSsm {
+            source: ssm::Error,
+        },
+
+        #[snafu(display("Failed to find templates: {}", source))]
+        FindTemplates {
+            source: template::Error,
+        },
+
+        #[snafu(display("Infra.toml is missing {}", missing))]
+        MissingConfig {
+            missing: String,
+        },
+
+        ParseRegion {
+            source: crate::aws::Error,
+        },
+
+        #[snafu(display("Failed to render templates: {}", source))]
+        RenderTemplates {
+            source: template::Error,
+        },
+
+        #[snafu(display("Failed to set SSM parameters: {}", source))]
+        SetSsm {
+            source: ssm::Error,
+        },
+
+        ValidateSsm {
+            source: ssm::Error,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -1,0 +1,366 @@
+//! The ssm module owns the 'ssm' subcommand and controls the process of setting SSM parameters
+//! based on current build information
+
+pub(crate) mod ssm;
+pub(crate) mod template;
+
+use crate::aws::{ami::Image, client::build_client, region_from_string};
+use crate::config::{AwsConfig, InfraConfig};
+use crate::Args;
+use log::{info, trace};
+use rusoto_core::Region;
+use rusoto_ssm::SsmClient;
+use serde::Serialize;
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::iter::FromIterator;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Sets SSM parameters based on current build information
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct SsmArgs {
+    // This is JSON output from `pubsys ami` like `{"us-west-2": "ami-123"}`
+    /// Path to the JSON file containing regional AMI IDs to modify
+    #[structopt(long, parse(from_os_str))]
+    ami_input: PathBuf,
+
+    /// The architecture of the machine image
+    #[structopt(long)]
+    arch: String,
+
+    /// The variant name for the current build
+    #[structopt(long)]
+    variant: String,
+
+    /// The version of the current build
+    #[structopt(long)]
+    version: String,
+
+    /// Regions where you want parameters published
+    #[structopt(long, use_delimiter = true)]
+    regions: Vec<String>,
+
+    /// Directory holding the parameter template files
+    #[structopt(long)]
+    template_dir: PathBuf,
+
+    /// Allows overwrite of existing parameters
+    #[structopt(long)]
+    allow_clobber: bool,
+}
+
+/// Common entrypoint from main()
+pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
+    // Setup   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    info!(
+        "Using infra config from path: {}",
+        args.infra_config_path.display()
+    );
+    let infra_config = InfraConfig::from_path(&args.infra_config_path).context(error::Config)?;
+    trace!("Parsed infra config: {:#?}", infra_config);
+    let aws = infra_config.aws.unwrap_or_else(Default::default);
+    let ssm_prefix = aws.ssm_prefix.as_deref().unwrap_or_else(|| "");
+
+    // If the user gave an override list of regions, use that, otherwise use what's in the config.
+    let regions = if !ssm_args.regions.is_empty() {
+        ssm_args.regions.clone()
+    } else {
+        aws.regions.clone().into()
+    };
+    ensure!(!regions.is_empty(), error::MissingConfig { missing: "aws.regions" });
+    let base_region = region_from_string(&regions[0], &aws).context(error::ParseRegion)?;
+
+    let amis = parse_ami_input(&regions, &ssm_args, &aws)?;
+
+    let mut ssm_clients = HashMap::with_capacity(amis.len());
+    for region in amis.keys() {
+        let ssm_client = build_client::<SsmClient>(&region, &base_region, &aws).context(error::Client {
+            client_type: "SSM",
+            region: region.name(),
+        })?;
+        ssm_clients.insert(region.clone(), ssm_client);
+    }
+
+    // Template setup   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    // Non-image-specific context for building and rendering templates
+    let build_context = BuildContext {
+        variant: &ssm_args.variant,
+        arch: &ssm_args.arch,
+        image_version: &ssm_args.version,
+    };
+
+    info!(
+        "Parsing SSM parameter templates from {}",
+        ssm_args.template_dir.display()
+    );
+    let template_parameters = template::get_parameters(&ssm_args.template_dir, &build_context)
+        .context(error::FindTemplates)?;
+
+    let new_parameters =
+        template::render_parameters(template_parameters, amis, ssm_prefix, &build_context)
+            .context(error::RenderTemplates)?;
+    trace!("Generated templated parameters: {:#?}", new_parameters);
+
+    // SSM get/compare   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    info!("Getting current SSM parameters");
+    let new_parameter_names: Vec<&SsmKey> = new_parameters.keys().collect();
+    let current_parameters = ssm::get_parameters(&new_parameter_names, &ssm_clients)
+        .await
+        .context(error::FetchSsm)?;
+    trace!("Current SSM parameters: {:#?}", current_parameters);
+
+    // Show the difference between source and target parameters in SSM.
+    let parameters_to_set = key_difference(&new_parameters, &current_parameters);
+    if parameters_to_set.is_empty() {
+        info!("No changes necessary.");
+        return Ok(());
+    }
+
+    // Unless the user wants to allow it, make sure we're not going to overwrite any existing
+    // keys.
+    if !ssm_args.allow_clobber {
+        let current_keys: HashSet<&SsmKey> = current_parameters.keys().collect();
+        let new_keys: HashSet<&SsmKey> = parameters_to_set.keys().collect();
+        ensure!(current_keys.is_disjoint(&new_keys), error::NoClobber);
+    }
+
+    // SSM set   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    info!("Setting updated SSM parameters.");
+    ssm::set_parameters(&parameters_to_set, &ssm_clients)
+        .await
+        .context(error::SetSsm)?;
+
+    info!("Validating whether live parameters in SSM reflect changes.");
+    ssm::validate_parameters(&parameters_to_set, &ssm_clients)
+        .await
+        .context(error::ValidateSsm)?;
+
+    info!("All parameters match requested values.");
+    Ok(())
+}
+
+/// The key to a unique SSM parameter
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub(crate) struct SsmKey {
+    pub(crate) region: Region,
+    pub(crate) name: String,
+}
+
+impl SsmKey {
+    pub(crate) fn new(region: Region, name: String) -> Self {
+        Self { region, name }
+    }
+}
+
+impl AsRef<SsmKey> for SsmKey {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+/// Non-image-specific context for building and rendering templates
+#[derive(Debug, Serialize)]
+pub(crate) struct BuildContext<'a> {
+    pub(crate) variant: &'a str,
+    pub(crate) arch: &'a str,
+    pub(crate) image_version: &'a str,
+}
+
+/// A map of SsmKey to its value
+type SsmParameters = HashMap<SsmKey, String>;
+
+/// Parse the AMI input file
+fn parse_ami_input(regions: &[String], ssm_args: &SsmArgs, aws: &AwsConfig) -> Result<HashMap<Region, Image>> {
+    info!("Using AMI data from path: {}", ssm_args.ami_input.display());
+    let file = File::open(&ssm_args.ami_input).context(error::File {
+        op: "open",
+        path: &ssm_args.ami_input,
+    })?;
+    let mut ami_input: HashMap<String, Image> =
+        serde_json::from_reader(file).context(error::Deserialize {
+            path: &ssm_args.ami_input,
+        })?;
+    trace!("Parsed AMI input: {:#?}", ami_input);
+
+    // pubsys will not create a file if it did not create AMIs, so we should only have an empty
+    // file if a user created one manually, and they shouldn't be creating an empty file.
+    ensure!(
+        !ami_input.is_empty(),
+        error::Input {
+            path: &ssm_args.ami_input
+        }
+    );
+
+    // Check that the requested regions are a subset of the regions we *could* publish from the AMI
+    // input JSON.
+    let requested_regions = HashSet::from_iter(regions.iter());
+    let known_regions = HashSet::<&String>::from_iter(ami_input.keys());
+    ensure!(
+        requested_regions.is_subset(&known_regions),
+        error::UnknownRegions {
+            regions: requested_regions
+                .difference(&known_regions)
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
+        }
+    );
+
+    // Parse region names, adding endpoints from InfraConfig if specified
+    let mut amis = HashMap::with_capacity(regions.len());
+    for name in regions {
+        let image = ami_input
+            .remove(name)
+            // This could only happen if someone removes the check above...
+            .with_context(|| error::UnknownRegions {
+                regions: vec![name.clone()],
+            })?;
+        let region = region_from_string(&name, &aws).context(error::ParseRegion)?;
+        amis.insert(region, image);
+    }
+
+    Ok(amis)
+}
+
+/// Shows the user the difference between two sets of parameters.  We look for parameters in
+/// `wanted` that are either missing or changed in `current`.  We print these differences for the
+/// user, then return the `wanted` values.
+pub(crate) fn key_difference(wanted: &SsmParameters, current: &SsmParameters) -> SsmParameters {
+    let mut parameters_to_set = HashMap::new();
+
+    let wanted_keys: HashSet<&SsmKey> = wanted.keys().collect();
+    let current_keys: HashSet<&SsmKey> = current.keys().collect();
+
+    for key in wanted_keys.difference(&current_keys) {
+        let new_value = &wanted[key];
+        println!(
+            "{} - {} - new parameter:\n   new value: {}",
+            key.name,
+            key.region.name(),
+            new_value,
+        );
+        parameters_to_set.insert(
+            SsmKey::new(key.region.clone(), key.name.clone()),
+            new_value.clone(),
+        );
+    }
+
+    for key in wanted_keys.intersection(&current_keys) {
+        let current_value = &current[key];
+        let new_value = &wanted[key];
+
+        if current_value == new_value {
+            println!("{} - {} - no change", key.name, key.region.name());
+        } else {
+            println!(
+                "{} - {} - changing value:\n   old value: {}\n   new value: {}",
+                key.name,
+                key.region.name(),
+                current_value,
+                new_value
+            );
+            parameters_to_set.insert(
+                SsmKey::new(key.region.clone(), key.name.clone()),
+                new_value.clone(),
+            );
+        }
+    }
+    // Note: don't care about items that are in current but not wanted; that could happen if you
+    // remove a parameter from your templates, for example.
+
+    parameters_to_set
+}
+
+mod error {
+    use crate::aws;
+    use crate::aws::ssm::{ssm, template};
+    use snafu::Snafu;
+    use std::io;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Error creating {} client in {}: {}", client_type, region, source))]
+        Client {
+            client_type: String,
+            region: String,
+            source: aws::client::Error,
+        },
+
+        #[snafu(display("Error reading config: {}", source))]
+        Config {
+            source: crate::config::Error,
+        },
+
+        #[snafu(display("Failed to deserialize input from '{}': {}", path.display(), source))]
+        Deserialize {
+            path: PathBuf,
+            source: serde_json::Error,
+        },
+
+        #[snafu(display("Failed to fetch parameters from SSM: {}", source))]
+        FetchSsm {
+            source: ssm::Error,
+        },
+
+        #[snafu(display("Failed to {} '{}': {}", op, path.display(), source))]
+        File {
+            op: String,
+            path: PathBuf,
+            source: io::Error,
+        },
+
+        #[snafu(display("Failed to find templates: {}", source))]
+        FindTemplates {
+            source: template::Error,
+        },
+
+        #[snafu(display("Input '{}' is empty", path.display()))]
+        Input {
+            path: PathBuf,
+        },
+
+        #[snafu(display("Infra.toml is missing {}", missing))]
+        MissingConfig {
+            missing: String,
+        },
+
+        #[snafu(display("Cowardly refusing to overwrite parameters without ALLOW_CLOBBER"))]
+        NoClobber,
+
+        ParseRegion {
+            source: crate::aws::Error,
+        },
+
+        #[snafu(display("Failed to render templates: {}", source))]
+        RenderTemplates {
+            source: template::Error,
+        },
+
+        #[snafu(display("Failed to set SSM parameters: {}", source))]
+        SetSsm {
+            source: ssm::Error,
+        },
+
+        #[snafu(display(
+            "Given region(s) in Infra.toml / regions argument that are not in --ami-input file: {}",
+            regions.join(", ")
+        ))]
+        UnknownRegions {
+            regions: Vec<String>,
+        },
+
+        ValidateSsm {
+            source: ssm::Error,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ssm/ssm.rs
+++ b/tools/pubsys/src/aws/ssm/ssm.rs
@@ -1,0 +1,377 @@
+//! The ssm module owns the getting and setting of parameters in SSM.
+
+use super::{SsmKey, SsmParameters};
+use futures::future::{join, ready};
+use futures::stream::{self, StreamExt};
+use log::{debug, error, trace, warn};
+use rusoto_core::{Region, RusotoError};
+use rusoto_ssm::{
+    GetParametersError, GetParametersRequest, GetParametersResult, PutParameterError,
+    PutParameterRequest, PutParameterResult, Ssm, SsmClient,
+};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+use tokio::time::throttle;
+
+/// Fetches the values of the given SSM keys using the given clients
+// TODO: We can batch GET requests so throttling is less likely here, but if we need to handle
+// hundreds of parameters for a given build, we could use the throttling logic from
+// `set_parameters`
+pub(crate) async fn get_parameters<K>(
+    requested: &[K],
+    clients: &HashMap<Region, SsmClient>,
+) -> Result<SsmParameters>
+where
+    K: AsRef<SsmKey>,
+{
+    // Build requests for parameters; we have to request with a regional client so we split them by
+    // region
+    let mut requests = Vec::with_capacity(requested.len());
+    let mut regional_names: HashMap<Region, Vec<String>> = HashMap::new();
+    for key in requested {
+        let SsmKey { region, name } = key.as_ref();
+        regional_names
+            .entry(region.clone())
+            .or_default()
+            .push(name.clone());
+    }
+    for (region, names) in regional_names {
+        // At most 10 parameters can be requested at a time.
+        for names_chunk in names.chunks(10) {
+            trace!("Requesting {:?} in {}", names_chunk, region.name());
+            let ssm_client = &clients[&region];
+            let len = names_chunk.len();
+            let get_request = GetParametersRequest {
+                names: names_chunk.to_vec(),
+                ..Default::default()
+            };
+            let get_future = ssm_client.get_parameters(get_request);
+
+            // Store the region so we can include it in errors and the output map
+            let info_future = ready((region.clone(), len));
+            requests.push(join(info_future, get_future));
+        }
+    }
+
+    // Send requests in parallel and wait for responses, collecting results into a list.
+    let request_stream = stream::iter(requests).buffer_unordered(4);
+    let responses: Vec<(
+        (Region, usize),
+        std::result::Result<GetParametersResult, RusotoError<GetParametersError>>,
+    )> = request_stream.collect().await;
+
+    // If you're checking parameters in a region you haven't pushed to before, you can get an
+    // error here about the parameter's namespace being new.  We want to treat these as new
+    // parameters rather than failing.  Unfortunately, we don't know which parameter in the region
+    // was considered new, but we expect that most people are publishing all of their parameters
+    // under the same namespace, so treating the whole region as new is OK.  We use this just to
+    // warn the user.
+    let mut new_regions = HashSet::new();
+
+    // For each existing parameter in the response, get the name and value for our output map.
+    let mut parameters = HashMap::with_capacity(requested.len());
+    for ((region, expected_len), response) in responses {
+        // Get the image description, ensuring we only have one.
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => {
+                // Note: there's no structured error type for this so we have to string match.
+                if e.to_string().contains("is not a valid namespace") {
+                    new_regions.insert(region.name().to_string());
+                    continue;
+                } else {
+                    return Err(e).context(error::GetParameters {
+                        region: region.name(),
+                    });
+                }
+            }
+        };
+
+        // Check that we received a response including every parameter
+        // Note: response.invalid_parameters includes both new parameters and ill-formatted
+        // parameter names...
+        let valid_count = response.parameters.as_ref().map(|v| v.len()).unwrap_or(0);
+        let invalid_count = response.invalid_parameters.map(|v| v.len()).unwrap_or(0);
+        let total_count = valid_count + invalid_count;
+        ensure!(
+            total_count == expected_len,
+            error::MissingInResponse {
+                region: region.name(),
+                request_type: "GetParameters",
+                missing: format!(
+                    "parameters - got {}, expected {}",
+                    total_count, expected_len
+                ),
+            }
+        );
+
+        // Save the successful parameters
+        if let Some(valid_parameters) = response.parameters {
+            if !valid_parameters.is_empty() {
+                for parameter in valid_parameters {
+                    let name = parameter.name.context(error::MissingInResponse {
+                        region: region.name(),
+                        request_type: "GetParameters",
+                        missing: "parameter name",
+                    })?;
+                    let value = parameter.value.context(error::MissingInResponse {
+                        region: region.name(),
+                        request_type: "GetParameters",
+                        missing: format!("value for parameter {}", name),
+                    })?;
+                    parameters.insert(SsmKey::new(region.clone(), name), value);
+                }
+            }
+        }
+    }
+
+    for region in new_regions {
+        warn!(
+            "Invalid namespace in {}, this is OK for the first publish in a region",
+            region
+        );
+    }
+
+    Ok(parameters)
+}
+
+/// Sets the values of the given SSM keys using the given clients
+pub(crate) async fn set_parameters(
+    parameters_to_set: &SsmParameters,
+    ssm_clients: &HashMap<Region, SsmClient>,
+) -> Result<()> {
+    // Start with a small delay between requests, and increase if we get throttled.
+    let mut request_interval = Duration::from_millis(100);
+    let max_interval = Duration::from_millis(1600);
+    let interval_factor = 2;
+    let mut should_increase_interval = false;
+
+    // We run all requests in a batch, and any failed requests are added to the next batch for
+    // retry
+    let mut failed_parameters: HashMap<Region, Vec<(String, RusotoError<_>)>> = HashMap::new();
+    let max_failures = 5;
+
+    /// Stores the values we need to be able to retry requests
+    struct RequestContext<'a> {
+        region: &'a Region,
+        name: &'a str,
+        value: &'a str,
+        failures: u8,
+    }
+
+    // Create the initial request contexts
+    let mut contexts = Vec::new();
+    for (SsmKey { region, name }, value) in parameters_to_set {
+        contexts.push(RequestContext {
+            region,
+            name,
+            value,
+            failures: 0,
+        });
+    }
+    let total_count = contexts.len();
+
+    // We drain requests out of the contexts list and put them back if we need to retry; we do this
+    // until all requests have succeeded or we've hit the max failures
+    while !contexts.is_empty() {
+        debug!("Starting {} SSM put requests", contexts.len());
+
+        if should_increase_interval {
+            request_interval *= interval_factor;
+            warn!(
+                "Requests were throttled, increasing interval to {:?}",
+                request_interval
+            );
+        }
+        should_increase_interval = false;
+
+        ensure!(
+            request_interval <= max_interval,
+            error::Throttled { max_interval }
+        );
+
+        // Build requests for parameters.  We need to group them by region so we can run each
+        // region in parallel.  Each region's stream will be throttled to run one request per
+        // request_interval.
+        let mut regional_requests = HashMap::new();
+        // Remove contexts from the list with drain; they get added back in if we retry the
+        // request.
+        for context in contexts.drain(..) {
+            let ssm_client = &ssm_clients[&context.region];
+            let put_request = PutParameterRequest {
+                name: context.name.to_string(),
+                value: context.value.to_string(),
+                overwrite: Some(true),
+                type_: Some("String".to_string()),
+                ..Default::default()
+            };
+            let put_future = ssm_client.put_parameter(put_request);
+
+            let regional_list = regional_requests
+                .entry(context.region)
+                .or_insert_with(Vec::new);
+            // Store the context so we can retry as needed
+            regional_list.push(join(ready(context), put_future));
+        }
+
+        // Create a throttled stream per region; throttling applies per region.  (Request futures
+        // are already regional, by virtue of being created with a regional client, so we don't
+        // need the region again here.)
+        let mut throttled_streams = Vec::new();
+        for (_region, request_list) in regional_requests {
+            throttled_streams.push(throttle(request_interval, stream::iter(request_list)));
+        }
+
+        // Run all regions in parallel and wait for responses.
+        let parallel_requests = stream::select_all(throttled_streams).buffer_unordered(4);
+        let responses: Vec<(
+            RequestContext<'_>,
+            std::result::Result<PutParameterResult, RusotoError<PutParameterError>>,
+        )> = parallel_requests.collect().await;
+
+        // For each error response, check if we should retry or bail.
+        for (context, response) in responses {
+            if let Err(e) = response {
+                // Throttling errors in Rusoto are structured like this:
+                // RusotoError::Unknown(BufferedHttpResponse {status: 400, body: "{\"__type\":\"ThrottlingException\",\"message\":\"Rate exceeded\"}", headers: ...})
+                // Even if we were to do a structural match, we would still have to string match
+                // the body of the error.  Simpler to match the string form.
+                if e.to_string().contains("ThrottlingException") {
+                    // We only want to increase the interval once per loop, not once per error,
+                    // because when you get throttled you're likely to get a bunch of throttling
+                    // errors at once.
+                    should_increase_interval = true;
+                    // Retry the request without increasing the failure counter; the request didn't
+                    // fail, a throttle means we couldn't even make the request.
+                    contexts.push(context);
+                // -1 so we don't try again next loop; this keeps failure checking in one place
+                } else if context.failures >= max_failures - 1 {
+                    // Past max failures, store the failure for reporting, don't retry.
+                    failed_parameters
+                        .entry(context.region.clone())
+                        .or_default()
+                        .push((context.name.to_string(), e));
+                } else {
+                    // Increase failure counter and try again.
+                    let context = RequestContext {
+                        failures: context.failures + 1,
+                        ..context
+                    };
+                    debug!(
+                        "Request attempt {} of {} failed in {}: {}",
+                        context.failures,
+                        max_failures,
+                        context.region.name(),
+                        e
+                    );
+                    contexts.push(context);
+                }
+            }
+        }
+    }
+
+    if !failed_parameters.is_empty() {
+        for (region, failures) in &failed_parameters {
+            for (parameter, error) in failures {
+                error!(
+                    "Failed to set {} in {}: {}",
+                    parameter,
+                    region.name(),
+                    error
+                );
+            }
+        }
+        return error::SetParameters {
+            failure_count: failed_parameters.len(),
+            total_count,
+        }
+        .fail();
+    }
+
+    Ok(())
+}
+
+/// Fetch the given parameters, and ensure the live values match the given values
+pub(crate) async fn validate_parameters(
+    expected_parameters: &SsmParameters,
+    ssm_clients: &HashMap<Region, SsmClient>,
+) -> Result<()> {
+    // Fetch the given parameter names
+    let expected_parameter_names: Vec<&SsmKey> = expected_parameters.keys().collect();
+    let updated_parameters = get_parameters(&expected_parameter_names, &ssm_clients).await?;
+
+    // Walk through and check each value
+    let mut success = true;
+    for (expected_key, expected_value) in expected_parameters {
+        let SsmKey {
+            region: expected_region,
+            name: expected_name,
+        } = expected_key;
+        // All parameters should have a value, and it should match the given value, otherwise the
+        // parameter wasn't updated / created.
+        if let Some(updated_value) = updated_parameters.get(expected_key) {
+            if updated_value != expected_value {
+                error!(
+                    "Failed to set {} in {}",
+                    expected_name,
+                    expected_region.name()
+                );
+                success = false;
+            }
+        } else {
+            error!(
+                "{} in {} still doesn't exist",
+                expected_name,
+                expected_region.name()
+            );
+            success = false;
+        }
+    }
+    ensure!(success, error::ValidateParameters);
+
+    Ok(())
+}
+
+mod error {
+    use rusoto_core::RusotoError;
+    use rusoto_ssm::GetParametersError;
+    use snafu::Snafu;
+    use std::time::Duration;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Failed to fetch SSM parameters in {}: {}", region, source))]
+        GetParameters {
+            region: String,
+            source: RusotoError<GetParametersError>,
+        },
+
+        #[snafu(display("Response to {} was missing {}", request_type, missing))]
+        MissingInResponse {
+            region: String,
+            request_type: String,
+            missing: String,
+        },
+
+        #[snafu(display("Failed to {} of {} parameters; see above", failure_count, total_count))]
+        SetParameters {
+            failure_count: usize,
+            total_count: usize,
+        },
+
+        #[snafu(display(
+            "SSM requests throttled too many times, went beyond our max interval {:?}",
+            max_interval
+        ))]
+        Throttled {
+            max_interval: Duration,
+        },
+
+        #[snafu(display("Failed to validate all changes; see above."))]
+        ValidateParameters,
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ssm/template.rs
+++ b/tools/pubsys/src/aws/ssm/template.rs
@@ -1,0 +1,216 @@
+//! The template module owns the finding and rendering of parameter templates that used to generate
+//! SSM parameter names and values.
+
+use super::{BuildContext, SsmKey, SsmParameters};
+use crate::aws::ami::Image;
+use log::{info, trace};
+use rusoto_core::Region;
+use serde::{Deserialize, Serialize};
+use snafu::{ensure, ResultExt};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use tinytemplate::TinyTemplate;
+
+/// Represents a single SSM parameter
+#[derive(Debug, Deserialize)]
+pub(crate) struct TemplateParameter {
+    pub(crate) name: String,
+    pub(crate) value: String,
+}
+
+/// Represents a set of SSM parameters, in a format that allows for clear definition of
+/// parameters in TOML files
+#[derive(Debug, Deserialize)]
+pub(crate) struct TemplateParameters {
+    // In a TOML table, it's clearer to define a single entry as a "parameter".
+    #[serde(default, rename = "parameter")]
+    pub(crate) parameters: Vec<TemplateParameter>,
+}
+
+impl TemplateParameters {
+    fn extend(&mut self, other: Self) {
+        self.parameters.extend(other.parameters)
+    }
+}
+
+/// Finds and deserializes template parameters from the template directory, taking into account
+/// overrides requested by the user
+pub(crate) fn get_parameters(
+    template_dir: &Path,
+    build_context: &BuildContext<'_>,
+) -> Result<TemplateParameters> {
+    let defaults_path = template_dir.join("defaults.toml");
+    let defaults_str = fs::read_to_string(&defaults_path).context(error::File {
+        op: "read",
+        path: &defaults_path,
+    })?;
+    let mut template_parameters: TemplateParameters =
+        toml::from_str(&defaults_str).context(error::InvalidToml {
+            path: &defaults_path,
+        })?;
+    trace!("Parsed default templates: {:#?}", template_parameters);
+
+    // Allow the user to add/override parameters specific to variant or arch.  Because these are
+    // added after the defaults, they will take precedence. (It doesn't make sense to override
+    // based on the version argument.)
+    let mut context = HashMap::new();
+    context.insert("variant", build_context.variant);
+    context.insert("arch", build_context.arch);
+    for (key, value) in context {
+        let override_path = template_dir.join(key).join(format!("{}.toml", value));
+        if override_path.exists() {
+            info!(
+                "Parsing SSM parameter overrides from {}",
+                override_path.display()
+            );
+            let template_str = fs::read_to_string(&override_path).context(error::File {
+                op: "read",
+                path: &override_path,
+            })?;
+            let override_parameters: TemplateParameters =
+                toml::from_str(&template_str).context(error::InvalidToml {
+                    path: &override_path,
+                })?;
+            trace!("Parsed override templates: {:#?}", override_parameters);
+            template_parameters.extend(override_parameters);
+        }
+    }
+
+    ensure!(
+        !template_parameters.parameters.is_empty(),
+        error::NoTemplates { path: template_dir }
+    );
+
+    Ok(template_parameters)
+}
+
+/// Render the given template parameters using the data from the given AMIs
+pub(crate) fn render_parameters(
+    template_parameters: TemplateParameters,
+    amis: HashMap<Region, Image>,
+    ssm_prefix: &str,
+    build_context: &BuildContext<'_>,
+) -> Result<SsmParameters> {
+    /// Values that we allow as template variables
+    #[derive(Debug, Serialize)]
+    struct TemplateContext<'a> {
+        variant: &'a str,
+        arch: &'a str,
+        image_id: &'a str,
+        image_name: &'a str,
+        image_version: &'a str,
+        region: &'a str,
+    }
+    let mut new_parameters = HashMap::new();
+    for (region, image) in amis {
+        let context = TemplateContext {
+            variant: build_context.variant,
+            arch: build_context.arch,
+            image_id: &image.id,
+            image_name: &image.name,
+            image_version: build_context.image_version,
+            region: region.name(),
+        };
+
+        for tp in &template_parameters.parameters {
+            let mut tt = TinyTemplate::new();
+            tt.add_template("name", &tp.name)
+                .context(error::AddTemplate { template: &tp.name })?;
+            tt.add_template("value", &tp.value)
+                .context(error::AddTemplate {
+                    template: &tp.value,
+                })?;
+            let name_suffix = tt
+                .render("name", &context)
+                .context(error::RenderTemplate { template: &tp.name })?;
+            let value = tt
+                .render("value", &context)
+                .context(error::RenderTemplate {
+                    template: &tp.value,
+                })?;
+
+            new_parameters.insert(
+                SsmKey::new(region.clone(), join_name(ssm_prefix, &name_suffix)),
+                value,
+            );
+        }
+    }
+
+    Ok(new_parameters)
+}
+
+/// Render the names of the given template parameters using the fixed data about the current build.
+/// Returns a mapping of templated name to rendered name, so we can associate rendered names to a
+/// common source name
+pub(crate) fn render_parameter_names(
+    template_parameters: &TemplateParameters,
+    ssm_prefix: &str,
+    build_context: &BuildContext<'_>,
+) -> Result<HashMap<String, String>> {
+    let mut new_parameters = HashMap::new();
+    for tp in &template_parameters.parameters {
+        let mut tt = TinyTemplate::new();
+        tt.add_template("name", &tp.name)
+            .context(error::AddTemplate { template: &tp.name })?;
+        let name_suffix = tt
+            .render("name", &build_context)
+            .context(error::RenderTemplate { template: &tp.name })?;
+        new_parameters.insert(tp.name.clone(), join_name(ssm_prefix, &name_suffix));
+    }
+
+    Ok(new_parameters)
+}
+
+/// Make sure prefix and parameter name are separated by one slash
+fn join_name(ssm_prefix: &str, name_suffix: &str) -> String {
+    if ssm_prefix.ends_with('/') && name_suffix.starts_with('/') {
+        format!("{}{}", ssm_prefix, &name_suffix[1..])
+    } else if ssm_prefix.ends_with('/') || name_suffix.starts_with('/') {
+        format!("{}{}", ssm_prefix, name_suffix)
+    } else {
+        format!("{}/{}", ssm_prefix, name_suffix)
+    }
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::io;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Error building template from '{}': {}", template, source))]
+        AddTemplate {
+            template: String,
+            source: tinytemplate::error::Error,
+        },
+
+        #[snafu(display("Failed to {} '{}': {}", op, path.display(), source))]
+        File {
+            op: String,
+            path: PathBuf,
+            source: io::Error,
+        },
+
+        #[snafu(display("Invalid config file at '{}': {}", path.display(), source))]
+        InvalidToml {
+            path: PathBuf,
+            source: toml::de::Error,
+        },
+
+        #[snafu(display("Found no parameter templates in {}", path.display()))]
+        NoTemplates {
+            path: PathBuf,
+        },
+
+        #[snafu(display("Error rendering template from '{}': {}", template, source))]
+        RenderTemplate {
+            template: String,
+            source: tinytemplate::error::Error,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/config.rs
+++ b/tools/pubsys/src/config.rs
@@ -42,6 +42,7 @@ pub(crate) struct AwsConfig {
     pub(crate) profile: Option<String>,
     #[serde(default)]
     pub(crate) region: HashMap<String, AwsRegionConfig>,
+    pub(crate) ssm_prefix: Option<String>,
 }
 
 /// AWS region-specific configuration


### PR DESCRIPTION
`cargo make ssm` will use the amis.json from `cargo make ami` to populate
parameter name/value templates from files in `policies/ssm`.  The parameters
are set in SSM using the full build version, e.g. "0.5.0-abcdef", and it won't
overwrite by default.

`cargo make promote-ssm -e SSM_TARGET=VERSION` will promote (copy) those values
from the full-build-version name to a more general one.  It's recommended to
promote from the full version to a short version like "0.5.0", then to a
well-known pointer like "latest".  This allows for easy rollback by promoting
from an older version, using `-e SSM_SOURCE=OLD_VERSION`.

**Testing done:**
* Tested setting more than 100 parameters in a region - request chunking and throttling worked, parameters got through                                                                                         
* Tested the "new namespace" issue in opt-in region - error was caught properly and it was treated as a new parameter                                                                                          
* Tested many regions at once                                                                                                                                                                                  
* Confirmed no overwrite allowed unless ALLOW_CLOBBER                                                                                                                                                          
* Confirmed that adding regions / parameters will add the new ones without considering it a clobber  (existing parameters show no change; idempotent)                                                          
* Confirmed that override templates work, and it doesn't run overrides not matching current values
* Confirmed that set_parameter retries work, or at least that bad requests are retried and eventually fail, and good requests pass, and the output is clear about failures and failure count.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
