### PR TITLE
Update docs to use new apiclient update mode

### DIFF
--- a/sources/api/apiclient/README.md
+++ b/sources/api/apiclient/README.md
@@ -4,10 +4,43 @@ Current version: 0.1.0
 
 ## apiclient binary
 
-The `apiclient` binary helps you talk to an HTTP API over a Unix-domain socket.
+The `apiclient` binary provides some high-level, synchronous methods of interacting with the API, for example an `update` subcommand that wraps the individual API calls needed to update the host.
+There's also a low-level `raw` subcommand for direct interaction with the HTTP API.
 
 It talks to the Bottlerocket socket by default.
 It can be pointed to another socket using `--socket-path`, for example for local testing.
+
+### Update mode
+
+To start, you can check what updates are available:
+
+```
+apiclient update check
+```
+
+This will show you the current state of the system along with any updates available in the repo; see the [updater README](../../updater/README.md#walkthrough) for details.
+
+Assuming you want to accept the chosen update, you can apply it:
+
+```
+apiclient update apply
+```
+
+This downloads and writes the update to the alternate partition set, then marks it as active.
+The next time you reboot, for example with `apiclient reboot`, the update will take effect.
+
+If you're confident that you want to update immediately to the latest version, you can do all of the above in one step:
+
+```
+apiclient update apply --check --reboot
+```
+
+> Note that available updates are controlled by your settings under `settings.updates`; see [README](../../../README.md#updates-settings) for details.
+
+### Raw mode
+
+Raw mode lets you make HTTP requests to a UNIX socket.
+You can think of it kind of like `curl`, but with more understanding of the Bottlerocket API server; for example, it understands the default path to the API socket, the hostname, and the content type.
 
 The URI path is specified with `-u` or `--uri`, for example `-u /settings`.
 This should include the query string, if any.
@@ -19,39 +52,40 @@ Specify the data after `-d` or `--data`.
 
 To see verbose response data, including the HTTP status code, use `-v` or `--verbose`.
 
-### Example usage
+#### Examples
 
 Getting settings:
 
 ```
-apiclient -m GET -u /settings
+apiclient raw -m GET -u /settings
 ```
 
 Changing settings:
 
 ```
-apiclient -X PATCH -u /settings -d '{"motd": "my own value!"}'
-apiclient -m POST -u /tx/commit_and_apply
+apiclient raw -X PATCH -u /settings -d '{"motd": "my own value!"}'
+apiclient raw -m POST -u /tx/commit_and_apply
 ```
 
 You can also check what you've changed but not commited by looking at the pending transaction:
 
 ```
-apiclient -m GET -u /tx
+apiclient raw -m GET -u /tx
 ```
 
 (You can group changes into transactions by adding a parameter like `?tx=FOO` to the calls above.)
 
 ## apiclient library
 
-The apiclient library provides simple methods to query an HTTP API over a Unix-domain socket.
+The apiclient library provides high-level methods to interact with the Bottlerocket API.  See
+the documentation for the [`update`] submodule for high-level helpers.
+
+For more control, and to handle APIs without high-level wrappers, there are also 'raw' methods
+to query an HTTP API over a Unix-domain socket.
 
 The `raw_request` method takes care of the basics of making an HTTP request on a Unix-domain
 socket, and requires you to specify the socket path, the URI (including query string), the
 HTTP method, and any request body data.
-
-In the future, we intend to add methods that understand the Bottlerocket API and help more with common
-types of requests.
 
 ## Colophon
 

--- a/sources/api/apiclient/README.tpl
+++ b/sources/api/apiclient/README.tpl
@@ -4,10 +4,43 @@ Current version: {{version}}
 
 ## apiclient binary
 
-The `apiclient` binary helps you talk to an HTTP API over a Unix-domain socket.
+The `apiclient` binary provides some high-level, synchronous methods of interacting with the API, for example an `update` subcommand that wraps the individual API calls needed to update the host.
+There's also a low-level `raw` subcommand for direct interaction with the HTTP API.
 
 It talks to the Bottlerocket socket by default.
 It can be pointed to another socket using `--socket-path`, for example for local testing.
+
+### Update mode
+
+To start, you can check what updates are available:
+
+```
+apiclient update check
+```
+
+This will show you the current state of the system along with any updates available in the repo; see the [updater README](../../updater/README.md#walkthrough) for details.
+
+Assuming you want to accept the chosen update, you can apply it:
+
+```
+apiclient update apply
+```
+
+This downloads and writes the update to the alternate partition set, then marks it as active.
+The next time you reboot, for example with `apiclient reboot`, the update will take effect.
+
+If you're confident that you want to update immediately to the latest version, you can do all of the above in one step:
+
+```
+apiclient update apply --check --reboot
+```
+
+> Note that available updates are controlled by your settings under `settings.updates`; see [README](../../../README.md#updates-settings) for details.
+
+### Raw mode
+
+Raw mode lets you make HTTP requests to a UNIX socket.
+You can think of it kind of like `curl`, but with more understanding of the Bottlerocket API server; for example, it understands the default path to the API socket, the hostname, and the content type.
 
 The URI path is specified with `-u` or `--uri`, for example `-u /settings`.
 This should include the query string, if any.
@@ -19,25 +52,25 @@ Specify the data after `-d` or `--data`.
 
 To see verbose response data, including the HTTP status code, use `-v` or `--verbose`.
 
-### Example usage
+#### Examples
 
 Getting settings:
 
 ```
-apiclient -m GET -u /settings
+apiclient raw -m GET -u /settings
 ```
 
 Changing settings:
 
 ```
-apiclient -X PATCH -u /settings -d '{"motd": "my own value!"}'
-apiclient -m POST -u /tx/commit_and_apply
+apiclient raw -X PATCH -u /settings -d '{"motd": "my own value!"}'
+apiclient raw -m POST -u /tx/commit_and_apply
 ```
 
 You can also check what you've changed but not commited by looking at the pending transaction:
 
 ```
-apiclient -m GET -u /tx
+apiclient raw -m GET -u /tx
 ```
 
 (You can group changes into transactions by adding a parameter like `?tx=FOO` to the calls above.)

--- a/sources/api/apiclient/src/lib.rs
+++ b/sources/api/apiclient/src/lib.rs
@@ -1,13 +1,14 @@
 #![deny(rust_2018_idioms)]
 
-//! The apiclient library provides simple methods to query an HTTP API over a Unix-domain socket.
+//! The apiclient library provides high-level methods to interact with the Bottlerocket API.  See
+//! the documentation for the [`update`] submodule for high-level helpers.
+//!
+//! For more control, and to handle APIs without high-level wrappers, there are also 'raw' methods
+//! to query an HTTP API over a Unix-domain socket.
 //!
 //! The `raw_request` method takes care of the basics of making an HTTP request on a Unix-domain
 //! socket, and requires you to specify the socket path, the URI (including query string), the
 //! HTTP method, and any request body data.
-//!
-//! In the future, we intend to add methods that understand the Bottlerocket API and help more with common
-//! types of requests.
 
 // Think "reqwest" but for Unix-domain sockets.  Would be nice to use the simpler reqwest instead
 // of hyper, but it lacks Unix-domain socket support:

--- a/sources/updater/README.md
+++ b/sources/updater/README.md
@@ -66,16 +66,21 @@ In general, the process of using the update API looks like this:
 You refresh the list of known updates, then apply one to the system.
 Calls to `/updates/status` will tell you the current state and give more details on any errors.
 
+`apiclient` understands this workflow and automates the calls for most use cases.
+See the [apiclient README](../api/apiclient/README.md) for details.
+
 ### Walkthrough
+
+If you don't want to use the simpler update mode available in [apiclient](../api/apiclient/README.md), or you just want to control what's going on at a lower level, read on.
 
 First, refresh the list of available updates:
 ```
-apiclient -u /actions/refresh-updates -m POST
+apiclient raw -u /actions/refresh-updates -m POST
 ```
 
 Now you can see the list of available updates, along with the chosen update, according to your `version-lock` [setting](../../README.md#updates-settings):
 ```
-apiclient -u /updates/status
+apiclient raw -u /updates/status
 ```
 
 This will return the current update status in JSON format. The status should look something like the following (pretty-printed):
@@ -113,22 +118,22 @@ You can see that we're running `v0.3.2` in the active partition, and that `v0.4.
 If you're happy with that selection, you can request that the update be downloaded and applied to disk.
 (The update will remain inactive until you make the `activate-update` call below.)
 ```
-apiclient -u /actions/prepare-update -m POST
+apiclient raw -u /actions/prepare-update -m POST
 ```
 
 After you request that the update be prepared, you can check the update status again until it reflects the new version in the staging partition.
 ```
-apiclient -u /updates/status
+apiclient raw -u /updates/status
 ```
 
 If the staging partition shows the new version, you can proceed to "activate" the update.
 This means that as soon as the host is rebooted it will try to run the new version.
 (If the new version can't boot, we automatically flip back to the old version.)
 ```
-apiclient -u /actions/activate-update -m POST
+apiclient raw -u /actions/activate-update -m POST
 ```
 
 You can reboot the host with:
 ```
-apiclient -u /actions/reboot -m POST
+apiclient raw -u /actions/reboot -m POST
 ```


### PR DESCRIPTION
**Description of changes:**

This updates our documentation to explain and take advantage of the new higher-level `update` subcommand of apiclient.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
