### PR TITLE
Parallel describe

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -212,6 +212,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
 
     // First we need to find the account IDs for any given roles, so we can grant access to those
     // accounts to copy the AMI and snapshots.
+    info!("Getting account IDs for target regions so we can grant access to copy source AMI");
     let mut account_ids = get_account_ids(&regions, &base_region, &aws).await?;
 
     // Get the account ID used in the base region; we don't need to grant to it so we can remove it
@@ -235,6 +236,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
 
     // If we have any accounts other than the base account, grant them access.
     if !account_ids.is_empty() {
+        info!("Granting access to target accounts so we can copy the AMI");
         let account_id_vec: Vec<_> = account_ids.into_iter().collect();
 
         modify_snapshots(
@@ -279,6 +281,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     }
 
     // First, we check if the AMI already exists in each region.
+    info!("Checking whether AMIs already exist in target regions");
     let mut get_requests = Vec::with_capacity(regions.len());
     for region in regions.iter() {
         let ec2_client = &ec2_clients[region];


### PR DESCRIPTION
**Description of changes:**

```
Add info logging before service requests to help explain timing
```

```
pubsys: check for copied AMIs in parallel
    
We were waiting on the get_ami_id calls serially which led to an unnecessary
increase in runtime when we increase region count.
```

**Testing done:**

Before, it takes 16 seconds for 16 regions consistently, with less information shown:
```
18:45:48 [INFO] Found ami-12345 available in us-west-2
18:46:04 [INFO] Starting copy from us-west-2 to ap-northeast-1
```

After, it takes 7 seconds for 16 regions consistently, and shows useful information between calls:
```
19:06:43 [INFO] Found ami-23456 available in us-west-2
19:06:43 [INFO] Getting account IDs for target regions so we can grant access to copy source AMI
19:06:46 [INFO] Checking whether AMIs already exist in target regions
19:06:50 [INFO] Starting copy from us-west-2 to ap-northeast-1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
