### PR TITLE
build-kmod-kit: don't rebuild if kernel hasn't changed

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -266,17 +266,29 @@ cargo build \
 
 [tasks.build-kmod-kit]
 dependencies = ["build-packages"]
+script_runner = "bash"
 script = [
 '''
 mkdir -p "${BUILDSYS_ARCHIVES_DIR}"
 kmod_kit="${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-kmod-kit-v${BUILDSYS_VERSION_IMAGE}"
-rm -f "${BUILDSYS_ARCHIVES_DIR}/${kmod_kit}.tar.xz"
+kmod_kit_path="${BUILDSYS_ARCHIVES_DIR}/${kmod_kit}.tar.xz"
+
 
 # Find the most recent kernel archive. If we have more than one, we want the
 # last one that was built.
 kernel_archive="$(find "${BUILDSYS_PACKAGES_DIR}" \
   -type f -name '*-'"${BUILDSYS_ARCH}"'-kernel-archive-*.rpm' \
-  -printf '%T@ %f\n' | sort -r | awk 'NR==1{print $2}')"
+  -printf '%T@ %p\n' | sort -r | awk 'NR==1{print $2}')"
+
+if [ "${?}" -ne 0 ] || [ -z "${kernel_archive}" ] || [ ! -s "${kernel_archive}" ]; then
+  echo "Unable to find latest kernel archive for ${BUILDSYS_ARCH} in ${BUILDSYS_PACKAGES_DIR}"
+  exit 1
+fi
+
+if [ -s "${kmod_kit_path}" ] && [ "${kmod_kit_path}" -nt "${kernel_archive}" ]; then
+  echo "Existing kmod kit ${kmod_kit_path} is newer than kernel archive ${kernel_archive}; skipping build."
+  exit 0
+fi
 
 prepare_kmod_kit="
 set -e -o pipefail
@@ -287,7 +299,7 @@ mkdir -p /tmp/kit/${kmod_kit} /tmp/extract
 pushd /tmp/extract >/dev/null
 curl --silent --fail --show-error --output /tmp/kit/${kmod_kit}/toolchain.tar.xz \
   https://${BUILDSYS_SDK_SITE}/${BUILDSYS_TOOLCHAIN}.tar.xz
-find /tmp/rpms -name "${kernel_archive}" \
+find /tmp/rpms -name "${kernel_archive##*/}" \
   -exec rpm2cpio {} \; | cpio -idmu --quiet
 find -name 'kernel-devel.tar.xz' -exec mv {} /tmp/kit/${kmod_kit} \;
 popd >/dev/null


### PR DESCRIPTION
```
If the kernel archive is older than the kmod kit, we can assume that the kmod
kit is up to date and skip its 20+ second build.
```

**Note:** This is built on top of #1285.  The goal is to have this be fast enough that it can be added as a dependency to build-variant, so the kmod kit can consistently be added to repos.

**Testing done:**

With no existing archive, a new one is prepared:
```
> ls build/archives/
> cargo make build-archives
...
[cargo-make] INFO - Running Task: build-packages
    Finished dev [optimized] target(s) in 0.12s
[cargo-make] INFO - Running Task: build-kmod-kit
[cargo-make] INFO - Build Done in 24 seconds.
```

A rerun notices the existing artifact:
```
[cargo-make] INFO - Running Task: build-kmod-kit
Existing kmod kit /home/tjk/work/bottlerocket/build/archives/aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz is newer than kernel archive /home/tjk/work/bottlerocket/build/rpms/bottlerocket-x86_64-kernel-archive-5.4.80-1.x86_64.rpm; skipping build.
[cargo-make] INFO - Build Done in 3 seconds.
```

Updating the kernel results in a new archive being build:
```
> touch build/rpms/*kernel*
> cargo make build-archives
...
[cargo-make] INFO - Running Task: build-kmod-kit
[cargo-make] INFO - Build Done in 24 seconds.
```

Removing the kernel forces the new error.  (This wouldn't normally happen because build-kmod-kit depends on build-packages which builds this kernel archive.)
```
> mv build/rpms/*kernel* ~
> cargo make build-archives
...
[cargo-make] INFO - Running Task: build-kmod-kit
Unable to find latest kernel archive for x86_64 in /home/tjk/work/bottlerocket/build/rpms
[cargo-make] ERROR - Error while executing command, exit code: 1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
