### PR TITLE
modify default label for containers

### DIFF
--- a/SECURITY_GUIDANCE.md
+++ b/SECURITY_GUIDANCE.md
@@ -45,8 +45,7 @@ Seccomp filters can be used to allow access to a subset of syscalls.
 Bottlerocket uses `containerd` as the container runtime which provides [a default seccomp profile](https://github.com/containerd/containerd/blob/master/contrib/seccomp/seccomp_default.go).
 
 SELinux labels are part of mandatory access controls, which impose constraints after discretionary access controls are checked.
-Bottlerocket runs all containers with the unprivileged `container_t` label today.
-However, privileged containers may run with the privileged `super_t` label in the future.
+Bottlerocket runs unprivileged containers with the restrictive `container_t` label.
 
 Orchestrators provide ways to disable these protections:
 * Docker can run containers with the `--privileged` flag
@@ -158,9 +157,12 @@ These changes are called "transitions".
 The SELinux policy for Bottlerocket defines special transition rules for container runtimes.
 
 A container runtime can transition a child processes to any of these labels:
-* `container_t` (the default, for ordinary containers)
-* `control_t` (for containers that need to access the API)
-* `super_t` (for "superpowered" containers)
+* `container_t` (the default for ordinary containers)
+* `control_t` (the default for privileged containers)
+* `super_t` (opt-in for "superpowered" containers)
+
+The `control_t` and `super_t` labels allow writes to the API socket.
+The `super_t` label allows modifications to any file or directory on the host OS.
 
 Some orchestrators allow SELinux labels to be defined in the container specification, including Kubernetes and Amazon ECS.
 If `control_t` or `super_t` is specified in this way, it will override the default transition rules and the container will run with additional privileges.

--- a/packages/selinux-policy/lxc_contexts
+++ b/packages/selinux-policy/lxc_contexts
@@ -1,3 +1,12 @@
+# Runtimes that use the Go SELinux implementation, such as Docker and
+# the containerd CRI plugin, will apply the 'process' label to the
+# initial process for unprivileged containers, unless the option for
+# automatic labeling is disabled.
 process = "system_u:system_r:container_t:s0"
+
+# The 'file' label should always be applied to the container's root
+# filesystem, regardless of privileged status or automatic labeling.
 file = "system_u:object_r:local_t:s0"
+
+# The 'ro_file' label is not currently used by the above runtimes.
 ro_file = "system_u:object_r:cache_t:s0"

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -53,13 +53,16 @@
 (allow init_t runtime_t (processes (transform)))
 (allow runtime_t runtime_exec_t (file (entrypoint)))
 
-; `runc` starts container processes as "container_t" by default, but
-; it can use other "container" subject labels like "super_t".
-; Unlike the above transitions, this depends on correct labeling for
-; objects on local storage.
-(typetransition runtime_t local_t process container_t)
-(typetransition runtime_t cache_t process container_t)
-(typetransition runtime_t state_t process container_t)
+; `runc` starts container processes as "control_t" by default, but it
+; can use other "container" subject labels like "container_t". This
+; depends on correct labeling for objects on local storage.
+;
+; Runtimes that use the Go SELinux library will override this label
+; with the "process" label from the `lxc_contexts` when launching
+; unprivileged containers, unless automatic labeling is disabled.
+(typetransition runtime_t local_t process control_t)
+(typetransition runtime_t cache_t process control_t)
+(typetransition runtime_t state_t process control_t)
 (allow runtime_t container_s (processes (transform)))
 (allow container_s local_t (file (entrypoint)))
 (allow container_s cache_t (file (entrypoint)))


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
The goal here is to better align our SELinux policy transitions with the behavior of Docker and containerd's CRI plugin, which expect that privileged containers will take the default path and end up with a more powerful label, while unprivileged ones will allocate an MCS pair that facilitates isolation between containers.

Although we don't yet support MCS isolation, this lays the groundwork for that by introducing a distinct label for privileged containers. That will let us add more restrictions to the `container_t` type, such as MCS constraints, without simultaneously restricting the `control_t` type in ways that are incompatible with expectations in the ecosystem.

Note that `control_t` and privileged are already quite similar in terms of their ability to affect the system: `control_t` offers highly privileged access to the host by means of the API, while privileged containers can bypass many access controls without using the API. 

Instead of repurposing the `control_t` type and granting the additional permissions to privileged containers, we could define a new type, such as `privileged_t`. Maintaining a separate but similar label would require duplicating many additional rules over time; for example, both labels would need access to host sockets, and both would need to be able to bypass MCS constraints.

**Testing done:**
I verified that Docker now uses `control_t` for "privileged" and "label disabled" containers.

As part of the work to update to containerd 1.4, I also verified that `control_t` is used for privileged containers launched via CRI. Until then, `container_t` will continue to be used because of our SELinux patches on containerd 1.3.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
