### PR TITLE
apiclient: move to async/await

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -781,6 +782,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tokio",
  "toml",
 ]
 
@@ -809,6 +811,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -1225,6 +1228,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2299,6 +2303,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2399,6 +2404,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2413,6 +2419,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2601,6 +2608,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2685,6 +2693,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2710,6 +2719,7 @@ dependencies = [
  "simplelog",
  "snafu",
  "tempfile",
+ "tokio",
  "update_metadata",
 ]
 
@@ -2766,7 +2776,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -12,10 +12,12 @@ exclude = ["README.md"]
 [dependencies]
 futures = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = { version = "0.13", default-features = false }
 hyper-unix-connector = "0.1"
 snafu = "0.6"
-tokio = { version = "0.2", features = ["stream"] }
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/apiclient/README.md
+++ b/sources/api/apiclient/README.md
@@ -44,8 +44,7 @@ apiclient -m GET -u /tx
 
 ## apiclient library
 
-The apiclient library provides simple, synchronous methods to query an HTTP API over a
-Unix-domain socket.
+The apiclient library provides simple methods to query an HTTP API over a Unix-domain socket.
 
 The `raw_request` method takes care of the basics of making an HTTP request on a Unix-domain
 socket, and requires you to specify the socket path, the URI (including query string), the

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.8"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.8"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
 
 [build-dependencies]

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -16,6 +16,9 @@ models = { path = "../../models" }
 schnauzer = { path = "../schnauzer" }
 log = "0.4"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -53,19 +53,21 @@ struct ECSConfig {
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
 // https://github.com/shepmaster/snafu/issues/110
-pub(crate) fn main() {
-    if let Err(e) = run() {
+pub(crate) async fn main() -> () {
+    if let Err(e) = run().await {
         eprintln!("{}", e);
         process::exit(1);
     }
 }
 
-fn run() -> Result<()> {
+async fn run() -> Result<()> {
     let args = parse_args(env::args());
 
     // Get all settings values for config file templates
     debug!("Requesting settings values");
-    let settings = schnauzer::get_settings(&args.socket_path).context(error::Settings)?;
+    let settings = schnauzer::get_settings(&args.socket_path)
+        .await
+        .context(error::Settings)?;
 
     debug!("settings = {:#?}", settings.settings);
     let ecs = settings

--- a/sources/api/ecs-settings-applier/src/main.rs
+++ b/sources/api/ecs-settings-applier/src/main.rs
@@ -2,8 +2,9 @@
 mod ecs;
 
 #[cfg(variant = "aws-ecs-1")]
-fn main() {
-    ecs::main()
+#[tokio::main]
+async fn main() {
+    ecs::main().await
 }
 
 #[cfg(not(variant = "aws-ecs-1"))]

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.8"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -22,6 +22,9 @@ percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -56,7 +56,7 @@ type Result<T> = std::result::Result<T, error::Error>;
 
 /// Simple helper that extends the API client, abstracting the repeated request logic and
 /// deserialization from JSON.
-pub fn get_json<T, P, S1, S2, S3>(
+pub async fn get_json<T, P, S1, S2, S3>(
     socket_path: P,
     uri: S1,
     // Query parameter name, query parameter value
@@ -80,6 +80,7 @@ where
     let method = "GET";
     trace!("{}ing from {}", method, uri);
     let (code, response_body) = apiclient::raw_request(socket_path, &uri, method, None)
+        .await
         .context(error::APIRequest { method, uri: &uri })?;
 
     if !code.is_success() {
@@ -98,12 +99,13 @@ where
 
 /// Requests all settings from the API so they can be used as the data source for a handlebars
 /// templating call.
-pub fn get_settings<P>(socket_path: P) -> Result<model::Model>
+pub async fn get_settings<P>(socket_path: P) -> Result<model::Model>
 where
     P: AsRef<Path>,
 {
     debug!("Querying API for settings data");
-    let settings: model::Model = get_json(&socket_path, "/", None as Option<(String, String)>)?;
+    let settings: model::Model =
+        get_json(&socket_path, "/", None as Option<(String, String)>).await?;
     trace!("Model values: {:?}", settings);
 
     Ok(settings)

--- a/sources/api/servicedog/Cargo.toml
+++ b/sources/api/servicedog/Cargo.toml
@@ -19,6 +19,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.8"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -17,6 +17,9 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.8"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -19,6 +19,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.8"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/sundog/src/main.rs
+++ b/sources/api/sundog/src/main.rs
@@ -157,7 +157,7 @@ use error::SundogError;
 type Result<T> = std::result::Result<T, SundogError>;
 
 /// Request the setting generators from the API.
-fn get_setting_generators<S>(socket_path: S) -> Result<HashMap<String, String>>
+async fn get_setting_generators<S>(socket_path: S) -> Result<HashMap<String, String>>
 where
     S: AsRef<str>,
 {
@@ -165,6 +165,7 @@ where
 
     debug!("Requesting setting generators from API");
     let (code, response_body) = apiclient::raw_request(socket_path.as_ref(), uri, "GET", None)
+        .await
         .context(error::APIRequest { method: "GET", uri })?;
     ensure!(
         code.is_success(),
@@ -184,7 +185,7 @@ where
 }
 
 /// Given a list of settings, query the API for any that are currently set.
-fn get_populated_settings<P>(socket_path: P, to_query: Vec<&str>) -> Result<HashSet<Key>>
+async fn get_populated_settings<P>(socket_path: P, to_query: Vec<&str>) -> Result<HashSet<Key>>
 where
     P: AsRef<Path>,
 {
@@ -197,6 +198,7 @@ where
     let uri = &format!("{}?keys={}", API_SETTINGS_URI, query);
 
     let (code, response_body) = apiclient::raw_request(socket_path.as_ref(), uri, "GET", None)
+        .await
         .context(error::APIRequest { method: "GET", uri })?;
     ensure!(
         code.is_success(),
@@ -227,7 +229,7 @@ where
 }
 
 /// Run the setting generators and collect the output
-fn get_dynamic_settings<P>(
+async fn get_dynamic_settings<P>(
     socket_path: P,
     generators: HashMap<String, String>,
 ) -> Result<model::Settings>
@@ -241,7 +243,7 @@ where
     // `generators` keys are setting names in the proper dotted
     // format, i.e. "settings.kubernetes.node-ip"
     let settings_to_query: Vec<&str> = generators.keys().map(|s| s.as_ref()).collect();
-    let populated_settings = get_populated_settings(&socket_path, settings_to_query)?;
+    let populated_settings = get_populated_settings(&socket_path, settings_to_query).await?;
 
     // For each generator, run it and capture the output
     for (setting_str, generator) in generators {
@@ -353,7 +355,7 @@ where
 }
 
 /// Send the settings to the datastore through the API
-fn set_settings<S>(socket_path: S, settings: model::Settings) -> Result<()>
+async fn set_settings<S>(socket_path: S, settings: model::Settings) -> Result<()>
 where
     S: AsRef<str>,
 {
@@ -365,6 +367,7 @@ where
     trace!("Settings to {} to {}: {}", method, uri, &request_body);
     let (code, response_body) =
         apiclient::raw_request(socket_path.as_ref(), uri, method, Some(request_body))
+            .await
             .context(error::APIRequest { method, uri })?;
     ensure!(
         code.is_success(),
@@ -439,7 +442,7 @@ fn parse_args(args: env::Args) -> Args {
     }
 }
 
-fn run() -> Result<()> {
+async fn run() -> Result<()> {
     // Parse and store the args passed to the program
     let args = parse_args(env::args());
 
@@ -450,17 +453,17 @@ fn run() -> Result<()> {
     info!("Sundog started");
 
     info!("Retrieving setting generators");
-    let generators = get_setting_generators(&args.socket_path)?;
+    let generators = get_setting_generators(&args.socket_path).await?;
     if generators.is_empty() {
         info!("No settings to generate, exiting");
         process::exit(0)
     }
 
     info!("Retrieving settings values");
-    let settings = get_dynamic_settings(&args.socket_path, generators)?;
+    let settings = get_dynamic_settings(&args.socket_path, generators).await?;
 
     info!("Sending settings values to the API");
-    set_settings(&args.socket_path, settings)?;
+    set_settings(&args.socket_path, settings).await?;
 
     Ok(())
 }
@@ -468,8 +471,9 @@ fn run() -> Result<()> {
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
 // https://github.com/shepmaster/snafu/issues/110
-fn main() {
-    if let Err(e) = run() {
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
         eprintln!("{}", e);
         process::exit(1);
     }

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -20,6 +20,9 @@ schnauzer = { path = "../schnauzer" }
 serde_json = "1"
 simplelog = "0.8"
 snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 /// Query the API for ConfigurationFile data
 #[allow(clippy::implicit_hasher)]
-pub fn get_affected_config_files<P>(
+pub async fn get_affected_config_files<P>(
     socket_path: P,
     files_limit: Option<HashSet<String>>,
 ) -> Result<model::ConfigurationFiles>
@@ -19,8 +19,9 @@ where
 
     debug!("Querying API for configuration file metadata");
     let uri = "/configuration-files";
-    let config_files: model::ConfigurationFiles =
-        schnauzer::get_json(socket_path, uri, query).context(error::GetJson { uri })?;
+    let config_files: model::ConfigurationFiles = schnauzer::get_json(socket_path, uri, query)
+        .await
+        .context(error::GetJson { uri })?;
 
     Ok(config_files)
 }

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -28,6 +28,9 @@ signpost = { path = "../../updater/signpost" }
 simplelog = "0.8.0"
 snafu = "0.6.8"
 tempfile = "3.1.0"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 update_metadata = { path = "../../updater/update_metadata" }
 
 [build-dependencies]

--- a/sources/api/thar-be-updates/src/main.rs
+++ b/sources/api/thar-be-updates/src/main.rs
@@ -182,7 +182,7 @@ macro_rules! fork_and_return {
 
 /// Spawns updog process to get list of updates and check if any of them can be updated to.
 /// Returns true if there is an available update, returns false otherwise.
-fn refresh(status: &mut UpdateStatus, socket_path: &str) -> Result<bool> {
+async fn refresh(status: &mut UpdateStatus, socket_path: &str) -> Result<bool> {
     fork_and_return!({
         debug!("Spawning 'updog whats'");
         let output = Command::new("updog")
@@ -196,7 +196,9 @@ fn refresh(status: &mut UpdateStatus, socket_path: &str) -> Result<bool> {
         }
         let update_info: Vec<update_metadata::Update> =
             serde_json::from_slice(&output.stdout).context(error::UpdateInfo)?;
-        status.update_available_updates(socket_path, update_info)
+        status
+            .update_available_updates(socket_path, update_info)
+            .await
     })
 }
 
@@ -257,7 +259,7 @@ fn deactivate(status: &mut UpdateStatus) -> Result<()> {
 }
 
 /// Given the update command, this drives the update state machine.
-fn drive_state_machine(
+async fn drive_state_machine(
     update_status: &mut UpdateStatus,
     operation: &UpdateCommand,
     socket_path: &str,
@@ -265,7 +267,7 @@ fn drive_state_machine(
     let new_state = match (operation, update_status.update_state()) {
         (UpdateCommand::Refresh, UpdateState::Idle)
         | (UpdateCommand::Refresh, UpdateState::Available) => {
-            if refresh(update_status, socket_path)? {
+            if refresh(update_status, socket_path).await? {
                 // Transitions state to `Available` if there is an available update
                 UpdateState::Available
             } else {
@@ -275,7 +277,7 @@ fn drive_state_machine(
         }
         // Refreshing the list of updates is allowed under every update state
         (UpdateCommand::Refresh, _) => {
-            refresh(update_status, socket_path)?;
+            refresh(update_status, socket_path).await?;
             // No need to transition state here as we're already beyond `Available`
             update_status.update_state().to_owned()
         }
@@ -326,7 +328,7 @@ fn drive_state_machine(
     Ok(())
 }
 
-fn run() -> Result<()> {
+async fn run() -> Result<()> {
     // Parse and store the args passed to the program
     let args = parse_args(env::args());
 
@@ -347,7 +349,7 @@ fn run() -> Result<()> {
         initialize_update_status()?;
     }
     let mut update_status = get_update_status(&lockfile)?;
-    drive_state_machine(&mut update_status, &args.subcommand, &args.socket_path)?;
+    drive_state_machine(&mut update_status, &args.subcommand, &args.socket_path).await?;
     write_update_status(&update_status)?;
     Ok(())
 }
@@ -364,8 +366,9 @@ fn match_error_to_exit_status(err: Error) -> i32 {
     .unwrap_or(1)
 }
 
-fn main() {
-    if let Err(e) = run() {
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
         eprintln!("{}", e);
         std::process::exit(match_error_to_exit_status(e));
     }

--- a/sources/api/thar-be-updates/src/status.rs
+++ b/sources/api/thar-be-updates/src/status.rs
@@ -242,7 +242,7 @@ impl UpdateStatus {
 
     /// Checks the list of updates to for an available update.
     /// If the 'version-lock'ed version is available returns true. Otherwise returns false
-    pub fn update_available_updates(
+    pub async fn update_available_updates(
         &mut self,
         socket_path: &str,
         updates: Vec<update_metadata::Update>,
@@ -254,6 +254,7 @@ impl UpdateStatus {
         let uri = "/settings";
         let method = "GET";
         let (code, response_body) = apiclient::raw_request(&socket_path, uri, method, None)
+            .await
             .context(error::APIRequest { method, uri })?;
         ensure!(
             code.is_success(),

--- a/sources/clarify.toml
+++ b/sources/clarify.toml
@@ -82,3 +82,9 @@ license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 },
     { path = "third_party/fiat/LICENSE", hash = 0xdad0527d },
 ]
+
+[clarify.tokio-macros]
+expression = "MIT"
+license-files = [
+    { path = "LICENSE", hash = 0xff97fcac },
+]


### PR DESCRIPTION
```
Previously, we created a Tokio runtime inside raw_request, and used some
(rather complicated) logic around hyper futures to get the result.  After
moving to async/await, we can use more natural APIs that depend on await, and
just read the response body into a string.

This also means that other async programs can use raw_request; no panic.

This change means that users of the apiclient library need to await its
results, and this cascades async into those function definitions, and requires
their binaries to set up a Tokio event loop, which is the bulk of the diff.
```

This is part of a cleanup of apiclient that I'm doing before adding more functionality.  I also wanted to update to tokio 0.3, but hyper hasn't quite updated yet, and hyper can't use a different tokio version's event loop.

**Testing done:**

`cargo test` OK.  I ran apiserver and apiclient locally first to confirm the basics.  I made an AMI and confirmed that all our API-related startup services are coming up OK and able to talk to the server.  `systemctl status` is `running`, no failures.  A pod worked fine.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
