### PR TITLE
pubsys: minor cleanup

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -273,7 +273,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         let ec2_client =
             build_client::<Ec2Client>(&region, &base_region, &aws).context(error::Client {
                 client_type: "EC2",
-                region: base_region.name(),
+                region: region.name(),
             })?;
         ec2_clients.insert(region.clone(), ec2_client);
     }
@@ -286,7 +286,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             .context(error::GetAmiId {
                 name: &ami_args.name,
                 arch: &ami_args.arch,
-                region: base_region.name(),
+                region: region.name(),
             })?
         {
             info!(

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -3,7 +3,7 @@
 
 mod register;
 mod snapshot;
-mod wait;
+pub(crate) mod wait;
 
 use crate::aws::publish_ami::{get_snapshots, modify_image, modify_snapshots};
 use crate::aws::{client::build_client, region_from_string};

--- a/tools/pubsys/src/aws/ami/register.rs
+++ b/tools/pubsys/src/aws/ami/register.rs
@@ -63,7 +63,7 @@ async fn _register_image(
     })?;
     cleanup_snapshot_ids.push(data_snapshot.clone());
 
-    debug!(
+    info!(
         "Waiting for root and data snapshots to become available in {}",
         region
     );
@@ -111,7 +111,7 @@ async fn _register_image(
         ..Default::default()
     };
 
-    debug!("Registering AMI in {}", region);
+    info!("Making register image call in {}", region);
     let register_response = ec2_client
         .register_image(register_request)
         .await

--- a/tools/pubsys/src/aws/ami/wait.rs
+++ b/tools/pubsys/src/aws/ami/wait.rs
@@ -33,16 +33,6 @@ pub(crate) async fn wait_for_ami(
                 region: region.name()
             }
         );
-        if attempts % 5 == 1 {
-            info!(
-                "Waiting for {} in {} to be {}... (attempt {} of {})",
-                id,
-                region.name(),
-                state,
-                attempts,
-                max_attempts
-            );
-        }
 
         let describe_request = DescribeImagesRequest {
             image_ids: Some(vec![id.to_string()]),
@@ -102,6 +92,17 @@ pub(crate) async fn wait_for_ami(
             // Did not receive list; reset success count and try again (if we have spare attempts)
             successes = 0;
         };
+
+        if attempts % 5 == 1 {
+            info!(
+                "Waiting for {} in {} to be {}... (attempt {} of {})",
+                id,
+                region.name(),
+                state,
+                attempts,
+                max_attempts
+            );
+        }
         sleep(Duration::from_secs(seconds_between_attempts));
     }
 }


### PR DESCRIPTION
```
commit 5b684ea3be5b84cd1aeffda5e274a2d9ee6a2156
Author: Tom Kirchner <tjk@amazon.com>
Date:   Sun Aug 23 17:16:09 2020 -0700

    pubsys: wait for AMIs to be available before granting access

    Without a wait, if you use publish_ami right after registering/copying AMIs,
    describe images responses can include partial information that doesn't include
    snapshot IDs.
```

```
commit afe9526e7ee415ac169bcdf4a3e055d59a7ddf87
Author: Tom Kirchner <tjk@amazon.com>
Date:   Sun Aug 23 17:35:06 2020 -0700

    pubsys: print waiting message only if we're going to sleep

    If the AMI is found on the first attempt, the success message is enough.
```

```
commit 08b31055ab117d03a252287311dc95ce8b3d80e5
Author: Tom Kirchner <tjk@amazon.com>
Date:   Sun Aug 23 17:04:21 2020 -0700

    pubsys: increase log level inside AMI registration process

    Waiting for snapshots is the longest part of AMI registration and there wasn't
    much explanation of what was happening, so this bumps a couple debug messages
    up to info level.
```

```
commit 6f60d7a2267491f313fdbf8769b772d487558d76
Author: Tom Kirchner <tjk@amazon.com>
Date:   Sun Aug 23 16:57:37 2020 -0700

    pubsys: rename client variable to reduce confusion

    It's too easy to use "ec2_client" by accident when you need a regional client,
    when this is actually a client just for the base region.
```

```
commit 996385ce19454653f037f81e35983f9012924610
Author: Tom Kirchner <tjk@amazon.com>
Date:   Sun Aug 23 16:55:21 2020 -0700

    pubsys: fix region name in error message
```

A few small bug fixes and a performance improvement, now that the blockers are out of the way.

**Testing done:**

* Ran an `ami` / `ami-public` / `ami-private` cycle successfully; before, if you ran `ami-public` immediately after `ami` you could get a failure based on partial describe-images responses not having snapshot IDs.
* Ran an `ami-public` / `ami-private` cycle with AMIs that already existed and saw the waits finish immediately.
* Saw the improved logging, for example:
```
00:48:25 [INFO] Registering 'bottlerocket-aws-k8s-1.17-x86_64-v0.5.0-5b684ea3' in us-west-2
00:50:17 [INFO] Waiting for root and data snapshots to become available in us-west-2
00:50:26 [INFO] Making register image call in us-west-2
00:50:26 [INFO] Registered AMI 'bottlerocket-aws-k8s-1.17-x86_64-v0.5.0-5b684ea3' in us-west-2: ami-12345
```
and:
```
00:56:07 [INFO] Waiting for AMIs to be available...
00:56:07 [INFO] Found ami-23456 available in us-west-1
...
00:56:11 [INFO] Updating snapshot permissions - making private
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
