### PR TITLE
[docker] Add default nofiles ulimits for containers

### DIFF
--- a/packages/docker-engine/daemon.json
+++ b/packages/docker-engine/daemon.json
@@ -5,5 +5,6 @@
   "storage-driver": "overlay2",
   "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "data-root": "/var/lib/docker",
-  "selinux-enabled": true
+  "selinux-enabled": true,
+  "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 1024, "Hard": 4096 } }
 }


### PR DESCRIPTION
**Issue number:**
#1115 


**Description of changes:**

This change adds `--default-ulimit` to dockerd's options to set default nofiles limits for containers.  The values match what are currently used by the Amazon Linux and ECS AMIs.

**Testing done:**

Tested using the aws-dev variant

Without this change:
```
bash-5.0# time docker run amazonlinux:2 yum install -y tmux
Unable to find image 'amazonlinux:2' locally
```
...
```
Installed:
  tmux.x86_64 0:1.8-4.amzn2.0.1                                                 

  Dependency Installed:
    libevent.x86_64 0:2.0.21-4.amzn2.0.3                                          

    Complete!

    real    15m28.011s
    user    0m0.086s
    sys     0m0.034s
``` 

Now with the change:
```
bash-5.0# time docker run amazonlinux:2 yum install -y tmux
Unable to find image 'amazonlinux:2' locally
```
...
```
Installed:
  tmux.x86_64 0:1.8-4.amzn2.0.1

  Dependency Installed:
    libevent.x86_64 0:2.0.21-4.amzn2.0.3

    Complete!

    real    0m11.137s
    user    0m0.034s
    sys     0m0.039s
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
