### PR TITLE
thar-be-updates: fix early return upon error

### DIFF
--- a/sources/api/thar-be-updates/src/main.rs
+++ b/sources/api/thar-be-updates/src/main.rs
@@ -347,9 +347,13 @@ fn run() -> Result<()> {
         initialize_update_status()?;
     }
     let mut update_status = get_update_status(&lockfile)?;
-    drive_state_machine(&mut update_status, &args.subcommand, &args.socket_path)?;
+
+    // The commands inside drive_state_machine update the update_status object (hence &mut) to
+    // reflect success or failure, and we want to reflect that in our status file regardless of
+    // success, so we store the result rather than returning early here.
+    let result = drive_state_machine(&mut update_status, &args.subcommand, &args.socket_path);
     write_update_status(&update_status)?;
-    Ok(())
+    result
 }
 
 fn match_error_to_exit_status(err: Error) -> i32 {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Tangentially related  to https://github.com/bottlerocket-os/bottlerocket/issues/1212


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Sat Nov 14 16:00:42 2020 -0800

    thar-be-updates: fix early return upon error
    
    Fixes an issue where if when we encounter an error, we return too early
    and fail to update the update status file with the most recent command
    status.

```


**Testing done:**
Prior to this change, if t-b-u encountered an error with the update, it would exit before writing the updated status to the update status file.
With this change that no longer happens:

Using a bogus metadata base url, my refresh-updates command failed but t-b-u was able to write to the update status file before exiting.

```
bash-5.0# apiclient -u /actions/refresh-updates -m POST
bash-5.0# apiclient -u /updates/status
{"update_state":"Idle","available_updates":[],"chosen_update":null,"active_partition":{"image":{"arch":"x86_64","version":"1.0.2","variant":"aws-k8s-1.17"},"next_to_boot":true},"staging_partition":null,"most_recent_command":{"cmd_type":"refresh","cmd_status":"Failed","timestamp":"2020-11-15T02:55:47.856794834Z","exit_status":1,"stderr":"Metadata error: Failed to fetch https://blah.cloudfront.net/timestamp.json: Error fetching target from 'https://blah.cloudfront.net/timestamp.json?seed=46&version=1.0.2': HTTP status client error (403 Forbidden) for url (https://blah.cloudfront.net/timestamp.json?seed=46&version=1.0.2)\n"}}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
