### PR TITLE
Package updates

### DIFF
--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -9,5 +9,5 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2020-10-14.pem"
-sha512 = "f72d08913f2e1271a2f4bb1b77144bbea21fff28113074474f83d0a3bafc54cad69449bd98d6c228d78b409b6055a7efb341b75878724bd9d6a468dab20cf541"
+url = "https://curl.haxx.se/ca/cacert-2020-12-08.pem"
+sha512 = "d4e6573b3bbd6c5c63c5e77ffa79b05171f59c27c0ed458ebb00b42fef300dd17e42df2c91fa8da44cc37420785ce5a4bb083487ba66d3cac9d858b129fd3745"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2020.10.14
+Version: 2020.12.08
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2020-10-14.pem
+Source0: https://curl.haxx.se/ca/cacert-2020-12-08.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/plugins/archive/v0.8.7/plugins-0.8.7.tar.gz"
-sha512 = "1b11b080b1f54a8a792b1048573d7d882603b76929f0c9343eeb2e010f97700c0deea4489faeb493a1aeac12557b6847b26784c378d0430c47de6bdaca6aa70f"
+url = "https://github.com/containernetworking/plugins/archive/v0.9.0/plugins-0.9.0.tar.gz"
+sha512 = "8d545d17e6bf4180755708e47607c855b99f6ea4183a33930b7d05974d2151c90873f1e2064b806059a26caba6942502d9954fce697bf000995d539c2208811c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 %global gorepo plugins
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.8.7
+%global gover 0.9.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -58,5 +58,6 @@ install -p -m 0755 bin/* %{buildroot}%{_cross_factorydir}/opt/cni/bin
 %{_cross_factorydir}/opt/cni/bin/static
 %{_cross_factorydir}/opt/cni/bin/tuning
 %{_cross_factorydir}/opt/cni/bin/vlan
+%{_cross_factorydir}/opt/cni/bin/vrf
 
 %changelog

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v19.03.13/cli-19.03.13.tar.gz"
-sha512 = "738745548bcb416ccadefe1c340b3206b36efb3c222c310b853146f9fe0839bd879576d895bcc53f1f709850ef77888a9990742dd647b9f3cccaa05876a7c9d1"
+url = "https://github.com/docker/cli/archive/v19.03.14/cli-19.03.14.tar.gz"
+sha512 = "0cd72663ea9da2d1e2e74af8569c8e78a120a161cf40075a7cb8817b9c9f4ed94a5aebd48a754a896bcc9d7c7b67ed8a0f46203aeb34db0635f6693003c54edc"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,7 +2,7 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 19.03.13
+%global gover 19.03.14
 %global rpmver %{gover}
 %global gitrev 0ed913b885c8919944a2e4c8d0b80a318a8dd48b
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -9,13 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v19.03.13/moby-19.03.13.tar.gz"
-sha512 = "b034ba2d00f944bc57f44858f95f4db5960930e2fb3efe41183ed88a6f29fcb60ea007b0b28705a00b467ba38da557654c5611c6ef6731361802936568879698"
-
-[[package.metadata.build-package.external-files]]
-path = "awslogs_update_aws-sdk-go_to_support_imdsv2.patch.bz2"
-url = "https://github.com/docker/engine/commit/44a8e10bfc794dbbc4011a62fa8ba71d948d13cf.patch"
-sha512 = "36a775f5bcaf45616fcb27de1296035c6a1377f0a8b52ca5fa4e2b978b637693c04450553bc32f6d7fbd34ef1beb2aa8d05f98482290f34b5605ecec08a8465e"
+url = "https://github.com/moby/moby/archive/v19.03.14/moby-19.03.14.tar.gz"
+sha512 = "9ba589a2199ee272af50b60168a117a707c1fe0bfb039c8e4c0a9df68055add13b68b28e0937fdfeb9c42ec0e2936ac9ca3a671ff946d2d3f3e9d1bfe00ed6d1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,7 +3,7 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 19.03.13
+%global gover 19.03.14
 %global rpmver %{gover}
 %global gitrev 9dc6525e6118a25fab2be322d1914740ea842495
 
@@ -28,9 +28,6 @@ Source1000: clarify.toml
 # Bottlerocket-specific - Privileged containers should receive SELinux labels
 # https://github.com/bottlerocket-os/bottlerocket/issues/1011
 Patch0001: 0001-bottlerocket-privileged-shouldn-t-disable-SELinux.patch
-
-# Update aws-sdk-go for IMDSv2 support
-Patch0100: awslogs_update_aws-sdk-go_to_support_imdsv2.patch.bz2
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/docker-init/docker-init.spec
+++ b/packages/docker-init/docker-init.spec
@@ -3,7 +3,7 @@
 %global tiniver 0.19.0
 
 Name: %{_cross_os}docker-init
-Version: 19.03.13
+Version: 19.03.14
 Release: 1%{?dist}
 Summary: Init for containers
 License: MIT

--- a/packages/docker-proxy/Cargo.toml
+++ b/packages/docker-proxy/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/libnetwork/archive/026aabaa659832804b01754aaadd2c0f420c68b6/libnetwork-026aabaa659832804b01754aaadd2c0f420c68b6.tar.gz"
-sha512 = "fe8644611e975c051ee6e7ad4871624fb45862d9b4a2fd62ea4283e76ad9804d91d585e2165915b09356f11f9dfb31c40dd9ce6a66d63c5032c8c62354960538"
+url = "https://github.com/docker/libnetwork/archive/55e924b8a84231a065879156c0de95aefc5f5435/libnetwork-55e924b8a84231a065879156c0de95aefc5f5435.tar.gz"
+sha512 = "3d81ba20a91517e14da7e75a24d4e2eeb04c1dcb9c1bfe1115247982dbdb55d2fd72d0130093e9597363b742a20f2647f229c870da9a1cbdefc69aef65f02250"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -3,12 +3,12 @@
 %global goimport %{goproject}/%{gorepo}
 # Use the libnetwork commit listed in this file for the docker version we ship:
 # https://github.com/moby/moby/blob/DOCKER-VERSION-HERE/vendor.conf
-%global commit 026aabaa659832804b01754aaadd2c0f420c68b6
+%global commit 55e924b8a84231a065879156c0de95aefc5f5435
 
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}docker-proxy
-Version: 19.03.13
+Version: 19.03.14
 Release: 1%{?dist}
 Summary: Docker CLI
 # mostly Apache-2.0, client/mflag is BSD-3-Clause

--- a/packages/kubernetes-1.17/Cargo.toml
+++ b/packages/kubernetes-1.17/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.17"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.17.13/kubernetes-1.17.13.tar.gz"
-sha512 = "eaebc7d649a2a53f2a7bae8fe70ccd469f8f983a2d14148f86e86a05d66a40ce8b71d4422e653966daf4c86ccd353693cc0e9bfe3a44b5259239d047a20ddb7a"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.17.16/kubernetes-1.17.16.tar.gz"
+sha512 = "848b6334dbea5f6d714b22825538f5ae73c242fa31c63963bb94d7b43e3c1cbd27f89627af2ec5f6c6e581c29b85c4c3a859e2b4dae0f082b11b7a8b6f2dbecf"
 
 # This is a large patch, so we don't want to check it into the repo.  It's like
 # https://github.com/kubernetes/kubernetes/commit/a94346bef9806a135ebcfda03672966c336c1c17

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.17.13
+%global gover 1.17.16
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.18"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.18.10/kubernetes-1.18.10.tar.gz"
-sha512 = "967caccf8758bcdf4549ec83b795ec580e072d8108b2c8ef10f1d05696dedbfd5d472e27590bb952639f198003b44dc83da5435853337938035488959360e3d3"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.18.14/kubernetes-1.18.14.tar.gz"
+sha512 = "e19b834db4920db6b466662a8c001ecaad7a7bee6c4faef871bbc3f528e10b0b4c9fc6f3ac065953ce625db0ede98d76536cf3158b4fb241725115febb141946"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.18.10
+%global gover 1.18.14
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-audit/audit-userspace/archive/v2.8.5/audit-userspace-2.8.5.tar.gz"
-sha512 = "2b42791c53a610635f843b6b32e32ef36be36159d98ed69a7ce1cac32e5f28fbebfe8c113df4b09ea7dc80121e26d5ddbd3d8e499ee709f8479c2ae1dd0af937"
+url = "https://github.com/linux-audit/audit-userspace/archive/v3.0/audit-userspace-3.0.tar.gz"
+sha512 = "b7f196286dc603f8e2c4e87c58d3716092abaeae946f96f3e5e9458d64a824f865aa132108930af80157c76d0128cb3ee92d0ee4ca6e0f835e7bcad7416a6152"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libaudit
-Version: 2.8.5
+Version: 3.0
 Release: 1%{?dist}
 Summary: Library for the audit subsystem
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.44.tar.gz"
-sha512 = "d6a31dacd357a7c8fe553e4c004e8084c9025a72073073c92d0281e297172a0cab9174cb318f495eb51804cffcca376d8b7a650f6ba3d4fb31e207fcbc99116f"
+url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.46.tar.gz"
+sha512 = "d7d6d8d02701c2bef8f5095a0c923c1bb7033167894d573ad1c935d36d338adb9e58fe2e2779d5e9e8efaf5fe9bc87f43a85eafc733b76f953636038868d73d2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.44
+Version: 2.46
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause

--- a/packages/libpcre/Cargo.toml
+++ b/packages/libpcre/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.pcre.org/pub/pcre/pcre2-10.35.tar.bz2"
-sha512 = "ecfb8d48e219daff02874783b7b436fe7d70d8471e44eb66e1e29abb7b0aa67547e6b5fba7058b074ac90eef265ece7d12728f80afdda45b6b8124435f4561fd"
+url = "https://ftp.pcre.org/pub/pcre/pcre2-10.36.tar.bz2"
+sha512 = "fc2a920562c80c3d31cedd94028fab55314ae0fb168cac7178f286c344a11fc514939edc3b83b8e0b57c872db4e595fd5530fd1d4b8c779be629553e9ec965a3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libpcre/libpcre.spec
+++ b/packages/libpcre/libpcre.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libpcre
-Version: 10.35
+Version: 10.36
 Release: 1%{?dist}
 Summary: Library for regular expressions
 License: BSD-3-Clause

--- a/packages/libseccomp/Cargo.toml
+++ b/packages/libseccomp/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/seccomp/libseccomp/releases/download/v2.5.0/libseccomp-2.5.0.tar.gz"
-sha512 = "00ef5aeb4db8dafb546ae680b2d6d9b6aeed008df805d0f28f9dd15c074ff6ea7a5e5131ab503825b8011c59aa23046baedd5849ca040aa73352f43ab2d602ae"
+url = "https://github.com/seccomp/libseccomp/releases/download/v2.5.1/libseccomp-2.5.1.tar.gz"
+sha512 = "2be80a6323f9282dbeae8791724e5778b32e2382b2a3d1b0f77366371ec4072ea28128204f675cce101c091c0420d12c497e1a9ccbb7dc5bcbf61bfd777160af"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libseccomp/libseccomp.spec
+++ b/packages/libseccomp/libseccomp.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libseccomp
-Version: 2.5.0
+Version: 2.5.1
 Release: 1%{?dist}
 Summary: Library for enhanced seccomp
 License: LGPL-2.1-only

--- a/packages/readline/Cargo.toml
+++ b/packages/readline/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"
-sha512 = "41759d27bc3a258fefd7f4ff3277fa6ab9c21abb7b160e1a75aa8eba547bd90b288514e76264bd94fb0172da8a4faa54aab2c07b68a0356918ecf7f1969e866f"
+url = "https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz"
+sha512 = "27790d0461da3093a7fee6e89a51dcab5dc61928ec42e9228ab36493b17220641d5e481ea3d8fee5ee0044c70bf960f55c7d3f1a704cf6b9c42e5c269b797e00"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/readline/readline-8.1-shlib.patch
+++ b/packages/readline/readline-8.1-shlib.patch
@@ -1,5 +1,5 @@
 diff --git a/shlib/Makefile.in b/shlib/Makefile.in
-index f2ec3e4..5c8994c 100644
+index d138524..b68b0cc 100644
 --- a/shlib/Makefile.in
 +++ b/shlib/Makefile.in
 @@ -178,7 +178,7 @@ $(SHARED_READLINE):	$(SHARED_OBJ)
@@ -12,11 +12,11 @@ index f2ec3e4..5c8994c 100644
  # Since tilde.c is shared between readline and bash, make sure we compile 
  # it with the right flags when it's built as part of readline
 diff --git a/support/shobj-conf b/support/shobj-conf
-index 7920f1b..e7520cb 100644
+index 5a3f977..0668a33 100644
 --- a/support/shobj-conf
 +++ b/support/shobj-conf
 @@ -126,10 +126,11 @@ sunos5*|solaris2*)
- linux*-*|gnu*-*|k*bsd*-gnu-*|freebsd*-gentoo)
+ linux*-*|gnu*-*|k*bsd*-gnu-*|freebsd*|dragonfly*)
  	SHOBJ_CFLAGS=-fPIC
  	SHOBJ_LD='${CC}'
 -	SHOBJ_LDFLAGS='-shared -Wl,-soname,$@'
@@ -28,4 +28,4 @@ index 7920f1b..e7520cb 100644
 +	SHLIB_LIBS='-ltinfo'
  	;;
  
- freebsd2*)
+ # Darwin/MacOS X

--- a/packages/readline/readline.spec
+++ b/packages/readline/readline.spec
@@ -1,11 +1,11 @@
 Name: %{_cross_os}readline
-Version: 8.0
+Version: 8.1
 Release: 1%{?dist}
 Summary: A library for editing typed command lines
 License: GPL-3.0-or-later
 URL: https://tiswww.case.edu/php/chet/readline/rltop.html
 Source0: https://ftp.gnu.org/gnu/readline/readline-%{version}.tar.gz
-Patch1: readline-8.0-shlib.patch
+Patch1: readline-8.1-shlib.patch
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}ncurses-devel
 Requires: %{_cross_os}ncurses

--- a/packages/socat/Cargo.toml
+++ b/packages/socat/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "http://www.dest-unreach.org/socat/download/socat-1.7.3.4.tar.bz2"
-sha512 = "f338d28e5fd9d7ebb9e30b0fa700bcd5ff50ff9e668403474963a3310ba2b5f68b5236b928872c18e4b1ee95328374987e7e263ac7655a0d9b3fc9da77281123"
+url = "http://www.dest-unreach.org/socat/download/socat-1.7.4.0.tar.bz2"
+sha512 = "c4d166c2259271a70f81d6c4972549549c3fc60a9e47cc03eff1dd4d71c298ac39c177ae3c053dc0c97c2770fe8d157fd0bc6f2c14aef91625f868894d5d7c61"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/socat/socat.spec
+++ b/packages/socat/socat.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}socat
-Version: 1.7.3.4
+Version: 1.7.4.0
 Release: 1%{?dist}
 Summary: Transfer data between two channels
 License: GPL-2.0-only

--- a/packages/tcpdump/Cargo.toml
+++ b/packages/tcpdump/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "http://www.tcpdump.org/release/tcpdump-4.9.3.tar.gz"
-sha512 = "3aec673f78b996a4df884b1240e5d0a26a2ca81ee7aca8a2e6d50255bb53476e008a5ced4409e278a956710d8a4d31d85bbb800c9f1aab92b0b1046b59292a22"
+url = "http://www.tcpdump.org/release/tcpdump-4.99.0.tar.gz"
+sha512 = "03a434ec41c0026f237bc1e7a928b7ce67dbc342a8d982caded93d987bd356faf706a9d884231bd94f5e2a8580499fe95a28728e37a6672e371a1501ec5d6f79"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/tcpdump/tcpdump.spec
+++ b/packages/tcpdump/tcpdump.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}tcpdump
-Version: 4.9.3
+Version: 4.99.0
 Release: 1%{?dist}
 Summary: Network monitoring tool
 License: BSD-3-Clause


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Updates third-party dependencies in `packages/`.

Excluding ecs-agent as that is being covered by https://github.com/bottlerocket-os/bottlerocket/pull/1201
Excluding containerd 1.4 which is a major update that requires further inspection and testing.
systemd v247 and dbus-broker 25 update is in https://github.com/bottlerocket-os/bottlerocket/pull/1265

```
* 1d7baa43 - kubernetes-1.18: update to 1.18.14 <Erikson Tung>
* 3edc27cc - kubernetes-1.17: update to 1.17.13 <Erikson Tung>
* 2a7cdcf1 - docker-proxy: update to 19.03.14 <Erikson Tung>
* 2c8c9e72 - docker-engine: update to 19.03.14 <Erikson Tung>
* 5351e16a - docker-cli: update to 19.03.14 <Erikson Tung>
* 944d54b3 - tcpdump: update to 4.99.0 <Erikson Tung>
* c90749f7 - socat: update to 1.7.4.0 <Erikson Tung>
* d765c8c3 - readline: update to 8.1 <Erikson Tung>
* e432874e - libseccomp: update to 2.5.1 <Erikson Tung>
* 0289a32f - libpcre: update to 10.36 <Erikson Tung>
* d29c8f6e - libcap: update to 2.44 <Erikson Tung>
* b4b9c360 - libaudit: update to 3.0 <Erikson Tung>
* 65f4af13 - cni-plugins: update to 0.9.0 <Erikson Tung>
* 30c58e3e - ca-certificates: update to 2020.12.08 <Erikson Tung>
```


**Testing done:**

- [x] aws-k8s-1.15, aws-k8s-1.16, aws-k8s-1.17, aws-k8s-1.18, aws-k8s-1.19 on x86 and arm64
- Can run pods OK
- kubelet status look good, journal looks good
- journal in general looks normal

- [x] aws-ecs-1
- Runs tasks ok

- [x] aws-dev
- Runs containers ok


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
