### PR TITLE
k8s updates

### DIFF
--- a/packages/kubernetes-1.17/Cargo.toml
+++ b/packages/kubernetes-1.17/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.17"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.17.16/kubernetes-1.17.16.tar.gz"
-sha512 = "848b6334dbea5f6d714b22825538f5ae73c242fa31c63963bb94d7b43e3c1cbd27f89627af2ec5f6c6e581c29b85c4c3a859e2b4dae0f082b11b7a8b6f2dbecf"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.17.17/kubernetes-1.17.17.tar.gz"
+sha512 = "032b033a93416dd8d78672f62718990d129dd47575f79635be6f817d1a8f8d161faf46698627cabfffcd14261afaa8b773537ba5c85ebed4b78906fcad0d07d0"
 
 # This is a large patch, so we don't want to check it into the repo.  It's like
 # https://github.com/kubernetes/kubernetes/commit/a94346bef9806a135ebcfda03672966c336c1c17

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.17.16
+%global gover 1.17.17
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.18"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.18.14/kubernetes-1.18.14.tar.gz"
-sha512 = "e19b834db4920db6b466662a8c001ecaad7a7bee6c4faef871bbc3f528e10b0b4c9fc6f3ac065953ce625db0ede98d76536cf3158b4fb241725115febb141946"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.18.16/kubernetes-1.18.16.tar.gz"
+sha512 = "f525577f0e55736c6702663c9de9a54e7ece5701f334948ec56b2d0d5041e54b5fdc440dfbfede5e886c2b30c2223eba4d2da7131e58c48043cfa75513f7f59f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.18.14
+%global gover 1.18.16
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.19"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.19.6/kubernetes-1.19.6.tar.gz"
-sha512 = "d7c6db2fa399b04a3acae792546fa0384e6b3a3e5eaa2c1ba6c49d656da0197f5be3d009756313436816f3839825c66ce23a06a1ec35c37f1c3fcfba79f9ac32"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.19.8/kubernetes-1.19.8.tar.gz"
+sha512 = "0cefbe0cd29ee3916867549f2aa2a4eb60f87c9fc0fa4bae3748cc4eadd76685f868a9e30a50af092f55c0942bbd5e30648021ec0781afdcdd5f8d4014724c64"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.19.6
+%global gover 1.19.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Description of changes:**

Patch-level k8s bumps.

**Testing done:**

Ran a pod in the following configurations:
- k8s-1.17.17 x86_64 in a k8s 1.16 cluster ✅
- k8s-1.18.16 x86_64 in a k8s 1.18 cluster ✅
- k8s-1.19.8 x86_64 in a k8s 1.19 cluster ✅

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
