### PR TITLE
containerd: set version and revision strings

### DIFF
--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -4,6 +4,7 @@
 
 %global gover 1.3.7
 %global rpmver %{gover}
+%global gitrev 8fba4e9a7d01810a393d5d25a3621dc101981175
 
 %global _dwz_low_mem_die_limit 0
 
@@ -65,6 +66,8 @@ Requires: %{_cross_os}systemd
 %build
 %cross_go_configure %{goimport}
 export BUILDTAGS="no_btrfs seccomp selinux"
+export LD_VERSION="-X github.com/containerd/containerd/version.Version=%{gover}+bottlerocket"
+export LD_REVISION="-X github.com/containerd/containerd/version.Revision=%{gitrev}"
 for bin in \
   containerd \
   containerd-shim \
@@ -72,7 +75,12 @@ for bin in \
   containerd-shim-runc-v2 \
   ctr ;
 do
-  go build -buildmode=pie -ldflags=-linkmode=external -tags="${BUILDTAGS}" -o ${bin} %{goimport}/cmd/${bin}
+  go build \
+     -buildmode=pie \
+     -ldflags="-linkmode=external ${LD_VERSION} ${LD_REVISION}" \
+     -tags="${BUILDTAGS}" \
+     -o ${bin} \
+     %{goimport}/cmd/${bin}
 done
 
 %install


### PR DESCRIPTION
**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1241


**Description of changes:**
Set version and revision strings for containerd


**Testing done:**
```
bash-5.0# ctr -a /run/dockershim.sock version
Client:
  Version:  1.3.7+bottlerocket
  Revision: 8fba4e9a7d01810a393d5d25a3621dc101981175

Server:
  Version:  1.3.7+bottlerocket
  Revision: 8fba4e9a7d01810a393d5d25a3621dc101981175
  UUID: 5278435f-2098-4f42-8ee1-d55ec6f511ec
```

```
$ kubectl get nodes -o custom-columns=NAME:.metadata.name,OS-IMAGE:status.nodeInfo.osImage,CONTAINER-RUNTIME:status.nodeInfo.containerRuntimeVersion
NAME                                           OS-IMAGE                CONTAINER-RUNTIME
ip-192-168-58-191.us-west-2.compute.internal   Bottlerocket OS 1.0.4   containerd://1.3.7+bottlerocket
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
