### PR TITLE
pubsys: grant AMI permissions to target account before copying

### DIFF
--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -9,9 +9,8 @@ use futures::stream::{self, StreamExt};
 use log::{debug, error, info, trace};
 use rusoto_core::{Region, RusotoError};
 use rusoto_ec2::{
-    DescribeImagesError, DescribeImagesRequest, DescribeImagesResult, Ec2, Ec2Client,
-    ModifyImageAttributeError, ModifyImageAttributeRequest, ModifySnapshotAttributeError,
-    ModifySnapshotAttributeRequest,
+    DescribeImagesRequest, Ec2, Ec2Client, ModifyImageAttributeRequest,
+    ModifySnapshotAttributeError, ModifySnapshotAttributeRequest,
 };
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::{HashMap, HashSet};
@@ -90,7 +89,12 @@ pub(crate) async fn run(args: &Args, publish_args: &PublishArgs) -> Result<()> {
     } else {
         aws.regions.clone().into()
     };
-    ensure!(!regions.is_empty(), error::MissingConfig { missing: "aws.regions" });
+    ensure!(
+        !regions.is_empty(),
+        error::MissingConfig {
+            missing: "aws.regions"
+        }
+    );
     let base_region = region_from_string(&regions[0], &aws).context(error::ParseRegion)?;
 
     // Check that the requested regions are a subset of the regions we *could* publish from the AMI
@@ -124,164 +128,225 @@ pub(crate) async fn run(args: &Args, publish_args: &PublishArgs) -> Result<()> {
     // live until the future is resolved.
     let mut ec2_clients = HashMap::with_capacity(amis.len());
     for region in amis.keys() {
-        let ec2_client = build_client::<Ec2Client>(&region, &base_region, &aws).context(error::Client {
-            client_type: "EC2",
-            region: region.name(),
-        })?;
+        let ec2_client =
+            build_client::<Ec2Client>(&region, &base_region, &aws).context(error::Client {
+                client_type: "EC2",
+                region: region.name(),
+            })?;
         ec2_clients.insert(region.clone(), ec2_client);
     }
 
-    let snapshots = get_snapshots(&amis, &ec2_clients).await?;
+    let snapshots = get_regional_snapshots(&amis, &ec2_clients).await?;
     trace!("Found snapshots: {:?}", snapshots);
 
+    let all = Some(vec!["all".to_string()]);
     info!("Updating snapshot permissions - making {}", mode);
-    modify_snapshots(&snapshots, &ec2_clients, operation.clone()).await?;
+    modify_regional_snapshots(None, all.clone(), &operation, &snapshots, &ec2_clients).await?;
+
     info!("Updating image permissions - making {}", mode);
-    modify_images(&amis, &ec2_clients, operation.clone()).await?;
+    let ami_ids = amis
+        .into_iter()
+        .map(|(region, image)| (region, image.id))
+        .collect();
+    modify_regional_images(None, all, &operation, &ami_ids, &ec2_clients).await?;
 
     Ok(())
 }
 
+/// Returns the snapshot IDs associated with the given AMI.
+pub(crate) async fn get_snapshots(
+    image_id: &str,
+    region: &Region,
+    ec2_client: &Ec2Client,
+) -> Result<Vec<String>> {
+    let describe_request = DescribeImagesRequest {
+        image_ids: Some(vec![image_id.to_string()]),
+        ..Default::default()
+    };
+    let describe_response = ec2_client.describe_images(describe_request).await;
+    let describe_response = describe_response.context(error::DescribeImages {
+        region: region.name(),
+    })?;
+
+    // Get the image description, ensuring we only have one.
+    let mut images = describe_response.images.context(error::MissingInResponse {
+        request_type: "DescribeImages",
+        missing: "images",
+    })?;
+    ensure!(
+        !images.is_empty(),
+        error::MissingImage {
+            region: region.name(),
+            image_id: image_id.to_string(),
+        }
+    );
+    ensure!(
+        images.len() == 1,
+        error::MultipleImages {
+            region: region.name(),
+            images: images
+                .into_iter()
+                .map(|i| i.image_id.unwrap_or_else(|| "<missing>".to_string()))
+                .collect::<Vec<_>>()
+        }
+    );
+    let image = images.remove(0);
+
+    // Look into the block device mappings for snapshots.
+    let bdms = image
+        .block_device_mappings
+        .context(error::MissingInResponse {
+            request_type: "DescribeImages",
+            missing: "block_device_mappings",
+        })?;
+    ensure!(
+        !bdms.is_empty(),
+        error::MissingInResponse {
+            request_type: "DescribeImages",
+            missing: "non-empty block_device_mappings"
+        }
+    );
+    let mut snapshot_ids = Vec::with_capacity(bdms.len());
+    for bdm in bdms {
+        let ebs = bdm.ebs.context(error::MissingInResponse {
+            request_type: "DescribeImages",
+            missing: "ebs in block_device_mappings",
+        })?;
+        let snapshot_id = ebs.snapshot_id.context(error::MissingInResponse {
+            request_type: "DescribeImages",
+            missing: "snapshot_id in block_device_mappings.ebs",
+        })?;
+        snapshot_ids.push(snapshot_id);
+    }
+
+    Ok(snapshot_ids)
+}
+
 /// Returns a regional mapping of snapshot IDs associated with the given AMIs.
-async fn get_snapshots(
+async fn get_regional_snapshots(
     amis: &HashMap<Region, Image>,
     clients: &HashMap<Region, Ec2Client>,
 ) -> Result<HashMap<Region, Vec<String>>> {
     // Build requests for image information.
-    let mut describe_requests = Vec::with_capacity(amis.len());
+    let mut snapshots_requests = Vec::with_capacity(amis.len());
     for (region, image) in amis {
         let ec2_client = &clients[region];
-        let describe_request = DescribeImagesRequest {
-            image_ids: Some(vec![image.id.to_string()]),
-            ..Default::default()
-        };
-        let describe_future = ec2_client.describe_images(describe_request);
 
-        // Store the region and image ID so we can include it in errors
-        let info_future = ready((region.clone(), image.id.clone()));
-        describe_requests.push(join(info_future, describe_future));
+        let snapshots_future = get_snapshots(&image.id, region, ec2_client);
+
+        // Store the region so we can include it in errors
+        let info_future = ready(region.clone());
+        snapshots_requests.push(join(info_future, snapshots_future));
     }
 
     // Send requests in parallel and wait for responses, collecting results into a list.
-    let request_stream = stream::iter(describe_requests).buffer_unordered(4);
-    let describe_responses: Vec<(
-        (Region, String),
-        std::result::Result<DescribeImagesResult, RusotoError<DescribeImagesError>>,
-    )> = request_stream.collect().await;
+    let request_stream = stream::iter(snapshots_requests).buffer_unordered(4);
+    let snapshots_responses: Vec<(Region, Result<Vec<String>>)> = request_stream.collect().await;
 
     // For each described image, get the snapshot IDs from the block device mappings.
     let mut snapshots = HashMap::with_capacity(amis.len());
-    for ((region, image_id), describe_response) in describe_responses {
-        // Get the image description, ensuring we only have one.
-        let describe_response = describe_response.context(error::DescribeImages {
-            region: region.name(),
-        })?;
-        let mut images = describe_response.images.context(error::MissingInResponse {
-            request_type: "DescribeImages",
-            missing: "images",
-        })?;
-        ensure!(
-            !images.is_empty(),
-            error::MissingImage {
-                region: region.name(),
-                image_id,
-            }
-        );
-        ensure!(
-            images.len() == 1,
-            error::MultipleImages {
-                region: region.name(),
-                images: images
-                    .into_iter()
-                    .map(|i| i.image_id.unwrap_or_else(|| "<missing>".to_string()))
-                    .collect::<Vec<_>>()
-            }
-        );
-        let image = images.remove(0);
-
-        // Look into the block device mappings for snapshots.
-        let bdms = image
-            .block_device_mappings
-            .context(error::MissingInResponse {
-                request_type: "DescribeImages",
-                missing: "block_device_mappings",
-            })?;
-        ensure!(
-            !bdms.is_empty(),
-            error::MissingInResponse {
-                request_type: "DescribeImages",
-                missing: "non-empty block_device_mappings"
-            }
-        );
-        let mut snapshot_ids = Vec::with_capacity(bdms.len());
-        for bdm in bdms {
-            let ebs = bdm.ebs.context(error::MissingInResponse {
-                request_type: "DescribeImages",
-                missing: "ebs in block_device_mappings",
-            })?;
-            let snapshot_id = ebs.snapshot_id.context(error::MissingInResponse {
-                request_type: "DescribeImages",
-                missing: "snapshot_id in block_device_mappings.ebs",
-            })?;
-            snapshot_ids.push(snapshot_id);
-        }
+    for (region, snapshot_ids) in snapshots_responses {
+        let snapshot_ids = snapshot_ids?;
         snapshots.insert(region, snapshot_ids);
     }
 
     Ok(snapshots)
 }
 
-/// Modify snapshot attributes to make them public/private as requested.
-async fn modify_snapshots(
-    snapshots: &HashMap<Region, Vec<String>>,
-    clients: &HashMap<Region, Ec2Client>,
-    operation: String,
+/// Modify createVolumePermission for the given users/groups on the given snapshots.  The
+/// `operation` should be "add" or "remove" to allow/deny permission.
+pub(crate) async fn modify_snapshots(
+    user_ids: Option<Vec<String>>,
+    group_names: Option<Vec<String>>,
+    operation: &str,
+    snapshot_ids: &[String],
+    ec2_client: &Ec2Client,
+    region: &Region,
 ) -> Result<()> {
-    // Build requests to modify snapshot attributes.
-    let mut modify_snapshot_requests = Vec::new();
-    for (region, snapshot_ids) in snapshots {
-        for snapshot_id in snapshot_ids {
-            let ec2_client = &clients[region];
-            let modify_snapshot_request = ModifySnapshotAttributeRequest {
-                attribute: Some("createVolumePermission".to_string()),
-                group_names: Some(vec!["all".to_string()]),
-                operation_type: Some(operation.clone()),
-                snapshot_id: snapshot_id.clone(),
-                ..Default::default()
-            };
-            let modify_snapshot_future =
-                ec2_client.modify_snapshot_attribute(modify_snapshot_request);
-
-            // Store the region and snapshot ID so we can include it in errors
-            let info_future = ready((region.name().to_string(), snapshot_id.clone()));
-            modify_snapshot_requests.push(join(info_future, modify_snapshot_future));
-        }
+    let mut requests = Vec::new();
+    for snapshot_id in snapshot_ids {
+        let request = ModifySnapshotAttributeRequest {
+            attribute: Some("createVolumePermission".to_string()),
+            user_ids: user_ids.clone(),
+            group_names: group_names.clone(),
+            operation_type: Some(operation.to_string()),
+            snapshot_id: snapshot_id.clone(),
+            ..Default::default()
+        };
+        let response_future = ec2_client.modify_snapshot_attribute(request);
+        // Store the snapshot_id so we can include it in any errors
+        let info_future = ready(snapshot_id.to_string());
+        requests.push(join(info_future, response_future));
     }
 
     // Send requests in parallel and wait for responses, collecting results into a list.
-    let request_stream = stream::iter(modify_snapshot_requests).buffer_unordered(4);
-    let modify_snapshot_responses: Vec<(
-        (String, String),
+    let request_stream = stream::iter(requests).buffer_unordered(4);
+    let responses: Vec<(
+        String,
         std::result::Result<(), RusotoError<ModifySnapshotAttributeError>>,
     )> = request_stream.collect().await;
+
+    for (snapshot_id, response) in responses {
+        response.context(error::ModifyImageAttribute {
+            snapshot_id,
+            region: region.name(),
+        })?
+    }
+
+    Ok(())
+}
+
+/// Modify createVolumePermission for the given users/groups, across all of the snapshots in the
+/// given regional mapping.  The `operation` should be "add" or "remove" to allow/deny permission.
+pub(crate) async fn modify_regional_snapshots(
+    user_ids: Option<Vec<String>>,
+    group_names: Option<Vec<String>>,
+    operation: &str,
+    snapshots: &HashMap<Region, Vec<String>>,
+    clients: &HashMap<Region, Ec2Client>,
+) -> Result<()> {
+    // Build requests to modify snapshot attributes.
+    let mut requests = Vec::new();
+    for (region, snapshot_ids) in snapshots {
+        let ec2_client = &clients[region];
+        let modify_snapshot_future = modify_snapshots(
+            user_ids.clone(),
+            group_names.clone(),
+            operation,
+            snapshot_ids,
+            ec2_client,
+            region,
+        );
+
+        // Store the region and snapshot ID so we can include it in errors
+        let info_future = ready((region.clone(), snapshot_ids.clone()));
+        requests.push(join(info_future, modify_snapshot_future));
+    }
+
+    // Send requests in parallel and wait for responses, collecting results into a list.
+    let request_stream = stream::iter(requests).buffer_unordered(4);
+    let responses: Vec<((Region, Vec<String>), Result<()>)> = request_stream.collect().await;
 
     // Count up successes and failures so we can give a clear total in the final error message.
     let mut error_count = 0u16;
     let mut success_count = 0u16;
-    for ((region, snapshot_id), modify_snapshot_response) in modify_snapshot_responses {
-        match modify_snapshot_response {
+    for ((region, snapshot_ids), response) in responses {
+        match response {
             Ok(()) => {
                 success_count += 1;
                 debug!(
-                    "Modified permissions of snapshot {} in {}",
-                    snapshot_id, region,
+                    "Modified permissions in {} for snapshots [{}]",
+                    region.name(),
+                    snapshot_ids.join(", "),
                 );
             }
             Err(e) => {
                 error_count += 1;
                 error!(
-                    "Modifying permissions of {} in {} failed: {}",
-                    snapshot_id, region, e
+                    "Failed to modify permissions in {} for snapshots [{}]: {}",
+                    region.name(),
+                    snapshot_ids.join(", "),
+                    e
                 );
             }
         }
@@ -289,7 +354,7 @@ async fn modify_snapshots(
 
     ensure!(
         error_count == 0,
-        error::ModifySnapshotAttribute {
+        error::ModifySnapshotAttributes {
             error_count,
             success_count,
         }
@@ -298,41 +363,69 @@ async fn modify_snapshots(
     Ok(())
 }
 
-/// Modify image attributes to make them public/private as requested.
-async fn modify_images(
-    images: &HashMap<Region, Image>,
-    clients: &HashMap<Region, Ec2Client>,
-    operation: String,
+/// Modify launchPermission for the given users/groups on the given images.  The `operation`
+/// should be "add" or "remove" to allow/deny permission.
+pub(crate) async fn modify_image(
+    user_ids: Option<Vec<String>>,
+    user_groups: Option<Vec<String>>,
+    operation: &str,
+    image_id: &str,
+    ec2_client: &Ec2Client,
+    region: &Region,
 ) -> Result<()> {
     // Build requests to modify image attributes.
-    let mut modify_image_requests = Vec::new();
-    for (region, image) in images {
+    let modify_image_request = ModifyImageAttributeRequest {
+        attribute: Some("launchPermission".to_string()),
+        user_ids: user_ids.clone(),
+        user_groups: user_groups.clone(),
+        operation_type: Some(operation.to_string()),
+        image_id: image_id.to_string(),
+        ..Default::default()
+    };
+    ec2_client
+        .modify_image_attribute(modify_image_request)
+        .await
+        .context(error::ModifyImageAttributes {
+            image_id,
+            region: region.name(),
+        })
+}
+
+/// Modify launchPermission for the given users/groups, across all of the images in the given
+/// regional mapping.  The `operation` should be "add" or "remove" to allow/deny permission.
+pub(crate) async fn modify_regional_images(
+    user_ids: Option<Vec<String>>,
+    user_groups: Option<Vec<String>>,
+    operation: &str,
+    images: &HashMap<Region, String>,
+    clients: &HashMap<Region, Ec2Client>,
+) -> Result<()> {
+    let mut requests = Vec::new();
+    for (region, image_id) in images {
         let ec2_client = &clients[region];
-        let modify_image_request = ModifyImageAttributeRequest {
-            attribute: Some("launchPermission".to_string()),
-            user_groups: Some(vec!["all".to_string()]),
-            operation_type: Some(operation.clone()),
-            image_id: image.id.clone(),
-            ..Default::default()
-        };
-        let modify_image_future = ec2_client.modify_image_attribute(modify_image_request);
+
+        let modify_image_future = modify_image(
+            user_ids.clone(),
+            user_groups.clone(),
+            operation,
+            image_id,
+            ec2_client,
+            region,
+        );
 
         // Store the region and image ID so we can include it in errors
-        let info_future = ready((region.name().to_string(), image.id.clone()));
-        modify_image_requests.push(join(info_future, modify_image_future));
+        let info_future = ready((region.name().to_string(), image_id.clone()));
+        requests.push(join(info_future, modify_image_future));
     }
 
     // Send requests in parallel and wait for responses, collecting results into a list.
-    let request_stream = stream::iter(modify_image_requests).buffer_unordered(4);
-    let modify_image_responses: Vec<(
-        (String, String),
-        std::result::Result<(), RusotoError<ModifyImageAttributeError>>,
-    )> = request_stream.collect().await;
+    let request_stream = stream::iter(requests).buffer_unordered(4);
+    let responses: Vec<((String, String), Result<()>)> = request_stream.collect().await;
 
     // Count up successes and failures so we can give a clear total in the final error message.
     let mut error_count = 0u16;
     let mut success_count = 0u16;
-    for ((region, image_id), modify_image_response) in modify_image_responses {
+    for ((region, image_id), modify_image_response) in responses {
         match modify_image_response {
             Ok(()) => {
                 success_count += 1;
@@ -350,7 +443,7 @@ async fn modify_images(
 
     ensure!(
         error_count == 0,
-        error::ModifyImageAttribute {
+        error::ModifyImagesAttributes {
             error_count,
             success_count,
         }
@@ -361,6 +454,8 @@ async fn modify_images(
 
 mod error {
     use crate::aws;
+    use rusoto_core::RusotoError;
+    use rusoto_ec2::{ModifyImageAttributeError, ModifySnapshotAttributeError};
     use snafu::Snafu;
     use std::io;
     use std::path::PathBuf;
@@ -422,19 +517,43 @@ mod error {
         },
 
         #[snafu(display(
+            "Failed to modify permissions of {} in {}: {}",
+            snapshot_id,
+            region,
+            source
+        ))]
+        ModifyImageAttribute {
+            snapshot_id: String,
+            region: String,
+            source: RusotoError<ModifySnapshotAttributeError>,
+        },
+
+        #[snafu(display(
             "Failed to modify permissions of {} of {} images",
             error_count, error_count + success_count,
         ))]
-        ModifyImageAttribute {
+        ModifyImagesAttributes {
             error_count: u16,
             success_count: u16,
+        },
+
+        #[snafu(display(
+            "Failed to modify permissions of {} in {}: {}",
+            image_id,
+            region,
+            source
+        ))]
+        ModifyImageAttributes {
+            image_id: String,
+            region: String,
+            source: RusotoError<ModifyImageAttributeError>,
         },
 
         #[snafu(display(
             "Failed to modify permissions of {} of {} snapshots",
             error_count, error_count + success_count,
         ))]
-        ModifySnapshotAttribute {
+        ModifySnapshotAttributes {
             error_count: u16,
             success_count: u16,
         },


### PR DESCRIPTION
```
If you specify regional roles in Infra.toml that refer to different accounts,
those accounts need access to the AMI and its snapshots before it can copy
the AMI.  This change adds the missing grants:

* If we find an existing AMI, we describe its snapshots so we can grant them
  * publish_ami functions were split so we can handle single regions or lists
    of regions more easily
* Ask STS for the account IDs of the given roles (removing the original account
  ID that already has access)
* modify_snapshots and modify_images were updated with user/group parameters
  rather than hardcoding "all"
* A new RegisteredIds struct is used to pass around the image and snapshot IDs
  to grant
```

Sorry this looks so long, I don't think it's as bad as it seems; the changes to `publish_ami/mod.rs` are basically just splitting methods so we can get/modify snapshots/images individually or in groups, rather than having to construct artificial groups for the single cases.

**Testing done:**

* Confirmed normal ami / ami-public / ami-private path.
* Confirmed that AMI copy now works across account boundaries.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
