### PR TITLE
k8s settings: kube-reserved, eviction-hard, cpu-manager-policy, allow-unsafe-sysctls

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,13 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.standalone-mode`: Whether to run the kubelet in standalone mode, without connecting to an API server.  Defaults to `false`.
 * `settings.kubernetes.authentication-mode`: Which authentication method the kubelet should use to connect to the API server, and for incoming requests.  Defaults to `aws` for AWS variants, and `tls` for other variants.
 * `settings.kubernetes.bootstrap-token`: The token to use for [TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).  This is only used with the `tls` authentication mode, and is otherwise ignored.
+* `settings.kubernetes.eviction-hard`: The signals and thresholds that trigger pod eviction.
+  Remember to quote signals (since they all contain ".") and to quote all values.
+  * Example user data for setting up eviction hard:
+    ```
+    [settings.kubernetes.eviction-hard]
+    "memory.available" = "15%"
+    ```
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,11 @@ The following settings are optional and allow you to further configure your clus
     [settings.kubernetes.eviction-hard]
     "memory.available" = "15%"
     ```
+* `settings.kubernetes.allowed-unsafe-sysctls`: Enables specified list of unsafe sysctls.
+  * Example user data for setting up allowed unsafe sysctls:
+    ```
+    allowed-unsafe-sysctls = ["net.core.somaxconn", "net.ipv4.ip_local_port_range"]
+    ```
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,11 @@ The following settings are set for you automatically by [pluto](sources/api/) ba
 * `settings.kubernetes.cluster-dns-ip`: The CIDR block of the primary network interface.
 * `settings.kubernetes.node-ip`: The IPv4 address of this node.
 * `settings.kubernetes.pod-infra-container-image`: The URI of the "pause" container.
+* `settings.kubernetes.kube-reserved`: Resources reserved for node components.
+  * Bottlerocket provides default values for the resources by [schnauzer](sources/api/):
+    * `cpu`: in millicores from the total number of vCPUs available on the instance.
+    * `memory`: in mebibytes from the max num of pods on the instance. `memory_to_reserve = max_num_pods * 11 + 255`.
+    * `ephemeral-storage`: defaults to `1Gi`.
 
 #### Amazon ECS settings
 

--- a/Release.toml
+++ b/Release.toml
@@ -30,3 +30,7 @@ version = "1.0.7"
     "migrate_v1.0.6_admin-container-v0-6-0.lz4",
 ]
 "(1.0.6, 1.0.7)" = []
+"(1.0.7, 1.0.8)" = [
+    "migrate_v1.0.8_kubelet-eviction-hard.lz4",
+    "migrate_v1.0.8_kubelet-unsafe-sysctl-kube-reserved.lz4",
+]

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -35,6 +35,9 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -35,6 +35,9 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -35,6 +35,9 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -35,6 +35,9 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -35,6 +35,9 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1651,6 +1651,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-eviction-hard"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-standalone-tls-services"
 version = "0.1.0"
 dependencies = [
@@ -1659,6 +1666,13 @@ dependencies = [
 
 [[package]]
 name = "kubelet-standalone-tls-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kubelet-unsafe-sysctl-kube-reserved"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2654,6 +2654,7 @@ dependencies = [
  "lazy_static",
  "log",
  "models",
+ "num_cpus",
  "percent-encoding",
  "serde",
  "serde_json",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -46,6 +46,8 @@ members = [
     "api/migration/migrations/v1.0.6/control-container-v0-4-2",
     "api/migration/migrations/v1.0.6/add-shibaken",
     "api/migration/migrations/v1.0.6/admin-container-v0-6-0",
+    "api/migration/migrations/v1.0.8/kubelet-eviction-hard",
+    "api/migration/migrations/v1.0.8/kubelet-unsafe-sysctl-kube-reserved",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.0.8/kubelet-eviction-hard/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.8/kubelet-eviction-hard/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-eviction-hard"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.8/kubelet-eviction-hard/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.8/kubelet-eviction-hard/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new settings for configuring kubelet,`settings.kubernetes.eviction-hard`.
+/// We don't want to track all possible keys for these settings,
+/// so we remove the whole prefix when we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.eviction-hard",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.0.8/kubelet-unsafe-sysctl-kube-reserved/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.8/kubelet-unsafe-sysctl-kube-reserved/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-unsafe-sysctl-kube-reserved"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.8/kubelet-unsafe-sysctl-kube-reserved/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.8/kubelet-unsafe-sysctl-kube-reserved/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added two new settings for configuring kubelet, `kubernetes.allowed-unsafe-sysctls`
+/// `kubernetes.kube-reserved`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.allowed-unsafe-sysctls",
+        "settings.kubernetes.kube-reserved",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1"
 snafu = "0.6"
 tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
 url = "2.1"
+num_cpus = "1.0"
 # When hyper updates to tokio 0.3:
 #tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -124,6 +124,11 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
     template_registry.register_helper("host", Box::new(helpers::host));
     template_registry.register_helper("join_array", Box::new(helpers::join_array));
+    template_registry.register_helper("kube_reserve_cpu", Box::new(helpers::kube_reserve_cpu));
+    template_registry.register_helper(
+        "kube_reserve_memory",
+        Box::new(helpers::kube_reserve_memory),
+    );
 
     Ok(template_registry)
 }

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -100,8 +100,9 @@ use std::net::Ipv4Addr;
 use crate::modeled_types::{
     DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
-    KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64, KubernetesEvictionHardKey, KubernetesThresholdValue,
+    KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue, KubernetesQuantityValue,
+    KubernetesReservedResourceKey, KubernetesTaintValue, KubernetesThresholdValue, Lockdown,
+    SingleLineString, SysctlKey, Url, ValidBase64,
 };
 
 // Kubernetes static pod manifest settings
@@ -128,6 +129,7 @@ struct KubernetesSettings {
     bootstrap_token: KubernetesBootstrapToken,
     standalone_mode: bool,
     eviction_hard: HashMap<KubernetesEvictionHardKey, KubernetesThresholdValue>,
+    kube_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -101,7 +101,7 @@ use crate::modeled_types::{
     DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
     KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
+    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64, KubernetesEvictionHardKey, KubernetesThresholdValue,
 };
 
 // Kubernetes static pod manifest settings
@@ -127,6 +127,7 @@ struct KubernetesSettings {
     authentication_mode: KubernetesAuthenticationMode,
     bootstrap_token: KubernetesBootstrapToken,
     standalone_mode: bool,
+    eviction_hard: HashMap<KubernetesEvictionHardKey, KubernetesThresholdValue>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -130,6 +130,7 @@ struct KubernetesSettings {
     standalone_mode: bool,
     eviction_hard: HashMap<KubernetesEvictionHardKey, KubernetesThresholdValue>,
     kube_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
+    allowed_unsafe_sysctls: Vec<SingleLineString>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -62,6 +62,15 @@ pub mod error {
             field: String,
             source: serde_plain::Error,
         },
+
+        #[snafu(display("Invalid Kubernetes threshold percentage value '{}'", input))]
+        InvalidThresholdPercentage { input: String },
+
+        #[snafu(display("Invalid percentage value '{}'", input))]
+        InvalidPercentage {
+            input: String,
+            source: std::num::ParseFloatError,
+        },
     }
 }
 


### PR DESCRIPTION
**My fork draft PR**: https://github.com/gthao313/bottlerocket/pull/1
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

### **Description of changes:**

- Add new settings `eviction-hard`, `kube-reserved`, `allowed-unsafe-sysctls` to k8s. User can specify this setting in userdata.
- Enable `cpu-manager-policy` to static

- Add migration for `eviction-hard`, `kube-reserved`, `allowed-unsafe-sysctls` 


**example**: 

```
[settings.kubernetes.eviction-hard]
"memory.available" = "10Gi"
"nodefs.inodesFree" = “15%”
[settings.kubernetes.kube-reserved]
cpu = "70Mi"
memory = "1Gi"
ephemeral-storage = "1Gi"
[settings.kubernetes]
allowed-unsafe-sysctls = ["net.core.somaxconn", ...]
```

### **Testing done:**

- Build aws-eks-* images and launched instance.
- Migration test: tested the migration via upgrade and downgrade testing
- Unit tests for new model types `EvictionHardKey`, `KubernetesThresholdValue`, `ReservedResourcesKey`, `KubernetesQuantityValue`, and `CpuManagerPolicy` (all passes)

### Eviction-hard test
***Test step1***:
Go to control container run `apiclient -u /settings` to check if expected setting is there.

***Test step2***:
ssh to admin contianer and look `etc/kubernetes/kubelet/config` to check if expected config is there.
```
evictionHard:
  memory.available: 15%
```
***Test step3*** - test effected/behavior:
set up eviction threshold to a high value for triggering eviction.
```
[evictionHard.memory]
"memory.available" = "99.99%" (high percentage to trigger eviction)
```
a) Go to EKS to check node condition 

MemoryPressure | True | kubelet has insufficient memory available
-- | -- | --

b) In admin contianer, check kubelet log by `journalctl -u kubelet`
```
eviction_manager.go:335] eviction manager: attempting to reclaim memory
eviction_manager.go:346] eviction manager: must evict pod(s) to reclaim memory
```
### kube-reservd test
***Test step1***:
Go to control container run apiclient -u /settings to check if expected setting is there.

***Test step2***:
_NodeAllocatable = NodeCapacity - Kube-reserved - system-reserved - eviction-threshold_
**cpu**
[settings.kubernetes.kube-reserved.cpu]
cpu = 1
Allocatable cpu = 2 - 1 = 1
	
```
EKS Resource allocation:
Name Capacity Allocatable
CPU		2		1
```

**memory**
[settings.kubernetes.kube-reserved.Memory]
memory = 1Gi

```
EKS Resource allocation:
Name    Capacity    Allocatable
Memory	7844780Ki	6693804Ki
```

**ephemeral-storage**
[settings.kubernetes.kube-reserved.ephemeral-storage]
ephemeral-storage = 1Gi

```
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         2
  ephemeral-storage:           20624592Ki
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      7930796Ki
  pods:                        29
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         1
  ephemeral-storage:           19007623956
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      7828396Ki
  pods:                        29˜
```
### cpu-manager-policy test
***Test step1***:
Go to host find `cpu_manager_state`
```
bash-5.0# cat /var/lib/kubelet/cpu_manager_state
{"policyName":"static","defaultCpuSet":"0-1","checksum":3945352861}bash-5.0#
```

```
journalctl -u kubelet
cpu_manager.go:173] [cpumanager] starting with static policy
```
### allowed-unsafe-sysctls test
***Test step1***:
Go to control container run apiclient -u /settings to check if expected setting is there.

***Test step2***:
Go to kubelet-config to check if desired result is there.
```
cat eks/kubernetes/kubelet/config

allowed-unsafe-sysctls = ["net.core.somaxconn", ]
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
