### PR TITLE
Added option to enable spot instance draining

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ These settings can be changed at any time.
   Bottlerocket sets this value to false by default. 
 * `settings.ecs.loglevel`: The level of verbosity for the ECS agent's logs.
   Supported values are `debug`, `info`, `warn`, `error`, and `crit`, and the default is `info`.
+* `settings.ecs.enable-spot-instance-draining`: If the instance receives a spot termination notice, the agent will set the instance's state to `DRAINING`, so the workload can be moved gracefully before the instance is removed. Defaults to `false`.
 
 #### Updates settings
 

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.0.1"
+version = "1.0.2"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -9,3 +9,4 @@ version = "1.0.1"
 "(0.4.1, 0.5.0)" = ["migrate_v0.5.0_add-cluster-domain.lz4", "migrate_v0.5.0_admin-container-v0-5-2.lz4", "migrate_v0.5.0_control-container-v0-4-1.lz4"]
 "(0.5.0, 1.0.0)" = ["migrate_v1.0.0_ecr-helper-admin.lz4", "migrate_v1.0.0_ecr-helper-control.lz4"]
 "(1.0.0, 1.0.1)" = []
+"(1.0.1, 1.0.2)" = ["migrate_v1.0.2_add-enable-spot-instance-draining.lz4"]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -250,6 +250,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-enable-spot-instance-draining"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers 0.1.0",
+]
+
+[[package]]
 name = "add-version-lock-ignore-waves"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "api/migration/migrations/v0.5.0/add-cluster-domain",
     "api/migration/migrations/v1.0.0/ecr-helper-admin",
     "api/migration/migrations/v1.0.0/ecr-helper-control",
+    "api/migration/migrations/v1.0.2/add-enable-spot-instance-draining",
 
     "bottlerocket-release",
 

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -45,6 +45,9 @@ struct ECSConfig {
 
     #[serde(rename = "OverrideAWSLogsExecutionRole")]
     override_awslogs_execution_role: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    spot_instance_draining_enabled: Option<bool>,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -79,6 +82,7 @@ fn run() -> Result<()> {
             .iter()
             .map(|s| s.to_string())
             .collect(),
+        spot_instance_draining_enabled: ecs.enable_spot_instance_draining,
 
         // Task role support is always enabled
         task_iam_role_enabled: true,

--- a/sources/api/migration/migrations/v1.0.2/add-enable-spot-instance-draining/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.2/add-enable-spot-instance-draining/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-enable-spot-instance-draining"
+version = "0.1.0"
+authors = ["Magnus Kulke <mkulke@gmail.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.2/add-enable-spot-instance-draining/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.2/add-enable-spot-instance-draining/src/main.rs
@@ -1,0 +1,22 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting, `ecs.enable-spot-instance-draining`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.ecs.enable-spot-instance-draining",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -113,6 +113,7 @@ struct ECSSettings {
     allow_privileged_containers: bool,
     logging_drivers: Vec<SingleLineString>,
     loglevel: ECSAgentLogLevel,
+    enable_spot_instance_draining: bool,
 }
 
 // Update settings. Taken from userdata. The 'seed' setting is generated


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** 

 fixes #1099

**Description of changes:**

Added the option to have instance draining on spot instances, I used https://github.com/aws/amazon-ecs-agent/blob/a250409cf5eb4ad84a7b889023f1e4d2e274b7ab/agent/config/types.go as reference


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
