### PR TITLE
updog: respect proxy settings

### DIFF
--- a/packages/os/updog-toml
+++ b/packages/os/updog-toml
@@ -3,3 +3,9 @@ targets_base_url = "{{settings.updates.targets-base-url}}"
 seed = {{settings.updates.seed}}
 version_lock = "{{settings.updates.version-lock}}"
 ignore_waves = {{settings.updates.ignore-waves}}
+{{~#if settings.network.https-proxy}}
+https_proxy="{{settings.network.https-proxy}}"
+{{~/if}}
+{{~#if settings.network.no-proxy}}
+no_proxy=[{{join_array ", " settings.network.no-proxy}}]
+{{~/if}}

--- a/sources/updater/updog/README.md
+++ b/sources/updater/updog/README.md
@@ -47,3 +47,8 @@ Starting update to 0.1.4
 ** Updating immediately **
 Update applied: aws-k8s-1.15 0.1.4
 ```
+
+## Proxy Support
+
+The `network.https-proxy` and `network.no-proxy` settings are taken from updog's config file.
+These will override the environment variables `HTTPS_PROXY` and `NO_PROXY`.

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -109,6 +109,13 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Unable to parse proxy setting '{}': {}", proxy, source))]
+    Proxy {
+        proxy: String,
+        source: url::ParseError,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Failed to reboot: {}", source))]
     RebootFailure {
         source: std::io::Error,


### PR DESCRIPTION

**Issue number:**

#1300

**Description of changes:**

Adds https-proxy and no-proxy settings to updog's config file. These are
used to set HTTPS_PROXY and NO_PROXY environment variables for the
process at the beginning of the program which ensures that they
are used by the underlying HTTP client.


**Testing done:**

- I ran with an https-proxy setting and observed that updog used the proxy during check-update, I also ran a pod.
- I ran with an https-proxy setting and with my repo's domain in the no-proxy setting. I observed that updog did not use the proxy during check-update. I also ran a pod.
- I ran with no https-proxy setting and no no-proxy setting. I observed that updog did not use the proxy during check-update. I also ran a pod.

**Upgrade Downgrade**

- I created a proxy with tinyproxy.
- I checked out tag v1.0.5 and built an AMI and a repo.
- I built what's in this PR and called it v1.0.6, added it to the repo.
- I ran v1.0.5, upgraded to v1.0.6
- I used updog on v1.0.6 and observed it using tinyproxy
- I observed the updog.toml had an https_proxy value. The no_proxy key was absent as expected.
- I downgraded back to v1.0.5.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
