### PR TITLE
host-containers@: limit host container restarts

### DIFF
--- a/packages/os/host-containers@.service
+++ b/packages/os/host-containers@.service
@@ -2,6 +2,8 @@
 Description=Host container: %i
 After=host-containerd.service
 Wants=host-containerd.service
+StartLimitBurst=5
+StartLimitIntervalSec=300s
 
 [Service]
 Type=simple


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1430


**Description of changes:**

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Mar 30 17:02:56 2021 -0700

    host-containers@: limit host container restarts
    
    If a host container fails to start more than 5 times in a 5 minute interval, 
    the unit will no longer be restarted.
    
    This way if the container is exiting quickly after each restart due to some
    persistent error, we don't restart indefinitely.
    
    Currently there is a 45 seconds delay between restarts. So if the container
    exits within 15 seconds of it restarting 5 times in a row, we'll stop trying
    to restart the service.
    
    For other transient errors such as image pull errors (maybe the registry is
    down for a few hours), the service should be allowed to restart until the
    error is resolved. (host-ctr has expotential backoff implemented for
    image pulls that maxes out after ~45 seconds of retries, so it'll never
    exceed the restart burst limit)
    
    Once the host-container unit enters a state where it no longer
    automatically restarts, the user can still manually restart the unit
    (through enabling and disabling the host-container via settings) and thus
    restarting the restart cycle.

```


**Testing done:**
Built AMI, launched instance. Both control and admin containers start up fine.

Set the control container source to gibberish and cycled the host container via settings.
```
bash-5.0# apiclient set settings.host-containers.control.source="gibberish"
bash-5.0# apiclient set settings.host-containers.control.enabled=false     
bash-5.0# apiclient set settings.host-containers.control.enabled=true 
```
Saw the container restart continuously, never triggering the restart burst limit as expected.
```
bash-5.0# systemctl show host-containers@control -p NRestarts
NRestarts=6

bash-5.0# systemctl status host-containers@control           
● host-containers@control.service - Host container: control
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/host-containers@.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2021-03-31 01:44:33 UTC; 13s ago
    Process: 10042 ExecStartPre=/usr/bin/mkdir -m 1777 -p ${LOCAL_DIR}/host-containers/control (code=exited, status=0/SUCCESS)
   Main PID: 10063 (host-ctr)
      Tasks: 8 (limit: 9185)
     Memory: 12.5M
     CGroup: /system.slice/system-host\x2dcontainers.slice/host-containers@control.service
             └─10063 /usr/bin/host-ctr run --container-id=control --source=gibberish --superpowered=false

Mar 31 01:44:33 ip-192-168-20-141.us-west-2.compute.internal systemd[1]: Starting Host container: control...
Mar 31 01:44:33 ip-192-168-20-141.us-west-2.compute.internal systemd[1]: Started Host container: control.
Mar 31 01:44:33 ip-192-168-20-141.us-west-2.compute.internal host-ctr[10063]: time="2021-03-31T01:44:33Z" level=warning msg="failed to pull image. waiting 6.094s before retrying..." error="failed to resolve reference \"gibberish\": object required"
Mar 31 01:44:39 ip-192-168-20-141.us-west-2.compute.internal host-ctr[10063]: time="2021-03-31T01:44:39Z" level=warning msg="failed to pull image. waiting 5.936s before retrying..." error="failed to resolve reference \"gibberish\": object required"
Mar 31 01:44:45 ip-192-168-20-141.us-west-2.compute.internal host-ctr[10063]: time="2021-03-31T01:44:45Z" level=warning msg="failed to pull image. waiting 7.98s before retrying..." error="failed to resolve reference \"gibberish\": object required"

```

Then to simulate fast failing control containers. I just kept killing the control container from the admin container every time it restarted. A lot of spamming `kill -9` later, I was able to get the control container to stay failed after 5 times.
```
bash-5.0# systemctl status host-containers@control
● host-containers@control.service - Host container: control
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/host-containers@.service; enabled; vendor preset: enabled)
     Active: failed (Result: signal) since Wed 2021-03-31 03:12:50 UTC; 34s ago
    Process: 28806 ExecStartPre=/usr/bin/mkdir -m 1777 -p ${LOCAL_DIR}/host-containers/control (code=exited, status=0/SUCCESS)
    Process: 28807 ExecStart=/usr/bin/host-ctr run --container-id=control --source=${CTR_SOURCE} --superpowered=${CTR_SUPERPOWERED} (code=killed, signal=KILL)
   Main PID: 28807 (code=killed, signal=KILL)

Mar 31 03:12:50 ip-192-168-6-81.us-west-2.compute.internal systemd[1]: host-containers@control.service: Scheduled restart job, restart counter is at 5.
Mar 31 03:12:50 ip-192-168-6-81.us-west-2.compute.internal systemd[1]: Stopped Host container: control.
Mar 31 03:12:50 ip-192-168-6-81.us-west-2.compute.internal systemd[1]: host-containers@control.service: Start request repeated too quickly.
Mar 31 03:12:50 ip-192-168-6-81.us-west-2.compute.internal systemd[1]: host-containers@control.service: Failed with result 'signal'.
Mar 31 03:12:50 ip-192-168-6-81.us-west-2.compute.internal systemd[1]: Failed to start Host container: control.

bash-5.0# systemctl show host-containers@control -p NRestarts
NRestarts=5
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
