### PR TITLE
GitHub Actions: Force Rust 1.46.0 temporarily

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+      - run: rustup toolchain install 1.46.0 && rustup default 1.46.0
       - run: cargo install --version 0.30.0 cargo-make
       - run: cargo install --version 0.6.6 cargo-deny --no-default-features
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests


### PR DESCRIPTION
**Issue number:**
#1153 


**Description of changes:**
Pin Rust to 1.46.0 in the GitHub Actions workflow

**Testing done:**
I was able to build locally with Rust 1.46.0


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
