### PR TITLE
selinux-policy: allow api helpers to modify state files

### DIFF
--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -117,10 +117,11 @@
 ; "local" files and directories on /local.
 (allow unconfined_s local_t (files (mutate mount)))
 
-; Subjects that control the OS can write to and manage mounts
-; for "state" files and directories on /local. Our runtimes
-; also need to be able to perform these operations so that
+; Subjects that control the OS, including helpers spawned by apiserver, can
+; write to and manage mounts for "state" files and directories on /local.
+; Our runtimes also need to be able to perform these operations so that
 ; they can launch host containers.
+(allow api_s state_t (files (mutate mount)))
 (allow control_s state_t (files (mutate mount)))
 (allow runtime_s state_t (files (mutate mount)))
 


### PR DESCRIPTION
```
Specifically, this allows the host-containers program to write user-data files
to the host container's persistent storage area when modified by API calls
after boot, when host-containers is spawned by apiserver (through
thar-be-settings).  Without this, it only works at boot time, because it's
called outside of the apiserver context.
```

Related: #1244, which adds the user-data key.

**Testing done:**

Before, changing host-container user-data after boot wouldn't work, and I saw host-containers give a permission denied error when trying to write the user-data file.  This AVC denial was in dmesg:
```
audit: type=1400 audit(1608167357.016:3): avc:  denied  { write } for  pid=9016 comm="host-containers" name="admin" dev="nvme1n1p1" ino=1177347 scontext=system_u:system_r:api_t:s0 tcontext=system_u:object_r:state_t:s0 tclass=dir permissive=0
```

After, it works:
```
bash-5.0# apiclient -u /settings -m PATCH -d '{"host-containers": {"admin": {"user-data": "aGkgdGhlcmUKaG93IGFyZSB5b3UK"}}}'
bash-5.0# apiclient -u /tx/commit_and_apply -m POST  
["settings.host-containers.admin.user-data"]
bash-5.0# cat /local/host-containers/admin/user-data 
hi there
how are you
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
