### PR TITLE
pubsys: don't require Infra.toml to get started

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -74,6 +74,8 @@ cargo make grant-ami -e GRANT_TO_USERS=0123456789,9876543210
 cargo make revoke-ami -e REVOKE_FROM_USERS=0123456789,9876543210
 ```
 
+> Note: similar to `cargo make ami`, you can specify `PUBLISH_REGIONS` on the command line if you don't want to make an `Infra.toml` config.
+
 ## Build a repo
 
 Bottlerocket uses [TUF repositories](https://theupdateframework.io/overview/) to make system updates available to hosts.
@@ -82,6 +84,7 @@ You can read more about how Bottlerocket uses TUF in the [updater README](source
 If you plan to update hosts rather than replace them, you'll need to make a repo.
 Initially, the repo will only contain the image you just built.
 Later, when you build updates, you can [add them to the repo](#configuring-your-repo-location), which allows your hosts to update to new versions.
+(If you don't have an `Infra.toml` file, it will always try to build a brand new repo.)
 
 ### Build process
 

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use url::Url;
 
 /// Configuration needed to load and create repos
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InfraConfig {
     // Repo subcommand config
@@ -23,13 +23,26 @@ pub struct InfraConfig {
 
 impl InfraConfig {
     /// Deserializes an InfraConfig from a given path
-    pub fn from_path<P>(path: P) -> Result<InfraConfig>
+    pub fn from_path<P>(path: P) -> Result<Self>
     where
         P: AsRef<Path>,
     {
         let path = path.as_ref();
         let infra_config_str = fs::read_to_string(path).context(error::File { path })?;
         toml::from_str(&infra_config_str).context(error::InvalidToml { path })
+    }
+
+    /// Deserializes an InfraConfig from a given path, if it exists, otherwise builds a default
+    /// config
+    pub fn from_path_or_default<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        if path.as_ref().exists() {
+            Self::from_path(path)
+        } else {
+            Ok(Self::default())
+        }
     }
 }
 
@@ -94,7 +107,7 @@ impl TryFrom<SigningKeyConfig> for Url {
 }
 
 /// Represents a Bottlerocket repo's location and the metadata needed to update the repo
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepoConfig {
     pub root_role_url: Option<Url>,

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -92,11 +92,12 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     let mut amis = HashMap::new();
 
     info!(
-        "Using infra config from path: {}",
+        "Checking for infra config at path: {}",
         args.infra_config_path.display()
     );
-    let infra_config = InfraConfig::from_path(&args.infra_config_path).context(error::Config)?;
-    trace!("Parsed infra config: {:?}", infra_config);
+    let infra_config =
+        InfraConfig::from_path_or_default(&args.infra_config_path).context(error::Config)?;
+    trace!("Using infra config: {:?}", infra_config);
 
     let aws = infra_config.aws.unwrap_or_else(|| Default::default());
 

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -86,11 +86,12 @@ pub(crate) async fn run(args: &Args, publish_args: &PublishArgs) -> Result<()> {
     );
 
     info!(
-        "Using infra config from path: {}",
+        "Checking for infra config at path: {}",
         args.infra_config_path.display()
     );
-    let infra_config = InfraConfig::from_path(&args.infra_config_path).context(error::Config)?;
-    trace!("Parsed infra config: {:?}", infra_config);
+    let infra_config =
+        InfraConfig::from_path_or_default(&args.infra_config_path).context(error::Config)?;
+    trace!("Using infra config: {:?}", infra_config);
 
     let aws = infra_config.aws.unwrap_or_else(Default::default);
 


### PR DESCRIPTION
**Issue number:**

Found by @izaakschroeder in #1162 (issue is unrelated)

**Description of changes:**

```
If the user has no Infra.toml, we can continue with defaults most of the time.
For making an AMI, only passing PUBLISH_REGIONS is required.  For making a
repo, we can use a default configuration and write it under 'default'. SSM
still requires Infra.toml.
```

**Testing done:**

Tested ami, publish-ami, and repo tasks (and ssm, though it didn't change) with and without an Infra.toml file.  They worked as expected:
* With Infra.toml:
  * ami and publish-ami use region from file
  * repo is built in `build/repos/default` by default
  * ssm works
* Without Infra.toml:
  * ami and publish-ami require `-e PUBLISH_REGIONS`, and work
  * repo is still built in `build/repos/default` and that section of my config is detected
  * ssm doesn't work, as expected; prefix is required.  (This could be a future improvement, passing through prefix from a variable.)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
