### PR TITLE
updog: update signal-hook dependency

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2855,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -27,8 +27,7 @@ tough = { version = "0.10", features = ["http"] }
 update_metadata = { path = "../update_metadata" }
 structopt = "0.3"
 url = "2.1.0"
-# TODO - update signal-hook to the latest version. https://github.com/bottlerocket-os/bottlerocket/issues/1268
-signal-hook = "0.1.13"
+signal-hook = "0.3"
 models = { path = "../../models" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Issue number:

Closes #1268

## Description of changes:

Update to the latest version of `signal-hook`, used in `updog`.

## Testing done:

### Manual Testing

I added a sleep before updog initiates the shutdown, and I added SIGINT to the list of signals trapped. I waited for the sleep to happen and tried to stop updog with control-C. Updog ignored my SIGINT signals as we would expect.

```
**22:22:53 [INFO] sleeping before shutdown
^C^C^C^C^C^C^C^C^C^C^C^C^C
```

### Brupop

- Ran three nodes (with the changes of this PR, i.e. not with the extra sleep and signal described above).
- Ran brupop.
- Applied the 1.0.0 interface version to my nodes like this: `kubectl label node $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}') bottlerocket.aws/updater-interface-version=1.0.0`
- I watched things like this:
  - `watch -c -- make get-nodes-status`, and
  - `kubectl logs --follow update-operator-controller-689f485f46-d6xvq --namespace bottlerocket`

I observed that things were happening. After things were done happening I logged into the Bottlerocket nodes and found that they had been updated. (This was the first time I used brupop, heh, that's pretty cool @jahkeup and @etungsten, fun to watch.)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
