### PR TITLE
apiclient: fix unused import warning

### DIFF
--- a/sources/api/apiclient/src/update.rs
+++ b/sources/api/apiclient/src/update.rs
@@ -24,7 +24,6 @@ use http::StatusCode;
 use log::{debug, info, trace, warn};
 use snafu::{ensure, ResultExt};
 use std::path::Path;
-use std::thread;
 use std::time::Duration;
 use tokio::time;
 


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Fixes "unused import: `std::thread`" warning in apiclient


**Testing done:**
apiclient builds without warnings after the change


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
