### PR TITLE
makefile: add script runner bash to link-variant

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -380,6 +380,7 @@ done
 
 [tasks.link-variant]
 dependencies = ["build-variant"]
+script_runner = "bash"
 script = [
 '''
 mkdir -p ${BUILDSYS_OUTPUT_DIR}/latest


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Without this change, builds were failing on some systems.

**Testing done:**

Add script runner=bash to the Makefile.toml for the link-variant target.
I haven't tested it, but @sanu11 reported that this fixed a build issue.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
