### PR TITLE
Add (short term) conditional compilation to early-boot-config

### DIFF
--- a/sources/api/early-boot-config/README.md
+++ b/sources/api/early-boot-config/README.md
@@ -9,8 +9,10 @@ early-boot-config sends provider-specific platform data to the Bottlerocket API.
 For most providers this means configuration from user data and platform metadata, taken from
 something like an instance metadata service.
 
-Currently, Amazon EC2 is supported through the IMDSv1 HTTP API.  Data will be taken from files in
-/etc/early-boot-config instead, if available, for testing purposes.
+This program is conditionally compiled to include the appropriate data providers for a specific
+Bottlerocket platform.  Currently, Amazon EC2 is supported through the IMDSv2 HTTP API.  For
+development variants, data will be taken from files in /etc/early-boot-config instead, if
+available, for testing purposes.
 
 ## Colophon
 

--- a/sources/api/early-boot-config/build.rs
+++ b/sources/api/early-boot-config/build.rs
@@ -4,8 +4,30 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::process;
 
 fn main() {
+    // The code below emits `cfg` operators to conditionally compile this program based on the
+    // current variant.  This approach is only meant to be in use for the short term; when the
+    // build system supports ideas like "variant families" we should be able to drive the
+    // conditional compilation in a less brittle way.
+    println!("cargo:rerun-if-env-changed=VARIANT");
+    if let Ok(variant) = env::var("VARIANT") {
+        // The aws-dev variant includes the ability to read user data from local file
+        if variant == "aws-dev" {
+            println!("cargo:rustc-cfg=bottlerocket_platform=\"aws-dev\"");
+        } else if variant.starts_with("aws") {
+            println!("cargo:rustc-cfg=bottlerocket_platform=\"aws\"");
+        } else {
+            eprintln!(
+            "For local builds, you must set the 'VARIANT' environment variable so we know which data \
+            provider to build. Valid values are the directories in models/src/variants/, for \
+            example 'aws-k8s-1.17'."
+            );
+            process::exit(1);
+        }
+    }
+
     // Check for environment variable "SKIP_README". If it is set,
     // skip README generation
     if env::var_os("SKIP_README").is_some() {


### PR DESCRIPTION
**Issue number:**
Related to #1218


**Description of changes:**
```
This change adds a simple (short term) solution for conditionally
compiling early-boot-config based on the current variant.  As part of
the change, local file handling (which was previously broken) is split
out into its own trait implementation and only compiled into the program
for "aws-dev" variants.
```


**Testing done:**
* Built and ran the `aws-dev` variant both with and without local files.  The system boots and correctly uses local files if they exist.
* Build the `aws-k8s-1.17` variant and made sure it correctly fetches user data from IMDS on a new instance.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
