### PR TITLE
migrations: adds necessary migrations for `settings.network`

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -12,4 +12,11 @@ version = "1.0.4"
 "(1.0.1, 1.0.2)" = ["migrate_v1.0.2_add-enable-spot-instance-draining.lz4"]
 "(1.0.2, 1.0.3)" = ["migrate_v1.0.3_add-sysctl.lz4"]
 "(1.0.3, 1.0.4)" = []
-"(1.0.4, 1.0.5)" = ["migrate_v1.0.5_add-lockdown.lz4", "migrate_v1.0.5_sysctl-subcommand.lz4", "migrate_v1.0.5_add-user-data.lz4"]
+"(1.0.4, 1.0.5)" = [
+    "migrate_v1.0.5_add-lockdown.lz4",
+    "migrate_v1.0.5_sysctl-subcommand.lz4",
+    "migrate_v1.0.5_add-user-data.lz4",
+    "migrate_v1.0.5_add-network-settings.lz4",
+    "migrate_v1.0.5_add-proxy-restart.lz4",
+    "migrate_v1.0.5_add-proxy-services.lz4"
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -281,6 +281,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-network-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "add-proxy-restart"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "add-proxy-services"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-sysctl"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -34,6 +34,9 @@ members = [
     "api/migration/migrations/v1.0.5/add-lockdown",
     "api/migration/migrations/v1.0.5/sysctl-subcommand",
     "api/migration/migrations/v1.0.5/add-user-data",
+    "api/migration/migrations/v1.0.5/add-network-settings",
+    "api/migration/migrations/v1.0.5/add-proxy-restart",
+    "api/migration/migrations/v1.0.5/add-proxy-services",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.0.5/add-network-settings/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.5/add-network-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-network-settings"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.5/add-network-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.5/add-network-settings/src/main.rs
@@ -1,0 +1,25 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a set of settings for configuring service network behavior and their associated
+/// configuration file. Remove the whole `settings.network`, `configuration-files.proxy-env` prefix
+/// if we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.network",
+        "configuration-files.proxy-env",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.0.5/add-proxy-restart/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.5/add-proxy-restart/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-proxy-restart"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.5/add-proxy-restart/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.5/add-proxy-restart/src/main.rs
@@ -1,0 +1,53 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the restart-commands and configuration-files settings for several existing services.
+/// We need to replace them upon downgrades and upgrades
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![
+        ListReplacement {
+            setting: "services.containerd.configuration-files",
+            old_vals: &["containerd-config-toml"],
+            new_vals: &["containerd-config-toml", "proxy-env"],
+        },
+        ListReplacement {
+            setting: "services.containerd.restart-commands",
+            old_vals: &[],
+            new_vals: &["/bin/systemctl try-restart containerd.service"],
+        },
+        ListReplacement {
+            setting: "services.kubernetes.configuration-files",
+            old_vals: &[
+                "kubelet-env",
+                "kubelet-config",
+                "kubelet-kubeconfig",
+                "kubernetes-ca-crt",
+            ],
+            new_vals: &[
+                "kubelet-env",
+                "kubelet-config",
+                "kubelet-kubeconfig",
+                "kubernetes-ca-crt",
+                "proxy-env",
+            ],
+        },
+        ListReplacement {
+            setting: "services.kubernetes.restart-commands",
+            old_vals: &[],
+            new_vals: &["/bin/systemctl try-restart kubelet.service"],
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.0.5/add-proxy-services/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.5/add-proxy-services/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-proxy-services"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.5/add-proxy-services/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.5/add-proxy-services/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new configuration files and restart commands for docker and host-containerd.
+/// On downgrade we need to remove all settings under these services
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "services.docker",
+        "services.host-containerd",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

This adds the migration related to https://github.com/bottlerocket-os/bottlerocket/pull/1204 and https://github.com/bottlerocket-os/bottlerocket/pull/1231.

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Jan 5 17:45:43 2021 -0800

    migrations: adds necessary migrations for `settings.network`
    
    Adds new migrations for migrating new settings and affected service
    settings. We also added new service settings for docker and
    host-containerd to incorporate restart commands for those services.

```


**Testing done:**

Built a custom TUF repository with a v1.0.5 aws-k8s-1.18 image.
Launched a v1.0.4 aws-k8s-1.18 host with a custom root.json and upgraded it to v1.0.5.
The instance came up fine and is able to run pods. Checked the settings and they got migrated as expected.
Rolled back the instance to v1.0.4, the host came back fine and is able to run pods. Backwards migration run successfully, all settings expected to be migrated got migrated.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
