### PR TITLE
host-ctr: specify non-colliding runc root

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/runtime/v2/runc/options"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -244,6 +245,9 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 			containerID,
 			containerd.WithImage(img),
 			containerd.WithNewSnapshot(containerID+"-snapshot", img),
+			containerd.WithRuntime("io.containerd.runc.v2", &options.Options{
+				Root: "/run/host-containerd/runc",
+			}),
 			ctrOpts,
 		)
 		if err != nil {


### PR DESCRIPTION
**Description of changes:**
The runc root directory is used for storing state needed by the runtime shim.  By default, this is /run/containerd/runc.  Since we configure host containers to use /run/host-containerd instead of /run/containerd, this change allows all host container state to be inside /run/host-containerd.


**Testing done:**
Built an `aws-ecs-1` AMI and launched it.  Verified that the host containers (both `control` and `admin`) now had their `state.json` files stored in `/run/host-containerd/runc/default/{admin,control}`.  Verified that I could run containers manually with `ctr` and their state was kept in `/run/containerd/runc/default/$id`.  Verified that I could run containers manually with Docker and that their files were unaffected at `/run/docker/runtime-runc/moby`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
