### PR TITLE
[Draft] Add new setting: eviction-hard

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,16 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.standalone-mode`: Whether to run the kubelet in standalone mode, without connecting to an API server.  Defaults to `false`.
 * `settings.kubernetes.authentication-mode`: Which authentication method the kubelet should use to connect to the API server, and for incoming requests.  Defaults to `aws` for AWS variants, and `tls` for other variants.
 * `settings.kubernetes.bootstrap-token`: The token to use for [TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).  This is only used with the `tls` authentication mode, and is otherwise ignored.
+* `settings.kubernetes.eviction-hard`: The hard eviction Signal and Thresholds you set up to reclaim the associated starved resource.
+  Remember to quote keys (since they often contain ".") and to quote all values.
+  * Example user data for setting up eviction hard:
+  ```
+    [settings.kubernetes.eviction-hard]
+    "memory.available" = "15%"
+    "nodefs.inodesFree" = "15Mi"
+    "pid.available" = "15%"
+    ```
+
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -29,6 +29,8 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+evictionHard:
+  {{join_map ": " "\n  " "no-fail-if-missing" settings.kubernetes.eviction-hard}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -29,6 +29,8 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+evictionHard:
+  {{join_map ": " "\n  " "no-fail-if-missing" settings.kubernetes.eviction-hard}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -29,6 +29,8 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+evictionHard:
+  {{join_map ": " "\n  " "no-fail-if-missing" settings.kubernetes.eviction-hard}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -29,6 +29,8 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+evictionHard:
+  {{join_map ": " "\n  " "no-fail-if-missing" settings.kubernetes.eviction-hard}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -29,6 +29,8 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+evictionHard:
+  {{join_map ": " "\n  " "no-fail-if-missing" settings.kubernetes.eviction-hard}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -101,7 +101,7 @@ use crate::modeled_types::{
     DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
     KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
+    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64, EvictionHardKey, EvictionHardValue,
 };
 
 // Kubernetes static pod manifest settings
@@ -127,6 +127,7 @@ struct KubernetesSettings {
     authentication_mode: KubernetesAuthenticationMode,
     bootstrap_token: KubernetesBootstrapToken,
     standalone_mode: bool,
+    eviction_hard: HashMap<EvictionHardKey, EvictionHardValue>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -62,6 +62,8 @@ pub mod error {
             field: String,
             source: serde_plain::Error,
         },
+        #[snafu(display("Invalid eviction hard '{}': {}", input, msg))]
+        InvalideEvictionHard { input: String, msg: String },
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Get some feedbacks from this draft, which can help me in implementing another three settings**

**Issue number:**
#1140

**Description of changes:**
Add new setting `eviction-hard` to k8s. User can specify this setting in userdata.
* example: 
    [settings.kubernetes.eviction-hard]
     "memory.available" = "10Gi"
     "nodefs.inodesFree" = “15%”


**Testing done:**
Build aws-eks-* images and launched instance.

***Test step1***:
Go to control container run `apiclient -u /settings` to check if expected setting is there.
`eviction-hard":{"memory.available":"99.999%"} `

***Test step2***:
ssh to admin contianer and look `etc/kubernetes/kubelet/config` to check if expected config is there.
```
evictionHard:
  memory.available: 15%
```
***Test step3*** - test effected/behavior:
set up eviction threshold to a high value for triggering eviction.
```
[evictionHard.memory]
"memory.available" = "99.99%" (high percentage to trigger eviction)
```
a) Go to EKS to check node condition 

MemoryPressure | True | kubelet has insufficient memory available
-- | -- | --

b) In admin contianer, check kubelet log by `journalctl -u kubelet`
```
eviction_manager.go:335] eviction manager: attempting to reclaim memory
eviction_manager.go:346] eviction manager: must evict pod(s) to reclaim memory
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
