### PR TITLE
ecs-settings-applier: remove bottlerocket.version attribute

### DIFF
--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -17,7 +17,6 @@ use std::{env, process};
 const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const DEFAULT_ECS_CONFIG_PATH: &str = "/etc/ecs/ecs.config.json";
 const VARIANT_ATTRIBUTE_NAME: &str = "bottlerocket.variant";
-const VERSION_ATTRIBUTE_NAME: &str = "bottlerocket.version";
 
 #[derive(Serialize, Debug, Default)]
 #[serde(rename_all = "PascalCase")]
@@ -102,10 +101,6 @@ async fn run() -> Result<()> {
         config
             .instance_attributes
             .insert(VARIANT_ATTRIBUTE_NAME.to_string(), os.variant_id);
-        config.instance_attributes.insert(
-            VERSION_ATTRIBUTE_NAME.to_string(),
-            os.version_id.to_string(),
-        );
     }
     if let Some(attributes) = ecs.instance_attributes {
         for (key, value) in attributes {


### PR DESCRIPTION
**Issue number:**

[#1292](https://github.com/bottlerocket-os/bottlerocket/issues/1293)


**Description of changes:**

This commit will remove the somewhat deceptive bottlerocket.version attribute. The attributes described in ecs.config.json are set when the instance first joins an ECS cluster, but are not updated in subsequent runs of the ECS agent. This leads to updated Bottlerocket instances continuing to show the lower version they were at first initialization within the ECS API.


**Testing done:**

- Built `aws-ecs-1` ami and launched instance.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Connected to control container via ssm session.
- Enabled and launched admin container.
- Connected to admin container via ssh.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.
- Verified that `/etc/ecs/ecs.config.json` did not contain `bottlerocket.version`
- Used `aws ecs describe-container-instances` to verify the `bottlerocket.version` attribute was absent on the ECS side.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
