### PR TITLE
defaults, migrations: admin container version bump to v0.6.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -27,4 +27,5 @@ version = "1.0.5"
     "migrate_v1.0.6_kubelet-standalone-tls-services.lz4",
     "migrate_v1.0.6_control-container-v0-4-2.lz4",
     "migrate_v1.0.6_add-shibaken.lz4",
+    "migrate_v1.0.6_admin-container-v0-6-0.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -354,6 +354,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "admin-container-v0-6-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "api/migration/migrations/v1.0.6/kubelet-standalone-tls-services",
     "api/migration/migrations/v1.0.6/control-container-v0-4-2",
     "api/migration/migrations/v1.0.6/add-shibaken",
+    "api/migration/migrations/v1.0.6/admin-container-v0-6-0",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.0.6/admin-container-v0-6-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.6/admin-container-v0-6-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "admin-container-v0-6-0"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.6/admin-container-v0-6-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.6/admin-container-v0-6-0/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.5.2";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.6.0";
+
+/// We bumped the version of the default admin container from v0.5.2 to v0.6.0
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.5.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.6.0"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Migrates default version of admin container from v0.5.2 to v0.6.0

**Testing done:**

> @etungsten 
Tested the migrations via upgrade/downgrade on a Bottlerocket host and it works as expected (source template gets replaced, admin container source points to v0.6.0)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
