### PR TITLE
parse-datetime: removed generate_constants logic from build.rs

### DIFF
--- a/sources/parse-datetime/build.rs
+++ b/sources/parse-datetime/build.rs
@@ -1,11 +1,11 @@
 // Automatically generate README.md from rustdoc.
 
 use std::env;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-fn generate_readme() {
+fn main() {
     // Check for environment variable "SKIP_README". If it is set,
     // skip README generation
     if env::var_os("SKIP_README").is_some() {
@@ -29,17 +29,4 @@ fn generate_readme() {
 
     let mut readme = File::create("README.md").unwrap();
     readme.write_all(content.as_bytes()).unwrap();
-}
-
-fn generate_constants() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let contents = format!("const ARCH: &str = \"{}\";", arch);
-    let path = Path::new(&out_dir).join("constants.rs");
-    fs::write(path, contents).unwrap();
-}
-
-fn main() {
-    generate_readme();
-    generate_constants();
 }


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Modified the build.rs to remove the extraneous generate_constants logic.

**Testing done:**

- Built aws-ecs-1 ami and launched instance.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Connected via ssm session.
- Enabled and launched admin container.
- Connected to admin container and ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
