### PR TITLE
docs: update quickstarts to have arm64 examples

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -59,6 +59,12 @@ aws ssm get-parameters --region us-west-2 \
 You can replace the architecture (`x86_64`) and region (`us-west-2`) to look for other images.
 If you know a specific Bottlerocket version you'd like to use, you can replace `latest` with that version.
 
+For example, to find the `1.0.0` version of the `aws-ecs-1` variant for the `arm64` architecture (also known as `aarch64`) in the `eu-west-1` region, you can use the following command:
+
+```
+aws ssm get-parameter --region eu-west-1 --name "/aws/service/bottlerocket/aws-ecs-1/arm64/1.0.0/image_id" --query Parameter.Value --output text
+```
+
 You can also see all available parameters
 [through the web console](https://us-west-2.console.aws.amazon.com/systems-manager/parameters/#list_parameter_filters=Path:Recursive:%2Faws%2Fservice%2Fbottlerocket).
 

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -142,6 +142,12 @@ You can replace the variant (`aws-k8s-1.17`) and architecture (`x86_64`) to look
 Supported variants and architectures are described in the [README](README.md).
 If you know a specific Bottlerocket version you'd like to use, you can replace `latest` with that version.
 
+For example, to find the `1.0.0` version of the `aws-k8s-1.15` variant for the `arm64` architecture (also known as `aarch64`) in the `eu-west-1` region, you can use the following command:
+
+```
+aws ssm get-parameter --region eu-west-1 --name "/aws/service/bottlerocket/aws-k8s-1.15/arm64/1.0.0/image_id" --query Parameter.Value --output text
+```
+
 You can also see all available parameters [through the web console](https://us-west-2.console.aws.amazon.com/systems-manager/parameters/#list_parameter_filters=Path:Recursive:%2Faws%2Fservice%2Fbottlerocket).
 
 ### Cluster setup


### PR DESCRIPTION
**Description of changes:**
Update the quickstart docs to have examples showing how to find `arm64` AMI IDs.


**Testing done:**
None


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
