### PR TITLE
feat: Add `bpffs` mount to default installation.

### DIFF
--- a/packages/release/bpffs.mount
+++ b/packages/release/bpffs.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mount BPF filesystem
+DefaultDependencies=no
+Before=local-fs.target umount.target
+After=swap.target
+
+[Mount]
+What=bpffs
+Where=/sys/fs/bpf
+Type=bpf
+Options=rw,nosuid,nodev,noexec,relatime,mode=700
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -23,6 +23,7 @@ Source1009: usr-src-kernels.mount.in
 Source1010: var-lib-bottlerocket.mount
 Source1011: usr-share-licenses.mount.in
 Source1012: etc-cni.mount
+Source1013: bpffs.mount
 
 BuildArch: noarch
 Requires: %{_cross_os}acpid
@@ -97,7 +98,7 @@ EOF
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
-  %{S:1002} %{S:1006} %{S:1007} %{S:1008} %{S:1010} %{S:1012} \
+  %{S:1002} %{S:1006} %{S:1007} %{S:1008} %{S:1010} %{S:1012} %{S:1013} \
   %{buildroot}%{_cross_unitdir}
 # Mounting on usr/src/kernels requires using the real path: %{_cross_usrsrc}/kernels
 KERNELPATH=$(systemd-escape --path %{_cross_usrsrc}/kernels)
@@ -127,6 +128,7 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 %{_cross_unitdir}/*-kernels.mount
 %{_cross_unitdir}/*-licenses.mount
 %{_cross_unitdir}/var-lib-bottlerocket.mount
+%{_cross_unitdir}/bpffs.mount
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/motd
 


### PR DESCRIPTION
Since the rootfs is immutable, CNI plugins that rely on bootstrapping to mount `bpffs` won't work (i.e. Cilium). There is little overhead in adding this functionality. I'm uncertain what security concerns would arise from having this mounted, as only privileged process should be able to access it. There are other hardening options available which one might consider, e.g. https://wiki.archlinux.org/index.php/Security#BPF_hardening (perhaps also related to https://github.com/bottlerocket-os/bottlerocket/issues/1063?).

**Issue number:**

See: https://github.com/bottlerocket-os/bottlerocket/issues/1159

**Description of changes:**

Add a `bpffs` to `release` package that adds a `bpffs.mount` entry for `systemd` using reference from the Cilium codebase here: https://github.com/cilium/cilium/blob/e9cb43c03179af6f7cd5d0abb9974daeb5a21e5a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml#L111.

**Testing done:**

Built a new AMI in `us-west-2` (`ami-060ac8bae2db28b67`) with the changes in this PR and ran an EKS cluster using this AMI. Installed `cilium@1.8.3` using `terraform` + `helm` with the following settings:

```
  set {
    name  = "global.kubeProxyReplacement"
    value = "strict"
  }
  set {
    name  = "global.k8sServiceHost"
    value = var.k8s_host
  }
  set {
    name  = "global.k8sServicePort"
    value = var.k8s_port
  }
  set {
    name  = "global.egressMasqueradeInterfaces"
    value = "eth0"
  }
  set {
    name  = "global.proxy.sidecarImageRegex"
    value = "cilium/proxyv2"
  }
  set {
    name  = "global.prometheus.enabled"
    value = "true"
  }
```

Which is pretty close to the recommendations they have for installation on EKS here: https://docs.cilium.io/en/v1.8/gettingstarted/k8s-install-eks/. The cilium pods seem to run fine:

```
NAME                                  READY   STATUS             RESTARTS   AGE
pod/cilium-j5qz5                      1/1     Running            0          27m
pod/cilium-kbw9h                      1/1     Running            0          27m
pod/cilium-operator-c9f6c4577-cv6s8   1/1     Running            0          12m
pod/cilium-operator-c9f6c4577-t6vts   1/1     Running            0          21m
```

The logs for `cilium` indicate:

```
level=info msg="linking environment: OK!" subsys=linux-datapath
level=info msg="Detected mounted BPF filesystem at /sys/fs/bpf" subsys=bpf
```

Which leads me to believe these changes are at least necessary if not sufficient to allow Cilium to work.

**Other notes:**

Not related to this PR, but the startup logs also indicate:

```
level=warning msg="Session affinity for host reachable services needs kernel 5.7.0 or newer to work properly when accessed from inside cluster: the same service endpoint will be selected from all network namespaces on the host." subsys=daemon
```

The current kernel according to logs:

```
level=info msg="clang (10.0.0) and kernel (5.4.50) versions: OK!" subsys=linux-datapath
```

Does `bottlerocket` have a recommended or required kernel? I haven't tried changing it through my launch template yet, but was just wondering if this is supported and if there are any gotchas I need to be aware of?

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
