### PR TITLE
aws-ecs-1: add ecs.loglevel setting

### DIFF
--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -21,10 +21,11 @@ Source0: https://%{goimport}/archive/v%{gover}/amazon-ecs-agent-v%{gover}.tar.gz
 Source1: ecs.service
 Source2: ecs-tmpfiles.conf
 Source3: ecs-sysctl.conf
-Source4: pause-image-VERSION
-Source5: pause-config.json
-Source6: pause-manifest.json
-Source7: pause-repositories
+Source4: ecs.config
+Source5: pause-image-VERSION
+Source6: pause-config.json
+Source7: pause-manifest.json
+Source8: pause-repositories
 
 # Bottlerocket-specific - filesystem location of the pause image
 Patch0001: 0001-bottlerocket-default-filesystem-locations.patch
@@ -73,11 +74,11 @@ go build -a \
   mkdir -p image/rootfs
   %tar_cf image/rootfs/layer.tar -C rootfs .
   DIGEST=$(sha256sum image/rootfs/layer.tar | sed -e 's/ .*//')
-  install -m 0644 %{S:4} image/rootfs/VERSION
-  install -m 0644 %{S:5} image/config.json
+  install -m 0644 %{S:5} image/rootfs/VERSION
+  install -m 0644 %{S:6} image/config.json
   sed -i "s/~~digest~~/${DIGEST}/" image/config.json
-  install -m 0644 %{S:6} image/manifest.json
-  install -m 0644 %{S:7} image/repositories
+  install -m 0644 %{S:7} image/manifest.json
+  install -m 0644 %{S:8} image/repositories
   %tar_cf ../../../amazon-ecs-pause.tar -C image .
 )
 
@@ -88,6 +89,7 @@ install -D -p -m 0644 amazon-ecs-pause.tar %{buildroot}%{_cross_libdir}/amazon-e
 install -D -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/ecs.service
 install -D -p -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}/ecs.conf
 install -D -p -m 0644 %{S:3} %{buildroot}%{_cross_sysctldir}/90-ecs.conf
+install -D -p -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/ecs.config
 
 %cross_scan_attribution go-vendor agent/vendor
 
@@ -99,6 +101,7 @@ install -D -p -m 0644 %{S:3} %{buildroot}%{_cross_sysctldir}/90-ecs.conf
 %{_cross_unitdir}/ecs.service
 %{_cross_tmpfilesdir}/ecs.conf
 %{_cross_sysctldir}/90-ecs.conf
+%{_cross_templatedir}/ecs.config
 %{_cross_libdir}/amazon-ecs-agent/amazon-ecs-pause.tar
 
 %changelog

--- a/packages/ecs-agent/ecs.config
+++ b/packages/ecs-agent/ecs.config
@@ -1,0 +1,2 @@
+ECS_LOGFILE=/var/log/ecs/ecs-agent.log
+ECS_LOGLEVEL="{{settings.ecs.loglevel}}"

--- a/packages/ecs-agent/ecs.service
+++ b/packages/ecs-agent/ecs.service
@@ -11,7 +11,6 @@ Restart=on-failure
 RestartPreventExitStatus=5
 RestartSec=1s
 EnvironmentFile=-/etc/ecs/ecs.config
-Environment=ECS_LOGFILE=/var/log/ecs/ecs-agent.log ECS_LOGLEVEL=debug
 Environment=ECS_CHECKPOINT=true
 ExecStartPre=/sbin/iptables -t nat -A PREROUTING -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -17,6 +17,7 @@ model-derive = { path = "model-derive" }
 regex = "1.1"
 semver = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_plain = "0.3.0"
 snafu = "0.6"
 toml = "0.5"
 url = "2.1"

--- a/sources/models/src/aws-ecs-1/override-defaults.toml
+++ b/sources/models/src/aws-ecs-1/override-defaults.toml
@@ -5,7 +5,11 @@ template-path = "/usr/share/templates/containerd-config-toml_aws-ecs-1"
 # ECS
 [services.ecs]
 restart-commands = ["/usr/bin/ecs-settings-applier", "/bin/systemctl try-reload-or-restart ecs.service"]
-configuration-files = []
+configuration-files = ["ecs-config"]
+
+[configuration-files.ecs-config]
+path = "/etc/ecs/ecs.config"
+template-path = "/usr/share/templates/ecs.config"
 
 [metadata.settings.ecs]
 affected-services = ["ecs"]
@@ -13,3 +17,4 @@ affected-services = ["ecs"]
 [settings.ecs]
 allow-privileged-containers = false
 logging-drivers = ["json-file", "awslogs", "none"]
+loglevel = "info"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -81,9 +81,9 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    DNSDomain, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, KubernetesClusterName,
-    KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue, SingleLineString, Url,
-    ValidBase64,
+    DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion,
+    KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
+    SingleLineString, Url, ValidBase64,
 };
 
 // Kubernetes related settings. The dynamic settings are retrieved from
@@ -112,6 +112,7 @@ struct ECSSettings {
     instance_attributes: HashMap<ECSAttributeKey, ECSAttributeValue>,
     allow_privileged_containers: bool,
     logging_drivers: Vec<SingleLineString>,
+    loglevel: ECSAgentLogLevel,
 }
 
 // Update settings. Taken from userdata. The 'seed' setting is generated

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -47,6 +47,12 @@ pub mod error {
 
         #[snafu(display("Invalid domain name '{}': {}", input, msg))]
         InvalidDomainName { input: String, msg: String },
+
+        #[snafu(display("Invalid input for field {}: {}", field, source))]
+        InvalidPlainValue {
+            field: String,
+            source: serde_plain::Error,
+        },
     }
 }
 


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/815

(Note: this overlaps with https://github.com/bottlerocket-os/bottlerocket/pull/1053 as it adds a new setting.  I will update either this one or the other one depending on which gets merged first.)

**Description of changes:**
The log level for the ECS agent cannot be set using ecs.config.json.  Instead, for this setting we use a template file which is then sourced as an EnvironmentFile in ecs.service.

This change also reduces the default logging level from "debug" (which is quite chatty) to "info" (which is the default on the ECS-optimized AMIs).

**Testing done:**
Built a new AMI.  Observed that the correct default value was populated to `/etc/ecs/ecs.config` and that the ECS agent was logging at the correct level.  Used `apiclient` to patch the value to "debug", committed the change, and observed the correct change to `/etc/ecs/ecs.config` as well as the ECS agent's logging behavior.  Used `apiclient` to try and set an invalid value, received an appropriate error response.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
