### PR TITLE
vmware-dev: Change image format to vmdk

### DIFF
--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [package.metadata.build-variant]
+image-format = "vmdk"
 included-packages = [
 # core
     "release",


### PR DESCRIPTION
**Description of changes:**
This change makes the default image format for the `vmware-dev` variant VMDK. 

**Testing done:**
Built and booted said VMDK images. :)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
