### PR TITLE
Update default host containers

### DIFF
--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.6.0"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.0"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.4.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.0"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates the default control container from v0.4.2 to v0.5.0
and the default admin container from v0.6.0. to v0.7.0.

**Testing done:**

- [x] Built `aws-ecs-1` ami based on the latest `develop`.
- [x] Connected to control container via SSM.
- [x] Checked api settings and verified containers were at the proper versions.
- [x] Enabled the admin container and ssh'd to it.
- [x] Verified that I was able to log in.
- [x] Checked EC2 console for any errors

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
