### PR TITLE
Makefile: remove `tasks.publish-setup-without-key`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -361,10 +361,6 @@ pubsys-setup \
 '''
 ]
 
-[tasks.publish-setup-without-key]
-env = { "ALLOW_MISSING_KEY" = "true" }
-run_task = "publish-setup"
-
 # Builds a local repository based on the 'latest' built targets.  Uses pubsys
 # to create a repo under /build/repos, named after the arch/variant/version,
 # containing subdirectories for the repo metadata and targets.
@@ -433,7 +429,8 @@ ln -sfn "${PUBLISH_REPO_OUTPUT_DIR##*/}" "${PUBLISH_REPO_OUTPUT_DIR%/*}/latest"
 ]
 
 [tasks.validate-repo]
-dependencies = ["publish-setup-without-key", "publish-tools"]
+env = { "ALLOW_MISSING_KEY" = "true" }
+dependencies = ["publish-setup", "publish-tools"]
 script_runner = "bash"
 script = [
 '''
@@ -460,7 +457,8 @@ pubsys \
 ]
 
 [tasks.check-repo-expirations]
-dependencies = ["publish-setup-without-key", "publish-tools"]
+env = { "ALLOW_MISSING_KEY" = "true" }
+dependencies = ["publish-setup", "publish-tools"]
 script_runner = "bash"
 script = [
 '''


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Oct 21 23:40:30 2020 -0700

    Makefile: remove `tasks.publish-setup-without-key`
    
    For all tasks that depend on both `pubsys-setup-without-key` and `pubsys-tools`,
    `tasks.fetch-sources` is invoked twice when it's not suppose to.
    
    Apparently cargo-make does not check if a task has already ran if
    you use the `run_task` directive.
    
    This adds some unnecessary overhead to pubsys repo validation tasks (+1 seconds
    per invocation).
    
    By setting `ALLOW_MISSING_KEY` env var in the tasks we need to `pubsys-setup`
    without a signing key, we avoid needing a separate `tasks.pubsys-setup-without-key`.

```

**Testing done:**
Without the change, running `cargo make validate-repo`:
```
$ cargo make validate-repo -e PUBLISH_REPO=etung --time-summary
[cargo-make] INFO - cargo make 0.32.7
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: validate-repo
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup
22:57:19 [INFO] Found infra config at path: Infra.toml
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: validate-repo
22:57:21 [INFO] Using infra config from path: Infra.toml
22:57:21 [INFO] Loaded TUF repo: https://7777777777777.cloudfront.net/2020-07-07/aws-k8s-1.17/x86_64
22:57:21 [INFO] Downloading target: 2.txt
22:57:21 [INFO] Downloading target: 1.txt
[cargo-make] INFO - ================Time Summary================
[cargo-make] INFO - validate-repo:               29.19%	   1.27 seconds
[cargo-make] INFO - fetch-sources:               23.17%	   1.01 seconds
[cargo-make] INFO - fetch-sources:               22.91%	   1.00 seconds
[cargo-make] INFO - tuftool:                     9.69%	   0.42 seconds
[cargo-make] INFO - publish-tools:               6.00%	   0.26 seconds
[cargo-make] INFO - publish-setup:               4.49%	   0.20 seconds
[cargo-make] INFO - publish-setup-tools:         3.53%	   0.15 seconds
[cargo-make] INFO - setup:                       0.50%	   0.02 seconds
[cargo-make] INFO - setup:                       0.50%	   0.02 seconds
[cargo-make] INFO - publish-setup-without-key:   0.00%	   0.00 seconds
[cargo-make] INFO - ============================================
[cargo-make] INFO - Build Done in 4 seconds.
```

With the change:
```
$ cargo make validate-repo -e PUBLISH_REPO=etung --time-summary
[cargo-make] INFO - cargo make 0.32.7
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: validate-repo
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup
23:00:21 [INFO] Found infra config at path:
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: validate-repo
23:00:22 [INFO] Using infra config from path: 
23:00:22 [INFO] Loaded TUF repo: https://7777777777777.cloudfront.net/2020-07-07/aws-k8s-1.17/x86_64
23:00:22 [INFO] Downloading target: 1.txt
23:00:22 [INFO] Downloading target: 2.txt
[cargo-make] INFO - ================Time Summary================
[cargo-make] INFO - validate-repo:         34.43%	   1.04 seconds
[cargo-make] INFO - fetch-sources:         31.93%	   0.97 seconds
[cargo-make] INFO - tuftool:               14.18%	   0.43 seconds
[cargo-make] INFO - publish-tools:         8.18%	   0.25 seconds
[cargo-make] INFO - publish-setup:         5.61%	   0.17 seconds
[cargo-make] INFO - publish-setup-tools:   4.88%	   0.15 seconds
[cargo-make] INFO - setup:                 0.79%	   0.02 seconds
[cargo-make] INFO - ============================================
[cargo-make] INFO - Build Done in 3 seconds.
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
