### PR TITLE
Fix documentation/comment nits

### DIFF
--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -154,10 +154,8 @@ You can set up a new cluster like this:
 eksctl create cluster --region us-west-2 --name bottlerocket
 ```
 
-Now that the cluster is created, we can have `eksctl` create the configuration for `kubectl`:
-```
-eksctl utils write-kubeconfig --region us-west-2 --name bottlerocket
-```
+This will automatically add a "context" so `kubectl` knows how to interact with your cluster, and it'll set that context as your default.
+You can see your contexts (clusters) using `kubectl config get-contexts` and change your current one with `kubectl config use-context 'NEW-CONTEXT-HERE'`.
 
 ### Cluster info
 

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -286,7 +286,8 @@ For the instance to be able to communicate with the EKS cluster control plane an
 Run the following command:
 
 ```
-aws ec2 describe-security-groups --filters 'Name=tag:Name,Values=*bottlerocket*' \
+aws ec2 describe-security-groups --region us-west-2 \
+  --filters 'Name=tag:Name,Values=*bottlerocket*' \
   --query "SecurityGroups[*].{Name:GroupName,ID:GroupId}"
 ```
 

--- a/tools/pubsys/src/aws/ssm/ssm.rs
+++ b/tools/pubsys/src/aws/ssm/ssm.rs
@@ -355,7 +355,7 @@ mod error {
             missing: String,
         },
 
-        #[snafu(display("Failed to {} of {} parameters; see above", failure_count, total_count))]
+        #[snafu(display("Failed to set {} of {} parameters; see above", failure_count, total_count))]
         SetParameters {
             failure_count: usize,
             total_count: usize,


### PR DESCRIPTION
**Description of changes:**

```
QUICKSTART-EKS: correct the note about eksctl writing kubectl context

It's done automatically now, so it's better to have a quick description of
contexts and how the user can change it if desired.
```

```
QUICKSTART-EKS: Add missing region argument to describe-security-groups call

All other aws calls (other than iam, which is regionless) have a region
argument, but this one is missing.  It could lead users astray when it doesn't
find their security group, if they're setting up in another region.
```

```
pubsys: fix typo in SSM error message
```


**Testing done:**

They render real nice!

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
