### PR TITLE
apiclient: accept -s for --socket-path, as per usage message

### DIFF
--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -49,10 +49,10 @@ fn parse_args(args: env::Args) -> Args {
         match arg.as_ref() {
             "-v" | "--verbose" => verbosity += 1,
 
-            "--socket-path" => {
+            "-s" | "--socket-path" => {
                 socket_path = Some(
                     iter.next()
-                        .unwrap_or_else(|| usage_msg("Did not give argument to --socket-path")),
+                        .unwrap_or_else(|| usage_msg("Did not give argument to -s | --socket-path")),
                 )
             }
 


### PR DESCRIPTION
**Issue number:**

Fixes #1068

**Description of changes:**

Usage described `-s` for `--socket-path` but it wasn't accepted; this adds `-s`.

**Testing done:**

Ran it with `-s` and saw the program start, rather than show the usage message.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
