### PR TITLE
Package updates

### DIFF
--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/cni/archive/v0.8.0/cni-0.8.0.tar.gz"
-sha512 = "2b0baa5be5a8b4b886c821fb03d8a186b30afd1165d6c9ea6b876a0e93a5f54375ea5cf774dbdfcc648bab05ca368add59cea2c0e1c7a7f4f4bbb9634fed6280"
+url = "https://github.com/containernetworking/cni/archive/v0.8.1/cni-0.8.1.tar.gz"
+sha512 = "b869e76806c6e259743715831ddf5754a56e79fa7f25435e54e3f0648700e473e5778630e592f5c5d181058e74c7542aeac5c4f3d8cd26b83f7758bb186f43e9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -2,7 +2,7 @@
 %global gorepo cni
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.8.0
+%global gover 0.8.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.1/e2fsprogs-1.46.1.tar.xz"
-sha512 = "fe6aa55b62f183633872209cd69cf6be0753d5a430542a7c73dbbd428e5fa93b5df7efa7507bb60f9f90a1c61cb8f5cf10665675eea8bd72aad3d04dd2dae15c"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.2/e2fsprogs-1.46.2.tar.xz"
+sha512 = "5297a4d7bf944806d8ee77227eac596b5e5efed2c665561d40094c40b9f321616c60975a2716f1499a9f72243df6e3b6e2267b98ec1fdc1dfd646d7be887fc4d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}e2fsprogs
-Version: 1.46.1
+Version: 1.46.2
 Release: 1%{?dist}
 Summary: Tools for managing ext2, ext3, and ext4 file systems
 License: GPL-2.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND BSD-3-Clause

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -10,8 +10,8 @@ path = "pkg.rs"
 
 # ECS agent
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.50.2/amazon-ecs-agent-v1.50.2.tar.gz"
-sha512 = "5bc946a529c2678b0cd45c3be556b116c26f6d3a3fe3f1cd598cf4fc09eaa8de1ed514bbf62b78892339980b647be49b5152508219181fe567b01152d230db31"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.51.0/amazon-ecs-agent-v1.51.0.tar.gz"
+sha512 = "355c6ddc157266e13dfd4665670612cd2983bcdaa7598c12203361ff7987937a18b4c4448a0e94dfa7bfe3a4f4699bc5b8c8dcb22da1c18f6f0f7be86c4a6dae"
 
 # TODO: Package the CNI plugins
 # The ECS agent repository includes two CNI plugins as git submodules.  git

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,9 +2,9 @@
 %global gorepo amazon-ecs-agent
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.50.2
+%global gover 1.51.0
 # git rev-parse --short=8
-%global gitrev 5be7aa08
+%global gitrev 5c821610
 
 # Construct reproducible tar archives
 # See https://reproducible-builds.org/docs/archives/

--- a/packages/kernel/Cargo.toml
+++ b/packages/kernel/Cargo.toml
@@ -10,5 +10,5 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/cf12975d70edce3beb7042007609dc355b47ce27babb08b436829f7500de6b76/kernel-5.4.95-42.163.amzn2.src.rpm"
-sha512 = "4dcfb86a2664edd9cf08d1f32b388ec6b9874ae62a21fc655aa80599270af5fdf15ff1f4dc250e36e7559a1c8a08901e428823d7c3e212cf13bada298fdf4dbd"
+url = "https://cdn.amazonlinux.com/blobstore/c9c16a56ef978680bd95df30d81add144807ffe0c43def257038586bb6b52388/kernel-5.4.105-48.177.amzn2.src.rpm"
+sha512 = "ef506706434bc94df6e845e5262c8d022ebb91ff6bc6a71ac656851c0de66d81392acedb9be39b2be4724f106df21d3b58de71387410e103e4b05a48fa955059"

--- a/packages/kernel/kernel.spec
+++ b/packages/kernel/kernel.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel
-Version: 5.4.95
+Version: 5.4.105
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/cf12975d70edce3beb7042007609dc355b47ce27babb08b436829f7500de6b76/kernel-5.4.95-42.163.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/c9c16a56ef978680bd95df30d81add144807ffe0c43def257038586bb6b52388/kernel-5.4.105-48.177.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.18"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.18.16/kubernetes-1.18.16.tar.gz"
-sha512 = "f525577f0e55736c6702663c9de9a54e7ece5701f334948ec56b2d0d5041e54b5fdc440dfbfede5e886c2b30c2223eba4d2da7131e58c48043cfa75513f7f59f"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.18.17/kubernetes-1.18.17.tar.gz"
+sha512 = "5d8ae2fb8a962b8a09b58667d57114a4c75c2b7ae75c9ba0f8b68fccd0f58a3cdb44288a71fbd2f528fe93e280c6b95ea57fe0bbf1b2203aec9fd39fc7fd3f79"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.18.16
+%global gover 1.18.17
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.19"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.19.8/kubernetes-1.19.8.tar.gz"
-sha512 = "0cefbe0cd29ee3916867549f2aa2a4eb60f87c9fc0fa4bae3748cc4eadd76685f868a9e30a50af092f55c0942bbd5e30648021ec0781afdcdd5f8d4014724c64"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.19.9/kubernetes-1.19.9.tar.gz"
+sha512 = "0aa01de3cf3e7d1b000a422768cc665a0b58eac10045629c5eabae6688a47d19ef36b98f6d1719263b3c9877808f0f13f43cd764f691849bda385f4f96ea92d1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.19.8
+%global gover 1.19.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/libattr/Cargo.toml
+++ b/packages/libattr/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download-mirror.savannah.gnu.org/releases/attr/attr-2.4.48.tar.gz"
-sha512 = "75f870a0e6e19b8975f3fdceee786fbaff3eadaa9ab9af01996ffa8e50fe5b2bba6e4c22c44a6722d11b55feb9e89895d0151d6811c1d2b475ef4ed145f0c923"
+url = "https://download-mirror.savannah.gnu.org/releases/attr/attr-2.5.1.tar.xz"
+sha512 = "9e5555260189bb6ef2440c76700ebb813ff70582eb63d446823874977307d13dfa3a347dfae619f8866943dfa4b24ccf67dadd7e3ea2637239fdb219be5d2932"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libattr/libattr.spec
+++ b/packages/libattr/libattr.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}libattr
-Version: 2.4.48
+Version: 2.5.1
 Release: 1%{?dist}
 Summary: Library for extended attribute support
 License: LGPL-2.1-or-later
 URL: https://savannah.nongnu.org/projects/attr
-Source0: https://download-mirror.savannah.gnu.org/releases/attr/attr-%{version}.tar.gz
+Source0: https://download-mirror.savannah.gnu.org/releases/attr/attr-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
 
 %description

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.48.tar.gz"
-sha512 = "90ac6e46531e4893b78b14171537c6dfd06cf617af9e90f38ea0ce4b50161451528aefff41dbe983719e76582cf39f8d7d432f99756e976f62403d5bc3c209c8"
+url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.49.tar.gz"
+sha512 = "0f0bcf1e52cb9c326634bb804b79c5f1bd82c043b0ed1d59ab6e22e0b33380d28f717c4b7ec7e0f53c02041676f48a926e510c7a22b8a1961723ba3de22792a5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.48
+Version: 2.49
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -9,9 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-path = "expat-2.2.10.tar.gz"
-url = "https://github.com/libexpat/libexpat/archive/R_2_2_10.tar.gz#/expat-2.2.10.tar.gz"
-sha512 = "5f2d00ead20139aae89910cc08246cf15f7562af2a4fe1b37ebe4c1500a71d9f0a655ebc43f10164ac846be3186ff43f2b94287b18d2a3af882cbd0a1de41a36"
+url = "https://github.com/libexpat/libexpat/releases/download/R_2_3_0/expat-2.3.0.tar.xz"
+sha512 = "dde8a9a094b18d795a0e86ca4aa68488b352dc67019e0d669e8b910ed149628de4c2a49bc3a5b832f624319336a01f9e4debe03433a43e1c420f36356d886820"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -1,4 +1,4 @@
-%global unversion 2_2_10
+%global unversion 2_3_0
 
 Name: %{_cross_os}libexpat
 Version: %(echo %{unversion} | sed 's/_/./g')
@@ -6,7 +6,7 @@ Release: 1%{?dist}
 Summary: Library for XML parsing
 License: MIT
 URL: https://libexpat.github.io/
-Source0: https://github.com/libexpat/libexpat/archive/R_%{unversion}.tar.gz#/expat-%{version}.tar.gz
+Source0: https://github.com/libexpat/libexpat/releases/download/R_%{unversion}/expat-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
 
 %description
@@ -20,8 +20,7 @@ Requires: %{name}
 %{summary}.
 
 %prep
-%autosetup -n libexpat-R_%{unversion}/expat -p1
-./buildconf.sh
+%autosetup -n expat-%{version} -p1
 
 %build
 %cross_configure \
@@ -45,5 +44,6 @@ Requires: %{name}
 %{_cross_includedir}/*.h
 %{_cross_pkgconfigdir}/*.pc
 %exclude %{_cross_libdir}/*.la
+%exclude %{_cross_libdir}/cmake
 
 %changelog

--- a/packages/libselinux/Cargo.toml
+++ b/packages/libselinux/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/libselinux-3.1.tar.gz"
-sha512 = "57730cddd2d4751556d9e1f207c0f85119c81848f0620c16239e997150989e3f9a586a8c23861fd51ed89f7e084ad441190a58a288258a49a95f7beef7dbbb13"
+url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/libselinux-3.2.tar.gz"
+sha512 = "18129ac0b9936e1f66021f1b311cf1c1e27a01e50cb70f08a3e1c642c5251e4538aec25a8427778569dfecf5333cf1fb84f1a59afdce8019328d0cff7e5833c5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libselinux/libselinux.spec
+++ b/packages/libselinux/libselinux.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}libselinux
-Version: 3.1
+Version: 3.2
 Release: 1%{?dist}
 Summary: Library for SELinux
 License: LicenseRef-SELinux-PD
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/libselinux-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/%{version}/libselinux-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libpcre-devel
 BuildRequires: %{_cross_os}libsepol-devel

--- a/packages/libsemanage/Cargo.toml
+++ b/packages/libsemanage/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/libsemanage-3.1.tar.gz"
-sha512 = "8609ca7d13b5c603677740f2b14558fea3922624af182d20d618237ba11fcf2559fab82fc68d1efa6ff118f064d426f005138521652c761de92cd66150102197"
+url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/libsemanage-3.2.tar.gz"
+sha512 = "6ad670bb298b1bab506217b12a3fda5d2209f4387a11410f0c1b65f765ffb579b0d70795dee19048909e0b72ef904fc318be60d5a01f80ab12742ce07647a084"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libsemanage/libsemanage.spec
+++ b/packages/libsemanage/libsemanage.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}libsemanage
-Version: 3.1
+Version: 3.2
 Release: 1%{?dist}
 Summary: Library for SELinux binary policy manipulation
 License: LGPL-2.1-or-later
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/libsemanage-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/%{version}/libsemanage-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libaudit-devel
 BuildRequires: %{_cross_os}libbzip2-devel

--- a/packages/libsepol/Cargo.toml
+++ b/packages/libsepol/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/libsepol-3.1.tar.gz"
-sha512 = "4b5f4e82853ff3e9b4fac2dbdea5c2fc3bb7b508af912217ac4b75da6540fbcd77aa314ab95cd9dfa94fbc4a885000656a663c1a152f65b4cf6970ea0b6034ab"
+url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/libsepol-3.2.tar.gz"
+sha512 = "1a6b3489ff766958a4b444b9be63a794267243aed303d3e7d87278f11be492dbf603a0c8181c4c5e01cb0e1ceb43810a77f738f0b9bd1d7d2be67053f9c67a6f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libsepol/libsepol.spec
+++ b/packages/libsepol/libsepol.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}libsepol
-Version: 3.1
+Version: 3.2
 Release: 1%{?dist}
 Summary: Library for SELinux policy manipulation
 License: LGPL-2.1-or-later
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/libsepol-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/%{version}/libsepol-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 
 %description

--- a/packages/policycoreutils/Cargo.toml
+++ b/packages/policycoreutils/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/SELinuxProject/selinux/releases/download/20200710/policycoreutils-3.1.tar.gz"
-sha512 = "0592f218563a99ba95d2cfd07fdc3761b61c1cc3c01a17ab89ad840169e1a7d4083521d5cacc72d1b76911d516bf592db7a3f90d9ef0cc11ceed007e4580e140"
+url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/policycoreutils-3.2.tar.gz"
+sha512 = "d16781d2d61b8b78d6fc242f2b5c3a03f47ea524fb61655823b6b0f0327ff376c65fe7bdf7a53f5863c01e599cf4a7050f21fda0fe6a8f2c2c16f89b156a4346"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/policycoreutils/policycoreutils.spec
+++ b/packages/policycoreutils/policycoreutils.spec
@@ -1,10 +1,10 @@
 Name: %{_cross_os}policycoreutils
-Version: 3.1
+Version: 3.2
 Release: 1%{?dist}
 Summary: A set of SELinux policy tools
 License: GPL-2.0-only
 URL: https://github.com/SELinuxProject/
-Source0: https://github.com/SELinuxProject/selinux/releases/download/20200710/policycoreutils-%{version}.tar.gz
+Source0: https://github.com/SELinuxProject/selinux/releases/download/%{version}/policycoreutils-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libselinux-devel
 BuildRequires: %{_cross_os}libsemanage-devel
@@ -40,13 +40,15 @@ done
 for dir in load_policy semodule sestatus setfiles ; do
   %make_install -C ${dir}
 done
+# remove unneeded compatibility symlink
+rm %{buildroot}%{_cross_sbindir}/sestatus
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_sbindir}/load_policy
 %{_cross_sbindir}/semodule
-%{_cross_sbindir}/sestatus
+%{_cross_bindir}/sestatus
 %{_cross_sbindir}/setfiles
 %exclude %{_cross_sbindir}/genhomedircon
 %exclude %{_cross_sbindir}/restorecon

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd-stable/archive/v247.4/systemd-stable-247.4.tar.gz"
-sha512 = "a35dd12646b6b4dc6f7b1dee3bf7ad797e80859b78a7f1b244411270f6d7727498b54b8b5a1bce6d767830a874c8b3af871a5c78d0a17f90470fa19db7b2b81d"
+url = "https://github.com/systemd/systemd-stable/archive/v247.6/systemd-stable-247.6.tar.gz"
+sha512 = "54e6d95dba615cd221ad588ff46a98801fc44f73f7c61c3716cec54c9dec45a0b56d5482a6ca4ca7fe957dcdbf1b96a150ff86ea42ced7691ed71404543ead31"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,7 +2,7 @@
 %global _cross_allow_rpath 1
 
 Name: %{_cross_os}systemd
-Version: 247.4
+Version: 247.6
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later

--- a/packages/wicked/Cargo.toml
+++ b/packages/wicked/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/openSUSE/wicked/archive/version-0.6.64.tar.gz"
-sha512 = "5f0ef9831cba74b06f660a086c92e7c93c756fce9e402fc011bc14f2e29cb5be2ae1793844b7a1e89f3d423e10cdbe579f7fc73a02ad62cbe5ed49a0eef4b648"
+url = "https://github.com/openSUSE/wicked/archive/version-0.6.65.tar.gz"
+sha512 = "e0a1668bb0e841cb034ddcb46609af708b6c279d089c7b78ec881f189faf690f4b069defc057efc99a6a5b78c57a7a56093dffb90b43ac4806970437102d61f3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -11,7 +11,7 @@
 %bcond_with bootstrap # without
 
 Name: %{_cross_os}wicked
-Version: 0.6.64
+Version: 0.6.65
 Release: 1%{?dist}
 Summary: Network configuration infrastructure
 License: GPL-2.0-or-later AND (GPL-2.0-only OR BSD-3-Clause)


### PR DESCRIPTION
**Description of changes:**

```
2034210b Update cni to 0.8.1
563af8e5 Update e2fsprogs to 1.46.2
af0f8eed Update ecs-agent to 1.51.0
c44642de Update kernel to 5.4.105
bd552753 Update kubernetes-1.18 to 1.18.17
e86b79a5 Update kubernetes-1.19 to 1.19.9
3faae4f5 Update libattr to 2.5.1
141354a2 Update libcap to 2.49
1218d9d5 Update libexpat to 2.3.0
b78af2f0 Update libselinux to 3.2
27bb3bb9 Update libsemanage to 3.2
25295b36 Update libsepol to 3.2
266b4184 Update policycoreutils to 3.2
91f119e3 Update systemd to 247.6
dc7f1eb3 Update wicked to 0.6.65
```

Not updated: [libxcrypt](https://github.com/bottlerocket-os/bottlerocket-sdk/issues/47)

**Testing done:**

* Compared console output before and after - some minor changes from #1423 but nothing scary.  Saw the isolate sequence.
* No SELinux errors / AVC denials.
* sestatus still works fine.  (It moved.)
* Compared kubelet 1.19 logs - output is less consistent and harder to compare, but (expected) errors are the same, and nothing new looked bad.
* Compared kubelet 1.18 logs - same.
* Ran pod on 1.19 OK.
* Ran pod on 1.18 OK.
* Compared ecs-agent log before and after - just version and IDs different, looks good.
* Ran an ECS task OK.
* aws-dev variant OK, ran a docker container.
* aarch64 build of aws-k8s-1.19 is OK too.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
