### PR TITLE
BUILDING: add missing setup information

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,13 +21,13 @@ Ensure the following OS packages are installed:
 ##### Ubuntu
 
 ```
-apt install build-essential libssl-dev pkg-config
+apt install build-essential openssl libssl-dev pkg-config liblz4-tool
 ```
 
 ##### Fedora
 
 ```
-yum install make automake gcc openssl-devel pkg-config
+yum install make automake gcc openssl openssl-devel pkg-config lz4 perl-FindBin perl-lib
 ```
 
 
@@ -54,6 +54,10 @@ Builds rely on Docker's integrated BuildKit support, which has received many fix
 
 You'll need to have Docker installed and running, with your user account added to the `docker` group.
 Docker's [post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/) will walk you through that.
+
+> Note: If you're on a newer Linux distribution using the unified cgroup hierarchy with cgroups v2, you may need to disable it to work with current versions of runc.
+> You'll know this is the case if you see an error like `docker: Error response from daemon: OCI runtime create failed: this version of runc doesn't work on cgroups v2: unknown.`
+> Set the kernel parameter `systemd.unified_cgroup_hierarchy=0` in your boot configuration (e.g. GRUB) and reboot.
 
 ### Build process
 


### PR DESCRIPTION
**Description of changes:**

While setting up a new machine, I found that I had to do a couple things that weren't yet in the guide.
* openssl is needed to create key/role that we put into images
* lz4 is used to compress/decompress images during build
* perl-FindBin and perl-lib are used when building openssl-sys for cargo-deny  (these were already on my Ubuntu machine from the perl-base and perl-modules packages, without my having to install them)

**Testing done:**

Set up a new build machine and confirmed `cargo make` works after these additions.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
