### PR TITLE
Revert "Makefile: remove `tasks.publish-setup-without-key`"

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -361,6 +361,10 @@ pubsys-setup \
 '''
 ]
 
+[tasks.publish-setup-without-key]
+env = { "ALLOW_MISSING_KEY" = "true" }
+run_task = "publish-setup"
+
 # Builds a local repository based on the 'latest' built targets.  Uses pubsys
 # to create a repo under /build/repos, named after the arch/variant/version,
 # containing subdirectories for the repo metadata and targets.
@@ -429,8 +433,7 @@ ln -sfn "${PUBLISH_REPO_OUTPUT_DIR##*/}" "${PUBLISH_REPO_OUTPUT_DIR%/*}/latest"
 ]
 
 [tasks.validate-repo]
-env = { "ALLOW_MISSING_KEY" = "true" }
-dependencies = ["publish-setup", "publish-tools"]
+dependencies = ["publish-setup-without-key", "publish-tools"]
 script_runner = "bash"
 script = [
 '''
@@ -457,8 +460,7 @@ pubsys \
 ]
 
 [tasks.check-repo-expirations]
-env = { "ALLOW_MISSING_KEY" = "true" }
-dependencies = ["publish-setup", "publish-tools"]
+dependencies = ["publish-setup-without-key", "publish-tools"]
 script_runner = "bash"
 script = [
 '''


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
When I was testing https://github.com/bottlerocket-os/bottlerocket/pull/1182 I did not notice the repo config I was testing already had a signing key defined, so `publish-setup` did not complain about a missing key. I therefore thought `publish-setup` was doing the right thing in allowing missing keys, but sadly that was not the case.

```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Oct 26 15:52:44 2020 -0700

    Revert "Makefile: remove `tasks.publish-setup-without-key`"
    
    This reverts commit 8c961cf7aa227a1c84377eba3ebd0e347f4a1858.
    
    Defining environment variables for a task with `env = { ... }`
    does not propagate the variable to the task's dependencies.

```


**Testing done:**
`tasks.fetch-sources` still runs twice, but at least it does not error out when there's no defined signing key
```
$ cargo make validate-repo -e PUBLISH_REPO=2020-02-02 --time-summary
[cargo-make] INFO - cargo make 0.32.7
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: validate-repo
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Running Task: publish-setup-tools
[cargo-make] INFO - Running Task: publish-setup
22:56:17 [INFO] Found infra config at path: 
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: publish-tools
[cargo-make] INFO - Running Task: validate-repo
22:56:18 [INFO] Using infra config from path: 
22:56:20 [INFO] Loaded TUF repo: https://updates.bottlerocket.aws/2020-02-02/aws-k8s-1.17/x86_64
22:56:21 [INFO] Downloading target: migrate_v0.4.1_add-version-lock-ignore-waves.lz4
22:56:21 [INFO] Downloading target: manifest.json
22:56:21 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-0.4.1-a29a1450-root.verity.lz4
22:56:22 [INFO] Downloading target: migrate_v0.4.1_pivot-repo-2020-07-07.lz4
22:56:22 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-0.4.1-a29a1450-root.ext4.lz4
22:56:23 [INFO] Downloading target: bottlerocket-aws-k8s-1.17-x86_64-0.4.1-a29a1450-boot.ext4.lz4
[cargo-make] INFO - ================Time Summary================
[cargo-make] INFO - validate-repo:               85.47%	   21.89 seconds
[cargo-make] INFO - tuftool:                     4.86%	   1.25 seconds
[cargo-make] INFO - fetch-sources:               3.51%	   0.90 seconds
[cargo-make] INFO - fetch-sources:               3.14%	   0.81 seconds
[cargo-make] INFO - publish-setup-tools:         1.33%	   0.34 seconds
[cargo-make] INFO - publish-tools:               1.30%	   0.33 seconds
[cargo-make] INFO - publish-setup:               0.25%	   0.07 seconds
[cargo-make] INFO - setup:                       0.09%	   0.02 seconds
[cargo-make] INFO - setup:                       0.04%	   0.01 seconds
[cargo-make] INFO - publish-setup-without-key:   0.00%	   0.00 seconds
[cargo-make] INFO - ============================================
[cargo-make] INFO - Build Done in 25 seconds.

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
