### PR TITLE
host-containers: make host containers inherit proxy env vars

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -33,4 +33,5 @@ version = "1.0.7"
 "(1.0.7, 1.0.8)" = [
     "migrate_v1.0.8_kubelet-eviction-hard.lz4",
     "migrate_v1.0.8_kubelet-unsafe-sysctl-kube-reserved.lz4",
+    "migrate_v1.0.8_proxy-affect-host-containers.lz4",
 ]

--- a/packages/os/host-containers@.service
+++ b/packages/os/host-containers@.service
@@ -5,6 +5,7 @@ Wants=host-containerd.service
 
 [Service]
 Type=simple
+EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/host-containers/%i.env
 Environment=LOCAL_DIR=/local
 # Create directories for container persistent storage

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2399,6 +2399,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxy-affect-host-containers"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "api/migration/migrations/v1.0.6/admin-container-v0-6-0",
     "api/migration/migrations/v1.0.8/kubelet-eviction-hard",
     "api/migration/migrations/v1.0.8/kubelet-unsafe-sysctl-kube-reserved",
+    "api/migration/migrations/v1.0.8/proxy-affect-host-containers",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -87,6 +87,18 @@ pub enum Error {
         setting: String,
         data: Vec<serde_json::Value>,
     },
+
+    #[snafu(display(
+        "Metadata '{}' for setting '{}' contains non-string item: {:?}",
+        metadata,
+        setting,
+        data
+    ))]
+    ReplaceMetadataListContents {
+        setting: String,
+        metadata: String,
+        data: Vec<serde_json::Value>,
+    },
 }
 
 /// Result alias containing our Error type.

--- a/sources/api/migration/migrations/v1.0.8/proxy-affect-host-containers/Cargo.toml
+++ b/sources/api/migration/migrations/v1.0.8/proxy-affect-host-containers/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "proxy-affect-host-containers"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.0.8/proxy-affect-host-containers/src/main.rs
+++ b/sources/api/migration/migrations/v1.0.8/proxy-affect-host-containers/src/main.rs
@@ -1,0 +1,64 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{
+    MetadataListReplacement, ReplaceMetadataListsMigration,
+};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the 'affected-services' list metadata for 'settings.network' to include
+/// host-containers. The metadata list need to be restored to the prior value on downgrade and
+/// updated to include host-containers on upgrades.
+/// We're trying to match old values for different variants.
+fn run() -> Result<()> {
+    migrate(ReplaceMetadataListsMigration(vec![
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &["containerd", "host-containerd"],
+            new_vals: &["containerd", "host-containerd", "host-containers"],
+        },
+        // For K8S variants
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &["containerd", "kubernetes", "host-containerd"],
+            new_vals: &[
+                "containerd",
+                "kubernetes",
+                "host-containerd",
+                "host-containers",
+            ],
+        },
+        // For the aws-ecs-1 variant
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &["containerd", "docker", "ecs", "host-containerd"],
+            new_vals: &[
+                "containerd",
+                "docker",
+                "ecs",
+                "host-containerd",
+                "host-containers",
+            ],
+        },
+        // For aws-dev and vmware-dev variants
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &["containerd", "docker", "host-containerd"],
+            new_vals: &["containerd", "docker", "host-containerd", "host-containers"],
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -74,7 +74,7 @@ path = "/etc/network/proxy.env"
 template-path = "/usr/share/templates/proxy-env"
 
 [metadata.settings.network]
-affected-services = ["containerd", "host-containerd"]
+affected-services = ["containerd", "host-containerd", "host-containers"]
 
 # NTP
 

--- a/sources/models/src/aws-dev/defaults.d/50-aws-dev.toml
+++ b/sources/models/src/aws-dev/defaults.d/50-aws-dev.toml
@@ -14,4 +14,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd"]
+affected-services = ["containerd", "docker", "host-containerd", "host-containers"]

--- a/sources/models/src/aws-ecs-1/defaults.d/50-aws-ecs-1.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/50-aws-ecs-1.toml
@@ -30,4 +30,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "ecs", "host-containerd"]
+affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-containers"]

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -72,4 +72,4 @@ affected-services = ["static-pods"]
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "kubernetes", "host-containerd"]
+affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers"]

--- a/sources/models/src/vmware-dev/defaults.d/50-vmware-dev.toml
+++ b/sources/models/src/vmware-dev/defaults.d/50-vmware-dev.toml
@@ -9,7 +9,7 @@ configuration-files = ["proxy-env"]
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd"]
+affected-services = ["containerd", "docker", "host-containerd", "host-containers"]
 
 # NTP
 # Use a public endpoint, don't assume any local ones.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1424


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Mar 30 14:39:00 2021 -0700

    host-containers: make host containers inherit proxy env vars
    
    host-containers systemd services now reads proxy env vars.
    host-ctr passes the proxy env vars to the host containers.
    host-containers are added to the list of affected services under
    `metadata.settings.network`
```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Apr 1 13:13:16 2021 -0700

    migration-helpers: new ReplaceMetadataListsMigration helper
    
    Adds a new migration helper for migrating setting's metadata list changes

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Apr 1 13:24:39 2021 -0700

    migrations: add migration for list of network proxy affected-services
    
    Adds a new migration for migrating the 'affected-services' list for
    'settings.network' to include 'host-containers' on upgrades and restore
    old list values on downgrade.

```

**Testing done:**
Set up a simple http proxy 
Built AMI, launched instance with userdata specifying my proxy server:
```
[settings.network]
https-proxy="somewhere:9898"
no-proxy = [".local"]
```

Instance came up successfully, was able to ssh to admin container and sudo sheltie:
Both host-containers@control and host-containers@admin services ran fine:

I started an SSM session with the control host container and was able to verify the environment variables were successfully inherited:
```
[ssm-user@ /]$ echo $HTTPS_PROXY 
somewhere:9898
[ssm-user@ /]$ echo $NO_PROXY 
.local,localhost,127.0.0.1,abcdefghijklmnopqrstuv.us-west-2.eks.amazonaws.com,.cluster.local
[ssm-user@ /]$ 
```

- Migration helper: All unit tests pass

- Migration test: Build aws-k8s-1.19 AMI off v1.0.7 release and created a TUF repository with a aws-k8s-1.19 with my changes and migration with release version set to v1.0.8.

Launched v1.0.7 aws-k8s-1.19.
Forward migration (after updating to v1.0.8):
```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/network.affected-services 
["containerd","kubernetes","host-containerd","host-containers"]
```
Backwards migration (after downgrading to v1.0.7):
```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/network.affected-services 
["containerd","kubernetes","host-containerd"]
```



**Note that the default admin container's entry point is [`start_admin_sshd.sh`](https://github.com/bottlerocket-os/bottlerocket-admin-container/blob/79a71586e0d56c9bab07d4b0830d5ee3766ed228/start_admin_sshd.sh)  and at the end of the script it execs the sshd daemon and proxy environment variables won't be present in the sshd spawned shells**
This is being addressed in https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/24

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
