### PR TITLE
pubsys: use requested size for volume, keeping snapshot to minimum size

### DIFF
--- a/tools/pubsys/src/aws/ami/register.rs
+++ b/tools/pubsys/src/aws/ami/register.rs
@@ -40,7 +40,7 @@ async fn _register_image(
     let root_snapshot = snapshot_from_image(
         &ami_args.root_image,
         &uploader,
-        ami_args.root_volume_size,
+        None,
         ami_args.no_progress,
     )
     .await
@@ -53,7 +53,7 @@ async fn _register_image(
     let data_snapshot = snapshot_from_image(
         &ami_args.data_image,
         &uploader,
-        Some(ami_args.data_volume_size),
+        None,
         ami_args.no_progress,
     )
     .await
@@ -88,6 +88,7 @@ async fn _register_image(
             delete_on_termination: Some(true),
             snapshot_id: Some(root_snapshot.clone()),
             volume_type: Some(VOLUME_TYPE.to_string()),
+            volume_size: ami_args.root_volume_size,
             ..Default::default()
         }),
         ..Default::default()
@@ -97,6 +98,7 @@ async fn _register_image(
     data_bdm.device_name = Some(DATA_DEVICE_NAME.to_string());
     if let Some(ebs) = data_bdm.ebs.as_mut() {
         ebs.snapshot_id = Some(data_snapshot.clone());
+        ebs.volume_size = Some(ami_args.data_volume_size);
     }
 
     let register_request = RegisterImageRequest {


### PR DESCRIPTION
```
The volume size used at instance launch time is determined by the block device
mapping, defaulting to the snapshot size.  Here we configure the
BlockDeviceMappings to use the requested size rather than the snapshot size.
The snapshots used to create those volumes, then, don't need to be more than
the size of the data inside.  (Users creating AMIs based on snapshots from
existing AMIs can specify any desired size above the snapshot size in their own
block device mappings.)
```

**Testing done:**

Registered an image.  Still see `"VolumeSize": 2` for root volume and `"VolumeSize": 20` for data volume in the block device mappings.  When describing the snapshots, however, I now see `"VolumeSize": 2` and `"VolumeSize": 1`, respectively.

The image launched OK and ran a pod OK.  The volumes looked OK, still 20GB for /local.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
