### PR TITLE
Add migration for sysctl values

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -10,3 +10,4 @@ version = "1.0.2"
 "(0.5.0, 1.0.0)" = ["migrate_v1.0.0_ecr-helper-admin.lz4", "migrate_v1.0.0_ecr-helper-control.lz4"]
 "(1.0.0, 1.0.1)" = []
 "(1.0.1, 1.0.2)" = ["migrate_v1.0.2_add-enable-spot-instance-draining.lz4"]
+"(1.0.2, 1.0.3)" = ["migrate_v1.0.3_add-sysctl.lz4"]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -271,6 +271,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-sysctl"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-version-lock-ignore-waves"
 version = "0.1.0"
 dependencies = [
@@ -1527,6 +1534,7 @@ dependencies = [
  "apiserver",
  "bottlerocket-release",
  "handlebars",
+ "maplit",
  "schnauzer",
  "serde",
  "serde_json",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "api/migration/migrations/v1.0.0/ecr-helper-admin",
     "api/migration/migrations/v1.0.0/ecr-helper-control",
     "api/migration/migrations/v1.0.2/add-enable-spot-instance-draining",
+    "api/migration/migrations/v1.0.3/add-sysctl",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -17,3 +17,6 @@ snafu = "0.6"
 toml = "0.5"
 serde_json = "1.0"
 serde = "1.0.104"
+
+[dev-dependencies]
+maplit = "1.0"

--- a/sources/api/migration/migrations/v1.0.3/add-sysctl/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.3/add-sysctl/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-sysctl"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.3/add-sysctl/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.3/add-sysctl/src/main.rs
@@ -1,0 +1,21 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added the ability to set sysctl keys via API settings.  We don't want to track all possible
+/// Linux sysctl keys, so we remove the whole prefix if we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixMigration("settings.kernel.sysctl"))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
**Description of changes:**

This adds the migration related to #1158.

**Testing done:**

I added some sysctl settings via API:
```
{
...
  "kernel": {
    "sysctl": {
      "hi": "there",
      "sup": "you"
    }
  }
}
```
Forward and backward migrations look OK:
```
> ./sources/target/debug/add-sysctl --source-datastore /tmp/data-store/v0.0.1_2LGOZBMlK5kF1tSU/ --target-datastore /tmp/data-store/v0.0.2_hi --forward
AddPrefixMigration("settings.kernel.sysctl") has no work to do on upgrade.
> ./sources/target/debug/add-sysctl --source-datastore /tmp/data-store/v0.0.2_hi --target-datastore /tmp/data-store/v0.0.2_backward --backward
Removed settings.kernel.sysctl.hi, which was set to '"there"'
Removed settings.kernel.sysctl.sup, which was set to '"you"'
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
