### PR TITLE
metricdog: respect proxy settings

### DIFF
--- a/packages/os/mark-successful-boot.service
+++ b/packages/os/mark-successful-boot.service
@@ -5,6 +5,7 @@ After=multi-user.target
 # and include "RequiredBy=mark-successful-boot.service" in its [Install] section.
 
 [Service]
+EnvironmentFile=/etc/network/proxy.env
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/bin/signpost mark-successful-boot

--- a/packages/os/metricdog.service
+++ b/packages/os/metricdog.service
@@ -2,6 +2,7 @@
 Description=Send a Metricdog Ping
 
 [Service]
+EnvironmentFile=/etc/network/proxy.env
 Type=oneshot
 RemainAfterExit=false
 StandardError=journal+console

--- a/sources/metricdog/README.md
+++ b/sources/metricdog/README.md
@@ -10,6 +10,13 @@ It does so by sending key-value pairs as query params in an HTTP GET request.
 Metricdog also has the ability to check that a list of critical services is running.
 It does so using `systemctl` and reports services that are not healthy.
 
+#### Proxy Support
+
+Metricdog respects the environment variables `HTTPS_PROXY` and `NO_PROXY` to determine whether or
+not its traffic should be proxied. These are set with the `network.http-proxy` and `network.noproxy`
+settings when Metricdog is invoked by systemd. If you run Metricdog manually, you would need to
+seed the environment with these variables manually.
+
 ## What it Sends
 
 #### The standard set of metrics:

--- a/sources/metricdog/src/main.rs
+++ b/sources/metricdog/src/main.rs
@@ -9,6 +9,13 @@ It does so by sending key-value pairs as query params in an HTTP GET request.
 Metricdog also has the ability to check that a list of critical services is running.
 It does so using `systemctl` and reports services that are not healthy.
 
+### Proxy Support
+
+Metricdog respects the environment variables `HTTPS_PROXY` and `NO_PROXY` to determine whether or
+not its traffic should be proxied. These are set with the `network.http-proxy` and `network.noproxy`
+settings when Metricdog is invoked by systemd. If you run Metricdog manually, you would need to
+seed the environment with these variables manually.
+
 # What it Sends
 
 ### The standard set of metrics:

--- a/sources/metricdog/src/metricdog.rs
+++ b/sources/metricdog/src/metricdog.rs
@@ -140,6 +140,7 @@ impl Metricdog {
 
     fn send_get_request(url: Url, timeout_sec: Option<u64>) -> Result<()> {
         debug!("sending: {}", url.as_str());
+        fix_https_proxy_env();
         let client = Client::builder()
             .timeout(Duration::from_secs(
                 timeout_sec.unwrap_or(DEFAULT_TIMEOUT_SECONDS),
@@ -154,5 +155,32 @@ impl Metricdog {
             .error_for_status()
             .context(error::HttpResponse { url })?;
         Ok(())
+    }
+}
+
+/// reqwest needs a URL protocol scheme to be present, but other implementations assume
+/// `http://` as the scheme when none is present. We need to check the `HTTPS_PROXY` env and
+/// reset it with `http://` when no scheme is present. This can be removed when we are using
+/// reqwest >= 0.11.1
+// TODO - remove this workaround, see https://github.com/bottlerocket-os/bottlerocket/issues/1332
+fn fix_https_proxy_env() {
+    let proxy = match std::env::var("HTTPS_PROXY") {
+        Ok(s) if !s.is_empty() => s,
+        _ => return,
+    };
+
+    // try to parse it as a URL. if it works, a scheme is present
+    if Url::parse(&proxy).is_ok() {
+        return;
+    }
+
+    // since the URL could not be parsed, try parsing with http:// prepended
+    let proxy = format!("http://{}", proxy);
+
+    // use URL again to see if the proxy value is now valid
+    if Url::parse(&proxy).is_ok() {
+        debug!("Adding a scheme to HTTPS_PROXY: '{}'", proxy);
+        // success, so let's change the HTTPS_PROXY value for the sake of reqwest
+        std::env::set_var("HTTPS_PROXY", proxy);
     }
 }

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -70,8 +70,8 @@ send-metrics = true
 service-checks = ["apiserver", "chronyd", "containerd", "host-containerd"]
 
 [services.metricdog]
-configuration-files = ["metricdog-toml"]
-restart-commands = []
+configuration-files = ["metricdog-toml", "proxy-env"]
+restart-commands = ["/bin/systemctl try-restart metricdog.service"]
 
 [configuration-files.metricdog-toml]
 path = "/etc/metricdog.toml"


### PR DESCRIPTION

**Issue number:**

#1298

**Description of changes:**

Use the `proxy.env` file to give proxy values to metricdog.

A second commit provides a workaround for https://github.com/seanmonstar/reqwest/issues/1176

**Testing done:**

- Set metricdog's timer to send every 30 seconds 
- Created a tinyproxy near Bottlerocket at `192.168.57.178:8888` and set `network.https-proxy` to this value.
- Started Bottlerocket, observed metricdog using the tinyproxy.
- Used apiclient to set `network.no-proxy` to `["metrics.bottlerocket.aws"]`, observed the metricdog pings stopped arriving at the tinyproxy.
- Used apiclient to set `network.no-proxy` to `[]`, observed the metricdog pings start arriving at the tinyproxy again.
- Started a new Bottlerocket instance without setting `network.https-proxy` (this value cannot be unset once it has been set). Observed that metricdog pings were working.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
