### PR TITLE
kernel: disable CMDLINE_EXTEND

### DIFF
--- a/packages/kernel/config-bottlerocket
+++ b/packages/kernel/config-bottlerocket
@@ -57,3 +57,7 @@ CONFIG_IKHEADERS=y
 
 # BTF debug info at /sys/kernel/btf/vmlinux
 CONFIG_DEBUG_INFO_BTF=y
+
+# We don't want to extend the kernel command line with any upstream defaults;
+# Bottlerocket uses a fairly custom setup that needs tight control over it.
+CONFIG_CMDLINE_EXTEND=n


### PR DESCRIPTION
**Description of changes:**

```
kernel: disable CMDLINE_EXTEND

This can be used to extend the kernel command line with default options.
Bottlerocket has fairly specific needs for the kernel command line, so we want
to use what we set in grub (via rpm2img) and nothing else.
```

In particular, the upstream aarch64 kernel config has `CONFIG_CMDLINE="console=ttyAMA0"`, which isn't compatible with EC2 arm64 instances the way we use them - you see kernel startup messages, but nothing from systemd/journald.  This only started to impact us with the kernel update in #1460 which enabled CMDLINE_EXTEND.

The x86 kernel config has no `CONFIG_CMDLINE` and so isn't impacted.

**Testing done:**

With this, on an aarch64 instance, I now see systemd/journald output in the EC2 console.  Also confirmed that an x86 instance is unimpacted, and that basic functionality and health were still OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
