### PR TITLE
host-ctr: add support for authenticated image pulls from ECR Public

### DIFF
--- a/sources/host-ctr/go.mod
+++ b/sources/host-ctr/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Microsoft/go-winio v0.4.15 // indirect
 	github.com/Microsoft/hcsshim v0.8.10 // indirect
-	github.com/aws/aws-sdk-go v1.35.25 // indirect
+	github.com/aws/aws-sdk-go v1.37.0
 	github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20200922205237-bbd7175f7bd0
 	github.com/containerd/cgroups v0.0.0-20201109155418-13abef5d31ec // indirect
 	github.com/containerd/containerd v1.3.7
@@ -24,7 +24,6 @@ require (
 	github.com/willf/bitset v1.1.11 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.opencensus.io v0.22.5 // indirect
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
 	golang.org/x/sys v0.0.0-20201109165425-215b40eba54c // indirect
 	golang.org/x/text v0.3.4 // indirect

--- a/sources/host-ctr/go.sum
+++ b/sources/host-ctr/go.sum
@@ -12,8 +12,8 @@ github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg3
 github.com/Microsoft/hcsshim v0.8.10 h1:k5wTrpnVU2/xv8ZuzGkbXVd3js5zJ8RnumPo5RxiIxU=
 github.com/Microsoft/hcsshim v0.8.10/go.mod h1:g5uw8EV2mAlzqe94tfNBNdr89fnbD/n3HV0OhsddkmM=
 github.com/aws/aws-sdk-go v1.32.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/aws/aws-sdk-go v1.35.25 h1:0+UC6ZquMOLvYABoz0olShCAe+M9oKllgPfr2hnv9zE=
-github.com/aws/aws-sdk-go v1.35.25/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/aws/aws-sdk-go v1.37.0 h1:GzFnhOIsrGyQ69s7VgqtrG2BG8v7X7vwB3Xpbd/DBBk=
+github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20200922205237-bbd7175f7bd0 h1:mxzIxXHpy2nmQH1FG/5y0Mr1LRk7RqzwBB+cKe0YwmQ=
 github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20200922205237-bbd7175f7bd0/go.mod h1:KuTNnZvgS7awNYUpeTkWpvz3GZoj6GNkwr/Mn2TCF8Y=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jan 28 15:25:47 2021 -0800

    host-ctr: add support for authenticated image pulls from ECR Public
    
    Add support for authenticated image pulls from ECR Public registries.
    Unlike ECR private registries, we have to use Docker's registry API for
    resolving ECR Public image references. This means having to manage
    ECR Public registry auth credentials ourselves

```


**Testing done:**

Verified that `ecrpublic::GetAuthorizationToken` calls from host-ctr are successful and I get credentials back without problems.

Verified the request header includes the base64-encoded authorization token and the image gets pulled successfully:
```
time="2021-02-01T10:02:25-08:00" level=debug msg="do request" digest="sha256:6c72cf34ed39ff40a5ad8abd57c66e6766897f311a28f6b993f4b87545195204" mediatype=application/vnd.docker.distribution.manifest.list.v2+json 
request.header.accept="application/vnd.docker.distribution.manifest.list.v2+json, */*" 
request.header.authorization="Bearer  <BASE64-ENCODED AUTHORIZATION TOKEN>"
request.header.user-agent=containerd/1.3.7+unknown 
request.method=GET 
size=743 
url="https://public.ecr.aws/v2/nginx/nginx/manifests/sha256:6c72cf34ed39ff40a5ad8abd57c66e6766897f311a28f6b993f4b87545195204"
time="2021-02-01T10:02:25-08:00" level=debug msg="fetch response received" host=public.ecr.aws response.header.content-length=743 response.header.content-type=application/vnd.docker.distribution.manifest.list.v2+json response.header.date="Mon, 01 Feb 2021 18:02:25 GMT" response.header.docker-content-digest="sha256:6c72cf34ed39ff40a5ad8abd57c66e6766897f311a28f6b993f4b87545195204" response.header.docker-distribution-api-version=registry/2.0 response.status="200 OK" url="https://public.ecr.aws/v2/nginx/nginx/manifests/latest"
....
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
