### PR TITLE
host-ctr: export containerID as HOST_CONTAINER_NAME env variable

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -213,6 +213,9 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 			oci.WithHostNamespace(runtimespec.NetworkNamespace),
 			oci.WithHostHostsFile,
 			oci.WithHostResolvconf,
+			// Set environment variable for host containers to reference their name.
+			// This is essential for containers to reference their persistent storage location.
+			oci.WithEnv([]string{"HOST_CONTAINER_NAME=" + containerID}),
 			// Mount in the API socket for the Bottlerocket API server, and the API
 			// client used to interact with it
 			oci.WithMounts([]runtimespec.Mount{


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds a `HOST_CONTAINER_NAME` environment variable to host containers so that they are able to reference their own names. This is useful for scripts that want to take advantage of the persistent storage location `/.bottlerocket/host-containers/NAME`.

**Testing done:**

- Built `aws-ecs-1` ami and launched instance.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Connected to control container via ssm session.
- Replaced control and admin containers with patched containers that take advantage of the HOST_CONTAINER_NAME environment variable.
- Verified that `/.bottlerocket/host-containers/` contained a `control` directory.
- Enabled and launched admin container.
- Connected to admin container via ssh.
- Verified that `/.bottlerocket/host-containers/` contained an `admin`.
- Disabled the control and admin containers and replaced them with containers named `custom-control` and `custom-admin`
- Connected to each of the containers and verified they were still functioning.
- Verified that `/.bottlerocket/host-containers/` contained a single directory with a name that matched the `containerID`.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
