### PR TITLE
Add support for bootstrap containers via API settings

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.0.7"
+version = "1.0.8"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -36,4 +36,5 @@ version = "1.0.7"
     "migrate_v1.0.8_proxy-affect-host-containers.lz4",
     "migrate_v1.0.8_control-container-v0-5-0.lz4",
     "migrate_v1.0.8_admin-container-v0-7-0.lz4",
+    "migrate_v1.0.8_add-bootstrap-containers.lz4"
 ]

--- a/packages/os/bootstrap-containers-tmpfiles.conf
+++ b/packages/os/bootstrap-containers-tmpfiles.conf
@@ -1,0 +1,3 @@
+d /etc/bootstrap-containers 0750 root root -
+d /local/bootstrap-containers 0700 root root -
+T /local/bootstrap-containers - - - - security.selinux=system_u:object_r:state_t:s0

--- a/packages/os/bootstrap-containers@.service
+++ b/packages/os/bootstrap-containers@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=bootstrap container %i
+Before=configured.target
+After=host-containerd.service
+Wants=host-containers.service
+# Block manual interactions with bootstrap containers, since they should only be
+# started by systemd
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/bootstrap-containers/%i.env
+ExecStart=/usr/bin/host-ctr run \
+    --container-id='%i' \
+    --source='${CTR_SOURCE}' \
+    --container-type='bootstrap'
+ExecStartPost=/usr/bin/bootstrap-containers mark-bootstrap \
+    --container-id '%i' \
+    --mode '${CTR_MODE}'
+RemainAfterExit=true
+StandardError=journal+console

--- a/packages/os/host-containers-tmpfiles.conf
+++ b/packages/os/host-containers-tmpfiles.conf
@@ -1,3 +1,3 @@
-d /etc/host-containers 0755 root root -
+d /etc/host-containers 0750 root root -
 d /local/host-containers 0700 root root -
 T /local/host-containers - - - - security.selinux=system_u:object_r:state_t:s0

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -35,11 +35,13 @@ Source110: mark-successful-boot.service
 Source111: metricdog.service
 Source112: metricdog.timer
 Source113: send-boot-success.service
+Source114: bootstrap-containers@.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
 Source201: host-containers-tmpfiles.conf
 Source202: thar-be-updates-tmpfiles.conf
+Source203: bootstrap-containers-tmpfiles.conf
 
 # 3xx sources: udev rules
 Source300: ephemeral-storage.rules
@@ -200,6 +202,12 @@ Requires: %{_cross_os}apiserver = %{version}-%{release}
 %{summary}.
 %endif
 
+%package -n %{_cross_os}bootstrap-containers
+Summary: Manages bootstrap-containers
+Requires: %{_cross_os}apiserver = %{version}-%{release}
+%description -n %{_cross_os}bootstrap-containers
+%{summary}.
+
 %prep
 %setup -T -c
 %cargo_prep
@@ -257,6 +265,7 @@ echo "** Output from non-static builds:"
     -p ghostdog \
     -p growpart \
     -p corndog \
+    -p bootstrap-containers \
 %if "%{_cross_variant}" == "aws-ecs-1"
     -p ecs-settings-applier \
 %endif
@@ -283,7 +292,7 @@ for p in \
   storewolf settings-committer \
   migrator \
   signpost updog metricdog logdog \
-  ghostdog \
+  ghostdog bootstrap-containers \
 %if "%{_cross_variant}" == "aws-ecs-1"
   ecs-settings-applier \
 %endif
@@ -338,13 +347,15 @@ install -p -m 0644 %{S:5} %{S:6} %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:100} %{S:101} %{S:102} %{S:103} %{S:105} \
-  %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} %{S:113}\
+  %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
+  %{S:113} %{S:114} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.conf
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_tmpfilesdir}/thar-be-updates.conf
+install -p -m 0644 %{S:203} %{buildroot}%{_cross_tmpfilesdir}/bootstrap-containers.conf
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-storage.rules
@@ -460,5 +471,10 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %files -n %{_cross_os}static-pods
 %{_cross_bindir}/static-pods
 %endif
+
+%files -n %{_cross_os}bootstrap-containers
+%{_cross_bindir}/bootstrap-containers
+%{_cross_unitdir}/bootstrap-containers@.service
+%{_cross_tmpfilesdir}/bootstrap-containers.conf
 
 %changelog

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -81,6 +81,7 @@ Requires: %{_cross_os}logdog
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}wicked
 Requires: %{_cross_os}os
+Requires: %{_cross_os}bootstrap-containers
 
 %description
 %{summary}.

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -262,6 +262,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-bootstrap-containers"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-cluster-domain"
 version = "0.1.0"
 dependencies = [
@@ -614,6 +621,24 @@ name = "block-party"
 version = "0.1.0"
 dependencies = [
  "snafu",
+]
+
+[[package]]
+name = "bootstrap-containers"
+version = "0.1.0"
+dependencies = [
+ "apiclient",
+ "base64 0.13.0",
+ "cargo-readme",
+ "datastore",
+ "http",
+ "log",
+ "models",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "snafu",
+ "tokio",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "api/apiserver",
     "api/apiclient",
+    "api/bootstrap-containers",
     "api/bork",
     "api/corndog",
     "api/datastore",
@@ -51,6 +52,7 @@ members = [
     "api/migration/migrations/v1.0.8/proxy-affect-host-containers",
     "api/migration/migrations/v1.0.8/control-container-v0-5-0",
     "api/migration/migrations/v1.0.8/admin-container-v0-7-0",
+    "api/migration/migrations/v1.0.8/add-bootstrap-containers",
 
     "bottlerocket-release",
 

--- a/sources/api/bootstrap-containers/Cargo.toml
+++ b/sources/api/bootstrap-containers/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "bootstrap-containers"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+apiclient = { path = "../apiclient" }
+datastore = { path = "../datastore" }
+base64 = "0.13"
+http = "0.2"
+log = "0.4"
+models = { path = "../../models" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+simplelog = "0.10"
+snafu = "0.6"
+tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
+# When hyper updates to tokio 0.3:
+#tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/api/bootstrap-containers/README.md
+++ b/sources/api/bootstrap-containers/README.md
@@ -1,0 +1,77 @@
+# bootstrap-containers
+
+Current version: 0.1.0
+
+## Bootstrap containers
+
+bootstrap-containers ensures that bootstrap containers are executed as defined in the system settings
+
+It queries the API for their settings, then configures the system by:
+
+* creating a user-data file in the host container's persistent storage area, if a base64-encoded
+  user-data setting is set for the host container.  (The decoded contents are available to the
+  container at /.bottlerocket/bootstrap-containers/<name>/user-data)
+* creating an environment file used by a bootstrap-container-specific instance of a systemd service
+* creating a systemd drop-in configureation file used by a bootstrap-container-specific
+instance of a systemd service
+* ensuring that the bootstap container's systemd service is enabled/disabled for the next boot
+
+## Examples
+Given a bootstrap container called `bear` with the following configuration:
+
+```toml
+[settings.bootstrap-containers.bear]
+source="<SOURCE>"
+mode="once"
+user-data="ypXCt82h4bSlwrfKlA=="
+```
+
+Where `<SOURCE>`, is the url of an image with the following definition:
+
+```Dockerfile
+FROM alpine
+ADD bootstrap-script /
+RUN chmod +x /bootstrap-script
+ENTRYPOINT ["sh", "bootstrap-script"]
+```
+
+And `bootstrap-script` as:
+
+```sh
+#!/usr/bin/env sh
+# We'll read some data to be written out from given user-data.
+USER_DATA_DIR=/.bottlerocket/bootstrap-containers/current
+# This is the in-container view of where the host's `/var` can be accessed.
+HOST_VAR_DIR=/.bottlerocket/rootfs/var
+# The directory that'll be created by this bootstrap container
+MY_HOST_DIR=$VAR_DIR/lib/my_directory
+# Create it!
+mkdir -p "$MY_HOST_DIR"
+# Write the user-data to stdout (to the journal) and to our new path:
+tee /dev/stdout "$MY_HOST_DIR/bear.txt" < "$USER_DATA_DIR/user-data"
+# The bootstrap container can set the permissions which are seen by the host:
+chmod -R o+r "$MY_HOST_DIR"
+chown -R 1000:1000 "$MY_HOST_DIR"
+# Bootstrap containers *must* finish before boot continues.
+#
+# With this, the boot process will be delayed 120 seconds. You can check the
+# status of `preconfigured.target` and `bootstrap-containers@bear` to see
+# that this sleep kept the system from starting up the apiserver.
+#
+# From the admin container:
+#
+# systemctl status preconfigured.target bootstrap-containers@bear
+sleep 120
+```
+
+You should see a new directory under `/var/lib` called `my_directory`, a file in that
+directory called `bear.txt` and the following command should show `ʕ·͡ᴥ·ʔ` in the bootstrap
+containers logs:
+
+```sh
+journalctl -u bootstrap-containers@bear.service
+```
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/bootstrap-containers/README.tpl
+++ b/sources/api/bootstrap-containers/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/bootstrap-containers/build.rs
+++ b/sources/api/bootstrap-containers/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -1,0 +1,712 @@
+/*!
+# Bootstrap containers
+
+bootstrap-containers ensures that bootstrap containers are executed as defined in the system settings
+
+It queries the API for their settings, then configures the system by:
+
+* creating a user-data file in the host container's persistent storage area, if a base64-encoded
+  user-data setting is set for the host container.  (The decoded contents are available to the
+  container at /.bottlerocket/bootstrap-containers/<name>/user-data)
+* creating an environment file used by a bootstrap-container-specific instance of a systemd service
+* creating a systemd drop-in configureation file used by a bootstrap-container-specific
+instance of a systemd service
+* ensuring that the bootstap container's systemd service is enabled/disabled for the next boot
+
+# Examples
+Given a bootstrap container called `bear` with the following configuration:
+
+```toml
+[settings.bootstrap-containers.bear]
+source="<SOURCE>"
+mode="once"
+user-data="ypXCt82h4bSlwrfKlA=="
+```
+
+Where `<SOURCE>`, is the url of an image with the following definition:
+
+```Dockerfile
+FROM alpine
+ADD bootstrap-script /
+RUN chmod +x /bootstrap-script
+ENTRYPOINT ["sh", "bootstrap-script"]
+```
+
+And `bootstrap-script` as:
+
+```sh
+#!/usr/bin/env sh
+# We'll read some data to be written out from given user-data.
+USER_DATA_DIR=/.bottlerocket/bootstrap-containers/current
+# This is the in-container view of where the host's `/var` can be accessed.
+HOST_VAR_DIR=/.bottlerocket/rootfs/var
+# The directory that'll be created by this bootstrap container
+MY_HOST_DIR=$VAR_DIR/lib/my_directory
+# Create it!
+mkdir -p "$MY_HOST_DIR"
+# Write the user-data to stdout (to the journal) and to our new path:
+tee /dev/stdout "$MY_HOST_DIR/bear.txt" < "$USER_DATA_DIR/user-data"
+# The bootstrap container can set the permissions which are seen by the host:
+chmod -R o+r "$MY_HOST_DIR"
+chown -R 1000:1000 "$MY_HOST_DIR"
+# Bootstrap containers *must* finish before boot continues.
+#
+# With this, the boot process will be delayed 120 seconds. You can check the
+# status of `preconfigured.target` and `bootstrap-containers@bear` to see
+# that this sleep kept the system from starting up the apiserver.
+#
+# From the admin container:
+#
+# systemctl status preconfigured.target bootstrap-containers@bear
+sleep 120
+```
+
+You should see a new directory under `/var/lib` called `my_directory`, a file in that
+directory called `bear.txt` and the following command should show `ʕ·͡ᴥ·ʔ` in the bootstrap
+containers logs:
+
+```sh
+journalctl -u bootstrap-containers@bear.service
+```
+*/
+
+#![deny(rust_2018_idioms)]
+
+#[macro_use]
+extern crate log;
+
+use datastore::{serialize_scalar, Key, KeyType};
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::env;
+use std::ffi::OsStr;
+use std::fmt::Write;
+use std::fs;
+use std::path::Path;
+use std::process::{self, Command};
+use std::str::FromStr;
+
+use model::modeled_types::{BootstrapContainerMode, Identifier};
+
+// FIXME Get from configuration in the future
+const DEFAULT_API_SOCKET: &str = "/run/api.sock";
+const API_SETTINGS_URI: &str = "/settings";
+
+const ENV_FILE_DIR: &str = "/etc/bootstrap-containers";
+const DROPIN_FILE_DIR: &str = "/etc/systemd/system";
+const PERSISTENT_STORAGE_DIR: &str = "/local/bootstrap-containers";
+const DROP_IN_FILENAME: &str = "overrides.conf";
+
+const SYSTEMCTL_BIN: &str = "/bin/systemctl";
+const HOST_CTR_BIN: &str = "/bin/host-ctr";
+
+/// Stores user-supplied global arguments
+#[derive(Debug)]
+struct Args {
+    log_level: LevelFilter,
+    socket_path: String,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            log_level: LevelFilter::Info,
+            socket_path: DEFAULT_API_SOCKET.to_string(),
+        }
+    }
+}
+
+/// Stores the subcommand to be executed
+#[derive(Debug)]
+enum Subcommand {
+    CreateContainers,
+    MarkBootstrap(MarkBootstrapArgs),
+}
+
+#[derive(Debug)]
+struct MarkBootstrapArgs {
+    container_id: String,
+    mode: BootstrapContainerMode,
+}
+
+/// Print a usage message in the event a bad arg is passed
+fn usage() {
+    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
+    eprintln!(
+        r"Usage: {} SUBCOMMAND [ ARGUMENTS... ]
+
+    Subcommands:
+        create-containers
+        mark-bootstrap
+
+    Global arguments:
+        [ --socket-path PATH ]
+        [ --log-level trace|debug|info|warn|error ]
+
+    Mark bootstrap arguments:
+        --container-id CONTAINER-ID
+        --mode MODE
+
+    Socket path defaults to {}",
+        program_name, DEFAULT_API_SOCKET,
+    );
+}
+
+/// Parses user arguments into an Args struct
+fn parse_args(args: env::Args) -> Result<(Args, Subcommand)> {
+    let mut global_args = Args::default();
+    let mut subcommand = None;
+    let mut subcommand_args = Vec::new();
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            // Global args
+            "--log-level" => {
+                let log_level = iter.next().context(error::Usage {
+                    message: "Did not give argument to --log-level",
+                })?;
+                global_args.log_level =
+                    LevelFilter::from_str(&log_level).context(error::LogLevel { log_level })?;
+            }
+
+            "-s" | "--socket-path" => {
+                global_args.socket_path = iter.next().context(error::Usage {
+                    message: "Did not give argument to --socket-path",
+                })?
+            }
+
+            // Subcommands
+            "create-containers" | "mark-bootstrap"
+                if subcommand.is_none() && !arg.starts_with('-') =>
+            {
+                subcommand = Some(arg)
+            }
+
+            // Other arguments are passed to the subcommand parser
+            _ => subcommand_args.push(arg),
+        }
+    }
+
+    match subcommand.as_deref() {
+        Some("create-containers") => Ok((global_args, Subcommand::CreateContainers {})),
+        Some("mark-bootstrap") => Ok((global_args, parse_mark_bootstrap_args(subcommand_args)?)),
+        None => {
+            return error::Usage {
+                message: format!("Missing subcommand"),
+            }
+            .fail()
+        }
+        Some(x) => {
+            return error::Usage {
+                message: format!("Unknown subcommand '{}'", x),
+            }
+            .fail()
+        }
+    }
+}
+
+/// Parses arguments for the 'mark-bootstrap' subcommand
+fn parse_mark_bootstrap_args(args: Vec<String>) -> Result<Subcommand> {
+    let mut container_id = None;
+    let mut mode = None;
+
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            "--container-id" => {
+                container_id = Some(iter.next().context(error::Usage {
+                    message: "Did not give argument to --container-id",
+                })?);
+            }
+
+            "--mode" => {
+                mode = Some(iter.next().context(error::Usage {
+                    message: "Did not give argument to --mode",
+                })?);
+            }
+
+            x => {
+                return error::Usage {
+                    message: format!("Unexpected argument '{}'", x),
+                }
+                .fail()
+            }
+        }
+    }
+
+    let container_id = container_id.context(error::Usage {
+        message: format!("Did not give argument to --container-id"),
+    })?;
+
+    let mode = mode.context(error::Usage {
+        message: format!("Did not give argument to --mode"),
+    })?;
+
+    Ok(Subcommand::MarkBootstrap(MarkBootstrapArgs {
+        container_id: container_id,
+        // Fail if 'mode' is invalid
+        mode: BootstrapContainerMode::try_from(mode.to_string())
+            .context(error::BootstrapContainerMode)?,
+    }))
+}
+
+/// Handles how the bootstrap containers' systemd units are created
+fn handle_bootstrap_container<S>(
+    name: S,
+    container_details: &model::BootstrapContainer,
+) -> Result<()>
+where
+    S: AsRef<str>,
+{
+    let name = name.as_ref();
+
+    info!("Handling bootstrap container '{}'", name);
+
+    // Get basic settings, as retrieved from API.
+    let source = container_details
+        .source
+        .as_ref()
+        .context(error::MissingField {
+            name,
+            field: "source",
+        })?;
+
+    let mode = container_details.mode.clone().unwrap_or_default();
+
+    let essential = container_details.essential.unwrap_or_else(|| false);
+
+    // Create the directory regardless if user data was provided for the container
+    let dir = Path::new(PERSISTENT_STORAGE_DIR).join(name);
+    fs::create_dir_all(&dir).context(error::Mkdir { dir: &dir })?;
+
+    // If user data was specified, decode it and write it out
+    if let Some(user_data) = &container_details.user_data {
+        debug!("Decoding user data for container '{}'", name);
+        let decoded_bytes = base64::decode(user_data.as_bytes()).context(error::Base64Decode)?;
+
+        let path = dir.join("user-data");
+        debug!("Storing user data in {}", path.display());
+        fs::write(path, decoded_bytes).context(error::UserDataWrite { name })?;
+    }
+
+    // Start/stop the container according to the 'mode' setting
+    let unit_name = format!("bootstrap-containers@{}.service", name);
+    let systemd_unit = SystemdUnit::new(&unit_name);
+    let host_containerd_unit = SystemdUnit::new("host-containerd.service");
+
+    // Write the environment file needed for the systemd service to have details
+    // this specific bootstrap container
+    write_config_files(name, source, &mode, essential)?;
+
+    if mode == "off" {
+        // If mode is 'off', disable the container, and clean up any left over tasks
+        info!(
+            "Bootstrap container mode for '{}' is 'off', disabling unit",
+            name
+        );
+        systemd_unit.disable()?;
+
+        if host_containerd_unit.is_active()? {
+            debug!("Cleaning up container '{}'", name);
+            command(
+                HOST_CTR_BIN,
+                &[
+                    "clean-up",
+                    "--container-id",
+                    format!("boot.{}", name).as_ref(),
+                ],
+            )?;
+        }
+    } else {
+        info!("Bootstrap container mode for '{}' is '{}'", name, mode);
+
+        // Clean up any left over tasks, before the container is enabled
+        if host_containerd_unit.is_active()? && !systemd_unit.is_enabled()? {
+            command(
+                HOST_CTR_BIN,
+                &[
+                    "clean-up",
+                    "--container-id",
+                    format!("boot.{}", name).as_ref(),
+                ],
+            )?;
+        }
+
+        info!("Enabling unit '{}'", unit_name);
+        systemd_unit.enable()?;
+    }
+
+    Ok(())
+}
+
+/// Write out the EnvironmentFile that systemd uses to fill in arguments to host-ctr
+fn write_config_files<S1, S2, S3>(name: S1, source: S2, mode: S3, essential: bool) -> Result<()>
+where
+    S1: AsRef<str>,
+    S2: AsRef<str>,
+    S3: AsRef<str>,
+{
+    let name = name.as_ref();
+
+    // Build environment file
+    let env_filename = format!("{}.env", name);
+    let env_path = Path::new(ENV_FILE_DIR).join(env_filename);
+    let mut output = String::new();
+
+    writeln!(output, "CTR_SOURCE={}", source.as_ref()).context(error::WriteConfigurationValue {
+        value: source.as_ref(),
+    })?;
+    writeln!(output, "CTR_MODE={}", mode.as_ref()).context(error::WriteConfigurationValue {
+        value: mode.as_ref(),
+    })?;
+
+    debug!("Writing environment file for unit '{}'", name);
+    fs::write(&env_path, output).context(error::WriteConfigurationFile { path: env_path })?;
+
+    // Build unit's drop-in file, used to override the unit's configurations
+    let mut output = String::new();
+    let drop_in_dir =
+        Path::new(DROPIN_FILE_DIR).join(format!("bootstrap-containers@{}.service.d", name));
+    let drop_in_path = drop_in_dir.join(DROP_IN_FILENAME);
+
+    // Override the type of dependency the `configured` target has in the unit
+    let dependency = if essential { "RequiredBy" } else { "WantedBy" };
+
+    writeln!(output, "[Install]").context(error::WriteConfigurationValue { value: "[Install]" })?;
+    writeln!(output, "{}=configured.target", dependency)
+        .context(error::WriteConfigurationValue { value: dependency })?;
+    debug!("Writing drop-in file for {}", name);
+    fs::create_dir_all(&drop_in_dir).context(error::Mkdir { dir: &drop_in_dir })?;
+    fs::write(&drop_in_path, output)
+        .context(error::WriteConfigurationFile { path: drop_in_path })?;
+
+    Ok(())
+}
+
+/// Query the API for the currently defined bootstrap containers
+async fn get_bootstrap_containers<P>(
+    socket_path: P,
+) -> Result<HashMap<Identifier, model::BootstrapContainer>>
+where
+    P: AsRef<Path>,
+{
+    debug!("Querying the API for settings");
+
+    let method = "GET";
+    let uri = API_SETTINGS_URI;
+    let (_code, response_body) = apiclient::raw_request(&socket_path, uri, method, None)
+        .await
+        .context(error::APIRequest { method, uri })?;
+
+    // Build a Settings struct from the response string
+    debug!("Deserializing response");
+    let settings: model::Settings =
+        serde_json::from_str(&response_body).context(error::ResponseJson { method, uri })?;
+
+    // If bootstrap containers aren't defined, return an empty map
+    Ok(settings.bootstrap_containers.unwrap_or_default())
+}
+
+/// SystemdUnit stores the systemd unit being manipulated
+struct SystemdUnit<'a> {
+    unit: &'a str,
+}
+
+impl<'a> SystemdUnit<'a> {
+    fn new(unit: &'a str) -> Self {
+        SystemdUnit { unit }
+    }
+
+    fn is_enabled(&self) -> Result<bool> {
+        match command(SYSTEMCTL_BIN, &["is-enabled", &self.unit]) {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                // If the systemd unit is not enabled, then `systemctl is-enabled` will return a
+                // non-zero exit code.
+                match e {
+                    error::Error::CommandFailure { .. } => Ok(false),
+                    _ => {
+                        // Otherwise, we return the error
+                        Err(e)
+                    }
+                }
+            }
+        }
+    }
+
+    fn is_active(&self) -> Result<bool> {
+        match command(SYSTEMCTL_BIN, &["is-active", &self.unit]) {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                // If the systemd unit is not active(running), then `systemctl is-active` will
+                // return a non-zero exit code.
+                match e {
+                    error::Error::CommandFailure { .. } => Ok(false),
+                    _ => {
+                        // Otherwise, we return the error
+                        Err(e)
+                    }
+                }
+            }
+        }
+    }
+
+    fn enable(&self) -> Result<()> {
+        // Only enable the unit, since it will be started once systemd reaches the `preconfigured`
+        // target
+        command(SYSTEMCTL_BIN, &["enable", &self.unit])
+    }
+
+    fn disable(&self) -> Result<()> {
+        // Bootstrap containers won't be up by the time the user sends configurations through
+        // `apiclient`, so there is no need to add `--now` to stop them
+        command(SYSTEMCTL_BIN, &["disable", &self.unit])
+    }
+}
+
+/// Wrapper around process::Command that adds error checking.
+fn command<I, S>(bin_path: &str, args: I) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new(bin_path);
+    command.args(args);
+    let output = command
+        .output()
+        .context(error::ExecutionFailure { command })?;
+
+    trace!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+    trace!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    ensure!(
+        output.status.success(),
+        error::CommandFailure { bin_path, output }
+    );
+    Ok(())
+}
+
+/// Handles the `create-containers` subcommand
+async fn create_containers<P>(socket_path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let mut failed = 0usize;
+    let bootstrap_containers = get_bootstrap_containers(socket_path).await?;
+    for (name, container_details) in bootstrap_containers.iter() {
+        // Continue to handle other bootstrap containers if we fail one
+        if let Err(e) = handle_bootstrap_container(name, container_details) {
+            failed += 1;
+            error!("Failed to handle bootstrap container '{}': {}", &name, e);
+        }
+    }
+
+    ensure!(
+        failed == 0,
+        error::ManageContainersFailed {
+            failed,
+            tried: bootstrap_containers.len()
+        }
+    );
+
+    Ok(())
+}
+
+/// Handles the `mark-bootstrap` subcommand, which is called by the bootstrap
+/// container's systemd unit, which could potentially cause a concurrent invocation
+/// in this binary after the API setting finalizes.
+async fn mark_bootstrap<P>(args: MarkBootstrapArgs, socket_path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let container_id: &str = args.container_id.as_ref();
+    let mode = args.mode.as_ref();
+    info!("Mode for '{}' is '{}'", container_id, mode);
+
+    // When 'mode' is 'once', the container is marked as 'off' once it
+    // finishes. This guarantees that the the container is only started in
+    // the boot where it was created.
+    if mode != "always" {
+        let formatted = format!("settings.bootstrap-containers.{}.mode", container_id);
+        let key =
+            Key::new(KeyType::Data, &formatted).context(error::KeyFormat { key: formatted })?;
+        let value = serialize_scalar(&"off".to_string()).context(error::Serialize)?;
+
+        let mut map = HashMap::new();
+        map.insert(key, value);
+        let settings: model::Settings = datastore::deserialization::from_map(&map)
+            .context(error::SettingsDeserialize { settings: map })?;
+
+        info!("Turning off container '{}'", container_id);
+        apiclient::set::set(socket_path, &settings)
+            .await
+            .context(error::Set)?;
+    }
+
+    Ok(())
+}
+
+async fn run() -> Result<()> {
+    let (args, subcommand) = parse_args(env::args())?;
+
+    // SimpleLogger will send errors to stderr and anything less to stdout.
+    SimpleLogger::init(args.log_level, LogConfig::default()).context(error::Logger)?;
+
+    info!("bootstrap-containers started");
+
+    match subcommand {
+        Subcommand::CreateContainers => create_containers(args.socket_path).await,
+        Subcommand::MarkBootstrap(mark_bootstrap_args) => {
+            mark_bootstrap(mark_bootstrap_args, args.socket_path).await
+        }
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        match e {
+            error::Error::Usage { .. } => {
+                eprintln!("{}", e);
+                usage();
+                process::exit(1);
+            }
+            _ => {
+                eprintln!("{}", e);
+                process::exit(1);
+            }
+        }
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+mod error {
+    use datastore::Key;
+    use snafu::Snafu;
+    use std::collections::HashMap;
+    use std::fmt;
+    use std::io;
+    use std::path::PathBuf;
+    use std::process::{Command, Output};
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("Error sending {} to {}: {}", method, uri, source))]
+        APIRequest {
+            method: String,
+            uri: String,
+            source: apiclient::Error,
+        },
+
+        #[snafu(display("Unable to base64 decode user-data: '{}'", source))]
+        Base64Decode {
+            source: base64::DecodeError,
+        },
+
+        // `try_from` in `BootstrapContainerMode` already returns a useful error message
+        #[snafu(display("Failed to parse mode: {}", source))]
+        BootstrapContainerMode {
+            source: model::modeled_types::error::Error,
+        },
+
+        #[snafu(display("'{}' failed - stderr: {}",
+                        bin_path, String::from_utf8_lossy(&output.stderr)))]
+        CommandFailure { bin_path: String, output: Output },
+
+        #[snafu(display("Failed to execute '{:?}': {}", command, source))]
+        ExecutionFailure {
+            command: Command,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to deserialize key '{}': '{}'", key, source))]
+        KeyDeserialize {
+            key: String,
+            source: datastore::deserialization::Error,
+        },
+
+        #[snafu(display(
+            "Adding container name to key '{}' resulted in invalid format: {}",
+            key,
+            source
+        ))]
+        KeyFormat {
+            key: String,
+            source: datastore::Error,
+        },
+
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Invalid log level '{}'", log_level))]
+        LogLevel {
+            log_level: String,
+            source: log::ParseLevelError,
+        },
+
+        #[snafu(display("Failed to manage {} of {} bootstrap containers", failed, tried))]
+        ManageContainersFailed { failed: usize, tried: usize },
+
+        #[snafu(display("Bootstrap containers '{}' missing field '{}'", name, field))]
+        MissingField { name: String, field: String },
+
+        #[snafu(display("Failed to create directory '{}': '{}'", dir.display(), source))]
+        Mkdir {
+            dir: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display(
+            "Error deserializing response as JSON from {} to {}: {}",
+            method,
+            uri,
+            source
+        ))]
+        ResponseJson {
+            method: &'static str,
+            uri: String,
+            source: serde_json::Error,
+        },
+
+        #[snafu(display("Unable to serialize data: {}", source))]
+        Serialize { source: serde_json::Error },
+
+        #[snafu(display("Failed to change settings: {}", source))]
+        Set { source: apiclient::set::Error },
+
+        #[snafu(display("Failed to deserialize settings '{:#?}': '{}'", settings, source))]
+        SettingsDeserialize {
+            settings: HashMap<Key, String>,
+            source: datastore::deserialization::Error,
+        },
+
+        #[snafu(display("{}", message))]
+        Usage { message: String },
+
+        #[snafu(display(
+            "Failed to write user-data for bootstrap container '{}': {}",
+            name,
+            source
+        ))]
+        UserDataWrite {
+            name: String,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to write configuration file {}: {}", path.display(), source))]
+        WriteConfigurationFile { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Failed write value '{}': {}", value, source))]
+        WriteConfigurationValue { value: String, source: fmt::Error },
+    }
+}
+
+type Result<T> = std::result::Result<T, error::Error>;

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -140,7 +140,7 @@ type Result<T> = std::result::Result<T, error::Error>;
 /// Query the API for the currently defined host containers
 async fn get_host_containers<P>(
     socket_path: P,
-) -> Result<HashMap<Identifier, model::ContainerImage>>
+) -> Result<HashMap<Identifier, model::HostContainer>>
 where
     P: AsRef<Path>,
 {
@@ -351,7 +351,7 @@ fn parse_args(args: env::Args) -> Args {
     }
 }
 
-fn handle_host_container<S>(name: S, image_details: &model::ContainerImage) -> Result<()>
+fn handle_host_container<S>(name: S, image_details: &model::HostContainer) -> Result<()>
 where
     S: AsRef<str>,
 {

--- a/sources/api/migration/migrations/v1.0.8/add-bootstrap-containers/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.8/add-bootstrap-containers/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-bootstrap-containers"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.8/add-bootstrap-containers/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.8/add-bootstrap-containers/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added the setting `bootstrap-containers`
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.bootstrap-containers",
+        "services.bootstrap-containers",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -110,3 +110,12 @@ restart-commands = ["/usr/bin/corndog lockdown"]
 
 [metadata.settings.kernel.lockdown]
 affected-services = ["lockdown"]
+
+# Bootstrap Containers
+
+[services.bootstrap-containers]
+configuration-files = []
+restart-commands = ["/usr/bin/bootstrap-containers create-containers"]
+
+[metadata.settings.bootstrap-containers]
+affected-services = ["bootstrap-containers"]

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, ContainerImage, KernelSettings, MetricsSettings,
+    AwsSettings, BootstrapContainer, HostContainer, KernelSettings, MetricsSettings,
     NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
@@ -14,7 +14,7 @@ use crate::{
 struct Settings {
     motd: String,
     updates: UpdatesSettings,
-    host_containers: HashMap<Identifier, ContainerImage>,
+    host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, KernelSettings, MetricsSettings, NetworkSettings, NtpSettings,
-    UpdatesSettings,
+    AwsSettings, BootstrapContainer, ContainerImage, KernelSettings, MetricsSettings,
+    NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -15,6 +15,7 @@ struct Settings {
     motd: String,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
+    bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,
     kernel: KernelSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, ECSSettings, KernelSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, UpdatesSettings,
+    AwsSettings, BootstrapContainer, ContainerImage, ECSSettings, KernelSettings, MetricsSettings,
+    NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -15,6 +15,7 @@ struct Settings {
     motd: String,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
+    bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,
     kernel: KernelSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, ContainerImage, ECSSettings, KernelSettings, MetricsSettings,
+    AwsSettings, BootstrapContainer, ECSSettings, HostContainer, KernelSettings, MetricsSettings,
     NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
@@ -14,7 +14,7 @@ use crate::{
 struct Settings {
     motd: String,
     updates: UpdatesSettings,
-    host_containers: HashMap<Identifier, ContainerImage>,
+    host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.15/mod.rs
+++ b/sources/models/src/aws-k8s-1.15/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, ContainerImage, KernelSettings, KubernetesSettings,
+    AwsSettings, BootstrapContainer, HostContainer, KernelSettings, KubernetesSettings,
     MetricsSettings, NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
@@ -15,7 +15,7 @@ struct Settings {
     motd: String,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
-    host_containers: HashMap<Identifier, ContainerImage>,
+    host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.15/mod.rs
+++ b/sources/models/src/aws-k8s-1.15/mod.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, ContainerImage, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, UpdatesSettings,
+    AwsSettings, BootstrapContainer, ContainerImage, KernelSettings, KubernetesSettings,
+    MetricsSettings, NetworkSettings, NtpSettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -16,6 +16,7 @@ struct Settings {
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
+    bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,
     kernel: KernelSettings,

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -98,11 +98,11 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
-    KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
-    KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue, KubernetesQuantityValue,
-    KubernetesReservedResourceKey, KubernetesTaintValue, KubernetesThresholdValue, Lockdown,
-    SingleLineString, SysctlKey, Url, ValidBase64,
+    BootstrapContainerMode, DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
+    FriendlyVersion, Identifier, KubernetesAuthenticationMode, KubernetesBootstrapToken,
+    KubernetesClusterName, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
+    KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
+    KubernetesThresholdValue, Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
 };
 
 // Kubernetes static pod manifest settings
@@ -165,7 +165,7 @@ struct UpdatesSettings {
 }
 
 #[model]
-struct ContainerImage {
+struct HostContainer {
     source: Url,
     enabled: bool,
     superpowered: bool,
@@ -240,4 +240,14 @@ struct Metadata {
     key: SingleLineString,
     md: SingleLineString,
     val: toml::Value,
+}
+
+///// Bootstrap Containers
+
+#[model]
+struct BootstrapContainer {
+    source: Url,
+    mode: BootstrapContainerMode,
+    user_data: ValidBase64,
+    essential: bool,
 }

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -45,6 +45,9 @@ pub mod error {
         #[snafu(display("Invalid Kubernetes authentication mode '{}'", input))]
         InvalidAuthenticationMode { input: String },
 
+        #[snafu(display("Invalid bootstrap container mode '{}'", input))]
+        InvalidBootstrapContainerMode { input: String },
+
         #[snafu(display("Given invalid cluster name '{}': {}", name, msg))]
         InvalidClusterName { name: String, msg: String },
 
@@ -144,6 +147,24 @@ macro_rules! string_impls_for {
         impl From<$for> for String {
             fn from(x: $for) -> Self {
                 x.inner
+            }
+        }
+
+        impl PartialEq<str> for $for {
+            fn eq(&self, other: &str) -> bool {
+                &self.inner == other
+            }
+        }
+
+        impl PartialEq<String> for $for {
+            fn eq(&self, other: &String) -> bool {
+                &self.inner == other
+            }
+        }
+
+        impl PartialEq<&str> for $for {
+            fn eq(&self, other: &&str) -> bool {
+                &self.inner == other
             }
         }
     };

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootstrapContainer, ContainerImage, KernelSettings, NetworkSettings, NtpSettings,
+    BootstrapContainer, HostContainer, KernelSettings, NetworkSettings, NtpSettings,
     UpdatesSettings,
 };
 
@@ -14,7 +14,7 @@ use crate::{
 struct Settings {
     motd: String,
     updates: UpdatesSettings,
-    host_containers: HashMap<Identifier, ContainerImage>,
+    host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
-use crate::{ContainerImage, KernelSettings, NetworkSettings, NtpSettings, UpdatesSettings};
+use crate::{
+    BootstrapContainer, ContainerImage, KernelSettings, NetworkSettings, NtpSettings,
+    UpdatesSettings,
+};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -12,6 +15,7 @@ struct Settings {
     motd: String,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, ContainerImage>,
+    bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: NtpSettings,
     network: NetworkSettings,
     kernel: KernelSettings,


### PR DESCRIPTION
**Issue number:**
bottlerocket-os/bottlerocket#1392

**Description of changes:**

```
5153d08c host-containers: change permissions in `/etc/host-containers`
```
This commit updates the permissions in `/etc/host-containers` from `755` to `750`

```
d59628c7 models: change ContainerImage to HostContainer
```
This commit updates the model name used to configure a host container from `ContainerImage` to `HostContainer`

```
8ce2cae3 Add support for bootstrap-containers via settings
```
This commit adds support to create bootstrap containers through the API. Bootstrap containers are host containers that can be used to setup the host during the execution of the `configured` target.

These containers are created with the prefix `boot` to prevent collisions with normal host containers. They can be setup to fail the boot process if the underlying container task exists with a non-zero status code.

```
f5e29ce9 host-ctr: support for bootstrap containers
```
This commit adds support for bootstrap containers in `host-ctr`. The  `container-type` flag was added to specify the type of container to be setup, which defaults to `host`. This allows to add support for other type of containers in the future without adding flags for each of them.

The root filesystem mounts were refactored out from `withSuperpowered` to `withRootFilesystemMounts`, since bootstrap containers require access to the underlying root filesystem without being given the superpowered treatment.

Failed container tasks will now return an error if the task exited with a non-zero status.

**Testing done:**
In `k8s 1.18`, `ecs` and `dev` aarch64:

* Run `systemctl status` to check that no units were failing
* Create `nginx` pods/containers, access them and `curl http://localhost` successfully
* Verifiy that both the control and admin host containers are running, with the proper configurations
* Execute `systemctl isolate multi-user` to verify that no services were killed/restarted
* Migrate from 1.0.7 to 1.0.8, back and forth to verify the new configurations were deleted/created
* Create a bootstrap container with the following configurations:
```toml
# user-data
[settings.bootstrap-containers.admin]
mode = "once"
source = "docker.io/arnaldo2792/sleeper:latest"
user-data = "ypXCt82h4bSlwrfKlA==" # base64 of ʕ·͡ᴥ·ʔ
``` 
```Dockerfile
# Image definition
FROM alpine
ADD bootstrap-script /
RUN chmod +x /bootstrap-script
ENTRYPOINT ["sh", "bootstrap-script"]
```

```sh
# bootstrap-script
set -e
CURRENT_DIR=/.bottlerocket/bootstrap-containers/current
BEAR_DIR=/.bottlerocket/bootstrap-containers/admin
VAR_DIR=/.bottlerocket/rootfs/var
MY_DIR=$VAR_DIR/lib/my_directory
cat $BEAR_DIR/user-data
touch $CURRENT_DIR/access
mkdir $MY_DIR
chmod -R o+r $MY_DIR
chown -R 1000:1000 $MY_DIR
sleep 120
```
* Verified that:
    * `ʕ·͡ᴥ·ʔ` appears in the journal logs
    * The directory `/var/lib/my_directory` was created, with the expected user/group ids, and permissions
    * The file `/local/bootstrap-containers/access` created through the `current` mount
    * `configured.target` was "blocked" for two minutes
    * `mark-successful-boot.service` executed successfully
    * After a reboot, the bootstrap container wasn't executed

* Update the bootstrap container's configuration with `apiclient set bootstrap-containers.admin.mode=once`, reboot and verified its execution failed because `/var/lib/my_dir` already exists.

```sh
Starting bootstrap container admin...
[8.350595] host-ctr[456]: mkdir: can't create directory '/.bottlerocket/rootfs/var/lib/my_directory': File exists
[ 8.415213] host-ctr[456]: time="2021-04-02T00:54:43Z" level=fatal msg="Container exited with non-zero status"
[FAILED] Failed to start bootstrap container admin.
```

* Update the bootstrap container's configuration with `apiclient set bootstrap-containers.admin.essential=true`, reboot and verified the boot failed:

```sh
[FAILED] Failed to start bootstrap container admin.
See 'systemctl status bootstrap-containers@admin.service' for details.
[DEPEND] Dependency failed for Bottlerocket final configuration complete.
[DEPEND] Dependency failed for Isolates multi-user.target.
[FAILED] Failed to start Isolates configured.target.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
