### PR TITLE
shibaken: return empty key list if IMDS returns 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Add a vmware-dev variant ([#1292], [#1288], [#1290])
 * Add Kubernetes static pods support ([#1317])
 * Add high-level 'set' subcommand for changing settings using apiclient ([#1278])
-* Allow admin container to use SSH public keys from user data ([#1331], [#19])
+* Allow admin container to use SSH public keys from user data ([#1331], [#1358], [#19])
 * Add support for kubelet in standalone mode and TLS auth ([#1338])
 * Add https-proxy and no-proxy settings to updog ([#1324])
 * Add support for pulling host-containers from ECR Public ([#1296])
@@ -80,6 +80,7 @@
 [#1353]: (https://github.com/bottlerocket-os/bottlerocket/pull/1353)
 [#1356]: (https://github.com/bottlerocket-os/bottlerocket/pull/1356)
 [#1357]: (https://github.com/bottlerocket-os/bottlerocket/pull/1357)
+[#1358]: (https://github.com/bottlerocket-os/bottlerocket/pull/1358)
 [#19]: (https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/19)
 
 # v1.0.5 (2021-01-15)


### PR DESCRIPTION
**Issue number:**

N/A


**Description of changes:**

In the case where there are no keys available in IMDS, shibaken will create an empty public key list instead of returning an error.

This addresses a rare scenario where a user launches an instance of Bottlerocket without attaching a key to the EC2 instance. Rather than returning an empty string, the IMDS request for available keys returns a 404. The 404 status causes shibaken to return an error and prevents Bottlerocket from booting.

**Testing done:**

Set `IMDS_PUBLIC_KEY_BASE_URI` to an invalid URI and cargo ran `shibaken`
> @webern
I have tested these changes. Before these changes an instance without a key failed to boot. With these changes the instance came up and I ran an ECS task. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
