### PR TITLE
fixes for the SELinux policy

### DIFF
--- a/packages/selinux-policy/files.cil
+++ b/packages/selinux-policy/files.cil
@@ -1,5 +1,5 @@
 ; Permission groups for files.
-(classmap files (relabel mount relax enter load mutate watch))
+(classmap files (relabel mount relax enter load mutate block))
 
 ; Permission group for relabeling files.
 (classmapping files relabel relabel_file)
@@ -45,15 +45,14 @@
 (classmapping files load load_filesystem)
 (classmapping files load load_fd)
 
-; Permission group for watching files.
-(classmapping files watch watch_file)
-(classmapping files watch watch_dir)
-(classmapping files watch watch_lnk_file)
-(classmapping files watch watch_chr_file)
-(classmapping files watch watch_blk_file)
-(classmapping files watch watch_sock_file)
-(classmapping files watch watch_fifo_file)
-(classmapping files watch watch_filesystem)
+; Permission group for blocking access to files.
+(classmapping files block block_file)
+(classmapping files block block_dir)
+(classmapping files block block_lnk_file)
+(classmapping files block block_chr_file)
+(classmapping files block block_blk_file)
+(classmapping files block block_sock_file)
+(classmapping files block block_fifo_file)
 
 ; Permission group for mutating files.
 (classmapping files mutate mutate_file)
@@ -159,49 +158,61 @@
 (classpermission load_filesystem)
 (classpermission load_fd)
 (classpermissionset load_file (
-  file (execute getattr ioctl map open read execute_no_trans)))
+  file (
+    execute getattr ioctl map open read execute_no_trans
+    watch watch_mount watch_reads watch_sb)))
 (classpermissionset load_dir (
-  dir (execute getattr ioctl map open read search)))
+  dir (
+    execute getattr ioctl map open read search
+    watch watch_mount watch_reads watch_sb)))
 (classpermissionset load_lnk_file (
-  lnk_file (execute ioctl getattr map open read)))
+  lnk_file (
+    execute ioctl getattr map open read
+    watch watch_mount watch_reads watch_sb)))
 (classpermissionset load_chr_file (
-  chr_file (execute ioctl getattr map open read)))
+  chr_file (
+    execute ioctl getattr map open read
+    watch watch_mount watch_reads watch_sb)))
 (classpermissionset load_blk_file (
-  blk_file (execute ioctl getattr map open read)))
+  blk_file (
+    execute ioctl getattr map open read
+    watch watch_mount watch_reads watch_sb)))
 (classpermissionset load_sock_file (
-  sock_file (execute ioctl getattr map open read)))
+  sock_file (
+    execute ioctl getattr map open read
+    watch watch_mount watch_reads watch_sb)))
 (classpermissionset load_fifo_file (
-  fifo_file (execute ioctl getattr map open read)))
+  fifo_file (
+    execute ioctl getattr map open read
+    watch watch_mount watch_reads watch_sb)))
 (classpermissionset load_filesystem (
-  filesystem (getattr quotaget)))
+  filesystem (
+    getattr quotaget watch)))
 (classpermissionset load_fd (
   fd (use)))
 
-; Sets of permissions for watching file objects.
-(classpermission watch_file)
-(classpermission watch_dir)
-(classpermission watch_lnk_file)
-(classpermission watch_chr_file)
-(classpermission watch_blk_file)
-(classpermission watch_sock_file)
-(classpermission watch_fifo_file)
-(classpermission watch_filesystem)
-(classpermissionset watch_file (
-  file (watch watch_mount watch_reads watch_sb watch_with_perm)))
-(classpermissionset watch_dir (
-  dir (watch watch_mount watch_reads watch_sb watch_with_perm)))
-(classpermissionset watch_lnk_file (
-  lnk_file (watch watch_mount watch_reads watch_sb watch_with_perm)))
-(classpermissionset watch_chr_file (
-  chr_file (watch watch_mount watch_reads watch_sb watch_with_perm)))
-(classpermissionset watch_blk_file (
-  blk_file (watch watch_mount watch_reads watch_sb watch_with_perm)))
-(classpermissionset watch_sock_file (
-  sock_file (watch watch_mount watch_reads watch_sb watch_with_perm)))
-(classpermissionset watch_fifo_file (
-  fifo_file (watch watch_mount watch_reads watch_sb watch_with_perm)))
-(classpermissionset watch_filesystem (
-  filesystem (watch)))
+; Sets of permissions for blocking access to file objects.
+(classpermission block_file)
+(classpermission block_dir)
+(classpermission block_lnk_file)
+(classpermission block_chr_file)
+(classpermission block_blk_file)
+(classpermission block_sock_file)
+(classpermission block_fifo_file)
+(classpermissionset block_file (
+  file (watch_with_perm)))
+(classpermissionset block_dir (
+  dir (watch_with_perm)))
+(classpermissionset block_lnk_file (
+  lnk_file (watch_with_perm)))
+(classpermissionset block_chr_file (
+  chr_file (watch_with_perm)))
+(classpermissionset block_blk_file (
+  blk_file (watch_with_perm)))
+(classpermissionset block_sock_file (
+  sock_file (watch_with_perm)))
+(classpermissionset block_fifo_file (
+  fifo_file (watch_with_perm)))
 
 ; Sets of permissions for mutating file objects, which includes all
 ; actions that are not covered by other policy restrictions.

--- a/packages/selinux-policy/files.cil
+++ b/packages/selinux-policy/files.cil
@@ -89,7 +89,7 @@
 (classpermissionset relabel_fifo_file (
   fifo_file (relabelfrom relabelto)))
 (classpermissionset relabel_filesystem (
-  filesystem (associate relabelfrom relabelto)))
+  filesystem (relabelfrom relabelto)))
 (classpermissionset relabel_kernel_service (
   kernel_service (create_files_as)))
 

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -97,79 +97,75 @@
 
 ; All subjects are allowed to write to objects with their own label.
 ; This includes files like the ones under /proc/self.
-; They can also set watches on those objects.
-(allow all_s self (files (mutate watch)))
+(allow all_s self (files (mutate)))
 
-; All subjects are allowed to write to, set watches for, and manage
-; mounts for "ephemeral" objects, such as files in /mnt and /tmp.
-(allow all_s ephemeral_o (files (mutate watch mount)))
+; All subjects are allowed to write to and manage mounts for
+; "ephemeral" objects, such as files in /mnt and /tmp.
+(allow all_s ephemeral_o (files (mutate mount)))
 
-; Trusted subjects are allowed to write to, set watches for, and
-; manage mounts for "dynamic" files in /etc.
-(allow trusted_s dynamic_o (files (mutate watch mount)))
+; Trusted subjects are allowed to write to and manage mounts
+; for "dynamic" files in /etc.
+(allow trusted_s dynamic_o (files (mutate mount)))
 
 ; wicked calls netdog which writes /etc/resolv.conf.
 (allow network_t etc_t (files (mutate)))
 
 ; Other subjects cannot modify these "dynamic" files.
-(neverallow other_s dynamic_o (files (mutate watch mount)))
+(neverallow other_s dynamic_o (files (mutate mount)))
 
-; Most subjects are allowed to write to, set watches for, and manage
-; mounts for "local" files and directories on /local.
-(allow unconfined_s local_t (files (mutate watch mount)))
+; Most subjects are allowed to write to and manage mounts for
+; "local" files and directories on /local.
+(allow unconfined_s local_t (files (mutate mount)))
 
-; Subjects that control the OS can write to, set watches for, and
-; manage mounts for "state" files and directories on /local. Our
-; runtimes also need to be able to perform these operations so that
+; Subjects that control the OS can write to and manage mounts
+; for "state" files and directories on /local. Our runtimes
+; also need to be able to perform these operations so that
 ; they can launch host containers.
-(allow control_s state_t (files (mutate watch mount)))
-(allow runtime_s state_t (files (mutate watch mount)))
+(allow control_s state_t (files (mutate mount)))
+(allow runtime_s state_t (files (mutate mount)))
 
 ; Untrusted subjects cannot modify the "state" files.
-(neverallow untrusted_s state_t (files (mutate watch mount)))
+(neverallow untrusted_s state_t (files (mutate mount)))
 
 ; Confined subjects cannot modify either "state" or "local" files.
-(neverallow confined_s local_t (files (mutate watch mount)))
-(neverallow confined_s state_t (files (mutate watch mount)))
+(neverallow confined_s local_t (files (mutate mount)))
+(neverallow confined_s state_t (files (mutate mount)))
 
 ; Trusted components are allowed to manage mounts everywhere.
 (allow trusted_s global (files (mount)))
 
-; Trusted components can set watches on immutable files, since we
-; expect this behavior from systemd.
-(allow trusted_s immutable_o (files (watch)))
-
-; dbus-broker watches /usr/share/dbus-1/system.d.
-(allow bus_t os_t (files (watch)))
-
 ; Only specific components can write to these objects, as they
 ; provide a means to persist changes across container restarts
-; and reboots. We also restrict the ability to set watches as
-; this can be used to block access for other processes.
-(allow api_s private_t (files (mutate watch)))
-(allow clock_s measure_t (files (mutate watch)))
-(allow network_s lease_t (files (mutate watch)))
-(allow runtime_s cache_t (files (mutate watch)))
+; and reboots.
+(allow api_s private_t (files (mutate)))
+(allow clock_s measure_t (files (mutate)))
+(allow network_s lease_t (files (mutate)))
+(allow runtime_s cache_t (files (mutate)))
 
 ; Other components should not be permitted to modify these files,
-; set watches for them, or to manage mounts for these directories.
-(neverallow other_s protected_o (files (mutate watch mount)))
-(neverallow other_s immutable_o (files (watch)))
+; or to manage mounts for these directories.
+(neverallow other_s protected_o (files (mutate mount)))
 
 ; Only the API server and specific components can use the API
 ; socket, as this provides a means to escalate privileges and
 ; persist changes.
-(allow api_s api_socket_t (files (mutate watch)))
-(allow control_s api_socket_t (files (mutate watch)))
+(allow api_s api_socket_t (files (mutate)))
+(allow control_s api_socket_t (files (mutate)))
 
 ; Untrusted components are not allowed to use the API socket.
-(neverallow untrusted_s api_socket_t (files (mutate watch)))
+(neverallow untrusted_s api_socket_t (files (mutate)))
 
 ; Only trusted components are allowed to relabel files.
 (allow trusted_s global (files (relabel)))
 
 ; Untrusted components are not allowed to relabel files.
 (neverallow untrusted_s global (files (relabel)))
+
+; No components are allowed to block access to files by using
+; fanotify permission events. Fanotify only sends events for
+; accesses from within the mount namespace, so it's unlikely to
+; be useful for containers, and we don't use it in the host.
+(neverallow all_s global (files (block)))
 
 ; All object labels can be used for files on filesystems that have
 ; the same label, and for files on ephemeral storage.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -171,6 +171,14 @@
 ; Untrusted components are not allowed to relabel files.
 (neverallow untrusted_s global (files (relabel)))
 
+; All object labels can be used for files on filesystems that have
+; the same label, and for files on ephemeral storage.
+(allow all_o self (filesystem (associate)))
+(allow all_o ephemeral_o (filesystem (associate)))
+
+; Protected object labels can also be used on local storage.
+(allow protected_o local_t (filesystem (associate)))
+
 ; Containers are allowed to relax security constraints, since we
 ; don't control what code they run or how it's built.
 (allow container_s self (processes (relax)))

--- a/packages/selinux-policy/sid.cil
+++ b/packages/selinux-policy/sid.cil
@@ -30,41 +30,49 @@
 (sid scmp_packet)
 (sid devnull)
 
-; The order of ISIDs must match the kernel's order.
+; The order of ISIDs must match the kernel's order, for now.
 (sidorder (
    kernel security unlabeled fs file file_labels init any_socket port
    netif netmsg node igmp_packet icmp_socket tcp_socket sysctl_modprobe
    sysctl sysctl_fs sysctl_kernel sysctl_net sysctl_net_unix sysctl_vm
    sysctl_dev kmod policy scmp_packet devnull))
 
-; We associate the same context with all ISIDs, with two exceptions.
-; "unlabeled" is used for entities with an invalid context, such as
-; a file labeled on a different system. "file" is used for entities
-; that have no context at all, such as a file with no label.
+; Apply the "kernel" context for kernel and SELinux-related entities.
 (sidcontext kernel kernel)
 (sidcontext security kernel)
-(sidcontext unlabeled unlabeled)
-(sidcontext fs kernel)
-(sidcontext file unlabeled)
-(sidcontext file_labels kernel)
-(sidcontext init kernel)
-(sidcontext any_socket kernel)
-(sidcontext port kernel)
-(sidcontext netif kernel)
-(sidcontext netmsg kernel)
-(sidcontext node kernel)
-(sidcontext igmp_packet kernel)
-(sidcontext icmp_socket kernel)
-(sidcontext tcp_socket kernel)
-(sidcontext sysctl_modprobe kernel)
-(sidcontext sysctl kernel)
-(sidcontext sysctl_fs kernel)
-(sidcontext sysctl_kernel kernel)
-(sidcontext sysctl_net kernel)
-(sidcontext sysctl_net_unix kernel)
-(sidcontext sysctl_vm kernel)
-(sidcontext sysctl_dev kernel)
-(sidcontext kmod kernel)
-(sidcontext policy kernel)
-(sidcontext scmp_packet kernel)
 (sidcontext devnull kernel)
+
+; Apply the "unlabeled" context for entities with an invalid context,
+; and for files with no context at all, which are treated the same.
+(sidcontext unlabeled unlabeled)
+(sidcontext file unlabeled)
+
+; Apply the "any" context for entities like sockets, ports, and
+; network interfaces if they are otherwise unlabeled.
+(sidcontext any_socket any)
+(sidcontext port any)
+(sidcontext netif any)
+(sidcontext netmsg any)
+(sidcontext node any)
+
+; Most of the initial SIDs have never been used, or are no longer used.
+; We use the placeholder "unused" context for all of these, since the
+; policy isn't allowed to omit them yet. We'll need a 5.7+ kernel and
+; updated userspace tools first.
+(sidcontext fs unused)
+(sidcontext file_labels unused)
+(sidcontext init unused)
+(sidcontext igmp_packet unused)
+(sidcontext icmp_socket unused)
+(sidcontext tcp_socket unused)
+(sidcontext sysctl_modprobe unused)
+(sidcontext sysctl unused)
+(sidcontext sysctl_fs unused)
+(sidcontext sysctl_kernel unused)
+(sidcontext sysctl_net unused)
+(sidcontext sysctl_net_unix unused)
+(sidcontext sysctl_vm unused)
+(sidcontext sysctl_dev unused)
+(sidcontext kmod unused)
+(sidcontext policy unused)
+(sidcontext scmp_packet unused)

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -72,7 +72,7 @@
 
 ; Subjects that are treated as a trusted part of the OS.
 (typeattribute trusted_s)
-(typeattributeset trusted_s (not (untrusted_s)))
+(typeattributeset trusted_s (xor (all_s) (untrusted_s)))
 
 ; Subjects that are part of the OS, but confined through policy.
 (typeattribute confined_s)
@@ -80,7 +80,7 @@
 
 ; Subjects that are not confined by policy.
 (typeattribute unconfined_s)
-(typeattributeset unconfined_s (not (confined_s)))
+(typeattributeset unconfined_s (xor (all_s) (confined_s)))
 
 ; Subjects that are not part of the OS.
 (typeattribute other_s)
@@ -96,7 +96,7 @@
 
 ; Subjects that are shipped with the OS.
 (typeattribute host_s)
-(typeattributeset host_s (not container_s))
+(typeattributeset host_s (xor (all_s) (container_s)))
 
 ; Subjects that are allowed to manage the API datastore.
 (typeattribute api_s)

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -8,6 +8,11 @@
 (roletype system_r kernel_t)
 (context kernel (system_u system_r kernel_t s0))
 
+; Unused ISIDs.
+(type unused_t)
+(roletype system_r unused_t)
+(context unused (system_u system_r unused_t s0))
+
 ; PID 1.
 (type init_t)
 (roletype system_r init_t)


### PR DESCRIPTION
**Issue number:**
Fixes #1151


**Description of changes:**
Revise access rules for inotify, dnotify, and fanotify, as the policy previously blocked pods from collecting journal logs.

Adjust initial SIDs for network entities, as a preliminary step toward blocking network access from containers to the host.

Fix logic error in sets of subject types, which I uncovered while adding audit rules to log access to host sockets. 


**Testing done:**
Ran the sonobuoy tests for the aws-k8s-1.18 variant (x86_64, aarch64). Test suite passed. Tested Cilium, Falco, EBS CSI driver, and the local storage provisioner on x86_64. Confirmed that the Cloudwatch Container Insights agent can collect journal logs. Ran a task for the aws-ecs-1 variant using the ECS CLI.

Verified in all cases that no new AVC denials were logged in `dmesg` or in the journal.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
