### PR TITLE
enable early LSM support for lockdown

### DIFF
--- a/packages/kernel/config-bottlerocket
+++ b/packages/kernel/config-bottlerocket
@@ -41,6 +41,10 @@ CONFIG_SECURITY_SELINUX_CHECKREQPROT_VALUE=0
 # Enable support for the kernel lockdown security module.
 CONFIG_SECURITY_LOCKDOWN_LSM=y
 
+# Enable lockdown early so that if the option is present on the
+# kernel command line, it can be enforced.
+CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=y
+
 # Enable zstd compression for squashfs.
 CONFIG_SQUASHFS_ZSTD=y
 


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Initialize the lockdown LSM early, in case a custom build specifies `lockdown=integrity` or similar on the kernel command line.

This also ensures that the lockdown LSM is consulted for policy decisions, which it previously was not because it was not listed in `CONFIG_LSM`.


**Testing done:**
Verified that unsigned kernel modules cannot be loaded after enabling "integrity" mode:
```
$ apiclient -u /settings -m PATCH -d '{"kernel": {"lockdown": "integrity"}}'
$ apiclient -u /tx/commit_and_apply -m POST

$ sudo insmod test.ko
insmod: ERROR: could not insert module test.ko: Operation not permitted

$ sudo dmesg|grep -i lockdown
[   38.282301] Kernel is locked down from securityfs; see man kernel_lockdown.7
[   81.111626] Lockdown: insmod: unsigned module loading is restricted; see man kernel_lockdown.7
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
