### PR TITLE
static-pods: write manifest to tempfile before persisting it

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2970,6 +2970,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tempfile",
  "tokio",
 ]
 

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -21,6 +21,7 @@ snafu = "0.6"
 tokio = { version = "0.2", default-features = false, features = ["macros", "rt-threaded"] }
 # When we update hyper to 0.14+ which has tokio 1:
 #tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
+tempfile = "3.2.0"
 
 [build-dependencies]
 cargo-readme = "3.1"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1396


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Mar 23 16:52:49 2021 -0700

    static-pods: write manifest to tempfile before persisting it
    
    When writing static pod manifest, create them as temporary files and
    finish writing to them before persisting them in the destination file
    path.

```


**Testing done:**
Built aws-k8s-1.19 image and launched 4 instances

For each instance I was able to set 3 static pods repeatedly like so:
```
[ec2-user@ip ~]$ for pod in a b c ; do
apiclient set \
   "kubernetes.static-pods.${pod}.manifest"="$(base64 -w 0 manifests/$pod.yaml)" \
   "kubernetes.static-pods.${pod}.enabled"=true
done

```

Then `sudo sheltie`d to check kubelet logs. I no longer see any error logs pertaining to empty config files. All static pods gets created successfully and runs on the node. I repeated the for loop a few more times to make sure.


<details>

Note that the three static pods I created uses a generic manifest for nginx pods, that's why the image is `docker.io/library/nginx:1.14.2`

```
bash-5.0# cat /etc/kubernetes/static-pods/*  
apiVersion: v1
kind: Pod
metadata:
   name: a
spec:
   containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
           - containerPort: 80
apiVersion: v1
kind: Pod
metadata:
   name: b
spec:
   containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
           - containerPort: 82
apiVersion: v1
kind: Pod
metadata:
   name: c
spec:
   containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
           - containerPort: 81
```

```
bash-5.0# ctr -a /run/dockershim.sock -n k8s.io containers ls
CONTAINER                                                           IMAGE                                                                                                                                      
18a40cad51210af34b8f6d98920980b9eb5ca487c7b69d8c7c762deaf2b9faa8    docker.io/library/nginx:1.14.2                                                                                                         
280cdd55cc9fdd60fd3b145880480d65953427f0d7870a75c909ee51604e8530    docker.io/library/nginx:1.14.2                                                                                                         
f1f31d9d25523bfb110fd1f050fa7feaa9689762a119831f11b5306e43f266d6    docker.io/library/nginx:1.14.2            
...
```

</details>

I also tried launching instances with static pods specified in the userdata, those pods also get created successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
