### PR TITLE
Update README to point to discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can look at [existing issues](https://github.com/bottlerocket-os/bottlerocke
 If not, you can select from a few templates and get some guidance on the type of information that would be most helpful.
 [Contact us with a new issue here.](https://github.com/bottlerocket-os/bottlerocket/issues/new/choose)
 
-If you just have questions about Bottlerocket. please feel free to [start or join a discussion](https://github.com/bottlerocket-os/bottlerocket/discussions)
+If you just have questions about Bottlerocket, please feel free to [start or join a discussion](https://github.com/bottlerocket-os/bottlerocket/discussions).
 
 We don't have other communication channels set up quite yet, but don't worry about making an issue or a discussion thread!
 You can let us know about things that seem difficult, or even ways you might like to help.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ You can look at [existing issues](https://github.com/bottlerocket-os/bottlerocke
 If not, you can select from a few templates and get some guidance on the type of information that would be most helpful.
 [Contact us with a new issue here.](https://github.com/bottlerocket-os/bottlerocket/issues/new/choose)
 
-We don't have other communication channels set up quite yet, but don't worry about making an issue!
+If you just have questions about Bottlerocket. please feel free to [start or join a discussion](https://github.com/bottlerocket-os/bottlerocket/discussions)
+
+We don't have other communication channels set up quite yet, but don't worry about making an issue or a discussion thread!
 You can let us know about things that seem difficult, or even ways you might like to help.
 
 ## Variants


### PR DESCRIPTION
Simple text change to point out to people that we're now using GitHub Discussions to answer questions.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
