### PR TITLE
switch to SDK v0.13.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -100,7 +100,7 @@ mkdir -p ${BUILDSYS_OUTPUT_DIR}
 mkdir -p ${BUILDSYS_PACKAGES_DIR}
 mkdir -p ${GO_MOD_CACHE}
 
-for cmd in bash curl docker gunzip ; do
+for cmd in bash curl docker gunzip lz4 ; do
   if ! command -v ${cmd} >/dev/null 2>&1 ; then
     echo "required program '${cmd}' not found" >&2
     exit 1

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -72,7 +72,7 @@ DOCKER_BUILDKIT = "1"
 # on the command line.
 
 # Depends on ${BUILDSYS_ARCH}.
-BUILDSYS_SDK_IMAGE = "bottlerocket/sdk-${BUILDSYS_ARCH}:v0.12.0"
+BUILDSYS_SDK_IMAGE = { script = [ "echo bottlerocket/sdk-${BUILDSYS_ARCH}:v0.13.0-$(uname -m)" ] }
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"

--- a/macros/cargo
+++ b/macros/cargo
@@ -11,8 +11,8 @@
 
 %__cargo %{_bindir}/cargo
 %__cargo_common_opts --offline --locked --verbose
-%__cargo_target %{_cross_arch}-unknown-linux-gnu
-%__cargo_target_static %{_cross_arch}-unknown-linux-musl
+%__cargo_target %{_cross_triple}-gnu
+%__cargo_target_static %{_cross_triple}-musl
 %__cargo_cross_opts %{__cargo_common_opts} --target %{__cargo_target}
 %__cargo_cross_opts_static %{__cargo_common_opts} --target %{__cargo_target_static}
 %__cargo_env CARGO_TARGET_DIR="${HOME}/.cache" SKIP_README="true"
@@ -28,12 +28,12 @@ cat > %{_builddir}/.cargo/config << EOF \
 rustc = "%{__rustc}"\
 rustdoc = "%{__rustdoc}"\
 \
-[target.%{_cross_arch}-unknown-linux-gnu]\
+[target.%{_cross_triple}-gnu]\
 linker = "%{_bindir}/%{_cross_triple}-gnu-gcc"\
 ar = "%{_bindir}/%{_cross_triple}-gnu-gcc-ar"\
 rustflags = %{__global_rustflags_shared_toml}\
 \
-[target.%{_cross_arch}-unknown-linux-musl]\
+[target.%{_cross_triple}-musl]\
 linker = "%{_bindir}/%{_cross_triple}-musl-gcc"\
 ar = "%{_bindir}/%{_cross_triple}-musl-gcc-ar"\
 rustflags = %{__global_rustflags_static_toml}\

--- a/macros/shared
+++ b/macros/shared
@@ -226,8 +226,8 @@ CROSS_COMPILATION_CONF_EOF\
 %_find_debuginfo_dwz_opts %{nil}
 
 # Compress RPM payloads with zstd level 1 in single-threaded mode.
-%_source_payload w1T0.zstdio
-%_binary_payload w1T0.zstdio
+%_source_payload w1.zstdio
+%_binary_payload w1.zstdio
 
 %__arch_install_post \
   %{?!_cross_allow_rpath:/usr/lib/rpm/check-rpaths} \

--- a/packages/glibc/Cargo.toml
+++ b/packages/glibc/Cargo.toml
@@ -9,5 +9,5 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/glibc/glibc-2.31.tar.xz"
-sha512 = "735e4c0ef10418b6ea945ad3906585e5bbd8b282d76f2131309dce4cec6b15066a5e4a3731773ce428a819b542579c9957867bb0abf05ed2030983fca4412306"
+url = "https://ftp.gnu.org/gnu/glibc/glibc-2.32.tar.xz"
+sha512 = "8460c155b7003e04f18dabece4ed9ad77445fa2288a7dc08e80a8fc4c418828af29e0649951bd71a54ea2ad2d4da7570aafd9bdfe4a37e9951b772b442afe50b"

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}glibc
-Version: 2.31
+Version: 2.32
 Release: 1%{?dist}
 Summary: The GNU libc libraries
 License: LGPL-2.1-or-later AND (LGPL-2.1-or-later WITH GCC-exception-2.0) AND GPL-2.0-or-later AND (GPL-2.0-or-later WITH GCC-exception-2.0) AND BSD-3-Clause AND ISC

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -1,4 +1,5 @@
 %global debug_package %{nil}
+%global __strip %{_bindir}/strip
 
 Name: %{_cross_os}grub
 Version: 2.04
@@ -82,7 +83,7 @@ cp unicode/COPYING COPYING.unicode
 
 %build
 export \
-  CPP="%{_cross_target}-gcc -E" \
+  TARGET_CPP="%{_cross_target}-gcc -E" \
   TARGET_CC="%{_cross_target}-gcc" \
   TARGET_CFLAGS="%{grub_cflags}" \
   TARGET_CPPFLAGS="%{grub_cflags}" \
@@ -96,6 +97,7 @@ export \
 %cross_configure \
   CFLAGS="" \
   LDFLAGS="" \
+  --host="%{_build}" \
   --target="%{_cross_grub_target}" \
   --with-platform="%{_cross_grub_platform}" \
   --disable-grub-mkfont \

--- a/packages/libstd-rust/libstd-rust.spec
+++ b/packages/libstd-rust/libstd-rust.spec
@@ -18,8 +18,7 @@ URL: https://www.rust-lang.org/
 cp /usr/share/licenses/rust/* .
 
 %build
-%define _rust_target %{_cross_arch}-unknown-linux-%{_cross_libc}
-install -p -m0755 %{_libexecdir}/rust/lib/rustlib/%{_rust_target}/lib/libstd-*.so .
+install -p -m0755 %{_libexecdir}/rust/lib/rustlib/%{__cargo_target}/lib/libstd-*.so .
 
 %install
 mkdir -p %{buildroot}%{_cross_libdir}


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This updates to SDK v0.13.0, and includes fixes for building Bottlerocket on a Graviton instance.

The major change is the switch to using our vendor Rust targets, which unblocks the glibc update.

I found the zstd compression warning when inspecting the build logs for grub, which needed a fix to avoid building x86_64 tools on an aarch64 host.


**Testing done:**
Verified that an x86_64 host could build the OS for both targets, and likewise that an aarch64 host could build the OS for both targets. Verified that the resulting artifacts worked as expected when registered as AMIs.

Note: CI will fail until bottlerocket-os/bottlerocket-sdk/pull/33 is merged and the SDKs are built.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
