### PR TITLE
migration-helpers: ReplaceListMigration -> ReplaceListsMigration

### DIFF
--- a/sources/api/migration/migrations/v1.0.5/sysctl-subcommand/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.5/sysctl-subcommand/src/main.rs
@@ -1,17 +1,17 @@
 #![deny(rust_2018_idioms)]
 
-use migration_helpers::common_migrations::ReplaceListMigration;
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;
 
 /// We changed corndog to use subcommands so it can handle different kernel settings without having
 /// to apply them all every time.
 fn run() -> Result<()> {
-    migrate(ReplaceListMigration {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
         setting: "services.sysctl.restart-commands",
         old_vals: &["/usr/bin/corndog"],
         new_vals: &["/usr/bin/corndog sysctl"],
-    })
+    }]))
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

ReplaceListMigration becomes ReplaceListsMigration.
ReplaceListsMigration now can handle multiple settings that contain lists to be replaced.


**Testing done:**
Unit tests updated and passes

Testing `sysctl-subcommand` migration:
Downgrade:
```
$ VARIANT=aws-k8s-1.17 cargo run -- --source-datastore ~/thar/testing/ds-test/current --target-datastore ~/thar/testing/ds-test/backward --backward

Changed value of 'services.sysctl.restart-commands' from ["/usr/bin/corndog sysctl"] to ["/usr/bin/corndog"] on downgrade
Found no 'services.sysctl.restart-commands' to change on downgrade

```

Forward:
```
$ VARIANT=aws-k8s-1.17 cargo run -- --source-datastore ~/thar/testing/ds-test/backward --target-datastore ~/thar/testing/ds-test/current --forward
Changed value of 'services.sysctl.restart-commands' from ["/usr/bin/corndog"] to ["/usr/bin/corndog sysctl"] on upgrade
Found no 'services.sysctl.restart-commands' to change on upgrade
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
