### PR TITLE
Add kernel lockdown setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ These settings can be changed at any time.
 
 #### Kernel settings
 
+* `settings.kernel.lockdown`: This allows further restrictions on what the Linux kernel will allow, for example preventing the loading of unsigned modules.
+  May be set to "none" (the default), "integrity", or "confidentiality".
+  **Important note:** this setting cannot be lowered (toward 'none') at runtime.
+  You must reboot for a change to a lower level to take effect.
 * `settings.kernel.sysctl`: Key/value pairs representing Linux kernel parameters.
   Remember to quote keys (since they often contain ".") and to quote all values.
   * Example user data for setting up sysctl:

--- a/Release.toml
+++ b/Release.toml
@@ -12,3 +12,4 @@ version = "1.0.4"
 "(1.0.1, 1.0.2)" = ["migrate_v1.0.2_add-enable-spot-instance-draining.lz4"]
 "(1.0.2, 1.0.3)" = ["migrate_v1.0.3_add-sysctl.lz4"]
 "(1.0.3, 1.0.4)" = []
+"(1.0.4, 1.0.5)" = ["migrate_v1.0.5_add-lockdown.lz4", "migrate_v1.0.5_sysctl-subcommand.lz4"]

--- a/packages/kernel/config-bottlerocket
+++ b/packages/kernel/config-bottlerocket
@@ -47,3 +47,6 @@ CONFIG_IKHEADERS=y
 
 # BTF debug info at /sys/kernel/btf/vmlinux
 CONFIG_DEBUG_INFO_BTF=y
+
+# Enable support for the kernel lockdown security module.
+CONFIG_SECURITY_LOCKDOWN_LSM=y

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -274,6 +274,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-lockdown"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-sysctl"
 version = "0.1.0"
 dependencies = [
@@ -2795,6 +2802,13 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysctl-subcommand"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -30,6 +30,8 @@ members = [
     "api/migration/migrations/v1.0.0/ecr-helper-control",
     "api/migration/migrations/v1.0.2/add-enable-spot-instance-draining",
     "api/migration/migrations/v1.0.3/add-sysctl",
+    "api/migration/migrations/v1.0.5/add-lockdown",
+    "api/migration/migrations/v1.0.5/sysctl-subcommand",
 
     "bottlerocket-release",
 

--- a/sources/api/corndog/README.md
+++ b/sources/api/corndog/README.md
@@ -3,7 +3,9 @@
 Current version: 0.1.0
 
 corndog is a delicious way to get at the meat inside the kernels.
-It sets kernel sysctl values based on key/value pairs in `settings.kernel.sysctl`.
+It sets kernel-related settings, for example:
+* sysctl values, based on key/value pairs in `settings.kernel.sysctl`
+* lockdown mode, based on the value of `settings.kernel.lockdown`
 
 ## Colophon
 

--- a/sources/api/corndog/src/main.rs
+++ b/sources/api/corndog/src/main.rs
@@ -38,7 +38,7 @@ async fn run() -> Result<()> {
         if let Some(kernel) = settings.kernel {
             if let Some(sysctls) = kernel.sysctl {
                 debug!("Applying sysctls: {:#?}", sysctls);
-                set_sysctls(sysctls)?;
+                set_sysctls(sysctls);
             }
         }
     }
@@ -85,7 +85,7 @@ where
 
 /// Applies the requested sysctls to the system.  The keys are used to generate the appropriate
 /// path, and the value its contents.
-fn set_sysctls<K>(sysctls: HashMap<K, String>) -> Result<()>
+fn set_sysctls<K>(sysctls: HashMap<K, String>)
 where
     K: AsRef<str>,
 {
@@ -100,7 +100,6 @@ where
             error!("Failed to write sysctl value '{}': {}", key, e);
         }
     }
-    Ok(())
 }
 
 /// Print a usage message in the event a bad argument is given.

--- a/sources/api/corndog/src/main.rs
+++ b/sources/api/corndog/src/main.rs
@@ -1,11 +1,13 @@
 /*!
 corndog is a delicious way to get at the meat inside the kernels.
-It sets kernel sysctl values based on key/value pairs in `settings.kernel.sysctl`.
+It sets kernel-related settings, for example:
+* sysctl values, based on key/value pairs in `settings.kernel.sysctl`
+* lockdown mode, based on the value of `settings.kernel.lockdown`
 */
 
 #![deny(rust_2018_idioms)]
 
-use log::{debug, error, trace};
+use log::{debug, error, info, trace, warn};
 use simplelog::{Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
 use snafu::ResultExt;
 use std::collections::HashMap;
@@ -17,9 +19,11 @@ use std::{env, process};
 
 const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const SYSCTL_PATH_PREFIX: &str = "/proc/sys";
+const LOCKDOWN_PATH: &str = "/sys/kernel/security/lockdown";
 
 /// Store the args we receive on the command line.
 struct Args {
+    subcommand: String,
     log_level: LevelFilter,
     socket_path: String,
 }
@@ -32,19 +36,32 @@ async fn run() -> Result<()> {
     TermLogger::init(args.log_level, LogConfig::default(), TerminalMode::Mixed)
         .context(error::Logger)?;
 
-    // If the user has sysctl settings, apply them.
+    // If the user has kernel settings, apply them.
     let model = get_model(args.socket_path).await?;
     if let Some(settings) = model.settings {
         if let Some(kernel) = settings.kernel {
-            if let Some(sysctls) = kernel.sysctl {
-                debug!("Applying sysctls: {:#?}", sysctls);
-                set_sysctls(sysctls);
+            match args.subcommand.as_ref() {
+                "sysctl" => {
+                    if let Some(sysctls) = kernel.sysctl {
+                        debug!("Applying sysctls: {:#?}", sysctls);
+                        set_sysctls(sysctls);
+                    }
+                }
+                "lockdown" => {
+                    if let Some(lockdown) = kernel.lockdown {
+                        debug!("Setting lockdown: {:#?}", lockdown);
+                        set_lockdown(&lockdown)?;
+                    }
+                }
+                _ => usage_msg(format!("Unknown subcommand '{}'", args.subcommand)), // should be unreachable
             }
         }
     }
 
     Ok(())
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 /// Retrieve the current model from the API.
 async fn get_model<P>(socket_path: P) -> Result<model::Model>
@@ -102,13 +119,68 @@ where
     }
 }
 
+/// Sets the requested lockdown mode in the kernel.
+///
+/// The Linux kernel won't allow lowering the lockdown setting, but we want to allow users to
+/// change the Bottlerocket setting and reboot for it to take effect.  Changing the Bottlerocket
+/// setting means this code will run to write it out, but it wouldn't be able to convince the
+/// kernel.  So, we just warn the user rather than trying to write and causing a failure that could
+/// prevent the rest of a settings-changing transaction from going through.  We'll run again after
+/// reboot to set lockdown as it was requested.
+fn set_lockdown(lockdown: &str) -> Result<()> {
+    let current_raw = fs::read_to_string(LOCKDOWN_PATH).unwrap_or_else(|_| "unknown".to_string());
+    let current = parse_kernel_setting(&current_raw);
+    trace!("Parsed lockdown setting '{}' to '{}'", current_raw, current);
+
+    // The kernel doesn't allow rewriting the current value.
+    if current == lockdown {
+        info!("Requested lockdown setting is already in effect.");
+        return Ok(());
+    // As described above, the kernel doesn't allow lowering the value.
+    } else if current == "confidentiality" || (current == "integrity" && lockdown == "none") {
+        warn!("Can't lower lockdown setting at runtime; please reboot for it to take effect.",);
+        return Ok(());
+    }
+
+    fs::write(LOCKDOWN_PATH, lockdown).context(error::Lockdown { current, lockdown })
+}
+
+/// The Linux kernel provides human-readable output like `[none] integrity confidentiality` when
+/// you read settings from virtual files like /sys/kernel/security/lockdown.  This parses out the
+/// current value of the setting from that human-readable output.
+///
+/// There are also some files that only output the current value without the other options, so we
+/// return the output as-is (except for trimming whitespace) if there are no brackets.
+fn parse_kernel_setting(setting: &str) -> &str {
+    let mut setting = setting.trim();
+    // Take after the '['
+    if let Some(idx) = setting.find('[') {
+        if setting.len() > idx + 1 {
+            setting = &setting[idx + 1..];
+        }
+    }
+    // Take before the ']'
+    if let Some(idx) = setting.find(']') {
+        setting = &setting[..idx];
+    }
+    setting
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
 /// Print a usage message in the event a bad argument is given.
 fn usage() -> ! {
     let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
     eprintln!(
-        r"Usage: {}
-            [ --socket-path PATH ]
-            [ --log-level trace|debug|info|warn|error ]
+        r"Usage: {} SUBCOMMAND [ ARGUMENTS... ]
+
+    Subcommands:
+        sysctl
+        lockdown
+
+    Global arguments:
+        --socket-path PATH
+        --log-level trace|debug|info|warn|error
 
     Socket path defaults to {}",
         program_name, DEFAULT_API_SOCKET,
@@ -126,6 +198,7 @@ fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
 fn parse_args(args: env::Args) -> Args {
     let mut log_level = None;
     let mut socket_path = None;
+    let mut subcommand = None;
 
     let mut iter = args.skip(1);
     while let Some(arg) = iter.next() {
@@ -146,11 +219,14 @@ fn parse_args(args: env::Args) -> Args {
                 )
             }
 
+            "sysctl" | "lockdown" => subcommand = Some(arg),
+
             _ => usage(),
         }
     }
 
     Args {
+        subcommand: subcommand.unwrap_or_else(|| usage_msg("Must specify a subcommand.")),
         log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
     }
@@ -167,9 +243,12 @@ async fn main() {
     }
 }
 
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
 mod error {
     use http::StatusCode;
     use snafu::Snafu;
+    use std::io;
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility = "pub(super)")]
@@ -187,6 +266,18 @@ mod error {
             uri: String,
             code: StatusCode,
             response_body: String,
+        },
+
+        #[snafu(display(
+            "Failed to change lockdown from '{}' to '{}': {}",
+            current,
+            lockdown,
+            source
+        ))]
+        Lockdown {
+            current: String,
+            lockdown: String,
+            source: io::Error,
         },
 
         #[snafu(display("Logger setup error: {}", source))]
@@ -216,6 +307,31 @@ mod test {
         assert_eq!(
             sysctl_path("../../root/file").to_string_lossy(),
             format!("{}/root/file", SYSCTL_PATH_PREFIX)
+        );
+    }
+
+    #[test]
+    fn brackets() {
+        assert_eq!(
+            "none",
+            parse_kernel_setting("[none] integrity confidentiality")
+        );
+        assert_eq!(
+            "integrity",
+            parse_kernel_setting("none [integrity] confidentiality\n")
+        );
+        assert_eq!(
+            "confidentiality",
+            parse_kernel_setting("none integrity [confidentiality]")
+        );
+    }
+
+    #[test]
+    fn no_brackets() {
+        assert_eq!("none", parse_kernel_setting("none"));
+        assert_eq!(
+            "none integrity confidentiality",
+            parse_kernel_setting("none integrity confidentiality\n")
         );
     }
 }

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -85,6 +85,12 @@ pub enum Error {
     NewKey {
         source: apiserver::datastore::error::Error,
     },
+
+    #[snafu(display("Setting '{}' contains non-string item: {:?}", setting, data))]
+    ReplaceListContents {
+        setting: String,
+        data: Vec<serde_json::Value>,
+    },
 }
 
 /// Result alias containing our Error type.

--- a/sources/api/migration/migrations/v1.0.5/add-lockdown/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.5/add-lockdown/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-lockdown"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.5/add-lockdown/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.5/add-lockdown/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added the ability to set kernel lockdown mode through a setting, so on downgrade we need to
+/// remove the setting and the associated settings for the service that writes out changes.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kernel.lockdown",
+        "services.lockdown",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.0.5/sysctl-subcommand/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.5/sysctl-subcommand/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sysctl-subcommand"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.5/sysctl-subcommand/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.5/sysctl-subcommand/src/main.rs
@@ -1,0 +1,25 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceListMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We changed corndog to use subcommands so it can handle different kernel settings without having
+/// to apply them all every time.
+fn run() -> Result<()> {
+    migrate(ReplaceListMigration {
+        setting: "services.sysctl.restart-commands",
+        old_vals: &["/usr/bin/corndog"],
+        new_vals: &["/usr/bin/corndog sysctl"],
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -95,9 +95,19 @@ affected-services = ["chronyd"]
 
 # Kernel
 
+[settings.kernel]
+lockdown = "none"
+
 [services.sysctl]
 configuration-files = []
-restart-commands = ["/usr/bin/corndog"]
+restart-commands = ["/usr/bin/corndog sysctl"]
 
 [metadata.settings.kernel.sysctl]
 affected-services = ["sysctl"]
+
+[services.lockdown]
+configuration-files = []
+restart-commands = ["/usr/bin/corndog lockdown"]
+
+[metadata.settings.kernel.lockdown]
+affected-services = ["lockdown"]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -88,7 +88,7 @@ use std::net::Ipv4Addr;
 use crate::modeled_types::{
     DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion,
     KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    SingleLineString, SysctlKey, Url, ValidBase64,
+    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
 };
 
 // Kubernetes related settings. The dynamic settings are retrieved from
@@ -149,6 +149,7 @@ struct NtpSettings {
 // Kernel settings
 #[model]
 struct KernelSettings {
+    lockdown: Lockdown,
     // Values are almost always a single line and often just an integer... but not always.
     sysctl: HashMap<SysctlKey, String>,
 }

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -48,6 +48,9 @@ pub mod error {
         #[snafu(display("Invalid domain name '{}': {}", input, msg))]
         InvalidDomainName { input: String, msg: String },
 
+        #[snafu(display("Invalid Linux lockdown mode '{}'", input))]
+        InvalidLockdown { input: String },
+
         #[snafu(display("Invalid sysctl key '{}': {}", input, msg))]
         InvalidSysctlKey { input: String, msg: String },
 

--- a/sources/models/src/modeled_types/shared.rs
+++ b/sources/models/src/modeled_types/shared.rs
@@ -530,3 +530,28 @@ mod test_sysctl_key {
         }
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// Lockdown represents a string that is a valid Linux kernel lockdown mode name.  It stores the
+/// original string and makes it accessible through standard traits.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Lockdown {
+    inner: String,
+}
+
+impl TryFrom<&str> for Lockdown {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, error::Error> {
+        ensure!(
+            matches!(input, "none" | "integrity" | "confidentiality"),
+            error::InvalidLockdown { input }
+        );
+        Ok(Lockdown {
+            inner: input.to_string(),
+        })
+    }
+}
+
+string_impls_for!(Lockdown, "Lockdown");


### PR DESCRIPTION
**Issue number:**

Adds the capability we'll need for #813.

**Description of changes:**

```
93f90b4a kernel: enable support for lockdown mode, disabled by default
f431a254 corndog: remove Result from set_sysctls to reflect that we don't let it fail
74e5cd21 Add a kernel lockdown setting and corndog helper
0b96d45a Add migrations necessary for kernel lockdown feature
```

This should cause no functional difference on the system since we default to 'none', but will allow users to set a lockdown level.  Raising the lockdown level is probably safe for most use cases, but wouldn't work with some use cases described in #813, so we can't increase it by default at the moment.

**Testing done:**

Unit tests pass.  Migrations work locally.

Created a 1.0.3 AMI without this change, and a repo including this change marked as version 1.0.5 (to match the migration list added to Release.toml).  Updated from 1.0.3 to 1.0.5 successfully.  Confirmed I could run a pod OK.  Confirmed that the lockdown setting showed up in the API and the restart-commands list for sysctl was updated correctly by the migration.  Further testing:

Default state:
```
bash-5.0# cat /sys/kernel/security/lockdown
[none] integrity confidentiality
```

Bad values are rejected:
```
bash-5.0# apiclient -u /settings -m PATCH -d '{"kernel": {"lockdown": "bad"}}'
Failed PATCH request to '/settings': Status 400 when PATCHing /settings: Json deserialize error: Unable to deserialize into Lockdown: Invalid Linux lockdown mode 'bad' at line 1 column 30
```

Good values accepted and applied:
```
bash-5.0# apiclient -u /settings -m PATCH -d '{"kernel": {"lockdown": "integrity"}}'
bash-5.0# apiclient -u /tx/commit_and_apply -m POST
["settings.kernel.lockdown"]
bash-5.0# cat /sys/kernel/security/lockdown
none [integrity] confidentiality

bash-5.0# apiclient -u /settings -m PATCH -d '{"kernel": {"lockdown": "confidentiality"}}'
bash-5.0# apiclient -u /tx/commit_and_apply -m POST
["settings.kernel.lockdown"]
bash-5.0# cat /sys/kernel/security/lockdown
none integrity [confidentiality]
```

Setting is still applied after reboot:
```
bash-5.0# reboot
...
[ec2-user@ip-192-168-16-84 ~]$ sudo sheltie
bash-5.0# cat /sys/kernel/security/lockdown
none integrity [confidentiality]
```

Applying the setting multiple times is handled safely in corndog (the kernel rejects the write):
```
bash-5.0# corndog lockdown
19:05:38 [INFO] Requested lockdown setting is already in effect.
```

Here's a manual run of corndog after changing the setting, and committing but *not* applying the changes, just to show it's happy:
```
bash-5.0# apiclient -u /settings -m PATCH -d '{"kernel": {"lockdown": "confidentiality"}}'
bash-5.0# apiclient -u /tx/commit -m POST
["settings.kernel.lockdown"]
bash-5.0# corndog lockdown
bash-5.0# corndog lockdown
19:07:30 [INFO] Requested lockdown setting is already in effect.
```

You can't downgrade at runtime...
```
bash-5.0# apiclient -u /settings -m PATCH -d '{"kernel": {"lockdown": "integrity"}}'
bash-5.0# apiclient -u /tx/commit_and_apply -m POST
["settings.kernel.lockdown"]
bash-5.0# corndog lockdown
19:13:51 [WARN] Can't lower lockdown setting at runtime; please reboot for it to take effect.
```

...but after a reboot, your request takes effect:
```
bash-5.0# cat /sys/kernel/security/lockdown
none [integrity] confidentiality
```

I confirmed that I could downgrade successfully to 1.0.3 and the lockdown setting was removed, and the restart-commands list was reverted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.