### PR TITLE
apiclient: add subcommand parsing

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "hyper-unix-connector",
  "snafu",
  "tokio",
+ "unindent",
 ]
 
 [[package]]
@@ -2990,6 +2991,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "untrusted"

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -18,6 +18,7 @@ snafu = "0.6"
 tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
 # When hyper updates to tokio 0.3:
 #tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
+unindent = "0.1"
 
 [build-dependencies]
 cargo-readme = "3.1"


### PR DESCRIPTION
```
To start, the only subcommand is 'raw', which does the same thing
apiclient has always done - HTTP requests over a socket, like a
specialized curl.  This subcommand is the default, and can be omitted,
so apiclient's interface doesn't change.
```

**Description of changes:**

This will allow us to add new, higher-level modes of operation to apiclient, while keeping the same interface for the existing "raw" usage of sending HTTP requests.  It's not as fancy as an arg parser, but I tried a while with structopt, and since it doesn't handle default subcommands, I had to do a lot of hacks and the usage information was never going to be clear.

**Testing done:**

I ran a local apiserver and tested many GETs, PATCHes, and POSTs with various combinations of arguments, with and without the `raw` subcommand.  I also tested [adding a subcommand](https://gist.github.com/tjkirch/3420ee9b8c210e07749fbc2d822c2800) and it worked as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
