### PR TITLE
storewolf: declare dependencies on model and defaults files

### DIFF
--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -23,6 +23,9 @@ toml = "0.5"
 [build-dependencies]
 cargo-readme = "3.1"
 merge-toml = { path = "merge-toml" }
+# model dep because we read default settings from the model directory; we also
+# reflect it with cargo:rerun-if-changed statements in build.rs.
+models = { path = "../../models" }
 snafu = "0.6"
 toml = "0.5"
 walkdir = "2"

--- a/sources/api/storewolf/build.rs
+++ b/sources/api/storewolf/build.rs
@@ -23,6 +23,9 @@ fn main() -> Result<()> {
     generate_readme();
     generate_defaults_toml()?;
 
+    // Reflect that we need to rerun if variant has changed to pick up the new default settings.
+    println!("cargo:rerun-if-env-changed=VARIANT");
+
     Ok(())
 }
 
@@ -68,6 +71,10 @@ fn generate_defaults_toml() -> Result<()> {
     let mut defaults = Value::Table(Map::new());
     for entry in walker {
         let entry = entry.context(error::ListFiles { dir: DEFAULTS_DIR })?;
+
+        // Reflect that we need to rerun if any of the default settings files have changed.
+        println!("cargo:rerun-if-changed={}", entry.path().display());
+
         let data = fs::read_to_string(entry.path()).context(error::File {
             op: "read",
             path: entry.path(),


### PR DESCRIPTION
**Description of changes:**

```
storewolf: declare dependencies on model and defaults files

Without this, you can change a defaults file and not haven those changes in a
new build, or change the variant and still use the prior cached model link.
```

I believe this should also address the rare file-not-found issue seen in https://github.com/bottlerocket-os/bottlerocket/pull/1303 and in the checks of a couple PRs after.

**Testing done:**

Before, I built a k8s AMI and it was fine, but then I built an ECS AMI and it had the wrong model, spewing lots of errors about deserializing the incorrect data that storewolf had put in the data store.  (@etungsten originally reported this behavior and I verified.)

After, I built a k8s AMI and it was fine, and then I built an ECS AMI and it was also fine, with the correct ECS settings.

Also confirmed that changes to the defaults files now rebuild:
* cargo make build-packages
* cargo make build-packages again; it did not rebuild os.
* touch 10-defaults.toml, cargo make build-packages, it does rebuild os.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
