### PR TITLE
Apply patch for CVE-2020-14386

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.0.0"
+version = "1.0.1"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -8,3 +8,4 @@ version = "1.0.0"
 "(0.4.0, 0.4.1)" = ["migrate_v0.4.1_add-version-lock-ignore-waves.lz4", "migrate_v0.4.1_pivot-repo-2020-07-07.lz4"]
 "(0.4.1, 0.5.0)" = ["migrate_v0.5.0_add-cluster-domain.lz4", "migrate_v0.5.0_admin-container-v0-5-2.lz4", "migrate_v0.5.0_control-container-v0-4-1.lz4"]
 "(0.5.0, 1.0.0)" = ["migrate_v1.0.0_ecr-helper-admin.lz4", "migrate_v1.0.0_ecr-helper-control.lz4"]
+"(1.0.0, 1.0.1)" = []

--- a/packages/kernel/0001-lustrefsx-Disable-Werror-stringop-overflow.patch
+++ b/packages/kernel/0001-lustrefsx-Disable-Werror-stringop-overflow.patch
@@ -1,7 +1,7 @@
-From b85e7195a25319afb421a6a3ee2065fc8d225a8b Mon Sep 17 00:00:00 2001
+From a5f6b26082e0022d3c3e70e0718e4787939778d8 Mon Sep 17 00:00:00 2001
 From: iliana destroyer of worlds <iweller@amazon.com>
 Date: Tue, 30 Jul 2019 12:59:09 -0700
-Subject: [PATCH] lustrefsx: Disable -Werror=stringop-overflow=
+Subject: [PATCH 1/2] lustrefsx: Disable -Werror=stringop-overflow=
 
 Signed-off-by: iliana destroyer of worlds <iweller@amazon.com>
 ---

--- a/packages/kernel/0002-net-packet-fix-overflow-in-tpacket_rcv.patch
+++ b/packages/kernel/0002-net-packet-fix-overflow-in-tpacket_rcv.patch
@@ -1,0 +1,47 @@
+From eea7a6a08ef3acf437c6ce8a28694c3659542569 Mon Sep 17 00:00:00 2001
+From: Or Cohen <orcohen@paloaltonetworks.com>
+Date: Sun, 30 Aug 2020 20:04:51 +0300
+Subject: [PATCH 2/2] net/packet: fix overflow in tpacket_rcv
+
+Using tp_reserve to calculate netoff can overflow as
+tp_reserve is unsigned int and netoff is unsigned short.
+
+This may lead to macoff receving a smaller value then
+sizeof(struct virtio_net_hdr), and if po->has_vnet_hdr
+is set, an out-of-bounds write will occur when
+calling virtio_net_hdr_from_skb.
+
+The bug is fixed by converting netoff to unsigned int
+and checking if it exceeds USHRT_MAX.
+
+Fixes: 8913336a7e8d ("packet: add PACKET_RESERVE sockopt")
+Signed-off-by: Or Cohen <orcohen@paloaltonetworks.com>
+---
+ net/packet/af_packet.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/net/packet/af_packet.c b/net/packet/af_packet.c
+index 1d63ab3a878a..56084a16d0f9 100644
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -2167,7 +2167,8 @@ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+ 	int skb_len = skb->len;
+ 	unsigned int snaplen, res;
+ 	unsigned long status = TP_STATUS_USER;
+-	unsigned short macoff, netoff, hdrlen;
++	unsigned short macoff, hdrlen;
++	unsigned int netoff;
+ 	struct sk_buff *copy_skb = NULL;
+ 	struct timespec ts;
+ 	__u32 ts_status;
+@@ -2236,6 +2237,10 @@ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+ 		}
+ 		macoff = netoff - maclen;
+ 	}
++	if (netoff > USHRT_MAX) {
++		atomic_inc(&po->tp_drops);
++		goto drop_n_restore;
++	}
+ 	if (po->tp_version <= TPACKET_V2) {
+ 		if (macoff + snaplen > po->rx_ring.frame_size) {
+ 			if (po->copy_thresh &&

--- a/packages/kernel/kernel.spec
+++ b/packages/kernel/kernel.spec
@@ -10,6 +10,7 @@ URL: https://www.kernel.org/
 Source0: https://cdn.amazonlinux.com/blobstore/9e3beaecef0b030d83fb215be7ca67c01009cfec52fe9b12eb4b24fdb46eebce/kernel-5.4.50-25.83.amzn2.src.rpm
 Source100: config-bottlerocket
 Patch0001: 0001-lustrefsx-Disable-Werror-stringop-overflow.patch
+Patch0002: 0002-net-packet-fix-overflow-in-tpacket_rcv.patch
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

This applies the patch for CVE-2020-14386 to our kernel build.

**Testing done:**

Host built and booted, host containers operate normally.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
