### PR TITLE
thar-be-updates: reduce tokio runtime scope

### DIFF
--- a/sources/api/thar-be-updates/src/error.rs
+++ b/sources/api/thar-be-updates/src/error.rs
@@ -148,6 +148,9 @@ pub enum Error {
 
     #[snafu(display("Logger setup error: {}", source))]
     Logger { source: simplelog::TermLogError },
+
+    #[snafu(display("Unable to create a tokio runtime: {}", source))]
+    Runtime { source: std::io::Error },
 }
 
 /// Map errors to specific exit codes to return to caller


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#1212

**Description of changes:**

Demonstrates a possible fix for the issue where the tokio runtime cannot survive forking and hangs the process. Consider this 'option 1'.

**Testing done:**

None yet.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
