### PR TITLE
improve support for out-of-tree kernel modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /.gomodcache
 /build/**/*.img
 /build/**/*.lz4
+/build/**/*.xz
 /build/**/*.tar
 /build/**/*-debuginfo-*.rpm
 /build/**/*-debugsource-*.rpm

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,6 +7,7 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 BUILDSYS_BUILD_DIR = "${BUILDSYS_ROOT_DIR}/build"
 BUILDSYS_PACKAGES_DIR = "${BUILDSYS_BUILD_DIR}/rpms"
 BUILDSYS_IMAGES_DIR = "${BUILDSYS_BUILD_DIR}/images"
+BUILDSYS_ARCHIVES_DIR = "${BUILDSYS_BUILD_DIR}/archives"
 BUILDSYS_TOOLS_DIR = "${BUILDSYS_ROOT_DIR}/tools"
 BUILDSYS_SOURCES_DIR = "${BUILDSYS_ROOT_DIR}/sources"
 BUILDSYS_TIMESTAMP = { script = ["date +%s"] }
@@ -80,8 +81,9 @@ DOCKER_BUILDKIT = "1"
 # Certain variables are defined here to allow us to override a component value
 # on the command line.
 
-# Depends on ${BUILDSYS_ARCH}.
+# Depends on ${BUILDSYS_ARCH} and ${BUILDSYS_SDK_VERSION}.
 BUILDSYS_SDK_IMAGE = { script = [ "echo bottlerocket/sdk-${BUILDSYS_ARCH}:v${BUILDSYS_SDK_VERSION}-$(uname -m)" ] }
+BUILDSYS_TOOLCHAIN = { script = [ "echo bottlerocket/toolchain-${BUILDSYS_ARCH}:v${BUILDSYS_SDK_VERSION}-${BUILDSYS_ARCH}" ] }
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"
@@ -153,7 +155,7 @@ set -o pipefail
 if ! docker image inspect ${BUILDSYS_SDK_IMAGE} >/dev/null 2>&1 ; then
   # Let curl resolve the certificates instead of the tasks resolved bundle.
   unset SSL_CERT_FILE SSL_CERT_DIR
-  if ! curl https://${BUILDSYS_SDK_SITE}/${BUILDSYS_SDK_IMAGE}.tar.gz \
+  if ! curl --silent --fail --show-error https://${BUILDSYS_SDK_SITE}/${BUILDSYS_SDK_IMAGE}.tar.gz \
        | gunzip | docker load ; then
     echo "failed to load '${BUILDSYS_SDK_IMAGE}'" >&2
     exit 1
@@ -261,6 +263,63 @@ cargo build \
   --all
 '''
 ]
+
+[tasks.build-kmod-kit]
+dependencies = ["build-packages"]
+script = [
+'''
+mkdir -p "${BUILDSYS_ARCHIVES_DIR}"
+kmod_kit="${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-kmod-kit-v${BUILDSYS_VERSION_IMAGE}"
+rm -f "${BUILDSYS_ARCHIVES_DIR}/${kmod_kit}.tar.xz"
+
+# Find the most recent kernel archive. If we have more than one, we want the
+# last one that was built.
+kernel_archive="$(find "${BUILDSYS_PACKAGES_DIR}" \
+  -type f -name '*-'"${BUILDSYS_ARCH}"'-kernel-archive-*.rpm' \
+  -printf '%T@ %f\n' | sort -r | awk 'NR==1{print $2}')"
+
+prepare_kmod_kit="
+set -e -o pipefail
+
+mkdir /tmp/${kmod_kit}
+
+# Retrieve the toolchain and kernel archives.
+curl --silent --fail --show-error --output /tmp/${kmod_kit}/toolchain.tar.xz \
+  https://${BUILDSYS_SDK_SITE}/${BUILDSYS_TOOLCHAIN}.tar.xz
+find ./rpms -name "${kernel_archive}" \
+  -exec rpm2cpio {} \; | cpio -idmu --quiet
+find -name 'kernel-devel.tar.xz' -exec mv {} /tmp/${kmod_kit} \;
+
+# Extract them into the same directory.
+pushd /tmp/${kmod_kit} >/dev/null
+tar xf kernel-devel.tar.xz
+rm kernel-devel.tar.xz
+tar xf toolchain.tar.xz
+rm toolchain.tar.xz
+popd >/dev/null
+
+# Merge them together into a unified archive.
+pushd /tmp >/dev/null
+tar cf ${kmod_kit}.tar ${kmod_kit}
+xz -T0 ${kmod_kit}.tar
+popd >/dev/null
+
+mv /tmp/${kmod_kit}.tar.xz ./archives
+"
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
+  -v "${BUILDSYS_PACKAGES_DIR}":/home/builder/rpms \
+  -v "${BUILDSYS_ARCHIVES_DIR}":/home/builder/archives \
+  -w /home/builder \
+  "${BUILDSYS_SDK_IMAGE}" \
+  bash -c "${prepare_kmod_kit}"
+'''
+]
+
+[tasks.build-archives]
+dependencies = ["build-kmod-kit"]
 
 [tasks.build-variant]
 dependencies = ["build-packages"]
@@ -774,6 +833,7 @@ pubsys \
 dependencies = [
   "clean-sources",
   "clean-packages",
+  "clean-archives",
   "clean-images",
   "clean-repos",
 ]
@@ -799,6 +859,14 @@ for ws in packages; do
   cargo clean --manifest-path ${ws}/Cargo.toml
 done
 rm -rf ${BUILDSYS_PACKAGES_DIR}
+'''
+]
+
+[tasks.clean-archives]
+script_runner = "bash"
+script = [
+'''
+rm -rf ${BUILDSYS_ARCHIVES_DIR}
 '''
 ]
 

--- a/packages/kernel/1001-Makefile-add-prepare-target-for-external-modules.patch
+++ b/packages/kernel/1001-Makefile-add-prepare-target-for-external-modules.patch
@@ -1,0 +1,50 @@
+From 6e4fa756a327a510f8713d60dc257aaeed5e33d7 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Fri, 13 Nov 2020 23:37:11 +0000
+Subject: [PATCH] Makefile: add prepare target for external modules
+
+We need to ensure that native versions of programs like `objtool` are
+built before trying to build out-of-tree modules, or else the build
+will fail.
+
+Unlike other distributions, we cannot include these programs in our
+kernel-devel archive, because we rely on cross-compilation: these are
+"host" programs and may not match the architecture of the target.
+
+Ideally, out-of-tree builds would run `make prepare` first, so that
+these programs could be compiled in the normal fashion. We ship all
+the files needed for this to work. However, this requirement is
+specific to our use case, and DKMS does not support it.
+
+Adding a minimal prepare target to the dependency graph causes the
+programs to be built automatically and improves compatibility with
+existing solutions.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ Makefile | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 29948bc4a0d2..2f766911437c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1613,6 +1613,15 @@ $(objtree)/Module.symvers:
+ 	echo "           is missing; modules will have no dependencies and modversions."; \
+ 	echo )
+ 
++PHONY += modules_prepare
++modules_prepare: $(objtool_target)
++	$(Q)$(MAKE) $(build)=scripts/basic
++	$(Q)$(MAKE) $(build)=scripts/dtc
++	$(Q)$(MAKE) $(build)=scripts/mod
++	$(Q)$(MAKE) $(build)=scripts
++
++prepare: modules_prepare
++
+ build-dirs := $(KBUILD_EXTMOD)
+ PHONY += modules
+ modules: descend $(objtree)/Module.symvers
+-- 
+2.21.0
+

--- a/packages/kernel/config-bottlerocket
+++ b/packages/kernel/config-bottlerocket
@@ -38,6 +38,12 @@ CONFIG_SECURITY_SELINUX_DEVELOP=n
 # rather than the protection requested by userspace.
 CONFIG_SECURITY_SELINUX_CHECKREQPROT_VALUE=0
 
+# Enable support for the kernel lockdown security module.
+CONFIG_SECURITY_LOCKDOWN_LSM=y
+
+# Enable zstd compression for squashfs.
+CONFIG_SQUASHFS_ZSTD=y
+
 # enable /proc/config.gz
 CONFIG_IKCONFIG=y
 CONFIG_IKCONFIG_PROC=y
@@ -47,6 +53,3 @@ CONFIG_IKHEADERS=y
 
 # BTF debug info at /sys/kernel/btf/vmlinux
 CONFIG_DEBUG_INFO_BTF=y
-
-# Enable support for the kernel lockdown security module.
-CONFIG_SECURITY_LOCKDOWN_LSM=y

--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -36,6 +36,14 @@ ExecStart=/usr/bin/mount \
 ExecStart=/usr/lib/systemd/systemd-growfs ${LOCAL_DIR}
 ExecStart=/usr/bin/mkdir -p ${LOCAL_DIR}/var ${LOCAL_DIR}/opt
 
+# Create the directories we need to set up a read-write overlayfs for the kernel
+# development sources.
+ExecStart=/usr/bin/rm -rf ${LOCAL_DIR}/var/lib/kernel-devel
+ExecStart=/usr/bin/mkdir -p \
+    ${LOCAL_DIR}/var/lib/kernel-devel/lower \
+    ${LOCAL_DIR}/var/lib/kernel-devel/upper \
+    ${LOCAL_DIR}/var/lib/kernel-devel/work
+
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -16,13 +16,18 @@ Source200: motd.template
 
 Source1000: eth0.xml
 Source1002: configured.target
+
+# Mounts for writable local storage.
 Source1006: prepare-local.service
 Source1007: var.mount
 Source1008: opt.mount
-Source1009: usr-src-kernels.mount.in
-Source1010: var-lib-bottlerocket.mount
-Source1011: usr-share-licenses.mount.in
-Source1012: etc-cni.mount
+Source1009: var-lib-bottlerocket.mount
+Source1010: etc-cni.mount
+
+# Mounts that require build-time edits.
+Source1020: var-lib-kernel-devel-lower.mount.in
+Source1021: usr-src-kernels.mount.in
+Source1022: usr-share-licenses.mount.in
 
 BuildArch: noarch
 Requires: %{_cross_os}acpid
@@ -98,15 +103,21 @@ EOF
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
-  %{S:1002} %{S:1006} %{S:1007} %{S:1008} %{S:1010} %{S:1012} \
+  %{S:1002} %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} \
   %{buildroot}%{_cross_unitdir}
+
+LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/lower)
+sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1020} > ${LOWERPATH}.mount
+install -p -m 0644 ${LOWERPATH}.mount %{buildroot}%{_cross_unitdir}
+
 # Mounting on usr/src/kernels requires using the real path: %{_cross_usrsrc}/kernels
 KERNELPATH=$(systemd-escape --path %{_cross_usrsrc}/kernels)
-sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1009} > ${KERNELPATH}.mount
+sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1021} > ${KERNELPATH}.mount
 install -p -m 0644 ${KERNELPATH}.mount %{buildroot}%{_cross_unitdir}
 
+# Mounting on usr/share/licenses requires using the real path: %{_cross_datadir}/licenses
 LICENSEPATH=$(systemd-escape --path %{_cross_licensedir})
-sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1011} > ${LICENSEPATH}.mount
+sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1022} > ${LICENSEPATH}.mount
 install -p -m 0644 ${LICENSEPATH}.mount %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_templatedir}
@@ -125,6 +136,7 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/etc-cni.mount
+%{_cross_unitdir}/*-lower.mount
 %{_cross_unitdir}/*-kernels.mount
 %{_cross_unitdir}/*-licenses.mount
 %{_cross_unitdir}/var-lib-bottlerocket.mount

--- a/packages/release/usr-src-kernels.mount.in
+++ b/packages/release/usr-src-kernels.mount.in
@@ -1,13 +1,14 @@
 [Unit]
-Description=Kernel Development Sources
+Description=Kernel Development Sources (Read-Write)
 Conflicts=umount.target
+RequiresMountsFor=/var/lib/kernel-devel/lower
 Before=local-fs.target umount.target
 
 [Mount]
-What=PREFIX/share/bottlerocket/kernel-devel.squashfs
+What=overlay
 Where=PREFIX/src/kernels
-Type=squashfs
-Options=defaults,ro,loop,noatime,nosuid,nodev,context=system_u:object_r:os_t:s0
+Type=overlay
+Options=noatime,nosuid,nodev,lowerdir=/var/lib/kernel-devel/lower,upperdir=/var/lib/kernel-devel/upper,workdir=/var/lib/kernel-devel/work,context=system_u:object_r:local_t:s0
 
 [Install]
 WantedBy=local-fs.target

--- a/packages/release/var-lib-kernel-devel-lower.mount.in
+++ b/packages/release/var-lib-kernel-devel-lower.mount.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Kernel Development Sources (Read-Only)
+DefaultDependencies=no
+Conflicts=umount.target
+RequiresMountsFor=/var
+Before=local-fs.target umount.target
+
+[Mount]
+What=PREFIX/share/bottlerocket/kernel-devel.squashfs
+Where=/var/lib/kernel-devel/lower
+Type=squashfs
+Options=defaults,ro,loop,noatime,nosuid,nodev,context=system_u:object_r:os_t:s0
+
+[Install]
+WantedBy=local-fs.target

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -402,7 +402,7 @@ func withSuperpowered(superpowered bool) oci.SpecOpts {
 				Source:      "/lib/modules",
 			},
 			{
-				Options:     []string{"rbind", "ro"},
+				Options:     []string{"rbind", "rw"},
 				Destination: "/usr/src/kernels",
 				Source:      "/usr/src/kernels",
 			},

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -81,7 +81,10 @@ sgdisk --clear \
 
 rpm -iv --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
 install -p -m 0644 /host/{COPYRIGHT,LICENSE-APACHE,LICENSE-MIT} "${ROOT_MOUNT}"/usr/share/licenses/
-mksquashfs "${ROOT_MOUNT}"/usr/share/licenses "${ROOT_MOUNT}"/usr/share/bottlerocket/licenses.squashfs
+mksquashfs \
+  "${ROOT_MOUNT}"/usr/share/licenses \
+  "${ROOT_MOUNT}"/usr/share/bottlerocket/licenses.squashfs \
+  -no-exports -all-root -comp zstd
 rm -rf "${ROOT_MOUNT}"/var/lib "${ROOT_MOUNT}"/usr/share/licenses/*
 
 if [[ "${ARCH}" == "x86_64" ]]; then


### PR DESCRIPTION
**Issue number:**
#1141 


**Description of changes:**
This overhauls our packaging of kernel development sources, so that they can be used on an architecture that differs from the build host, and can be extracted for use outside of a running host.


**Testing done:**
Tests were repeated across this matrix:
* x86_64 image and kmod kit built on an x86_64 host
* x86_64 image and kmod kit built on an aarch64 host
* aarch64 image and kmod kit built on an x86_64 host
* aarch64 image and kmod kit built on an aarch64 host

Images were tested by launching nodes, logging into a Fedora-based admin container, building the Wireguard out-of-tree module, and then running `make prepare`.

x86_64 images were additionally tested by using Helm to install Falco, and verifying that the module could be built by DKMS and loaded:
```
helm install falco falcosecurity/falco \
  --namespace kube-system \
  --set docker.enabled=false
```

The kmod kits were tested on Fedora 32 and Amazon Linux 2, by building the Wireguard and ZFS out-of-tree modules, using snippets like this:
```
FROM base as wireguard-build
ARG VARIANT="aws-k8s-1.18"
ARG ARCH="x86_64"
ARG VERSION="1.0.3"
ARG KIT="${VARIANT}-${ARCH}-kmod-kit-v${VERSION}"
ARG KERNELDIR="/tmp/${KIT}/kernel-devel"
ARG CROSS_COMPILE="${ARCH}-bottlerocket-linux-musl-"
ARG INSTALL_MOD_STRIP=1
RUN \
  export PATH="/tmp/${KIT}/toolchain/usr/bin:${PATH}" && \
  make -C wireguard-linux-compat/src module
```

The modules were then loaded on a running instance to confirm they were built correctly.

x86_64 kmod kits were additionally tested by building the Falco module.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
