### PR TITLE
Update packages

### DIFF
--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -9,5 +9,5 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2020-12-08.pem"
-sha512 = "d4e6573b3bbd6c5c63c5e77ffa79b05171f59c27c0ed458ebb00b42fef300dd17e42df2c91fa8da44cc37420785ce5a4bb083487ba66d3cac9d858b129fd3745"
+url = "https://curl.haxx.se/ca/cacert-2021-01-19.pem"
+sha512 = "659e8d36bcb65a7fdd299ee008fc4ecd42be87d8ae7d7d15828567b9be44b4ed8a316978f2f7d3d5d7e96a4da0b30bb8bdcfae5202ef099691daa796318a869e"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2020.12.08
+Version: 2021.01.09
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2020-12-08.pem
+Source0: https://curl.haxx.se/ca/cacert-2021-01-19.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/plugins/archive/v0.9.0/plugins-0.9.0.tar.gz"
-sha512 = "8d545d17e6bf4180755708e47607c855b99f6ea4183a33930b7d05974d2151c90873f1e2064b806059a26caba6942502d9954fce697bf000995d539c2208811c"
+url = "https://github.com/containernetworking/plugins/archive/v0.9.1/plugins-0.9.1.tar.gz"
+sha512 = "24e8fcedbff2ae7a83aa96085b546b164de6a0884d593e3b5386e9d2de3c4d9a215db9e9405332020cc45c371709a32b600e263e4f8dee62c51adafdc0180f24"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 %global gorepo plugins
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.9.0
+%global gover 0.9.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bus1/dbus-broker/releases/download/v26/dbus-broker-26.tar.xz"
-sha512 = "51062edba619cdd7242c89422cf232f269feda2ad2fa221f66b09a616a3a76b90b25646b9b7f548290cddfbdac0e0da0c7347270ac3807cae2db056a1d4f480d"
+url = "https://github.com/bus1/dbus-broker/releases/download/v27/dbus-broker-27.tar.xz"
+sha512 = "d3964cd7bc5553924f5786fe1a7f43c4298fa661aa6cde79e98d2aee67ee3e17eb5c689d39228efad905af59296a6ae52485c61d564bb0a35c937573323ea1fb"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}dbus-broker
-Version: 26
+Version: 27
 Release: 1%{?dist}
 Summary: D-BUS message broker
 License: Apache-2.0

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.45.6/e2fsprogs-1.45.6.tar.xz"
-sha512 = "f3abfb6fe7ef632bb81152e2127d601cadd3fa93162178576a1d5ed82c2286627184b207b85a5b2a1793db0addf0885dfc3b9523bb340443224caf9c6d613b84"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.1/e2fsprogs-1.46.1.tar.xz"
+sha512 = "fe6aa55b62f183633872209cd69cf6be0753d5a430542a7c73dbbd428e5fa93b5df7efa7507bb60f9f90a1c61cb8f5cf10665675eea8bd72aad3d04dd2dae15c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}e2fsprogs
-Version: 1.45.6
+Version: 1.46.1
 Release: 1%{?dist}
 Summary: Tools for managing ext2, ext3, and ext4 file systems
 License: GPL-2.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND BSD-3-Clause

--- a/packages/findutils/Cargo.toml
+++ b/packages/findutils/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/pub/gnu/findutils/findutils-4.7.0.tar.xz"
-sha512 = "650a24507f8f4ebff83ad28dd27daa4785b4038dcaadc4fe00823b976e848527074cce3f9ec34065b7f037436d2aa6e9ec099bc05d7472c29864ac2c69de7f2e"
+url = "https://ftp.gnu.org/pub/gnu/findutils/findutils-4.8.0.tar.xz"
+sha512 = "eaa2da304dbeb2cd659b9210ac37da1bde4cd665c12a818eca98541c5ed5cba1050641fc0c39c0a446a5a7a87a8d654df0e0e6b0cee21752ea485188c9f1071e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/findutils/findutils.spec
+++ b/packages/findutils/findutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}findutils
-Version: 4.7.0
+Version: 4.8.0
 Release: 1%{?dist}
 Summary: A set of GNU tools for finding
 License: GPL-3.0-or-later

--- a/packages/iptables/Cargo.toml
+++ b/packages/iptables/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "http://www.netfilter.org/projects/iptables/files/iptables-1.8.6.tar.bz2"
-sha512 = "d06e4cddb69822c4618664a35877fc5811992936cade2040bb0e4eb25a4d879eadc7c84401c40fb39ffac7888568505adcb1cfe995cd166a15c702237daf6acf"
+url = "http://www.netfilter.org/projects/iptables/files/iptables-1.8.7.tar.bz2"
+sha512 = "c0a33fafbf1139157a9f52860938ebedc282a1394a68dcbd58981159379eb525919f999b25925f2cb4d6b18089bd99a94b00b3e73cff5cb0a0e47bdff174ed75"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iptables/iptables.spec
+++ b/packages/iptables/iptables.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}iptables
-Version: 1.8.6
+Version: 1.8.7
 Release: 1%{?dist}
 Summary: Tools for managing Linux kernel packet filtering capabilities
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/iputils/Cargo.toml
+++ b/packages/iputils/Cargo.toml
@@ -9,9 +9,9 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-path = "iputils-s20200821.tar.gz"
-url = "https://github.com/iputils/iputils/archive/s20200821.tar.gz"
-sha512 = "4a57c3637cdd9aab2600682774e27370716cbdf1c7ac8ae61bf86c21c08701a5b697792df4aa95309b196eaa74f3cb6b2836a40f04da0e602156e982ac99d8c9"
+path = "iputils-20210202.tar.gz"
+url = "https://github.com/iputils/iputils/archive/20210202.tar.gz"
+sha512 = "af600fe74e1b78c0da66c378f55eb468d62206aaae1864693f7ec79833c9c0de95843573d1792627695f08ecfcdb4e79c354065daf178d393fcc6ef9a8a5d526"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iputils/iputils.spec
+++ b/packages/iputils/iputils.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}iputils
-Version: 20200821
+Version: 20210202
 Release: 1%{?dist}
 Summary: A set of network monitoring tools
 License: GPL-2.0-or-later AND BSD-3-Clause
 URL: https://github.com/iputils/iputils
-Source0: https://github.com/iputils/iputils/archive/s%{version}.tar.gz#/iputils-s%{version}.tar.gz
+Source0: https://github.com/iputils/iputils/archive/%{version}.tar.gz#/iputils-%{version}.tar.gz
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libcap-devel
@@ -14,7 +14,7 @@ Requires: %{_cross_os}libcap
 %{summary}.
 
 %prep
-%autosetup -n iputils-s%{version} -p1
+%autosetup -n iputils-%{version} -p1
 cp ninfod/COPYING COPYING.ninfod
 
 %build

--- a/packages/kernel/Cargo.toml
+++ b/packages/kernel/Cargo.toml
@@ -10,5 +10,5 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/5923078ac40834106f279fb42b9b177fea5c8136725a231e353772dbae9bce93/kernel-5.4.80-40.140.amzn2.src.rpm"
-sha512 = "b09194da42aabe041992ed654dcca86bb245093e62b9a2c7a542fb6b6343f397cc96dd7d8734b258a01566a42027dc96ef80ebcf593222e50c722ec3ca74eff0"
+url = "https://cdn.amazonlinux.com/blobstore/49c95ec15f0cae8eda22d691177e2cc401c5d1a16ef31680b542de9bcad1490a/kernel-5.4.91-41.139.amzn2.src.rpm"
+sha512 = "4500ab769265aa8c3ada672e0e12ad06d63ce5c22079bdc8850294d3bd0e5b673f391c404c133b1df25787c8ac1fc4f3724e0e35a5324ab6e4928da2aabc785a"

--- a/packages/kernel/kernel.spec
+++ b/packages/kernel/kernel.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel
-Version: 5.4.80
+Version: 5.4.91
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/5923078ac40834106f279fb42b9b177fea5c8136725a231e353772dbae9bce93/kernel-5.4.80-40.140.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/49c95ec15f0cae8eda22d691177e2cc401c5d1a16ef31680b542de9bcad1490a/kernel-5.4.91-41.139.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-27.tar.xz"
-sha512 = "e0513094935333fca1fb4c3e3493b232507a579ab00a6457cc9ed3e928363d05aad80634fb65a8287a336bf9895194c7be8ddc41bb088a6c2cca44fc1bfbdb6c"
+url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-28.tar.xz"
+sha512 = "50646dc72675a5e17b01e327e3d41b972f18aaeac20c8b00983c4d099c6218f35c32c184a833a2d7f716755d6a86851c90913d2835874cef933bdc4a9722df9a"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kmod/kmod.spec
+++ b/packages/kmod/kmod.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kmod
-Version: 27
+Version: 28
 Release: 1%{?dist}
 Summary: Tools for kernel module loading and unloading
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-audit/audit-userspace/archive/v3.0/audit-userspace-3.0.tar.gz"
-sha512 = "b7f196286dc603f8e2c4e87c58d3716092abaeae946f96f3e5e9458d64a824f865aa132108930af80157c76d0128cb3ee92d0ee4ca6e0f835e7bcad7416a6152"
+url = "https://github.com/linux-audit/audit-userspace/archive/v3.0.1/audit-userspace-3.0.1.tar.gz"
+sha512 = "2c77c5a62c8693fcf5727098fb8219b876b0ccc49638c521386b1795bf4febfac48994e505cc8c439ad952c57935ebafa82fe3874f3c5a88be4f0560f0f31abe"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libaudit
-Version: 3.0
+Version: 3.0.1
 Release: 1%{?dist}
 Summary: Library for the audit subsystem
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.46.tar.gz"
-sha512 = "d7d6d8d02701c2bef8f5095a0c923c1bb7033167894d573ad1c935d36d338adb9e58fe2e2779d5e9e8efaf5fe9bc87f43a85eafc733b76f953636038868d73d2"
+url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.48.tar.gz"
+sha512 = "90ac6e46531e4893b78b14171537c6dfd06cf617af9e90f38ea0ce4b50161451528aefff41dbe983719e76582cf39f8d7d432f99756e976f62403d5bc3c209c8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.46
+Version: 2.48
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause

--- a/packages/libnftnl/Cargo.toml
+++ b/packages/libnftnl/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.1.8.tar.bz2"
-sha512 = "173d8a7b95eb964a9fbe7ffcb46541a6bae976b4d4f2a28fbf9b03bf3e50a29b1ea12faa49926d2d33bc088580a833fc6e15ff59a30bcfe67c91c524f00c778e"
+url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.1.9.tar.bz2"
+sha512 = "8e2551a902a320769198e0ebce52596501c548e230c3172ba4989e25dcb3dd6c9b97a104af69b93ede4ef298811cff10608758e6f1d274e758d87306c4b50f25"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnftnl/libnftnl.spec
+++ b/packages/libnftnl/libnftnl.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnftnl
-Version: 1.1.8
+Version: 1.1.9
 Release: 1%{?dist}
 Summary: Library for nftables netlink
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/libpcap/Cargo.toml
+++ b/packages/libpcap/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "http://www.tcpdump.org/release/libpcap-1.9.1.tar.gz"
-sha512 = "ae0d6b0ad8253e7e059336c0f4ed3850d20d7d2f4dc1d942c2951f99a5443a690f0cc42c6f8fdc4a0ccb19e9e985192ba6f399c4bde2c7076e420f547fddfb08"
+url = "http://www.tcpdump.org/release/libpcap-1.10.0.tar.gz"
+sha512 = "007710386ff3435ef97fc99293076eae3c39b424e986141184c712b0285f8589357a1b25085f7eba28730de04312042c724d193934a399797e95a56f5301da7f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libpcap/libpcap.spec
+++ b/packages/libpcap/libpcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libpcap
-Version: 1.9.1
+Version: 1.10.0
 Release: 1%{?dist}
 Summary: Library for packet capture
 License: BSD-3-Clause

--- a/packages/procps/Cargo.toml
+++ b/packages/procps/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://gitlab.com/procps-ng/procps/-/archive/v3.3.16/procps-v3.3.16.tar.gz"
-sha512 = "40ed713afbca979265b0c0f582b9eb0a8def429c78430d21d6c115d5481e3bc6e7c051771313faf2efbb6f09010cce879aed55e82ea55d78279e9c0a1f793337"
+url = "https://gitlab.com/procps-ng/procps/-/archive/v3.3.17/procps-v3.3.17.tar.gz"
+sha512 = "070076cf6bbbd8b6b342af361035f11d9c7381c5d1e2e430a5f2584ff55656254e8f863a40ca75a38870a5007d1b22a0d452bef13fa0ab89e4bf9676826fd788"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/procps/procps.spec
+++ b/packages/procps/procps.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}procps
-Version: 3.3.16
+Version: 3.3.17
 Release: 1%{?dist}
 Summary: A set of process monitoring tools
 License: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -51,6 +51,7 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %{_cross_bindir}/pmap
 %{_cross_bindir}/ps
 %{_cross_bindir}/pwdx
+%{_cross_bindir}/pwait
 %{_cross_bindir}/skill
 %{_cross_bindir}/snice
 %{_cross_bindir}/tload

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/5.9/strace-5.9.tar.xz"
-sha512 = "f28d5dcceccb44557b39ed6f295f3250662804dc3ad79959bfadffcecc9b736e532c7c90dc89ebf9d07eb3e02a5ace231605851148ca09d41c8c60dc1ff68206"
+url = "https://strace.io/files/5.11/strace-5.11.tar.xz"
+sha512 = "688bec8d620c7ca701561ed7479e42687cc30737f944b82201731d827775cd2864787ecca7c93ba149b06d5d654d9f6bd109a977f8138bab34339cd5930828f0"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 5.9
+Version: 5.11
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later


### PR DESCRIPTION
**Description of changes:**

This updates almost all the third-party dependencies in `packages/`. Exceptions include:

- containerd 1.4.3/runc 1.0.0-rc93, which will be updated as part of #1336 
- ecs-agent, which will be updated in a separate PR

**Testing done:**
- aws-k8s 1.15, 1.16, 1.17, 1.18, 1.19 on aarch64
    - run pods OK
    - journalctl shows the same warnings as the current upstream releases
    - e2fsprogs (major version update) working: the testing for this package included using the [local-static-provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) with an instance with local ephemeral disks, mounted as volumes in the pods.
- aws-k8s 1.18 on x86_64
    - same testing
- aws-ecs-1 on aarch64
    - Launched a nginx container/task/service through the ECS console - ran OK, and I was able to `curl http://localhost` from within the container
- aws-dev on aarch64
    - Launched a nginx container - ran OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
