### PR TITLE
ignore more artifacts during builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,7 @@
 /.git
 /.gomodcache
-/build/**/*.img
-/build/**/*.lz4
-/build/**/*.xz
-/build/**/*.tar
-/build/**/*-debuginfo-*.rpm
-/build/**/*-debugsource-*.rpm
+/build/*
+!/build/rpms/*.rpm
+/build/rpms/*-debuginfo-*.rpm
+/build/rpms/*-debugsource-*.rpm
 **/target/*


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
We only need RPMs in the Docker build context, so handle that case more explicitly.


**Testing done:**
`cargo make && cargo make repo && cargo make ami` all still work.

I confirmed that I no longer see `vmdk` and `json` files in the build context.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
