### PR TITLE
update to systemd 246 and dbus-broker 24

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -90,7 +90,6 @@ name = "dbus-broker"
 version = "0.1.0"
 dependencies = [
  "glibc",
- "libcap",
  "libexpat",
  "libselinux",
  "systemd",

--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -9,12 +9,11 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bus1/dbus-broker/releases/download/v23/dbus-broker-23.tar.xz"
-sha512 = "b9431a9733342d4b6214a6a35ad05d3278ab2c8cfdc35537dba86ba9ee3f59eef4e31687c2fe8a6444072eaf8384bc71a41617fec0539a8c00be9eae0efa9832"
+url = "https://github.com/bus1/dbus-broker/releases/download/v24/dbus-broker-24.tar.xz"
+sha512 = "7fbe6c689eff27ec842bb9d839a418abc356b026bb0a54dfa8b680a655409aa1ea4cb90655a6b04561a88c6e703cacf8800fddfe1abc21e7ee60db2dac1c2db9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }
-libcap = { path = "../libcap" }
 libexpat = { path = "../libexpat" }
 libselinux = { path = "../libselinux" }
 systemd = { path = "../systemd" }

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}dbus-broker
-Version: 23
+Version: 24
 Release: 1%{?dist}
 Summary: D-BUS message broker
 License: Apache-2.0
@@ -11,11 +11,9 @@ Source3: dbus-sysusers.conf
 Source4: dbus-broker.service
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
-BuildRequires: %{_cross_os}libcap-devel
 BuildRequires: %{_cross_os}libexpat-devel
 BuildRequires: %{_cross_os}libselinux-devel
 BuildRequires: %{_cross_os}systemd-devel
-Requires: %{_cross_os}libcap
 Requires: %{_cross_os}libexpat
 Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}systemd

--- a/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
@@ -1,4 +1,4 @@
-From 761f4dfb91c5b8d80dafd7a8b7952c09e61bc981 Mon Sep 17 00:00:00 2001
+From f138446c6b5f931d143c036cc4e2d33a5979d42b Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 17 Sep 2019 01:35:51 +0000
 Subject: [PATCH 9001/9005] use absolute path for /var/run symlink
@@ -25,5 +25,5 @@ index 0e2c509..6716540 100644
  d /var/log 0755 - - -
  m4_ifdef(`ENABLE_UTMP',
 -- 
-2.21.0
+2.26.2
 

--- a/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
+++ b/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
@@ -1,4 +1,4 @@
-From adcae5edbf78586335a64744dca2df6449537953 Mon Sep 17 00:00:00 2001
+From 0626e5d7b323a62b251ef66742b3b65d4531eacf Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 10 Mar 2020 20:30:10 +0000
 Subject: [PATCH 9002/9005] core: add separate timeout for system shutdown
@@ -33,10 +33,10 @@ index 970654a..9251bb9 100644
  #define DEFAULT_UNIX_MAX_DGRAM_QLEN 512UL
  
 diff --git a/src/core/main.c b/src/core/main.c
-index 3c6b66e..f2e9776 100644
+index 4a37697..619bad4 100644
 --- a/src/core/main.c
 +++ b/src/core/main.c
-@@ -114,6 +114,7 @@ static ExecOutput arg_default_std_error;
+@@ -121,6 +121,7 @@ static ExecOutput arg_default_std_error;
  static usec_t arg_default_restart_usec;
  static usec_t arg_default_timeout_start_usec;
  static usec_t arg_default_timeout_stop_usec;
@@ -44,7 +44,7 @@ index 3c6b66e..f2e9776 100644
  static usec_t arg_default_timeout_abort_usec;
  static bool arg_default_timeout_abort_set;
  static usec_t arg_default_start_limit_interval;
-@@ -1398,7 +1399,7 @@ static int become_shutdown(
+@@ -1468,7 +1469,7 @@ static int become_shutdown(
          env_block = strv_copy(environ);
  
          xsprintf(log_level, "%d", log_get_max_level());
@@ -53,7 +53,7 @@ index 3c6b66e..f2e9776 100644
  
          switch (log_get_target()) {
  
-@@ -2151,6 +2152,7 @@ static void reset_arguments(void) {
+@@ -2282,6 +2283,7 @@ static void reset_arguments(void) {
          arg_default_restart_usec = DEFAULT_RESTART_USEC;
          arg_default_timeout_start_usec = DEFAULT_TIMEOUT_USEC;
          arg_default_timeout_stop_usec = DEFAULT_TIMEOUT_USEC;
@@ -62,5 +62,5 @@ index 3c6b66e..f2e9776 100644
          arg_default_timeout_abort_set = false;
          arg_default_start_limit_interval = DEFAULT_START_LIMIT_INTERVAL;
 -- 
-2.21.0
+2.26.2
 

--- a/packages/systemd/9003-repart-always-use-random-UUIDs.patch
+++ b/packages/systemd/9003-repart-always-use-random-UUIDs.patch
@@ -1,4 +1,4 @@
-From b080e8af77c4484a3fdd40c599454b69e5a193a5 Mon Sep 17 00:00:00 2001
+From dee2b33e3d7969210078d483f6575a347904bdff Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 16 Apr 2020 15:10:41 +0000
 Subject: [PATCH 9003/9005] repart: always use random UUIDs
@@ -22,10 +22,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  2 files changed, 14 insertions(+), 90 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index fc216d2..eb28daa 100644
+index dbbddb6..09fe7b6 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1305,8 +1305,7 @@ substs.set('DEFAULT_DNS_OVER_TLS_MODE', default_dns_over_tls)
+@@ -1357,8 +1357,7 @@ substs.set('DEFAULT_LLMNR_MODE', default_llmnr)
  
  want_repart = get_option('repart')
  if want_repart != 'false'
@@ -36,7 +36,7 @@ index fc216d2..eb28daa 100644
                  error('repart support was requested, but dependencies are not available')
          endif
 diff --git a/src/partition/repart.c b/src/partition/repart.c
-index 3e52f26..93f6834 100644
+index 2e5f5d1..1ce24e3 100644
 --- a/src/partition/repart.c
 +++ b/src/partition/repart.c
 @@ -13,9 +13,6 @@
@@ -49,7 +49,7 @@ index 3e52f26..93f6834 100644
  #include "sd-id128.h"
  
  #include "alloc-util.h"
-@@ -1143,26 +1140,18 @@ static int fdisk_set_disklabel_id_by_uuid(struct fdisk_context *c, sd_id128_t id
+@@ -1191,26 +1188,18 @@ static int fdisk_set_disklabel_id_by_uuid(struct fdisk_context *c, sd_id128_t id
  #define DISK_UUID_TOKEN "disk-uuid"
  
  static int disk_acquire_uuid(Context *context, sd_id128_t *ret) {
@@ -83,7 +83,7 @@ index 3e52f26..93f6834 100644
          return 0;
  }
  
-@@ -2073,83 +2062,19 @@ static int context_wipe_and_discard(Context *context, bool from_scratch) {
+@@ -2184,83 +2173,19 @@ static int context_copy_blocks(Context *context) {
  }
  
  static int partition_acquire_uuid(Context *context, Partition *p, sd_id128_t *ret) {
@@ -174,5 +174,5 @@ index 3e52f26..93f6834 100644
  }
  
 -- 
-2.21.0
+2.26.2
 

--- a/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen.patch
+++ b/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen.patch
@@ -1,4 +1,4 @@
-From 2c7e1e97cd82ed7c20f63d1842cd26de37b53f34 Mon Sep 17 00:00:00 2001
+From d37bf45e3f00f4a3c87a0b6c6bbbf19a54fd0957 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 7 Jul 2020 22:38:20 +0000
 Subject: [PATCH 9004/9005] machine-id-setup: generate stable ID under Xen
@@ -10,7 +10,7 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  2 files changed, 12 insertions(+), 1 deletion(-)
 
 diff --git a/man/machine-id.xml b/man/machine-id.xml
-index ebee065..8150bdb 100644
+index bd55366..6a58b9d 100644
 --- a/man/machine-id.xml
 +++ b/man/machine-id.xml
 @@ -100,7 +100,8 @@
@@ -24,7 +24,7 @@ index ebee065..8150bdb 100644
      <para>After the machine ID is established,
      <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>
 diff --git a/src/core/machine-id-setup.c b/src/core/machine-id-setup.c
-index 284b77c..275daf5 100644
+index f76b82a..d2024ee 100644
 --- a/src/core/machine-id-setup.c
 +++ b/src/core/machine-id-setup.c
 @@ -73,6 +73,16 @@ static int generate_machine_id(const char *root, sd_id128_t *ret) {
@@ -45,5 +45,5 @@ index 284b77c..275daf5 100644
          }
  
 -- 
-2.21.0
+2.26.2
 

--- a/packages/systemd/9005-core-mount-etc-with-specific-label.patch
+++ b/packages/systemd/9005-core-mount-etc-with-specific-label.patch
@@ -1,4 +1,4 @@
-From b84340cd6e390483a22839c7c3d8d8ff39534d11 Mon Sep 17 00:00:00 2001
+From 322a02dd4bd9bfe17bacb4dd1e792a5293c18342 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 9 Jul 2020 20:00:36 +0000
 Subject: [PATCH 9005/9005] core: mount /etc with specific label
@@ -12,18 +12,18 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/src/core/mount-setup.c b/src/core/mount-setup.c
-index 5dfcb61..5cad963 100644
+index feb88f3..ce2ae73 100644
 --- a/src/core/mount-setup.c
 +++ b/src/core/mount-setup.c
-@@ -74,6 +74,8 @@ static const MountPoint mount_table[] = {
-         { "tmpfs",       "/dev/shm",                  "tmpfs",      "mode=1777,smackfsroot=*", MS_NOSUID|MS_NODEV|MS_STRICTATIME,
+@@ -75,6 +75,8 @@ static const MountPoint mount_table[] = {
+         { "tmpfs",       "/dev/shm",                  "tmpfs",      "mode=1777,smackfsroot=*",                 MS_NOSUID|MS_NODEV|MS_STRICTATIME,
            mac_smack_use, MNT_FATAL                  },
  #endif
 +        { "tmpfs",       "/etc",                      "tmpfs",      "mode=755,context=system_u:object_r:etc_t:s0", MS_NOSUID|MS_NODEV|MS_NOATIME|MS_NOEXEC,
 +          NULL,          MNT_FATAL|MNT_IN_CONTAINER },
-         { "tmpfs",       "/dev/shm",                  "tmpfs",      "mode=1777",               MS_NOSUID|MS_NODEV|MS_STRICTATIME,
+         { "tmpfs",       "/dev/shm",                  "tmpfs",      "mode=1777",                               MS_NOSUID|MS_NODEV|MS_STRICTATIME,
            NULL,          MNT_FATAL|MNT_IN_CONTAINER },
-         { "devpts",      "/dev/pts",                  "devpts",     "mode=620,gid=" STRINGIFY(TTY_GID), MS_NOSUID|MS_NOEXEC,
+         { "devpts",      "/dev/pts",                  "devpts",     "mode=620,gid=" STRINGIFY(TTY_GID),        MS_NOSUID|MS_NOEXEC,
 -- 
-2.21.0
+2.26.2
 

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd/archive/v245/systemd-245.tar.gz"
-sha512 = "1b80d0e02472dfc4197f11dab4f56cf90e8a6e105ce19f837cb11335b6d8577ed49031dad94cdb41aa9bdc06ec8eec62c8e9246272b83935e7bb9dcd3cd8c012"
+url = "https://github.com/systemd/systemd/archive/v246/systemd-246.tar.gz"
+sha512 = "7103f7da53f7ced3b5543c238f23bd11c82af8e37166c1720a90576b6b431b4329320c78726166c65a9f5e101dd465c0a86dd13c586c4e55e608a6273d8f324f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,7 +2,7 @@
 %global _cross_allow_rpath 1
 
 Name: %{_cross_os}systemd
-Version: 245
+Version: 246
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -36,6 +36,7 @@ fn notify_unix_socket_ready() -> Result<()> {
         ensure!(
             Command::new("systemd-notify")
                 .arg("--ready")
+                .arg("--no-block")
                 .status()
                 .context(error::SystemdNotify)?
                 .success(),


### PR DESCRIPTION
**Issue number:**
Fixes #1015, fixes #1175 


**Description of changes:**
Update systemd and dbus-broker to the latest release.

Work around a behavior change in systemd-notify that caused an SELinux denial when starting apiserver.


**Testing done:**
Launched x86_64 and aarch64 nodes. Confirmed that the nodes joined the cluster, ran pods OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
