### PR TITLE
models README: fix broken links for symlink'd files

### DIFF
--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -29,23 +29,23 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 
 ### aws-k8s-1.16: Kubernetes 1.16
 
-* [Model](src/aws-k8s-1.16/mod.rs)
-* [Default settings](src/aws-k8s-1.16/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ### aws-k8s-1.17: Kubernetes 1.17
 
-* [Model](src/aws-k8s-1.17/mod.rs)
-* [Default settings](src/aws-k8s-1.17/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ### aws-k8s-1.18: Kubernetes 1.18
 
-* [Model](src/aws-k8s-1.18/mod.rs)
-* [Default settings](src/aws-k8s-1.18/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ### aws-k8s-1.19: Kubernetes 1.19
 
-* [Model](src/aws-k8s-1.19/mod.rs)
-* [Default settings](src/aws-k8s-1.19/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ### aws-ecs-1: Amazon ECS
 

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -26,23 +26,23 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 
 ## aws-k8s-1.16: Kubernetes 1.16
 
-* [Model](src/aws-k8s-1.16/mod.rs)
-* [Default settings](src/aws-k8s-1.16/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ## aws-k8s-1.17: Kubernetes 1.17
 
-* [Model](src/aws-k8s-1.17/mod.rs)
-* [Default settings](src/aws-k8s-1.17/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ## aws-k8s-1.18: Kubernetes 1.18
 
-* [Model](src/aws-k8s-1.18/mod.rs)
-* [Default settings](src/aws-k8s-1.18/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ## aws-k8s-1.19: Kubernetes 1.19
 
-* [Model](src/aws-k8s-1.19/mod.rs)
-* [Default settings](src/aws-k8s-1.19/defaults.d/)
+* [Model](src/aws-k8s-1.15/mod.rs)
+* [Default settings](src/aws-k8s-1.15/defaults.d/)
 
 ## aws-ecs-1: Amazon ECS
 


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Apr 2 15:41:58 2021 -0700

    models README: fix broken links for symlink'd files
    
    The links for all the aws-k8s-* variants don't work when accessing them
    on github since we can't follow symlinks in that context.
    
    Since all aws-k8s-* variants currently use the same model and default
    values, let's link directly to the source of all the symlinks.

```


**Testing done:**

Links are no longer broken when accessing them on github.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
