### PR TITLE
shibaken: switch outputted JSON keys from snake_case to kebab-case

### DIFF
--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -32,6 +32,7 @@ struct UserData {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
 struct Ssh {
     authorized_keys: Vec<String>,
 }


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This renames the `snake_case` in the `Ssh` struct to `kebab-case` when serializing the user data JSON.
This effectively replaces `authorized_keys` with `authorized-keys` which is more in line with Bottlerocket's current API standards.

This change is dependent on [bottlerocket-os/bottlerocket-admin-container/pull/26](https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/26)

**Testing done:**

- Launched `aws-ecs-1` instance.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Switched the admin container source to point to a [patched admin container](https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/26).
- Enabled and launched admin container.
- Connected to admin container via ssh.
- Verified that `/.bottlerocket/host-containers/current/user-data` contained the expected JSON:
```
{
   "ssh":{
      "authorized-keys":[
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQClKsfkNkuSevGj3eYhCe53pcjqP3maAhDFcvBS7O6V
          hz2ItxCih+PnDSUaw+WNQn/mZphTk/a/gU8jEzoOWbkM4yxyb/wB96xbiFveSFJuOp/d6RJhJOI0iBXr
          lsLnBItntckiJ7FbtxJMXLvvwJryDUilBMTjYtwB+QhYXUMOzce5Pjz5/i8SeJtjnV3iAoG/cQk+0FzZ
          qaeJAAHco+CY/5WrUBkrHmFJr6HcXkvJdWPkYQS3xqC0+FmUZofz221CBt5IMucxXPkX4rWi+z7wB3Rb
          BQoQzd8v7yeb7OzlPnWOyN0qFU0XA246RA8QFYiCNYwI3f05p6KLxEXAMPLE my-key-pair"
      ]
   }
}
```
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
