### PR TITLE
update_metadata: remove tough dependency

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3570,7 +3570,6 @@ dependencies = [
  "serde_plain",
  "snafu",
  "toml",
- "tough",
 ]
 
 [[package]]

--- a/sources/api/migration/migrator/src/error.rs
+++ b/sources/api/migration/migrator/src/error.rs
@@ -70,11 +70,6 @@ pub(crate) enum Error {
     #[snafu(display("Failed listing migration directory '{}': {}", dir.display(), source))]
     ListMigrations { dir: PathBuf, source: io::Error },
 
-    #[snafu(display("Error loading manifest: {}", source))]
-    LoadManifest {
-        source: update_metadata::error::Error,
-    },
-
     #[snafu(display("Error loading migration '{}': {}", migration, source))]
     LoadMigration {
         migration: String,
@@ -85,6 +80,17 @@ pub(crate) enum Error {
     Lz4Decode {
         migration: String,
         source: std::io::Error,
+    },
+
+    #[snafu(display("Error loading manifest: {}", source))]
+    ManifestLoad { source: tough::error::Error },
+
+    #[snafu(display("Manifest not found in repository"))]
+    ManifestNotFound,
+
+    #[snafu(display("Error parsing manifest: {}", source))]
+    ManifestParse {
+        source: update_metadata::error::Error,
     },
 
     #[snafu(display("Migration '{}' not found", migration))]

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -18,7 +18,6 @@ serde_json = "1.0.40"
 serde_plain = "0.3.0"
 snafu = "0.6.0"
 toml = "0.5"
-tough = "0.10"
 
 [lib]
 name = "update_metadata"

--- a/sources/updater/update_metadata/src/error.rs
+++ b/sources/updater/update_metadata/src/error.rs
@@ -62,9 +62,6 @@ pub enum Error {
     #[snafu(display("Duplicate version key: {}", key))]
     DuplicateVersionKey { backtrace: Backtrace, key: String },
 
-    #[snafu(display("Manifest not found in repository"))]
-    ManifestNotFound { backtrace: Backtrace },
-
     #[snafu(display("Failed to parse manifest file: {}", source))]
     ManifestParse {
         source: serde_json::Error,
@@ -89,12 +86,6 @@ pub enum Error {
     FileWrite {
         path: PathBuf,
         source: std::io::Error,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Manifest load error: {}", source))]
-    ManifestLoad {
-        source: tough::error::Error,
         backtrace: Backtrace,
     },
 

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -66,6 +66,21 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Manifest load error: {}", source))]
+    ManifestLoad {
+        source: tough::error::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Manifest not found in repository"))]
+    ManifestNotFound { backtrace: Backtrace },
+
+    #[snafu(display("Error parsing manifest: {}", source))]
+    ManifestParse {
+        source: update_metadata::error::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Metadata error: {}", source))]
     Metadata {
         source: tough::error::Error,

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -25,7 +25,7 @@ use std::process;
 use std::str::FromStr;
 use std::thread;
 use tough::{Repository, RepositoryLoader};
-use update_metadata::{find_migrations, load_manifest, Manifest, Update};
+use update_metadata::{find_migrations, Manifest, Update};
 use url::Url;
 
 #[cfg(target_arch = "x86_64")]
@@ -599,6 +599,17 @@ fn main_inner() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn load_manifest(repository: &tough::Repository) -> Result<Manifest> {
+    let target = "manifest.json";
+    Manifest::from_json(
+        repository
+            .read_target(target)
+            .context(error::ManifestLoad)?
+            .context(error::ManifestNotFound)?,
+    )
+    .context(error::ManifestParse)
 }
 
 fn main() -> ! {

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "tough 0.11.0",
+ "tough",
  "tough-kms",
  "tough-ssm",
  "update_metadata",
@@ -2045,30 +2045,6 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc3534fa46badec98ac633028f47a3cea590e9c9a63d85bd15a0436f8b6eb94"
-dependencies = [
- "chrono",
- "dyn-clone",
- "globset",
- "hex",
- "log",
- "olpc-cjson",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "serde_plain",
- "snafu",
- "tempfile",
- "untrusted",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "tough"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "203cc46930159ea049e9308ca0e31815bb57f761e6345fa5d42dbcbd06c1809c"
@@ -2105,7 +2081,7 @@ dependencies = [
  "rusoto_kms",
  "snafu",
  "tokio",
- "tough 0.11.0",
+ "tough",
 ]
 
 [[package]]
@@ -2121,7 +2097,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
- "tough 0.11.0",
+ "tough",
 ]
 
 [[package]]
@@ -2223,7 +2199,6 @@ dependencies = [
  "serde_plain",
  "snafu",
  "toml",
- "tough 0.10.0",
 ]
 
 [[package]]


### PR DESCRIPTION

**Issue number:**

#1377

**Description of changes:**

```
Removes the update_metadata dependency on tough. This removes a lot of
heavyweight dependencies from update_metadata, including tokio, reqwest,
hyper, and tough. update_metadata is used cross-workspace by pubsys, so
removing tough from update_metadata keeps the cross-workspace dependency
duplication to a minimum.
```

**Testing done:**

Ran pods, did an upgrade.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
