### PR TITLE
k8s static pods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ The following settings can be optionally set to customize the node labels and ta
 The following settings are optional and allow you to further configure your cluster.
 * `settings.kubernetes.cluster-domain`: The DNS domain for this cluster, allowing all Kubernetes-run containers to search this domain before the host's search domains.  Defaults to `cluster.local`.
 
+You can also optionally specify static pods for your node with the following settings.
+* `settings.kubernetes.static-pods.<custom identifier>.manifest`: A base64-encoded pod manifest.
+* `settings.kubernetes.static-pods.<custom identifier>.enabled`: Whether the static pod is enabled.
+
 The following settings are set for you automatically by [pluto](sources/api/) based on runtime instance information, but you can override them if you know what you're doing!
 * `settings.kubernetes.max-pods`: The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)
 * `settings.kubernetes.cluster-dns-ip`: The CIDR block of the primary network interface.

--- a/Release.toml
+++ b/Release.toml
@@ -20,5 +20,5 @@ version = "1.0.5"
     "migrate_v1.0.5_add-proxy-restart.lz4",
     "migrate_v1.0.5_add-proxy-services.lz4"
 ]
-"(1.0.5, 1.0.6)" = ["migrate_v1.0.6_metricdog-init.lz4"]
+"(1.0.5, 1.0.6)" = ["migrate_v1.0.6_metricdog-init.lz4", "migrate_v1.0.6_add-static-pods.lz4"]
 

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -31,3 +31,4 @@ configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.15/kubernetes-1.15.spec
+++ b/packages/kubernetes-1.15/kubernetes-1.15.spec
@@ -20,6 +20,7 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
+Source6: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -79,6 +80,9 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.15
@@ -92,5 +96,6 @@ install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_tmpfilesdir}/kubernetes.conf
 
 %changelog

--- a/packages/kubernetes-1.15/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.15/kubernetes-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/kubernetes/static-pods - - - -
+L /etc/kubernetes/manifests - - - - static-pods

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -31,3 +31,4 @@ configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.16/kubernetes-1.16.spec
+++ b/packages/kubernetes-1.16/kubernetes-1.16.spec
@@ -20,6 +20,7 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
+Source6: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -75,6 +76,9 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.16
@@ -88,5 +92,6 @@ install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_tmpfilesdir}/kubernetes.conf
 
 %changelog

--- a/packages/kubernetes-1.16/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.16/kubernetes-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/kubernetes/static-pods - - - -
+L /etc/kubernetes/manifests - - - - static-pods

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -32,3 +32,4 @@ configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -20,6 +20,7 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
+Source6: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -75,6 +76,9 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.17
@@ -88,5 +92,6 @@ install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_tmpfilesdir}/kubernetes.conf
 
 %changelog

--- a/packages/kubernetes-1.17/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.17/kubernetes-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/kubernetes/static-pods - - - -
+L /etc/kubernetes/manifests - - - - static-pods

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -32,3 +32,4 @@ configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -20,6 +20,7 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
+Source6: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -72,6 +73,9 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.18
@@ -85,5 +89,6 @@ install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_tmpfilesdir}/kubernetes.conf
 
 %changelog

--- a/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/kubernetes/static-pods - - - -
+L /etc/kubernetes/manifests - - - - static-pods

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -33,3 +33,4 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -20,6 +20,7 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
+Source6: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -69,6 +70,9 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.19
@@ -82,5 +86,6 @@ install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_tmpfilesdir}/kubernetes.conf
 
 %changelog

--- a/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/kubernetes/static-pods - - - -
+L /etc/kubernetes/manifests - - - - static-pods

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -74,7 +74,9 @@ Requires: %{_cross_os}apiserver = %{version}-%{release}
 Summary: Updates settings dynamically based on user-specified generators
 Requires: %{_cross_os}apiserver = %{version}-%{release}
 Requires: %{_cross_os}schnauzer = %{version}-%{release}
+%if %{_is_k8s_variant}
 Requires: %{_cross_os}pluto = %{version}-%{release}
+%endif
 Requires: %{_cross_os}bork = %{version}-%{release}
 %description -n %{_cross_os}sundog
 %{summary}.
@@ -93,11 +95,6 @@ Requires: %{_cross_os}apiserver = %{version}-%{release}
 %package -n %{_cross_os}schnauzer
 Summary: Setting generator for templated settings values.
 %description -n %{_cross_os}schnauzer
-%{summary}.
-
-%package -n %{_cross_os}pluto
-Summary: Dynamic setting generator for kubernetes
-%description -n %{_cross_os}pluto
 %{summary}.
 
 %package -n %{_cross_os}thar-be-settings
@@ -184,6 +181,11 @@ Summary: Settings generator for ECS
 %endif
 
 %if %{_is_k8s_variant}
+%package -n %{_cross_os}pluto
+Summary: Dynamic setting generator for kubernetes
+%description -n %{_cross_os}pluto
+%{summary}.
+
 %package -n %{_cross_os}static-pods
 Summary: Manages user-defined K8S static pods
 Requires: %{_cross_os}apiserver = %{version}-%{release}
@@ -203,7 +205,6 @@ mkdir bin
     -p netdog \
     -p sundog \
     -p schnauzer \
-    -p pluto \
     -p bork \
     -p thar-be-settings \
     -p thar-be-updates \
@@ -223,6 +224,7 @@ mkdir bin
     -p ecs-settings-applier \
 %endif
 %if %{_is_k8s_variant}
+    -p pluto \
     -p static-pods \
 %endif
     %{nil}
@@ -246,7 +248,7 @@ done
 install -d %{buildroot}%{_cross_bindir}
 for p in \
   apiserver \
-  early-boot-config netdog sundog schnauzer pluto bork corndog \
+  early-boot-config netdog sundog schnauzer bork corndog \
   thar-be-settings thar-be-updates servicedog host-containers \
   storewolf settings-committer \
   migrator \
@@ -256,7 +258,7 @@ for p in \
   ecs-settings-applier \
 %endif
 %if %{_is_k8s_variant}
-  static-pods \
+  pluto static-pods \
 %endif
 ; do
   install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/${p} %{buildroot}%{_cross_bindir}
@@ -292,8 +294,10 @@ install -d %{buildroot}%{_cross_datadir}/bottlerocket
 install -d %{buildroot}%{_cross_sysusersdir}
 install -p -m 0644 %{S:2} %{buildroot}%{_cross_sysusersdir}/api.conf
 
+%if %{_is_k8s_variant}
 install -d %{buildroot}%{_cross_datadir}/eks
 install -p -m 0644 %{S:3} %{buildroot}%{_cross_datadir}/eks
+%endif
 
 install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
@@ -346,11 +350,6 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 
 %files -n %{_cross_os}schnauzer
 %{_cross_bindir}/schnauzer
-
-%files -n %{_cross_os}pluto
-%{_cross_bindir}/pluto
-%dir %{_cross_datadir}/eks
-%{_cross_datadir}/eks/eni-max-pods
 
 %files -n %{_cross_os}bork
 %{_cross_bindir}/bork
@@ -419,6 +418,11 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %endif
 
 %if %{_is_k8s_variant}
+%files -n %{_cross_os}pluto
+%{_cross_bindir}/pluto
+%dir %{_cross_datadir}/eks
+%{_cross_datadir}/eks/eni-max-pods
+
 %files -n %{_cross_os}static-pods
 %{_cross_bindir}/static-pods
 %endif

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -63,7 +63,6 @@ Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}policycoreutils
 Requires: %{_cross_os}signpost
 Requires: %{_cross_os}sundog
-Requires: %{_cross_os}pluto
 Requires: %{_cross_os}storewolf
 Requires: %{_cross_os}host-containers
 Requires: %{_cross_os}settings-committer

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -302,6 +302,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-static-pods"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-sysctl"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2895,6 +2895,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "static-pods"
+version = "0.1.0"
+dependencies = [
+ "base64 0.13.0",
+ "cargo-readme",
+ "log",
+ "models",
+ "schnauzer",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "snafu",
+ "tokio",
+]
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "api/migration/migrations/v1.0.5/add-proxy-restart",
     "api/migration/migrations/v1.0.5/add-proxy-services",
     "api/migration/migrations/v1.0.6/metricdog-init",
+    "api/migration/migrations/v1.0.6/add-static-pods",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "api/pluto",
     "api/servicedog",
     "api/host-containers",
+    "api/static-pods",
     "api/storewolf",
     "api/thar-be-settings",
     "api/thar-be-updates",

--- a/sources/api/migration/migrations/v1.0.6/add-static-pods/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.6/add-static-pods/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-static-pods"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.6/add-static-pods/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.6/add-static-pods/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for defining k8s static pods.
+/// Remove `settings.kubernetes.static-pods`, `services.static-pods` prefixes when we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.static-pods",
+        "services.static-pods",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "static-pods"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+base64 = "0.13"
+log = "0.4"
+models = { path = "../../models" }
+schnauzer = { path = "../schnauzer" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+simplelog = "0.9"
+snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When we update hyper to 0.14+ which has tokio 1:
+#tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/api/static-pods/README.md
+++ b/sources/api/static-pods/README.md
@@ -1,0 +1,18 @@
+# static-pods
+
+Current version: 0.1.0
+
+## Background
+
+static-pods ensures static pods are running as defined in settings.
+
+It queries for all existing static pod settings, then configures the system as follows:
+* If the pod is enabled, it creates the manifest file in the pod manifest path that kubelet is
+  configured to read from and populates the file with the base64-decoded manifest setting value.
+* If the pod is enabled and the manifest file already exists, it overwrites the existing manifest
+  file with the base64-decoded manifest setting value.
+* If the pod is disabled, it ensures the manifest file is removed from the pod manifest path.
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/static_pods.rs`.

--- a/sources/api/static-pods/README.tpl
+++ b/sources/api/static-pods/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/static_pods.rs`.

--- a/sources/api/static-pods/build.rs
+++ b/sources/api/static-pods/build.rs
@@ -1,0 +1,41 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // TODO: Replace this approach when the build system supports ideas like "variant
+    // tags": https://github.com/bottlerocket-os/bottlerocket/issues/1260
+    println!("cargo:rerun-if-env-changed=VARIANT");
+    if let Ok(variant) = env::var("VARIANT") {
+        if variant.contains("k8s") {
+            println!("cargo:rustc-cfg=k8s_variant");
+        }
+    }
+
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/static_pods.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/api/static-pods/src/main.rs
+++ b/sources/api/static-pods/src/main.rs
@@ -1,0 +1,16 @@
+#![deny(rust_2018_idioms)]
+
+#[cfg(k8s_variant)]
+mod static_pods;
+#[cfg(k8s_variant)]
+#[macro_use]
+extern crate log;
+
+#[cfg(k8s_variant)]
+#[tokio::main]
+async fn main() {
+    static_pods::main().await
+}
+
+#[cfg(not(k8s_variant))]
+fn main() {}

--- a/sources/api/static-pods/src/static_pods.rs
+++ b/sources/api/static-pods/src/static_pods.rs
@@ -1,0 +1,281 @@
+/*!
+# Background
+
+static-pods ensures static pods are running as defined in settings.
+
+It queries for all existing static pod settings, then configures the system as follows:
+* If the pod is enabled, it creates the manifest file in the pod manifest path that kubelet is
+  configured to read from and populates the file with the base64-decoded manifest setting value.
+* If the pod is enabled and the manifest file already exists, it overwrites the existing manifest
+  file with the base64-decoded manifest setting value.
+* If the pod is disabled, it ensures the manifest file is removed from the pod manifest path.
+*/
+
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::str::FromStr;
+
+use model::modeled_types::Identifier;
+
+// FIXME Get from configuration in the future
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
+
+const STATIC_POD_DIR: &str = "/etc/kubernetes/static-pods";
+
+type Result<T> = std::result::Result<T, error::Error>;
+
+/// Query the API for the currently defined static pods
+async fn get_static_pods<P>(socket_path: P) -> Result<Option<HashMap<Identifier, model::StaticPod>>>
+where
+    P: AsRef<Path>,
+{
+    debug!("Requesting settings values");
+    let settings = schnauzer::get_settings(socket_path)
+        .await
+        .context(error::RetrieveSettings)?
+        .settings
+        .context(error::MissingSettings)?;
+
+    Ok(settings
+        .kubernetes
+        .context(error::MissingSettings)?
+        .static_pods)
+}
+
+/// Write out the manifest file to the pod manifest path with a given filename
+fn write_manifest_file<S1, S2>(name: S1, manifest: S2) -> Result<()>
+where
+    S1: AsRef<str>,
+    S2: AsRef<[u8]>,
+{
+    let name = name.as_ref();
+
+    let dir = Path::new(STATIC_POD_DIR);
+    fs::create_dir_all(&dir).context(error::Mkdir { dir: &dir })?;
+    let path = dir.join(name);
+    // Create the file if it does not exist, completely replace its contents
+    // if it does (constitutes an update).
+    fs::write(path, manifest).context(error::ManifestWrite { name })?;
+
+    Ok(())
+}
+
+/// Deletes the named manifest file if it exists
+fn delete_manifest_file<S1>(name: S1) -> Result<()>
+where
+    S1: AsRef<str>,
+{
+    let name = name.as_ref();
+    let path = Path::new(STATIC_POD_DIR).join(name);
+    if path.exists() {
+        fs::remove_file(path).context(error::ManifestDelete { name })?;
+    }
+
+    Ok(())
+}
+
+fn handle_static_pod<S>(name: S, pod_info: &model::StaticPod) -> Result<()>
+where
+    S: AsRef<str>,
+{
+    // Get basic settings, as retrieved from API.
+    let name = name.as_ref();
+    let enabled = pod_info.enabled.context(error::MissingField {
+        name,
+        field: "enabled",
+    })?;
+
+    if enabled {
+        let manifest = pod_info.manifest.as_ref().context(error::MissingField {
+            name,
+            field: "manifest",
+        })?;
+
+        let manifest = base64::decode(manifest.as_bytes()).context(error::Base64Decode {
+            base64_string: manifest.as_ref(),
+        })?;
+
+        info!("Writing static pod '{}' to '{}'", name, STATIC_POD_DIR);
+
+        // Write the manifest file for this static pod
+        write_manifest_file(name, manifest)?;
+    } else {
+        info!("Removing static pod '{}' from '{}'", name, STATIC_POD_DIR);
+
+        // Delete the manifest file so the static pod no longer runs (disabled)
+        delete_manifest_file(name)?;
+    }
+
+    Ok(())
+}
+
+async fn run() -> Result<()> {
+    let args = parse_args(env::args())?;
+
+    // SimpleLogger will send errors to stderr and anything less to stdout.
+    SimpleLogger::init(args.log_level, LogConfig::default()).context(error::Logger)?;
+
+    info!("static-pods started");
+
+    let mut failed = 0u32;
+    if let Some(static_pods) = get_static_pods(args.socket_path).await? {
+        for (name, pod) in static_pods.iter() {
+            // Continue to handle other static pods if we fail one
+            if let Err(e) = handle_static_pod(name, pod) {
+                failed += 1;
+                error!("Failed to handle static pod '{}': {}", &name, e);
+            }
+        }
+
+        ensure!(
+            failed == 0,
+            error::ManageStaticPodsFailed {
+                failed,
+                tried: static_pods.len()
+            }
+        );
+    }
+
+    Ok(())
+}
+
+/// Store the args we receive on the command line
+struct Args {
+    log_level: LevelFilter,
+    socket_path: PathBuf,
+}
+
+/// Print a usage message in the event a bad arg is passed
+fn usage() {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            [ --socket-path PATH ]
+            [ --log-level trace|debug|info|warn|error ]
+
+    Socket path defaults to {}",
+        program_name, DEFAULT_API_SOCKET,
+    );
+}
+
+/// Parse the args to the program and return an Args struct
+fn parse_args(args: env::Args) -> Result<Args> {
+    let mut log_level = None;
+    let mut socket_path = None;
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--log-level" => {
+                let log_level_str = iter.next().ok_or_else(|| error::Error::Usage {
+                    message: "Did not give argument to --log-level".into(),
+                })?;
+                log_level = Some(LevelFilter::from_str(&log_level_str).map_err(|_| {
+                    error::Error::Usage {
+                        message: format!("Invalid log level '{}'", log_level_str),
+                    }
+                })?);
+            }
+
+            "--socket-path" => {
+                socket_path = Some(
+                    iter.next()
+                        .ok_or_else(|| error::Error::Usage {
+                            message: "Did not give argument to --socket-path".into(),
+                        })?
+                        .into(),
+                )
+            }
+
+            _ => {
+                return Err(error::Error::Usage {
+                    message: "unexpected argument".into(),
+                })
+            }
+        }
+    }
+
+    Ok(Args {
+        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.into()),
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+pub(crate) async fn main() -> () {
+    if let Err(e) = run().await {
+        match e {
+            error::Error::Usage { .. } => {
+                eprintln!("{}", e);
+                usage();
+                process::exit(2);
+            }
+            _ => {
+                eprintln!("{}", e);
+                process::exit(1);
+            }
+        }
+    }
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("{}", message))]
+        Usage { message: String },
+
+        #[snafu(display("Failed to retrieve settings: {}", source))]
+        RetrieveSettings { source: schnauzer::Error },
+
+        #[snafu(display("settings.kubernetes.static_pods missing in API response"))]
+        MissingSettings {},
+
+        #[snafu(display("Static pod '{}' missing field '{}'", name, field))]
+        MissingField { name: String, field: String },
+
+        #[snafu(display("Failed to manage {} of {} static pods", failed, tried))]
+        ManageStaticPodsFailed { failed: u32, tried: usize },
+
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Unable to base64 decode manifest '{}': '{}'", base64_string, source))]
+        Base64Decode {
+            base64_string: String,
+            source: base64::DecodeError,
+        },
+
+        #[snafu(display("Failed to create directory '{}': '{}'", dir.display(), source))]
+        Mkdir {
+            dir: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to write manifest for static pod '{}': {}", name, source))]
+        ManifestWrite {
+            name: String,
+            source: std::io::Error,
+        },
+
+        #[snafu(display(
+            "Failed to delete manifest file for static pod '{}': {}'",
+            name,
+            source
+        ))]
+        ManifestDelete {
+            name: String,
+            source: std::io::Error,
+        },
+    }
+}

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -41,6 +41,13 @@ cluster-domain = "cluster.local"
 [settings.metrics]
 service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kubelet"]
 
+[services.static-pods]
+configuration-files = []
+restart-commands = ["/usr/bin/static-pods"]
+
+[metadata.settings.kubernetes.static-pods]
+affected-services = ["static-pods"]
+
 # Network
 [metadata.settings.network]
 affected-services = ["containerd", "kubernetes", "host-containerd"]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -93,10 +93,17 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion,
+    DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
     KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
     Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
 };
+
+// Kubernetes static pod manifest settings
+#[model]
+struct StaticPod {
+    enabled: bool,
+    manifest: ValidBase64,
+}
 
 // Kubernetes related settings. The dynamic settings are retrieved from
 // IMDS via Sundog's child "Pluto".
@@ -108,6 +115,7 @@ struct KubernetesSettings {
     api_server: Url,
     node_labels: HashMap<KubernetesLabelKey, KubernetesLabelValue>,
     node_taints: HashMap<KubernetesLabelKey, KubernetesTaintValue>,
+    static_pods: HashMap<Identifier, StaticPod>,
 
     // Dynamic settings.
     max_pods: u32,

--- a/variants/aws-k8s-1.15/Cargo.toml
+++ b/variants/aws-k8s-1.15/Cargo.toml
@@ -16,7 +16,8 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.15",
     "release",
-    "static-pods"
+    "static-pods",
+    "pluto"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.15/Cargo.toml
+++ b/variants/aws-k8s-1.15/Cargo.toml
@@ -16,6 +16,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.15",
     "release",
+    "static-pods"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.16/Cargo.toml
+++ b/variants/aws-k8s-1.16/Cargo.toml
@@ -16,6 +16,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.16",
     "release",
+    "static-pods"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.16/Cargo.toml
+++ b/variants/aws-k8s-1.16/Cargo.toml
@@ -16,7 +16,8 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.16",
     "release",
-    "static-pods"
+    "static-pods",
+    "pluto"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.17/Cargo.toml
+++ b/variants/aws-k8s-1.17/Cargo.toml
@@ -16,6 +16,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.17",
     "release",
+    "static-pods"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.17/Cargo.toml
+++ b/variants/aws-k8s-1.17/Cargo.toml
@@ -16,7 +16,8 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.17",
     "release",
-    "static-pods"
+    "static-pods",
+    "pluto"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.18/Cargo.toml
+++ b/variants/aws-k8s-1.18/Cargo.toml
@@ -16,6 +16,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.18",
     "release",
+    "static-pods"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.18/Cargo.toml
+++ b/variants/aws-k8s-1.18/Cargo.toml
@@ -16,7 +16,8 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.18",
     "release",
-    "static-pods"
+    "static-pods",
+    "pluto"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.19/Cargo.toml
+++ b/variants/aws-k8s-1.19/Cargo.toml
@@ -16,7 +16,8 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.19",
     "release",
-    "static-pods"
+    "static-pods",
+    "pluto"
 ]
 
 [lib]

--- a/variants/aws-k8s-1.19/Cargo.toml
+++ b/variants/aws-k8s-1.19/Cargo.toml
@@ -16,6 +16,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.19",
     "release",
+    "static-pods"
 ]
 
 [lib]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Feb 9 13:20:22 2021 -0800

    settings, static-pods: new settings and helper for k8s static pods
    
    Adds a set of new settings for managing k8s static pods.
    Adds a new binary helper to manage k8s static pod manifests.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Feb 9 13:27:48 2021 -0800

    aws-k8s-*: specify 'staticPodPath' in kubelet config
    
    Specify pod manifest path in kubelet config for all kubernetes variants.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Feb 12 12:17:29 2021 -0800

    pluto: only build for kubernetes variants
    
    We only need to build pluto for kubernetes variants

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Feb 12 13:23:43 2021 -0800

    Makefile: conditionally exclude packages from cargo test
    
    In tasks.unit-test, we need to conditionally exclude variant specific
    packages from being compiled if the variant does not match up

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Feb 16 10:41:34 2021 -0800

    migrations: add `add-static-pods` migration
    
    Adds a new migration for new k8s static-pods settings

```

**Testing done:**

Verified that buildsys does not build the package for non-k8s variants.

Build aws-k8s-1.15, aws-k8s-1.16, aws-k8s-1.17, aws-k8s-1.18, aws-k8s-1.19 images and launched instances for all of them

Kubelet started up fine.

Then I specified a static pod that ran nginx on port 80 with host networking:
```
apiclient set kubernetes.static-pods.control-plane-stuff.manifest=YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogICBuYW1lOiBzdGF0aWMtcG9kLW5naW54LXRlc3QKc3BlYzoKICAgaG9zdE5ldHdvcms6IHRydWUKICAgY29udGFpbmVyczoKICAgICAgLSBuYW1lOiBuZ2lueAogICAgICAgIGltYWdlOiBuZ2lueDoxLjE0LjIKICAgICAgICBwb3J0czoKICAgICAgICAgICAtIGNvbnRhaW5lclBvcnQ6IDgwCg==
apiclient set kubernetes.static-pods.control-plane-stuff.enabled=true
```

The base64 blob decodes to the following:
```
apiVersion: v1
kind: Pod
metadata:
   name: static-pod-nginx-test
spec:
   hostNetwork: true
   containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
           - containerPort: 80

```

Observed that the manifest gets created successfully in the pod manifest path:
```
bash-5.0# cat /etc/kubernetes/static-pods/control-plane-stuff 
apiVersion: v1
kind: Pod
metadata:
   name: static-pod-nginx-test
spec:
   hostNetwork: true
   containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
           - containerPort: 80
```

Then curling localhost:80 from within the admin container I can see nginx is running as expected:
```
[ec2-user@ip-192-168-3-187 ~]$ curl localhost:80
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
[ec2-user@ip-192-168-3-187 ~]$ 
```

Checking pods via kubectl, I can see mirror pod entries in the k8s API:
```
$ kubectl get pods -A
NAMESPACE      NAME                                                                READY   STATUS    RESTARTS   AGE
default        static-pod-nginx-test-ip-192-168-3-187.us-west-2.compute.internal   1/1     Running   0          6m16s
default        static-pod-nginx-test-ip-192-168-8-47.us-west-2.compute.internal    1/1     Running   0          20m
....
```

Disabling the static pod by setting `enabled` to `false` also works as expected. The manifest file gets correctly deleted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
