### PR TITLE
add compat symlink for kubelet volume plugins

### DIFF
--- a/packages/kubernetes-1.15/kubernetes-1.15.spec
+++ b/packages/kubernetes-1.15/kubernetes-1.15.spec
@@ -87,6 +87,11 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubec
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+ln -rs \
+  %{buildroot}%{_sharedstatedir}/kubelet/plugins \
+  %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.15
@@ -103,5 +108,7 @@ install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
+%dir %{_cross_libexecdir}/kubernetes
+%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
 %changelog

--- a/packages/kubernetes-1.16/kubernetes-1.16.spec
+++ b/packages/kubernetes-1.16/kubernetes-1.16.spec
@@ -83,6 +83,11 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubec
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+ln -rs \
+  %{buildroot}%{_sharedstatedir}/kubelet/plugins \
+  %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.16
@@ -99,5 +104,7 @@ install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
+%dir %{_cross_libexecdir}/kubernetes
+%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
 %changelog

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -83,6 +83,11 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubec
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+ln -rs \
+  %{buildroot}%{_sharedstatedir}/kubelet/plugins \
+  %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.17
@@ -99,5 +104,7 @@ install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
+%dir %{_cross_libexecdir}/kubernetes
+%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
 %changelog

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -80,6 +80,11 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubec
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+ln -rs \
+  %{buildroot}%{_sharedstatedir}/kubelet/plugins \
+  %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.18
@@ -96,5 +101,7 @@ install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
+%dir %{_cross_libexecdir}/kubernetes
+%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
 %changelog

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -77,6 +77,11 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubec
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+ln -rs \
+  %{buildroot}%{_sharedstatedir}/kubelet/plugins \
+  %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files -n %{_cross_os}kubelet-1.19
@@ -93,5 +98,7 @@ install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
 %{_cross_tmpfilesdir}/kubernetes.conf
+%dir %{_cross_libexecdir}/kubernetes
+%{_cross_libexecdir}/kubernetes/kubelet-plugins
 
 %changelog


### PR DESCRIPTION
**Issue number:**
Fixes #1354


**Description of changes:**
This allows existing manifests that try to install a flexvol plugin to the default `/usr/libexec/kubernetes` path to work, rather than failing because the root filesystem is read-only.


**Testing done:**
Followed the steps to "Install EKS with Calico networking":
https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/eks

The symlink worked as expected from both the `/usr` path and the target prefix:
```
# ls -latr /usr/libexec/kubernetes/kubelet-plugins
lrwxrwxrwx. 1 root root 38 Mar 24 23:19 /usr/libexec/kubernetes/kubelet-plugins -> ../../../../../var/lib/kubelet/plugins

# ls -latr /usr/libexec/kubernetes/kubelet-plugins/
drwxr-xr-x. 3 root root 4096 Mar 24 23:55 volume
drwxr-xr-x. 2 root root 4096 Mar 24 23:56 ebs.csi.aws.com
drwxr-xr-x. 2 root root 4096 Mar 24 23:56 efs.csi.aws.com

# ls -latr /x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/kubernetes/kubelet-plugins
lrwxrwxrwx. 1 root root 38 Mar 24 23:19 /x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/kubernetes/kubelet-plugins -> ../../../../../var/lib/kubelet/plugins

# ls -latr /x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/kubernetes/kubelet-plugins/
drwxr-xr-x. 3 root root 4096 Mar 24 23:55 volume
drwxr-xr-x. 2 root root 4096 Mar 24 23:56 ebs.csi.aws.com
drwxr-xr-x. 2 root root 4096 Mar 24 23:56 efs.csi.aws.com
```

The node agent plugin showed up in the expected location:
```
# find /var/lib/kubelet/plugins -type s -o -type f
/var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock
/var/lib/kubelet/plugins/volume/exec/nodeagent~uds/uds
/var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
