### PR TITLE
Allow specifying AMI name with PUBLISH_AMI_NAME

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -89,8 +89,8 @@ BUILDSYS_NAME_FULL="${BUILDSYS_NAME_VARIANT}-${BUILDSYS_VERSION_FULL}"
 # Repo directories have subdirectories for variant/arch, so we only want version here.
 PUBLISH_REPO_BASE_DIR = "${BUILDSYS_BUILD_DIR}/repos"
 PUBLISH_REPO_OUTPUT_DIR = "${PUBLISH_REPO_BASE_DIR}/${BUILDSYS_NAME_VERSION}"
-# The name of registered AMIs.
-PUBLISH_AMI_NAME = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
+# The default name of registered AMIs; override by setting PUBLISH_AMI_NAME.
+PUBLISH_AMI_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
 
 [tasks.setup]
 script = [
@@ -400,6 +400,8 @@ esac
 ami_output="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-amis.json"
 ami_output_latest="${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_VARIANT}-amis.json"
 
+ami_name="${PUBLISH_AMI_NAME:-${PUBLISH_AMI_NAME_DEFAULT}}"
+
 pubsys \
    --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
    \
@@ -411,8 +413,8 @@ pubsys \
    --data-volume-size "${PUBLISH_DATA_VOLUME_SIZE}" \
    \
    --arch "${arch}" \
-   --name "${PUBLISH_AMI_NAME}" \
-   --description "${PUBLISH_AMI_DESCRIPTION:-${PUBLISH_AMI_NAME}}" \
+   --name "${ami_name}" \
+   --description "${PUBLISH_AMI_DESCRIPTION:-${ami_name}}" \
    \
    --ami-output "${ami_output}" \
    \


### PR DESCRIPTION
AMI name wasn't overridable because it was in the env.development section of
the Makefile, since it depends on variables from the env section.

This change sets a DEFAULT version of the variable to the fixed name we had
before, and uses it if the user didn't set PUBLISH_AMI_NAME.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Testing done:**

`cargo make ami` produced an AMI with the existing name/description format.  `cargo make ami -e PUBLISH_AMI_NAME=foo` produced an AMI named `foo`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
