### PR TITLE
Add host-container user-data setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,9 @@ These settings can be changed at any time.
 Beyond just changing the settings above to affect the `admin` and `control` containers, you can add and remove host containers entirely.
 As long as you define the three fields above -- `source` with a URI, and `enabled` and `superpowered` with true/false -- you can add host containers with an API call or user data.
 
+You can optionally define a `user-data` field with arbitrary base64-encoded data, which will be made available in the container at `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME/user-data`.
+(It was inspired by instance user data, but is entirely separate; it can be any data your host container feels like interpreting.)
+
 Here's an example of adding a custom host container with API calls:
 ```
 apiclient -u /settings -X PATCH -d '{"host-containers": {"custom": {"source": "MY-CONTAINER-URI", "enabled": true, "superpowered": false}}}'

--- a/Release.toml
+++ b/Release.toml
@@ -12,4 +12,4 @@ version = "1.0.4"
 "(1.0.1, 1.0.2)" = ["migrate_v1.0.2_add-enable-spot-instance-draining.lz4"]
 "(1.0.2, 1.0.3)" = ["migrate_v1.0.3_add-sysctl.lz4"]
 "(1.0.3, 1.0.4)" = []
-"(1.0.4, 1.0.5)" = ["migrate_v1.0.5_add-lockdown.lz4", "migrate_v1.0.5_sysctl-subcommand.lz4"]
+"(1.0.4, 1.0.5)" = ["migrate_v1.0.5_add-lockdown.lz4", "migrate_v1.0.5_sysctl-subcommand.lz4", "migrate_v1.0.5_add-user-data.lz4"]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -288,6 +288,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-user-data"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-version-lock-ignore-waves"
 version = "0.1.0"
 dependencies = [
@@ -1256,6 +1263,7 @@ name = "host-containers"
 version = "0.1.0"
 dependencies = [
  "apiclient",
+ "base64 0.13.0",
  "cargo-readme",
  "http",
  "log",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "api/migration/migrations/v1.0.3/add-sysctl",
     "api/migration/migrations/v1.0.5/add-lockdown",
     "api/migration/migrations/v1.0.5/sysctl-subcommand",
+    "api/migration/migrations/v1.0.5/add-user-data",
 
     "bottlerocket-release",
 

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+base64 = "0.13"
 http = "0.2"
 log = "0.4"
 models = { path = "../../models" }

--- a/sources/api/host-containers/README.md
+++ b/sources/api/host-containers/README.md
@@ -4,9 +4,14 @@ Current version: 0.1.0
 
 ## Background
 
-host-containers is a tool that queries the API for the currently enabled host containers and
-ensures the relevant systemd service is enabled/started or disabled/stopped for each one depending
-on its 'enabled' flag.
+host-containers ensures that host containers are running as defined in system settings.
+
+It queries the API for their settings, then configures the system by:
+* creating a user-data file in the host container's persistent storage area, if a base64-encoded
+  user-data setting is set for the host container.  (The decoded contents are available to the
+  container at /.bottlerocket/host-containers/NAME/user-data)
+* creating an environment file used by a host-container-specific instance of a systemd service
+* ensuring the host container's systemd service is enabled/started or disabled/stopped
 
 ## Colophon
 

--- a/sources/api/migration/migrations/v1.0.5/add-user-data/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.5/add-user-data/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-user-data"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.5/add-user-data/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.5/add-user-data/src/main.rs
@@ -1,0 +1,45 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use std::process;
+
+/// This migration removes host-container user data settings when downgrading to versions that
+/// don't understand them.
+pub struct AddUserDataMigration;
+
+impl Migration for AddUserDataMigration {
+    /// There's no user data by default, it's just left empty on upgrade.
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("AddUserDataMigration has no work to do on upgrade.");
+        Ok(input)
+    }
+
+    /// Older versions don't know about the user-data settings; we remove them so that old versions
+    /// don't see them and fail deserialization.
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        for setting in input.data.clone().keys() {
+            // We don't currently have structured data available to migrations, and we don't want
+            // to re-parse keys.  We know no other keys could match these basic patterns.
+            if setting.starts_with("settings.host-containers.") && setting.ends_with(".user-data") {
+                if let Some(data) = input.data.remove(setting) {
+                    println!("Removed {}, which was set to '{}'", setting, data);
+                }
+            }
+        }
+        Ok(input)
+    }
+}
+
+fn run() -> Result<()> {
+    migrate(AddUserDataMigration)
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -138,6 +138,7 @@ struct ContainerImage {
     source: Url,
     enabled: bool,
     superpowered: bool,
+    user_data: ValidBase64,
 }
 
 // NTP settings


### PR DESCRIPTION
```
You can set settings.host-containers.NAME.user-data to a valid base64-encoded
string to have the (decoded) data placed in a file accessible to the host
container at /.bottlerocket/host-containers/NAME/user-data.
```

This is a prerequisite for other upcoming work, but the basic idea is to allow easier customization of host-container agents.

**Testing done:**

I added this to my instance user data:
```toml
[settings.host-containers.admin]
enabled = true
user-data = "aGkgdGhlcmUKaG93IGFyZSB5b3UK"
```

Here's the result, the basic functionality of this change:
```
[ec2-user@ip-192-168-19-177 ~]$ cat /.bottlerocket/host-containers/admin/user-data
hi there
how are you
```

Invalid base64 data is rejected:
```
[ec2-user@ip-192-168-0-110 ~]$ apiclient -u /settings -m PATCH -d '{"host-containers": {"admin": {"user-data": "lkajsdf"}}}'
Failed PATCH request to '/settings': Status 400 when PATCHing /settings: Json deserialize error: Unable to deserialize into ValidBase64: Invalid base64 input: Invalid last symbol 102, offset 6. at line 1 column 54
```

To test the migration, I built a 1.0.4 image from the v1.0.4 tag, updated to a 1.0.5 image based on this branch, re-confirmed that the user-data setting worked, downgraded back to 1.0.4, and confirmed the user-data setting was removed and the host came back up OK.

I confirmed a pod runs OK after downgrade/upgrade cycles.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
