### PR TITLE
logdog: add eni logs for k8s

### DIFF
--- a/sources/logdog/conf/aws-k8s.conf
+++ b/sources/logdog/conf/aws-k8s.conf
@@ -1,1 +1,3 @@
 exec kube-status systemctl status kube* -l --no-pager
+file ipamd.log /var/log/aws-routed-eni/ipamd.log
+file plugin.log /var/log/aws-routed-eni/plugin.log


### PR DESCRIPTION

**Issue number:**

Closes #1313 

**Description of changes:**

Added
`/var/log/aws-routed-eni/ipamd.log`
`/var/log/aws-routed-eni/plugin.log`

To the files collected by logdog for k8s.
For me, the `plugin.log` did not exist. Logdog still works fine when a file is missing and reports the missing file in its `logdog.errors` file.

**Testing done:**

Ran a pod, used logdog.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
