### PR TITLE
docker: depend on procps for "docker top"

### DIFF
--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -40,6 +40,7 @@ Requires: %{_cross_os}containerd
 Requires: %{_cross_os}libseccomp
 Requires: %{_cross_os}iptables
 Requires: %{_cross_os}systemd
+Requires: %{_cross_os}procps
 
 %description
 %{summary}.


### PR DESCRIPTION
**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1134


**Description of changes:**
Add `procps` as a dependency of `docker` so `docker top` works.


**Testing done:**
Built an `aws-ecs-1` AMI, launched it, and ran `docker top`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
