### PR TITLE
Include kmod kit in repos

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -107,6 +107,10 @@ PUBLISH_REPO_OUTPUT_DIR = "${PUBLISH_REPO_BASE_DIR}/${PUBLISH_REPO}/${BUILDSYS_N
 # The default name of registered AMIs; override by setting PUBLISH_AMI_NAME.
 PUBLISH_AMI_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
 
+# The name of the kmod kit archive, used to ease building out-of-tree kernel modules.
+BUILDSYS_KMOD_KIT = "${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-kmod-kit-v${BUILDSYS_VERSION_IMAGE}"
+BUILDSYS_KMOD_KIT_PATH="${BUILDSYS_ARCHIVES_DIR}/${BUILDSYS_KMOD_KIT}.tar.xz"
+
 [tasks.setup]
 script = [
 '''
@@ -270,9 +274,6 @@ script_runner = "bash"
 script = [
 '''
 mkdir -p "${BUILDSYS_ARCHIVES_DIR}"
-kmod_kit="${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-kmod-kit-v${BUILDSYS_VERSION_IMAGE}"
-kmod_kit_path="${BUILDSYS_ARCHIVES_DIR}/${kmod_kit}.tar.xz"
-
 
 # Find the most recent kernel archive. If we have more than one, we want the
 # last one that was built.
@@ -285,27 +286,27 @@ if [ "${?}" -ne 0 ] || [ -z "${kernel_archive}" ] || [ ! -s "${kernel_archive}" 
   exit 1
 fi
 
-if [ -s "${kmod_kit_path}" ] && [ "${kmod_kit_path}" -nt "${kernel_archive}" ]; then
-  echo "Existing kmod kit ${kmod_kit_path} is newer than kernel archive ${kernel_archive}; skipping build."
+if [ -s "${BUILDSYS_KMOD_KIT_PATH}" ] && [ "${BUILDSYS_KMOD_KIT_PATH}" -nt "${kernel_archive}" ]; then
+  echo "Existing kmod kit ${BUILDSYS_KMOD_KIT_PATH} is newer than kernel archive ${kernel_archive}; skipping build."
   exit 0
 fi
 
 prepare_kmod_kit="
 set -e -o pipefail
 
-mkdir -p /tmp/kit/${kmod_kit} /tmp/extract
+mkdir -p /tmp/kit/${BUILDSYS_KMOD_KIT} /tmp/extract
 
 # Retrieve the toolchain and kernel archives.
 pushd /tmp/extract >/dev/null
-curl --silent --fail --show-error --output /tmp/kit/${kmod_kit}/toolchain.tar.xz \
+curl --silent --fail --show-error --output /tmp/kit/${BUILDSYS_KMOD_KIT}/toolchain.tar.xz \
   https://${BUILDSYS_SDK_SITE}/${BUILDSYS_TOOLCHAIN}.tar.xz
 find /tmp/rpms -name "${kernel_archive##*/}" \
   -exec rpm2cpio {} \; | cpio -idmu --quiet
-find -name 'kernel-devel.tar.xz' -exec mv {} /tmp/kit/${kmod_kit} \;
+find -name 'kernel-devel.tar.xz' -exec mv {} /tmp/kit/${BUILDSYS_KMOD_KIT} \;
 popd >/dev/null
 
 # Extract them into the same directory.
-pushd /tmp/kit/${kmod_kit} >/dev/null
+pushd /tmp/kit/${BUILDSYS_KMOD_KIT} >/dev/null
 tar xf kernel-devel.tar.xz
 rm kernel-devel.tar.xz
 tar xf toolchain.tar.xz
@@ -314,11 +315,11 @@ popd >/dev/null
 
 # Merge them together into a unified archive.
 pushd /tmp/kit >/dev/null
-tar cf ${kmod_kit}.tar ${kmod_kit}
-xz -T0 ${kmod_kit}.tar
+tar cf ${BUILDSYS_KMOD_KIT}.tar ${BUILDSYS_KMOD_KIT}
+xz -T0 ${BUILDSYS_KMOD_KIT}.tar
 popd >/dev/null
 
-mv /tmp/kit/${kmod_kit}.tar.xz /tmp/archives
+mv /tmp/kit/${BUILDSYS_KMOD_KIT}.tar.xz /tmp/archives
 "
 
 docker run --rm \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -449,7 +449,7 @@ run_task = "publish-setup"
 # Rather than depend on "build", which currently rebuilds images each run, we
 # check for the image files below to save time.  This does mean that `cargo
 # make` must be run before `cargo make repo`.
-dependencies = ["publish-setup", "publish-tools"]
+dependencies = ["publish-setup", "publish-tools", "build-archives"]
 script_runner = "bash"
 script = [
 '''
@@ -470,14 +470,19 @@ if [ ! -s "${bootlz4}" ] || [ ! -s "${rootlz4}" ] || [ ! -s "${hashlz4}" ]; then
    exit 1
 fi
 
+COPY_REPO_TARGETS=()
+
 # TODO: only add migrations from Release.toml, not all
 MIGRATIONS_DIR="$(mktemp -d)"
 tar xpf "${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-migrations.tar" -C "${MIGRATIONS_DIR}"
-ADD_MIGRATION_TARGETS=()
 for file in ${MIGRATIONS_DIR}/*; do
    [ -e "${file}" ] || continue
-   ADD_MIGRATION_TARGETS+=("--copy-target ${file}")
+   COPY_REPO_TARGETS+=("--copy-target ${file}")
 done
+
+# Include the kmod kit in the repo so it's easier to build out-of-tree kernel
+# modules for a given release.
+LINK_REPO_TARGETS=("--link-target ${BUILDSYS_KMOD_KIT_PATH}")
 
 pubsys \
    --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
@@ -492,7 +497,8 @@ pubsys \
    --boot-image "${bootlz4}" \
    --root-image "${rootlz4}" \
    --hash-image "${hashlz4}" \
-   ${ADD_MIGRATION_TARGETS[*]} \
+   ${LINK_REPO_TARGETS[*]} \
+   ${COPY_REPO_TARGETS[*]} \
    \
    --repo-expiration-policy-path "${PUBLISH_EXPIRATION_POLICY_PATH}" \
    --release-config-path "${BUILDSYS_RELEASE_CONFIG_PATH}" \


### PR DESCRIPTION
**Issue number:**

Fixes #1275.

**Description of changes:**

```
5b032daf Extract kmod kit archive naming to cargo-make variable
e08fdb2f Include kmod kit in repo targets
e157671f BUILDING: update to describe retrieval and use of kmod kit
```

This allows for easy, safe retrieval of the kmod kit for a given Bottlerocket release.  Updating the `repo` target means we'll automatically upload kits in future releases, starting with v1.0.6.

**Note:** This is based on #1286 and #1285.

**Testing done:**

Making a repo now includes the kmod kit:
```
> cargo make repo
...
23:49:28 [INFO] Writing repo targets to: /home/tjk/work/bottlerocket/build/repos/default/bottlerocket-1.0.5-e08fdb2f/targets
23:49:29 [INFO] Writing repo metadata to: /home/tjk/work/bottlerocket/build/repos/default/bottlerocket-1.0.5-e08fdb2f/aws-k8s-1.17/x86_64
[cargo-make] INFO - Build Done in 6 seconds.

> exa --tree build/repos/default/bottlerocket-1.0.5-e08fdb2f/
build/repos/default/bottlerocket-1.0.5-e08fdb2f
├── aws-k8s-1.17
...
└── targets
...
   ├── d29cee5253a81c8debc701389c1670531c81b2ca6bf478e1900be2d106e4432c.aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz -> /home/tjk/work/bottlerocket/build/archives/aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz

> grep -A5 kit build/repos/default/bottlerocket-1.0.5-e08fdb2f/aws-k8s-1.17/x86_64/*targets.json
      "aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz": {
        "length": 63348696,
        "hashes": {
          "sha256": "d29cee5253a81c8debc701389c1670531c81b2ca6bf478e1900be2d106e4432c"
        }
      },
```

I synced the repo to an S3 bucket and was able to download it with tuftool:
```
> tuftool download . --target-name aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz --root ./roles/default.root.json --metadata-url "https://redacted/aws-k8s-1.17/x86_64/" --targets-url "https://redacted/targets/"
Downloading targets to "."
        -> aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz
```

Kit is as expected:
```
> tar tf aws-k8s-1.17-x86_64-kmod-kit-v1.0.5.tar.xz | head -n5
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/kernel-devel/
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/kernel-devel/Documentation/
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/kernel-devel/Documentation/kbuild/
aws-k8s-1.17-x86_64-kmod-kit-v1.0.5/kernel-devel/Documentation/kbuild/Kconfig.select-break
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
