### PR TITLE
Add a systemd mount unit for CD-ROM devices

### DIFF
--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -29,6 +29,7 @@ mkdir -p %{buildroot}%{_cross_mandir}
 mkdir -p %{buildroot}%{_cross_localstatedir}
 mkdir -p %{buildroot}/{boot,dev,proc,root,run,sys,tmp}
 mkdir -p %{buildroot}/{home,local,media,mnt,opt,srv}
+mkdir -p %{buildroot}/media/cdrom
 
 ln -s .%{_cross_prefix} %{buildroot}%{_prefix}
 ln -s .%{_cross_bindir} %{buildroot}/bin

--- a/packages/release/media-cdrom.mount
+++ b/packages/release/media-cdrom.mount
@@ -1,0 +1,21 @@
+[Unit]
+Description=CD-ROM mount (/media/cdrom)
+# Only run this unit if /dev/cdrom exists and is tracked via systemd. (systemd
+# ships with a udev rule to tag and symlink the first suspected cdrom device to
+# /dev/cdrom)
+Requires=dev-cdrom.device
+After=dev-cdrom.device
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+
+[Mount]
+What=/dev/cdrom
+Where=/media/cdrom
+Type=iso9660
+Options=defaults,noexec
+
+[Install]
+# This dependency ensures that systemd attempts to run this unit if the device
+# exists.
+WantedBy=dev-cdrom.device

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -25,6 +25,9 @@ Source1008: opt.mount
 Source1009: var-lib-bottlerocket.mount
 Source1010: etc-cni.mount
 
+# CD-ROM mount
+Source1015: media-cdrom.mount
+
 # Mounts that require build-time edits.
 Source1020: var-lib-kernel-devel-lower.mount.in
 Source1021: usr-src-kernels.mount.in
@@ -104,7 +107,7 @@ EOF
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
-  %{S:1002} %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} \
+  %{S:1002} %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} %{S:1015} \
   %{buildroot}%{_cross_unitdir}
 
 LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/lower)
@@ -138,6 +141,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/etc-cni.mount
+%{_cross_unitdir}/media-cdrom.mount
 %{_cross_unitdir}/*-lower.mount
 %{_cross_unitdir}/*-kernels.mount
 %{_cross_unitdir}/*-licenses.mount


### PR DESCRIPTION
**Issue number:**
Related to #1288 


**Description of changes:**
This change adds a mount unit that will mount a CD-ROM device located at
`/dev/cdrom` to `/media/cdrom` if that device exists.  systemd includes a
udev rule to symlink the first suspected CD-ROM device to `/dev/cdrom`.  The
primary use of said device to supply user data to a Bottlerocket host.


**Testing done:**
* Build and ran a Bottlerocket AMI to ensure that this unit doesn't interfere with or delay boot
* Built and ran a fake variant using the changes from #1288 (based on aws-dev) locally to test the cd-rom user data capability. Both xml and user-data files worked as expected.
* Built and ran the same fake variant without cd-rom connected and the instance booted as expected, did not delay, and `early-boot-config` properly exited gracefully after no user data was found at the cd-rom location.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
