### PR TITLE
os: run static and non-static Rust builds in parallel

### DIFF
--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -26,8 +26,8 @@ merge-toml = { path = "merge-toml" }
 # We have a models build-dep because we read default settings from the models
 # directory and need its build.rs to run first; we also reflect the dependency
 # with cargo:rerun-if-changed statements in our build.rs.  The models build.rs
-# runs twice, once for the above dependency and once for this build-dependency;
-# there's a check in models build.rs to skip running the second time.
+# runs twice, once for the above dependency and once for this build-dependency,
+# so it's important that it remains reentrant.
 models = { path = "../../models" }
 snafu = "0.6"
 toml = "0.5"

--- a/sources/models/build.rs
+++ b/sources/models/build.rs
@@ -17,17 +17,11 @@ const MOD_LINK: &str = "src/variant/mod.rs";
 const VARIANT_ENV: &str = "VARIANT";
 
 fn main() {
-    // Tell cargo when we have to rerun, regardless of early-exit below.
+    // Tell cargo when we have to rerun; we always want variant links to be correct, especially
+    // after changing the variant we're building for.
     println!("cargo:rerun-if-env-changed={}", VARIANT_ENV);
     println!("cargo:rerun-if-changed={}", VARIANT_LINK);
     println!("cargo:rerun-if-changed={}", MOD_LINK);
-
-    // This build.rs runs once as a build-dependency of storewolf, and again as a (regular)
-    // dependency of storewolf.  There's no reason to do this work twice.
-    if env::var("CARGO_CFG_TARGET_VENDOR").unwrap_or_else(|_| String::new()) == "bottlerocket" {
-        println!("cargo:warning=Already ran model build.rs for host, skipping for target");
-        process::exit(0);
-    }
 
     generate_readme();
     link_current_variant();


### PR DESCRIPTION
**Description of changes:**

```
There's a long tail of crate builds for each that can be mitigated by running
them in parallel, saving a fair amount of time.
```

This saves ~1.5 minutes on every build!  (On a fast machine.)  :tada:

(Parallel cargo has been [safe](https://github.com/rust-lang/cargo/pull/2486) for a while now, for reference.)

Other options considered:
* A Makefile that runs each part in parallel.  Discarded because it's another file in another format, because it'd be harder to separate output of each job, and because we don't expect our needs in this area to expand.
* Shell functions to handle background jobs more generically, saving PIDs and output files.  Discarded because it'd be harder to have pertinent messaging around each job, and because it added a fair amount of complexity where we don't expect our needs to expand.
* Similar to this PR, but running both jobs in the background and saving output to separate files.  Discarded because it adds a bit more complexity without clear benefit, and I hold out hope for a way to see logs from package builds as they're running, though today they seem to be buffered and only written to the log file when complete.

**Testing done:**

With the change, I see static and non-static rustc processes at the same time.  If I `touch sources/**/*.rs`, building the `os` package is pretty consistent at 4 minutes 18 seconds.

Without the change, I see non-static and then static processes serially, and it's pretty consistent at around 5 minutes 48 seconds.

I tested the failure cases by adding a nonexistent crate name to the build list for static and non-static (in separate runs).  With a fake package in non-static list: quick failure, clear error.  With a fake package in static list: still get a clear error, though after a few minutes, when the non-static build has finished.  (Since static builds used to run afterward, it's about the same delay.)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
