### PR TITLE
API Readme: Fix broken link to top-level README

### DIFF
--- a/sources/api/README.md
+++ b/sources/api/README.md
@@ -24,7 +24,7 @@ It's described in context in the [API server docs](apiserver/).
 
 Users can access the API through the `apiclient` binary.
 It's available in Bottlerocket, whether you're accessing it through a control channel like SSM or the admin container.
-(See the top-level [README](../../) for information about those.)
+(See the top-level [README](../../README.md#exploration) for information about those.)
 
 Rust code can use the `apiclient` library to make requests to the Unix-domain socket of the [apiserver](#apiserver).
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Fixes a broken link the API System README. The link should go to the "Exploration" section of the top level README


**Testing done:**
The link previously didn't work and now it works.

Enable rich-diff to test the link.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
