### PR TITLE
host-ctr: remove KillMode=mixed and don't create the container task under the unit's cgroup

### DIFF
--- a/packages/os/host-containers@.service
+++ b/packages/os/host-containers@.service
@@ -16,7 +16,6 @@ ExecStart=/usr/bin/host-ctr run \
 Restart=always
 RestartSec=45
 TimeoutStopSec=60
-KillMode=mixed
 StandardError=journal+console
 
 [Install]

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -201,13 +200,6 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 
 	// If the container doesn't already exist, create it
 	if container == nil {
-		// Get the cgroup path of the systemd service
-		cgroupPath, err := cgroups.GetOwnCgroup("name=systemd")
-		if err != nil {
-			log.G(ctx).WithError(err).Error("failed to discover systemd cgroup path")
-			return err
-		}
-
 		// Set up the container spec. See `withSuperpowered` for conditional options
 		// set when configured as superpowered.
 		ctrOpts := containerd.WithNewSpec(
@@ -215,8 +207,6 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 			oci.WithHostNamespace(runtimespec.NetworkNamespace),
 			oci.WithHostHostsFile,
 			oci.WithHostResolvconf,
-			// Launch the container under the systemd unit's cgroup
-			oci.WithCgroup(cgroupPath),
 			// Mount in the API socket for the Bottlerocket API server, and the API
 			// client used to interact with it
 			oci.WithMounts([]runtimespec.Mount{

--- a/sources/host-ctr/go.mod
+++ b/sources/host-ctr/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/containerd/ttrpc v1.0.2 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/opencontainers/runc v1.0.0-rc8
+	github.com/opencontainers/runc v1.0.0-rc8 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2
 	github.com/opencontainers/selinux v1.6.0
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1237


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Dec 4 14:31:26 2020 -0800

    host-containers@: remove KillMode=mixed
    
    We don't need systemd to go and actively try kill all processes
    of the unit's cgroup.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Dec 14 13:47:04 2020 -0800

    host-ctr: don't create the container task under the service's cgroup
    
    We no longer need to launch the host container task under the systemd
    service unit's cgroup. We're managing the life-cycle of the host
    container directly without the help of systemd
```

**Testing done:**
Built aws-k8s-1.17 x86 ami and launched instance.
Restarting `host-containerd` doesn't kill any running host-containers as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
