### PR TITLE
add compatibility symlink for cert bundle

### DIFF
--- a/packages/ca-certificates/ca-certificates-tmpfiles.conf
+++ b/packages/ca-certificates/ca-certificates-tmpfiles.conf
@@ -1,1 +1,2 @@
 C /etc/pki/tls/certs/ca-bundle.crt - - - -
+L /etc/ssl/certs - - - - ../pki/tls/certs

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -7,7 +7,7 @@ License: MPL-2.0
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
 Source0: https://curl.haxx.se/ca/cacert-2020-10-14.pem
-Source1: ca-certificates.conf
+Source1: ca-certificates-tmpfiles.conf
 
 %description
 %{summary}.


### PR DESCRIPTION
**Issue number:**
Fixes #1202


**Description of changes:**
Add a symlink for the path where the cluster autoscaler expects to find the CA certificate bundle.

Also renames the tmpfiles snippet to follow the convention we've since adopted elsewhere, to distinguish it from other "conf" files.

**Testing done:**
Verified that the symlink is created.

```
# ls -latr /etc/ssl/certs
lrwxrwxrwx. 1 root root 16 Nov 12 16:52 /etc/ssl/certs -> ../pki/tls/certs

# ls -latr /etc/ssl/certs/ca-bundle.crt
-rw-r--r--. 1 root root 221418 Nov  6 18:35 /etc/ssl/certs/ca-bundle.crt
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
