### PR TITLE
Makefile: split tasks.setup into tasks.setup and tasks.setup-build

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -108,8 +108,14 @@ mkdir -p ${BUILDSYS_BUILD_DIR}
 mkdir -p ${BUILDSYS_OUTPUT_DIR}
 mkdir -p ${BUILDSYS_PACKAGES_DIR}
 mkdir -p ${GO_MOD_CACHE}
+'''
+]
 
-for cmd in bash curl docker gunzip lz4 ; do
+[tasks.setup-build]
+dependencies = ["setup"]
+script = [
+'''
+for cmd in curl docker gunzip lz4; do
   if ! command -v ${cmd} >/dev/null 2>&1 ; then
     echo "required program '${cmd}' not found" >&2
     exit 1
@@ -126,7 +132,7 @@ dependencies = [
 ]
 
 [tasks.fetch-sdk]
-dependencies = ["setup"]
+dependencies = ["setup-build"]
 script_runner = "bash"
 script = [
 '''
@@ -157,7 +163,7 @@ chmod -R o+r ${CARGO_HOME}
 ]
 
 [tasks.fetch-vendored]
-dependencies = ["setup", "fetch-sdk"]
+dependencies = ["fetch-sdk"]
 script = [
 '''
 ${BUILDSYS_TOOLS_DIR}/docker-go \
@@ -169,7 +175,7 @@ ${BUILDSYS_TOOLS_DIR}/docker-go \
 ]
 
 [tasks.unit-tests]
-dependencies = ["setup", "fetch-sdk", "fetch-sources", "fetch-vendored"]
+dependencies = ["fetch-sdk", "fetch-sources", "fetch-vendored"]
 script = [
 '''
 export VARIANT="${BUILDSYS_VARIANT}"
@@ -190,7 +196,7 @@ ${BUILDSYS_TOOLS_DIR}/docker-go \
 ]
 
 [tasks.build-tools]
-dependencies = ["setup", "fetch"]
+dependencies = ["fetch"]
 script = [
 '''
 cargo install \
@@ -500,7 +506,7 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the image files below to save time.
 # This does mean that `cargo make` must be run before `cargo make ami`.
-dependencies = ["publish-tools"]
+dependencies = ["setup-build", "publish-tools"]
 script_runner = "bash"
 script = [
 '''


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Oct 19 14:33:13 2020 -0700

    Makefile: add `setup-build` task
    
    Not all cargo-make tasks need docker, lz4 or curl (i.e. pubsys related tasks).
    This separates original setup task into `setup` and `setup-build`.
    `setup` sets up the build/output directories.
    `setup-build` checks for all the necessary tools to build and release
    images.

```


**Testing done:**
I'm still able to build and create AMIs.
I can `cargo make validate-repo` without needing docker.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
