### PR TITLE
Update suggested Kubernetes version in sample eksctl config files

### DIFF
--- a/sample-eksctl-ssh.yaml
+++ b/sample-eksctl-ssh.yaml
@@ -5,7 +5,7 @@ kind: ClusterConfig
 metadata:
   name: bottlerocket
   region: us-west-2
-  version: '1.15'
+  version: '1.17'
 
 nodeGroups:
   - name: ng-bottlerocket

--- a/sample-eksctl.yaml
+++ b/sample-eksctl.yaml
@@ -5,7 +5,7 @@ kind: ClusterConfig
 metadata:
   name: bottlerocket
   region: us-west-2
-  version: '1.15'
+  version: '1.17'
 
 nodeGroups:
   - name: ng-bottlerocket


### PR DESCRIPTION
**Description of changes:**

Updates the sample eksctl config files for the Kubernetes 1.17 default; I missed this in #1002.

**Testing done:**

Ran eksctl [per the quickstart](https://github.com/bottlerocket-os/bottlerocket/blob/0e5dd14/QUICKSTART.md#cluster-setup) with the updated file and got a working 1.17 cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
