### PR TITLE
pubsys: map to EC2 architecture names

### DIFF
--- a/tools/pubsys/policies/ssm/README.md
+++ b/tools/pubsys/policies/ssm/README.md
@@ -15,7 +15,8 @@ The `name` and `value` can contain template variables that will be replaced with
 
 The available variables include:
 * `variant`, for example "aws-k8s-1.17"
-* `arch`, for example "x86_64"
+* `arch`, for example "x86_64" or "arm64".
+  * Note: "amd64" and "aarch64" are mapped to "x86_64" and "arm64", respectively, to match the names used by EC2.
 * `image_id`, for example "ami-0123456789abcdef0"
 * `image_name`, for example "bottlerocket-aws-k8s-1.17-x86_64-v0.5.0-e0ddf1b"
 * `image_version`, for example "0.5.0-e0ddf1b"

--- a/tools/pubsys/src/aws/mod.rs
+++ b/tools/pubsys/src/aws/mod.rs
@@ -23,12 +23,27 @@ fn region_from_string(name: &str, aws: &AwsConfig) -> Result<Region> {
     })
 }
 
+/// Parses the given string as an architecture, mapping values to the ones used in EC2.
+pub(crate) fn parse_arch(input: &str) -> Result<String> {
+    match input {
+        "x86_64" | "amd64" => Ok("x86_64".to_string()),
+        "arm64" | "aarch64" => Ok("arm64".to_string()),
+        _ => error::ParseArch { input, msg: "unknown architecture" }.fail(),
+    }
+}
+
 mod error {
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility = "pub(super)")]
     pub(crate) enum Error {
+        #[snafu(display("Failed to parse arch '{}': {}", input, msg))]
+        ParseArch {
+            input: String,
+            msg: String
+        },
+
         #[snafu(display("Failed to parse region '{}': {}", name, source))]
         ParseRegion {
             name: String,

--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -2,7 +2,7 @@
 //! SSM parameters from one version to another
 
 use crate::aws::client::build_client;
-use crate::aws::region_from_string;
+use crate::aws::{parse_arch, region_from_string};
 use crate::aws::ssm::{key_difference, ssm, template, BuildContext, SsmKey};
 use crate::config::InfraConfig;
 use crate::Args;
@@ -19,7 +19,7 @@ use structopt::StructOpt;
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 pub(crate) struct PromoteArgs {
     /// The architecture of the machine image
-    #[structopt(long)]
+    #[structopt(long, parse(try_from_str = parse_arch))]
     arch: String,
 
     /// The variant name for the current build

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -4,7 +4,7 @@
 pub(crate) mod ssm;
 pub(crate) mod template;
 
-use crate::aws::{ami::Image, client::build_client, region_from_string};
+use crate::aws::{ami::Image, client::build_client, parse_arch, region_from_string};
 use crate::config::{AwsConfig, InfraConfig};
 use crate::Args;
 use log::{info, trace};
@@ -28,7 +28,7 @@ pub(crate) struct SsmArgs {
     ami_input: PathBuf,
 
     /// The architecture of the machine image
-    #[structopt(long)]
+    #[structopt(long, parse(try_from_str = parse_arch))]
     arch: String,
 
     /// The variant name for the current build


### PR DESCRIPTION
```
SSM parameters are used to find EC2 AMI information, so the arch name used in
parameters should match the name used by EC2.
```

**Testing done:**
* Published multiple SSM parameters with all 4 architecture strings to confirm they were mapped correctly
* Attempted to publish an invalid architecture string to prove it will cause an error


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
