### PR TITLE
update containerd to 1.4.4

### DIFF
--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.4.3/containerd-1.4.3.tar.gz"
-sha512 = "40501a45c46e4f2f6df1ce9e4142612863b400bb2e804b1e23a0b9f0b1ed3d5c83a6fcce4e70f82a4557ce0f301e2de11cf2935039cb74b8ebec0dc71752406e"
+url = "https://github.com/containerd/containerd/archive/v1.4.4/containerd-1.4.4.tar.gz"
+sha512 = "f09930d19f53381d86cf522954458ecc949f15a0c6a49f990bdb61fe19afee075356338998ed84bd756f16ba85211f55f9c638de8b7083d71e24d8e87335e070"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.4.3
+%global gover 1.4.4
 %global rpmver %{gover}
-%global gitrev 269548fa27e0089a8b8278fc4fc781d7f65a939b
+%global gitrev 05f951a3781f4f2c1911b05e61c160e9c30eaa8e
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This includes the fix for CVE-2021-21334.


**Testing done:**
Tested `aws-dev` under QEMU, confirmed that the startup sequence was normal, no new errors. Ran a Docker container, it came up fine.

Working on more extensive testing for Kubernetes and ECS.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
