### PR TITLE
Adds rtcsync directive to chrony config file

### DIFF
--- a/packages/chrony/chrony-conf
+++ b/packages/chrony/chrony-conf
@@ -6,3 +6,4 @@ makestep 1.0 3
 dumponexit
 dumpdir /var/lib/chrony
 user chrony
+rtcsync


### PR DESCRIPTION
**Issue number:**

Fixes #1183

**Description of changes:**

Adds the `rtcsync` directive to the chrony config file.

I think this is a resonable change to make, as it allready seems to be the default in Amazon Linux 2.

**Testing done:**

I have added this directive to the config file on a running instance and restarted chronyd, and observed that the value of `node_timex_sync` exported by the prometheus node exporter is 1.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
