### PR TITLE
pubsys: fix kms signing issue

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -135,6 +135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,12 +302,12 @@ dependencies = [
 
 [[package]]
 name = "coldsnap"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fd66a760caaf8647b3e60a068a03f4adee0091338c69b05a46d263e9efa3bd"
+checksum = "4e1073ef4f7d65b3df89ce61595ff7fcad286b1d82ff646c360547ac75df1901"
 dependencies = [
  "argh",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytes",
  "futures",
  "indicatif",
@@ -510,21 +516,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -848,19 +839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,24 +1041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,37 +1128,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
-dependencies = [
- "bitflags",
- "cfg-if 0.1.10",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_pipe"
@@ -1296,12 +1229,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
@@ -1610,7 +1537,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-tls",
+ "hyper-rustls 0.20.0",
  "lazy_static",
  "log",
  "md5",
@@ -2417,16 +2344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,12 +2577,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1623,14 +1623,14 @@ dependencies = [
 
 [[package]]
 name = "rusoto_kms"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5a083f44d08db76d4deedd7527bb215dd008fa08f4b1d8ca40071522bdbcb7"
+checksum = "111b99b940b1b02f5a98a5fcc96467a24ab899c43c1caff60d4a863342798c6e"
 dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "rusoto_core 0.44.0",
+ "rusoto_core 0.45.0",
  "serde",
  "serde_json",
 ]
@@ -2413,15 +2413,15 @@ dependencies = [
 
 [[package]]
 name = "tough-kms"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d5273998150708e8639464e4fe21eba7afbf7372f57f4d7ae0dabffd3d8dab"
+checksum = "cfb9491d4cc35dafcb72c69254c27da97bad4d5796305ffe9974ed1f470ffc39"
 dependencies = [
  "bytes",
  "pem",
  "ring",
- "rusoto_core 0.44.0",
- "rusoto_credential 0.44.0",
+ "rusoto_core 0.45.0",
+ "rusoto_credential 0.45.0",
  "rusoto_kms",
  "snafu",
  "tokio",

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -36,7 +36,7 @@ tinytemplate = "1.1"
 tokio = { version = "0.2.21", features = ["time"] }
 toml = "0.5"
 tough = { version = "0.9", features = ["http"] }
-tough-kms = "0.1"
+tough-kms = "0.1.1"
 tough-ssm = "0.4"
 update_metadata = { path = "../../sources/updater/update_metadata/" }
 url = { version = "2.1.0", features = ["serde"] }

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 async-trait = "0.1.36"
 chrono = "0.4"
 clap = "2.33"
-coldsnap = "0.1"
+coldsnap = { version = "0.2", default-features = false, features = ["rusoto-rustls"]}
 pubsys-config = { path = "../pubsys-config/" }
 futures = "0.3.5"
 indicatif = "0.15.0"
@@ -19,13 +19,13 @@ log = "0.4"
 parse-datetime = { path = "../../sources/parse-datetime" }
 # Need to bring in reqwest with a TLS feature so tough can support TLS repos.
 reqwest = { version = "0.10.1", default-features = false, features = ["rustls-tls", "blocking"] }
-rusoto_core = "0.45.0"
+rusoto_core = { version = "0.45.0", default-features = false, features = ["rustls"] }
 rusoto_credential = "0.45.0"
-rusoto_ebs = "0.45.0"
-rusoto_ec2 = "0.45.0"
+rusoto_ebs = { version = "0.45.0", default-features = false, features = ["rustls"] }
+rusoto_ec2 = { version = "0.45.0", default-features = false, features = ["rustls"] }
 rusoto_signature = "0.45.0"
-rusoto_ssm = "0.45.0"
-rusoto_sts = "0.45.0"
+rusoto_ssm = { version = "0.45.0", default-features = false, features = ["rustls"] }
+rusoto_sts = { version = "0.45.0", default-features = false, features = ["rustls"] }
 simplelog = "0.8"
 snafu = "0.6"
 semver = "0.11.0"


### PR DESCRIPTION

**Issue number:**

https://github.com/awslabs/tough/issues/262

**Description of changes:**

In `pubsys`:

- update tough-kms to v0.1.1 to fix an intermittent issue where a repo could be produced that was not loadable
- coldsnap needed to be updated because of some conflicts with rustls in rusoto when updating tough-kms

**Testing done:**

 - [x] `cargo make repo` works with a KMS key when creating a new repo.
 - [x] The above repo can be loaded with tuftool download.
 - [x] `cargo make ami` works with the new coldsnap version.
 - [x] `cargo make repo` works with a KMS key when updating an existing repo.
 - [x] The above repo can be loaded with tuftool download.
 - [x] @etungsten should be able to tell us if his signing automation scripts are fixed by this branch/sha.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
