### PR TITLE
packages: change systemd boot sequence

### DIFF
--- a/packages/acpid/acpid.service
+++ b/packages/acpid/acpid.service
@@ -6,4 +6,4 @@ Type=forking
 ExecStart=/usr/sbin/acpid -c /usr/lib/acpid/events
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=preconfigured.target

--- a/packages/chrony/chronyd.service
+++ b/packages/chrony/chronyd.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=A versatile implementation of the Network Time Protocol
 Documentation=https://chrony.tuxfamily.org
-After=network-online.target configured.target
-Requires=network-online.target configured.target
+After=network-online.target preconfigured.target
+Wants=network-online.target preconfigured.target
 
 [Service]
 Type=simple
 ExecStart=/usr/sbin/chronyd -d -F -1
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=configured.target

--- a/packages/dbus-broker/dbus-broker.service
+++ b/packages/dbus-broker/dbus-broker.service
@@ -19,4 +19,4 @@ ExecReload=/usr/bin/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.f
 
 [Install]
 Alias=dbus.service
-WantedBy=multi-user.target
+WantedBy=preconfigured.target

--- a/packages/ecs-agent/ecs.service
+++ b/packages/ecs-agent/ecs.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Amazon Elastic Container Service - container agent
 Documentation=https://aws.amazon.com/documentation/ecs/
-Requires=docker.service configured.target
+Requires=docker.service
 After=docker.service configured.target
 Wants=network-online.target configured.target
 

--- a/packages/host-ctr/host-containerd.service
+++ b/packages/host-ctr/host-containerd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=containerd runtime for host containers
 Documentation=https://containerd.io
-After=network-online.target configured.target
-Wants=network-online.target configured.target
+After=network-online.target preconfigured.target
+Wants=network-online.target preconfigured.target
 
 [Service]
 EnvironmentFile=/etc/network/proxy.env
@@ -19,4 +19,4 @@ LimitNOFILE=infinity
 TasksMax=infinity
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=configured.target

--- a/packages/kubernetes-1.15/kubelet.service
+++ b/packages/kubernetes-1.15/kubelet.service
@@ -29,4 +29,3 @@ MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target
-RequiredBy=mark-successful-boot.service

--- a/packages/kubernetes-1.16/kubelet.service
+++ b/packages/kubernetes-1.16/kubelet.service
@@ -29,4 +29,3 @@ MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target
-RequiredBy=mark-successful-boot.service

--- a/packages/kubernetes-1.17/kubelet.service
+++ b/packages/kubernetes-1.17/kubelet.service
@@ -29,4 +29,3 @@ MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target
-RequiredBy=mark-successful-boot.service

--- a/packages/kubernetes-1.18/kubelet.service
+++ b/packages/kubernetes-1.18/kubelet.service
@@ -29,4 +29,3 @@ MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target
-RequiredBy=mark-successful-boot.service

--- a/packages/kubernetes-1.19/kubelet.service
+++ b/packages/kubernetes-1.19/kubelet.service
@@ -29,4 +29,3 @@ MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target
-RequiredBy=mark-successful-boot.service

--- a/packages/libaudit/audit-rules.service
+++ b/packages/libaudit/audit-rules.service
@@ -12,4 +12,4 @@ ExecStart=/sbin/auditctl -R /usr/share/audit/audit.rules
 ExecStop=-/sbin/auditctl -D
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=preconfigured.target

--- a/packages/os/apiserver.service
+++ b/packages/os/apiserver.service
@@ -9,4 +9,4 @@ ExecStart=/usr/bin/apiserver --datastore-path /var/lib/bottlerocket/datastore/cu
 StandardError=journal+console
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=preconfigured.target

--- a/packages/os/early-boot-config.service
+++ b/packages/os/early-boot-config.service
@@ -1,11 +1,18 @@
 [Unit]
 Description=Bottlerocket userdata configuration system
 # Need network online to talk to IMDS.
-After=network-online.target apiserver.service
-Requires=network-online.target apiserver.service
+After=network-online.target apiserver.service storewolf.service
+# Don't restart the unit if the network goes offline or apiserver restarts
+Wants=apiserver.service network-online.target
+# Don't start the unit if storewolf.service fails
+Requires=storewolf.service
 # We only want to run once, at first boot.  This file is created by early-boot-config
 # after a successful run.
 ConditionPathExists=!/var/lib/bottlerocket/early-boot-config.ran
+# Block manual interactions with this service, since it could leave the system in an
+# unexpected state
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot
@@ -14,4 +21,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=preconfigured.target

--- a/packages/os/host-containers@.service
+++ b/packages/os/host-containers@.service
@@ -7,8 +7,6 @@ Wants=host-containerd.service
 Type=simple
 EnvironmentFile=/etc/host-containers/%i.env
 Environment=LOCAL_DIR=/local
-# Create directories for container persistent storage
-ExecStartPre=/usr/bin/mkdir -m 1777 -p ${LOCAL_DIR}/host-containers/%i
 ExecStart=/usr/bin/host-ctr run \
     --container-id='%i' \
     --source='${CTR_SOURCE}' \

--- a/packages/os/mark-successful-boot.service
+++ b/packages/os/mark-successful-boot.service
@@ -1,15 +1,18 @@
 [Unit]
 Description=Call signpost to mark the boot as successful after all required targets are met.
-After=multi-user.target
-# Each service that must start correctly in order for a boot to be successful should be of type "notify"
-# and include "RequiredBy=mark-successful-boot.service" in its [Install] section.
+# This unit is in charge of updating the partitions on successful boots. Use other service
+# units instead of adding more `ExecStart*` lines to prevent indirect dependencies on
+# other units not listed in the `RequiredBy` section.
+Requires=migrator.service
+# Block manual interactions with this service, manually running it could leave the system in an
+# unexpected state
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
-EnvironmentFile=/etc/network/proxy.env
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/bin/signpost mark-successful-boot
-ExecStartPost=-/usr/bin/metricdog send-boot-success
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=preconfigured.target

--- a/packages/os/migrator.service
+++ b/packages/os/migrator.service
@@ -1,11 +1,18 @@
 [Unit]
 Description=Bottlerocket data store migrator
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/migrator --datastore-path /var/lib/bottlerocket/datastore/current --migration-directory /var/lib/bottlerocket-migrations --root-path /usr/share/updog/root.json --metadata-directory /var/cache/bottlerocket-metadata --migrate-to-version-from-os-release
+ExecStart=/usr/bin/migrator \
+  --datastore-path /var/lib/bottlerocket/datastore/current \
+  --migration-directory /var/lib/bottlerocket-migrations \
+  --root-path /usr/share/updog/root.json \
+  --metadata-directory /var/cache/bottlerocket-metadata \
+  --migrate-to-version-from-os-release
 RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=preconfigured.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -34,6 +34,7 @@ Source107: host-containers@.service
 Source110: mark-successful-boot.service
 Source111: metricdog.service
 Source112: metricdog.timer
+Source113: send-boot-success.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -337,7 +338,7 @@ install -p -m 0644 %{S:5} %{S:6} %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:100} %{S:101} %{S:102} %{S:103} %{S:105} \
-  %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
+  %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} %{S:113}\
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
@@ -440,6 +441,7 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %{_cross_templatedir}/metricdog-toml
 %{_cross_unitdir}/metricdog.service
 %{_cross_unitdir}/metricdog.timer
+%{_cross_unitdir}/send-boot-success.service
 
 %files -n %{_cross_os}logdog
 %{_cross_bindir}/logdog

--- a/packages/os/send-boot-success.service
+++ b/packages/os/send-boot-success.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Send boot success
+# The unit depends on 'configured.target' since Metricdog indirectly
+# depends on the proxy.env file created by settings-applier in the
+# preconfigured target
+After=network-online.target configured.target
+Wants=network-online.target configured.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+EnvironmentFile=/etc/network/proxy.env
+ExecStart=-/usr/bin/metricdog send-boot-success
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/os/settings-applier.service
+++ b/packages/os/settings-applier.service
@@ -1,8 +1,13 @@
 [Unit]
 Description=Applies settings to create config files
 After=storewolf.service sundog.service early-boot-config.service apiserver.service
-Requires=apiserver.service
-Wants=storewolf.service sundog.service early-boot-config.service
+Requires=storewolf.service sundog.service early-boot-config.service
+# We don't want to restart the unit if apiserver restarts
+Wants=apiserver.service
+# Block manual interactions with this service, since it could leave the system in an
+# unexpected state
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot
@@ -12,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=preconfigured.target

--- a/packages/os/storewolf.service
+++ b/packages/os/storewolf.service
@@ -2,6 +2,10 @@
 Description=Datastore creator
 After=migrator.service
 Requires=migrator.service
+# Block manual interactions with this service, since it could leave the system in an
+# unexpected state
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot
@@ -10,4 +14,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=preconfigured.target

--- a/packages/os/sundog.service
+++ b/packages/os/sundog.service
@@ -1,8 +1,14 @@
 [Unit]
 Description=User-specified setting generators
-# Need network access to support commands talking to IMDS.
+# Needs network access to support commands talking to IMDS.
 After=network-online.target apiserver.service early-boot-config.service
-Requires=network-online.target apiserver.service
+Requires=early-boot-config.service
+# We don't want to restart the unit if the network goes offline or apiserver restarts
+Wants=network-online.target apiserver.service
+# Block manual interactions with this service, since it could leave the system in an
+# unexpected state
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot
@@ -13,4 +19,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=preconfigured.target

--- a/packages/release/activate-configured.service
+++ b/packages/release/activate-configured.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Isolates configured.target
+After=preconfigured.target
+Requires=preconfigured.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl set-default configured
+ExecStart=/usr/bin/systemctl isolate default
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/release/activate-multi-user.service
+++ b/packages/release/activate-multi-user.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Isolates multi-user.target
+After=configured.target
+Requires=configured.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl set-default multi-user
+ExecStart=/usr/bin/systemctl isolate default
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+WantedBy=configured.target

--- a/packages/release/configured.target
+++ b/packages/release/configured.target
@@ -1,5 +1,8 @@
 [Unit]
-Description=Bottlerocket user and dynamic configuration complete
-After=settings-applier.service
-Requires=settings-applier.service early-boot-config.service
+Description=Bottlerocket final configuration complete
+After=preconfigured.target
+Requires=preconfigured.target
 AllowIsolate=yes
+
+[Install]
+RequiredBy=multi-user.target

--- a/packages/release/multi-user.target
+++ b/packages/release/multi-user.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Multi-User System
+Documentation=man:systemd.special(7)
+Requires=basic.target configured.target
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target configured.target
+AllowIsolate=yes

--- a/packages/release/preconfigured.target
+++ b/packages/release/preconfigured.target
@@ -1,0 +1,11 @@
+[Unit]
+Description=Bottlerocket initial configuration complete
+AllowIsolate=yes
+After=basic.target
+Requires=basic.target
+# Prevent manually starting/stopping the target
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Install]
+RequiredBy=configured.target multi-user.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -16,7 +16,11 @@ Source200: motd.template
 Source201: proxy-env
 
 Source1000: eth0.xml
+Source1001: multi-user.target
 Source1002: configured.target
+Source1003: preconfigured.target
+Source1004: activate-configured.service
+Source1005: activate-multi-user.service
 
 # Mounts for writable local storage.
 Source1006: prepare-local.service
@@ -108,7 +112,8 @@ EOF
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
-  %{S:1002} %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} %{S:1015} \
+  %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} \
+  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} %{S:1015} \
   %{buildroot}%{_cross_unitdir}
 
 LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/lower)
@@ -129,6 +134,8 @@ install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
 
+ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
+
 %files
 %{_cross_factorydir}%{_cross_sysconfdir}/hosts
 %{_cross_factorydir}%{_cross_sysconfdir}/nsswitch.conf
@@ -138,6 +145,11 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
 %{_cross_libdir}/os-release
 %{_cross_libdir}/systemd/system.conf.d/80-release.conf
 %{_cross_unitdir}/configured.target
+%{_cross_unitdir}/preconfigured.target
+%{_cross_unitdir}/multi-user.target
+%{_cross_unitdir}/default.target
+%{_cross_unitdir}/activate-configured.service
+%{_cross_unitdir}/activate-multi-user.service
 %{_cross_unitdir}/prepare-local.service
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -212,6 +212,13 @@ install -p -m 0644 %{S:3} %{buildroot}%{_cross_libdir}/systemd/journald.conf.d/j
 # with container networking by attempting to manage veth devices.
 rm -f %{buildroot}%{_cross_libdir}/systemd/network/*
 
+# Remove default, multi-user and graphical targets provided by systemd,
+# we override default/multi-user in the release spec and graphical
+# is never used
+rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/default.target
+rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/multi-user.target
+rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
+
 %files
 %license LICENSE.GPL2 LICENSE.LGPL2.1
 %{_cross_attribution_file}


### PR DESCRIPTION
**Issue number:**
#1392

**Description of changes:**

```
packages: change systemd boot sequence
```

The current systemd boot sequence is error prone on isolated scenarios like sending invalid configurations through user data. These scenarios could cause inconsistent states at the end of the boot process, which affect the mechanism to determine if a boot was successful after applying new configurations or updates.

With the current boot sequence, it is difficult to implement features that require a strict services' initialization order (a.k.a run levels).

In order to fix the problems presented above, this commit defines a new boot sequence, with three main systemd targets: preconfigured, configured and multi-user. The "host-containers" crate was modified to enable the host-container service units only when multi-user is the current default target.

The "mark-successful-boot" service unit was moved from the "multi-user" target to the "preconfigured" target, and it only depends on the "migrator" oneshot service unit since it is the only service required (for now) to determine if a boot was successful. The "mark-successful-boot" service unit used to send metrics after it was executed. However, doing so indirectly declared a strong dependency on "settings-applier" since the unit was setup to use the "proxy.env" file. The "metricdog-successful-boot" oneshot service unit was created to remove such dependency from "mark-successful-boot".

#### Preconfigured
This target is used to start the boot process (a.k.a default target), it is based on the "multi-user" target provided by systemd so that other basic systemd units are started during this stage. Failures in the required "oneshot" service units will cause the target to fail, stopping the boot process. The boot is marked as successful during the execution of this target, only if the migrator "oneshot" service exits successfully. Services initialized during this phase include:

* acpid
* chrony
* dbus-broker
* audit-rules
* migrator (required)
* metricdog-successful-boot
* storewolf (required)
* early-boot-config (required)
* sundog (required)
* settings-applier(required)

Once the target is reached (completed), the "activate-configured.service" unit will set the configured target as the default target and start it.

#### Configured
This target should be used to setup additional configurations in the host before services like kubernetes/ecs start. Services initialized during this phase include:

* chronyd
* host-containerd

Once the target is reached (completed) the "activate-multi-user.service" unit will set the multi-user target as the default target, and start it.

#### Multi-user
This is the final target enabled in the boot sequence. Services initialized during this phase include:

* host-containers@*
* docker
* ecs
* kubernetes

**Testing done:**
* `systemctl status` didn't show any failures on successful boots
* Run nginx pod/task/container
* Admin/Control containers were enabled once the `multi-user` target was reached
* Custom host container sent as user data was enabled once  the `multi-user`  target was reached
* Custom host container created after boot was enabled after the new settings were applied

```sh
apiclient set --json \
    '{"host-containers": { "test": { "source": "docker.io/arnaldo2792/blocker:latest", "superpowered": false, "enabled": true}}}'
```

```sh
ps ax -o pid,args | grep host-ctr
479 /usr/bin/host-ctr run --container-id=admin --source=328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.6.0 --superpowered=true
480 /usr/bin/host-ctr run --container-id=control --source=328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.4.2 --superpowered=false
481 /usr/bin/host-ctr run --container-id=custom-at-boot --source=docker.io/arnaldo2792/blocker:latest --superpowered=false
16546 /usr/bin/host-ctr run --container-id=test --source=docker.io/arnaldo2792/blocker:latest --superpowered=false
```
* Failed boot with bad configurations

```toml
[settings.host-containers.admin]
enabled = true

[settings.bad]
bad = "data"
```

```sh
[   11.365797] early-boot-config[366]: Error PATCHing '/settings?tx=bottlerocket-launch': Status 400 when PATCHing /settings?tx=bottlerocket-launch: Json deserialize error: unknown field `bad`, expected one of `source`, `enabled`, `superpowered`, `user-data` at line 1 column 85
[FAILED] Failed to start Bottlerocket userdata configuration system.
See 'systemctl status early-boot-config.service' for details.
[DEPEND] Dependency failed for User-specified setting generators.
[DEPEND] Dependency failed for Applies settings to create config files.
[DEPEND] Dependency failed for Bottlerocket dynamic pre-configuration.
[DEPEND] Dependency failed for Isolates configured.target.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
