### PR TITLE
Fix build.yml to ignore changes that include only .md files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 on:
   pull_request:
     branches: [develop]
+    paths-ignore: 
+      - '**.md'
 jobs:
   build:
     runs-on: [self-hosted, linux, x64]


### PR DESCRIPTION
That's a lot of CI to run for a PR to a markdown file. This PR should allow build.yml to say "hey, if it's all md files, just, y'know, don't do all that stuff."

I can't think of any cases in which we'd want .md file changes to kick off CI runs, but if you can, feel free to reject this PR.

Also, cheers to the GitHub built-in editor for making sure the yaml is right.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**



**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
