### PR TITLE
add support for kubelet in standalone mode and TLS auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,10 @@ The following settings can be optionally set to customize the node labels and ta
 
 The following settings are optional and allow you to further configure your cluster.
 * `settings.kubernetes.cluster-domain`: The DNS domain for this cluster, allowing all Kubernetes-run containers to search this domain before the host's search domains.  Defaults to `cluster.local`.
+* `settings.kubernetes.standalone-mode`: Whether to run the kubelet in standalone mode, without connecting to an API server.  Defaults to `false`.
 
 You can also optionally specify static pods for your node with the following settings.
+Static pods can be particularly useful when running in standalone mode.
 * `settings.kubernetes.static-pods.<custom identifier>.manifest`: A base64-encoded pod manifest.
 * `settings.kubernetes.static-pods.<custom identifier>.enabled`: Whether the static pod is enabled.
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ The following settings can be optionally set to customize the node labels and ta
 The following settings are optional and allow you to further configure your cluster.
 * `settings.kubernetes.cluster-domain`: The DNS domain for this cluster, allowing all Kubernetes-run containers to search this domain before the host's search domains.  Defaults to `cluster.local`.
 * `settings.kubernetes.standalone-mode`: Whether to run the kubelet in standalone mode, without connecting to an API server.  Defaults to `false`.
+* `settings.kubernetes.authentication-mode`: Which authentication method the kubelet should use to connect to the API server, and for incoming requests.  Defaults to `aws` for AWS variants, and `tls` for other variants.
+* `settings.kubernetes.bootstrap-token`: The token to use for [TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).  This is only used with the `tls` authentication mode, and is otherwise ignored.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -20,5 +20,10 @@ version = "1.0.5"
     "migrate_v1.0.5_add-proxy-restart.lz4",
     "migrate_v1.0.5_add-proxy-services.lz4"
 ]
-"(1.0.5, 1.0.6)" = ["migrate_v1.0.6_metricdog-init.lz4", "migrate_v1.0.6_add-static-pods.lz4"]
+"(1.0.5, 1.0.6)" = [
+    "migrate_v1.0.6_metricdog-init.lz4",
+    "migrate_v1.0.6_add-static-pods.lz4",
+    "migrate_v1.0.6_kubelet-standalone-tls-settings.lz4",
+    "migrate_v1.0.6_kubelet-standalone-tls-services.lz4",
+]
 

--- a/packages/kubernetes-1.15/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.15/kubelet-bootstrap-kubeconfig
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{~#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{~#if settings.kubernetes.bootstrap-token}}
+  user:
+    token: "{{settings.kubernetes.bootstrap-token}}"
+{{~/if}}

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -1,6 +1,16 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+{{~#if settings.kubernetes.standalone-mode}}
+address: 127.0.0.1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{~else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -15,6 +25,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
+{{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}

--- a/packages/kubernetes-1.15/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.15/kubelet-exec-start-conf
@@ -1,0 +1,17 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet \
+    --cloud-provider aws \
+    --config /etc/kubernetes/kubelet/config \
+    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+    --container-runtime=remote \
+    --container-runtime-endpoint=unix:///run/dockershim.sock \
+    --containerd=/run/dockershim.sock \
+    --network-plugin cni \
+    --root-dir /var/lib/kubelet \
+    --cert-dir /var/lib/kubelet/pki \
+    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
+    --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.15/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.15/kubelet-exec-start-conf
@@ -4,6 +4,9 @@ ExecStart=/usr/bin/kubelet \
 {{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+    --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
+{{~/if}}
 {{~else}}
     --cloud-provider "" \
 {{~/unless}}

--- a/packages/kubernetes-1.15/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.15/kubelet-exec-start-conf
@@ -1,9 +1,13 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
+{{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~else}}
+    --cloud-provider "" \
+{{~/unless}}
+    --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \
     --containerd=/run/dockershim.sock \

--- a/packages/kubernetes-1.15/kubelet-kubeconfig
+++ b/packages/kubernetes-1.15/kubelet-kubeconfig
@@ -3,8 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
+{{~#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
   name: kubernetes
 contexts:
 - context:
@@ -14,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -22,3 +25,4 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}

--- a/packages/kubernetes-1.15/kubelet-kubeconfig
+++ b/packages/kubernetes-1.15/kubelet-kubeconfig
@@ -16,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
 {{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
@@ -25,4 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}
+{{~/if}}
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+  user:
+    client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+    client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
 {{~/if}}

--- a/packages/kubernetes-1.15/kubelet.service
+++ b/packages/kubernetes-1.15/kubelet.service
@@ -16,21 +16,8 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE}
-ExecStart=/usr/bin/kubelet \
-    --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
-    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-    --container-runtime=remote \
-    --container-runtime-endpoint=unix:///run/dockershim.sock \
-    --containerd=/run/dockershim.sock \
-    --network-plugin cni \
-    --root-dir /var/lib/kubelet \
-    --cert-dir /var/lib/kubelet/pki \
-    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
-    --node-ip ${NODE_IP} \
-    --node-labels "${NODE_LABELS}" \
-    --register-with-taints "${NODE_TAINTS}" \
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+# Must be overridden by a drop-in file or `kubelet` won't start
+ExecStart=/usr/bin/false
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packages/kubernetes-1.15/kubernetes-1.15.spec
+++ b/packages/kubernetes-1.15/kubernetes-1.15.spec
@@ -21,7 +21,8 @@ Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
-Source7: kubernetes-tmpfiles.conf
+Source7: kubelet-bootstrap-kubeconfig
+Source8: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -81,9 +82,10 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
+install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -97,6 +99,7 @@ install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf

--- a/packages/kubernetes-1.15/kubernetes-1.15.spec
+++ b/packages/kubernetes-1.15/kubernetes-1.15.spec
@@ -20,7 +20,8 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
-Source6: kubernetes-tmpfiles.conf
+Source6: kubelet-exec-start-conf
+Source7: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -79,9 +80,10 @@ install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
+install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -95,6 +97,7 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
 

--- a/packages/kubernetes-1.15/kubernetes-ca-crt
+++ b/packages/kubernetes-1.15/kubernetes-ca-crt
@@ -1,1 +1,3 @@
+{{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.16/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.16/kubelet-bootstrap-kubeconfig
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{~#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{~#if settings.kubernetes.bootstrap-token}}
+  user:
+    token: "{{settings.kubernetes.bootstrap-token}}"
+{{~/if}}

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -1,6 +1,16 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+{{~#if settings.kubernetes.standalone-mode}}
+address: 127.0.0.1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{~else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -15,6 +25,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
+{{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}

--- a/packages/kubernetes-1.16/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.16/kubelet-exec-start-conf
@@ -1,0 +1,17 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet \
+    --cloud-provider aws \
+    --config /etc/kubernetes/kubelet/config \
+    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+    --container-runtime=remote \
+    --container-runtime-endpoint=unix:///run/dockershim.sock \
+    --containerd=/run/dockershim.sock \
+    --network-plugin cni \
+    --root-dir /var/lib/kubelet \
+    --cert-dir /var/lib/kubelet/pki \
+    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
+    --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.16/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.16/kubelet-exec-start-conf
@@ -4,6 +4,9 @@ ExecStart=/usr/bin/kubelet \
 {{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+    --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
+{{~/if}}
 {{~else}}
     --cloud-provider "" \
 {{~/unless}}

--- a/packages/kubernetes-1.16/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.16/kubelet-exec-start-conf
@@ -1,9 +1,13 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
+{{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~else}}
+    --cloud-provider "" \
+{{~/unless}}
+    --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \
     --containerd=/run/dockershim.sock \

--- a/packages/kubernetes-1.16/kubelet-kubeconfig
+++ b/packages/kubernetes-1.16/kubelet-kubeconfig
@@ -3,8 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
+{{~#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
   name: kubernetes
 contexts:
 - context:
@@ -14,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -22,3 +25,4 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}

--- a/packages/kubernetes-1.16/kubelet-kubeconfig
+++ b/packages/kubernetes-1.16/kubelet-kubeconfig
@@ -16,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
 {{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
@@ -25,4 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}
+{{~/if}}
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+  user:
+    client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+    client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
 {{~/if}}

--- a/packages/kubernetes-1.16/kubelet.service
+++ b/packages/kubernetes-1.16/kubelet.service
@@ -16,21 +16,8 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE}
-ExecStart=/usr/bin/kubelet \
-    --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
-    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-    --container-runtime=remote \
-    --container-runtime-endpoint=unix:///run/dockershim.sock \
-    --containerd=/run/dockershim.sock \
-    --network-plugin cni \
-    --root-dir /var/lib/kubelet \
-    --cert-dir /var/lib/kubelet/pki \
-    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
-    --node-ip ${NODE_IP} \
-    --node-labels "${NODE_LABELS}" \
-    --register-with-taints "${NODE_TAINTS}" \
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+# Must be overridden by a drop-in file or `kubelet` won't start
+ExecStart=/usr/bin/false
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packages/kubernetes-1.16/kubernetes-1.16.spec
+++ b/packages/kubernetes-1.16/kubernetes-1.16.spec
@@ -21,7 +21,8 @@ Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
-Source7: kubernetes-tmpfiles.conf
+Source7: kubelet-bootstrap-kubeconfig
+Source8: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -77,9 +78,10 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
+install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -93,6 +95,7 @@ install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf

--- a/packages/kubernetes-1.16/kubernetes-1.16.spec
+++ b/packages/kubernetes-1.16/kubernetes-1.16.spec
@@ -20,7 +20,8 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
-Source6: kubernetes-tmpfiles.conf
+Source6: kubelet-exec-start-conf
+Source7: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -75,9 +76,10 @@ install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
+install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -91,6 +93,7 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
 

--- a/packages/kubernetes-1.16/kubernetes-ca-crt
+++ b/packages/kubernetes-1.16/kubernetes-ca-crt
@@ -1,1 +1,3 @@
+{{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.17/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.17/kubelet-bootstrap-kubeconfig
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{~#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{~#if settings.kubernetes.bootstrap-token}}
+  user:
+    token: "{{settings.kubernetes.bootstrap-token}}"
+{{~/if}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -1,6 +1,16 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+{{~#if settings.kubernetes.standalone-mode}}
+address: 127.0.0.1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{~else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -15,6 +25,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
+{{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}

--- a/packages/kubernetes-1.17/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.17/kubelet-exec-start-conf
@@ -1,0 +1,17 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet \
+    --cloud-provider aws \
+    --config /etc/kubernetes/kubelet/config \
+    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+    --container-runtime=remote \
+    --container-runtime-endpoint=unix:///run/dockershim.sock \
+    --containerd=/run/dockershim.sock \
+    --network-plugin cni \
+    --root-dir /var/lib/kubelet \
+    --cert-dir /var/lib/kubelet/pki \
+    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
+    --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.17/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.17/kubelet-exec-start-conf
@@ -4,6 +4,9 @@ ExecStart=/usr/bin/kubelet \
 {{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+    --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
+{{~/if}}
 {{~else}}
     --cloud-provider "" \
 {{~/unless}}

--- a/packages/kubernetes-1.17/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.17/kubelet-exec-start-conf
@@ -1,9 +1,13 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
+{{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~else}}
+    --cloud-provider "" \
+{{~/unless}}
+    --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \
     --containerd=/run/dockershim.sock \

--- a/packages/kubernetes-1.17/kubelet-kubeconfig
+++ b/packages/kubernetes-1.17/kubelet-kubeconfig
@@ -3,8 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
+{{~#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
   name: kubernetes
 contexts:
 - context:
@@ -14,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -22,3 +25,4 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}

--- a/packages/kubernetes-1.17/kubelet-kubeconfig
+++ b/packages/kubernetes-1.17/kubelet-kubeconfig
@@ -16,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
 {{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
@@ -25,4 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}
+{{~/if}}
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+  user:
+    client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+    client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
 {{~/if}}

--- a/packages/kubernetes-1.17/kubelet.service
+++ b/packages/kubernetes-1.17/kubelet.service
@@ -16,21 +16,8 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE}
-ExecStart=/usr/bin/kubelet \
-    --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
-    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-    --container-runtime=remote \
-    --container-runtime-endpoint=unix:///run/dockershim.sock \
-    --containerd=/run/dockershim.sock \
-    --network-plugin cni \
-    --root-dir /var/lib/kubelet \
-    --cert-dir /var/lib/kubelet/pki \
-    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
-    --node-ip ${NODE_IP} \
-    --node-labels "${NODE_LABELS}" \
-    --register-with-taints "${NODE_TAINTS}" \
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+# Must be overridden by a drop-in file or `kubelet` won't start
+ExecStart=/usr/bin/false
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -21,7 +21,8 @@ Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
-Source7: kubernetes-tmpfiles.conf
+Source7: kubelet-bootstrap-kubeconfig
+Source8: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -77,9 +78,10 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
+install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -93,6 +95,7 @@ install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -20,7 +20,8 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
-Source6: kubernetes-tmpfiles.conf
+Source6: kubelet-exec-start-conf
+Source7: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -75,9 +76,10 @@ install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
+install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -91,6 +93,7 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
 

--- a/packages/kubernetes-1.17/kubernetes-ca-crt
+++ b/packages/kubernetes-1.17/kubernetes-ca-crt
@@ -1,1 +1,3 @@
+{{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.18/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.18/kubelet-bootstrap-kubeconfig
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{~#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{~#if settings.kubernetes.bootstrap-token}}
+  user:
+    token: "{{settings.kubernetes.bootstrap-token}}"
+{{~/if}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -1,6 +1,16 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+{{~#if settings.kubernetes.standalone-mode}}
+address: 127.0.0.1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{~else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -15,6 +25,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
+{{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}

--- a/packages/kubernetes-1.18/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.18/kubelet-exec-start-conf
@@ -1,0 +1,17 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet \
+    --cloud-provider aws \
+    --config /etc/kubernetes/kubelet/config \
+    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+    --container-runtime=remote \
+    --container-runtime-endpoint=unix:///run/dockershim.sock \
+    --containerd=/run/dockershim.sock \
+    --network-plugin cni \
+    --root-dir /var/lib/kubelet \
+    --cert-dir /var/lib/kubelet/pki \
+    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
+    --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.18/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.18/kubelet-exec-start-conf
@@ -4,6 +4,9 @@ ExecStart=/usr/bin/kubelet \
 {{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+    --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
+{{~/if}}
 {{~else}}
     --cloud-provider "" \
 {{~/unless}}

--- a/packages/kubernetes-1.18/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.18/kubelet-exec-start-conf
@@ -1,9 +1,13 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
+{{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~else}}
+    --cloud-provider "" \
+{{~/unless}}
+    --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \
     --containerd=/run/dockershim.sock \

--- a/packages/kubernetes-1.18/kubelet-kubeconfig
+++ b/packages/kubernetes-1.18/kubelet-kubeconfig
@@ -3,8 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
+{{~#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
   name: kubernetes
 contexts:
 - context:
@@ -14,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -22,3 +25,4 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}

--- a/packages/kubernetes-1.18/kubelet-kubeconfig
+++ b/packages/kubernetes-1.18/kubelet-kubeconfig
@@ -16,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
 {{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
@@ -25,4 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}
+{{~/if}}
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+  user:
+    client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+    client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
 {{~/if}}

--- a/packages/kubernetes-1.18/kubelet.service
+++ b/packages/kubernetes-1.18/kubelet.service
@@ -16,21 +16,8 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE}
-ExecStart=/usr/bin/kubelet \
-    --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
-    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-    --container-runtime=remote \
-    --container-runtime-endpoint=unix:///run/dockershim.sock \
-    --containerd=/run/dockershim.sock \
-    --network-plugin cni \
-    --root-dir /var/lib/kubelet \
-    --cert-dir /var/lib/kubelet/pki \
-    --volume-plugin-dir /var/lib/kubelet/plugins/volume/exec \
-    --node-ip ${NODE_IP} \
-    --node-labels "${NODE_LABELS}" \
-    --register-with-taints "${NODE_TAINTS}" \
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+# Must be overridden by a drop-in file or `kubelet` won't start
+ExecStart=/usr/bin/false
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -21,7 +21,8 @@ Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
-Source7: kubernetes-tmpfiles.conf
+Source7: kubelet-bootstrap-kubeconfig
+Source8: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -74,9 +75,10 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
+install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -90,6 +92,7 @@ install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -20,7 +20,8 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
-Source6: kubernetes-tmpfiles.conf
+Source6: kubelet-exec-start-conf
+Source7: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -72,9 +73,10 @@ install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
+install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -88,6 +90,7 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
 

--- a/packages/kubernetes-1.18/kubernetes-ca-crt
+++ b/packages/kubernetes-1.18/kubernetes-ca-crt
@@ -1,1 +1,3 @@
+{{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.19/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.19/kubelet-bootstrap-kubeconfig
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{~#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{~#if settings.kubernetes.bootstrap-token}}
+  user:
+    token: "{{settings.kubernetes.bootstrap-token}}"
+{{~/if}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -1,6 +1,16 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+{{~#if settings.kubernetes.standalone-mode}}
+address: 127.0.0.1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{~else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -15,6 +25,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
+{{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}

--- a/packages/kubernetes-1.19/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.19/kubelet-exec-start-conf
@@ -4,6 +4,9 @@ ExecStart=/usr/bin/kubelet \
 {{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+    --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
+{{~/if}}
 {{~else}}
     --cloud-provider "" \
 {{~/unless}}

--- a/packages/kubernetes-1.19/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.19/kubelet-exec-start-conf
@@ -1,0 +1,16 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet \
+    --cloud-provider aws \
+    --config /etc/kubernetes/kubelet/config \
+    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+    --container-runtime=remote \
+    --container-runtime-endpoint=unix:///run/dockershim.sock \
+    --containerd=/run/dockershim.sock \
+    --network-plugin cni \
+    --root-dir /var/lib/kubelet \
+    --cert-dir /var/lib/kubelet/pki \
+    --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.19/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.19/kubelet-exec-start-conf
@@ -1,9 +1,13 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
+{{~#unless settings.kubernetes.standalone-mode}}
     --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{~else}}
+    --cloud-provider "" \
+{{~/unless}}
+    --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \
     --containerd=/run/dockershim.sock \

--- a/packages/kubernetes-1.19/kubelet-kubeconfig
+++ b/packages/kubernetes-1.19/kubelet-kubeconfig
@@ -3,8 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
+{{~#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
+{{~/if}}
   name: kubernetes
 contexts:
 - context:
@@ -14,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -22,3 +25,4 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}

--- a/packages/kubernetes-1.19/kubelet-kubeconfig
+++ b/packages/kubernetes-1.19/kubelet-kubeconfig
@@ -16,6 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
+{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
 {{~#if settings.kubernetes.cluster-name}}
   user:
     exec:
@@ -25,4 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+{{~/if}}
+{{~/if}}
+{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+  user:
+    client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+    client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
 {{~/if}}

--- a/packages/kubernetes-1.19/kubelet.service
+++ b/packages/kubernetes-1.19/kubelet.service
@@ -15,20 +15,8 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE}
-ExecStart=/usr/bin/kubelet \
-    --cloud-provider aws \
-    --config /etc/kubernetes/kubelet/config \
-    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-    --container-runtime=remote \
-    --container-runtime-endpoint=unix:///run/dockershim.sock \
-    --containerd=/run/dockershim.sock \
-    --network-plugin cni \
-    --root-dir /var/lib/kubelet \
-    --cert-dir /var/lib/kubelet/pki \
-    --node-ip ${NODE_IP} \
-    --node-labels "${NODE_LABELS}" \
-    --register-with-taints "${NODE_TAINTS}" \
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+# Must be overridden by a drop-in file or `kubelet` won't start
+ExecStart=/usr/bin/false
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -20,7 +20,8 @@ Source2: kubelet-env
 Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
-Source6: kubernetes-tmpfiles.conf
+Source6: kubelet-exec-start-conf
+Source7: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -69,9 +70,10 @@ install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
+install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -85,6 +87,7 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
 

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -21,7 +21,8 @@ Source3: kubelet-config
 Source4: kubelet-kubeconfig
 Source5: kubernetes-ca-crt
 Source6: kubelet-exec-start-conf
-Source7: kubernetes-tmpfiles.conf
+Source7: kubelet-bootstrap-kubeconfig
+Source8: kubernetes-tmpfiles.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
 
@@ -71,9 +72,10 @@ install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
+install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -87,6 +89,7 @@ install -p -m 0644 %{S:7} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf

--- a/packages/kubernetes-1.19/kubernetes-ca-crt
+++ b/packages/kubernetes-1.19/kubernetes-ca-crt
@@ -1,1 +1,3 @@
+{{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
+{{~/if~}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1622,6 +1622,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-standalone-tls-services"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kubelet-standalone-tls-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -40,6 +40,8 @@ members = [
     "api/migration/migrations/v1.0.5/add-proxy-services",
     "api/migration/migrations/v1.0.6/metricdog-init",
     "api/migration/migrations/v1.0.6/add-static-pods",
+    "api/migration/migrations/v1.0.6/kubelet-standalone-tls-settings",
+    "api/migration/migrations/v1.0.6/kubelet-standalone-tls-services",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-services/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-services/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-standalone-tls-services"
+version = "0.1.0"
+authors = ["Ben Cressey <bcressey@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-services/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-services/src/main.rs
@@ -1,0 +1,50 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the configuration files and restart commands to support running kubelet in
+/// standalone mode, and for configuring it to use TLS auth. They need to be restored to
+/// the prior values on downgrade.
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![
+        ListReplacement {
+            setting: "services.kubernetes.configuration-files",
+            old_vals: &[
+                "kubelet-env",
+                "kubelet-config",
+                "kubelet-kubeconfig",
+                "kubernetes-ca-crt",
+                "proxy-env",
+            ],
+            new_vals: &[
+                "kubelet-env",
+                "kubelet-config",
+                "kubelet-kubeconfig",
+                "kubelet-bootstrap-kubeconfig",
+                "kubelet-exec-start-conf",
+                "kubernetes-ca-crt",
+                "proxy-env",
+            ],
+        },
+        ListReplacement {
+            setting: "services.kubernetes.restart-commands",
+            old_vals: &["/bin/systemctl try-restart kubelet.service"],
+            new_vals: &[
+                "/usr/bin/systemctl daemon-reload",
+                "/bin/systemctl try-restart kubelet.service",
+            ],
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-settings/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-standalone-tls-settings"
+version = "0.1.0"
+authors = ["Ben Cressey <bcressey@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.6/kubelet-standalone-tls-settings/src/main.rs
@@ -1,0 +1,28 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for running kubelet in standalone mode, and for using TLS auth.
+/// We also added new configuration files to apply these settings. They need to be removed
+/// when we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.bootstrap-token",
+        "settings.kubernetes.authentication-mode",
+        "settings.kubernetes.standalone-mode",
+        "configuration-files.kubelet-bootstrap-kubeconfig",
+        "configuration-files.kubelet-exec-start-conf",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -5,8 +5,19 @@ template-path = "/usr/share/templates/containerd-config-toml_aws-k8s"
 # Kubernetes.
 
 [services.kubernetes]
-configuration-files = ["kubelet-env", "kubelet-config", "kubelet-kubeconfig", "kubernetes-ca-crt", "proxy-env"]
-restart-commands = ["/bin/systemctl try-restart kubelet.service"]
+configuration-files = [
+  "kubelet-env",
+  "kubelet-config",
+  "kubelet-kubeconfig",
+  "kubelet-exec-start-conf",
+  "kubernetes-ca-crt",
+  "proxy-env",
+]
+
+restart-commands = [
+  "/usr/bin/systemctl daemon-reload",
+  "/usr/bin/systemctl try-restart kubelet.service"
+]
 
 [configuration-files.kubelet-env]
 path = "/etc/kubernetes/kubelet/env"
@@ -23,6 +34,10 @@ template-path = "/usr/share/templates/kubelet-kubeconfig"
 [configuration-files.kubernetes-ca-crt]
 path = "/etc/kubernetes/pki/ca.crt"
 template-path = "/usr/share/templates/kubernetes-ca-crt"
+
+[configuration-files.kubelet-exec-start-conf]
+path = "/etc/systemd/system/kubelet.service.d/exec-start.conf"
+template-path = "/usr/share/templates/kubelet-exec-start-conf"
 
 [metadata.settings.kubernetes]
 max-pods.setting-generator = "pluto max-pods"

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -51,6 +51,7 @@ affected-services = ["kubernetes", "containerd"]
 
 [settings.kubernetes]
 cluster-domain = "cluster.local"
+standalone-mode = false
 
 # Metrics
 [settings.metrics]

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -9,6 +9,7 @@ configuration-files = [
   "kubelet-env",
   "kubelet-config",
   "kubelet-kubeconfig",
+  "kubelet-bootstrap-kubeconfig",
   "kubelet-exec-start-conf",
   "kubernetes-ca-crt",
   "proxy-env",
@@ -31,6 +32,10 @@ template-path = "/usr/share/templates/kubelet-config"
 path = "/etc/kubernetes/kubelet/kubeconfig"
 template-path = "/usr/share/templates/kubelet-kubeconfig"
 
+[configuration-files.kubelet-bootstrap-kubeconfig]
+path = "/etc/kubernetes/kubelet/bootstrap-kubeconfig"
+template-path = "/usr/share/templates/kubelet-bootstrap-kubeconfig"
+
 [configuration-files.kubernetes-ca-crt]
 path = "/etc/kubernetes/pki/ca.crt"
 template-path = "/usr/share/templates/kubernetes-ca-crt"
@@ -52,6 +57,7 @@ affected-services = ["kubernetes", "containerd"]
 [settings.kubernetes]
 cluster-domain = "cluster.local"
 standalone-mode = false
+authentication-mode = "aws"
 
 # Metrics
 [settings.metrics]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -99,7 +99,8 @@ use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
     DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
-    KubernetesClusterName, KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
+    KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
+    KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
     Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
 };
 
@@ -116,13 +117,15 @@ struct StaticPod {
 struct KubernetesSettings {
     // Settings that must be specified via user data or through API requests.  Not all settings are
     // useful for all modes. For example, in standalone mode the user does not need to specify any
-    // cluster information.
+    // cluster information, and the bootstrap token is only needed for TLS authentication mode.
     cluster_name: KubernetesClusterName,
     cluster_certificate: ValidBase64,
     api_server: Url,
     node_labels: HashMap<KubernetesLabelKey, KubernetesLabelValue>,
     node_taints: HashMap<KubernetesLabelKey, KubernetesTaintValue>,
     static_pods: HashMap<Identifier, StaticPod>,
+    authentication_mode: KubernetesAuthenticationMode,
+    bootstrap_token: KubernetesBootstrapToken,
     standalone_mode: bool,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -114,15 +114,19 @@ struct StaticPod {
 // IMDS via Sundog's child "Pluto".
 #[model]
 struct KubernetesSettings {
-    // Settings we require the user to specify, likely via user data.
+    // Settings that must be specified via user data or through API requests.  Not all settings are
+    // useful for all modes. For example, in standalone mode the user does not need to specify any
+    // cluster information.
     cluster_name: KubernetesClusterName,
     cluster_certificate: ValidBase64,
     api_server: Url,
     node_labels: HashMap<KubernetesLabelKey, KubernetesLabelValue>,
     node_taints: HashMap<KubernetesLabelKey, KubernetesTaintValue>,
     static_pods: HashMap<Identifier, StaticPod>,
+    standalone_mode: bool,
 
-    // Dynamic settings.
+    // Settings where we generate a value based on the runtime environment.  The user can specify a
+    // value to override the generated one, but typically would not.
     max_pods: u32,
     cluster_dns_ip: Ipv4Addr,
     cluster_domain: DNSDomain,

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -42,6 +42,9 @@ pub mod error {
         #[snafu(display("{} given invalid input: {}", thing, input))]
         BigPattern { thing: String, input: String },
 
+        #[snafu(display("Invalid Kubernetes authentication mode '{}'", input))]
+        InvalidAuthenticationMode { input: String },
+
         #[snafu(display("Given invalid cluster name '{}': {}", name, msg))]
         InvalidClusterName { name: String, msg: String },
 


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Refactored handling of kubelet args so they can be templated. Added support for "standalone" mode, where the kubelet is started without a kubeconfig file and does not connect to an API server. 

**Testing done:**
Verified that 1.18 and 1.19 nodes came up with the expected defaults: standalone mode off, AWS authentication on.

Launched 1.15, 1.16, 1.17, 1.18, and 1.19 in standalone mode running a static redis pod. Confirmed that kubelet started correctly and brought up redis.

```
[settings.kubernetes]
standalone-mode = true

[settings.kubernetes.static-pods.redis]
manifest = "YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IHJlZGlzCnNwZWM6CiAgaG9zdE5ldHdvcms6IHRydWUKICBjb250YWluZXJzOgogIC0gbmFtZTogcmVkaXMKICAgIGltYWdlOiByZWRpczpsYXRlc3QKICAgIHBvcnRzOgogICAgLSBjb250YWluZXJQb3J0OiA2Mzc5CiAgICByZXNvdXJjZXM6CiAgICAgIGxpbWl0czoKICAgICAgICBjcHU6ICIwLjEiCg=="
enabled = true
```

Launched 1.15, 1.16, 1.17, 1.18, and 1.19 in TLS authentication mode with a bootstrap token to join a cluster provisioned by the Cluster API Provider for AWS (CAPA). All nodes joined.
```
❯ kubectl --kubeconfig snowflake.kubeconfig get nodes
NAME                                         STATUS     ROLES    AGE     VERSION
ip-10-0-116-63.us-west-2.compute.internal    NotReady   <none>   3m37s   v1.17.16
ip-10-0-121-4.us-west-2.compute.internal     NotReady   <none>   2m12s   v1.15.12
ip-10-0-123-129.us-west-2.compute.internal   NotReady   <none>   11m     v1.18.14
ip-10-0-73-82.us-west-2.compute.internal     NotReady   <none>   3m43s   v1.16.15
ip-10-0-81-70.us-west-2.compute.internal     NotReady   <none>   73s     v1.19.6
```

(Nodes are in `NotReady` status because I haven't set up a CNI plugin.)

Tested upgrade and downgrade from 1.0.5 into 1.0.6 with the migrations. Verified that new settings were removed and old lists restored on downgrade.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
