### PR TITLE
Add support for specifying a variant's supported architectures

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -65,6 +65,8 @@ use error::Result;
 
 use serde::Deserialize;
 use snafu::ResultExt;
+use std::collections::HashSet;
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -115,6 +117,12 @@ impl ManifestInfo {
         self.build_variant().and_then(|b| b.image_format.as_ref())
     }
 
+    /// Convenience method to return the supported architectures for this variant.
+    pub(crate) fn supported_arches(&self) -> Option<&HashSet<SupportedArch>> {
+        self.build_variant()
+            .and_then(|b| b.supported_arches.as_ref())
+    }
+
     /// Helper methods to navigate the series of optional struct fields.
     fn build_package(&self) -> Option<&BuildPackage> {
         self.package
@@ -158,6 +166,7 @@ pub(crate) struct BuildPackage {
 pub(crate) struct BuildVariant {
     pub(crate) included_packages: Option<Vec<String>>,
     pub(crate) image_format: Option<ImageFormat>,
+    pub(crate) supported_arches: Option<HashSet<SupportedArch>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -167,10 +176,26 @@ pub(crate) enum ImageFormat {
     Vmdk,
 }
 
+#[derive(Deserialize, Debug, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum SupportedArch {
+    X86_64,
+    Aarch64,
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct ExternalFile {
     pub(crate) path: Option<PathBuf>,
     pub(crate) sha512: String,
     pub(crate) url: String,
+}
+
+impl fmt::Display for SupportedArch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SupportedArch::X86_64 => write!(f, "x86_64"),
+            SupportedArch::Aarch64 => write!(f, "aarch64"),
+        }
+    }
 }

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -9,6 +9,7 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant]
 image-format = "vmdk"
+supported-arches = ["x86_64"]
 included-packages = [
 # core
     "release",


### PR DESCRIPTION
**Issue number:**
Fixes #1404 
Related to #1393 

**Description of changes:**
```
buildsys: Add ability for variants to specify supported architectures

This change adds an additional key that can be specified in a variant's
`Cargo.toml`, `supported-arches`.  It is a list and the supported enum
values are `x86_64` and `aarch64`.  If `supported-arches` is specified,
the current `BUILDSYS_ARCH` is checked against the list.  If
`supported-arches` is not specified, the build continues as before.
```

```
 vmware-dev: Support x86_64 only

This change adds the `supported-arch` key to `vmware-dev`'s `Cargo.toml`
and ensure's the variant will only be built for `x86_64`.
```

**Testing done:**
* Build an `aws-k8s-1.18` image for both `x86_64` and `aarch64`
* Successfully build `vmware-dev` for `x86_64`
* Attempt to build `vmware-dev` for `aarch64` and it correctly fails

```Caused by:
  process didn't exit successfully: `<long path>/bottlerocket/bottlerocket/variants/vmware-dev/target/debug/build/vmware-dev-bce40105c9e5560f/b
...
  --- stderr
  BuildAttempt: Unsupported architecture 'aarch64', check the variant's Cargo.toml for supported architectures
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
