### PR TITLE
create links for ephemeral storage devices

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -8,6 +8,7 @@
 * [**early-boot-config**](sources/api/early-boot-config): A program run at boot to read platform-specific data, such as EC2 user data, and send requested configuration to the API.
 * **gptprio:** A structure of bits in GPT partition headers that specifies priority, tries remaining, and whether the partition booted successfully before.
   signpost sets these and GRUB uses them to determine which partition set to boot.
+* [**ghostdog**](sources/ghostdog): A program used to manage ephemeral disks.
 * [**growpart**](sources/growpart): A program used to expand disk partitions upon boot.
 * **host containers**: Containers that run in a separate instance of containerd than "user" containers spawned by an orchestrator (e.g. Kubernetes).
   Used for system maintenance and connectivity.

--- a/SECURITY_GUIDANCE.md
+++ b/SECURITY_GUIDANCE.md
@@ -17,6 +17,7 @@ We provide these recommendations, along with [details](#details) and [examples](
 | [Limit use of privileged SELinux labels](#limit-use-of-privileged-selinux-labels)                   | Important |
 | [Limit access to system mounts](#limit-access-to-system-mounts)                                     | Important |
 | [Limit access to host namespaces](#limit-access-to-host-namespaces)                                 | Important |
+| [Limit access to block devices](#limit-access-to-block-devices)                                     | Important |
 | [Do not run containers as UID 0](#do-not-run-containers-as-uid-0)                                   | Moderate  |
 
 ## Details
@@ -177,6 +178,23 @@ Sharing the host PID namespace also enables access to the host filesystem throug
 This can bypass intended restrictions for system mounts.
 
 We recommend limiting access to all host namespaces.
+
+### Limit access to block devices
+
+Direct access to block devices can be used to bypass abstractions such as filesystems and caches.
+This is useful for databases and storage applications that want full control over the data layout on disk.
+
+The order in which the kernel enumerates block devices is inconsistent and subject to change.
+To avoid referring to the wrong device, Linux distributions use links under `/dev/disk` to map predictable identifiers to specific devices.
+Bottlerocket relies on partition type GUIDs and partition names to discover its devices.
+
+Orchestrators offer ways to associate block devices with containers.
+For example, Kubernetes allows pods to claim a "block mode" volume and mount the device to a desired path.
+Containers with direct access to a block device can alter the partition table or modify the filesystem metadata.
+If the same partition type or partition name is used for another device, the `/dev/disk` link may point to the wrong device.
+This could compromise the integrity of the host.
+
+We recommend limiting access to block devices.
 
 ### Do not run containers as UID 0
 

--- a/macros/shared
+++ b/macros/shared
@@ -50,6 +50,7 @@
 %_cross_sysctldir %{_cross_rootdir}%{_sysctldir}
 %_cross_templatedir %{_cross_datadir}/templates
 %_cross_usrsrc %{_cross_prefix}/src
+%_cross_udevrulesdir %{_cross_rootdir}%{_udevrulesdir}
 %_cross_licensedir %{_cross_datadir}/licenses
 %_defaultlicensedir %{_cross_licensedir}
 %_uncross_name %(name=%{name}; echo ${name#%{_cross_os}})

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -11,6 +11,7 @@ source-groups = [
     "api",
     "bottlerocket-release",
     "parse-datetime",
+    "ghostdog",
     "growpart",
     "updater",
     "webpki-roots-shim",

--- a/packages/os/ephemeral-storage.rules
+++ b/packages/os/ephemeral-storage.rules
@@ -1,0 +1,27 @@
+# ephemeral storage links: /dev/disk/ephemeral
+
+ACTION=="remove", GOTO="ephemeral_storage_end"
+SUBSYSTEM!="block", GOTO="ephemeral_storage_end"
+ENV{DEVTYPE}!="disk", GOTO="ephemeral_storage_end"
+
+# Known sources of ephemeral disks:
+# - EC2 instance types with instance storage volumes
+# - KVM VMs with additional virtio disks
+KERNEL!="nvme*|vd*", GOTO="ephemeral_storage_end"
+
+# We can't be sure that devices with similar kernel names are all ephemeral.
+# Our udev helper checks for known system partitions to classify the device.
+IMPORT{program}=="/usr/bin/ghostdog scan $devnode"
+ENV{BOTTLEROCKET_DEVICE_TYPE}!="ephemeral", GOTO="ephemeral_storage_end"
+
+# EBS volumes will show up as "Amazon Elastic Block Store", but we expect these
+# to be either system volumes or managed by the EBS CSI driver.
+KERNEL=="nvme*", ATTRS{model}=="Amazon EC2 NVMe Instance Storage*", ENV{ID_SERIAL}=="?*", \
+  SYMLINK+="disk/ephemeral/nvme-$env{ID_SERIAL}"
+
+# Fow now, virtio support is meant to enable local development, so only create
+# links if the serial matches a specific prefix.
+KERNEL=="vd*", ENV{ID_SERIAL}=="eph*", \
+  SYMLINK+="disk/ephemeral/virtio-$env{ID_SERIAL}"
+
+LABEL="ephemeral_storage_end"

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -36,6 +36,9 @@ Source200: migration-tmpfiles.conf
 Source201: host-containers-tmpfiles.conf
 Source202: thar-be-updates-tmpfiles.conf
 
+# 3xx sources: udev rules
+Source300: ephemeral-storage.rules
+
 BuildRequires: %{_cross_os}glibc-devel
 
 %description
@@ -134,6 +137,11 @@ Summary: Commits settings from user data, defaults, and generators at boot
 %description -n %{_cross_os}settings-committer
 %{summary}.
 
+%package -n %{_cross_os}ghostdog
+Summary: Tool to manage ephemeral disks
+%description -n %{_cross_os}ghostdog
+%{summary}.
+
 %package -n %{_cross_os}growpart
 Summary: Tool to grow partitions
 %description -n %{_cross_os}growpart
@@ -190,6 +198,7 @@ mkdir bin
     -p signpost \
     -p updog \
     -p logdog \
+    -p ghostdog \
     -p growpart \
     -p corndog \
 %if "%{_cross_variant}" == "aws-ecs-1"
@@ -215,6 +224,7 @@ for p in \
   storewolf settings-committer \
   migrator \
   signpost updog logdog \
+  ghostdog \
 %if "%{_cross_variant}" == "aws-ecs-1"
   ecs-settings-applier \
 %endif
@@ -271,6 +281,9 @@ install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.conf
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_tmpfilesdir}/thar-be-updates.conf
+
+install -d %{buildroot}%{_cross_udevrulesdir}
+install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-storage.rules
 
 %cross_scan_attribution --clarify %{_builddir}/sources/clarify.toml \
     cargo --offline --locked %{_builddir}/sources/Cargo.toml
@@ -342,6 +355,10 @@ install -p -m 0644 %{S:202} %{buildroot}%{_cross_tmpfilesdir}/thar-be-updates.co
 
 %files -n %{_cross_os}settings-committer
 %{_cross_bindir}/settings-committer
+
+%files -n %{_cross_os}ghostdog
+%{_cross_bindir}/ghostdog
+%{_cross_udevrulesdir}/80-ephemeral-storage.rules
 
 %files -n %{_cross_os}growpart
 %{_cross_sbindir}/growpart

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -38,6 +38,7 @@ Requires: %{_cross_os}libgcc
 Requires: %{_cross_os}libstd-rust
 Requires: %{_cross_os}filesystem
 Requires: %{_cross_os}glibc
+Requires: %{_cross_os}ghostdog
 Requires: %{_cross_os}growpart
 Requires: %{_cross_os}grub
 Requires: %{_cross_os}iproute

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -358,6 +358,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
+name = "argh"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1877e24cecacd700d469066e0160c4f8497cc5635367163f50c8beec820154"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e742194e0f43fc932bcb801708c2b279d3ec8f527e3acda05a6a9f342c5ef764"
+dependencies = [
+ "argh_shared",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ba68f4276a778591e36a0c348a269888f3a177c8d2054969389e3b59611ff5"
+
+[[package]]
 name = "async-trait"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1060,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "ghostdog"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "cargo-readme",
+ "gptman",
+ "hex-literal",
+ "lazy_static",
+ "signpost",
+ "snafu",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -32,6 +32,8 @@ members = [
 
     "bottlerocket-release",
 
+    "ghostdog",
+
     "growpart",
 
     "logdog",

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ghostdog"
+version = "0.1.0"
+authors = ["Ben Cressey <bcressey@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+argh = "0.1.3"
+gptman = { version = "0.6.1", default-features = false }
+hex-literal = "0.2.0"
+lazy_static = "1.2"
+signpost = { path = "../updater/signpost" }
+snafu = "0.6"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/ghostdog/README.md
+++ b/sources/ghostdog/README.md
@@ -1,0 +1,10 @@
+# ghostdog
+
+Current version: 0.1.0
+
+ghostdog is a tool to manage ephemeral disks.
+It can be called as a udev helper program to identify ephemeral disks.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/ghostdog/README.tpl
+++ b/sources/ghostdog/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/ghostdog/build.rs
+++ b/sources/ghostdog/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/ghostdog/src/main.rs
+++ b/sources/ghostdog/src/main.rs
@@ -1,0 +1,181 @@
+/*!
+ghostdog is a tool to manage ephemeral disks.
+It can be called as a udev helper program to identify ephemeral disks.
+*/
+
+use argh::FromArgs;
+use gptman::GPT;
+use hex_literal::hex;
+use lazy_static::lazy_static;
+use signpost::uuid_to_guid;
+use snafu::ResultExt;
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Read, Seek};
+use std::path::PathBuf;
+
+#[derive(FromArgs, PartialEq, Debug)]
+/// Manage ephemeral disks.
+struct Args {
+    #[argh(subcommand)]
+    subcommand: SubCommand,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand)]
+enum SubCommand {
+    Scan(ScanArgs),
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "scan")]
+/// Scan a device to see if it is an ephemeral disk.
+struct ScanArgs {
+    #[argh(positional)]
+    device: PathBuf,
+}
+
+// Main entry point.
+fn run() -> Result<()> {
+    let args: Args = argh::from_env();
+    match args.subcommand {
+        SubCommand::Scan(scan_args) => {
+            let path = scan_args.device;
+            let mut f = fs::File::open(&path).context(error::DeviceOpen { path })?;
+            let device_type = find_device_type(&mut f)?;
+            emit_device_type(&device_type);
+        }
+    }
+    Ok(())
+}
+
+/// Find the device type by examining the partition table, if present.
+fn find_device_type<R>(reader: &mut R) -> Result<String>
+where
+    R: Read + Seek,
+{
+    // We expect the udev rules to only match block disk devices, so it's fair
+    // to assume it could have a partition table, and that it's probably an
+    // unformatted ephemeral disk if it doesn't.
+    let mut device_type = "ephemeral";
+
+    // System disks will either have a known partition type or a partition name
+    // that starts with BOTTLEROCKET.
+    if let Ok(gpt) = GPT::find_from(reader) {
+        let system_device = gpt.iter().any(|(_, p)| {
+            p.is_used()
+                && (SYSTEM_PARTITION_TYPES.contains(&p.partition_type_guid)
+                    || p.partition_name.as_str().starts_with("BOTTLEROCKET"))
+        });
+        if system_device {
+            device_type = "system"
+        }
+    }
+
+    Ok(device_type.to_string())
+}
+
+/// Print the device type in the environment key format udev expects.
+fn emit_device_type(device_type: &str) -> () {
+    println!("BOTTLEROCKET_DEVICE_TYPE={}", device_type);
+}
+
+// Known system partition types for Bottlerocket.
+lazy_static! {
+    static ref SYSTEM_PARTITION_TYPES: HashSet<[u8; 16]> = [
+        uuid_to_guid(hex!("c12a7328 f81f 11d2 ba4b 00a0c93ec93b")), // EFI_SYSTEM
+        uuid_to_guid(hex!("6b636168 7420 6568 2070 6c616e657421")), // BOTTLEROCKET_BOOT
+        uuid_to_guid(hex!("5526016a 1a97 4ea4 b39a b7c8c6ca4502")), // BOTTLEROCKET_ROOT
+        uuid_to_guid(hex!("598f10af c955 4456 6a99 7720068a6cea")), // BOTTLEROCKET_HASH
+        uuid_to_guid(hex!("0c5d99a5 d331 4147 baef 08e2b855bdc9")), // BOTTLEROCKET_RESERVED
+        uuid_to_guid(hex!("440408bb eb0b 4328 a6e5 a29038fad706")), // BOTTLEROCKET_PRIVATE
+        uuid_to_guid(hex!("626f7474 6c65 6474 6861 726d61726b73")), // BOTTLEROCKET_DATA
+    ].iter().copied().collect();
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+/// Potential errors during `ghostdog` execution.
+mod error {
+    use snafu::Snafu;
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("Failed to open '{}': {}", path.display(), source))]
+        DeviceOpen {
+            path: std::path::PathBuf,
+            source: std::io::Error,
+        },
+    }
+}
+
+type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use gptman::{GPTPartitionEntry, GPT};
+    use signpost::uuid_to_guid;
+    use std::io::Cursor;
+
+    fn gpt_data(partition_type: [u8; 16], partition_name: &str) -> Vec<u8> {
+        let mut data = vec![0; 21 * 512 * 2048];
+        let mut cursor = Cursor::new(&mut data);
+        let mut gpt = GPT::new_from(&mut cursor, 512, [0xff; 16]).unwrap();
+        gpt[1] = GPTPartitionEntry {
+            partition_name: partition_name.into(),
+            partition_type_guid: partition_type,
+            unique_parition_guid: [0xff; 16],
+            starting_lba: gpt.header.first_usable_lba,
+            ending_lba: gpt.header.last_usable_lba,
+            attribute_bits: 0,
+        };
+        gpt.write_into(&mut cursor).unwrap();
+        cursor.into_inner().to_vec()
+    }
+
+    #[test]
+    fn empty_disk() {
+        let data = vec![0; 21 * 512 * 2048];
+        assert_eq!(
+            find_device_type(&mut Cursor::new(&data)).unwrap(),
+            "ephemeral"
+        );
+    }
+
+    #[test]
+    fn partitioned_disk_with_unknown_type() {
+        let partition_type = uuid_to_guid(hex!("00000000 0000 0000 0000 000000000000"));
+        let partition_name = "";
+        let data = gpt_data(partition_type, partition_name);
+        assert_eq!(
+            find_device_type(&mut Cursor::new(&data)).unwrap(),
+            "ephemeral"
+        );
+    }
+
+    #[test]
+    fn partitioned_disk_with_system_type() {
+        let partition_type = uuid_to_guid(hex!("440408bb eb0b 4328 a6e5 a29038fad706"));
+        let partition_name = "";
+        let data = gpt_data(partition_type, partition_name);
+        assert_eq!(find_device_type(&mut Cursor::new(&data)).unwrap(), "system");
+    }
+
+    #[test]
+    fn partitioned_disk_with_system_name() {
+        let partition_type = uuid_to_guid(hex!("11111111 1111 1111 1111 111111111111"));
+        let partition_name = "BOTTLEROCKET-STUFF";
+        let data = gpt_data(partition_type, partition_name);
+        assert_eq!(find_device_type(&mut Cursor::new(&data)).unwrap(), "system");
+    }
+}


### PR DESCRIPTION
**Issue number:**
#1088


**Description of changes:**
Populate `/dev/disk/ephemeral` with links to ephemeral storage devices.

Update security guidance to reflect the risks of mapping a block device into an untrusted container.

**Testing done:**

Verified that the two ephemeral disks were linked on an `m5ad.4xlarge`:
```
# ls -latr /dev/disk/ephemeral/

lrwxrwxrwx. 1 root root  13 Oct 18 04:11 nvme-Amazon_EC2_NVMe_Instance_Storage_AWS27A87D8ECFBD312B5 -> ../../nvme3n1
lrwxrwxrwx. 1 root root  13 Oct 18 04:11 nvme-Amazon_EC2_NVMe_Instance_Storage_AWS220C24D1769700C7B -> ../../nvme2n1
```

Verified that other disks were classified as "system":
```
# ghostdog scan /dev/nvme0n1
BOTTLEROCKET_DEVICE_TYPE=system

# ghostdog scan /dev/nvme1n1
BOTTLEROCKET_DEVICE_TYPE=system

# ghostdog scan /dev/nvme2n1
BOTTLEROCKET_DEVICE_TYPE=ephemeral

# ghostdog scan /dev/nvme3n1
BOTTLEROCKET_DEVICE_TYPE=ephemeral
```

Verified that the external static provisioner could discover the ephemeral disks:
```
$ kubectl describe pv local-pv-eddb9f1f
...
Source:
    Type:  LocalVolume (a persistent volume backed by local storage on a node)
    Path:  /dev/disk/ephemeral/nvme-Amazon_EC2_NVMe_Instance_Storage_AWS220C24D1769700C7B
Events:    <none>
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
