### PR TITLE
ecs-agent: bind introspection to localhost

### DIFF
--- a/packages/ecs-agent/0004-bottlerocket-bind-introspection-to-localhost.patch
+++ b/packages/ecs-agent/0004-bottlerocket-bind-introspection-to-localhost.patch
@@ -1,0 +1,25 @@
+From 6aaaf9421b894100ea765d2ec5afef64235e00e4 Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Fri, 21 Aug 2020 11:07:32 -0700
+Subject: [PATCH 4/4] bottlerocket: bind introspection to localhost
+
+---
+ agent/handlers/introspection_server_setup.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/agent/handlers/introspection_server_setup.go b/agent/handlers/introspection_server_setup.go
+index 07f138a2..bda910f7 100644
+--- a/agent/handlers/introspection_server_setup.go
++++ b/agent/handlers/introspection_server_setup.go
+@@ -56,7 +56,7 @@ func introspectionServerSetup(containerInstanceArn *string, taskEngine handlersu
+ 	loggingServeMux.Handle("/", LoggingHandler{serverMux})
+ 
+ 	server := &http.Server{
+-		Addr:         ":" + strconv.Itoa(config.AgentIntrospectionPort),
++		Addr:         "127.0.0.1:" + strconv.Itoa(config.AgentIntrospectionPort),
+ 		Handler:      loggingServeMux,
+ 		ReadTimeout:  readTimeout,
+ 		WriteTimeout: writeTimeout,
+-- 
+2.28.0
+

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -35,6 +35,10 @@ Patch0002: 0002-bottlerocket-version-values-settable-with-linker.patch
 # Bottlerocket-specific - remove unsupported capabilities
 Patch0003: 0003-bottlerocket-remove-unsupported-capabilities.patch
 
+# bind introspection to localhost
+# https://github.com/aws/amazon-ecs-agent/pull/2588
+Patch0004: 0004-bottlerocket-bind-introspection-to-localhost.patch 
+
 BuildRequires: %{_cross_os}glibc-devel
 
 Requires: %{_cross_os}docker-engine


### PR DESCRIPTION
**Description of changes:**
Bind the ECS agent's introspection API explicitly to localhost.


**Testing done:**
Built an AMI.  Validated that the API was correctly bound to localhost.  Tested calling the API from the control container and admin container.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
