### PR TITLE
pubsys: add `validate-repo`, `check-repo-expirations`, `refresh-repo` subcommands

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -46,6 +46,7 @@ PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm/def
 REPO_VALIDATE_TARGETS = "true"
 # Specifies the timeframe to look for upcoming repository metadata expirations
 REPO_METADATA_EXPIRING_WITHIN = "3 days"
+# When refreshing repositories, you can set REPO_UNSAFE_REFRESH=true to refresh repositories that have expired metadata files.
 
 # You can also set PUBLISH_REGIONS to override the list of regions from
 # Infra.toml for AMI and SSM commands; it's a comma-separated list like
@@ -463,6 +464,35 @@ pubsys \
    \
    --root-role-path "${PUBLISH_REPO_ROOT_JSON}" \
    --expiration-limit "${REPO_METADATA_EXPIRING_WITHIN}"
+'''
+]
+
+[tasks.refresh-repo]
+dependencies = ["publish-setup", "publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+if [ "${REPO_UNSAFE_REFRESH}" = "true" ]; then
+   REPO_UNSAFE_REFRESH_ARG="--unsafe-refresh"
+fi
+
+pubsys \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   \
+   refresh-repo \
+   \
+   --repo "${PUBLISH_REPO}" \
+   --arch "${BUILDSYS_ARCH}" \
+   --variant "${BUILDSYS_VARIANT}" \
+   \
+   --root-role-path "${PUBLISH_REPO_ROOT_JSON}" \
+   --repo-expiration-policy-path "${PUBLISH_EXPIRATION_POLICY_PATH}" \
+   ${REPO_UNSAFE_REFRESH_ARG} \
+   --outdir "${PUBLISH_REPO_OUTPUT_DIR}"
 '''
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -42,6 +42,9 @@ PUBLISH_DATA_VOLUME_SIZE = "20"
 # tools/pubsys/policies/ssm/README.md for more information.
 PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm/defaults.toml"
 
+# Specifies whether to validate all targets when validating TUF repositories
+REPO_VALIDATE_TARGETS = "true"
+
 # You can also set PUBLISH_REGIONS to override the list of regions from
 # Infra.toml for AMI and SSM commands; it's a comma-separated list like
 # "us-west-2,us-east-1".
@@ -340,6 +343,10 @@ pubsys-setup \
 '''
 ]
 
+[tasks.publish-setup-without-key]
+env = { "ALLOW_MISSING_KEY" = "true" }
+run_task = "publish-setup"
+
 # Builds a local repository based on the 'latest' built targets.  Uses pubsys
 # to create a repo under /build/repos, named after the arch/variant/version,
 # containing subdirectories for the repo metadata and targets.
@@ -404,6 +411,33 @@ pubsys \
    --outdir "${PUBLISH_REPO_OUTPUT_DIR}"
 
 ln -sfn "${PUBLISH_REPO_OUTPUT_DIR##*/}" "${PUBLISH_REPO_OUTPUT_DIR%/*}/latest"
+'''
+]
+
+[tasks.validate-repo]
+dependencies = ["publish-setup-without-key", "publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+if [ "${REPO_VALIDATE_TARGETS}" = "true" ]; then
+   REPO_VALIDATE_TARGETS_ARG="--validate-targets"
+fi
+
+pubsys \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   \
+   validate-repo \
+   \
+   --repo "${PUBLISH_REPO}" \
+   --arch "${BUILDSYS_ARCH}" \
+   --variant "${BUILDSYS_VARIANT}" \
+   \
+   --root-role-path "${PUBLISH_REPO_ROOT_JSON}" \
+   ${REPO_VALIDATE_TARGETS_ARG}
 '''
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -44,6 +44,8 @@ PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm/def
 
 # Specifies whether to validate all targets when validating TUF repositories
 REPO_VALIDATE_TARGETS = "true"
+# Specifies the timeframe to look for upcoming repository metadata expirations
+REPO_METADATA_EXPIRING_WITHIN = "3 days"
 
 # You can also set PUBLISH_REGIONS to override the list of regions from
 # Infra.toml for AMI and SSM commands; it's a comma-separated list like
@@ -438,6 +440,29 @@ pubsys \
    \
    --root-role-path "${PUBLISH_REPO_ROOT_JSON}" \
    ${REPO_VALIDATE_TARGETS_ARG}
+'''
+]
+
+[tasks.check-repo-expirations]
+dependencies = ["publish-setup-without-key", "publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+pubsys \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   \
+   check-repo-expirations \
+   \
+   --repo "${PUBLISH_REPO}" \
+   --arch "${BUILDSYS_ARCH}" \
+   --variant "${BUILDSYS_VARIANT}" \
+   \
+   --root-role-path "${PUBLISH_REPO_ROOT_JSON}" \
+   --expiration-limit "${REPO_METADATA_EXPIRING_WITHIN}"
 '''
 ]
 

--- a/tools/pubsys-setup/src/main.rs
+++ b/tools/pubsys-setup/src/main.rs
@@ -32,7 +32,7 @@ struct Args {
     infra_config_path: PathBuf,
 
     #[structopt(long)]
-    /// Use this named repo from Infra.toml
+    /// Use this named repo infrastructure from Infra.toml
     repo: String,
 
     #[structopt(long, parse(from_os_str))]

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -5,6 +5,7 @@ Currently implemented:
 * building repos, whether starting from an existing repo or from scratch
 * validating repos by loading them and retrieving their targets
 * checking for repository metadata expirations within specified number of days
+* refreshing and re-signing repos' non-root metadata files
 * registering and copying EC2 AMIs
 * Marking EC2 AMIs public (or private again)
 * setting SSM parameters based on built AMIs
@@ -54,6 +55,9 @@ fn run() -> Result<()> {
         SubCommand::CheckRepoExpirations(ref check_expirations_args) => {
             repo::check_expirations::run(&args, &check_expirations_args)
                 .context(error::CheckExpirations)
+        }
+        SubCommand::RefreshRepo(ref refresh_repo_args) => {
+            repo::refresh_repo::run(&args, &refresh_repo_args).context(error::RefreshRepo)
         }
         SubCommand::Ami(ref ami_args) => {
             let mut rt = Runtime::new().context(error::Runtime)?;
@@ -110,6 +114,7 @@ enum SubCommand {
     Repo(repo::RepoArgs),
     ValidateRepo(repo::validate_repo::ValidateRepoArgs),
     CheckRepoExpirations(repo::check_expirations::CheckExpirationsArgs),
+    RefreshRepo(repo::refresh_repo::RefreshRepoArgs),
 
     Ami(aws::ami::AmiArgs),
     PublishAmi(aws::publish_ami::PublishArgs),
@@ -162,6 +167,11 @@ mod error {
         #[snafu(display("Check expirations error: {}", source))]
         CheckExpirations {
             source: crate::repo::check_expirations::Error,
+        },
+
+        #[snafu(display("Failed to refresh repository metadata: {}", source))]
+        RefreshRepo {
+            source: crate::repo::refresh_repo::Error,
         },
 
         #[snafu(display("Failed to create async runtime: {}", source))]

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -4,6 +4,7 @@
 Currently implemented:
 * building repos, whether starting from an existing repo or from scratch
 * validating repos by loading them and retrieving their targets
+* checking for repository metadata expirations within specified number of days
 * registering and copying EC2 AMIs
 * Marking EC2 AMIs public (or private again)
 * setting SSM parameters based on built AMIs
@@ -49,6 +50,10 @@ fn run() -> Result<()> {
                     .await
                     .context(error::ValidateRepo)
             })
+        }
+        SubCommand::CheckRepoExpirations(ref check_expirations_args) => {
+            repo::check_expirations::run(&args, &check_expirations_args)
+                .context(error::CheckExpirations)
         }
         SubCommand::Ami(ref ami_args) => {
             let mut rt = Runtime::new().context(error::Runtime)?;
@@ -104,6 +109,7 @@ struct Args {
 enum SubCommand {
     Repo(repo::RepoArgs),
     ValidateRepo(repo::validate_repo::ValidateRepoArgs),
+    CheckRepoExpirations(repo::check_expirations::CheckExpirationsArgs),
 
     Ami(aws::ami::AmiArgs),
     PublishAmi(aws::publish_ami::PublishArgs),
@@ -151,6 +157,11 @@ mod error {
         #[snafu(display("Failed to validate repository: {}", source))]
         ValidateRepo {
             source: crate::repo::validate_repo::Error,
+        },
+
+        #[snafu(display("Check expirations error: {}", source))]
+        CheckExpirations {
+            source: crate::repo::check_expirations::Error,
         },
 
         #[snafu(display("Failed to create async runtime: {}", source))]

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -1,6 +1,7 @@
 //! The repo module owns the 'repo' subcommand and controls the process of building a repository.
 
 pub(crate) mod check_expirations;
+pub(crate) mod refresh_repo;
 mod transport;
 pub(crate) mod validate_repo;
 
@@ -184,6 +185,46 @@ fn update_manifest(repo_args: &RepoArgs, manifest: &mut Manifest) -> Result<()> 
     Ok(())
 }
 
+/// Set expirations of all non-root role metadata based on a given `RepoExpirationPolicy` and an
+/// expiration start time
+fn set_expirations<'a>(
+    editor: &mut RepositoryEditor<'a, RepoTransport>,
+    expiration_policy: &RepoExpirationPolicy,
+    expiration_start_time: DateTime<Utc>,
+) -> Result<()> {
+    let snapshot_expiration = expiration_start_time + expiration_policy.snapshot_expiration;
+    let targets_expiration = expiration_start_time + expiration_policy.targets_expiration;
+    let timestamp_expiration = expiration_start_time + expiration_policy.timestamp_expiration;
+    info!(
+        "Setting non-root metadata expiration times:\n\tsnapshot:  {}\n\ttargets:   {}\n\ttimestamp: {}",
+        snapshot_expiration, targets_expiration, timestamp_expiration
+    );
+    editor
+        .snapshot_expires(snapshot_expiration)
+        .targets_expires(targets_expiration)
+        .context(error::SetTargetsExpiration {
+            expiration: targets_expiration,
+        })?
+        .timestamp_expires(timestamp_expiration);
+
+    Ok(())
+}
+
+/// Set versions of all role metadata; the version will be the UNIX timestamp of the current time.
+fn set_versions<'a>(editor: &mut RepositoryEditor<'a, RepoTransport>) -> Result<()> {
+    let seconds = Utc::now().timestamp();
+    let unsigned_seconds = seconds.try_into().expect("System clock before 1970??");
+    let version = NonZeroU64::new(unsigned_seconds).expect("System clock exactly 1970??");
+    debug!("Repo version: {}", version);
+    editor
+        .snapshot_version(version)
+        .targets_version(version)
+        .context(error::SetTargetsVersion { version })?
+        .timestamp_version(version);
+
+    Ok(())
+}
+
 /// Adds targets, expirations, and version to the RepositoryEditor
 fn update_editor<'a, P>(
     repo_args: &'a RepoArgs,
@@ -344,6 +385,24 @@ where
     }
 }
 
+/// Gets the corresponding `KeySource` according to the signing key config from Infra.toml
+fn get_signing_key_source(signing_key_config: &SigningKeyConfig) -> Box<dyn KeySource> {
+    match signing_key_config {
+        SigningKeyConfig::file { path } => Box::new(LocalKeySource { path: path.clone() }),
+        SigningKeyConfig::kms { key_id } => Box::new(KmsKeySource {
+            profile: None,
+            key_id: key_id.clone(),
+            client: None,
+            signing_algorithm: KmsSigningAlgorithm::RsassaPssSha256,
+        }),
+        SigningKeyConfig::ssm { parameter } => Box::new(SsmKeySource {
+            profile: None,
+            parameter_name: parameter.clone(),
+            key_id: None,
+        }),
+    }
+}
+
 /// Common entrypoint from main()
 pub(crate) fn run(args: &Args, repo_args: &RepoArgs) -> Result<()> {
     let metadata_out_dir = repo_args
@@ -442,30 +501,18 @@ pub(crate) fn run(args: &Args, repo_args: &RepoArgs) -> Result<()> {
     // generated local key.
     let signing_key_config = repo_config.signing_keys.as_ref();
 
-    let key_source: Box<dyn KeySource> = match signing_key_config {
-        Some(SigningKeyConfig::file { path }) => Box::new(LocalKeySource { path: path.clone() }),
-        Some(SigningKeyConfig::kms { key_id }) => Box::new(KmsKeySource {
-            profile: None,
-            key_id: key_id.clone(),
-            client: None,
-            signing_algorithm: KmsSigningAlgorithm::RsassaPssSha256,
-        }),
-        Some(SigningKeyConfig::ssm { parameter }) => Box::new(SsmKeySource {
-            profile: None,
-            parameter_name: parameter.clone(),
-            key_id: None,
-        }),
-        None => {
-            ensure!(
-                repo_args.default_key_path.exists(),
-                error::MissingConfig {
-                    missing: "signing_keys in repo config, and we found no local key",
-                }
-            );
-            Box::new(LocalKeySource {
-                path: repo_args.default_key_path.clone(),
-            })
-        }
+    let key_source = if let Some(signing_key_config) = signing_key_config {
+        get_signing_key_source(signing_key_config)
+    } else {
+        ensure!(
+            repo_args.default_key_path.exists(),
+            error::MissingConfig {
+                missing: "signing_keys in repo config, and we found no local key",
+            }
+        );
+        Box::new(LocalKeySource {
+            path: repo_args.default_key_path.clone(),
+        })
     };
 
     let signed_repo = editor.sign(&[key_source]).context(error::RepoSign)?;

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -1,5 +1,6 @@
 //! The repo module owns the 'repo' subcommand and controls the process of building a repository.
 
+pub(crate) mod check_expirations;
 mod transport;
 pub(crate) mod validate_repo;
 

--- a/tools/pubsys/src/repo/check_expirations/mod.rs
+++ b/tools/pubsys/src/repo/check_expirations/mod.rs
@@ -1,0 +1,197 @@
+//! The check_expirations module owns the 'check-repo-expirations' subcommand and provide methods for
+//! checking the metadata expirations of a given TUF repository.
+
+use super::RepoTransport;
+use crate::repo::{error as repo_error, repo_urls};
+use crate::Args;
+use chrono::{DateTime, Utc};
+use log::{error, info, trace, warn};
+use parse_datetime::parse_datetime;
+use pubsys_config::InfraConfig;
+use snafu::{OptionExt, ResultExt};
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::PathBuf;
+use structopt::StructOpt;
+use tempfile::tempdir;
+use tough::{ExpirationEnforcement, Limits, Repository, Settings};
+use url::Url;
+
+/// Checks for metadata expirations for a set of TUF repositories
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct CheckExpirationsArgs {
+    #[structopt(long)]
+    /// Use this named repo infrastructure from Infra.toml
+    repo: String,
+
+    #[structopt(long)]
+    /// The architecture of the repo being checked for expirations
+    arch: String,
+    #[structopt(long)]
+    /// The variant of the repo being checked for expirations
+    variant: String,
+
+    #[structopt(long, parse(from_os_str))]
+    /// Path to root.json for this repo
+    root_role_path: PathBuf,
+
+    #[structopt(long, parse(try_from_str = parse_datetime))]
+    /// Finds metadata files expiring between now and a specified time; RFC3339 date or "in X hours/days/weeks"
+    expiration_limit: DateTime<Utc>,
+}
+
+/// Checks for upcoming role expirations, gathering them in a map of role to expiration datetime.
+fn find_upcoming_metadata_expiration<T>(
+    repo: &Repository<'_, T>,
+    end_date: DateTime<Utc>,
+) -> HashMap<tough::schema::RoleType, DateTime<Utc>>
+where
+    T: tough::Transport,
+{
+    let mut expirations = HashMap::new();
+    info!(
+        "Looking for metadata expirations happening from now to {}",
+        end_date
+    );
+    if repo.root().signed.expires <= end_date {
+        expirations.insert(tough::schema::RoleType::Root, repo.root().signed.expires);
+    }
+    if repo.snapshot().signed.expires <= end_date {
+        expirations.insert(
+            tough::schema::RoleType::Snapshot,
+            repo.snapshot().signed.expires,
+        );
+    }
+    if repo.targets().signed.expires <= end_date {
+        expirations.insert(
+            tough::schema::RoleType::Targets,
+            repo.targets().signed.expires,
+        );
+    }
+    if repo.timestamp().signed.expires <= end_date {
+        expirations.insert(
+            tough::schema::RoleType::Timestamp,
+            repo.timestamp().signed.expires,
+        );
+    }
+
+    expirations
+}
+
+fn check_expirations(
+    transport: &RepoTransport,
+    root_role_path: &PathBuf,
+    metadata_url: &Url,
+    targets_url: &Url,
+    expiration_limit: DateTime<Utc>,
+) -> Result<()> {
+    // Create a temporary directory where the TUF client can store metadata
+    let workdir = tempdir().context(repo_error::TempDir)?;
+    let settings = Settings {
+        root: File::open(root_role_path).context(repo_error::File {
+            path: root_role_path,
+        })?,
+        datastore: workdir.path(),
+        metadata_base_url: metadata_url.as_str(),
+        targets_base_url: targets_url.as_str(),
+        limits: Limits::default(),
+        // We're gonna check the expiration ourselves
+        expiration_enforcement: ExpirationEnforcement::Unsafe,
+    };
+
+    // Load the repository
+    let repo = Repository::load(transport, settings).context(repo_error::RepoLoad {
+        metadata_base_url: metadata_url.clone(),
+    })?;
+    info!("Loaded TUF repo:\t{}", metadata_url);
+
+    info!("Root expiration:\t{}", repo.root().signed.expires);
+    info!("Snapshot expiration:\t{}", repo.snapshot().signed.expires);
+    info!("Targets expiration:\t{}", repo.targets().signed.expires);
+    info!("Timestamp expiration:\t{}", repo.timestamp().signed.expires);
+    // Check for upcoming metadata expirations if a timeframe is specified
+    let upcoming_expirations = find_upcoming_metadata_expiration(&repo, expiration_limit);
+    if !upcoming_expirations.is_empty() {
+        let now = Utc::now();
+        for (role, expiration_date) in upcoming_expirations {
+            if expiration_date < now {
+                error!(
+                    "Repo '{}': '{}' expired on {}",
+                    metadata_url, role, expiration_date
+                )
+            } else {
+                warn!(
+                    "Repo '{}': '{}' expiring in {} at {}",
+                    metadata_url,
+                    role,
+                    expiration_date - now,
+                    expiration_date
+                )
+            }
+        }
+        return Err(Error::RepoExpirations {
+            metadata_url: metadata_url.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Common entrypoint from main()
+pub(crate) fn run(args: &Args, check_expirations_args: &CheckExpirationsArgs) -> Result<()> {
+    info!(
+        "Using infra config from path: {}",
+        args.infra_config_path.display()
+    );
+    let infra_config =
+        InfraConfig::from_path(&args.infra_config_path).context(repo_error::Config)?;
+    trace!("Parsed infra config: {:?}", infra_config);
+    let repo_config = infra_config
+        .repo
+        .as_ref()
+        .context(repo_error::MissingConfig {
+            missing: "repo section",
+        })?
+        .get(&check_expirations_args.repo)
+        .with_context(|| repo_error::MissingConfig {
+            missing: format!("definition for repo {}", &check_expirations_args.repo),
+        })?;
+
+    let transport = RepoTransport::default();
+    let repo_urls = repo_urls(
+        &repo_config,
+        &check_expirations_args.variant,
+        &check_expirations_args.arch,
+    )?
+    .context(repo_error::MissingRepoUrls {
+        repo: &check_expirations_args.repo,
+    })?;
+    check_expirations(
+        &transport,
+        &check_expirations_args.root_role_path,
+        &repo_urls.0,
+        repo_urls.1,
+        check_expirations_args.expiration_limit,
+    )?;
+
+    Ok(())
+}
+
+mod error {
+    use snafu::Snafu;
+    use url::Url;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(context(false), display("{}", source))]
+        Repo { source: crate::repo::Error },
+
+        #[snafu(display("Found expiring/expired metadata in '{}'", metadata_url))]
+        RepoExpirations { metadata_url: Url },
+    }
+}
+pub(crate) use error::Error;
+
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/repo/refresh_repo/mod.rs
+++ b/tools/pubsys/src/repo/refresh_repo/mod.rs
@@ -1,0 +1,210 @@
+//! The refresh_repo module owns the 'refresh-repo' subcommand and provide methods for
+//! refreshing and re-signing the metadata files of a given TUF repository.
+
+use super::RepoTransport;
+use crate::repo::{
+    error as repo_error, get_signing_key_source, repo_urls, set_expirations, set_versions,
+};
+use crate::Args;
+use chrono::{DateTime, Utc};
+use lazy_static::lazy_static;
+use log::{info, trace};
+use pubsys_config::{InfraConfig, RepoExpirationPolicy};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::fs;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+use tempfile::tempdir;
+use tough::editor::RepositoryEditor;
+use tough::key_source::KeySource;
+use tough::{ExpirationEnforcement, Limits, Repository, Settings};
+use url::Url;
+
+lazy_static! {
+    static ref EXPIRATION_START_TIME: DateTime<Utc> = Utc::now();
+}
+
+/// Refreshes and re-sign TUF repositories' non-root metadata files with new expiration dates
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct RefreshRepoArgs {
+    #[structopt(long)]
+    /// Use this named repo infrastructure from Infra.toml
+    repo: String,
+
+    #[structopt(long)]
+    /// The architecture of the repo being refreshed and re-signed
+    arch: String,
+    #[structopt(long)]
+    /// The variant of the repo being refreshed and re-signed
+    variant: String,
+
+    #[structopt(long, parse(from_os_str))]
+    /// Path to root.json for this repo
+    root_role_path: PathBuf,
+
+    #[structopt(long, parse(from_os_str))]
+    /// Path to file that defines when repo non-root metadata should expire
+    repo_expiration_policy_path: PathBuf,
+
+    #[structopt(long, parse(from_os_str))]
+    /// Where to store the refresh/re-signed repository (just the metadata files)
+    outdir: PathBuf,
+
+    #[structopt(long)]
+    /// If this flag is set, repositories will succeed in loading and be refreshed even if they have
+    /// expired metadata files.
+    unsafe_refresh: bool,
+}
+
+fn refresh_repo(
+    transport: &RepoTransport,
+    root_role_path: &PathBuf,
+    metadata_out_dir: &PathBuf,
+    metadata_url: &Url,
+    targets_url: &Url,
+    key_source: Box<dyn KeySource>,
+    expiration: &RepoExpirationPolicy,
+    unsafe_refresh: bool,
+) -> Result<(), Error> {
+    // If the given metadata directory exists, throw an error.  We don't want to overwrite a user's
+    // existing repository.
+    ensure!(
+        !Path::exists(&metadata_out_dir),
+        repo_error::RepoExists {
+            path: metadata_out_dir
+        }
+    );
+
+    // Create a temporary directory where the TUF client can store metadata
+    let workdir = tempdir().context(repo_error::TempDir)?;
+    let settings = Settings {
+        root: File::open(root_role_path).context(repo_error::File {
+            path: root_role_path,
+        })?,
+        datastore: workdir.path(),
+        metadata_base_url: metadata_url.as_str(),
+        targets_base_url: targets_url.as_str(),
+        limits: Limits::default(),
+        expiration_enforcement: if unsafe_refresh {
+            ExpirationEnforcement::Unsafe
+        } else {
+            ExpirationEnforcement::Safe
+        },
+    };
+
+    // Load the repository and get the repo editor for it
+    let repo = Repository::load(transport, settings).context(repo_error::RepoLoad {
+        metadata_base_url: metadata_url.clone(),
+    })?;
+    let mut repo_editor =
+        RepositoryEditor::from_repo(&root_role_path, repo).context(repo_error::EditorFromRepo)?;
+    info!("Loaded TUF repo: {}", metadata_url);
+
+    // Refresh the expiration dates of all non-root metadata files
+    set_expirations(&mut repo_editor, &expiration, *EXPIRATION_START_TIME)?;
+
+    // Refresh the versions of all non-root metadata files
+    set_versions(&mut repo_editor)?;
+
+    // Sign the repository
+    let signed_repo = repo_editor
+        .sign(&[key_source])
+        .context(repo_error::RepoSign)?;
+
+    // Write out the metadata files for the repository
+    info!("Writing repo metadata to: {}", metadata_out_dir.display());
+    fs::create_dir_all(&metadata_out_dir).context(repo_error::CreateDir {
+        path: &metadata_out_dir,
+    })?;
+    signed_repo
+        .write(&metadata_out_dir)
+        .context(repo_error::RepoWrite {
+            path: &metadata_out_dir,
+        })?;
+
+    Ok(())
+}
+
+/// Common entrypoint from main()
+pub(crate) fn run(args: &Args, refresh_repo_args: &RefreshRepoArgs) -> Result<(), Error> {
+    info!(
+        "Using infra config from path: {}",
+        args.infra_config_path.display()
+    );
+    let infra_config =
+        InfraConfig::from_path(&args.infra_config_path).context(repo_error::Config)?;
+    trace!("Parsed infra config: {:?}", infra_config);
+
+    let repo_config = infra_config
+        .repo
+        .as_ref()
+        .context(repo_error::MissingConfig {
+            missing: "repo section",
+        })?
+        .get(&refresh_repo_args.repo)
+        .context(repo_error::MissingConfig {
+            missing: format!("definition for repo {}", &refresh_repo_args.repo),
+        })?;
+
+    // Get signing key config from repository configuration
+    let signing_key_config =
+        repo_config
+            .signing_keys
+            .as_ref()
+            .context(repo_error::MissingConfig {
+                missing: "signing_keys",
+            })?;
+    let key_source = get_signing_key_source(signing_key_config);
+
+    // Get the expiration policy
+    info!(
+        "Using repo expiration policy from path: {}",
+        refresh_repo_args.repo_expiration_policy_path.display()
+    );
+    let expiration =
+        RepoExpirationPolicy::from_path(&refresh_repo_args.repo_expiration_policy_path)
+            .context(repo_error::Config)?;
+
+    let transport = RepoTransport::default();
+    let repo_urls = repo_urls(
+        &repo_config,
+        &refresh_repo_args.variant,
+        &refresh_repo_args.arch,
+    )?
+    .context(repo_error::MissingRepoUrls {
+        repo: &refresh_repo_args.repo,
+    })?;
+    refresh_repo(
+        &transport,
+        &refresh_repo_args.root_role_path,
+        &refresh_repo_args
+            .outdir
+            .join(&refresh_repo_args.variant)
+            .join(&refresh_repo_args.arch),
+        &repo_urls.0,
+        repo_urls.1,
+        key_source,
+        &expiration,
+        refresh_repo_args.unsafe_refresh,
+    )?;
+
+    Ok(())
+}
+
+mod error {
+    use snafu::Snafu;
+    use url::Url;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(context(false), display("{}", source))]
+        Repo { source: crate::repo::Error },
+
+        #[snafu(display("Failed to refresh & re-sign metadata for: {:#?}", list_of_urls))]
+        RepoRefresh { list_of_urls: Vec<Url> },
+    }
+}
+pub(crate) use error::Error;

--- a/tools/pubsys/src/repo/transport.rs
+++ b/tools/pubsys/src/repo/transport.rs
@@ -23,7 +23,7 @@ pub(crate) struct RepoTransport {
 }
 
 impl Transport for RepoTransport {
-    type Stream = Box<dyn Read>;
+    type Stream = Box<dyn Read + Send>;
     type Error = error::Error;
 
     fn fetch(&self, url: Url) -> std::result::Result<Self::Stream, Self::Error> {

--- a/tools/pubsys/src/repo/validate_repo/mod.rs
+++ b/tools/pubsys/src/repo/validate_repo/mod.rs
@@ -1,0 +1,178 @@
+//! The validate_repo module owns the 'validate-repo' subcommand and provides methods for validating
+//! a given TUF repository by attempting to load the repository and download its targets.
+
+use super::RepoTransport;
+use crate::repo::{error as repo_error, repo_urls};
+use crate::Args;
+use futures::future::join_all;
+use log::{info, trace};
+use pubsys_config::InfraConfig;
+use snafu::{OptionExt, ResultExt};
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
+use structopt::StructOpt;
+use tempfile::tempdir;
+use tough::{ExpirationEnforcement, Limits, Repository, Settings};
+use url::Url;
+
+/// Validates a set of TUF repositories
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct ValidateRepoArgs {
+    #[structopt(long)]
+    /// Use this named repo infrastructure from Infra.toml
+    repo: String,
+
+    #[structopt(long)]
+    /// The architecture of the repo being validated
+    arch: String,
+    #[structopt(long)]
+    /// The variant of the repo being validated
+    variant: String,
+
+    #[structopt(long, parse(from_os_str))]
+    /// Path to root.json for this repo
+    root_role_path: PathBuf,
+
+    #[structopt(long)]
+    /// Specifies whether to validate all listed targets by attempting to download them
+    validate_targets: bool,
+}
+
+/// Retrieves listed targets and attempt to download them for validation purposes
+async fn retrieve_targets<T: 'static>(
+    repo: &Repository<'_, T>,
+) -> Result<(), Error>
+where
+    T: tough::Transport,
+    <T as tough::Transport>::Stream: std::marker::Send,
+{
+    let targets = &repo.targets().signed.targets;
+
+    let mut tasks = Vec::new();
+    for target in targets
+        .keys()
+        .cloned()
+    {
+        let target = target.to_string();
+        let mut reader = repo
+            .read_target(&target)
+            .with_context(|| repo_error::ReadTarget {
+                target: target.to_string(),
+            })?
+            .with_context(|| error::TargetMissing {
+                target: target.to_string(),
+            })?;
+        info!("Downloading target: {}", target);
+        tasks.push(tokio::spawn(async move {
+            // tough's `Read` implementation validates the target as it's being downloaded
+            io::copy(&mut reader, &mut io::sink()).context(error::TargetDownload {
+                target: target.to_string(),
+            })
+        }));
+    }
+    let results = join_all(tasks).await;
+    for result in results {
+        result.context(error::Join)??;
+    }
+
+    Ok(())
+}
+
+async fn validate_repo(
+    transport: &RepoTransport,
+    root_role_path: &PathBuf,
+    metadata_url: Url,
+    targets_url: &Url,
+    validate_targets: bool,
+) -> Result<(), Error> {
+    // Create a temporary directory where the TUF client can store metadata
+    let workdir = tempdir().context(repo_error::TempDir)?;
+    let settings = Settings {
+        root: File::open(root_role_path).context(repo_error::File {
+            path: root_role_path,
+        })?,
+        datastore: workdir.path(),
+        metadata_base_url: metadata_url.as_str(),
+        targets_base_url: targets_url.as_str(),
+        limits: Limits::default(),
+        expiration_enforcement: ExpirationEnforcement::Safe,
+    };
+
+    // Load the repository
+    let repo = Repository::load(transport, settings).context(repo_error::RepoLoad {
+        metadata_base_url: metadata_url.clone(),
+    })?;
+    info!("Loaded TUF repo: {}", metadata_url);
+    if validate_targets {
+        // Try retrieving listed targets
+        retrieve_targets(&repo).await?;
+    }
+
+    Ok(())
+}
+
+/// Common entrypoint from main()
+pub(crate) async fn run(args: &Args, validate_repo_args: &ValidateRepoArgs) -> Result<(), Error> {
+    info!(
+        "Using infra config from path: {}",
+        args.infra_config_path.display()
+    );
+    let infra_config =
+        InfraConfig::from_path(&args.infra_config_path).context(repo_error::Config)?;
+    trace!("Parsed infra config: {:?}", infra_config);
+    let repo_config = infra_config
+        .repo
+        .as_ref()
+        .context(repo_error::MissingConfig {
+            missing: "repo section",
+        })?
+        .get(&validate_repo_args.repo)
+        .context(repo_error::MissingConfig {
+            missing: format!("definition for repo {}", &validate_repo_args.repo),
+        })?;
+
+    let transport = RepoTransport::default();
+    let repo_urls = repo_urls(
+        &repo_config,
+        &validate_repo_args.variant,
+        &validate_repo_args.arch,
+    )?
+    .context(repo_error::MissingRepoUrls {
+        repo: &validate_repo_args.repo,
+    })?;
+    validate_repo(
+        &transport,
+        &validate_repo_args.root_role_path,
+        repo_urls.0,
+        repo_urls.1,
+        validate_repo_args.validate_targets,
+    )
+    .await
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::io;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Invalid percentage specified: {} is greater than 100", percentage))]
+        InvalidPercentage { percentage: u8 },
+
+        #[snafu(context(false), display("{}", source))]
+        Repo { source: crate::repo::Error },
+
+        #[snafu(display("Failed to download and write target '{}': {}", target, source))]
+        TargetDownload { target: String, source: io::Error },
+
+        #[snafu(display("Missing target: {}", target))]
+        TargetMissing { target: String },
+
+        #[snafu(display("Failed to spawn task for fetching target: {}", source))]
+        Join { source: tokio::task::JoinError },
+    }
+}
+pub(crate) use error::Error;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1117


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Sep 21 18:06:26 2020 -0700

    pubsys: add `validate-repo` for validating TUF repositories
    
    Adds a new pubsys subcommand `validate-repo` for validating a set of TUF
    repositories.
    
    Adds a new cargo make task `validate-repo` that invokes this new subcommand.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Sep 23 14:52:07 2020 -0700

    pubsys: add `check-repo-expirations` to check metadata expirations
    
    Adds new pubsys subcommand `check-repo-expirations` that checks for
    repository metadata expirations within a specified timeframe
    
    Adds a new Makefile.toml task that invokes `check-repo-expirations`
```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Sep 24 15:39:27 2020 -0700

    pubsys: add `refresh-repo` to refresh and resign TUF repositories
    
    Adds a new subcommand `refresh-repo` for refreshing and resigning
    non-root metadata files of TUF repositories.
    
    Add new Makefile.toml task `refresh-repo` for refreshing the expiration
    dates of TUF repositories' metadata files
```

**Testing done:**

**Validating repositories**
Normal validation run via `cargo make validate-repo` where 2020-07-07/aws-ecs-1/aarch64 is successfully loaded and its targets successfully retrieved.
<details>

```
$ cargo make -e PUBLISH_REPO="2020-07-07" -e BUILDSYS_VARIANT="aws-ecs-1" -e BUILDSYS_ARCH="aarch64" validate-repo
[cargo-make] INFO - cargo make 0.32.5
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: validate-repo
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup-without-key
00:42:54 [INFO] Found infra config at path: /home/etung/thar/Infra.toml
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: validate-repo
00:43:47 [INFO] Using infra config from path: /home/etung/thar/Infra.toml
00:43:48 [INFO] Loaded TUF repo: https://updates.bottlerocket.aws/2020-07-07/aws-ecs-1/aarch64
00:43:48 [INFO] Downloading 100% of listed targets from https://updates.bottlerocket.aws/2020-07-07/aws-ecs-1/aarch64
00:43:48 [INFO] Downloading target: bottlerocket-aws-ecs-1-aarch64-1.0.0-b0e2bc22-boot.ext4.lz4
00:43:49 [INFO] Downloading target: bottlerocket-aws-ecs-1-aarch64-1.0.1-2a181156-root.verity.lz4
00:43:49 [INFO] Downloading target: migrate_v0.4.1_add-version-lock-ignore-waves.lz4
00:43:49 [INFO] Downloading target: migrate_v1.0.0_ecr-helper-admin.lz4
00:43:49 [INFO] Downloading target: migrate_v1.0.0_ecr-helper-control.lz4
00:43:49 [INFO] Downloading target: bottlerocket-aws-ecs-1-aarch64-1.0.0-b0e2bc22-root.ext4.lz4
00:43:58 [INFO] Downloading target: migrate_v0.5.0_admin-container-v0-5-2.lz4
00:43:58 [INFO] Downloading target: migrate_v0.5.0_control-container-v0-4-1.lz4
00:43:59 [INFO] Downloading target: bottlerocket-aws-ecs-1-aarch64-1.0.1-2a181156-boot.ext4.lz4
00:44:00 [INFO] Downloading target: manifest.json
00:44:00 [INFO] Downloading target: bottlerocket-aws-ecs-1-aarch64-1.0.0-b0e2bc22-root.verity.lz4
00:44:00 [INFO] Downloading target: migrate_v0.4.1_pivot-repo-2020-07-07.lz4
00:44:00 [INFO] Downloading target: bottlerocket-aws-ecs-1-aarch64-1.0.1-2a181156-root.ext4.lz4
00:44:09 [INFO] Downloading target: migrate_v0.5.0_add-cluster-domain.lz4
00:44:09 [INFO] Downloading target: migrate_v0.3.2_admin-container-v0-5-0.lz4
[cargo-make] INFO - Build Done in 84 seconds.
```

</details>

Test validation run for 2020-07-07 repositories where I disable internet access halfway through to test error handling. 

<details>

```
$ cargo make -e PUBLISH_REPO="2020-07-07" -e BUILDSYS_VARIANT="aws-k8s-1.17" -e BUILDSYS_ARCH="x86_64" validate-repo
[cargo-make] INFO - cargo make 0.32.7
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: validate-repo
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup
17:05:16 [INFO] Found infra config at path: /Infra.toml
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: validate-repo
17:05:17 [INFO] Using infra config from path: /Infra.toml
17:05:20 [INFO] Loaded TUF repo: https://updates.bottlerocket.aws/2020-07-07/aws-k8s-1.17/x86_64
17:05:20 [INFO] Attempting to download 100% of listed targets from https://updates.bottlerocket.aws/2020-07-07/aws-k8s-1.17/x86_64 for validation purposes
17:05:20 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-0.5.0-e0ddf1b-boot.ext4.lz4
17:05:20 [INFO] Downloading target: migrate_v0.4.1_pivot-repo-2020-07-07.lz4
17:05:21 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-0.5.0-e0ddf1b-root.ext4.lz4
17:05:21 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-1.0.1-2a181156-root.verity.lz4
17:05:22 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-1.0.1-2a181156-boot.ext4.lz4
17:05:22 [INFO] Downloading target: migrate_v0.5.0_admin-container-v0-5-2.lz4
17:05:23 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-1.0.0-b0e2bc22-root.verity.lz4
17:05:23 [INFO] Downloading target: migrate_v0.4.1_add-version-lock-ignore-waves.lz4
17:05:23 [INFO] Downloading target: migrate_v0.3.2_admin-container-v0-5-0.lz4
17:05:24 [INFO] Downloading target: migrate_v1.0.0_ecr-helper-control.lz4
17:05:24 [INFO] Downloading target: migrate_v0.5.0_control-container-v0-4-1.lz4
Failed to validate repository: Failed to read target 'manifest.json' from repo: Failed to fetch https://updates.bottlerocket.aws/targets/004c373cb0899ed114a94692e245c4e45eeaa74155470de74b9a234c14920800.manifest.json: Could not fetch repo at 'https://updates.bottlerocket.aws/targets/004c373cb0899ed114a94692e245c4e45eeaa74155470de74b9a234c14920800.manifest.json': Failed to fetch 'https://updates.bottlerocket.aws/targets/004c373cb0899ed114a94692e245c4e45eeaa74155470de74b9a234c14920800.manifest.json' after 4 tries, final error: error sending request for url (https://updates.bottlerocket.aws/targets/004c373cb0899ed114a94692e245c4e45eeaa74155470de74b9a234c14920800.manifest.json): operation timed out
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.


```

</details>

**Checking for repository non-root metadata expirations**
Successfully ran the `check-repo-expirations` on 2020-02-02 prefixed Bottlerocket TUF repositories.
<details>

```
$ cargo make -e PUBLISH_REPO="2020-02-02" -e BUILDSYS_VARIANT="aws-k8s-1.17" -e BUILDSYS_ARCH="x86_64" -e check-repo-expirations
[cargo-make] INFO - cargo make 0.32.5
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: check-repo-expirations
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup-without-key
21:05:45 [INFO] Found infra config at path: /home//Infra.toml
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: check-repo-expirations
21:05:45 [INFO] Using infra config from path: /home/Infra.toml
21:05:49 [INFO] Loaded TUF repo:	https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.17/x86_64
21:05:49 [INFO] Root expiration:	2021-09-22 00:00:00 UTC
21:05:49 [INFO] Snapshot expiration:	2020-10-21 17:52:25.534814597 UTC
21:05:49 [INFO] Targets expiration:	2020-10-21 17:52:25.534815167 UTC
21:05:49 [INFO] Timestamp expiration:	2020-10-14 17:52:25.534815678 UTC
21:05:49 [INFO] Looking for metadata expirations happening from now to 2020-10-11 21:05:45.995390949 UTC
[cargo-make] INFO - Build Done in 5 seconds.
```

</details>

Specifying `--upcoming-expirations-in 10` will cause pubsys to list timestamp metadata files in upcoming expirations, which is expected.
<details>

```
$ cargo make -e PUBLISH_REPO="2020-02-02" -e BUILDSYS_VARIANT="aws-k8s-1.17" -e BUILDSYS_ARCH="x86_64" -e EXPIRING_WITHIN='10 days' check-repo-expirations
[cargo-make] INFO - cargo make 0.32.5
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: check-repo-expirations
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup-without-key
21:07:35 [INFO] Found infra config at path: /home//Infra.toml
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: check-repo-expirations
21:07:36 [INFO] Using infra config from path: /home//Infra.toml
21:07:38 [INFO] Loaded TUF repo:	https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.17/x86_64
21:07:38 [INFO] Root expiration:	2021-09-22 00:00:00 UTC
21:07:38 [INFO] Snapshot expiration:	2020-10-21 17:52:25.534814597 UTC
21:07:38 [INFO] Targets expiration:	2020-10-21 17:52:25.534815167 UTC
21:07:38 [INFO] Timestamp expiration:	2020-10-14 17:52:25.534815678 UTC
21:07:38 [INFO] Looking for metadata expirations happening from now to 2020-10-18 21:07:36.089668869 UTC
21:07:38 [WARN] Repo 'https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.17/x86_64': 'timestamp' expiring between now and 2020-10-18 21:07:36.089668869 UTC on 2020-10-14 17:52:25.534815678 UTC
Found expiring/expired metadata in 'https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.17/x86_64'
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```

</details>

**Refreshing and resigning repository non-root metadata files**
Successfully refreshed and resigned metadata for a test TUF repository using a given expiration policy

<details>

```
$ cargo make -e PUBLISH_REPO="etung" -e BUILDSYS_VARIANT="aws-k8s-1.17" -e BUILDSYS_ARCH="aarch64" -e UNSAFE_REFRESH=true refresh-repo
[cargo-make] INFO - cargo make 0.32.5
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: refresh-repo
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup
20:31:50 [INFO] Found infra config at path: /home//Infra.toml
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: refresh-repo
20:32:42 [INFO] Using infra config from path: /home/Infra.toml
20:32:42 [INFO] Using repo expiration policy from path: /home/tools/pubsys/policies/repo-expiration/2w-2w-1w.toml
20:32:45 [INFO] Loaded TUF repo: https://d31e403t2udbbh.cloudfront.net/aws-k8s-1.17/aarch64
20:32:45 [INFO] Setting non-root metadata expiration times:
	snapshot:  2020-10-22 20:32:45.590842865 UTC
	targets:   2020-10-22 20:32:45.590842865 UTC
	timestamp: 2020-10-15 20:32:45.590842865 UTC
20:32:45 [INFO] Writing repo metadata to: /home/build/repos/etung/bottlerocket-1.0.2-5119490c/aws-k8s-1.17/aarch64
[cargo-make] INFO - Build Done in 60 seconds.
```

</details>

The TUF repository passes validation checks after uploading the refreshed & resigned metadata files

<details>

```
$ cargo make -e PUBLISH_REPO="etung" -e BUILDSYS_VARIANT="aws-k8s-1.17" -e BUILDSYS_ARCH="x86_64" validate-repo
[cargo-make] INFO - cargo make 0.32.5
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: validate-repo
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup-without-key
16:57:33 [INFO] Found infra config at path: /home/etung/thar/Infra.toml
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: validate-repo
16:57:34 [INFO] Using infra config from path: /home/etung/thar/Infra.toml
16:57:34 [INFO] Loaded TUF repo: https://asdasdasdasdasd.cloudfront.net/aws-k8s-1.17/x86_64
16:57:34 [INFO] Downloading 100% of listed targets from https://asdasdasdasd.cloudfront.net/aws-k8s-1.17/x86_64
16:57:34 [INFO] Downloading target: 2.txt
16:57:34 [INFO] Downloading target: 1.txt
[cargo-make] INFO - Build Done in 2 seconds.

```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
