### PR TITLE
align opt-level for crate build deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - run: rustup toolchain install 1.46.0 && rustup default 1.46.0
       - run: cargo install --version 0.30.0 cargo-make
       - run: cargo install --version 0.6.6 cargo-deny --no-default-features
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -76,3 +76,6 @@ members = [
 [profile.dev]
 debug = false
 opt-level = 'z'
+
+[profile.dev.build-override]
+opt-level = 'z'


### PR DESCRIPTION
**Issue number:**
Fixes #1153


**Description of changes:**
Our OS packages are built as a byproduct of build script execution, while the final Rust artifacts are largely ignored.

Since Rust 1.47.0, cargo builds host dependencies like build scripts with opt-level "0" by default, which did not match the "z" level we picked to minimize the size of the output artifacts.

This caused package build dependencies to be built more than once, with concurrent Docker builds for the same package. This is wasteful and creates races that our build tool does not handle gracefully.

By aligning the opt-level we restore the previous behavior.


**Testing done:**
Built locally using Rust 1.47, with and without the change applied.

Without the change, packages like glibc were built more than once. With the change, they are only built once.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
