### PR TITLE
fix build-kmod-kit build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ## Build Changes
 
 * Add the ability to output vmdk via qemu-img ([#1289])
-* Add support for kmod kits to ease building of third-party kernel modules ([#1287], [#1286], [#1285])
+* Add support for kmod kits to ease building of third-party kernel modules ([#1287], [#1286], [#1285],[#1357])
 * storewolf: Declare dependencies on model and defaults files ([#1319])
 * storewolf: Refactor default settings files to allow sharing ([#1303], [#1329])
 * Switch from TermLogger to SimpleLogger ([#1282], **thanks @hencrice!**)
@@ -79,6 +79,7 @@
 [#1352]: (https://github.com/bottlerocket-os/bottlerocket/pull/1352)
 [#1353]: (https://github.com/bottlerocket-os/bottlerocket/pull/1353)
 [#1356]: (https://github.com/bottlerocket-os/bottlerocket/pull/1356)
+[#1357]: (https://github.com/bottlerocket-os/bottlerocket/pull/1357)
 [#19]: (https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/19)
 
 # v1.0.5 (2021-01-15)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -329,6 +329,7 @@ mv /tmp/kit/${BUILDSYS_KMOD_KIT}.tar.xz /tmp/archives
 "
 
 docker run --rm \
+  --network=host \
   --user "$(id -u):$(id -g)" \
   --security-opt label:disable \
   -v "${BUILDSYS_PACKAGES_DIR}":/tmp/rpms \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
NA


**Description of changes:**
The build was failing on the `build-kmod-kit` task on one host with the following error 

`WARNING: IPv4 forwarding is disabled. Networking will not work.       
curl: (6) Could not resolve host: cache.bottlerocket.aws`

Added a fix `--network=host` to the build-kmod-kit task's `docker run`  command and it worked..


**Testing done:**
`cargo make build-kmod-kit` worked



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
