### PR TITLE
Makefile.toml: clean up clean actions

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -574,7 +574,7 @@ for ws in packages; do
   [ -d "${ws}" ] || continue
   cargo clean --manifest-path ${ws}/Cargo.toml
 done
-rm -f ${BUILDSYS_PACKAGES_DIR}/*.rpm
+rm -rf ${BUILDSYS_PACKAGES_DIR}
 '''
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -555,7 +555,7 @@ for ws in sources packages variants/* tools/{buildsys,pubsys}; do
   cargo clean --manifest-path ${ws}/Cargo.toml
 done
 rm -f ${BUILDSYS_TOOLS_DIR}/bin/{buildsys,pubsys}
-for ext in tar lz4 img ; do
+for ext in tar lz4 img json; do
   rm -f ${BUILDSYS_OUTPUT_DIR}/*.${ext}
 done
 rm -rf ${PUBLISH_REPO_BASE_DIR}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -561,7 +561,6 @@ done
 rm -rf ${PUBLISH_REPO_BASE_DIR}
 rm -f ${BUILDSYS_PACKAGES_DIR}/*.rpm
 rm -rf ${BUILDSYS_OUTPUT_DIR}/latest
-rm -rf html
 '''
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -585,10 +585,7 @@ rm -f ${BUILDSYS_PACKAGES_DIR}/*.rpm
 script_runner = "bash"
 script = [
 '''
-for ext in tar lz4 img json; do
-  rm -f ${BUILDSYS_OUTPUT_DIR}/*.${ext}
-done
-rm -rf ${BUILDSYS_OUTPUT_DIR}/latest
+rm -rf ${BUILDSYS_OUTPUT_DIR}
 '''
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,6 +6,7 @@ BUILDSYS_ARCH = { script = ["uname -m"] }
 BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 BUILDSYS_BUILD_DIR = "${BUILDSYS_ROOT_DIR}/build"
 BUILDSYS_PACKAGES_DIR = "${BUILDSYS_BUILD_DIR}/rpms"
+BUILDSYS_IMAGES_DIR = "${BUILDSYS_BUILD_DIR}/images"
 BUILDSYS_TOOLS_DIR = "${BUILDSYS_ROOT_DIR}/tools"
 BUILDSYS_SOURCES_DIR = "${BUILDSYS_ROOT_DIR}/sources"
 BUILDSYS_TIMESTAMP = { script = ["date +%s"] }
@@ -78,7 +79,7 @@ BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.12.0"
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"
 
 # Depends on ${BUILDSYS_ARCH} and ${BUILDSYS_VARIANT}.
-BUILDSYS_OUTPUT_DIR = "${BUILDSYS_BUILD_DIR}/images/${BUILDSYS_ARCH}-${BUILDSYS_VARIANT}"
+BUILDSYS_OUTPUT_DIR = "${BUILDSYS_IMAGES_DIR}/${BUILDSYS_ARCH}-${BUILDSYS_VARIANT}"
 
 # Depends on a number of variables defined above, and each other.
 BUILDSYS_VERSION_FULL="${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
@@ -578,19 +579,14 @@ rm -rf ${BUILDSYS_PACKAGES_DIR}
 '''
 ]
 
-# Note: this only cleans images for the current arch and variant.  Specify
-# BUILDSYS_ARCH and/or BUILDSYS_VARIANT in your call to clean images for other
-# combinations.
 [tasks.clean-images]
 script_runner = "bash"
 script = [
 '''
-rm -rf ${BUILDSYS_OUTPUT_DIR}
+rm -rf ${BUILDSYS_IMAGES_DIR}
 '''
 ]
 
-# Note: this cleans all repos; the repo targets directory is shared between
-# arches/variants.
 [tasks.clean-repos]
 script_runner = "bash"
 script = [

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -547,20 +547,58 @@ pubsys \
 ]
 
 [tasks.clean]
+dependencies = [
+  "clean-sources",
+  "clean-packages",
+  "clean-images",
+  "clean-repos",
+]
+
+[tasks.clean-sources]
 script_runner = "bash"
 script = [
 '''
-for ws in sources packages variants/* tools/{buildsys,pubsys}; do
+for ws in sources variants/* tools/{buildsys,pubsys}; do
   [ -d "${ws}" ] || continue
   cargo clean --manifest-path ${ws}/Cargo.toml
 done
 rm -f ${BUILDSYS_TOOLS_DIR}/bin/{buildsys,pubsys}
+'''
+]
+
+[tasks.clean-packages]
+script_runner = "bash"
+script = [
+'''
+for ws in packages; do
+  [ -d "${ws}" ] || continue
+  cargo clean --manifest-path ${ws}/Cargo.toml
+done
+rm -f ${BUILDSYS_PACKAGES_DIR}/*.rpm
+'''
+]
+
+# Note: this only cleans images for the current arch and variant.  Specify
+# BUILDSYS_ARCH and/or BUILDSYS_VARIANT in your call to clean images for other
+# combinations.
+[tasks.clean-images]
+script_runner = "bash"
+script = [
+'''
 for ext in tar lz4 img json; do
   rm -f ${BUILDSYS_OUTPUT_DIR}/*.${ext}
 done
-rm -rf ${PUBLISH_REPO_BASE_DIR}
-rm -f ${BUILDSYS_PACKAGES_DIR}/*.rpm
 rm -rf ${BUILDSYS_OUTPUT_DIR}/latest
+'''
+]
+
+# Note: this cleans all repos; the repo targets directory is shared between
+# arches/variants.
+[tasks.clean-repos]
+script_runner = "bash"
+script = [
+'''
+rm -rf ${PUBLISH_REPO_BASE_DIR}
 '''
 ]
 


### PR DESCRIPTION
**Description of changes:**

My overall goal was adding `clean-images` as a quick way to save space from large objects that are easily rebuilt.  The other commits are cleanup around the "clean" space.

```
 Makefile.toml: make 'clean-images' remove all variant/arch images 
```

```
Makefile.toml: make clean-packages remove rpms directory

It was removing all artifacts inside and leaving an empty directory, which
doesn't match the behavior of the other clean tasks.
```

```
Makefile.toml: make clean-images remove images/arch-variant directory

It was removing all artifacts inside and leaving an empty directory, which
doesn't match the behavior of the other clean tasks.
```

```
Makefile.toml: split the clean task

This allows cleaning images, which take up the most space, without cleaning up
packages, which take a lot less space but a lot more time to rebuild.
```

```
Makefile.toml: remove deletion of 'html'

The directory is no longer created after 5e4cf9809b77.
```

```
Makefile.toml: make 'clean' delete json files from pubsys ami
```

**Testing done:**

Added `set -x` and ran each task individually, and the overall `clean` task, and saw the separated commands run OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
