### PR TITLE
Makefile: Build OVA packages and include them in repos

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -116,6 +116,11 @@ PUBLISH_AMI_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH
 BUILDSYS_KMOD_KIT = "${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-kmod-kit-v${BUILDSYS_VERSION_IMAGE}"
 BUILDSYS_KMOD_KIT_PATH="${BUILDSYS_ARCHIVES_DIR}/${BUILDSYS_KMOD_KIT}.tar.xz"
 
+# The name of the OVA bundle that will be built if the current variant builds VMDK artifacts
+BUILDSYS_OVA = "${BUILDSYS_NAME_FULL}.ova"
+BUILDSYS_OVA_PATH="${BUILDSYS_ARCHIVES_DIR}/${BUILDSYS_OVA}"
+BUILDSYS_OVF_TEMPLATE="${BUILDSYS_ROOT_DIR}/variants/${BUILDSYS_VARIANT}/template.ovf"
+
 [tasks.setup]
 script = [
 '''
@@ -351,6 +356,77 @@ cargo build \
   ${CARGO_BUILD_ARGS} \
   ${CARGO_MAKE_CARGO_ARGS} \
   --manifest-path variants/${BUILDSYS_VARIANT}/Cargo.toml
+'''
+]
+
+[tasks.build-ova]
+script_runner = "bash"
+script = [
+'''
+set -e -o pipefail
+
+cleanup() {
+   [ -n "${ova_tmp_dir}" ] && rm -rf "${ova_tmp_dir}"
+}
+trap 'cleanup' EXIT
+
+root_vmdk_path="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.vmdk"
+data_vmdk_path="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-data.vmdk"
+ova_tmp_dir="$(mktemp -d)"
+ovf="${BUILDSYS_NAME_FULL}.ovf"
+manifest="${BUILDSYS_NAME_FULL}.mf"
+
+# Short circuit if neither VMDK images nor an OVF template exist
+if [ ! -s "${BUILDSYS_OVF_TEMPLATE}" ] && \
+   [[ ! -s "${root_vmdk_path}" || ! -s "${data_vmdk_path}" ]]; then
+   echo "No OVF template or VMDK images, skipping OVA build"
+   exit 0
+fi
+
+# Warn the user if VMDK's exist but an OVF template does not.  Assume we do not
+# need to build an OVA in this case
+if [ ! -s "${BUILDSYS_OVF_TEMPLATE}" ] && \
+   [[ -s "${root_vmdk_path}" || -s "${data_vmdk_path}" ]]; then
+   echo "VMDK images exist, but OVF template '${BUILDSYS_OVF_TEMPLATE}' doesn't exist, skipping OVA build"
+   exit 0
+fi
+
+# If an OVF template exists but either of the images do not exist, fail
+if [ -s "${BUILDSYS_OVF_TEMPLATE}" ] && \
+   [[ ! -s "${root_vmdk_path}" || ! -s  "${data_vmdk_path}" ]]; then
+   echo "OVF template exists but VMDK images don't exist for the current version/commit - ${BUILDSYS_VERSION_FULL}. Unable to build an OVA" >&2
+   exit 1
+fi
+
+# Don't build a new OVA if the current one is newer than the images
+if [ -s "${BUILDSYS_OVA_PATH}" ] && \
+   [ "${BUILDSYS_OVA_PATH}" -nt "${root_vmdk_path}" ] && \
+   [ "${BUILDSYS_OVA_PATH}" -nt "${data_vmdk_path}" ]; then
+   echo "Existing OVA ${BUILDSYS_OVA_PATH} is newer than VMDKs for ${BUILDSYS_NAME_FULL}; skipping OVA build."
+   exit 0
+fi
+
+mkdir -p "${BUILDSYS_ARCHIVES_DIR}"
+
+# Create the OVF with the correct values
+sed "${BUILDSYS_OVF_TEMPLATE}" \
+   -e "s/{{ROOT_DISK}}/${root_vmdk_path##*/}/g" \
+   -e "s/{{DATA_DISK}}/${data_vmdk_path##*/}/g" \
+   > "${ova_tmp_dir}/${ovf}"
+
+# Create the manifest file with the SHA's of the VMDK's and the OVF
+root_sha256="$(sha256sum ${root_vmdk_path} | awk '{print $1}')"
+data_sha256="$(sha256sum ${data_vmdk_path} | awk '{print $1}')"
+ovf_sha256="$(sha256sum ${ova_tmp_dir}/${ovf} | awk '{print $1}')"
+echo "SHA256(${root_vmdk_path##*/})= ${root_sha256}" > "${ova_tmp_dir}/${manifest}"
+echo "SHA256(${data_vmdk_path##*/})= ${data_sha256}" >> "${ova_tmp_dir}/${manifest}"
+echo "SHA256(${ovf})= ${ovf_sha256}" >> "${ova_tmp_dir}/${manifest}"
+
+cp "${root_vmdk_path}" "${ova_tmp_dir}"
+cp "${data_vmdk_path}" "${ova_tmp_dir}"
+
+tar -cf "${ova_tmp_dir}/${BUILDSYS_OVA}" -C "${ova_tmp_dir}" "${manifest}" "${ovf}" "${root_vmdk_path##*/}" "${data_vmdk_path##*/}"
+mv "${ova_tmp_dir}/${BUILDSYS_OVA}" "${BUILDSYS_ARCHIVES_DIR}"
 '''
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -345,7 +345,7 @@ docker run --rm \
 ]
 
 [tasks.build-archives]
-dependencies = ["build-kmod-kit"]
+dependencies = ["build-kmod-kit", "build-ova"]
 
 [tasks.build-variant]
 dependencies = ["build-packages"]
@@ -560,6 +560,17 @@ done
 # Include the kmod kit in the repo so it's easier to build out-of-tree kernel
 # modules for a given release.
 LINK_REPO_TARGETS=("--link-target ${BUILDSYS_KMOD_KIT_PATH}")
+
+# Ensure we link an OVA if an OVF template exists (in which case we should have
+# built an OVA)
+if [ -s "${BUILDSYS_OVF_TEMPLATE}" ]; then
+   if [ -s "${BUILDSYS_OVA_PATH}" ]; then
+      LINK_REPO_TARGETS+=("--link-target ${BUILDSYS_OVA_PATH}")
+   else
+      echo "An OVA doesn't exist for the current version/commit - ${BUILDSYS_VERSION_FULL}. An OVA is required to build a repo" >&2
+      exit 1
+   fi
+fi
 
 pubsys \
    --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \

--- a/variants/vmware-dev/template.ovf
+++ b/variants/vmware-dev/template.ovf
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
+  <References>
+    <File ovf:id="file1" ovf:href="{{ROOT_DISK}}"/>
+    <File ovf:id="file2" ovf:href="{{DATA_DISK}}"/>
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks</Info>
+    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk1" ovf:capacity="2147483648" ovf:fileRef="file1"/>
+    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk2" ovf:capacity="21474836480" ovf:fileRef="file2"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>The list of logical networks</Info>
+    <Network ovf:name="VM Network">
+      <Description>The network</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="image">
+    <Info>A Virtual machine</Info>
+    <OperatingSystemSection ovf:id="100" vmw:osType="other4xLinux64Guest">
+      <Info>The operating system installed</Info>
+      <Description>Other 4.x or later Linux (64-bit)</Description>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemType>vmx-14</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>8192MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>8192</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>NVMe Controller</rasd:Description>
+        <rasd:ElementName>NVMe Controller 1</rasd:ElementName>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.nvme.controller</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 1</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>1</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 2</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk2</rasd:HostResource>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>VM Network</rasd:Connection>
+        <rasd:ElementName>Network adapter 1</rasd:ElementName>
+        <rasd:InstanceID>9</rasd:InstanceID>
+        <rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+      </Item>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>


### PR DESCRIPTION
**Issue number:**
Fixes #1415 


**Description of changes:**
```
Makefile: Add `build-ova` target
    
This change adds a new `build-ova` target that will build OVA packages
for variants that build VMDK images.  The OVA packages are named
identically to our images and end up in a new directory `build/ovas`. To
support the building of OVA packages, a new OVF template is included in
`variants/vmware-dev/template.ovf`.  When building an OVA package, the
current values are substituted into the template and it is included in
the final OVA package.
```
```
Makefile: Ensure OVAs are included in repositories

This change updates the `build-archives` target to depend on the `build-ova`
target.  This ensures that OVAs are built if necessary when building new
repos.  If the current variant is `vmware-*`, we ensure that the OVA is
included in the repository, similar to the way we include `kmod_kit`.
```

OVA packages allow for single file Bottlerocket VM deployment.  The OVA includes the disk images for the current Bottlerocket build, an OVF file that defines the makeup of the VM including hardware, and a manifest file that includes the hashes of the previously mentioned artifacts.  

The OVA is named just like our other images, signed and included in the Bottlerocket TUF repo alongside our other artifacts:  `bottlerocket-vmware-dev-x86_64-1.0.7-a5a8edcc.ova`
```
$ ls -lah build/repos/default/bottlerocket-1.0.7-a5a8edcc/targets/
...
<long sha>.bottlerocket-vmware-dev-x86_64-1.0.7-a5a8edcc.ova -> /<my dir>/build/ovas/bottlerocket-vmware-dev-x86_64-1.0.7-a5a8edcc.ova
...
```

**Testing done:**
* Build a `vmware-dev` OVA and run it in VMWare (yay!)
* Build a `vmware-dev` repo and ensure that the OVA is included
* Remove the template from vmware-dev directory, run the `build-ova` target and ensure that we are warned that VMDK artifacts exist but a template does not
* Delete the VMDK artifacts, run the `build-ova` target to ensure it properly exits with an error
* Attempt to build a repo without the `build-archives` dependency (just to make sure this works) and ensure it fails because there is no OVA.
* Run the `build-ova` step multiple times to ensure it doesn't attempt to rebuild an OVA if the current one is newer than the VMDKs
* `touch` the VMDKs, and re-run the `build-ova` step to ensure it rebuilds the OVA
* Build an `aws-k8s-1.18` image and repo, and ensure that OVAs aren't built or included in the repository (also see that a message is logged that we aren't building an OVA because OVF/VMDK doesn't exist)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
