### PR TITLE
host-ctr: Add "current" generic persistent storage location

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ If you're running a Kubernetes variant, the no-proxy list will automatically inc
 Beyond just changing the settings above to affect the `admin` and `control` containers, you can add and remove host containers entirely.
 As long as you define the three fields above -- `source` with a URI, and `enabled` and `superpowered` with true/false -- you can add host containers with an API call or user data.
 
-You can optionally define a `user-data` field with arbitrary base64-encoded data, which will be made available in the container at `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME/user-data`.
+You can optionally define a `user-data` field with arbitrary base64-encoded data, which will be made available in the container at `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME/user-data` and (since Bottlerocket v1.0.8) `/.bottlerocket/host-containers/current/user-data`.
 (It was inspired by instance user data, but is entirely separate; it can be any data your host container feels like interpreting.)
 
 Keep in mind that the default admin container (since Bottlerocket v1.0.6) relies on `user-data` to store SSH keys.  You can set `user-data` to [customize the keys](https://github.com/bottlerocket-os/bottlerocket-admin-container/#authenticating-with-the-admin-container), or you can use it for your own purposes in a custom container.
@@ -444,7 +444,8 @@ If the `enabled` flag is `true`, it will be started automatically.
 
 All host containers will have the `apiclient` binary available at `/usr/local/bin/apiclient` so they're able to [interact with the API](#using-the-api-client).
 
-In addition, all host containers come with persistent storage at `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME` that is persisted across reboots and container start/stop cycles.
+In addition, all host containers come with persistent storage that survives reboots and container start/stop cycles.
+It's available at `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME` and (since Bottlerocket v1.0.8) `/.bottlerocket/host-containers/current`.
 The default `admin` host-container, for example, stores its SSH host keys under `/.bottlerocket/host-containers/admin/etc/ssh/`.
 
 There are a few important caveats to understand about host containers:


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds an additional mount of the `/local/host-containers/NAME` directory as `/.bottlerocket/host-containers/current` to provide a generic persistent storage location that isn't tied to the name of the container. This makes it easier for scripts to utilize the storage.


**Testing done:**

- Built `aws-ecs-1` ami and launched instance.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Connected to control container via ssm session.
- Verified that `/.bottlerocket/host-containers/` contained both a `control` directory and a `current` directory.
- Enabled and launched admin container.
- Connected to admin container via ssh.
- Verified that `/.bottlerocket/host-containers/` contained both an `admin` directory and a `current` directory.
- Verified that `/.bottlerocket/host-containers/admin/` and `/.bottlerocket/host-containers/current/` had the same contents.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
