### PR TITLE
docker: update to 19.03.15

### DIFF
--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v19.03.14/cli-19.03.14.tar.gz"
-sha512 = "0cd72663ea9da2d1e2e74af8569c8e78a120a161cf40075a7cb8817b9c9f4ed94a5aebd48a754a896bcc9d7c7b67ed8a0f46203aeb34db0635f6693003c54edc"
+url = "https://github.com/docker/cli/archive/v19.03.15/cli-19.03.15.tar.gz"
+sha512 = "163f67a11b1d976eb91c84e59eb1fabf3f26b360ac726bb0bedb9a1532ef807b665f7461f52f6b236cb8af955af042466070800cd4d09b7a6b90092daf718b41"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 19.03.14
+%global gover 19.03.15
 %global rpmver %{gover}
-%global gitrev 0ed913b885c8919944a2e4c8d0b80a318a8dd48b
+%global gitrev eeec7e566a2d8e9c30b141bad529d54f2d46c71c
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v19.03.14/moby-19.03.14.tar.gz"
-sha512 = "9ba589a2199ee272af50b60168a117a707c1fe0bfb039c8e4c0a9df68055add13b68b28e0937fdfeb9c42ec0e2936ac9ca3a671ff946d2d3f3e9d1bfe00ed6d1"
+url = "https://github.com/moby/moby/archive/v19.03.15/moby-19.03.15.tar.gz"
+sha512 = "20e2a418e95f4575081afb2f898d9a6d37812a4c2976a8adff52c186672282cb3fdef1dd126fb2e90cbb09a559f719150e8e94fbf2a160e49bb64448872b5653"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 19.03.14
+%global gover 19.03.15
 %global rpmver %{gover}
-%global gitrev 9dc6525e6118a25fab2be322d1914740ea842495
+%global gitrev 420b1d36250f9cfdc561f086f25a213ecb669b6f
 
 %global source_date_epoch 1363394400
 

--- a/packages/docker-init/docker-init.spec
+++ b/packages/docker-init/docker-init.spec
@@ -3,7 +3,7 @@
 %global tiniver 0.19.0
 
 Name: %{_cross_os}docker-init
-Version: 19.03.14
+Version: 19.03.15
 Release: 1%{?dist}
 Summary: Init for containers
 License: MIT

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -8,7 +8,7 @@
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}docker-proxy
-Version: 19.03.14
+Version: 19.03.15
 Release: 1%{?dist}
 Summary: Docker CLI
 # mostly Apache-2.0, client/mflag is BSD-3-Clause


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #1305

**Description of changes:**

Update docker to 19.03.15

**Testing done:**

Ran an ECS task on x86 and on arm, it worked!


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
