### PR TITLE
build-kmod-kit: use explicit paths

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -281,17 +281,19 @@ kernel_archive="$(find "${BUILDSYS_PACKAGES_DIR}" \
 prepare_kmod_kit="
 set -e -o pipefail
 
-mkdir /tmp/${kmod_kit}
+mkdir -p /tmp/kit/${kmod_kit} /tmp/extract
 
 # Retrieve the toolchain and kernel archives.
-curl --silent --fail --show-error --output /tmp/${kmod_kit}/toolchain.tar.xz \
+pushd /tmp/extract >/dev/null
+curl --silent --fail --show-error --output /tmp/kit/${kmod_kit}/toolchain.tar.xz \
   https://${BUILDSYS_SDK_SITE}/${BUILDSYS_TOOLCHAIN}.tar.xz
-find ./rpms -name "${kernel_archive}" \
+find /tmp/rpms -name "${kernel_archive}" \
   -exec rpm2cpio {} \; | cpio -idmu --quiet
-find -name 'kernel-devel.tar.xz' -exec mv {} /tmp/${kmod_kit} \;
+find -name 'kernel-devel.tar.xz' -exec mv {} /tmp/kit/${kmod_kit} \;
+popd >/dev/null
 
 # Extract them into the same directory.
-pushd /tmp/${kmod_kit} >/dev/null
+pushd /tmp/kit/${kmod_kit} >/dev/null
 tar xf kernel-devel.tar.xz
 rm kernel-devel.tar.xz
 tar xf toolchain.tar.xz
@@ -299,20 +301,19 @@ rm toolchain.tar.xz
 popd >/dev/null
 
 # Merge them together into a unified archive.
-pushd /tmp >/dev/null
+pushd /tmp/kit >/dev/null
 tar cf ${kmod_kit}.tar ${kmod_kit}
 xz -T0 ${kmod_kit}.tar
 popd >/dev/null
 
-mv /tmp/${kmod_kit}.tar.xz ./archives
+mv /tmp/kit/${kmod_kit}.tar.xz /tmp/archives
 "
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \
   --security-opt label:disable \
-  -v "${BUILDSYS_PACKAGES_DIR}":/home/builder/rpms \
-  -v "${BUILDSYS_ARCHIVES_DIR}":/home/builder/archives \
-  -w /home/builder \
+  -v "${BUILDSYS_PACKAGES_DIR}":/tmp/rpms \
+  -v "${BUILDSYS_ARCHIVES_DIR}":/tmp/archives \
   "${BUILDSYS_SDK_IMAGE}" \
   bash -c "${prepare_kmod_kit}"
 '''


### PR DESCRIPTION
Before, this step used /home/builder for input and output artifacts and /tmp
for preparing the contents of the final output tarball.  It assumed that
/home/builder was readable and writable by the current user, though in the
image it's owned by builder:builder.  This can cause the following:

```
[cargo-make] INFO - Running Task: build-kmod-kit
find: './rpms': Permission denied
find: Failed to restore initial working directory: /home/builder: Permission denied
cpio: premature end of archive
[cargo-make] ERROR - Error while executing command, exit code: 2
```

This change makes the path usage more explicit by no longer relying on
/home/builder and avoiding use of the current working directory.  Working
artifacts and output artifacts are put in separate directory trees under /tmp.

**Testing done:**

Build now succeeds:
```
[cargo-make] INFO - Running Task: build-packages
    Finished dev [optimized] target(s) in 0.12s
[cargo-make] INFO - Running Task: build-kmod-kit
[cargo-make] INFO - Build Done in 24 seconds.
Took 24.631 seconds: cargo make build-archives
```

Kit artifact still looks good:
```
> ls -l build/archives/
total 61872
-rw-r--r--. 1 tjk tjk 63355624 01-20 21:47 aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz

> tar tf build/archives/aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/kernel-devel/
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/kernel-devel/Documentation/
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
