### PR TITLE
pubsys: change "parameter overrides" to "conditional parameters"

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,10 +37,11 @@ PUBLISH_KEY = "default"
 # AMIs.  (You can also specify PUBLISH_ROOT_VOLUME_SIZE to override the root
 # volume size; by default it's the image size, rounded up.)
 PUBLISH_DATA_VOLUME_SIZE = "20"
-# This can be overridden with -e to change the path to the directory containing
-# SSM parameter template files.  These files determine the parameter names and
-# values that will be published to SSM when you run `cargo make ssm`.
-PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm"
+# This can be overridden with -e to change the path to the file containing SSM
+# parameter templates.  This file determines the parameter names and values
+# that will be published to SSM when you run `cargo make ssm`.  See
+# tools/pubsys/policies/ssm/README.md for more information.
+PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm/defaults.toml"
 
 # You can also set PUBLISH_REGIONS to override the list of regions from
 # Infra.toml for AMI and SSM commands; it's a comma-separated list like
@@ -507,7 +508,7 @@ pubsys \
    --arch "${BUILDSYS_ARCH}" \
    --variant "${BUILDSYS_VARIANT}" \
    --version "${BUILDSYS_VERSION_FULL}" \
-   --template-dir "${PUBLISH_SSM_TEMPLATES_PATH}" \
+   --template-path "${PUBLISH_SSM_TEMPLATES_PATH}" \
    \
    ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"} \
    ${ALLOW_CLOBBER:+--allow-clobber}
@@ -539,7 +540,7 @@ pubsys \
    --variant "${BUILDSYS_VARIANT}" \
    --source "${source}" \
    --target "${target}" \
-   --template-dir "${PUBLISH_SSM_TEMPLATES_PATH}" \
+   --template-path "${PUBLISH_SSM_TEMPLATES_PATH}" \
    \
    ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"}
 '''

--- a/tools/pubsys/policies/ssm/README.md
+++ b/tools/pubsys/policies/ssm/README.md
@@ -21,10 +21,18 @@ The available variables include:
 * `image_version`, for example "0.5.0-e0ddf1b"
 * `region`, for example "us-west-2"
 
-# Overrides
+# Conditional parameters
 
-You can also add or override parameters that are specific to `variant` or `arch`.
-To do so, create a directory named "variant" or "arch" inside parameters directory, and create a file named after the specific variant or arch for which you want overrides.
+You can also list parameters that only apply to specific variants or architectures.
+To do so, add `variant` or `arch` keys (or both) to your parameter definition.
+The parameter will only be populated if the current `variant` or `arch` matches one of the values in the list.
+(If both `variant` and `arch` are listed, the build must match an entry from both lists.)
 
-For example, to add extra parameters just for the "aarch64" architecture, create `arch/aarch64.toml`.
-Inside you can put the same types of `[[parameter]]` declarations that you see in `defaults.toml`, but they'll only be applied for `aarch64` builds.
+For example, to add an extra parameter that's only set for "aarch64" builds of the "aws-ecs-1" variant:
+```
+[[parameter]]
+arch = ["aarch64"]
+variant = ["aws-ecs-1"]
+name = "/a/special/aarch64/ecs/parameter"
+value = "{image_name}"
+```


### PR DESCRIPTION
```
Rather than template directories with override files for specific variants and
architectures, this uses a single TOML file for all parameters with (optional)
keys restricting parameters to specific variants and arches.

This model is clearer, based on early feedback, and also allows users to
specify parameters that are conditional to a variant *and* an architecture,
whereas the override files were more like "or" matches.
```

Note: based on #1060.

**Testing done:**

I added parameters specific to current arch, to another arch, to current variant, to another variant, to lists of variants/arches separately, to lists of variants/arches together (for matching and non-matching combinations), and overall saw the expected behavior as described in the updated README.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
