### PR TITLE
models: link current variant more carefully

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1909,6 +1909,7 @@ dependencies = [
  "cargo-readme",
  "lazy_static",
  "model-derive",
+ "rand 0.8.1",
  "regex",
  "semver 0.11.0",
  "serde",

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -23,8 +23,11 @@ toml = "0.5"
 [build-dependencies]
 cargo-readme = "3.1"
 merge-toml = { path = "merge-toml" }
-# model dep because we read default settings from the model directory; we also
-# reflect it with cargo:rerun-if-changed statements in build.rs.
+# We have a models build-dep because we read default settings from the models
+# directory and need its build.rs to run first; we also reflect the dependency
+# with cargo:rerun-if-changed statements in our build.rs.  The models build.rs
+# runs twice, once for the above dependency and once for this build-dependency;
+# there's a check in models build.rs to skip running the second time.
 models = { path = "../../models" }
 snafu = "0.6"
 toml = "0.5"

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -24,6 +24,7 @@ url = "2.1"
 
 [build-dependencies]
 cargo-readme = "3.1"
+rand = "0.8"
 
 [lib]
 # We're picking the current *model* with build.rs, so users shouldn't think


### PR DESCRIPTION
**Description of changes:**

We were still seeing some rare, random build failures after #1303, and tracked it down to the fact that cargo calls models' build.rs script multiple times: once for the build-dep in storewolf, once for the (regular) dep in storewolf, and once (much later) for the dep in the static build of apiclient.  The first two have a chance of running at the same time and racing to delete/create the symlink, causing a failure.  (I think it's _correct_ for cargo to run it multiple times, since each of those is running in a different environment; build-dep vs. dep, for example, use the host build toolchain versus the target build toolchain.)

Example error from #1318: `Failed to create symlink at 'src/variant/current' pointing to '../aws-ecs-1' - we need this to support different API models for different variants.  Error: File exists (os error 17)"`

This PR makes a few related changes to make this process safer.  First, we only run the model build.rs once, during the "host" build for the build-dep in storewolf, by checking CARGO_CFG_TARGET_VENDOR.  Second, in case they do happen to run at the same time for other unexpected reasons, it now uses an atomic link-swap rather than a remove/create so we can't race.  Third, just to be tidy, it alerts cargo that it should rerun if either of our links change, though this should only happen if someone manually deletes a link or something.

```
    models: fix TOCTOU in build.rs by safely swapping links into place
```

```
    models: rerun if variant/mod links change
    
    We don't expect these links to change outside of this script, but if they do,
    we need to rerun this build.rs and reset the links properly.
```

```
    models: only run build.rs once, for host
```

**Testing done:**

I built and ran a k8s AMI OK, then an ECS AMI, then a k8s AMI again.  (This is to ensure I didn't reintroduce the issue solved in #1319, and for general health.)

I checked the build log and saw that later build.rs runs exited quickly:
```
#17 1.117      Running `/home/builder/.cache/release/build/models-b586c88a1f2e4d4b/build-script-build`
#17 1.117      Running `/home/builder/.cache/release/build/models-b586c88a1f2e4d4b/build-script-build`
#17 1.122 warning: Already ran model build.rs for host, skipping for target
...
#17 115.4      Running `/home/builder/.cache/.static/release/build/models-b87a178a21838d64/build-script-build`
#17 115.4 warning: Already ran model build.rs for host, skipping for target
```

Also, local testing shows the symlink being swapped around OK.  Starting with aws-k8s-1.17 linked, rebuilding keeps it:
```
> ls -ahlF --color=auto src/variant/current
lrwxrwxrwx. 1 tjk tjk 15 02-17 14:59 src/variant/current -> ../aws-k8s-1.17/
> cargo build
> ls -ahlF --color=auto src/variant/current
lrwxrwxrwx. 1 tjk tjk 15 02-17 15:42 src/variant/current -> ../aws-k8s-1.17/
```

Changing variant works:
```
> env VARIANT=aws-dev cargo build
> ls -ahlF --color=auto src/variant/current
lrwxrwxrwx. 1 tjk tjk 10 02-17 15:43 src/variant/current -> ../aws-dev/
```

Removing the files gets them recreated:
```
> rm src/variant/current
> cargo build
> ls -ahlF --color=auto src/variant/current
lrwxrwxrwx. 1 tjk tjk 15 02-17 15:43 src/variant/current -> ../aws-k8s-1.17/
```

Changing them does too:
```
> ln -snf bad src/variant/current
> cargo build
> ls -ahlF --color=auto src/variant/current
lrwxrwxrwx. 1 tjk tjk 15 02-17 15:45 src/variant/current -> ../aws-k8s-1.17/
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
