### PR TITLE
apiserver: reap exited child processes

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "semver 0.11.0",
  "serde",
  "serde_json",
+ "signal-hook",
  "simplelog",
  "snafu",
  "thar-be-updates",
@@ -2855,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
+checksum = "6aa894ef3fade0ee7243422f4fbbd6c2b48e6de767e621d37ef65f2310f53cea"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -25,6 +25,7 @@ percent-encoding = "2.1"
 semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+signal-hook = "0.3"
 simplelog = "0.9"
 snafu = "0.6"
 thar-be-updates = { path = "../thar-be-updates" }

--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -372,7 +372,8 @@ where
             .context(error::ConfigApplierStart)?;
     }
 
-    // Leave config applier to run in the background; we can't wait for it
+    // Leave config applier to run in the background; we can't wait for it.
+    // The apiserver binary waits for any exited children so they don't become zombies.
     Ok(())
 }
 


### PR DESCRIPTION
**Issue number:**

Fixes #1380

**Description of changes:**

```
We spawn some background processes, like thar-be-settings, when they might take
some time and we don't want to hold up API clients.  Unless we `wait` for those
children when they exit, their process ID lives on as a zombie.  This adds a
SIGCHLD handler to apiserver to call wait when any child exits.
```

**Testing done:**

Before, each `apiclient set` would leave a zombie.  After, no zombies!

I ran them in a tight loop with `i=0; while :; do apiclient set settings.motd=hi$i; let i++; done` which accomplished about 120 changes per second.  I separately watched the motd file and saw that the operations were successful, and saw that no zombies were stacking up.  You'd see 2-3 (live) thar-be-settings processes, presumably because they're waiting on the coarse API write lock.  I did once catch a `[thar-be-settings]` zombie before the signal/loop/wait caught it, but it was immediately cleaned up, so we know things are working.

I also tested:
* manual PATCH, /tx/commit, /tx/apply, because that follows a slightly different code path to call thar-be-settings, and it was fine.
* `apiclient update` still updated a host successfully.
* repeated `apiclient check` doesn't leave thar-be-updates zombies, either.
* `systemctl status` `running`, pod ran OK.
* 0% CPU usage from apiserver (after some sets) in its normal idle state, so no haywire loop.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
