### PR TITLE
thar-be-updates: manage tokio runtime manually so we don't fork threads

### DIFF
--- a/sources/api/thar-be-updates/src/error.rs
+++ b/sources/api/thar-be-updates/src/error.rs
@@ -148,6 +148,9 @@ pub enum Error {
 
     #[snafu(display("Logger setup error: {}", source))]
     Logger { source: simplelog::TermLogError },
+
+    #[snafu(display("Unable to create a tokio runtime: {}", source))]
+    Runtime { source: std::io::Error },
 }
 
 /// Map errors to specific exit codes to return to caller

--- a/sources/api/thar-be-updates/src/status.rs
+++ b/sources/api/thar-be-updates/src/status.rs
@@ -5,11 +5,12 @@ use chrono::{DateTime, Utc};
 use model::modeled_types::FriendlyVersion;
 use serde::{Deserialize, Serialize};
 use signpost::State;
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::{OptionExt, ResultExt};
 use std::convert::TryInto;
 use std::fs::File;
 use std::os::unix::process::ExitStatusExt;
 use std::process::Output;
+use tokio::runtime::Runtime;
 
 pub const UPDATE_LOCKFILE: &str = "/run/lock/thar-be-updates.lock";
 pub const UPDATE_STATUS_FILE: &str = "/run/cache/thar-be-updates/status.json";
@@ -104,6 +105,24 @@ pub fn get_update_status(_lockfile: &File) -> Result<UpdateStatus> {
             path: UPDATE_STATUS_FILE,
         })?,
     )
+}
+
+/// Retrieves settings from the API.
+///
+/// NOTE: this function creates its own tokio runtime to make the async apiclient call.  It should
+/// not be called if you're running another tokio runtime.  The program structure requires forking
+/// to handle long-running update actions, and the tokio runtime uses threading, which generally
+/// isn't safe over forks; instead, we create and drop one here for the short period we need it.
+fn get_settings(socket_path: &str) -> Result<serde_json::Value> {
+    let uri = "/settings";
+    let method = "GET";
+
+    let mut rt = Runtime::new().context(error::Runtime)?;
+    let try_response_body =
+        rt.block_on(async { apiclient::raw_request(&socket_path, uri, method, None).await });
+    let (_code, response_body) = try_response_body.context(error::APIRequest { method, uri })?;
+
+    serde_json::from_str(&response_body).context(error::ResponseJson { uri })
 }
 
 // This is how the UpdateStatus is stored on disk
@@ -242,7 +261,7 @@ impl UpdateStatus {
 
     /// Checks the list of updates to for an available update.
     /// If the 'version-lock'ed version is available returns true. Otherwise returns false
-    pub async fn update_available_updates(
+    pub fn update_available_updates(
         &mut self,
         socket_path: &str,
         updates: Vec<update_metadata::Update>,
@@ -251,22 +270,7 @@ impl UpdateStatus {
         self.available_updates = updates.iter().map(|u| u.version.to_owned()).collect();
         // Check if the 'version-lock'ed update is available as the 'chosen' update
         // Retrieve the 'version-lock' setting
-        let uri = "/settings";
-        let method = "GET";
-        let (code, response_body) = apiclient::raw_request(&socket_path, uri, method, None)
-            .await
-            .context(error::APIRequest { method, uri })?;
-        ensure!(
-            code.is_success(),
-            error::APIResponse {
-                method,
-                uri,
-                code,
-                response_body,
-            }
-        );
-        let settings: serde_json::Value =
-            serde_json::from_str(&response_body).context(error::ResponseJson { uri })?;
+        let settings = get_settings(socket_path)?;
         let locked_version: FriendlyVersion = serde_json::from_value(
             settings["updates"]["version-lock"].to_owned(),
         )


### PR DESCRIPTION
**Issue number:**

Fixes #1212

**Description of changes:**

```
The `refresh` command needs to talk to the API to get the current version-lock
setting.  390aafe3ebf made apiclient::raw_request an async call and changed
thar-be-settings to use tokio::main, but didn't consider that the async call is
happening after a fork in thar-be-updates.  In general it's not safe to use the
threaded tokio runtime over a fork, and it caused thar-be-updates to hang,
holding its lock file forever.

This undoes the changes from 390aafe3ebf for thar-be-updates so it doesn't have
a global runtime, and instead creates a runtime just for the single async call
we need to make, after the fork.
```

Note: `raw_request` already does the `code.is_success()` check, so I didn't include that in the new `get_settings` function.

**Testing done:**

Since 390aafe3ebf, calling `thar-be-updates refresh` would leave a process hanging and holding the lock file, so future update-related API calls would get an error like this forever:

```
Failed to check for updates: Failed getting update status: Status 423 when GETing /updates/status: Unable to obtain shared lock for reading update status: Resource temporarily unavailable (os error 11)
```

After this fix, I prepared a repo with an update, refreshed updates, confirmed that no processes were hanging, and saw the expected available update:
```json
{"update_state":"Available","available_updates":["1.0.3","1.0.2","1.0.2"],"chosen_update":{"arch":"x86_64","version":"1.0.3","variant":"aws-k8s-1.17"},"active_partition":{"image":{"arch":"x86_64","version":"1.0.2","variant":"aws-k8s-1.17"},"next_to_boot":true},"staging_partition":null,"most_recent_command":{"cmd_type":"refresh","cmd_status":"Success","timestamp":"2020-11-14T23:14:43.752064370Z","exit_status":0,"stderr":""}}
```

I also confirmed I could still prepare and activate an update successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
