### PR TITLE
pubsys: use base region for contacting STS

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -111,11 +111,11 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, String>
     })?;
 
     // Build EBS client for snapshot management, and EC2 client for registration
-    let ebs_client = build_client::<EbsClient>(&base_region, &aws).context(error::Client {
+    let ebs_client = build_client::<EbsClient>(&base_region, &base_region, &aws).context(error::Client {
         client_type: "EBS",
         region: base_region.name(),
     })?;
-    let ec2_client = build_client::<Ec2Client>(&base_region, &aws).context(error::Client {
+    let ec2_client = build_client::<Ec2Client>(&base_region, &base_region, &aws).context(error::Client {
         client_type: "EC2",
         region: base_region.name(),
     })?;
@@ -172,6 +172,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, String>
     wait_for_ami(
         &image_id,
         &base_region,
+        &base_region,
         "available",
         successes_required,
         &aws,
@@ -187,7 +188,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, String>
     // live until the future is resolved.
     let mut ec2_clients = HashMap::with_capacity(regions.len());
     for region in regions.iter() {
-        let ec2_client = build_client::<Ec2Client>(&region, &aws).context(error::Client {
+        let ec2_client = build_client::<Ec2Client>(&region, &base_region, &aws).context(error::Client {
             client_type: "EC2",
             region: base_region.name(),
         })?;

--- a/tools/pubsys/src/aws/ami/wait.rs
+++ b/tools/pubsys/src/aws/ami/wait.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 pub(crate) async fn wait_for_ami(
     id: &str,
     region: &Region,
+    sts_region: &Region,
     state: &str,
     successes_required: u8,
     aws: &AwsConfig,
@@ -49,7 +50,7 @@ pub(crate) async fn wait_for_ami(
         };
         // Use a new client each time so we have more confidence that different endpoints can see
         // the new AMI.
-        let ec2_client = build_client::<Ec2Client>(&region, &aws).context(error::Client {
+        let ec2_client = build_client::<Ec2Client>(&region, &sts_region, &aws).context(error::Client {
             client_type: "EC2",
             region: region.name(),
         })?;


### PR DESCRIPTION
```
The region used for the base credentials provider should be the one in which
you want to talk to STS to get temporary credentials, not the region in which
you want to talk to a service endpoint like EC2.  This is needed because you
may be assuming a role in an opt-in region from an account that has not
opted-in to that region, and you need to get session credentials from an STS
endpoint in a region to which you have access in the base account.
```

Note: this uses the first region in the given region list to talk to STS, the same way we use the first region to register an AMI and copy out from that region.  I think we should have a separate discussion about whether these belong in separate settings, like `base_region` perhaps, since there has been some confusion about the region list.

**Testing done:**
* Reconfirmed ami, ami-public, and ami-private in standard regions.                                                                                                                                            
* Confirmed that clients built with the updated method can now talk to services in opt-in regions from non-opted-in accounts.  Before, you'd get a `InvalidClientTokenId` 403 error.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
