### PR TITLE
Add "shibaken" generator to populate user-data with public keys from IMDS

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -14,13 +14,14 @@
   Used for system maintenance and connectivity.
 * [**host-ctr**](sources/host-ctr): The program started by `host-containers@.service` for each host container.
   Its job is to start the specified host container on the “host” instance of containerd, which is separate from the “user” instance of containerd used for Kubernetes pods.
-* [**logdog**](sources/logdog): A program that one can use to collect logs when things go wrong. 
+* [**logdog**](sources/logdog): A program that one can use to collect logs when things go wrong.
 * [**metricdog**](sources/metricdog): A program that sends anonymous health pings.
 * [**model**](sources/models): The API system has a data model defined for each variant, and this model is used by other programs to serialize and deserialize requests while maintaining safety around data types.
 * [**netdog**](sources/api/netdog): A program called by wicked to retrieve and write out network configuration from DHCP.
 * [**pluto**](sources/api/pluto): A setting generator called by sundog to find networking settings required by Kubernetes.
 * [**schnauzer**](sources/api/schnauzer): A setting generator called by sundog to build setting values that contain template variables referencing other settings.
 * **setting generator**: A binary that generates the default value of a setting.
+* [**shibaken**](sources/api/shibaken): A setting generator called by sundog to populate the admin container's user-data with public keys from IMDS, when running in AWS.
 * [**signpost**](sources/updater/signpost): A program used to manipulate the GPT header of the OS disk; fields in the header are used by GRUB to determine the partition set we should boot from.
 * [**storewolf**](sources/api/storewolf): A program that sets up the data store for the API upon boot.
 * [**sundog**](sources/api/sundog): A program run during boot that generates any settings that depend on runtime system information.

--- a/Release.toml
+++ b/Release.toml
@@ -18,13 +18,13 @@ version = "1.0.5"
     "migrate_v1.0.5_add-user-data.lz4",
     "migrate_v1.0.5_add-network-settings.lz4",
     "migrate_v1.0.5_add-proxy-restart.lz4",
-    "migrate_v1.0.5_add-proxy-services.lz4"
+    "migrate_v1.0.5_add-proxy-services.lz4",
 ]
 "(1.0.5, 1.0.6)" = [
     "migrate_v1.0.6_metricdog-init.lz4",
     "migrate_v1.0.6_add-static-pods.lz4",
     "migrate_v1.0.6_kubelet-standalone-tls-settings.lz4",
     "migrate_v1.0.6_kubelet-standalone-tls-services.lz4",
-    "migrate_v1.0.6_control-container-v0-4-2.lz4"
+    "migrate_v1.0.6_control-container-v0-4-2.lz4",
+    "migrate_v1.0.6_add-shibaken.lz4",
 ]
-

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -78,6 +78,7 @@ Requires: %{_cross_os}schnauzer = %{version}-%{release}
 Requires: %{_cross_os}pluto = %{version}-%{release}
 %endif
 Requires: %{_cross_os}bork = %{version}-%{release}
+Requires: %{_cross_os}shibaken = %{version}-%{release}
 %description -n %{_cross_os}sundog
 %{summary}.
 
@@ -95,6 +96,11 @@ Requires: %{_cross_os}apiserver = %{version}-%{release}
 %package -n %{_cross_os}schnauzer
 Summary: Setting generator for templated settings values.
 %description -n %{_cross_os}schnauzer
+%{summary}.
+
+%package -n %{_cross_os}shibaken
+Summary: Setting generator for populating admin container user-data from IMDS.
+%description -n %{_cross_os}shibaken
 %{summary}.
 
 %package -n %{_cross_os}thar-be-settings
@@ -206,6 +212,7 @@ mkdir bin
     -p sundog \
     -p schnauzer \
     -p bork \
+    -p shibaken \
     -p thar-be-settings \
     -p thar-be-updates \
     -p servicedog \
@@ -248,7 +255,7 @@ done
 install -d %{buildroot}%{_cross_bindir}
 for p in \
   apiserver \
-  early-boot-config netdog sundog schnauzer bork corndog \
+  early-boot-config netdog sundog schnauzer bork shibaken corndog \
   thar-be-settings thar-be-updates servicedog host-containers \
   storewolf settings-committer \
   migrator \
@@ -353,6 +360,9 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 
 %files -n %{_cross_os}bork
 %{_cross_bindir}/bork
+
+%files -n %{_cross_os}shibaken
+%{_cross_bindir}/shibaken
 
 %files -n %{_cross_os}thar-be-settings
 %{_cross_bindir}/thar-be-settings

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -63,6 +63,7 @@ Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}policycoreutils
 Requires: %{_cross_os}signpost
 Requires: %{_cross_os}sundog
+Requires: %{_cross_os}shibaken
 Requires: %{_cross_os}storewolf
 Requires: %{_cross_os}host-containers
 Requires: %{_cross_os}settings-committer

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -302,6 +302,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-shibaken"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-static-pods"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2821,6 +2821,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
+name = "shibaken"
+version = "0.1.0"
+dependencies = [
+ "base64 0.13.0",
+ "cargo-readme",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "snafu",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "api/migration/migrations/v1.0.6/kubelet-standalone-tls-settings",
     "api/migration/migrations/v1.0.6/kubelet-standalone-tls-services",
     "api/migration/migrations/v1.0.6/control-container-v0-4-2",
+    "api/migration/migrations/v1.0.6/add-shibaken",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "api/settings-committer",
     "api/migration/migrator",
     "api/migration/migration-helpers",
+    "api/shibaken",
 
     # "api/migration/migrations/vX.Y.Z/...
     "api/migration/migrations/v0.3.2/migrate-admin-container-v0-5-0",

--- a/sources/api/migration/migrations/v1.0.6/add-shibaken/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.6/add-shibaken/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-shibaken"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.6/add-shibaken/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.6/add-shibaken/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting metadata, `host-containers.admin.user-data.setting-generator`
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["setting-generator"],
+        setting: "settings.host-containers.admin.user-data",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "shibaken"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+base64 = "0.13"
+log = "0.4"
+reqwest = { version = "0.10", default-features = false, features = ["blocking"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+simplelog = "0.9"
+snafu = "0.6"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/api/shibaken/README.md
+++ b/sources/api/shibaken/README.md
@@ -1,0 +1,16 @@
+# shibaken
+
+Current version: 0.1.0
+
+## Introduction
+
+shibaken is called by sundog as a setting generator.
+
+shibaken will fetch and populate the admin container's user-data with authorized ssh keys from the
+AWS instance metadata service (IMDS).
+
+(The name "shibaken" comes from the fact that Shiba are small, but agile, hunting dogs.)
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/shibaken/README.tpl
+++ b/sources/api/shibaken/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/shibaken/build.rs
+++ b/sources/api/shibaken/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -1,0 +1,285 @@
+/*!
+# Introduction
+
+shibaken is called by sundog as a setting generator.
+
+shibaken will fetch and populate the admin container's user-data with authorized ssh keys from the
+AWS instance metadata service (IMDS).
+
+(The name "shibaken" comes from the fact that Shiba are small, but agile, hunting dogs.)
+*/
+
+#![deny(rust_2018_idioms)]
+
+use log::{debug, info, warn};
+use reqwest::blocking::Client;
+use serde::Serialize;
+use simplelog::{Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
+use snafu::{OptionExt, ResultExt};
+use std::str::FromStr;
+use std::{env, process};
+
+// Instance Meta Data Service.
+//
+// Currently only able to get fetch session tokens from `latest`
+// FIXME Pin to a date version that supports IMDSv2 once such a date version is available.
+const IMDS_PUBLIC_KEY_BASE_URI: &str = "http://169.254.169.254/latest/meta-data/public-keys";
+const IMDS_SESSION_TOKEN_URI: &str = "http://169.254.169.254/latest/api/token";
+
+#[derive(Serialize)]
+struct UserData {
+    ssh: Ssh,
+}
+
+#[derive(Serialize)]
+struct Ssh {
+    authorized_keys: Vec<String>,
+}
+impl UserData {
+    fn new(public_keys: Vec<String>) -> Self {
+        UserData {
+            ssh: Ssh {
+                authorized_keys: public_keys,
+            },
+        }
+    }
+}
+
+/// Helper to fetch an IMDSv2 session token that is valid for 60 seconds.
+fn fetch_imds_session_token(client: &Client) -> Result<String> {
+    let uri = IMDS_SESSION_TOKEN_URI;
+    let imds_session_token = client
+        .put(uri)
+        .header("X-aws-ec2-metadata-token-ttl-seconds", "60")
+        .send()
+        .context(error::ImdsRequest { method: "PUT", uri })?
+        .error_for_status()
+        .context(error::ImdsResponse { uri })?
+        .text()
+        .context(error::ImdsText { uri })?;
+    Ok(imds_session_token)
+}
+
+/// Helper to fetch data from IMDS. Taken from pluto.
+fn get_text_from_imds(client: &Client, uri: &str, session_token: &str) -> Result<String> {
+    client
+        .get(uri)
+        .header("X-aws-ec2-metadata-token", session_token)
+        .send()
+        .context(error::ImdsRequest { method: "GET", uri })?
+        .error_for_status()
+        .context(error::ImdsResponse { uri })?
+        .text()
+        .context(error::ImdsText { uri })
+}
+
+/// Returns a list of public keys.
+fn fetch_public_keys_from_imds() -> Result<Vec<String>> {
+    info!("Fetching IMDS session token");
+    let client = Client::new();
+    let imds_session_token = fetch_imds_session_token(&client)?;
+
+    info!("Fetching list of available public keys from IMDS");
+    // Returns a list of available public keys as '0=my-public-key'
+    let public_key_list =
+        get_text_from_imds(&client, IMDS_PUBLIC_KEY_BASE_URI, &imds_session_token)?;
+    debug!("available public keys '{}'", &public_key_list);
+
+    info!("Generating uris to fetch text of available public keys");
+    let public_key_uris = build_public_key_uris(&public_key_list);
+
+    info!("Fetching public keys from IMDS");
+    let mut public_keys = Vec::new();
+    for uri in public_key_uris {
+        let public_key_text = get_text_from_imds(&client, &uri, &imds_session_token)?;
+        let public_key = public_key_text.trim_end();
+        // Simple check to see if the text is probably an ssh key.
+        if public_key.starts_with("ssh") {
+            debug!("{}", &public_key);
+            public_keys.push(public_key.to_string())
+        } else {
+            warn!(
+                "'{}' does not appear to be a valid key. Skipping...",
+                &public_key_text
+            );
+            continue;
+        }
+    }
+    if public_keys.is_empty() {
+        warn!("No valid keys found");
+    }
+    Ok(public_keys)
+}
+
+/// Returns a list of public key uris strings for the public keys in IMDS. Since IMDS returns the
+/// list of available public keys as '0=my-public-key', we need to strip the index from the list and
+/// insert it into the key uri.
+fn build_public_key_uris(public_key_list: &str) -> Vec<String> {
+    let mut public_key_uris = Vec::new();
+    for available_key in public_key_list.lines() {
+        let f: Vec<&str> = available_key.split('=').collect();
+        // If f[0] isn't a number, then it isn't a valid index.
+        if f[0].parse::<u32>().is_ok() {
+            let public_key_uri = format!("{}/{}/openssh-key", IMDS_PUBLIC_KEY_BASE_URI, f[0]);
+            public_key_uris.push(public_key_uri);
+        } else {
+            warn!(
+                "'{}' does not appear to be a valid index. Skipping...",
+                &f[0]
+            );
+            continue;
+        }
+    }
+    if public_key_uris.is_empty() {
+        warn!("No valid key uris found");
+    }
+    public_key_uris
+}
+
+/// Store the args we receive on the command line.
+struct Args {
+    log_level: LevelFilter,
+}
+
+/// Print a usage message in the event a bad arg is passed
+fn usage() {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {}
+            [ --log-level trace|debug|info|warn|error ]",
+        program_name
+    );
+}
+
+/// Parse the args to the program and return an Args struct
+fn parse_args(args: env::Args) -> Result<Args> {
+    let mut log_level = None;
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--log-level" => {
+                let log_level_str = iter.next().context(error::Usage {
+                    message: "Did not give argument to --log-level",
+                })?;
+                log_level = Some(
+                    LevelFilter::from_str(&log_level_str)
+                        .context(error::LogLevel { log_level_str })?,
+                );
+            }
+
+            x => {
+                return error::Usage {
+                    message: format!("unexpected argument '{}'", x),
+                }
+                .fail()
+            }
+        }
+    }
+
+    Ok(Args {
+        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+    })
+}
+
+fn run() -> Result<()> {
+    let args = parse_args(env::args())?;
+
+    // TerminalMode::Stderr will send all logs to stderr, as sundog only expects the json output of
+    // the setting on stdout.
+    TermLogger::init(args.log_level, LogConfig::default(), TerminalMode::Stderr)
+        .context(error::Logger)?;
+
+    info!("shibaken started");
+
+    let public_keys = fetch_public_keys_from_imds()?;
+
+    let user_data = UserData::new(public_keys);
+
+    info!("Generating user-data");
+    // Serialize user_data to a JSON string that can be read by the admin container.
+    let user_data_json = serde_json::to_string(&user_data).context(error::SerializeJson)?;
+    debug!("{}", &user_data_json);
+
+    info!("Encoding user-data");
+    // admin container user-data must be base64-encoded to be passed through to the admin container
+    // using a setting, rather than another arbitrary storage mechanism. This approach allows the
+    // user to bypass shibaken and use their own user-data if desired.
+    let user_data_base64 = base64::encode(&user_data_json);
+
+    info!("Outputting user-data");
+    // sundog expects JSON-serialized output so that many types can be represented, allowing the
+    // API model to use more accurate types.
+    let output = serde_json::to_string(&user_data_base64).context(error::SerializeJson)?;
+
+    println!("{}", output);
+
+    Ok(())
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        match e {
+            error::Error::Usage { .. } => {
+                eprintln!("{}", e);
+                usage();
+                // sundog matches on the exit codes of the setting generators, so we should return 1
+                // to make sure that this is treated as a failure.
+                process::exit(1);
+            }
+            _ => {
+                eprintln!("{}", e);
+                process::exit(1);
+            }
+        }
+    }
+}
+
+mod error {
+    use snafu::Snafu;
+    fn code(source: &reqwest::Error) -> String {
+        source
+            .status()
+            .as_ref()
+            .map(|i| i.as_str())
+            .unwrap_or("Unknown")
+            .to_string()
+    }
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("Error {}ing '{}': {}", method, uri, source))]
+        ImdsRequest {
+            method: String,
+            uri: String,
+            source: reqwest::Error,
+        },
+
+        #[snafu(display("Error '{}' from '{}': {}", code(&source), uri, source))]
+        ImdsResponse { uri: String, source: reqwest::Error },
+
+        #[snafu(display("Error getting text response from {}: {}", uri, source))]
+        ImdsText { uri: String, source: reqwest::Error },
+
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Invalid log level '{}'", log_level_str))]
+        LogLevel {
+            log_level_str: String,
+            source: log::ParseLevelError,
+        },
+
+        #[snafu(display("Error serializing to JSON: {}", source))]
+        SerializeJson { source: serde_json::error::Error },
+
+        #[snafu(display("{}", message))]
+        Usage { message: String },
+    }
+}
+use error::Error;
+type Result<T> = std::result::Result<T, Error>;

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -6,6 +6,9 @@ superpowered = true
 setting-generator = "schnauzer settings.host-containers.admin.source"
 template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.5.2"
 
+[metadata.settings.host-containers.admin.user-data]
+setting-generator = "shibaken"
+
 [settings.host-containers.control]
 enabled = true
 superpowered = false


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**

Add "shibaken" generator to populate user-data with public keys from IMDS

This populates the host container's user-data setting with public keys
available from IMDS in the event that user-data has not been populated
by the user.

Adds a new migration helper `AddMetadataMigration` to remove setting
metadata (like setting-generators).

Adds a new migration for shibaken setting-generator.

**Testing done:**

Build aws-ecs-1 image and launched instance.

Verified that `host-containers.admin.user-data` contained a base64-encoded block.

Enabled and launched admin container, which started fine.

Verified that `/.bottlerocket/host-containers/admin/user-data` contained JSON with the following structure:

```
{
   "ssh":{
      "authorized_keys":[
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQClKsfkNkuSevGj3eYhCe53pcjqP3maAhDFcvBS7O6V
          hz2ItxCih+PnDSUaw+WNQn/mZphTk/a/gU8jEzoOWbkM4yxyb/wB96xbiFveSFJuOp/d6RJhJOI0iBXr
          lsLnBItntckiJ7FbtxJMXLvvwJryDUilBMTjYtwB+QhYXUMOzce5Pjz5/i8SeJtjnV3iAoG/cQk+0FzZ
          qaeJAAHco+CY/5WrUBkrHmFJr6HcXkvJdWPkYQS3xqC0+FmUZofz221CBt5IMucxXPkX4rWi+z7wB3Rb
          BQoQzd8v7yeb7OzlPnWOyN0qFU0XA246RA8QFYiCNYwI3f05p6KLxEXAMPLE my-key-pair"
      ]
   }
}
```

Ran `sudo sheltie` to verify root shell was still available.

@etungsten verified the migration between (1.0.5, 1.0.6)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
