### PR TITLE
defaults, migrations: control container version bump to v0.4.2

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -25,5 +25,6 @@ version = "1.0.5"
     "migrate_v1.0.6_add-static-pods.lz4",
     "migrate_v1.0.6_kubelet-standalone-tls-settings.lz4",
     "migrate_v1.0.6_kubelet-standalone-tls-services.lz4",
+    "migrate_v1.0.6_control-container-v0-4-2.lz4"
 ]
 

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -732,6 +732,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
+name = "control-container-v0-4-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "cookie"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "api/migration/migrations/v1.0.6/add-static-pods",
     "api/migration/migrations/v1.0.6/kubelet-standalone-tls-settings",
     "api/migration/migrations/v1.0.6/kubelet-standalone-tls-services",
+    "api/migration/migrations/v1.0.6/control-container-v0-4-2",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.0.6/control-container-v0-4-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.6/control-container-v0-4-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "control-container-v0-4-2"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.6/control-container-v0-4-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.6/control-container-v0-4-2/src/main.rs
@@ -1,0 +1,30 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.4.1";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.4.2";
+
+
+/// We bumped the version of the default control container from v0.4.1 to v0.4.2
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -12,4 +12,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.4.1"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.4.2"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Feb 23 10:00:58 2021 -0800

    migrations: control-container v0.4.2 default version migration
    
    Migrates default version of control container from v0.4.1 to v0.4.2
```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Feb 23 09:58:22 2021 -0800

    defaults: bump control container default version to v0.4.2
    
    Set default control container version to v0.4.2

```

**Testing done:**
Built image along with migrations, did upgrade/downgrade testing and the host comes up fine. 
Saw `settings.host-containers.control.source` change appropriately between upgrade/downgrades. 
Control container starts fine and can be reached after upgrade and downgrade.

<details>

```
bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
PRETTY_NAME="Bottlerocket OS 1.0.6"
VARIANT_ID=aws-k8s-1.19
VERSION_ID=1.0.6
BUILD_ID=d55d224b-dirty
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/host-containers/control/source
"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.4.2"
bash-5.0# signpost rollback-to-inactive
bash-5.0# reboot

....
$ ssh ec2-user@blah
Welcome to Bottlerocket's admin container!

This container provides access to the Bottlerocket host filesystems (see
/.bottlerocket/rootfs) and contains common tools for inspection and
troubleshooting.  It is based on Amazon Linux 2, and most things are in the
same places you would find them on an AL2 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[ec2-user@ip-192-168-14-64 ~]$ sudo sheltie
bash-5.0#  cat /var/lib/bottlerocket/datastore/current/live/settings/host-containers/control/source
"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.4.1"
bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
PRETTY_NAME="Bottlerocket OS 1.0.5"
VARIANT_ID=aws-k8s-1.19
VERSION_ID=1.0.5
BUILD_ID=b6264978
bash-5.0# 

```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
