### PR TITLE
update SDK to v0.14.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -20,6 +20,10 @@ BUILDSYS_VERSION_IMAGE = { script = ["awk -F '[ =\"]+' '$1 == \"version\" {print
 BUILDSYS_VARIANT = "aws-k8s-1.17"
 # Product name used for file and directory naming
 BUILDSYS_NAME = "bottlerocket"
+# SDK version used for building
+BUILDSYS_SDK_VERSION="0.14.0"
+# Site for fetching the SDK
+BUILDSYS_SDK_SITE="cache.bottlerocket.aws"
 
 # These can be overridden with -e to change configuration for pubsys (`cargo
 # make repo`).  In addition, you can set RELEASE_START_TIME to determine when
@@ -77,7 +81,7 @@ DOCKER_BUILDKIT = "1"
 # on the command line.
 
 # Depends on ${BUILDSYS_ARCH}.
-BUILDSYS_SDK_IMAGE = { script = [ "echo bottlerocket/sdk-${BUILDSYS_ARCH}:v0.13.0-$(uname -m)" ] }
+BUILDSYS_SDK_IMAGE = { script = [ "echo bottlerocket/sdk-${BUILDSYS_ARCH}:v${BUILDSYS_SDK_VERSION}-$(uname -m)" ] }
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"
@@ -149,7 +153,7 @@ set -o pipefail
 if ! docker image inspect ${BUILDSYS_SDK_IMAGE} >/dev/null 2>&1 ; then
   # Let curl resolve the certificates instead of the tasks resolved bundle.
   unset SSL_CERT_FILE SSL_CERT_DIR
-  if ! curl https://cache.bottlerocket.aws/${BUILDSYS_SDK_IMAGE}.tar.gz \
+  if ! curl https://${BUILDSYS_SDK_SITE}/${BUILDSYS_SDK_IMAGE}.tar.gz \
        | gunzip | docker load ; then
     echo "failed to load '${BUILDSYS_SDK_IMAGE}'" >&2
     exit 1

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -26,7 +26,7 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %build
 %set_cross_go_flags
-go build -buildmode pie -o aws-iam-authenticator ./cmd/aws-iam-authenticator
+go build -buildmode=pie -ldflags=-linkmode=external -o aws-iam-authenticator ./cmd/aws-iam-authenticator
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -28,7 +28,7 @@ Requires: %{_cross_os}iptables
 %build
 %cross_go_configure %{goimport}
 for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
-  go build -buildmode pie -o "bin/${d##*/}" %{goimport}/${d}
+  go build -buildmode=pie -ldflags=-linkmode=external -o "bin/${d##*/}" %{goimport}/${d}
 done
 
 %install

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -27,7 +27,7 @@ Requires: %{_cross_os}iptables
 
 %build
 %cross_go_configure %{goimport}
-go build -buildmode pie -o "bin/cnitool" %{goimport}/cnitool
+go build -buildmode=pie -ldflags=-linkmode=external -o "bin/cnitool" %{goimport}/cnitool
 
 %install
 install -d %{buildroot}%{_cross_factorydir}/opt/cni/bin

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -62,7 +62,7 @@ for bin in \
   containerd-shim-runc-v2 \
   ctr ;
 do
-  go build -buildmode pie -tags="${BUILDTAGS}" -o ${bin} %{goimport}/cmd/${bin}
+  go build -buildmode=pie -ldflags=-linkmode=external -tags="${BUILDTAGS}" -o ${bin} %{goimport}/cmd/${bin}
 done
 
 %install

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -36,8 +36,8 @@ LD_PLATFORM="-X \"github.com/docker/cli/cli/version.PlatformName=Docker Engine -
 BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 LD_BUILDTIME="-X github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}"
 go build \
-  -buildmode pie \
-  -ldflags "${LD_VERSION} ${LD_GIT_REV} ${LD_PLATFORM} ${LD_BUILDTIME}" \
+  -buildmode=pie \
+  -ldflags "-linkmode=external ${LD_VERSION} ${LD_GIT_REV} ${LD_PLATFORM} ${LD_BUILDTIME}" \
   -o docker \
   %{goimport}/cmd/docker
 

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -62,7 +62,7 @@ export BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null
 export PLATFORM="Docker Engine - Community"
 chmod +x ./hack/make/.go-autogen
 ./hack/make/.go-autogen
-go build -buildmode pie -tags="${BUILDTAGS}" -o dockerd %{goimport}/cmd/dockerd
+go build -buildmode=pie -ldflags=-linkmode=external -tags="${BUILDTAGS}" -o dockerd %{goimport}/cmd/dockerd
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -31,7 +31,7 @@ cp client/mflag/LICENSE LICENSE.mflag
 
 %build
 %cross_go_configure %{goimport}
-go build -buildmode pie -o docker-proxy %{goimport}/cmd/proxy
+go build -buildmode=pie -ldflags=-linkmode=external -o docker-proxy %{goimport}/cmd/proxy
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -62,8 +62,8 @@ LD_PAUSE_CONTAINER_TAG="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultP
 LD_VERSION="-X github.com/aws/amazon-ecs-agent/agent/version.Version=%{gover}"
 LD_GIT_REV="-X github.com/aws/amazon-ecs-agent/agent/version.GitShortHash=%{gitrev}"
 go build -a \
-  -buildmode pie \
-  -ldflags "${LD_PAUSE_CONTAINER_NAME} ${LD_PAUSE_CONTAINER_TAG} ${LD_VERSION} ${LD_GIT_REV}" \
+  -buildmode=pie \
+  -ldflags "-linkmode=external ${LD_PAUSE_CONTAINER_NAME} ${LD_PAUSE_CONTAINER_TAG} ${LD_VERSION} ${LD_GIT_REV}" \
   -o amazon-ecs-agent \
   ./agent
 

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -26,7 +26,7 @@ popd
 
 %build
 %set_cross_go_flags
-go build -buildmode=pie -o host-ctr ./cmd/host-ctr
+go build -buildmode=pie -ldflags=-linkmode=external -o host-ctr ./cmd/host-ctr
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/kubernetes-1.15/kubernetes-1.15.spec
+++ b/packages/kubernetes-1.15/kubernetes-1.15.spec
@@ -63,7 +63,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 %build
 %cross_go_configure %{goimport}
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
-export GOLDFLAGS="-buildmode=pie"
+export GOLDFLAGS="-buildmode=pie -linkmode=external"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/kubernetes-1.16/kubernetes-1.16.spec
+++ b/packages/kubernetes-1.16/kubernetes-1.16.spec
@@ -59,7 +59,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 %build
 %cross_go_configure %{goimport}
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
-export GOLDFLAGS="-buildmode=pie"
+export GOLDFLAGS="-buildmode=pie -linkmode=external"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -59,7 +59,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 %build
 %cross_go_configure %{goimport}
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
-export GOLDFLAGS="-buildmode=pie"
+export GOLDFLAGS="-buildmode=pie -linkmode=external"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -56,7 +56,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 %build
 %cross_go_configure %{goimport}
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
-export GOLDFLAGS="-buildmode=pie"
+export GOLDFLAGS="-buildmode=pie -linkmode=external"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -35,7 +35,7 @@ Requires: %{_cross_os}libseccomp
 %build
 %cross_go_configure %{goimport}
 export BUILDTAGS="ambient seccomp selinux"
-go build -buildmode pie -tags="${BUILDTAGS}" -o bin/runc .
+go build -buildmode=pie -ldflags=-linkmode=external -tags="${BUILDTAGS}" -o bin/runc .
 
 %install
 install -d %{buildroot}%{_cross_bindir}


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This release of the SDK includes Rust 1.47 and Go 1.15.4. It also changes the OS used to build the C/C++ toolchain from Fedora 32 to Ubuntu 16.04, to allow the C compiler to run on older distros.

Add `-linkmode=external` to ldflags for all Go packages, which preserves the behavior of using the external linker with `-buildmode=pie`.


**Testing done:**
Built for x86_64 and aarch64 on both architectures. Verified that AMIs started correctly - all services up, no unexpected errors in the journal.

Sonobuoy tests passed for aws-k8s-1.18. Note that I used the v1.17.9 conformance image for aarch64, and v1.18.8 for x86_64, since more recent conformance images do not run on aarch64.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
