### PR TITLE
model: don't include metrics defaults in vmware-dev

### DIFF
--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -58,25 +58,6 @@ template-path = "/usr/share/templates/updog-toml"
 affected-services = ["updog"]
 seed.setting-generator = "bork seed"
 
-# Metrics
-
-[settings.metrics]
-# the URL to which anonymous health metrics will be sent
-metrics-url = "https://metrics.bottlerocket.aws/v1/metrics"
-# whether or not health metrics will be sent. set to false to opt-out
-send-metrics = true
-# the list of services that are checked to determine if a host is healthy,
-# overridden in each variant to list services critical to that variant
-service-checks = ["apiserver", "chronyd", "containerd", "host-containerd"]
-
-[services.metricdog]
-configuration-files = ["metricdog-toml", "proxy-env"]
-restart-commands = ["/bin/systemctl try-restart metricdog.service"]
-
-[configuration-files.metricdog-toml]
-path = "/etc/metricdog.toml"
-template-path = "/usr/share/templates/metricdog-toml"
-
 # HostContainers
 
 [services.host-containers]

--- a/sources/models/shared-defaults/metrics.toml
+++ b/sources/models/shared-defaults/metrics.toml
@@ -1,0 +1,16 @@
+[settings.metrics]
+# the URL to which anonymous health metrics will be sent
+metrics-url = "https://metrics.bottlerocket.aws/v1/metrics"
+# whether or not health metrics will be sent. set to false to opt-out
+send-metrics = true
+# the list of services that are checked to determine if a host is healthy,
+# overridden in each variant to list services critical to that variant
+service-checks = ["apiserver", "chronyd", "containerd", "host-containerd"]
+
+[services.metricdog]
+configuration-files = ["metricdog-toml", "proxy-env"]
+restart-commands = ["/bin/systemctl try-restart metricdog.service"]
+
+[configuration-files.metricdog-toml]
+path = "/etc/metricdog.toml"
+template-path = "/usr/share/templates/metricdog-toml"

--- a/sources/models/src/aws-dev/defaults.d/30-metrics.toml
+++ b/sources/models/src/aws-dev/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/models/src/aws-ecs-1/defaults.d/30-metrics.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/models/src/aws-k8s-1.15/defaults.d/30-metrics.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml


### PR DESCRIPTION
**Description of changes:**

```
The vmware-dev model doesn't have settings.metrics because metricdog currently
relies on settings.aws.region.  If we update metricdog to support other
platforms and decide we want metrics there, we can link in this new
metrics.toml file.  Even then, it's useful to have separated in case other
people build variants where they don't want to send metrics.
```

**Testing done:**

In the vmware-dev variant, before the change, you would receive repeated messages on the console about not being able to deserialize settings because "settings.metrics" is unknown.

After, vmware-dev launches and runs fine, with no warnings, settings look good.

I also tested aws-k8s-1.17 and aws-ecs-1.  Both launched and ran pods/tasks successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
