### PR TITLE
early-boot-config: Add guestinfo to available VMWare user data retrieval methods

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -964,10 +964,12 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_json",
+ "serde_plain",
  "simplelog",
  "snafu",
  "tokio",
  "toml",
+ "vmw_backdoor",
 ]
 
 [[package]]
@@ -1046,6 +1048,27 @@ dependencies = [
  "rustversion",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+dependencies = [
+ "gcc",
+ "libc",
 ]
 
 [[package]]
@@ -1220,6 +1243,12 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -3631,6 +3660,20 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "vmw_backdoor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782273e25af43e3b255d00a72a22311feacabf9482bcbab26a8a03aae9197867"
+dependencies = [
+ "cc",
+ "cfg-if 0.1.10",
+ "errno",
+ "libc",
+ "log",
+ "thiserror",
+]
 
 [[package]]
 name = "void"

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4"
 reqwest = { version = "0.10", default-features = false, features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+serde_plain = "0.3"
 serde-xml-rs = "0.4.1"
 simplelog = "0.9"
 snafu = "0.6"
@@ -25,6 +26,10 @@ tokio = { version = "0.2", default-features = false, features = ["macros", "rt-t
 # When hyper updates to tokio 0.3:
 #tokio = { version = "0.3", default-features = false, features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+# vmw_backdoor includes x86_64 assembly, prevent it from building for ARM
+vmw_backdoor = "0.2"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/early-boot-config/src/main.rs
+++ b/sources/api/early-boot-config/src/main.rs
@@ -60,7 +60,7 @@ fn create_provider() -> Result<Box<dyn PlatformDataProvider>> {
 
     #[cfg(bottlerocket_platform = "vmware")]
     {
-        Ok(Box::new(provider::cdrom::CdromDataProvider))
+        Ok(Box::new(provider::vmware::VmwareDataProvider))
     }
 }
 
@@ -130,8 +130,7 @@ async fn run() -> Result<()> {
     let args = parse_args(env::args());
 
     // SimpleLogger will send errors to stderr and anything less to stdout.
-    SimpleLogger::init(args.log_level, LogConfig::default())
-        .context(error::Logger)?;
+    SimpleLogger::init(args.log_level, LogConfig::default()).context(error::Logger)?;
 
     info!("early-boot-config started");
 

--- a/sources/api/early-boot-config/src/provider.rs
+++ b/sources/api/early-boot-config/src/provider.rs
@@ -9,7 +9,7 @@ pub(crate) mod aws;
 pub(crate) mod local_file;
 
 #[cfg(bottlerocket_platform = "vmware")]
-pub(crate) mod cdrom;
+pub(crate) mod vmware;
 
 /// Support for new platforms can be added by implementing this trait.
 pub(crate) trait PlatformDataProvider {

--- a/sources/api/early-boot-config/src/provider/local_file.rs
+++ b/sources/api/early-boot-config/src/provider/local_file.rs
@@ -3,7 +3,7 @@
 
 use super::{PlatformDataProvider, SettingsJson};
 use crate::compression::expand_file_maybe;
-use snafu::{OptionExt, ResultExt};
+use snafu::ResultExt;
 
 pub(crate) struct LocalFileDataProvider;
 
@@ -26,15 +26,11 @@ impl PlatformDataProvider for LocalFileDataProvider {
             return Ok(output);
         }
 
-        // Remove outer "settings" layer before sending to API
-        let mut val: toml::Value =
-            toml::from_str(&user_data_str).context(error::TOMLUserDataParse)?;
-        let table = val.as_table_mut().context(error::UserDataNotTomlTable)?;
-        let inner = table
-            .remove("settings")
-            .context(error::UserDataMissingSettings)?;
-
-        let json = SettingsJson::from_val(&inner, "user data").context(error::SettingsToJSON)?;
+        let json = SettingsJson::from_toml_str(&user_data_str, "user data").context(
+            error::SettingsToJSON {
+                from: Self::USER_DATA_FILE,
+            },
+        )?;
         output.push(json);
 
         Ok(output)
@@ -52,16 +48,10 @@ mod error {
         #[snafu(display("Unable to read input file '{}': {}", path.display(), source))]
         InputFileRead { path: PathBuf, source: io::Error },
 
-        #[snafu(display("Error serializing TOML to JSON: {}", source))]
-        SettingsToJSON { source: serde_json::error::Error },
-
-        #[snafu(display("Error parsing TOML user data: {}", source))]
-        TOMLUserDataParse { source: toml::de::Error },
-
-        #[snafu(display("TOML data did not contain 'settings' section"))]
-        UserDataMissingSettings,
-
-        #[snafu(display("Data is not a TOML table"))]
-        UserDataNotTomlTable,
+        #[snafu(display("Unable to serialize settings from {}: {}", from, source))]
+        SettingsToJSON {
+            from: String,
+            source: crate::settings::Error,
+        },
     }
 }

--- a/sources/api/early-boot-config/src/provider/vmware.rs
+++ b/sources/api/early-boot-config/src/provider/vmware.rs
@@ -1,5 +1,5 @@
-//! The cdrom module implements the `PlatformDataProvider` trait for gathering userdata from a
-//! mounted CDRom.
+//! The vmware module implements the `PlatformDataProvider` trait for gathering userdata on VMWare
+//! via mounted CDRom or the guestinfo interface
 
 use super::{PlatformDataProvider, SettingsJson};
 use crate::compression::{expand_file_maybe, expand_slice_maybe, OptionalCompressionReader};
@@ -11,9 +11,9 @@ use std::io::BufReader;
 use std::iter::FromIterator;
 use std::path::Path;
 
-pub(crate) struct CdromDataProvider;
+pub(crate) struct VmwareDataProvider;
 
-impl CdromDataProvider {
+impl VmwareDataProvider {
     // This program expects that the CD-ROM is already mounted.  Mounting happens elsewhere in a
     // systemd unit file
     const CD_ROM_MOUNT: &'static str = "/media/cdrom";
@@ -134,7 +134,7 @@ impl CdromDataProvider {
     }
 }
 
-impl PlatformDataProvider for CdromDataProvider {
+impl PlatformDataProvider for VmwareDataProvider {
     fn platform_data(&self) -> std::result::Result<Vec<SettingsJson>, Box<dyn std::error::Error>> {
         let mut output = Vec::new();
 
@@ -229,7 +229,7 @@ mod test {
         let xml = test_data().join("namespaced_keys.xml");
         let expected_user_data = "settings.motd = \"hello\"";
 
-        let actual_user_data = CdromDataProvider::ovf_user_data(xml).unwrap();
+        let actual_user_data = VmwareDataProvider::ovf_user_data(xml).unwrap();
 
         assert_eq!(actual_user_data, expected_user_data)
     }
@@ -239,7 +239,7 @@ mod test {
         let xml = test_data().join("ovf-env.xml");
         let expected_user_data = "settings.motd = \"hello\"";
 
-        let actual_user_data = CdromDataProvider::ovf_user_data(xml).unwrap();
+        let actual_user_data = VmwareDataProvider::ovf_user_data(xml).unwrap();
 
         assert_eq!(actual_user_data, expected_user_data)
     }

--- a/sources/api/early-boot-config/src/settings.rs
+++ b/sources/api/early-boot-config/src/settings.rs
@@ -2,6 +2,7 @@
 //! sent to the API.
 
 use serde::Serialize;
+use snafu::{OptionExt, ResultExt};
 
 /// SettingsJson represents a change that a provider would like to make in the API.
 #[derive(Debug)]
@@ -17,16 +18,56 @@ impl SettingsJson {
     /// The serializable object is typically something like a toml::Value or serde_json::Value,
     /// since they can be easily deserialized from text input in the platform, and manipulated as
     /// desired.
-    pub(crate) fn from_val<S>(
-        data: &impl Serialize,
-        desc: S,
-    ) -> Result<Self, serde_json::error::Error>
+    pub(crate) fn from_val<S>(data: &impl Serialize, desc: S) -> Result<Self>
     where
         S: Into<String>,
     {
         Ok(Self {
-            json: serde_json::to_string(&data)?,
+            json: serde_json::to_string(&data).context(error::SettingsToJSON)?,
             desc: desc.into(),
         })
     }
+
+    /// Construct a SettingsJson from a string containing TOML-formatted data and a description of
+    /// the object, which is used for logging.
+    ///
+    /// This method takes care of the easy-to-miss task of removing the outer `settings` layer from
+    /// the TOML data before it gets submitted to the API.
+    pub(crate) fn from_toml_str<S1, S2>(data: S1, desc: S2) -> Result<Self>
+    where
+        S1: AsRef<str>,
+        S2: Into<String>,
+    {
+        let mut val: toml::Value =
+            toml::from_str(&data.as_ref()).context(error::TOMLUserDataParse)?;
+        let table = val.as_table_mut().context(error::UserDataNotTomlTable)?;
+        let inner = table
+            .remove("settings")
+            .context(error::UserDataMissingSettings)?;
+
+        SettingsJson::from_val(&inner, desc)
+    }
 }
+
+mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(crate)")]
+    pub(crate) enum Error {
+        #[snafu(display("Error serializing settings to JSON: {}", source))]
+        SettingsToJSON { source: serde_json::error::Error },
+
+        #[snafu(display("Error parsing TOML user data: {}", source))]
+        TOMLUserDataParse { source: toml::de::Error },
+
+        #[snafu(display("TOML data did not contain 'settings' section"))]
+        UserDataMissingSettings,
+
+        #[snafu(display("Data is not a TOML table"))]
+        UserDataNotTomlTable,
+    }
+}
+
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/sources/clarify.toml
+++ b/sources/clarify.toml
@@ -115,3 +115,12 @@ expression = "MIT"
 license-files = [
     { path = "LICENSE", hash = 0xff97fcac },
 ]
+
+[clarify.vmw_backdoor]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 0xac8571aa },
+    { path = "LICENSE-APACHE-2.0", hash = 0x18785531 },
+    { path = "LICENSE-MIT", hash = 0x28392cf3 },
+]
+


### PR DESCRIPTION
**Issue number:**
Closes #1369 


**Description of changes:**
The changes aren't vast here, but it's probably easiest to read the commits separately.  
```
    early-boot-config: Rename CdRomDataProvider to VmwareDataProvider
    
    Given that the CdRomDataProvider contained VMware-specific logic and
    more will continue to be added to it, naming it as such makes it clearer
    to the caller and still allows for the underlying logic to be factored
    out in the future should we deem necessary.
```
```
    early-boot-config: Add `from_toml_str` to SettingsJson
    
    This adds a method to SettingsJson that takes in a string (expected to
    be TOML data), and attempts to parse it, remove the "settings" layer,
    and create a `SettingsJson` from it.  This logic was previously
    sprinkled around in a few places, creating multiple identical error
    variants, etc.
```
```    
    early-boot-config: Add guestinfo to available VMWare retrieval methods
    
    This change adds an additional user data source to the VMWare provider;
    the guestinfo (host-guest) interface.  This source will be checked
    after the CD-ROM, and override any settings set via CD-ROM.
```

I do think that there's some refactoring to be done in this program, namely to separate "platform" from "data provider", but that will be done in another PR.

**Testing done:**
* Boot an `aws-k8s-1.17` AMI to ensure I didn't break anything over there
* Boot a `vmware-dev` image with a CD-ROM attached containing an `ovf-env.xml` file w/ user data 
* Boot a `vmware-dev` image with a CD-ROM attached containing a TOML `user-data` file
* In vSphere with guestinfo:
  * Traverse the entire matrix of encodings `base64`, `b64`, `B64`, `Base64` and `gz+b64`, `Gz+B64`, `gzip+base64`, and `Gzip+Base64` with user data set and unset
  * Ensure that raw TOML user data passed via guestinfo still works
  * Ensure that settings passed via guestinfo override setting from an attached CD-ROM


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
