### PR TITLE
settings.network: add new proxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,27 @@ These settings can be changed at any time.
 * `settings.updates.version-lock`: Controls the version that will be selected when you issue an update request.  Can be locked to a specific version like `v1.0.0`, or `latest` to take the latest available version.  Defaults to `latest`.
 * `settings.updates.ignore-waves`: Updates are rolled out in waves to reduce the impact of issues.  For testing purposes, you can set this to `true` to ignore those waves and update immediately.
 
+#### Network settings
+
+##### Proxy settings
+
+These settings will configure the proxying behavior of the following services:
+* For all variants:
+    * [containerd.service](packages/containerd/containerd.service)
+    * [host-containerd.service](packages/host-ctr/host-containerd.service)
+* For Kubernetes variants:
+    * [kubelet.service](packages/kubernetes-1.18/kubelet.service)
+* For the ECS variant:
+    * [docker.service](packages/docker-engine/docker.service)
+    * [ecs.service](packages/ecs-agent/ecs.service)
+
+* `settings.network.https-proxy`: The HTTPS proxy server to be used by services listed above.
+* `settings.network.no-proxy`: A list of hosts that are excluded from proxying.
+
+The no-proxy list will automatically include entries for localhost.
+
+If you're running a Kubernetes variant, the no-proxy list will automatically include the Kubernetes API server endpoint and other commonly used Kubernetes DNS suffixes to facilitate intra-cluster networking.
+
 #### Time settings
 
 * `settings.ntp.time-servers`: A list of NTP servers used to set and verify the system time.

--- a/packages/containerd/containerd.service
+++ b/packages/containerd/containerd.service
@@ -5,6 +5,7 @@ After=network-online.target configured.target
 Wants=network-online.target configured.target
 
 [Service]
+EnvironmentFile=/etc/network/proxy.env
 ExecStart=/usr/bin/containerd
 Type=notify
 Delegate=yes

--- a/packages/docker-engine/docker.service
+++ b/packages/docker-engine/docker.service
@@ -10,6 +10,7 @@ StartLimitIntervalSec=60s
 
 [Service]
 Type=notify
+EnvironmentFile=/etc/network/proxy.env
 ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
 ExecReload=/bin/kill -s HUP $MAINPID
 Delegate=yes

--- a/packages/ecs-agent/ecs.service
+++ b/packages/ecs-agent/ecs.service
@@ -11,6 +11,7 @@ Restart=on-failure
 RestartPreventExitStatus=5
 RestartSec=1s
 EnvironmentFile=-/etc/ecs/ecs.config
+EnvironmentFile=/etc/network/proxy.env
 Environment=ECS_CHECKPOINT=true
 ExecStartPre=/sbin/iptables -t nat -A PREROUTING -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679

--- a/packages/host-ctr/host-containerd.service
+++ b/packages/host-ctr/host-containerd.service
@@ -5,6 +5,7 @@ After=network-online.target configured.target
 Wants=network-online.target configured.target
 
 [Service]
+EnvironmentFile=/etc/network/proxy.env
 ExecStart=/usr/bin/containerd --config /etc/host-containerd/config.toml
 Type=notify
 Delegate=yes

--- a/packages/kubernetes-1.15/kubelet.service
+++ b/packages/kubernetes-1.15/kubelet.service
@@ -7,6 +7,7 @@ BindsTo=containerd.service
 
 [Service]
 Type=notify
+EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Pull the pause container image before starting `kubelet` so `containerd/cri` wouldn't have to

--- a/packages/kubernetes-1.16/kubelet.service
+++ b/packages/kubernetes-1.16/kubelet.service
@@ -7,6 +7,7 @@ BindsTo=containerd.service
 
 [Service]
 Type=notify
+EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Pull the pause container image before starting `kubelet` so `containerd/cri` wouldn't have to

--- a/packages/kubernetes-1.17/kubelet.service
+++ b/packages/kubernetes-1.17/kubelet.service
@@ -7,6 +7,7 @@ BindsTo=containerd.service
 
 [Service]
 Type=notify
+EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Pull the pause container image before starting `kubelet` so `containerd/cri` wouldn't have to

--- a/packages/kubernetes-1.18/kubelet.service
+++ b/packages/kubernetes-1.18/kubelet.service
@@ -7,6 +7,7 @@ BindsTo=containerd.service
 
 [Service]
 Type=notify
+EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Pull the pause container image before starting `kubelet` so `containerd/cri` wouldn't have to

--- a/packages/release/proxy-env
+++ b/packages/release/proxy-env
@@ -1,0 +1,6 @@
+{{#if settings.network.https-proxy}}
+HTTPS_PROXY={{settings.network.https-proxy}}
+https_proxy={{settings.network.https-proxy}}
+{{/if}}
+NO_PROXY={{#each settings.network.no-proxy}}{{this}},{{/each}}localhost,127.0.0.1{{#if settings.kubernetes.api-server}},{{host settings.kubernetes.api-server}}{{/if}}{{#if settings.kubernetes.cluster-domain}},.{{settings.kubernetes.cluster-domain}}{{/if}}
+no_proxy={{#each settings.network.no-proxy}}{{this}},{{/each}}localhost,127.0.0.1{{#if settings.kubernetes.api-server}},{{host settings.kubernetes.api-server}}{{/if}}{{#if settings.kubernetes.cluster-domain}},.{{settings.kubernetes.cluster-domain}}{{/if}}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -13,6 +13,7 @@ Source98: release-systemd-system.conf
 Source99: release-tmpfiles.conf
 
 Source200: motd.template
+Source201: proxy-env
 
 Source1000: eth0.xml
 Source1002: configured.target
@@ -122,6 +123,7 @@ install -p -m 0644 ${LICENSEPATH}.mount %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
+install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
 
 %files
 %{_cross_factorydir}%{_cross_sysconfdir}/hosts
@@ -142,5 +144,6 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 %{_cross_unitdir}/var-lib-bottlerocket.mount
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/motd
+%{_cross_templatedir}/proxy-env
 
 %changelog

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -976,6 +976,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,6 +2396,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -3297,10 +3308,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 snafu = "0.6"
 tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+url = "2.1"
 # When hyper updates to tokio 0.3:
 #tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -122,6 +122,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("join_map", Box::new(helpers::join_map));
     template_registry.register_helper("default", Box::new(helpers::default));
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
+    template_registry.register_helper("host", Box::new(helpers::host));
 
     Ok(template_registry)
 }

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -22,7 +22,7 @@ template-path = "/usr/share/templates/motd"
 # Container runtime.
 
 [services.containerd]
-configuration-files = ["containerd-config-toml"]
+configuration-files = ["containerd-config-toml", "proxy-env"]
 restart-commands = ["/bin/systemctl try-restart containerd.service"]
 
 [configuration-files.containerd-config-toml]
@@ -32,7 +32,7 @@ template-path = "/usr/share/templates/containerd-config-toml"
 # Host-container runtime
 
 [services.host-containerd]
-configuration-files = []
+configuration-files = ["proxy-env"]
 restart-commands = ["/bin/systemctl try-restart host-containerd.service"]
 
 # Updates.
@@ -82,6 +82,15 @@ restart-commands = ["/usr/bin/host-containers"]
 
 [metadata.settings.host-containers]
 affected-services = ["host-containers"]
+
+# Network
+
+[configuration-files.proxy-env]
+path = "/etc/network/proxy.env"
+template-path = "/usr/share/templates/proxy-env"
+
+[metadata.settings.network]
+affected-services = ["containerd", "host-containerd"]
 
 # NTP
 

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
-use crate::{AwsSettings, ContainerImage, KernelSettings, NtpSettings, UpdatesSettings};
+use crate::{
+    AwsSettings, ContainerImage, KernelSettings, NetworkSettings, NtpSettings, UpdatesSettings,
+};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -13,6 +15,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
     ntp: NtpSettings,
+    network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,
 }

--- a/sources/models/src/aws-dev/override-defaults.toml
+++ b/sources/models/src/aws-dev/override-defaults.toml
@@ -5,4 +5,8 @@ template-path = "/usr/share/templates/containerd-config-toml_aws-dev"
 # Docker
 [services.docker]
 restart-commands = ["/bin/systemctl try-restart docker.service"]
-configuration-files = []
+configuration-files = ["proxy-env"]
+
+# Network
+[metadata.settings.network]
+affected-services = ["containerd", "docker", "host-containerd"]

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, ECSSettings, KernelSettings, NtpSettings, UpdatesSettings,
+    AwsSettings, ContainerImage, ECSSettings, KernelSettings, NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -15,6 +15,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
     ntp: NtpSettings,
+    network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,
     ecs: ECSSettings,

--- a/sources/models/src/aws-ecs-1/override-defaults.toml
+++ b/sources/models/src/aws-ecs-1/override-defaults.toml
@@ -5,7 +5,7 @@ template-path = "/usr/share/templates/containerd-config-toml_aws-ecs-1"
 # Docker
 [services.docker]
 restart-commands = ["/bin/systemctl try-restart docker.service"]
-configuration-files = []
+configuration-files = ["proxy-env"]
 
 # ECS
 [services.ecs]
@@ -23,3 +23,7 @@ affected-services = ["ecs"]
 allow-privileged-containers = false
 logging-drivers = ["json-file", "awslogs", "none"]
 loglevel = "info"
+
+# Network
+[metadata.settings.network]
+affected-services = ["containerd", "docker", "ecs", "host-containerd"]

--- a/sources/models/src/aws-k8s-1.15/mod.rs
+++ b/sources/models/src/aws-k8s-1.15/mod.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, KernelSettings, KubernetesSettings, NtpSettings, UpdatesSettings,
+    AwsSettings, ContainerImage, KernelSettings, KubernetesSettings, NetworkSettings, NtpSettings,
+    UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -16,6 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
     ntp: NtpSettings,
+    network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,
 }

--- a/sources/models/src/aws-k8s-1.15/override-defaults.toml
+++ b/sources/models/src/aws-k8s-1.15/override-defaults.toml
@@ -5,7 +5,7 @@ template-path = "/usr/share/templates/containerd-config-toml_aws-k8s"
 # Kubernetes.
 
 [services.kubernetes]
-configuration-files = ["kubelet-env", "kubelet-config", "kubelet-kubeconfig", "kubernetes-ca-crt"]
+configuration-files = ["kubelet-env", "kubelet-config", "kubelet-kubeconfig", "kubernetes-ca-crt", "proxy-env"]
 restart-commands = ["/bin/systemctl try-restart kubelet.service"]
 
 [configuration-files.kubelet-env]
@@ -36,3 +36,8 @@ affected-services = ["kubernetes", "containerd"]
 
 [settings.kubernetes]
 cluster-domain = "cluster.local"
+
+
+# Network
+[metadata.settings.network]
+affected-services = ["containerd", "kubernetes", "host-containerd"]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -140,6 +140,14 @@ struct ContainerImage {
     superpowered: bool,
 }
 
+// Network settings. These settings will affect host service components' network behavior
+#[model]
+struct NetworkSettings {
+    https_proxy: Url,
+    // We allow some flexibility in NO_PROXY values because different services support different formats.
+    no_proxy: Vec<SingleLineString>,
+}
+
 // NTP settings
 #[model]
 struct NtpSettings {

--- a/sources/models/src/modeled_types/shared.rs
+++ b/sources/models/src/modeled_types/shared.rs
@@ -240,6 +240,9 @@ mod test_url {
             "http://localhost",
             "localhost/path",
             "localhost",
+            "localhost:8080",
+            ".internal",
+            ".cluster.local"
         ] {
             Url::try_from(*ok).unwrap();
         }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses https://github.com/bottlerocket-os/bottlerocket/issues/1178


**Description of changes:**

```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Nov 11 00:06:23 2020 -0800

    settings.network: add new proxy settings
    
    Add new settings for configuring HTTPS_PROXY/https_proxy and
    NO_PROXY/no_proxy environment variables.
    
    These environment variables will only be exposed to a limited set
    of services that need them.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Nov 10 23:49:38 2020 -0800

    schnauzer: add `host` helper
    
    Adds a new rendering-template helper that trims a fully qualified URL
    setting down to just its host portion.

```

**Testing done:**
Set up a simple HTTPS proxy server with [tinyproxy](http://tinyproxy.github.io/) with mostly default settings.

- [x] Kubernetes Variant testing

Built aws-k8s-1.17/arm64 AMI and launched several instances with the following settings in my userdata:
```
[settings.network]
https-proxy="myhttpserver:9898"
no-proxy=[".test"]
```
Host containers, both admin and control, come up fine.

All of the nodes came up fine in my EKS cluster. Can pull images and run pods.

Checked the HTTPS proxy server access logs and observed traffic from the instances I launched:
```
INFO      Dec 11 21:23:38 [18613]: Starting main loop. Accepting connections.
CONNECT   Dec 11 21:26:53 [18625]: Connect (file descriptor 7): ec2-18-236-101-17.us-west-2.compute.amazonaws.com [18.236.101.17]
CONNECT   Dec 11 21:26:53 [18625]: Request (file descriptor 7): CONNECT api.ecr.us-west-2.amazonaws.com:443 HTTP/1.1
INFO      Dec 11 21:26:53 [18625]: No upstream proxy for api.ecr.us-west-2.amazonaws.com
INFO      Dec 11 21:26:53 [18625]: opensock: opening connection to api.ecr.us-west-2.amazonaws.com:443
INFO      Dec 11 21:26:53 [18625]: opensock: getaddrinfo returned for api.ecr.us-west-2.amazonaws.com:443
CONNECT   Dec 11 21:26:53 [18625]: Established connection to host "api.ecr.us-west-2.amazonaws.com" using file descriptor 8.
INFO      Dec 11 21:26:53 [18625]: Not sending client headers to remote machine
INFO      Dec 11 21:26:54 [18625]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:26:54 [18624]: Connect (file descriptor 7): ec2-18-236-101-17.us-west-2.compute.amazonaws.com [18.236.101.17]
CONNECT   Dec 11 21:26:54 [18624]: Request (file descriptor 7): CONNECT ec2.us-west-2.amazonaws.com:443 HTTP/1.1
INFO      Dec 11 21:26:54 [18624]: No upstream proxy for ec2.us-west-2.amazonaws.com
INFO      Dec 11 21:26:54 [18624]: opensock: opening connection to ec2.us-west-2.amazonaws.com:443
INFO      Dec 11 21:26:54 [18624]: opensock: getaddrinfo returned for ec2.us-west-2.amazonaws.com:443
CONNECT   Dec 11 21:26:54 [18624]: Established connection to host "ec2.us-west-2.amazonaws.com" using file descriptor 8.
INFO      Dec 11 21:26:54 [18624]: Not sending client headers to remote machine
INFO      Dec 11 21:26:54 [18624]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:26:54 [18625]: Connect (file descriptor 7): ec2-18-236-101-17.us-west-2.compute.amazonaws.com [18.236.101.17]
CONNECT   Dec 11 21:26:54 [18625]: Request (file descriptor 7): CONNECT api.ecr.us-west-2.amazonaws.com:443 HTTP/1.1
INFO      Dec 11 21:26:54 [18625]: No upstream proxy for api.ecr.us-west-2.amazonaws.com
INFO      Dec 11 21:26:54 [18625]: opensock: opening connection to api.ecr.us-west-2.amazonaws.com:443
INFO      Dec 11 21:26:54 [18625]: opensock: getaddrinfo returned for api.ecr.us-west-2.amazonaws.com:443
CONNECT   Dec 11 21:26:54 [18625]: Established connection to host "api.ecr.us-west-2.amazonaws.com" using file descriptor 8.
INFO      Dec 11 21:26:54 [18625]: Not sending client headers to remote machine
INFO      Dec 11 21:26:54 [18625]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:26:54 [18623]: Connect (file descriptor 7): ec2-18-236-101-17.us-west-2.compute.amazonaws.com [18.236.101.17]
CONNECT   Dec 11 21:26:54 [18623]: Request (file descriptor 7): CONNECT ec2.us-west-2.amazonaws.com:443 HTTP/1.1
INFO      Dec 11 21:26:54 [18623]: No upstream proxy for ec2.us-west-2.amazonaws.com
INFO      Dec 11 21:26:54 [18623]: opensock: opening connection to ec2.us-west-2.amazonaws.com:443
INFO      Dec 11 21:26:54 [18623]: opensock: getaddrinfo returned for ec2.us-west-2.amazonaws.com:443
CONNECT   Dec 11 21:26:54 [18623]: Established connection to host "ec2.us-west-2.amazonaws.com" using file descriptor 8.
INFO      Dec 11 21:26:54 [18623]: Not sending client headers to remote machine
INFO      Dec 11 21:28:02 [18623]: Closed connection between local client (fd:7) and remote client (fd:8)

```

Ran Kubernetes certified-conformance tests and all of them pass.

To make sure that no_proxy'ing the Kubernetes API server works, I limited the API endpoint access to within the cluster's private VPC and the nodes fail to connect to the cluster as expected if I do not no_proxy the API server endpoint. Once I do (by rendering the `proxy-env` template with `settings.kubernetes.apiserver`), the node comes up fine.


- [x] **ECS variant testing**

Launched ECS variant with https-proxy set to my https proxy server. Started a simple nginx task and it runs fine. I'm able curl localhost:80 and get the nginx welcome page.
Observed traffic on my https server:

<details>

```
CONNECT   Dec 11 21:51:47 [19062]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:47 [19062]: Request (file descriptor 7): CONNECT registry-1.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:47 [19062]: No upstream proxy for registry-1.docker.io
INFO      Dec 11 21:51:47 [19062]: opensock: opening connection to registry-1.docker.io:443
INFO      Dec 11 21:51:47 [19062]: opensock: getaddrinfo returned for registry-1.docker.io:443
CONNECT   Dec 11 21:51:47 [19062]: Established connection to host "registry-1.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:47 [19062]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:47 [18625]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:47 [18625]: Request (file descriptor 7): CONNECT auth.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:47 [18625]: No upstream proxy for auth.docker.io
INFO      Dec 11 21:51:47 [18625]: opensock: opening connection to auth.docker.io:443
INFO      Dec 11 21:51:47 [18625]: opensock: getaddrinfo returned for auth.docker.io:443
CONNECT   Dec 11 21:51:47 [18625]: Established connection to host "auth.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:47 [18625]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:47 [19056]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:47 [19056]: Request (file descriptor 7): CONNECT registry-1.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:47 [19056]: No upstream proxy for registry-1.docker.io
INFO      Dec 11 21:51:47 [19056]: opensock: opening connection to registry-1.docker.io:443
INFO      Dec 11 21:51:47 [19056]: opensock: getaddrinfo returned for registry-1.docker.io:443
CONNECT   Dec 11 21:51:47 [19056]: Established connection to host "registry-1.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:47 [19056]: Not sending client headers to remote machine
INFO      Dec 11 21:51:48 [19056]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:48 [19061]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:48 [19061]: Request (file descriptor 7): CONNECT auth.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:48 [19061]: No upstream proxy for auth.docker.io
INFO      Dec 11 21:51:48 [19061]: opensock: opening connection to auth.docker.io:443
INFO      Dec 11 21:51:48 [19061]: opensock: getaddrinfo returned for auth.docker.io:443
CONNECT   Dec 11 21:51:48 [19061]: Established connection to host "auth.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:48 [19061]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:48 [19066]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:48 [19066]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:48 [19066]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:48 [19066]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:48 [19066]: opensock: getaddrinfo returned for registry.hub.docker.com:443
CONNECT   Dec 11 21:51:48 [19066]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:48 [19066]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:48 [18624]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:48 [18624]: Request (file descriptor 7): CONNECT registry-1.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:48 [18624]: No upstream proxy for registry-1.docker.io
INFO      Dec 11 21:51:48 [18624]: opensock: opening connection to registry-1.docker.io:443
INFO      Dec 11 21:51:48 [18624]: opensock: getaddrinfo returned for registry-1.docker.io:443
CONNECT   Dec 11 21:51:48 [18624]: Established connection to host "registry-1.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:48 [18624]: Not sending client headers to remote machine
INFO      Dec 11 21:51:48 [19066]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:48 [19066]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:48 [19066]: Request (file descriptor 7): CONNECT auth.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:48 [19066]: No upstream proxy for auth.docker.io
INFO      Dec 11 21:51:48 [19066]: opensock: opening connection to auth.docker.io:443
INFO      Dec 11 21:51:48 [19066]: opensock: getaddrinfo returned for auth.docker.io:443
CONNECT   Dec 11 21:51:48 [19066]: Established connection to host "auth.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:48 [19066]: Not sending client headers to remote machine
INFO      Dec 11 21:51:48 [19066]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:48 [19072]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:48 [19072]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:48 [19072]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:48 [19072]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:48 [19072]: opensock: getaddrinfo returned for registry.hub.docker.com:443
CONNECT   Dec 11 21:51:48 [19072]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:48 [19072]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:49 [19058]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:49 [19058]: Request (file descriptor 7): CONNECT registry-1.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:49 [19058]: No upstream proxy for registry-1.docker.io
INFO      Dec 11 21:51:49 [19058]: opensock: opening connection to registry-1.docker.io:443
CONNECT   Dec 11 21:51:49 [18619]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
INFO      Dec 11 21:51:49 [19058]: opensock: getaddrinfo returned for registry-1.docker.io:443
CONNECT   Dec 11 21:51:49 [18619]: Request (file descriptor 7): CONNECT registry-1.docker.io:443 HTTP/1.1
INFO      Dec 11 21:51:49 [18619]: No upstream proxy for registry-1.docker.io
INFO      Dec 11 21:51:49 [18619]: opensock: opening connection to registry-1.docker.io:443
INFO      Dec 11 21:51:49 [18619]: opensock: getaddrinfo returned for registry-1.docker.io:443
CONNECT   Dec 11 21:51:49 [19058]: Established connection to host "registry-1.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:49 [19058]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:49 [18619]: Established connection to host "registry-1.docker.io" using file descriptor 8.
INFO      Dec 11 21:51:49 [18619]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:49 [19065]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:49 [19065]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:49 [19065]: No upstream proxy for production.cloudflare.docker.com
INFO      Dec 11 21:51:49 [19065]: opensock: opening connection to production.cloudflare.docker.com:443
INFO      Dec 11 21:51:49 [19065]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:49 [19065]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:49 [19065]: Not sending client headers to remote machine
INFO      Dec 11 21:51:49 [19072]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:49 [18623]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:49 [18623]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:49 [18623]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:49 [18623]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [18623]: opensock: getaddrinfo returned for registry.hub.docker.com:443
CONNECT   Dec 11 21:51:49 [19063]: Connect (file descriptor 7): ec2-52-36-254-125.us-west-2.compute.amazonaws.com [52.36.254.125]
CONNECT   Dec 11 21:51:49 [19063]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:49 [19063]: No upstream proxy for production.cloudflare.docker.com
INFO      Dec 11 21:51:49 [19063]: opensock: opening connection to production.cloudflare.docker.com:443
INFO      Dec 11 21:51:49 [19063]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:49 [19063]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:49 [19063]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:49 [18623]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:49 [18623]: Not sending client headers to remote machine
INFO      Dec 11 21:51:49 [18619]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:49 [18623]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:49 [19071]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:49 [18623]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:49 [19059]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:49 [18621]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:49 [19067]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:49 [19070]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:49 [18623]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
CONNECT   Dec 11 21:51:49 [19071]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
CONNECT   Dec 11 21:51:49 [18621]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
CONNECT   Dec 11 21:51:49 [19059]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
CONNECT   Dec 11 21:51:49 [19067]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:49 [18621]: No upstream proxy for registry.hub.docker.com
CONNECT   Dec 11 21:51:49 [19070]: Request (file descriptor 7): CONNECT registry.hub.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:49 [19059]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:49 [19071]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:49 [18623]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:49 [18621]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19067]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:49 [19070]: No upstream proxy for registry.hub.docker.com
INFO      Dec 11 21:51:49 [19071]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19059]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19067]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [18623]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [18621]: opensock: getaddrinfo returned for registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19071]: opensock: getaddrinfo returned for registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19070]: opensock: opening connection to registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19067]: opensock: getaddrinfo returned for registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19059]: opensock: getaddrinfo returned for registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [18623]: opensock: getaddrinfo returned for registry.hub.docker.com:443
INFO      Dec 11 21:51:49 [19070]: opensock: getaddrinfo returned for registry.hub.docker.com:443
CONNECT   Dec 11 21:51:49 [19071]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
CONNECT   Dec 11 21:51:49 [19059]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:49 [19059]: Not sending client headers to remote machine
INFO      Dec 11 21:51:49 [19071]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:49 [18621]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
CONNECT   Dec 11 21:51:49 [18623]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:49 [18621]: Not sending client headers to remote machine
INFO      Dec 11 21:51:49 [18623]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:49 [19070]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:49 [19070]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:49 [19067]: Established connection to host "registry.hub.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:49 [19067]: Not sending client headers to remote machine
INFO      Dec 11 21:51:50 [19059]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:50 [19056]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:50 [19056]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:50 [19070]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [19056]: No upstream proxy for production.cloudflare.docker.com
CONNECT   Dec 11 21:51:50 [19070]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
INFO      Dec 11 21:51:50 [19071]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:50 [19070]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:50 [19056]: opensock: opening connection to production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:50 [19066]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
INFO      Dec 11 21:51:50 [19070]: No upstream proxy for production.cloudflare.docker.com
INFO      Dec 11 21:51:50 [19056]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
INFO      Dec 11 21:51:50 [19070]: opensock: opening connection to production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:50 [19066]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:50 [19066]: No upstream proxy for production.cloudflare.docker.com
INFO      Dec 11 21:51:50 [19070]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
INFO      Dec 11 21:51:50 [18621]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [19066]: opensock: opening connection to production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:50 [19059]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:50 [19059]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:50 [19066]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
INFO      Dec 11 21:51:50 [19059]: No upstream proxy for production.cloudflare.docker.com
CONNECT   Dec 11 21:51:50 [19056]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:50 [19059]: opensock: opening connection to production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:50 [19070]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:50 [19056]: Not sending client headers to remote machine
INFO      Dec 11 21:51:50 [19059]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
INFO      Dec 11 21:51:50 [19070]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:50 [19066]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:50 [19066]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:50 [19059]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:50 [19059]: Not sending client headers to remote machine
INFO      Dec 11 21:51:50 [19067]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:50 [18619]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:50 [18619]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:50 [18619]: No upstream proxy for production.cloudflare.docker.com
INFO      Dec 11 21:51:50 [18623]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [18619]: opensock: opening connection to production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:50 [19067]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:50 [19067]: Request (file descriptor 7): CONNECT production.cloudflare.docker.com:443 HTTP/1.1
INFO      Dec 11 21:51:50 [18619]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
INFO      Dec 11 21:51:50 [19067]: No upstream proxy for production.cloudflare.docker.com
INFO      Dec 11 21:51:50 [19067]: opensock: opening connection to production.cloudflare.docker.com:443
INFO      Dec 11 21:51:50 [19067]: opensock: getaddrinfo returned for production.cloudflare.docker.com:443
CONNECT   Dec 11 21:51:50 [18619]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:50 [18619]: Not sending client headers to remote machine
CONNECT   Dec 11 21:51:50 [19067]: Established connection to host "production.cloudflare.docker.com" using file descriptor 8.
INFO      Dec 11 21:51:50 [19067]: Not sending client headers to remote machine
INFO      Dec 11 21:51:50 [19056]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [19070]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [19066]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [18619]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [19059]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:50 [19067]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:52 [18625]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:52 [19062]: Closed connection between local client (fd:7) and remote client (fd:8)
CONNECT   Dec 11 21:51:53 [19062]: Connect (file descriptor 7): ec2-44-242-151-120.us-west-2.compute.amazonaws.com [44.242.151.120]
CONNECT   Dec 11 21:51:53 [19062]: Request (file descriptor 7): CONNECT ecs.us-west-2.amazonaws.com:443 HTTP/1.1
INFO      Dec 11 21:51:53 [19062]: No upstream proxy for ecs.us-west-2.amazonaws.com
INFO      Dec 11 21:51:53 [19062]: opensock: opening connection to ecs.us-west-2.amazonaws.com:443
INFO      Dec 11 21:51:53 [19062]: opensock: getaddrinfo returned for ecs.us-west-2.amazonaws.com:443
CONNECT   Dec 11 21:51:53 [19062]: Established connection to host "ecs.us-west-2.amazonaws.com" using file descriptor 8.
INFO      Dec 11 21:51:53 [19062]: Not sending client headers to remote machine
INFO      Dec 11 21:51:53 [19061]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:54 [19058]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:54 [18624]: Closed connection between local client (fd:7) and remote client (fd:8)
INFO      Dec 11 21:51:59 [19062]: Closed connection between local client (fd:7) and remote client (fd:8)

``` 

</details>

- [x] Testing the restart commands
Launched instance without specifying proxy settings. 
After host comes up, change proxy settings to route traffic through my https proxy server:
```bash
apiclient -u /settings -m PATCH -d '{"network": {"https-proxy": "myhttpsserver:9898", "no-proxy":[".local"]}}'
apiclient -u /tx/commit_and_apply -m POST
```

Observed that containerd, kubelet, host-containerd all restarted successfully and pod workloads continued without problems.

Please let me know if there is anything else that needs to be tested.

**Note: The migration for the new settings will fast-follow this PR.**

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
