### PR TITLE
sysctl migration: also remove services.sysctl

### DIFF
--- a/sources/api/migration/migrations/v1.0.3/add-sysctl/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.3/add-sysctl/src/main.rs
@@ -1,13 +1,16 @@
 #![deny(rust_2018_idioms)]
 
-use migration_helpers::common_migrations::AddPrefixMigration;
+use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;
 
 /// We added the ability to set sysctl keys via API settings.  We don't want to track all possible
 /// Linux sysctl keys, so we remove the whole prefix if we downgrade.
 fn run() -> Result<()> {
-    migrate(AddPrefixMigration("settings.kernel.sysctl"))
+    migrate(AddPrefixesMigration(vec![
+        "settings.kernel.sysctl",
+        "services.sysctl",
+    ]))
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu


### PR DESCRIPTION
```
Without this, downgrading to 1.0.2 results in corndog being called as a
restart-command when the corndog binary no longer exists.

AddPrefixMigration becomes AddPrefixesMigration; as we learned with
AddSettingMigration, it's simpler to take a list, and sysctl was the only user
of AddPrefixMigration so far.
```

**Testing done:**

```
> ../../target/debug/add-sysctl --source-datastore ~/.api-datastore/v0.0.1_DEOwFggAMTERp6g9/ --target-datastore ./forward --forward
AddPrefixesMigration(["settings.kernel.sysctl", "services.sysctl"]) has no work to do on upgrade.
```
```
> ../../target/debug/add-sysctl --source-datastore ~/.api-datastore/v0.0.1_DEOwFggAMTERp6g9/ --target-datastore ./backward --backward
Removed services.sysctl.restart-commands, which was set to '["/usr/bin/corndog"]'
Removed services.sysctl.configuration-files, which was set to '[]'
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
