### PR TITLE
Revert "kubelet: use static CPU manager policy by default"

### DIFF
--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -42,7 +42,6 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
-cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -42,7 +42,6 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
-cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -42,7 +42,6 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
-cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -42,7 +42,6 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
-cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -42,7 +42,6 @@ kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
-cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd


### PR DESCRIPTION
This reverts commit 227640c932be71436e661fdf11c68ed4891bbccc.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Revert this change since it triggers failed to start kubelet during migration.

error
```
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal kubelet[3496]: I0407 19:44:44.416175    3496 state_mem.go:36] [cpumanager] initializing new in-memory state store
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal kubelet[3496]: E0407 19:44:44.417137    3496 container_manager_linux.go:329] failed to initialize cpu manager: could not initialize checkpoint manager: could not restore state from checkpoint: configured policy "static" differs from state checkpoint policy "none"
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal kubelet[3496]: Please drain this node and delete the CPU manager checkpoint file "/var/lib/kubelet/cpu_manager_state" before restarting Kubelet.
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal kubelet[3496]: F0407 19:44:44.417153    3496 server.go:273] failed to run Kubelet: could not initialize checkpoint manager: could not restore state from checkpoint: configured policy "static" differs from state checkpoint policy "none"
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal kubelet[3496]: Please drain this node and delete the CPU manager checkpoint file "/var/lib/kubelet/cpu_manager_state" before restarting Kubelet.
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal systemd[1]: kubelet.service: Main process exited, code=exited, status=255/EXCEPTION
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal systemd[1]: kubelet.service: Failed with result 'exit-code'.
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal systemd[1]: Failed to start Kubelet.
Apr 07 19:44:44 ip-192-168-85-94.us-west-2.compute.internal systemd[1]: Reached target Multi-User System.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
