### PR TITLE
fix AVC denial for`docker run --init`

### DIFF
--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -65,6 +65,10 @@
 (allow container_s cache_t (file (entrypoint)))
 (allow container_s state_t (file (entrypoint)))
 
+; Also allow entry to container domains through `docker-init`, which
+; is mounted from the root filesystem and used as the init process.
+(allow container_s runtime_exec_t (file (entrypoint)))
+
 ; Allow containers to communicate with runtimes via pipes.
 (allow container_s runtime_t (files (mutate)))
 


### PR DESCRIPTION
**Issue number:**
Closes #1082 


**Description of changes:**
`docker-init` has the `runtime_exec_t` label, rather than one of the labels that signify local content, but it's still a valid entrypoint to the container domains.

**Testing done:**
```
# docker run -it --init --rm debian
...
root@6644230d2e95:/# ls -l /proc/1/exe
lrwxrwxrwx. 1 root root 0 Aug 27 17:32 /proc/1/exe -> /sbin/docker-init

root@6644230d2e95:/# ls -lZ /sbin/docker-init
-rwxr-xr-x. 1 root root system_u:object_r:runtime_exec_t:s0 589280 Aug 24 17:23 /sbin/docker-init
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
