### PR TITLE
apiclient: add 'apply' mode for applying settings from URIs

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -390,17 +390,22 @@ version = "0.1.0"
 dependencies = [
  "cargo-readme",
  "datastore",
+ "futures",
  "http",
  "hyper",
  "hyper-unix-connector",
  "log",
  "models",
  "rand 0.8.3",
+ "reqwest",
+ "serde",
  "serde_json",
  "simplelog",
  "snafu",
  "tokio",
+ "toml",
  "unindent",
+ "url",
 ]
 
 [[package]]
@@ -2916,6 +2921,8 @@ checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "backtrace",
  "doc-comment",
+ "futures-core",
+ "pin-project 0.4.27",
  "snafu-derive",
 ]
 

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -25,9 +25,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.9"
 snafu = { version = "0.6", features = ["futures"] }
-tokio = { version = "0.2", default-features = false, features = ["fs", "macros", "rt-threaded", "time"] }
+tokio = { version = "0.2", default-features = false, features = ["fs", "io-std", "macros", "rt-threaded", "time"] }
 # When we update hyper to 0.14+ which has tokio 1:
-#tokio = { version = "1", default-features = false, features = ["fs", "macros", "rt-multi-thread", "time"] }
+#tokio = { version = "1", default-features = false, features = ["fs", "io-std", "macros", "rt-multi-thread", "time"] }
 toml = "0.5"
 unindent = "0.1"
 url = "2.2.1"

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 datastore = { path = "../datastore" }
+futures = { version = "0.3", default-features = false }
 http = "0.2"
 hyper = { version = "0.13", default-features = false }
 hyper-unix-connector = "0.1"
@@ -19,13 +20,17 @@ hyper-unix-connector = "0.1"
 log = "0.4"
 models = { path = "../../models" }
 rand = "0.8"
+reqwest = { version = "0.10.1", default-features = false, features = ["rustls-tls"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.9"
-snafu = "0.6"
-tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded", "time"] }
+snafu = { version = "0.6", features = ["futures"] }
+tokio = { version = "0.2", default-features = false, features = ["fs", "macros", "rt-threaded", "time"] }
 # When we update hyper to 0.14+ which has tokio 1:
-#tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
+#tokio = { version = "1", default-features = false, features = ["fs", "macros", "rt-multi-thread", "time"] }
+toml = "0.5"
 unindent = "0.1"
+url = "2.2.1"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/apiclient/src/apply.rs
+++ b/sources/api/apiclient/src/apply.rs
@@ -1,0 +1,211 @@
+//! This module allows application of settings from given URIs.  The files at the URIs are expected
+//! to be TOML settings files, in the same format as user data.  The URIs are pulled and applied to
+//! the API server in a single transaction.
+
+use crate::rando;
+use futures::future::{join, ready, TryFutureExt};
+use futures::stream::{self, StreamExt};
+use reqwest::Url;
+use serde::de::{Deserialize, IntoDeserializer};
+use snafu::{futures::try_future::TryFutureExt as SnafuTryFutureExt, OptionExt, ResultExt};
+use std::path::Path;
+
+/// Downloads TOML settings files from the requested URIs, then commits them in a single
+/// transaction and applies them to the system.
+pub async fn apply<P>(socket_path: P, uris: Vec<String>) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    // We want to retrieve the URIs in parallel because they're arbitrary and could be slow.
+    // First, we build a list of request futures, and store the URI with the future for inclusion
+    // in later error messages.
+    let mut get_requests = Vec::with_capacity(uris.len());
+    for uri in &uris {
+        let get_future = get_uri(uri);
+        let info_future = ready(uri);
+        get_requests.push(join(info_future, get_future));
+    }
+
+    // Stream out the requests and await responses (in order).
+    let get_request_stream = stream::iter(get_requests).buffered(4);
+    let get_responses: Vec<(&String, Result<String>)> = get_request_stream.collect().await;
+
+    // Reformat the responses from TOML to (model-verified) JSON we can send to the API.
+    let mut changes = Vec::with_capacity(get_responses.len());
+    for (uri, get_response) in get_responses {
+        let toml = get_response?;
+        let json = format_change(&toml, &uri)?;
+        changes.push((uri, json));
+    }
+
+    // We use a specific transaction ID so we don't commit any other changes that may be pending.
+    let transaction = format!("apiclient-apply-{}", rando());
+
+    // Send the settings changes to the server in the same transaction.  (They're quick local
+    // requests, so don't add the complexity of making them run concurrently.)
+    for (input_uri, json) in changes {
+        let uri = format!("/settings?tx={}", transaction);
+        let method = "PATCH";
+        let (_status, _body) = crate::raw_request(&socket_path, &uri, method, Some(json))
+            .await
+            .context(error::Patch {
+                input_uri,
+                uri,
+                method,
+            })?;
+    }
+
+    // Commit the transaction and apply it to the system.
+    let uri = format!("/tx/commit_and_apply?tx={}", transaction);
+    let method = "POST";
+    let (_status, _body) = crate::raw_request(&socket_path, &uri, method, None)
+        .await
+        .context(error::CommitApply { uri })?;
+
+    Ok(())
+}
+
+/// Retrieves the given URI and returns the result in a String.
+// Until reqwest handles file:// URIs: https://github.com/seanmonstar/reqwest/issues/178
+async fn get_uri<S>(input: S) -> Result<String>
+where
+    S: Into<String>,
+{
+    let input = input.into();
+
+    let uri = Url::parse(&input).context(error::Uri { input: &input })?;
+    if uri.scheme() == "file" {
+        // Turn the URI to a file path, and return a future that reads it.
+        let path = uri
+            .to_file_path()
+            .ok()
+            .context(error::FileUri { input: &input })?;
+        tokio::fs::read_to_string(path)
+            .context(error::FileRead { input })
+            .await
+    } else {
+        // Return a future that contains the text of the (non-file) URI.
+        reqwest::get(uri)
+            .and_then(|response| ready(response.error_for_status()))
+            .and_then(|response| response.text())
+            .context(error::Reqwest {
+                uri: input,
+                method: "GET",
+            })
+            .await
+    }
+}
+
+/// Takes a string of TOML settings data, verifies that it fits the model, and reserializes it to
+/// JSON for sending to the API.
+fn format_change(toml: &str, input_uri: &str) -> Result<String> {
+    // Parse the input as (arbitrary) TOML.
+    let toml_val: toml::Value =
+        toml::from_str(&toml).context(error::TomlDeserialize { input_uri })?;
+
+    // We need JSON for the API.  serde lets us convert between Deserialize-able types by reusing
+    // the deserializer.  Turn the TOML value into a JSON value.
+    let d = toml_val.into_deserializer();
+    let mut json_val =
+        serde_json::Value::deserialize(d).context(error::TomlDeserialize { input_uri })?;
+
+    // Remove outer "settings" layer before sending to API or deserializing it into the model,
+    // neither of which expects it.
+    let json_object = json_val
+        .as_object_mut()
+        .context(error::ModelType { input_uri })?;
+    let json_inner = json_object
+        .remove("settings")
+        .context(error::MissingSettings { input_uri })?;
+
+    // Deserialize into the model to confirm the settings are valid.
+    let _settings =
+        model::Settings::deserialize(&json_inner).context(error::ModelDeserialize { input_uri })?;
+
+    // Return JSON text we can send to the API.
+    serde_json::to_string(&json_inner).context(error::JsonSerialize { input_uri })
+}
+
+mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub enum Error {
+        #[snafu(display("Failed to commit combined settings to '{}': {}", uri, source))]
+        CommitApply { uri: String, source: crate::Error },
+
+        #[snafu(display("Failed to read given file '{}': {}", input, source))]
+        FileRead {
+            input: String,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Given invalid file URI '{}'", input))]
+        FileUri { input: String },
+
+        #[snafu(display(
+            "Failed to serialize settings from '{}' to JSON: {}",
+            input_uri,
+            source
+        ))]
+        JsonSerialize {
+            input_uri: String,
+            source: serde_json::Error,
+        },
+
+        #[snafu(display(
+            "Settings from '{}' did not contain a 'settings' key at top level",
+            input_uri
+        ))]
+        MissingSettings { input_uri: String },
+
+        #[snafu(display(
+            "Failed to deserialize settings from '{}' into this variant's model: {}",
+            input_uri,
+            source
+        ))]
+        ModelDeserialize {
+            input_uri: String,
+            source: serde_json::Error,
+        },
+
+        #[snafu(display("Settings from '{}' are not a TOML table", input_uri))]
+        ModelType { input_uri: String },
+
+        #[snafu(display(
+            "Failed to {} settings from '{}' to '{}': {}",
+            method,
+            input_uri,
+            uri,
+            source
+        ))]
+        Patch {
+            input_uri: String,
+            uri: String,
+            method: String,
+            source: crate::Error,
+        },
+
+        #[snafu(display("Failed {} request to '{}': {}", method, uri, source))]
+        Reqwest {
+            method: String,
+            uri: String,
+            source: reqwest::Error,
+        },
+
+        #[snafu(display("Failed to parse settings from '{}' as TOML: {}", input_uri, source))]
+        TomlDeserialize {
+            input_uri: String,
+            source: toml::de::Error,
+        },
+
+        #[snafu(display("Given invalid URI '{}': {}", input, source))]
+        Uri {
+            input: String,
+            source: url::ParseError,
+        },
+    }
+}
+pub use error::Error;
+pub type Result<T> = std::result::Result<T, error::Error>;

--- a/sources/api/apiclient/src/lib.rs
+++ b/sources/api/apiclient/src/lib.rs
@@ -16,9 +16,11 @@
 
 use hyper::{body, header, Body, Client, Request};
 use hyper_unix_connector::{UnixClient, Uri};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use snafu::{ensure, ResultExt};
 use std::path::Path;
 
+pub mod apply;
 pub mod reboot;
 pub mod set;
 pub mod update;
@@ -139,4 +141,13 @@ where
     let body = String::from_utf8(body_bytes.to_vec()).context(error::NonUtf8Response)?;
 
     Ok((status, body))
+}
+
+/// Generates a random ID, affectionately known as a 'rando'.
+pub(crate) fn rando() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect()
 }

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -108,7 +108,7 @@ fn usage() -> ! {
         Subcommands:
             raw                        Makes an HTTP request and prints the response on stdout.
                                        'raw' is the default subcommand and may be omitted.
-            apply                      Applies settings from TOML files at given URIs.
+            apply                      Applies settings from TOML/JSON files at given URIs.
             set                        Changes settings and applies them to the system.
             update check               Prints information about available updates.
             update apply               Applies available updates.
@@ -121,8 +121,8 @@ fn usage() -> ! {
             -d, --data DATA            Data to include in the request body.  Default: empty
 
         apply options:
-            URI [URI ...]              The list of URIs to TOML settings files that you want to
-                                       apply to the system.
+            URI [URI ...]              The list of URIs to TOML or JSON settings files that you
+                                       want to apply to the system.
 
         reboot options:
             None.

--- a/sources/api/apiclient/src/set.rs
+++ b/sources/api/apiclient/src/set.rs
@@ -1,4 +1,4 @@
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use crate::rando;
 use snafu::ResultExt;
 use std::path::Path;
 
@@ -29,15 +29,6 @@ where
         .context(error::Request { uri, method })?;
 
     Ok(())
-}
-
-/// Generates a random ID, affectionately known as a 'rando'.
-fn rando() -> String {
-    thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(16)
-        .map(char::from)
-        .collect()
 }
 
 mod error {


### PR DESCRIPTION
**Description of changes:**

```
apiclient: rename update-related types with clearer prefix

Having types named "check", "apply", and "cancel" that are related to updates,
but don't have an "update" prefix, prevents us from having other types or
subcommands called "check", "apply", or "cancel".  This adds an "update" prefix
to each of them to make it clear what they're checking, applying, or canceling.
```
```
apiclient: add apply mode for applying settings from URIs
```
```
apiclient: also accept JSON files for 'apply'
```
```
apiclient: allow 'apply' input on stdin
```

There are a few potential benefits here:
* Easier to apply settings that may be large, like host container user data or keys, if [gzip](https://github.com/bottlerocket-os/bottlerocket/pull/1366) is insufficient or inconvenient.
* Easier to share sets of settings, whether by making settings files public or storing them privately in your network and using them across instances.
* `file://settings.toml` URIs open the way to potentially store settings in Bottlerocket images, rather than compiled into storewolf, for cases where having them available at runtime would be handy.  (Potentially as default backfill for deleted settings, or explicit requests to "return to default".  Potentially as alternate sets of defaults..?)

`apiclient apply` could be called from a host container or [bootstrap container](https://github.com/bottlerocket-os/bottlerocket/pull/1387).  We could have a default bootstrap container that applies a conveniently listed set of URLs, or something - just a thought.  (The downside there is that you're taking on some level of risk from potential network failure and inability to apply settings.)  Or settings files could be baked into custom host/bootstrap containers.

One potential use of JSON/stdin mode is https://github.com/mozilla/sops, which could help with encrypting inputs like keys; it doesn't support TOML, hence JSON, and you wouldn't want to store the file on disk after decryption, hence stdin rather than requiring creation of a file.  But they're generally useful, too.

**Testing done:**

Happy tests:
* I set up two settings files in S3, did `apiclient apply 'https://bla/settings-1.toml' 'https://bla/settings-2.toml'`, and saw settings from both apply to the system.
* I did the same with a single file.
* I did the same with a `file://` URL and a file I created in /tmp.
* I retested apiclient's normal get/set functionality.
* I tested normal BR system functionality; pods healthy, system services healthy.

<details>
<summary>Failure tests, to ensure errors are clear (CLICK ME)</summary>

* Tested a file with no `[settings]` block:
 ```
 apiclient apply 'good-url-1' 'good-url-2' 'https://bla/settings-no-settings.toml'`
 Failed to apply settings: Settings from 'https://bla/settings-no-settings.toml' did not contain a 'settings' key at top level
 ```
* Tested a file with bad TOML:
```
$ apiclient apply 'good-url-1' 'good-url-2' 'https://bla/settings-not-object.toml'
Failed to apply settings: Settings from 'https://bla/settings-not-object.toml' are not a TOML table / JSON object
```
* Tested a bad URL:
```
$ apiclient apply 'good-url-1' 'good-url-2' 'https://nope'
Failed to apply settings: Failed GET request to 'https://nope': error sending request for url (https://nope/): error trying to connect: dns error: failed to lookup address information: Name does not resolve
```
* Tested unknown settings in the file:
```
$ apiclient apply 'good-url-1' 'good-url-2' 'https://bla/settings-invalid.toml'
Failed to apply settings: Failed to deserialize settings from 'https://bla/settings-invalid.toml' into this variant's model: unknown field `xxx`, expected one of `motd`, `kubernetes`, `updates`, `host-containers`, `ntp`, `network`, `kernel`, `aws`, `metrics`
```
* Tested an HTTP error:
```
$ apiclient apply 'good-url-1' 'good-url-2' 'https://www.example.com/lksdjfaoiselekjr'
Failed to apply settings: Failed GET request to 'https://www.example.com/lksdjfaoiselekjr': HTTP status client error (404 Not Found) for url (https://www.example.com/lksdjfaoiselekjr)
```

In each failure scenario, as expected, the settings from 'good' URLs were not applied.  We want all-or-nothing behavior in a single apiclient call.
</details>

<details>
<summary>stdin/JSON tests (CLICK ME)</summary>

Input on stdin, ending with ctrl-d:
```
$ apiclient apply
[settings]
motd = "from stdin, neat"
bash-5.0# cat /etc/motd
from stdin, neat
```
Input piped in:
```
bash-5.0# echo -e '[settings]\nmotd = "from pipe stdin"' | apiclient apply
bash-5.0# cat /etc/motd
from pipe stdin
```
Input typed in, in between some URIs, where good-url-1 sets a motd and good-url-2 sets lockdown:
```
bash-5.0# apiclient apply 'good-url-1' - 'good-url-2'
[settings]
motd = 'in the middle'
bash-5.0# cat /etc/motd
in the middle
bash-5.0# cat /sys/kernel/security/lockdown
none [integrity] confidentiality
```
As before, no settings are applied if any settings fail:
```
bash-5.0# apiclient apply 'good-url-1' - 'https://nope'
[settings]
motd = 'more middle'
Failed to apply settings: Failed GET request to 'https://nope': error sending request for url (https://nope/): error trying to connect: dns error: failed to lookup address information: Name does not resolve
bash-5.0# cat /etc/motd
in the middle
```
The last input given takes effect, even if the earlier one takes (much) longer to retrieve, because I typed it by hand:
```
bash-5.0# apiclient apply - 'good-url-1'
[settings]
motd = 'dash'
bash-5.0# cat /etc/motd
settings 1
```
The same thing works with JSON:
```
bash-5.0# echo -e '{"settings": {"motd": "json pipe"}}' | apiclient apply 'good-url-1' -
bash-5.0# cat /etc/motd
json pipe
bash-5.0# echo -e '{"settings": {"motd": "json pipe"}}' | apiclient apply - 'good-url-1'  
bash-5.0# cat /etc/motd
settings 1
```
</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.