### PR TITLE
Change/add params to support CIS scan

### DIFF
--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -44,11 +44,13 @@ kubeReserved:
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
+readOnlyPort: 0
 cgroupDriver: systemd
 cgroupRoot: "/"
 runtimeRequestTimeout: 15m
 featureGates:
   RotateKubeletServerCertificate: true
+protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: true
 configMapAndSecretChangeDetectionStrategy: Cache

--- a/packages/kubernetes-1.15/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.15/kubelet-sysctl.conf
@@ -1,0 +1,2 @@
+# Overcommit handling mode - 1: Always overcommit
+vm.overcommit_memory = 1

--- a/packages/kubernetes-1.15/kubernetes-1.15.spec
+++ b/packages/kubernetes-1.15/kubernetes-1.15.spec
@@ -23,6 +23,7 @@ Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
 Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
+Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -92,6 +93,9 @@ ln -rs \
   %{buildroot}%{_sharedstatedir}/kubelet/plugins \
   %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
+mkdir -p %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.15
@@ -110,5 +114,6 @@ ln -rs \
 %{_cross_tmpfilesdir}/kubernetes.conf
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
+%{_cross_sysctldir}/90-kubelet.conf
 
 %changelog

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -44,11 +44,13 @@ kubeReserved:
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
+readOnlyPort: 0
 cgroupDriver: systemd
 cgroupRoot: "/"
 runtimeRequestTimeout: 15m
 featureGates:
   RotateKubeletServerCertificate: true
+protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: true
 configMapAndSecretChangeDetectionStrategy: Cache

--- a/packages/kubernetes-1.16/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.16/kubelet-sysctl.conf
@@ -1,0 +1,2 @@
+# Overcommit handling mode - 1: Always overcommit
+vm.overcommit_memory = 1

--- a/packages/kubernetes-1.16/kubernetes-1.16.spec
+++ b/packages/kubernetes-1.16/kubernetes-1.16.spec
@@ -23,6 +23,7 @@ Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
 Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
+Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -88,6 +89,9 @@ ln -rs \
   %{buildroot}%{_sharedstatedir}/kubelet/plugins \
   %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
+mkdir -p %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf  
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.16
@@ -106,5 +110,6 @@ ln -rs \
 %{_cross_tmpfilesdir}/kubernetes.conf
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
+%{_cross_sysctldir}/90-kubelet.conf
 
 %changelog

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -44,12 +44,14 @@ kubeReserved:
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
+readOnlyPort: 0
 cgroupDriver: systemd
 cgroupRoot: "/"
 runtimeRequestTimeout: 15m
 featureGates:
   RotateKubeletServerCertificate: true
   CSIMigration: false
+protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: true
 configMapAndSecretChangeDetectionStrategy: Cache

--- a/packages/kubernetes-1.17/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.17/kubelet-sysctl.conf
@@ -1,0 +1,2 @@
+# Overcommit handling mode - 1: Always overcommit
+vm.overcommit_memory = 1

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -23,6 +23,7 @@ Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
 Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
+Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -88,6 +89,9 @@ ln -rs \
   %{buildroot}%{_sharedstatedir}/kubelet/plugins \
   %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
+mkdir -p %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.17
@@ -106,5 +110,6 @@ ln -rs \
 %{_cross_tmpfilesdir}/kubernetes.conf
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
+%{_cross_sysctldir}/90-kubelet.conf
 
 %changelog

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -44,12 +44,14 @@ kubeReserved:
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
+readOnlyPort: 0
 cgroupDriver: systemd
 cgroupRoot: "/"
 runtimeRequestTimeout: 15m
 featureGates:
   RotateKubeletServerCertificate: true
   CSIMigration: false
+protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: true
 configMapAndSecretChangeDetectionStrategy: Cache

--- a/packages/kubernetes-1.18/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.18/kubelet-sysctl.conf
@@ -1,0 +1,2 @@
+# Overcommit handling mode - 1: Always overcommit
+vm.overcommit_memory = 1

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -23,6 +23,7 @@ Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
 Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
+Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -85,6 +86,9 @@ ln -rs \
   %{buildroot}%{_sharedstatedir}/kubelet/plugins \
   %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
+mkdir -p %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.18
@@ -103,5 +107,6 @@ ln -rs \
 %{_cross_tmpfilesdir}/kubernetes.conf
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
+%{_cross_sysctldir}/90-kubelet.conf
 
 %changelog

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -44,12 +44,14 @@ kubeReserved:
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
+readOnlyPort: 0
 cgroupDriver: systemd
 cgroupRoot: "/"
 runtimeRequestTimeout: 15m
 featureGates:
   RotateKubeletServerCertificate: true
   CSIMigration: false
+protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: true
 configMapAndSecretChangeDetectionStrategy: Cache

--- a/packages/kubernetes-1.19/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.19/kubelet-sysctl.conf
@@ -1,0 +1,2 @@
+# Overcommit handling mode - 1: Always overcommit
+vm.overcommit_memory = 1

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -23,6 +23,7 @@ Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
 Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
+Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -82,6 +83,9 @@ ln -rs \
   %{buildroot}%{_sharedstatedir}/kubelet/plugins \
   %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
+mkdir -p %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.19
@@ -100,5 +104,6 @@ ln -rs \
 %{_cross_tmpfilesdir}/kubernetes.conf
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
+%{_cross_sysctldir}/90-kubelet.conf
 
 %changelog

--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -2,8 +2,11 @@
 # Maximize console logging level for kernel printk messages
 kernel.printk = 8 4 1 7
 
-# Wait 30 seconds and then reboot
-kernel.panic = 30
+# Wait 10 seconds and then reboot
+kernel.panic = 10
+
+# Controls the kernel's behaviour when an oops or BUG is encountered
+kernel.panic_on_oops = 1
 
 # Allow neighbor cache entries to expire even when the cache is not full
 net.ipv4.neigh.default.gc_thresh1 = 0


### PR DESCRIPTION
**Summary**

**Issue number #1294** 

This PR update configs to achieve good results on a CIS scan using kube-bench.

These were my results:

**After update the kubelet location on kube-bench**
**Issue opened on kube-bench: https://github.com/aquasecurity/kube-bench/issues/808**

```
== Summary node ==
12 checks PASS
2 checks FAIL
1 checks WARN
0 checks INFO

== Summary total ==
12 checks PASS
2 checks FAIL
1 checks WARN
0 checks INFO
```

**After building a new Bottlerocket AMI with the changes requested in this PR**
```
== Summary node ==
14 checks PASS
0 checks FAIL
1 checks WARN
0 checks INFO

== Summary total ==
14 checks PASS
0 checks FAIL
1 checks WARN
0 checks INFO
```

**Testing done:**
I've only tested it by deploying a new image and running the CIS scan, but I'm more than happy to run any required tests.

**Important: I've only validated those changes in an EKS cluster running Kubernetes 1.18. Eventually, if this PR gets approved, I'll apply and validate the same change for different versions.**


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.

PS: Thanks to @gregdek for the support