### PR TITLE
use GOPROXY=direct for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
             arch: x86_64
             supported: false
       fail-fast: false
+    env:
+      GOPROXY: direct
     steps:
       - uses: actions/checkout@v2
       - run: cargo install --version 0.30.0 cargo-make

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -156,7 +156,7 @@ ${BUILDSYS_TOOLS_DIR}/docker-go \
   --module-path ${BUILDSYS_SOURCES_DIR}/host-ctr \
   --sdk-image ${BUILDSYS_SDK_IMAGE} \
   --go-mod-cache ${GO_MOD_CACHE} \
-  --command "go list -mod=readonly ./... >/dev/null && go mod vendor"
+  --command "set -x; time go list -mod=readonly ./... && time go mod vendor -v"
 '''
 ]
 

--- a/tools/docker-go
+++ b/tools/docker-go
@@ -62,6 +62,7 @@ for i in http_proxy https_proxy no_proxy goproxy HTTP_PROXY HTTPS_PROXY NO_PROXY
    fi
 done
 
+set -x
 docker run --rm \
   -e GOPRIVATE='*' \
   -e GOCACHE='/tmp/.cache' \

--- a/tools/docker-go
+++ b/tools/docker-go
@@ -56,7 +56,7 @@ parse_args "${@}"
 
 # Go accepts both lower and uppercase proxy variables, pass both through.
 proxy_env=( )
-for i in http_proxy https_proxy no_proxy HTTP_PROXY HTTPS_PROXY NO_PROXY; do
+for i in http_proxy https_proxy no_proxy goproxy HTTP_PROXY HTTPS_PROXY NO_PROXY GOPROXY ; do
    if [ -n "${!i}" ]; then
       proxy_env[${#proxy_env[@]}]="--env=$i=${!i}"
    fi


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Build jobs have started timing out after spending 15-30 minutes on the `go mod vendor` step.

This sets `GOPROXY=direct` in the environment and passes it through to the Docker container that runs the command.


**Testing done:**
None, yet.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
