### PR TITLE
Include source of invalid base64 data in error messages

### DIFF
--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -285,7 +285,8 @@ where
     // If user data was specified, decode it and write it out
     if let Some(user_data) = &container_details.user_data {
         debug!("Decoding user data for container '{}'", name);
-        let decoded_bytes = base64::decode(user_data.as_bytes()).context(error::Base64Decode)?;
+        let decoded_bytes =
+            base64::decode(user_data.as_bytes()).context(error::Base64Decode { name })?;
 
         let path = dir.join("user-data");
         debug!("Storing user data in {}", path.display());
@@ -606,8 +607,13 @@ mod error {
             source: apiclient::Error,
         },
 
-        #[snafu(display("Unable to base64 decode user-data: '{}'", source))]
+        #[snafu(display(
+            "Unable to decode base64 in user data of bootstrap container '{}': '{}'",
+            name,
+            source
+        ))]
         Base64Decode {
+            name: String,
             source: base64::DecodeError,
         },
 

--- a/sources/api/early-boot-config/src/provider/vmware.rs
+++ b/sources/api/early-boot-config/src/provider/vmware.rs
@@ -128,7 +128,7 @@ impl VmwareDataProvider {
 
         // Base64 decode the &str
         let decoded_bytes = base64::decode(&base64_str).context(error::Base64Decode {
-            base64_string: base64_str.to_string(),
+            what: "OVF user data",
         })?;
 
         // Decompress the data if it's compressed
@@ -312,9 +312,9 @@ mod error {
             source: vmw_backdoor::VmwError,
         },
 
-        #[snafu(display("Unable to base64 decode string '{}': '{}'", base64_string, source))]
+        #[snafu(display("Unable to decode base64 in {}: '{}'", what, source))]
         Base64Decode {
-            base64_string: String,
+            what: String,
             source: base64::DecodeError,
         },
 

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -105,9 +105,9 @@ mod error {
         #[snafu(display("Logger setup error: {}", source))]
         Logger { source: log::SetLoggerError },
 
-        #[snafu(display("Unable to base64 decode user-data '{}': '{}'", base64_string, source))]
+        #[snafu(display("Unable to base64 decode user-data for container '{}': '{}'", name, source))]
         Base64Decode {
-            base64_string: String,
+            name: String,
             source: base64::DecodeError,
         },
 
@@ -383,9 +383,7 @@ where
 
     // If user data was specified, unencode it and write it out before we start the container.
     if let Some(user_data) = &image_details.user_data {
-        let decoded_bytes = base64::decode(user_data.as_bytes()).context(error::Base64Decode {
-            base64_string: user_data.as_ref(),
-        })?;
+        let decoded_bytes = base64::decode(user_data.as_bytes()).context(error::Base64Decode { name })?;
 
         let path = dir.join("user-data");
         fs::write(path, decoded_bytes).context(error::UserDataWrite { name })?;

--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -131,14 +131,8 @@ mod error {
         ))]
         MissingTemplateData { template: String },
 
-        #[snafu(display(
-            "Unable to base64 decode string '{}' in template '{}': '{}'",
-            base64_string,
-            template,
-            source
-        ))]
+        #[snafu(display("Unable to decode base64 in template '{}': '{}'", template, source))]
         Base64Decode {
-            base64_string: String,
             template: String,
             source: base64::DecodeError,
         },
@@ -239,7 +233,6 @@ pub fn base64_decode(
 
     // Base64 decode the &str
     let decoded_bytes = base64::decode(&base64_str).context(error::Base64Decode {
-        base64_string: base64_str.to_string(),
         template: template_name.to_owned(),
     })?;
 

--- a/sources/api/static-pods/src/static_pods.rs
+++ b/sources/api/static-pods/src/static_pods.rs
@@ -117,9 +117,7 @@ where
             field: "manifest",
         })?;
 
-        let manifest = base64::decode(manifest.as_bytes()).context(error::Base64Decode {
-            base64_string: manifest.as_ref(),
-        })?;
+        let manifest = base64::decode(manifest.as_bytes()).context(error::Base64Decode { name })?;
 
         info!("Writing static pod '{}' to '{}'", name, STATIC_POD_DIR);
 
@@ -271,9 +269,10 @@ mod error {
         #[snafu(display("Logger setup error: {}", source))]
         Logger { source: log::SetLoggerError },
 
-        #[snafu(display("Unable to base64 decode manifest '{}': '{}'", base64_string, source))]
+        #[snafu(display(
+            "Unable to decode base64 in static pod '{}' manifest: {}", name, source))]
         Base64Decode {
-            base64_string: String,
+            name: String,
             source: base64::DecodeError,
         },
 


### PR DESCRIPTION
**Description of changes:**

```
Include source of invalid base64 data in error messages
    
The user data content could be sensitive.
```

Note for host-containers/bootstrap-containers: we don't save the output of restart-commands (including host-containers) today, so this is just to make sure we don't forget this if we do start to save it later.

Note for all of them: these shouldn't even be possible to hit with today's API protections, so again it's just being safe; see testing note...

**Testing done:**

These have the same problem, in that it's not really possible to hit the "invalid base64" error case without removing a bunch of protections in apiserver.  The base64 has to be valid to be accepted in the first place, and has to be valid later on for the apiserver to deserialize it from disk and give it to these programs.  Given the tiny changes and the strengths around this, I'm not sure it's worth ripping up everything else..?

I confirmed that it builds, tests pass, an AMI worked fine, admin and control host containers still worked fine.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
