### PR TITLE
Makefile: Check that $BUILDSYS_ARCH is a supported architecture

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -98,6 +98,15 @@ PUBLISH_AMI_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH
 [tasks.setup]
 script = [
 '''
+# Ensure we use a supported architecture
+case "${BUILDSYS_ARCH}" in
+   x86_64|aarch64) ;;
+   *)
+      echo "Unrecognized architecture '${BUILDSYS_ARCH}'; please use 'x86_64 or 'aarch64'"
+      exit 1
+      ;;
+esac
+
 mkdir -p ${BUILDSYS_BUILD_DIR}
 mkdir -p ${BUILDSYS_OUTPUT_DIR}
 mkdir -p ${BUILDSYS_PACKAGES_DIR}
@@ -437,16 +446,6 @@ fi
 lz4 -df "${rootlz4}" "${root_image}"
 lz4 -df "${datalz4}" "${data_image}"
 
-# Canonicalize architecture identifier to the value recognized by EC2.
-case "${BUILDSYS_ARCH,,}" in
-   arm64|aarch64)
-      arch=arm64 ;;
-   x86_64|amd64)
-      arch=x86_64 ;;
-   *)
-      arch="${BUILDSYS_ARCH}" ;;
-esac
-
 ami_output="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-amis.json"
 ami_output_latest="${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_VARIANT}-amis.json"
 
@@ -462,7 +461,7 @@ pubsys \
    ${PUBLISH_ROOT_VOLUME_SIZE:+--root-volume-size "${PUBLISH_ROOT_VOLUME_SIZE}"} \
    --data-volume-size "${PUBLISH_DATA_VOLUME_SIZE}" \
    \
-   --arch "${arch}" \
+   --arch "${BUILDSYS_ARCH}" \
    --name "${ami_name}" \
    --description "${PUBLISH_AMI_DESCRIPTION:-${ami_name}}" \
    \

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -6,7 +6,7 @@ mod snapshot;
 pub(crate) mod wait;
 
 use crate::aws::publish_ami::{get_snapshots, modify_image, modify_snapshots};
-use crate::aws::{client::build_client, region_from_string};
+use crate::aws::{client::build_client, parse_arch, region_from_string};
 use crate::Args;
 use futures::future::{join, lazy, ready, FutureExt};
 use futures::stream::{self, StreamExt};
@@ -48,7 +48,7 @@ pub(crate) struct AmiArgs {
     data_volume_size: i64,
 
     /// The architecture of the machine image
-    #[structopt(short = "a", long)]
+    #[structopt(short = "a", long, parse(try_from_str = parse_arch))]
     arch: String,
 
     /// The desired AMI name


### PR DESCRIPTION
**Issue number:**
Related to #1162 

**Description of changes:**
```
$BUILDSYS_ARCH is used all over the place in the Makefile, and if we don't
check that it's a valid supported architecture first, spurious directories get
created and commands further down the line will fail.  This change checks
$BUILDSYS_ARCH first before anything happens and fails.

    
It doesn't use any parameter expansion like the previous check did, meaning it
will be compatible with all versions of bash.
```

**Testing done:**
* `cargo make` commands fail if an invalid arch is supplied via `-e BUILDSYS_ARCH=`
```
...
[cargo-make] INFO - Running Task: setup
Unrecognized architecture 'bar'; please use 'x86_64 or 'aarch64'
...
```

* `cargo make` commands with valid architectures work as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
