### PR TITLE
track and clean output files for builds

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,6 +6,7 @@ BUILDSYS_ARCH = { script = ["uname -m"] }
 BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 BUILDSYS_BUILD_DIR = "${BUILDSYS_ROOT_DIR}/build"
 BUILDSYS_PACKAGES_DIR = "${BUILDSYS_BUILD_DIR}/rpms"
+BUILDSYS_STATE_DIR = "${BUILDSYS_BUILD_DIR}/state"
 BUILDSYS_IMAGES_DIR = "${BUILDSYS_BUILD_DIR}/images"
 BUILDSYS_ARCHIVES_DIR = "${BUILDSYS_BUILD_DIR}/archives"
 BUILDSYS_TOOLS_DIR = "${BUILDSYS_ROOT_DIR}/tools"
@@ -126,6 +127,7 @@ esac
 mkdir -p ${BUILDSYS_BUILD_DIR}
 mkdir -p ${BUILDSYS_OUTPUT_DIR}
 mkdir -p ${BUILDSYS_PACKAGES_DIR}
+mkdir -p ${BUILDSYS_STATE_DIR}
 mkdir -p ${GO_MOD_CACHE}
 '''
 ]
@@ -856,6 +858,7 @@ dependencies = [
   "clean-archives",
   "clean-images",
   "clean-repos",
+  "clean-state",
 ]
 
 [tasks.clean-sources]
@@ -903,6 +906,14 @@ script_runner = "bash"
 script = [
 '''
 rm -rf ${PUBLISH_REPO_BASE_DIR}
+'''
+]
+
+[tasks.clean-state]
+script_runner = "bash"
+script = [
+'''
+rm -rf ${BUILDSYS_STATE_DIR}
 '''
 ]
 

--- a/tools/buildsys/src/builder/error.rs
+++ b/tools/buildsys/src/builder/error.rs
@@ -16,6 +16,37 @@ pub(crate) enum Error {
         source: std::io::Error,
     },
 
+    #[snafu(display("Failed to get filename for '{}'", path.display()))]
+    BadFilename { path: PathBuf },
+
+    #[snafu(display("Failed to create directory '{}': {}", path.display(), source))]
+    DirectoryCreate {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to walk directory to find marker files: {}", source))]
+    DirectoryWalk { source: walkdir::Error },
+
+    #[snafu(display("Failed to create file '{}': {}", path.display(), source))]
+    FileCreate {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to remove file '{}': {}", path.display(), source))]
+    FileRemove {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to rename file '{}' to '{}': {}", old_path.display(), new_path.display(), source))]
+    FileRename {
+        old_path: PathBuf,
+        new_path: PathBuf,
+        source: std::io::Error,
+    },
+
     #[snafu(display("Missing environment variable '{}'", var))]
     Environment {
         var: String,


### PR DESCRIPTION
**Issue number:**
Fixes #1027


**Description of changes:**
Add a layer of indirection between the build artifacts and the final output directory, so we can keep track of what we've previously built for a given package or variant.

That allows us to remove the files before the next build, so they do not interact with other builds in unexpected ways.


**Testing done:**
Verified that the `state` directory is populated with marker files.
```
❯ find build/state/variants -type f
build/state/variants/aws-k8s-1.17/bottlerocket-aws-k8s-1.17-aarch64-1.0.5-e3234419-data.img.lz4.marker
build/state/variants/aws-k8s-1.17/bottlerocket-aws-k8s-1.17-aarch64-1.0.5-e3234419-root.ext4.lz4.marker
build/state/variants/aws-k8s-1.17/bottlerocket-aws-k8s-1.17-aarch64-1.0.5-e3234419-migrations.tar.marker
build/state/variants/aws-k8s-1.17/bottlerocket-aws-k8s-1.17-aarch64-1.0.5-e3234419-boot.ext4.lz4.marker
build/state/variants/aws-k8s-1.17/bottlerocket-aws-k8s-1.17-aarch64-1.0.5-e3234419.img.lz4.marker
build/state/variants/aws-k8s-1.17/bottlerocket-aws-k8s-1.17-aarch64-1.0.5-e3234419-root.verity.lz4.marker
```

Confirmed that the corresponding files in `packages` and `images` are removed before another build. For example, old variant images are cleaned up on each build, so we no longer accumulate artifacts named for older commits. I also bumped the release package to version 1000.0, built it, then reverted it to 0.0. The older package with the higher version number was cleaned up as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
