### PR TITLE
host-ctr, host-containers: proper restarts

### DIFF
--- a/packages/os/host-containers@.service
+++ b/packages/os/host-containers@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Host container: %i
 After=host-containerd.service
-BindsTo=host-containerd.service
+Wants=host-containerd.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**I recommend reviewing each commit separately**

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1229


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Sun Dec 6 20:54:03 2020 -0800

    host-containers: add safeguards against lingering host containers
    
    Now that host-ctr has the ability to rebind to existing host containers.
    We want to ensure whenever we enable host containers the container will
    be running with its latest configuration.
    
    We utilize `host-ctr`'s clean-up command to clean up any potential
    lingering host-container when we're enabling a previously disabled
    host-container and whenever a host-container is disabled.
```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Dec 4 20:02:37 2020 -0800

    host-ctr: add new subcommand `clean-up`
    
    Adds a new subcommand `clean-up` that checks if a given container
    exists, if it does, `host-ctr` will attempt to kill the container task
    and delete the container.
```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Dec 4 18:34:07 2020 -0800

    host-ctr: refactoring
    
    Refactors `host-ctr`.
    Categorizes functionality into subcommands.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Dec 4 14:31:26 2020 -0800

    host-containers@: remove KillMode=mixed
    
    We don't need systemd to go and actively try kill all processes
    of the unit's cgroup.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Dec 2 18:18:57 2020 -0800

    host-ctr: do not kill existing container, take over it
    
    If the host-container already exists, we should just take over the
    helm and not try to replace it with a new container. This is so that
    even if we temporarily lose connection with host-containerd, we can
    still eventually get the task status when containerd comes back up.

commit 0dbc03cdcde435aa259f34d80f6ec66a202b45a4
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Dec 2 14:45:44 2020 -0800

    host-containers: 'Wants' host-containerd instead of 'BindsTo'
    
    host-containers@ systemd units should not stop when host-containerd is
    restarted or killed.
    
    By changing host-containers' dependency on host-containerd.service from
    `BindsTo=` to `Wants=` we ensure host containers tasks won't be killed if
     host-containerd temporarily stops.
    
    host-ctr then has a chance to reclaim the container task when
    host-containerd comes back up.

```


**Testing done:**
- Built AMI, launched instance
- `sudo sheltie` into the host via the admin container
- Restarted host-containerd, and my ssh connection to the admin container was still alive
- Checked the status of `host-containers@admin` and saw that it exited and restarted successfully.

`host-containers@admin` initial starts successfully.
```
Dec 03 03:09:30 host-ctr[3077]: Server listening on 0.0.0.0 port 22.
Dec 03 03:09:30 host-ctr[3077]: Server listening on :: port 22.
Dec 03 03:10:48 host-ctr[3077]: Accepted publickey for ec2-user from 123.123.123.123 port 5417 ssh2
```

This is where I restarted `host-containerd`. `host-ctr` loses connection to the containerd server and exits.
```
Dec 03 03:11:28 host-ctr[3077]: time="2020-12-03T03:11:28Z" level=error msg="failed to get container task
 exit status" error="rpc error: code = Unavailable desc = transport is closing"
Dec 03 03:11:28 host-ctr[3077]: time="2020-12-03T03:11:28Z" level=error msg="failed to delete container t
ask" error="task must be stopped before deletion: running: failed precondition"
Dec 03 03:11:28 host-ctr[3077]: time="2020-12-03T03:11:28Z" level=error msg="failed to cleanup container"
 error="cannot delete running task admin: failed precondition"
Dec 03 03:11:28 systemd[1]: host-containers@admin.service: Main process exited, c
ode=exited, status=1/FAILURE
Dec 03 03:11:28 systemd[1]: host-containers@admin.service: Failed wit
h result 'exit-code'.
```

`host-containers@admin` restarts and `host-ctr` successfully rebinds to the admin container task that's already running.
```
Dec 03 03:12:14 systemd[1]: host-containers@admin.service: Scheduled restart job, restart counter is at 1
.
Dec 03 03:12:14 systemd[1]: Stopped Host container: admin.
Dec 03 03:12:14 systemd[1]: Starting Host container: admin...
Dec 03 03:12:14 systemd[1]: Started Host container: admin.
Dec 03 03:12:14 host-ctr[5096]: time="2020-12-03T03:12:14Z" level=info msg="Pulling with Amazon ECR Resol
ver" ref="ecr.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-admin:v0.5.2"
Dec 03 03:12:14 host-ctr[5096]: time="2020-12-03T03:12:14Z" level=info msg="Pulled successfully" img="ecr
.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-admin:v0.5.2"
Dec 03 03:12:14 host-ctr[5096]: time="2020-12-03T03:12:14Z" level=info msg=Unpacking... img="ecr.aws/arn:
aws:ecr:us-west-2:328549459982:repository/bottlerocket-admin:v0.5.2"
Dec 03 03:12:14 host-ctr[5096]: time="2020-12-03T03:12:14Z" level=info msg="Tagging image" imageName="328
549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.5.2"
Dec 03 03:12:14 host-ctr[5096]: time="2020-12-03T03:12:14Z" level=info msg="Container task is still runni
ng, proceeding to monitor it"
```

Testing for when both host-containers and host-containerd are restarted due to a single API transaction. We ensure the restarted host-ctr runs an up-to-date host container that reflects the setting changes:
See https://github.com/bottlerocket-os/bottlerocket/pull/1230#issuecomment-740085820

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
