### PR TITLE
add network proxy support to k8s 1.19

### DIFF
--- a/packages/kubernetes-1.19/kubelet.service
+++ b/packages/kubernetes-1.19/kubelet.service
@@ -7,6 +7,7 @@ BindsTo=containerd.service
 
 [Service]
 Type=notify
+EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Pull the pause container image before starting `kubelet` so `containerd/cri` wouldn't have to


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Adds the missing `EnvironmentFile` line to kubelet.service for k8s-1.19.


**Testing done:**
Confirmed that all the `kubelet.service` files match with the exception of 1.19:
```
❯ sha512sum packages/kubernetes-1.1*/kubelet.service
9f10ef80a617803a35937d86047d2557833c1d009165dd4609947574670c0f2004ecfa2625002582585623b0e53b47fdd16a263214017a9f392ab0780f802ad6  packages/kubernetes-1.15/kubelet.service
9f10ef80a617803a35937d86047d2557833c1d009165dd4609947574670c0f2004ecfa2625002582585623b0e53b47fdd16a263214017a9f392ab0780f802ad6  packages/kubernetes-1.16/kubelet.service
9f10ef80a617803a35937d86047d2557833c1d009165dd4609947574670c0f2004ecfa2625002582585623b0e53b47fdd16a263214017a9f392ab0780f802ad6  packages/kubernetes-1.17/kubelet.service
9f10ef80a617803a35937d86047d2557833c1d009165dd4609947574670c0f2004ecfa2625002582585623b0e53b47fdd16a263214017a9f392ab0780f802ad6  packages/kubernetes-1.18/kubelet.service
37f3e8b50267fac4a64bf1af2d7ab0baa2ab77ad2c5936f26f59aace1e7b94730598823293b8a9158d29d9a3470b21379d739ce3d378cdeb8e4402ee97c96d5c  packages/kubernetes-1.19/kubelet.service
```

The remaining difference is the `volume-plugin-dir` argument which was moved to the kubelet config file.
```
❯ diff packages/kubernetes-1.18/kubelet.service packages/kubernetes-1.19/kubelet.service
29d28
<     --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
