### PR TITLE
README: document `apiclient update` as primary CLI update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,26 +171,35 @@ For the ECS preview variant of Bottlerocket, we recommend updating hosts using o
 
 #### Update API
 
-The [Bottlerocket API](#api) includes methods for checking and starting system updates.  You can read more about the update APIs in our [update system documentation](sources/updater/README.md#update-api).
+The [Bottlerocket API](#api) includes methods for checking and starting system updates.
+You can read more about the update APIs in our [update system documentation](sources/updater/README.md#update-api).
 
-#### Updog
+apiclient knows how to handle those update APIs for you, and you can run it from the [control](#control-container) or [admin](#admin-container) containers.
 
-You can update Bottlerocket using a CLI tool, `updog`, if you [connect through the admin container](#admin-container).
-
-Here's how you can see whether there's an update:
-
+To see what updates are available:
 ```
-updog check-update
+apiclient update check
 ```
+If an update is available, it will show up in the `chosen_update` field.
+The `available_updates` field will show the full list of available versions, including older versions, because Bottlerocket supports safely rolling back.
 
-Here's how you initiate an update:
-
+To apply the latest update:
 ```
-updog update
-reboot
+apiclient update apply
 ```
 
-(If you know what you're doing and want to update *now*, you can run `updog update --reboot --now`)
+The next time you reboot, you'll start up in the new version, and system configuration will be automatically [migrated](sources/api/migration/).
+To reboot right away:
+```
+apiclient reboot
+```
+
+If you're confident about updating, the `apiclient update apply` command has `--check` and `--reboot` flags to combine the above actions, so you can accomplish all of the above steps like this:
+```
+apiclient update apply --check --reboot
+```
+
+See the [apiclient documentation](sources/api/apiclient/) for more details.
 
 #### Bottlerocket Update Operator
 
@@ -205,6 +214,8 @@ If the update is not functional for a given container workload, you can do a man
 signpost rollback-to-inactive
 reboot
 ```
+
+This doesn't require any external communication, so it's quicker than `apiclient`, and it's made to be as reliable as possible.
 
 ## Settings
 

--- a/sources/updater/README.md
+++ b/sources/updater/README.md
@@ -2,10 +2,11 @@
 This document describes the Bottlerocket update system and its components, namely;
 
 - [tough](#tuf-and-tough): implementation of "The Update Framework" (TUF)
-- [updog](#updog): update client that interfaces with a TUF repository to find and apply updates
+- [Bottlerocket update API](#update-api): allows for checking and starting system updates from TUF repo
+- [apiclient](../api/apiclient/README.md): automates interactions with the update API
+- [updog](#whats-updog): low-level client that interfaces with a TUF repository to find and apply updates
 - [signpost](#signpost): helper tool to update partition priority flags
 - [Bottlerocket update operator (brupop)](https://github.com/bottlerocket-os/bottlerocket-update-operator): an optional component that coordinates node updates with the rest of the cluster
-- [Bottlerocket update API](#update-api): a set of API calls for checking and starting system updates
 
 ![Update overview](update-system.png)
 ## TUF and tough
@@ -30,9 +31,12 @@ For Bottlerocket this includes a 'manifest.json' file and any update images or m
 Update metadata and files can be found by requesting and verifying these metadata files in order, and then requesting the manifest.json target which describes all available updates.
 Any file listed in the manifest is also a TUF 'target' listed in targets.json and can only be downloaded via the TUF repository, preventing the client from downloading untrusted data.
 
-## Updog
-Updog is the client tool that interacts with a 'The Update Framework' (TUF) repository to download and write updates to a Bottlerocket partition.
+## What's Updog
+[Updog](updog/) is a low-level update client, used behind the scenes by the update API, that interacts with a 'The Update Framework' (TUF) repository to download and write updates to a Bottlerocket partition.
 Updog will parse the manifest.json file from the TUF repository and will update to a new image if the following criteria are satisfied:
+
+(Most users should use [apiclient](../api/apiclient/README.md) to control updates, rather than using updog directly.)
+
 ### Version & Variant
 By default Updog only considers updates resulting in a version increase; downgrades are possible by using the `--image` option to force a specific version.
 Updog will respect the `max_version` field in the update manifest and refuse to update beyond it.


### PR DESCRIPTION
**Description of changes:**

README only described updog, with a link to other docs on the update APIs, but didn't show usage of `apiclient update`.  Since it can be used from non-superpowered containers, unlike updog, and it's more consistent with other apiclient usage, it's worth describing first.

**Testing done:**

Confirmed that the commands run, though they were copied from apiclient docs so I had already tested them.  Rendered the docs to confirm they read OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
