### PR TITLE
k8s: Improve kubeReserved to handle Null max-pods

### DIFF
--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -40,7 +40,13 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  {{~#if settings.kubernetes.kube-reserved.memory}}
+  memory: "{{settings.kubernetes.kube-reserved.memory}}"
+  {{~else}}
+  {{~#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  {{~/if}}
+  {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -40,7 +40,13 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  {{~#if settings.kubernetes.kube-reserved.memory}}
+  memory: "{{settings.kubernetes.kube-reserved.memory}}"
+  {{~else}}
+  {{~#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  {{~/if}}
+  {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -40,7 +40,13 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  {{~#if settings.kubernetes.kube-reserved.memory}}
+  memory: "{{settings.kubernetes.kube-reserved.memory}}"
+  {{~else}}
+  {{~#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  {{~/if}}
+  {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -40,7 +40,13 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  {{~#if settings.kubernetes.kube-reserved.memory}}
+  memory: "{{settings.kubernetes.kube-reserved.memory}}"
+  {{~else}}
+  {{~#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  {{~/if}}
+  {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -40,7 +40,13 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  {{~#if settings.kubernetes.kube-reserved.memory}}
+  memory: "{{settings.kubernetes.kube-reserved.memory}}"
+  {{~else}}
+  {{~#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  {{~/if}}
+  {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Description of changes:**
Improve kubeReserved to handle Null max-pods. When `settings.kubernetes.max-pods` returns Null, Bottlerocket should not reserve anything for `kube-reserved.memory`. 

**Testing done:**
Since Those changes in different version kube-config are an identical change, and it works the same way in all versions, so we just need build aws-k8s-1.19-x86_64 and aws-k8s-1.19-aarch64 images to do test. 

My repository does not have this change [k8s: update eni-max-pods](https://github.com/bottlerocket-os/bottlerocket/pull/1468), so `c6g.large` is still qualified to be a test instance. 

 `c6g.large`
Userdata
```
[settings.kubernetes.kube-reserved]
memory = "100Mi"
cpu = "1"
ephemeral-storage = "2Gi"
```

```
bash-5.0# cat etc/kubernetes/kubelet/config
ca/etc/kubernetes
kubeReserved:
  cpu: "1"
  memory: "100Mi"
  ephemeral-storage: "1Gi"
```

Default
```
bash-5.0# cat etc/kubernetes/kubelet/config
ca/etc/kubernetes
kubeReserved:
  cpu: "70m"
  ephemeral-storage: "1Gi"
```

`m5g.large` ( we have this instance data)
default
```
kubeReserved:
  cpu: "70m"
  memory: "574Mi"
  ephemeral-storage: "1Gi"
```
Userdata
```
[settings.kubernetes.kube-reserved]
memory = "100Mi"
cpu = "1"
ephemeral-storage = "2Gi"
```

```
bash-5.0# cat etc/kubernetes/kubelet/config
ca/etc/kubernetes
kubeReserved:
  cpu: "1"
  memory: "100Mi"
  ephemeral-storage: "1Gi"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
