### PR TITLE
disable keyed hashes for the systemd journal

### DIFF
--- a/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
@@ -1,7 +1,7 @@
-From f138446c6b5f931d143c036cc4e2d33a5979d42b Mon Sep 17 00:00:00 2001
+From 659b1d5916b16e0d0bde877a25a340c45278ef38 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 17 Sep 2019 01:35:51 +0000
-Subject: [PATCH 9001/9005] use absolute path for /var/run symlink
+Subject: [PATCH 9001/9006] use absolute path for /var/run symlink
 
 Otherwise the symlink may be broken if /var is a bind mount from
 somewhere else.

--- a/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
+++ b/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
@@ -1,7 +1,7 @@
-From 0626e5d7b323a62b251ef66742b3b65d4531eacf Mon Sep 17 00:00:00 2001
+From 6319499bc376c8e0843573261f395071ff03db90 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 10 Mar 2020 20:30:10 +0000
-Subject: [PATCH 9002/9005] core: add separate timeout for system shutdown
+Subject: [PATCH 9002/9006] core: add separate timeout for system shutdown
 
 There is an existing setting for this (DefaultTimeoutStopUSec), but
 changing it has no effect because `reset_arguments()` is called just

--- a/packages/systemd/9003-repart-always-use-random-UUIDs.patch
+++ b/packages/systemd/9003-repart-always-use-random-UUIDs.patch
@@ -1,7 +1,7 @@
-From dee2b33e3d7969210078d483f6575a347904bdff Mon Sep 17 00:00:00 2001
+From 42b00096598978558b8abb3e03daab9e3315b98d Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 16 Apr 2020 15:10:41 +0000
-Subject: [PATCH 9003/9005] repart: always use random UUIDs
+Subject: [PATCH 9003/9006] repart: always use random UUIDs
 
 We would like to avoid adding OpenSSL to the base OS, and for our use
 case we do not need the UUIDs assigned to disks or partitions to be

--- a/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen.patch
+++ b/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen.patch
@@ -1,7 +1,7 @@
-From d37bf45e3f00f4a3c87a0b6c6bbbf19a54fd0957 Mon Sep 17 00:00:00 2001
+From a659db335da0bf8e27c851fe3f8ae30c7c0f5eaf Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 7 Jul 2020 22:38:20 +0000
-Subject: [PATCH 9004/9005] machine-id-setup: generate stable ID under Xen
+Subject: [PATCH 9004/9006] machine-id-setup: generate stable ID under Xen
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 ---

--- a/packages/systemd/9005-core-mount-etc-with-specific-label.patch
+++ b/packages/systemd/9005-core-mount-etc-with-specific-label.patch
@@ -1,7 +1,7 @@
-From 322a02dd4bd9bfe17bacb4dd1e792a5293c18342 Mon Sep 17 00:00:00 2001
+From f7d3e4c5d991d910b6d73d357908dbf9fa6a631b Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 9 Jul 2020 20:00:36 +0000
-Subject: [PATCH 9005/9005] core: mount /etc with specific label
+Subject: [PATCH 9005/9006] core: mount /etc with specific label
 
 The filesystem is mounted after we load the SELinux policy, so we can
 apply the label we need to restrict access.

--- a/packages/systemd/9006-journal-disable-keyed-hashes-for-compatibility.patch
+++ b/packages/systemd/9006-journal-disable-keyed-hashes-for-compatibility.patch
@@ -1,0 +1,38 @@
+From 3d93e3d1e9bae766e6c436e9fbf4b156fcc44bca Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 12 Nov 2020 16:18:15 +0000
+Subject: [PATCH 9006/9006] journal: disable keyed hashes for compatibility
+
+Otherwise the journal is not readable by older versions of systemd.
+
+This is applied as a patch so it will fail to apply when upstream
+removes the environment variable override.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ src/journal/journal-file.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/journal/journal-file.c b/src/journal/journal-file.c
+index cdcded2..abfa14c 100644
+--- a/src/journal/journal-file.c
++++ b/src/journal/journal-file.c
+@@ -3390,13 +3390,12 @@ int journal_file_open(
+ #endif
+         };
+ 
+-        /* We turn on keyed hashes by default, but provide an environment variable to turn them off, if
+-         * people really want that */
++        /* Turn off keyed hashes by default. */
+         r = getenv_bool("SYSTEMD_JOURNAL_KEYED_HASH");
+         if (r < 0) {
+                 if (r != -ENXIO)
+                         log_debug_errno(r, "Failed to parse $SYSTEMD_JOURNAL_KEYED_HASH environment variable, ignoring.");
+-                f->keyed_hash = true;
++                f->keyed_hash = false;
+         } else
+                 f->keyed_hash = r;
+ 
+-- 
+2.26.2
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -30,6 +30,11 @@ Patch9004: 9004-machine-id-setup-generate-stable-ID-under-Xen.patch
 # Local patch to handle mounting /etc with our SELinux label.
 Patch9005: 9005-core-mount-etc-with-specific-label.patch
 
+# Local patch to disable the keyed hashes feature in the journal, which
+# makes it unreadable by older versions of systemd. Can be dropped once
+# there's sufficiently broad adoption of systemd >= 246.
+Patch9006: 9006-journal-disable-keyed-hashes-for-compatibility.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**
Fixes #1200


**Description of changes:**
Disable keyed hashes for the systemd journal, to retain compatibility with older releases of systemd.


**Testing done:**

Old behavior -
```
$ sudo journalctl -D /.bottlerocket/rootfs/var/log/journal/
Journal file /.bottlerocket/rootfs/var/log/journal/fc41112f488d4d299f8efa06ad0e0172/system.journal uses an unsupported feature, ignoring file.
Use SYSTEMD_LOG_LEVEL=debug journalctl --file=/.bottlerocket/rootfs/var/log/journal/fc41112f488d4d299f8efa06ad0e0172/system.journal to see the details.
-- No entries --
```

New behavior -
```
$ sudo journalctl -D /.bottlerocket/rootfs/var/log/journal/
-- Logs begin at Thu 2020-11-12 16:31:05 UTC, end at Thu 2020-11-12 16:33:17 UTC. --
Nov 12 16:31:05 localhost kernel: Booting Linux on physical CPU 0x0000000000 [0x413fd0c1]
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
