### PR TITLE
fix avc denial for dbus-broker

### DIFF
--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bus1/dbus-broker/releases/download/v27/dbus-broker-27.tar.xz"
-sha512 = "d3964cd7bc5553924f5786fe1a7f43c4298fa661aa6cde79e98d2aee67ee3e17eb5c689d39228efad905af59296a6ae52485c61d564bb0a35c937573323ea1fb"
+url = "https://github.com/bus1/dbus-broker/releases/download/v28/dbus-broker-28.tar.xz"
+sha512 = "81a05a3ad2fbc0292a7de0cc719c5946e2d70d0bf91abb2eb9764fdef738a460a0cc988e050d0985ff45009a51677df3f619f4e17c8712df34c85e84826efbee"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}dbus-broker
-Version: 27
+Version: 28
 Release: 1%{?dist}
 Summary: D-BUS message broker
 License: Apache-2.0

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -220,8 +220,10 @@
 (allow trusted_s global (systems (manage)))
 
 ; dbus-broker implements DBUS and uses SELinux for access control.
+; It also queries systemd for job status.
 (allow bus_t global (dbus (all)))
 (allow bus_t global (security (compute_av)))
+(allow bus_t init_t (system (status)))
 
 ; wicked needs DBUS for IPC.
 (allow network_t bus_t (dbus (all)))


### PR DESCRIPTION
**Issue number:**
Fixes #1364.


**Description of changes:**
Allows `dbus-broker` to query `systemd` for job status.


**Testing done:**
Built `aws-dev` and ran it under KVM, no AVC denials logged.

Built `aws-k8s-1.18` and it joined a cluster, brought up pods, no AVC denials logged.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
