### PR TITLE
Update to systemd v247 and dbus-broker 26

### DIFF
--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bus1/dbus-broker/releases/download/v24/dbus-broker-24.tar.xz"
-sha512 = "7fbe6c689eff27ec842bb9d839a418abc356b026bb0a54dfa8b680a655409aa1ea4cb90655a6b04561a88c6e703cacf8800fddfe1abc21e7ee60db2dac1c2db9"
+url = "https://github.com/bus1/dbus-broker/releases/download/v26/dbus-broker-26.tar.xz"
+sha512 = "51062edba619cdd7242c89422cf232f269feda2ad2fa221f66b09a616a3a76b90b25646b9b7f548290cddfbdac0e0da0c7347270ac3807cae2db056a1d4f480d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}dbus-broker
-Version: 24
+Version: 26
 Release: 1%{?dist}
 Summary: D-BUS message broker
 License: Apache-2.0

--- a/packages/systemd/9003-repart-always-use-random-UUIDs.patch
+++ b/packages/systemd/9003-repart-always-use-random-UUIDs.patch
@@ -1,4 +1,4 @@
-From 42b00096598978558b8abb3e03daab9e3315b98d Mon Sep 17 00:00:00 2001
+From d80f5878542dda9389fc5c491288a2e6b35a0c32 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 16 Apr 2020 15:10:41 +0000
 Subject: [PATCH 9003/9006] repart: always use random UUIDs
@@ -18,15 +18,15 @@ and disk UUIDs.
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 ---
  meson.build            |   3 +-
- src/partition/repart.c | 101 ++++++-----------------------------------
- 2 files changed, 14 insertions(+), 90 deletions(-)
+ src/partition/repart.c | 103 ++++++-----------------------------------
+ 2 files changed, 14 insertions(+), 92 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index dbbddb6..09fe7b6 100644
+index f406d595e6..c16b50c1e8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1357,8 +1357,7 @@ substs.set('DEFAULT_LLMNR_MODE', default_llmnr)
- 
+@@ -1374,8 +1374,7 @@ substs.set('DEFAULT_LLMNR_MODE', default_llmnr)
+
  want_repart = get_option('repart')
  if want_repart != 'false'
 -        have = (conf.get('HAVE_OPENSSL') == 1 and
@@ -36,56 +36,58 @@ index dbbddb6..09fe7b6 100644
                  error('repart support was requested, but dependencies are not available')
          endif
 diff --git a/src/partition/repart.c b/src/partition/repart.c
-index 2e5f5d1..1ce24e3 100644
+index 6db413ed5e..f771c3317a 100644
 --- a/src/partition/repart.c
 +++ b/src/partition/repart.c
 @@ -13,9 +13,6 @@
  #include <sys/ioctl.h>
  #include <sys/stat.h>
- 
+
 -#include <openssl/hmac.h>
 -#include <openssl/sha.h>
 -
  #include "sd-id128.h"
- 
+
  #include "alloc-util.h"
-@@ -1191,26 +1188,18 @@ static int fdisk_set_disklabel_id_by_uuid(struct fdisk_context *c, sd_id128_t id
- #define DISK_UUID_TOKEN "disk-uuid"
- 
- static int disk_acquire_uuid(Context *context, sd_id128_t *ret) {
+@@ -1347,28 +1344,18 @@ static int fdisk_set_disklabel_id_by_uuid(struct fdisk_context *c, sd_id128_t id
+ }
+
+ static int derive_uuid(sd_id128_t base, const char *token, sd_id128_t *ret) {
 -        union {
 -                unsigned char md[SHA256_DIGEST_LENGTH];
 -                sd_id128_t id;
 -        } result;
 +        sd_id128_t id;
 +        int r;
- 
-         assert(context);
+
+         assert(token);
          assert(ret);
- 
--        /* Calculate the HMAC-SHA256 of the string "disk-uuid", keyed off the machine ID. We use the machine
--         * ID as key (and not as cleartext!) since it's the machine ID we don't want to leak. */
+
+-        /* Derive a new UUID from the specified UUID in a stable and reasonably safe way. Specifically, we
+-         * calculate the HMAC-SHA256 of the specified token string, keyed by the supplied base (typically the
+-         * machine ID). We use the machine ID as key (and not as cleartext!) of the HMAC operation since it's
+-         * the machine ID we don't want to leak. */
 -
 -        if (!HMAC(EVP_sha256(),
--                  &context->seed, sizeof(context->seed),
--                  (const unsigned char*) DISK_UUID_TOKEN, strlen(DISK_UUID_TOKEN),
+-                  &base, sizeof(base),
+-                  (const unsigned char*) token, strlen(token),
 -                  result.md, NULL))
 -                return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE), "HMAC-SHA256 calculation failed.");
 +        /* Calculate a random UUID for the indicated disk. */
 +        r = sd_id128_randomize(&id);
 +        if (r < 0)
 +            return log_error_errno(r, "Failed to generate randomized UUID: %m");
- 
+
 -        /* Take the first half, mark it as v4 UUID */
 -        assert_cc(sizeof(result.md) == sizeof(result.id) * 2);
 -        *ret = id128_make_v4_uuid(result.id);
 +        *ret = id;
          return 0;
  }
- 
-@@ -2184,83 +2173,19 @@ static int context_copy_blocks(Context *context) {
+
+@@ -2810,83 +2797,19 @@ static int context_mkfs(Context *context) {
  }
- 
+
  static int partition_acquire_uuid(Context *context, Partition *p, sd_id128_t *ret) {
 -        struct {
 -                sd_id128_t type_uuid;
@@ -100,11 +102,11 @@ index 2e5f5d1..1ce24e3 100644
 -        Partition *q;
 +        sd_id128_t id;
          int r;
- 
+
          assert(context);
          assert(p);
          assert(ret);
- 
+
 -        /* Calculate a good UUID for the indicated partition. We want a certain degree of reproducibility,
 -         * hence we won't generate the UUIDs randomly. Instead we use a cryptographic hash (precisely:
 -         * HMAC-SHA256) to derive them from a single seed. The seed is generally the machine ID of the
@@ -167,12 +169,12 @@ index 2e5f5d1..1ce24e3 100644
 +        r = sd_id128_randomize(&id);
 +        if (r < 0)
 +                return log_error_errno(r, "Failed to generate randomized UUID: %m");
- 
+
 -        *ret = result.id;
 +        *ret = id;
          return 0;
  }
- 
--- 
-2.26.2
+
+--
+2.17.1
 

--- a/packages/systemd/9007-pkg-config-make-prefix-overridable-again.patch
+++ b/packages/systemd/9007-pkg-config-make-prefix-overridable-again.patch
@@ -1,0 +1,77 @@
+From c5bda93ca9c502ff982323a1645b55f37a88e9b9 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sat, 2 Jan 2021 02:46:33 +0100
+Subject: [PATCH] pkg-config: make prefix overridable again
+
+While we don't support prefix being != /usr, and this is hardcoded
+all over the place, variables in pkg-config file are expected
+to have overridable base directory.
+
+This is important for at least the following two use cases:
+
+- Installing projects to non-FHS package-specific prefixes for Nix-style
+  package managers. Of course, it is then their responsibility
+  to ensure systemd can find the service files.
+- Installing to local path for development purposes.
+  This is a compromise between running a program from a build directory,
+  and running it fully installed to system prefix.
+
+You will not want to write to system prefix in either case.
+
+For more information, see also
+https://www.bassi.io/articles/2018/03/15/pkg-config-and-paths/
+
+Fixes https://github.com/systemd/systemd/issues/18082
+
+Partially reverts 6e65df89c348242dbd10036abc7dd5e8181cf733
+---
+ src/core/systemd.pc.in | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
+index f2c045511d..b5cc8f94a5 100644
+--- a/src/core/systemd.pc.in
++++ b/src/core/systemd.pc.in
+@@ -26,10 +26,10 @@ systemdsystemunitdir=${systemd_system_unit_dir}
+ systemd_system_preset_dir=${rootprefix}/lib/systemd/system-preset
+ systemdsystempresetdir=${systemd_system_preset_dir}
+ 
+-systemd_user_unit_dir=/usr/lib/systemd/user
++systemd_user_unit_dir=${prefix}/lib/systemd/user
+ systemduserunitdir=${systemd_user_unit_dir}
+ 
+-systemd_user_preset_dir=/usr/lib/systemd/user-preset
++systemd_user_preset_dir=${prefix}/lib/systemd/user-preset
+ systemduserpresetdir=${systemd_user_preset_dir}
+ 
+ systemd_system_conf_dir=${sysconfdir}/systemd/system
+@@ -47,7 +47,7 @@ systemduserunitpath=${systemd_user_unit_path}
+ systemd_system_generator_dir=${root_prefix}/lib/systemd/system-generators
+ systemdsystemgeneratordir=${systemd_system_generator_dir}
+ 
+-systemd_user_generator_dir=/usr/lib/systemd/user-generators
++systemd_user_generator_dir=${prefix}/lib/systemd/user-generators
+ systemdusergeneratordir=${systemd_user_generator_dir}
+ 
+ systemd_system_generator_path=/run/systemd/system-generators:/etc/systemd/system-generators:/usr/local/lib/systemd/system-generators:${systemd_system_generator_dir}
+@@ -62,7 +62,7 @@ systemdsleepdir=${systemd_sleep_dir}
+ systemd_shutdown_dir=${root_prefix}/lib/systemd/system-shutdown
+ systemdshutdowndir=${systemd_shutdown_dir}
+ 
+-tmpfiles_dir=/usr/lib/tmpfiles.d
++tmpfiles_dir=${prefix}/lib/tmpfiles.d
+ tmpfilesdir=${tmpfiles_dir}
+ 
+ sysusers_dir=${rootprefix}/lib/sysusers.d
+@@ -77,7 +77,7 @@ binfmtdir=${binfmt_dir}
+ modules_load_dir=${rootprefix}/lib/modules-load.d
+ modulesloaddir=${modules_load_dir}
+ 
+-catalog_dir=/usr/lib/systemd/catalog
++catalog_dir=${prefix}/lib/systemd/catalog
+ catalogdir=${catalog_dir}
+ 
+ system_uid_max=@SYSTEM_UID_MAX@
+-- 
+2.17.1
+

--- a/packages/systemd/9008-pkg-config-stop-hardcoding-prefix-to-usr.patch
+++ b/packages/systemd/9008-pkg-config-stop-hardcoding-prefix-to-usr.patch
@@ -1,0 +1,28 @@
+From e59f3c3ac5a7939573e8562655e5ad9c933af9c7 Mon Sep 17 00:00:00 2001
+From: Erikson Tung <etung@amazon.com>
+Date: Wed, 27 Jan 2021 14:43:47 -0800
+Subject: [PATCH] pkg-config: stop hardcoding prefix to /usr
+
+While we ensure /usr points to the sys-root at runtime, for Bottlerocket's
+packaging we need to be careful to avoid dependencies on the host OS so
+the prefix needs to be configurable.
+---
+ src/core/systemd.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
+index b5cc8f94a5..ec4992b798 100644
+--- a/src/core/systemd.pc.in
++++ b/src/core/systemd.pc.in
+@@ -11,7 +11,7 @@
+ # considered deprecated (though there is no plan to remove them). New names
+ # shall have underscores.
+ 
+-prefix=/usr
++prefix=@prefix@
+ root_prefix=@rootprefix_noslash@
+ rootprefix=${root_prefix}
+ sysconf_dir=@sysconfdir@
+-- 
+2.17.1
+

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd/archive/v246/systemd-246.tar.gz"
-sha512 = "7103f7da53f7ced3b5543c238f23bd11c82af8e37166c1720a90576b6b431b4329320c78726166c65a9f5e101dd465c0a86dd13c586c4e55e608a6273d8f324f"
+url = "https://github.com/systemd/systemd/archive/v247/systemd-247.tar.gz"
+sha512 = "dd11cf46e5d9cbf44beb2d383262e9b13eb80fbb3403d86d011b4c2f9e0a4778c7c9779c856960f5654177581c20d7336c00ce687d35fe35ce069c56924604c2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,7 +2,7 @@
 %global _cross_allow_rpath 1
 
 Name: %{_cross_os}systemd
-Version: 246
+Version: 247
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later
@@ -34,6 +34,11 @@ Patch9005: 9005-core-mount-etc-with-specific-label.patch
 # makes it unreadable by older versions of systemd. Can be dropped once
 # there's sufficiently broad adoption of systemd >= 246.
 Patch9006: 9006-journal-disable-keyed-hashes-for-compatibility.patch
+
+# We need `prefix` to be configurable for our own packaging so we can avoid
+# dependencies on the host OS.
+Patch9007: 9007-pkg-config-make-prefix-overridable-again.patch
+Patch9008: 9008-pkg-config-stop-hardcoding-prefix-to-usr.patch
 
 BuildRequires: gperf
 BuildRequires: intltool
@@ -219,6 +224,7 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 %{_cross_bindir}/systemd-cat
 %{_cross_bindir}/systemd-cgls
 %{_cross_bindir}/systemd-cgtop
+%{_cross_bindir}/systemd-dissect
 %{_cross_bindir}/systemd-delta
 %{_cross_bindir}/systemd-detect-virt
 %{_cross_bindir}/systemd-escape
@@ -237,6 +243,7 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 %{_cross_bindir}/systemd-tty-ask-password-agent
 %{_cross_bindir}/systemd-umount
 %{_cross_bindir}/udevadm
+%exclude %{_cross_bindir}/oomctl
 %exclude %{_cross_bindir}/kernel-install
 
 %{_cross_sbindir}/halt
@@ -266,6 +273,7 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 %{_cross_tmpfilesdir}/*
 %exclude %{_cross_tmpfilesdir}/legacy.conf
 
+%exclude %{_cross_sysconfdir}/oomd.conf
 %exclude %{_cross_sysconfdir}/systemd/
 %exclude %{_cross_sysconfdir}/udev/
 %exclude %{_cross_sysconfdir}/X11
@@ -285,7 +293,6 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 %exclude %{_cross_docdir}
 %exclude %{_cross_localedir}
 %exclude %{_cross_localstatedir}/log/README
-%exclude %{_cross_rundir}
 
 %exclude %{_cross_bindir}/systemd-ask-password
 %exclude %{_cross_bindir}/systemd-tty-ask-password-agent
@@ -305,6 +312,7 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 %exclude %{_cross_unitdir}/systemd-ask-password-console.service
 %exclude %{_cross_unitdir}/systemd-ask-password-console.path
 %exclude %{_cross_unitdir}/systemd-ask-password-wall.path
+%exclude %{_cross_unitdir}/systemd-oomd.service
 %exclude %{_cross_unitdir}/sysinit.target.wants/systemd-ask-password-console.path
 %exclude %{_cross_unitdir}/multi-user.target.wants/systemd-ask-password-wall.path
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

- Updates systemd to v247
https://github.com/systemd/systemd/blob/v247/NEWS

systemd-oomd is a new thing that's in preview phase. I decided to exclude it for now as it was throwing errors in the system journal:

<details>

```
Jan 07 07:27:29 systemd[1]: systemd-oomd.service: Scheduled restart job, restart counter is at 2.
Jan 07 07:27:29 systemd[1]: Stopped Userspace Out-Of-Memory (OOM) Killer.
Jan 07 07:27:29 systemd[1]: Starting Userspace Out-Of-Memory (OOM) Killer...
Jan 07 07:27:29 systemd-oomd[359]: Requires swap to operate
Jan 07 07:27:29 systemd[1]: systemd-oomd.service: Main process exited, code=exited, status=1/FAILURE
Jan 07 07:27:29 systemd[1]: systemd-oomd.service: Failed with result 'exit-code'.
Jan 07 07:27:29 systemd[1]: Failed to start Userspace Out-Of-Memory (OOM) Killer.
Jan 07 07:27:29 storewolf[357]: 07:27:29 [INFO] Datastore populated
Jan 07 07:27:29 systemd[1]: Finished Datastore creator.
Jan 07 07:27:29 systemd[1]: systemd-oomd.service: Scheduled restart job, restart counter is at 3.
Jan 07 07:27:29 systemd[1]: Starting Bottlerocket API server...
Jan 07 07:27:29 systemd[1]: Stopped Userspace Out-Of-Memory (OOM) Killer.
Jan 07 07:27:29 systemd[1]: Starting Userspace Out-Of-Memory (OOM) Killer...
Jan 07 07:27:29 kernel: random: crng init done
Jan 07 07:27:29 kernel: random: 7 urandom warning(s) missed due to ratelimiting
Jan 07 07:27:29 systemd[1]: Finished Load/Save Random Seed.
Jan 07 07:27:29 systemd[1]: Reached target First Boot Complete.
Jan 07 07:27:29 systemd[1]: Starting Commit a transient machine-id on disk...
Jan 07 07:27:29 systemd-oomd[363]: Requires swap to operate
Jan 07 07:27:29 systemd[1]: systemd-oomd.service: Main process exited, code=exited, status=1/FAILURE
Jan 07 07:27:29 systemd[1]: systemd-oomd.service: Failed with result 'exit-code'.
Jan 07 07:27:29 systemd[1]: Failed to start Userspace Out-Of-Memory (OOM) Killer.
```
</details>

With regards to the udev event changes, the only udev rule we're maintaining is for ephemeral storage and it's still compatible with systemd  v247's changes.

No other systemd changes should impact us.

I updated the 9003 patch for systemd to accommodate new version changes, namely https://github.com/systemd/systemd/commit/53171c0453b564fa0bdc59da9e1bd9060575cf59.

I added a new patch to restore `prefix=@prefix@` in systemd's pkg-config to allow prefix to be overridable again so that we don't install things under `/usr` directly.


- Updates dbus-broker to v25

**Testing done:**
Launched aws-k8s-1.17 x86_64 and aws-k8s-1.18 aarch64 nodes. 
Both nodes are able to run pods OK.
System journal shows no abnormalities. 
I also confirmed that I was able to open the system journal produced by v247 with older versions of systemd.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
