### PR TITLE
update default variant to aws-k8s-1.19

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,7 +72,7 @@ To build an image, run:
 cargo make
 ```
 
-This will build an image for the default variant, `aws-k8s-1.17`.
+This will build an image for the default variant, `aws-k8s-1.19`.
 All packages will be built in turn, and then compiled into an `img` file in the `build/images/` directory.
 
 The version number in [Release.toml](Release.toml) will be used in naming the file, and will be used inside the image as the release version.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -19,7 +19,7 @@ BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*
 BUILDSYS_RELEASE_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Release.toml"
 BUILDSYS_VERSION_IMAGE = { script = ["awk -F '[ =\"]+' '$1 == \"version\" {print $2}' ${BUILDSYS_RELEASE_CONFIG_PATH}"] }
 # This can be overridden with -e to build a different variant from the variants/ directory
-BUILDSYS_VARIANT = "aws-k8s-1.17"
+BUILDSYS_VARIANT = "aws-k8s-1.19"
 # Product name used for file and directory naming
 BUILDSYS_NAME = "bottlerocket"
 # "Pretty" name used to identify OS in os-release, bootloader, etc.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -250,12 +250,12 @@ These default settings will be applied to your hosts at startup, meaning any hos
 
 The easiest way to change your repo URLs at run time is to include the settings changes in user data.
 This method is covered [in README](README.md#using-user-data).
-For example, if you built the `aws-k8s-1.17` variant for `x86_64` and uploaded to the public S3 bucket `my-bucket`, your URLs could look like:
+For example, if you built the `aws-k8s-1.19` variant for `x86_64` and uploaded to the public S3 bucket `my-bucket`, your URLs could look like:
 
 ```toml
 [settings.updates]
 targets-base-url = "https://my-bucket.s3-us-west-2.amazonaws.com/targets/"
-metadata-base-url = "https://my-bucket.s3-us-west-2.amazonaws.com/aws-k8s-1.17/x86_64/"
+metadata-base-url = "https://my-bucket.s3-us-west-2.amazonaws.com/aws-k8s-1.19/x86_64/"
 ```
 
 ### Waves
@@ -353,7 +353,7 @@ This isn't very discoverable yet, but it's useful for testing.
 As an example, a parameter might look like this:
 
 ```
-/your/prefix/here/aws-k8s-1.17/x86_64/1.0.1-dafe3b16/image_id
+/your/prefix/here/aws-k8s-1.19/x86_64/1.0.1-dafe3b16/image_id
 ```
 
 Once you're satisfied with your image and parameters, you can promote the parameters to simpler names (for example, "latest") using the [instructions below](#promoting-ssm-parameters).
@@ -395,12 +395,12 @@ cargo make promote-ssm -e SSM_TARGET=latest
 This will copy the fully versioned parameter from earlier, something like:
 
 ```
-/your/prefix/here/aws-k8s-1.17/x86_64/1.0.1-dafe3b16/image_id
+/your/prefix/here/aws-k8s-1.19/x86_64/1.0.1-dafe3b16/image_id
 ```
 
 ...to a simpler parameter name:
 ```
-/your/prefix/here/aws-k8s-1.17/x86_64/latest/image_id
+/your/prefix/here/aws-k8s-1.19/x86_64/latest/image_id
 ```
 
 You can then use this parameter name to get the latest AMI ID.

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -123,9 +123,9 @@ us-west-2
 ```
 
 The official AMI IDs are stored in [public SSM parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters.html).
-The parameter names look like this: `/aws/service/bottlerocket/aws-k8s-1.17/x86_64/latest/image_id`
+The parameter names look like this: `/aws/service/bottlerocket/aws-k8s-1.19/x86_64/latest/image_id`
 
-Just change the variant (`aws-k8s-1.17`) and architecture (`x86_64`) to the ones you want to use.
+Just change the variant (`aws-k8s-1.19`) and architecture (`x86_64`) to the ones you want to use.
 Supported variants and architectures are described in the [README](README.md#variants).
 For the purposes of SSM parameters, the valid architecture names are `x86_64` and `arm64` (also known as `aarch64`).
 Also, if you know a specific Bottlerocket version you'd like to use, for example `1.0.6`, you can replace `latest` with that version.
@@ -134,7 +134,7 @@ Once you have the parameter name you want to use, the easiest way to use it is t
 (You can also use this method for CloudFormation and other services that launch EC2 instances for you.)
 Just prefix the parameter name with `resolve:ssm:` and EC2 will fetch the current value for you.
 
-For example, to use the parameter above, you would pass this as the AMI ID in your launch request: `resolve:ssm:/aws/service/bottlerocket/aws-k8s-1.17/x86_64/latest/image_id`
+For example, to use the parameter above, you would pass this as the AMI ID in your launch request: `resolve:ssm:/aws/service/bottlerocket/aws-k8s-1.19/x86_64/latest/image_id`
 
 #### Manually querying SSM
 
@@ -142,14 +142,14 @@ If you prefer to fetch the AMI ID yourself, you can use [aws-cli](https://aws.am
 To fetch the example parameter above, for the us-west-2 region, you could run this:
 
 ```
-aws ssm get-parameter --region us-west-2 --name "/aws/service/bottlerocket/aws-k8s-1.17/x86_64/latest/image_id" --query Parameter.Value --output text
+aws ssm get-parameter --region us-west-2 --name "/aws/service/bottlerocket/aws-k8s-1.19/x86_64/latest/image_id" --query Parameter.Value --output text
 ```
 
 If you have `jq` and would like a bit more information, try this:
 ```
 aws ssm get-parameters --region us-west-2 \
-   --names "/aws/service/bottlerocket/aws-k8s-1.17/x86_64/latest/image_id" \
-           "/aws/service/bottlerocket/aws-k8s-1.17/x86_64/latest/image_version" \
+   --names "/aws/service/bottlerocket/aws-k8s-1.19/x86_64/latest/image_id" \
+           "/aws/service/bottlerocket/aws-k8s-1.19/x86_64/latest/image_version" \
    --output json | jq -r '.Parameters | .[] | "\(.Name): \(.Value) (updated \(.LastModifiedDate | gmtime | strftime("%c")) UTC)"'
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,19 @@ We’re excited to get early feedback and to continue working on more use cases!
 Bottlerocket is architected such that different cloud environments and container orchestrators can be supported in the future.
 A build of Bottlerocket that supports different features or integration characteristics is known as a 'variant'.
 The artifacts of a build will include the architecture and variant name.
-For example, an `x86_64` build of the `aws-k8s-1.17` variant will produce an image named `bottlerocket-aws-k8s-1.17-x86_64-<version>-<commit>.img`.
+For example, an `x86_64` build of the `aws-k8s-1.19` variant will produce an image named `bottlerocket-aws-k8s-1.19-x86_64-<version>-<commit>.img`.
 
-Our first supported variants, `aws-k8s-1.15`, `aws-k8s-1.16`, and `aws-k8s-1.17`, support EKS as described above.
-We also have a new `aws-ecs-1` variant designed to work with ECS.
+The following variants support EKS, as described above:
+
+- `aws-k8s-1.15`
+- `aws-k8s-1.16`
+- `aws-k8s-1.17`
+- `aws-k8s-1.18`
+- `aws-k8s-1.19`
+
+We also have a variant designed to work with ECS, currently in preview:
+
+- `aws-ecs-1`
 
 ## Architectures
 

--- a/sample-eksctl-ssh.yaml
+++ b/sample-eksctl-ssh.yaml
@@ -5,7 +5,7 @@ kind: ClusterConfig
 metadata:
   name: bottlerocket
   region: us-west-2
-  version: '1.17'
+  version: '1.19'
 
 nodeGroups:
   - name: ng-bottlerocket

--- a/sample-eksctl.yaml
+++ b/sample-eksctl.yaml
@@ -5,7 +5,7 @@ kind: ClusterConfig
 metadata:
   name: bottlerocket
   region: us-west-2
-  version: '1.17'
+  version: '1.19'
 
 nodeGroups:
   - name: ng-bottlerocket

--- a/sources/api/early-boot-config/build.rs
+++ b/sources/api/early-boot-config/build.rs
@@ -23,7 +23,7 @@ fn main() {
             eprintln!(
             "For local builds, you must set the 'VARIANT' environment variable so we know which data \
             provider to build. Valid values are the directories in models/src/variants/, for \
-            example 'aws-k8s-1.17'."
+            example 'aws-ecs-1'."
             );
             process::exit(1);
         }

--- a/sources/logdog/build.rs
+++ b/sources/logdog/build.rs
@@ -14,15 +14,15 @@ const ENV_VARIANT: &str = "VARIANT";
 /// Creates a file, `conf/current/logdog.conf` which is a symlink to a file with `logdog` commands
 /// for the current variant. Whatever the value of the `VARIANT` environment variable is, this
 /// function requires a file at `conf/logdog.$VARIANT.conf` and points to it from the `logdog.conf`
-/// symlink. For example, if the variant is `aws-k8s-1.17` then `conf/current/logdog.conf` will
-/// point to `conf/logdog.aws-k8s-1.17.conf`.
+/// symlink. For example, if the variant is `aws-ecs-1` then `conf/current/logdog.conf` will
+/// point to `conf/logdog.aws-ecs-1.conf`.
 fn symlink_variant() {
     println!("cargo:rerun-if-env-changed={}", ENV_VARIANT);
     let variant = env::var(ENV_VARIANT).unwrap_or_else(|_| {
         eprintln!(
             "For local builds, you must set the {} environment variable so we know which logdog \
             commands to build. Valid values are the directories in models/src/variants/, for \
-            example 'aws-k8s-1.17'.",
+            example 'aws-ecs-1'.",
             ENV_VARIANT
         );
         process::exit(1);

--- a/sources/models/build.rs
+++ b/sources/models/build.rs
@@ -32,7 +32,7 @@ fn link_current_variant() {
     // and is passed through as VARIANT by the top-level Dockerfile.  It represents which OS
     // variant we're building, and therefore which API model to use.
     let variant = env::var(VARIANT_ENV).unwrap_or_else(|_| {
-        eprintln!("For local builds, you must set the {} environment variable so we know which API model to build against.  Valid values are the directories in variants/, for example \"aws-k8s-1.17\".", VARIANT_ENV);
+        eprintln!("For local builds, you must set the {} environment variable so we know which API model to build against.  Valid values are the directories in variants/, for example \"aws-ecs-1\".", VARIANT_ENV);
         process::exit(1);
     });
 

--- a/sources/updater/updog/src/bin/updata.rs
+++ b/sources/updater/updog/src/bin/updata.rs
@@ -28,7 +28,7 @@ struct AddUpdateArgs {
     // metadata file to create/modify
     file: PathBuf,
 
-    // image 'variant', eg. 'aws-k8s-1.17'
+    // image 'variant', eg. 'aws-ecs-1'
     #[structopt(short = "f", long = "variant")]
     variant: String,
 
@@ -81,7 +81,7 @@ struct RemoveUpdateArgs {
     // metadata file to create/modify
     file: PathBuf,
 
-    // image 'variant', eg. 'aws-k8s-1.17'
+    // image 'variant', eg. 'aws-ecs-1'
     #[structopt(short = "l", long = "variant")]
     variant: String,
 
@@ -125,7 +125,7 @@ struct WaveArgs {
     // metadata file to create/modify
     file: PathBuf,
 
-    // image 'variant', eg. 'aws-k8s-1.17'
+    // image 'variant', eg. 'aws-ecs-1'
     #[structopt(short = "l", long = "variant")]
     variant: String,
 

--- a/tools/pubsys/policies/ssm/README.md
+++ b/tools/pubsys/policies/ssm/README.md
@@ -14,11 +14,11 @@ value = "{image_id}"
 The `name` and `value` can contain template variables that will be replaced with information from the current build and from the AMI registered from that build.
 
 The available variables include:
-* `variant`, for example "aws-k8s-1.17"
+* `variant`, for example "aws-ecs-1"
 * `arch`, for example "x86_64" or "arm64".
   * Note: "amd64" and "aarch64" are mapped to "x86_64" and "arm64", respectively, to match the names used by EC2.
 * `image_id`, for example "ami-0123456789abcdef0"
-* `image_name`, for example "bottlerocket-aws-k8s-1.17-x86_64-v0.5.0-e0ddf1b"
+* `image_name`, for example "bottlerocket-aws-ecs-1-x86_64-v0.5.0-e0ddf1b"
 * `image_version`, for example "0.5.0-e0ddf1b"
 * `region`, for example "us-west-2"
 


### PR DESCRIPTION
Make the build system's default variant aws-k8s-1.19, and update
documentation that refers to the previous default variant.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#1383


**Description of changes:**

Update the default variant to `aws-k8s-1.19`.


**Testing done:**

* Built a variant without specifying which variant I wanted. The k8s 1.19 was the result. Ran it ssh'ed to it, checked /etc/os-release.
* ran `eksctl create cluster --config-file sample-eksctl.yaml` and got a 1.19 cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
