### PR TITLE
models: add restart-commands for docker, kubelet, containerd

### DIFF
--- a/sources/models/defaults.toml
+++ b/sources/models/defaults.toml
@@ -23,11 +23,17 @@ template-path = "/usr/share/templates/motd"
 
 [services.containerd]
 configuration-files = ["containerd-config-toml"]
-restart-commands = []
+restart-commands = ["/bin/systemctl try-restart containerd.service"]
 
 [configuration-files.containerd-config-toml]
 path = "/etc/containerd/config.toml"
 template-path = "/usr/share/templates/containerd-config-toml"
+
+# Host-container runtime
+
+[services.host-containerd]
+configuration-files = []
+restart-commands = ["/bin/systemctl try-restart host-containerd.service"]
 
 # Updates.
 

--- a/sources/models/src/aws-dev/override-defaults.toml
+++ b/sources/models/src/aws-dev/override-defaults.toml
@@ -1,3 +1,8 @@
 [configuration-files.containerd-config-toml]
 # No override to path
 template-path = "/usr/share/templates/containerd-config-toml_aws-dev"
+
+# Docker
+[services.docker]
+restart-commands = ["/bin/systemctl try-restart docker.service"]
+configuration-files = []

--- a/sources/models/src/aws-ecs-1/override-defaults.toml
+++ b/sources/models/src/aws-ecs-1/override-defaults.toml
@@ -2,6 +2,11 @@
 # No override to path
 template-path = "/usr/share/templates/containerd-config-toml_aws-ecs-1"
 
+# Docker
+[services.docker]
+restart-commands = ["/bin/systemctl try-restart docker.service"]
+configuration-files = []
+
 # ECS
 [services.ecs]
 restart-commands = ["/usr/bin/ecs-settings-applier", "/bin/systemctl try-reload-or-restart ecs.service"]

--- a/sources/models/src/aws-k8s-1.15/override-defaults.toml
+++ b/sources/models/src/aws-k8s-1.15/override-defaults.toml
@@ -6,7 +6,7 @@ template-path = "/usr/share/templates/containerd-config-toml_aws-k8s"
 
 [services.kubernetes]
 configuration-files = ["kubelet-env", "kubelet-config", "kubelet-kubeconfig", "kubernetes-ca-crt"]
-restart-commands = []
+restart-commands = ["/bin/systemctl try-restart kubelet.service"]
 
 [configuration-files.kubelet-env]
 path = "/etc/kubernetes/kubelet/env"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Dec 3 12:17:30 2020 -0800

    models: add restart-commands for docker, kubelet, containerd
    
    Add `restart-commands` for `services.kubernetes`, `services.docker`,
    `services.containerd`, `services.host-containerd`.
```


**Testing done:**

Testing kubelet restarts for kubernetes variants:
1. Launched several nodes with built AMI
2. Applied the bottlerocket update operator on all nodes.
3. Waited for all the agent pods and the controller pods to start running
4. Set `settings.kubernetes.max-pods` to 29 to kick off the restart-command for `services.kubelet`
5. `sudo sheltie`'d and checked kubelet.service and saw that it restarted successfully.
6. Checked the agent pods and controller pod via kubectl and saw them all still running and outputting logs with the same name

Testing containerd restarts for kubernetes variants:
1. Launched several nodes with built AMI
2. Applied the bottlerocket update operator on all nodes.
3. Waited for all the agent pods and the controller pods to start running
4. Set `settings.kubernetes.pod-infra-container-image` to "gcr.io/google-containers/pause-amd64:3.2" to kick off the restart-command for `services.kubelet` AND `services.containerd`
5. `sudo sheltie`'d and checked kubelet.service containerd.service and saw that both restarted successfully.
6. Checked the agent pods and controller pod via kubectl and saw them all still running and outputting logs with the same name

Testing docker restarts for ECS variants:
1. Launched an ECS instance
2. Ran a simple ECS task that simply started an nginx server with host networking.
3. Got into the admin container as curl'ed `localhost:80` and saw nginx running successfully.

<details>

```
[ec2-user@ip- ~]$ curl localhost:80
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```
</details>

4. `sudo sheltie`'d and ran `systemctl try-restart docker.service` to simulate a docker restart due to settings/configuration file change
5. curl'd `localhost:80` and saw nginx is still running fine.
6. Checked ECS console and saw the task still running fine.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
