### PR TITLE
Removed aws-cli v1 requirement in docs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -48,7 +48,7 @@ To use the image in Amazon EC2, we need to register the image as an AMI.
 The `bin/amiize.sh` script does this for you.
 
 The script has some assumptions about your setup, in particular that you:
-  * have [aws-cli v1](https://aws.amazon.com/cli/) set up, and that its default profile can create and control EC2 resources
+  * have [aws-cli](https://aws.amazon.com/cli/) set up, and that its default profile can create and control EC2 resources
   * have [coldsnap](https://github.com/awslabs/coldsnap/) installed to upload snapshots
   * have a few other common tools installed, like `jq` and `du`
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -17,7 +17,7 @@ We recommend that you download the [latest version of eksctl](https://github.com
 
 You'll also need to [install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to augment `eksctl` during setup, and to run pods afterward.
 
-Finally, you'll need [aws-cli v1](https://aws.amazon.com/cli/) set up to interact with AWS.
+Finally, you'll need [aws-cli](https://aws.amazon.com/cli/) set up to interact with AWS.
 (You'll need a [recent v1 release](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html#install-tool-bundled) with EKS support.)
 
 ## Automated setup


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A



**Description of changes:**
Removed aws-cli (v1) requirement form docs

**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
