### PR TITLE
kernel: update to 5.4.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * Specify bash in link-variant task for use of bash features ([#1323])
 * Fix invalid symlinks when the BUILDSYS_NAME variable is set ([#1312])
 * Track and clean output files for builds ([#1291])
-* Update third-party software packages ([#1340], [#1336], [#1334], [#1333], [#1335], [#1190], [#1265], [#1315], [#1352])
+* Update third-party software packages ([#1340], [#1336], [#1334], [#1333], [#1335], [#1190], [#1265], [#1315], [#1352], [#1356])
 
 ## Documentation Changes
 
@@ -78,6 +78,7 @@
 [#1347]: (https://github.com/bottlerocket-os/bottlerocket/pull/1347)
 [#1352]: (https://github.com/bottlerocket-os/bottlerocket/pull/1352)
 [#1353]: (https://github.com/bottlerocket-os/bottlerocket/pull/1353)
+[#1356]: (https://github.com/bottlerocket-os/bottlerocket/pull/1356)
 [#19]: (https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/19)
 
 # v1.0.5 (2021-01-15)

--- a/packages/kernel/Cargo.toml
+++ b/packages/kernel/Cargo.toml
@@ -10,5 +10,5 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/49c95ec15f0cae8eda22d691177e2cc401c5d1a16ef31680b542de9bcad1490a/kernel-5.4.91-41.139.amzn2.src.rpm"
-sha512 = "4500ab769265aa8c3ada672e0e12ad06d63ce5c22079bdc8850294d3bd0e5b673f391c404c133b1df25787c8ac1fc4f3724e0e35a5324ab6e4928da2aabc785a"
+url = "https://cdn.amazonlinux.com/blobstore/cf12975d70edce3beb7042007609dc355b47ce27babb08b436829f7500de6b76/kernel-5.4.95-42.163.amzn2.src.rpm"
+sha512 = "4dcfb86a2664edd9cf08d1f32b388ec6b9874ae62a21fc655aa80599270af5fdf15ff1f4dc250e36e7559a1c8a08901e428823d7c3e212cf13bada298fdf4dbd"

--- a/packages/kernel/kernel.spec
+++ b/packages/kernel/kernel.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel
-Version: 5.4.91
+Version: 5.4.95
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/49c95ec15f0cae8eda22d691177e2cc401c5d1a16ef31680b542de9bcad1490a/kernel-5.4.91-41.139.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/cf12975d70edce3beb7042007609dc355b47ce27babb08b436829f7500de6b76/kernel-5.4.95-42.163.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.


### PR DESCRIPTION
**Testing done:**

Built and launched an aws-k8s-1.17 AMI.  Confirmed version with `uname -r`.  `systemctl status` `running`.  Ran a pod OK.  API looks OK, changed a setting and saw the effect.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
