### PR TITLE
add e2fsprogs

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -127,6 +127,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "e2fsprogs"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "util-linux",
+]
+
+[[package]]
 name = "ecs-agent"
 version = "0.1.0"
 dependencies = [

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "docker-engine",
     "docker-init",
     "docker-proxy",
+    "e2fsprogs",
     "ecs-agent",
     "filesystem",
     "findutils",

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "e2fsprogs"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.45.6/e2fsprogs-1.45.6.tar.xz"
+sha512 = "f3abfb6fe7ef632bb81152e2127d601cadd3fa93162178576a1d5ed82c2286627184b207b85a5b2a1793db0addf0885dfc3b9523bb340443224caf9c6d613b84"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+util-linux = { path = "../util-linux" }

--- a/packages/e2fsprogs/build.rs
+++ b/packages/e2fsprogs/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/e2fsprogs/e2fsprogs-tmpfiles.conf
+++ b/packages/e2fsprogs/e2fsprogs-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/mke2fs.conf - - - -

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,0 +1,125 @@
+Name: %{_cross_os}e2fsprogs
+Version: 1.45.6
+Release: 1%{?dist}
+Summary: Tools for managing ext2, ext3, and ext4 file systems
+License: GPL-2.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND BSD-3-Clause
+URL: http://e2fsprogs.sourceforge.net/
+Source0: https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/%{version}/e2fsprogs-%{version}.tar.xz
+Source10: mke2fs.conf
+Source11: e2fsprogs-tmpfiles.conf
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libuuid-devel
+BuildRequires: %{_cross_os}libblkid-devel
+Requires: %{_cross_os}e2fsprogs-libs
+
+%description
+%{summary}.
+
+%package libs
+Summary: Libraries for ext2, ext3, and ext4 file systems
+
+%description libs
+%{summary}.
+
+%package devel
+Summary: Files for development using the libraries for ext2, ext3, and ext4 file systems
+Requires: %{_cross_os}e2fsprogs-libs
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n e2fsprogs-%{version} -p1
+
+%build
+%cross_configure \
+  CFLAGS="${CFLAGS} -fno-strict-aliasing" \
+  --enable-elf-shlibs \
+  --enable-symlink-install \
+  --enable-relative-symlinks \
+  --disable-backtrace \
+  --disable-debugfs \
+  --disable-defrag \
+  --disable-e2initrd-helper \
+  --disable-fsck \
+  --disable-fuse2fs \
+  --disable-imager \
+  --disable-libblkid \
+  --disable-libuuid \
+  --disable-nls \
+  --disable-resizer \
+  --disable-rpath \
+  --disable-tdb \
+  --disable-uuidd \
+  --with-crond-dir=no \
+  --with-systemd-unit-dir=no \
+  --with-udev-rules-dir=no \
+
+%make_build
+
+%install
+%make_install install-libs \
+  root_sbindir=%{_cross_sbindir} \
+  root_libdir=%{_cross_libdir}
+
+chmod 644 %{buildroot}%{_cross_libdir}/*.a
+
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
+install -p -m 0644 %{S:10} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:11} %{buildroot}%{_cross_tmpfilesdir}/e2fsprogs.conf
+
+%files
+%license debian/copyright
+%{_cross_attribution_file}
+%{_cross_sbindir}/badblocks
+%{_cross_sbindir}/dumpe2fs
+%{_cross_sbindir}/e2fsck
+%{_cross_sbindir}/fsck.ext2
+%{_cross_sbindir}/fsck.ext3
+%{_cross_sbindir}/fsck.ext4
+%{_cross_sbindir}/mke2fs
+%{_cross_sbindir}/mkfs.ext2
+%{_cross_sbindir}/mkfs.ext3
+%{_cross_sbindir}/mkfs.ext4
+%{_cross_sbindir}/tune2fs
+%{_cross_factorydir}%{_cross_sysconfdir}/mke2fs.conf
+%{_cross_tmpfilesdir}/e2fsprogs.conf
+
+%exclude %{_cross_sbindir}/e2freefrag
+%exclude %{_cross_sbindir}/e2label
+%exclude %{_cross_sbindir}/e2mmpstatus
+%exclude %{_cross_sbindir}/e2scrub
+%exclude %{_cross_sbindir}/e2scrub_all
+%exclude %{_cross_sbindir}/e2undo
+%exclude %{_cross_sbindir}/e4crypt
+%exclude %{_cross_sbindir}/filefrag
+%exclude %{_cross_sbindir}/logsave
+%exclude %{_cross_sbindir}/mklost+found
+
+%exclude %{_cross_bindir}
+%exclude %{_cross_mandir}
+%exclude %{_cross_sysconfdir}
+%exclude %{_cross_datadir}/et
+%exclude %{_cross_datadir}/ss
+
+%files libs
+%{_cross_libdir}/*.so.*
+
+%files devel
+%{_cross_libdir}/*.a
+%{_cross_libdir}/*.so
+%{_cross_includedir}/*.h
+%dir %{_cross_includedir}/e2p
+%dir %{_cross_includedir}/et
+%dir %{_cross_includedir}/ext2fs
+%dir %{_cross_includedir}/ss
+%{_cross_includedir}/e2p/*.h
+%{_cross_includedir}/et/*.h
+%{_cross_includedir}/ext2fs/*.h
+%{_cross_includedir}/ss/*.h
+%{_cross_pkgconfigdir}/*.pc
+
+%changelog

--- a/packages/e2fsprogs/mke2fs.conf
+++ b/packages/e2fsprogs/mke2fs.conf
@@ -1,0 +1,50 @@
+# Note: new features must be added with care, as they may not be compatible
+# with the running kernel after a downgrade.
+
+[defaults]
+	base_features = sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr
+	default_mntopts = acl,user_xattr
+	enable_periodic_fsck = 0
+	blocksize = 4096
+	inode_size = 256
+	inode_ratio = 16384
+
+[fs_types]
+	ext3 = {
+		features = has_journal
+	}
+	ext4 = {
+		features = has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize
+		inode_size = 256
+	}
+	small = {
+		blocksize = 1024
+		inode_size = 128
+		inode_ratio = 4096
+	}
+	floppy = {
+		blocksize = 1024
+		inode_size = 128
+		inode_ratio = 8192
+	}
+	big = {
+		inode_ratio = 32768
+	}
+	huge = {
+		inode_ratio = 65536
+	}
+	news = {
+		inode_ratio = 4096
+	}
+	largefile = {
+		inode_ratio = 1048576
+		blocksize = -1
+	}
+	largefile4 = {
+		inode_ratio = 4194304
+		blocksize = -1
+	}
+	hurd = {
+	     blocksize = 4096
+	     inode_size = 128
+	}

--- a/packages/e2fsprogs/pkg.rs
+++ b/packages/e2fsprogs/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -49,7 +49,9 @@ rm -rf %{buildroot}%{_cross_docdir}/dbus/examples
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_bindir}
-%exclude %{_cross_datadir}
+%exclude %{_cross_datadir}/dbus-1
+%exclude %{_cross_datadir}/doc
+%exclude %{_cross_datadir}/xml
 %exclude %{_cross_libexecdir}
 %exclude %{_cross_sysconfdir}
 
@@ -57,9 +59,9 @@ rm -rf %{buildroot}%{_cross_docdir}/dbus/examples
 %{_cross_libdir}/*.a
 %{_cross_libdir}/*.so
 %dir %{_cross_libdir}/dbus-1.0
-%{_cross_libdir}/dbus-1.0
+%{_cross_libdir}/dbus-1.0/*
 %dir %{_cross_includedir}/dbus-1.0
-%{_cross_includedir}/dbus-1.0
+%{_cross_includedir}/dbus-1.0/*
 %{_cross_pkgconfigdir}/*.pc
 %exclude %{_cross_libdir}/*.la
 %exclude %{_cross_libdir}/cmake

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -33,6 +33,7 @@ Requires: %{_cross_os}ca-certificates
 Requires: %{_cross_os}chrony
 Requires: %{_cross_os}coreutils
 Requires: %{_cross_os}dbus-broker
+Requires: %{_cross_os}e2fsprogs
 Requires: %{_cross_os}libgcc
 Requires: %{_cross_os}libstd-rust
 Requires: %{_cross_os}filesystem


### PR DESCRIPTION
**Issue number:**
#877


**Description of changes:**
Package e2fsprogs and add to the default install via `release`.

This enables the kubelet functionality to format volumes prior to mount, which is used by both the (deprecated) in-tree volume plugins as well as the [local volume static provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner).

This also fixes a packaging error with libdbus that I caught while building this package.


**Testing done:**
Confirmed that kubelet was able to format and mount a local disk.

```
kubelet[3181]: I1002 18:08:18.390523    3181 reconciler.go:209] operationExecutor.VerifyControllerAttachedVolume started for volume "default-token-l2fwp" (UniqueName: "kubernetes.io/secret/a5746ea4-57a4-46ba-8807-ebd46c316093-default-token-l2fwp") pod "local-test-0" (UID: "a5746ea4-57a4-46ba-8807-ebd46c316093")
kubelet[3181]: I1002 18:08:18.509952    3181 mount_linux.go:287] `fsck` error fsck from util-linux 2.36
kubelet[3181]: fsck.ext2: Bad magic number in super-block while trying to open /dev/nvme2n1
kubelet[3181]: /dev/nvme2n1:
kubelet[3181]: The superblock could not be read or does not describe a valid ext2/ext3/ext4
kubelet[3181]: filesystem.  If the device is valid and it really contains an ext2/ext3/ext4
kubelet[3181]: filesystem (and not swap or ufs or something else), then the superblock
kubelet[3181]: is corrupt, and you might try running e2fsck with an alternate superblock:
kubelet[3181]:     e2fsck -b 8193 <device>
kubelet[3181]:  or
kubelet[3181]:     e2fsck -b 32768 <device>
kubelet[3181]: E1002 18:08:18.532275    3181 mount_linux.go:140] Mount failed: exit status 32
kubelet[3181]: Mounting command: systemd-run
kubelet[3181]: Mounting arguments: --description=Kubernetes transient mount for /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-f041dd31 --scope -- mount -t ext4 -o defaults /dev/disk/is-ephemeral/nvme2n1 /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-f041dd31
kubelet[3181]: Output: mount: /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-f041dd31: wrong fs type, bad option, bad superblock on /dev/nvme2n1, missing codepage or helper program, or other error.
kubelet[3181]: I1002 18:08:18.539414    3181 mount_linux.go:322] Disk "/dev/disk/is-ephemeral/nvme2n1" appears to be unformatted, attempting to format as type: "ext4" with options: [-F -m0 /dev/disk/is-ephemeral/nvme2n1]
kubelet[3181]: I1002 18:08:24.547764    3181 mount_linux.go:326] Disk successfully formatted (mkfs): ext4 - /dev/disk/is-ephemeral/nvme2n1 /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-f041dd31
kubelet[3181]: I1002 18:08:24.577716    3181 operation_generator.go:587] MountVolume.MountDevice succeeded for volume "local-pv-f041dd31" (UniqueName: "kubernetes.io/local-volume/local-pv-f041dd31") pod "local-test-0" (UID: "a5746ea4-57a4-46ba-8807-ebd46c316093") device mount path "/var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-f041dd31"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
