### PR TITLE
Add support for qcow2 as an image format.

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -98,6 +98,7 @@ impl VariantBuilder {
             "IMAGE_FORMAT",
             match image_format {
                 Some(ImageFormat::Raw) | None => "raw",
+                Some(ImageFormat::Qcow2) => "qcow2",
                 Some(ImageFormat::Vmdk) => "vmdk",
             },
         );

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -163,6 +163,7 @@ pub(crate) struct BuildVariant {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ImageFormat {
+    Qcow2,
     Raw,
     Vmdk,
 }

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -15,7 +15,7 @@ for opt in "$@"; do
 done
 
 case "${OUTPUT_FMT}" in
-   raw|vmdk) ;;
+   raw|qcow2|vmdk) ;;
    *)
       echo "unexpected image output format '${OUTPUT_FMT}'" >&2
       exit 1
@@ -222,22 +222,20 @@ sgdisk -v "${DATA_IMAGE}"
 if [[ ${OUTPUT_FMT} == "raw" ]]; then
   lz4 -vc "${DISK_IMAGE}" >"${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.img.lz4"
   lz4 -vc "${DATA_IMAGE}" >"${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.img.lz4"
-  chown 1000:1000 "${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.img.lz4" \
-    "${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.img.lz4"
+elif [[ ${OUTPUT_FMT} == "qcow2" ]]; then
+  qemu-img convert -f raw -O qcow2 "${DISK_IMAGE}" "${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.qcow2"
+  qemu-img convert -f raw -O qcow2 "${DATA_IMAGE}" "${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.qcow2"
 elif [[ ${OUTPUT_FMT} == "vmdk" ]]; then
   # Stream optimization is required for creating an Open Virtual Appliance (OVA)
   qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "${DISK_IMAGE}" "${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.vmdk"
   qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "${DATA_IMAGE}" "${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.vmdk"
-  chown 1000:1000 "${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.vmdk" \
-    "${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.vmdk"
 fi
 
 lz4 -9vc "${BOOT_IMAGE}" >"${OUTPUT_DIR}/${BOOT_IMAGE_NAME}"
 lz4 -9vc "${VERITY_IMAGE}" >"${OUTPUT_DIR}/${VERITY_IMAGE_NAME}"
 lz4 -9vc "${ROOT_IMAGE}" >"${OUTPUT_DIR}/${ROOT_IMAGE_NAME}"
-chown 1000:1000 "${OUTPUT_DIR}/${BOOT_IMAGE_NAME}" \
-    "${OUTPUT_DIR}/${VERITY_IMAGE_NAME}" \
-    "${OUTPUT_DIR}/${ROOT_IMAGE_NAME}"
+
+find "${OUTPUT_DIR}" -type f -print -exec chown 1000:1000 {} \;
 
 # Clean up temporary files to reduce size of layer.
 rm -f "${PACKAGE_DIR}"/*.rpm


### PR DESCRIPTION
**Issue number:**

None, should every PR have an associated issue? CONTRIBUTING.md appears ambigious on this point.

**Description of changes:**

Add support for qcow2 as an output format for iamges. qcow2 is pretty common in terms of image formats. Its what OpenStack, KVM, and so on use as their VM image format. This patch adds support
for creating images in that format. 

**Testing done:**

I have verified the output images by booting them on a KVM system.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
