### PR TITLE
Document the deprecation of the aws-k8s-1.15 variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ For example, an `x86_64` build of the `aws-k8s-1.19` variant will produce an ima
 
 The following variants support EKS, as described above:
 
-- `aws-k8s-1.15`
 - `aws-k8s-1.16`
 - `aws-k8s-1.17`
 - `aws-k8s-1.18`
@@ -59,6 +58,9 @@ The following variants support EKS, as described above:
 We also have a variant designed to work with ECS, currently in preview:
 
 - `aws-ecs-1`
+
+The `aws-k8s-1.15` variant is deprecated and will no longer be supported in Bottlerocket releases.
+We recommend users replace `aws-k8s-1.15` nodes with the [latest variant compatible with their cluster](variants/).
 
 ## Architectures
 

--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -22,7 +22,7 @@ Entries are sorted by filename, and later entries take precedence.
 
 The `#[model]` attribute on Settings and its sub-structs reduces duplication and adds some required metadata; see [its docs](model-derive/) for details.
 
-### aws-k8s-1.15: Kubernetes 1.15
+### aws-k8s-1.15: Kubernetes 1.15 (deprecated)
 
 * [Model](src/aws-k8s-1.15/mod.rs)
 * [Default settings](src/aws-k8s-1.15/defaults.d/)

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -19,7 +19,7 @@ Entries are sorted by filename, and later entries take precedence.
 
 The `#[model]` attribute on Settings and its sub-structs reduces duplication and adds some required metadata; see [its docs](model-derive/) for details.
 
-## aws-k8s-1.15: Kubernetes 1.15
+## aws-k8s-1.15: Kubernetes 1.15 (deprecated)
 
 * [Model](src/aws-k8s-1.15/mod.rs)
 * [Default settings](src/aws-k8s-1.15/defaults.d/)

--- a/variants/README.md
+++ b/variants/README.md
@@ -24,13 +24,6 @@ Information about API settings for variants can be found in the [models](../sour
 
 ## Variants
 
-### aws-k8s-1.15: Kubernetes 1.15 node
-
-The [aws-k8s-1.15](aws-k8s-1.15/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
-It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
-
-This variant is compatible with Kubernetes 1.15, 1.16, and 1.17 clusters.
-
 ### aws-k8s-1.16: Kubernetes 1.16 node
 
 The [aws-k8s-1.16](aws-k8s-1.16/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
@@ -75,6 +68,17 @@ User data will be read from IMDS.
 The [vmware-dev](vmware-dev/Cargo.toml) variant has useful packages for local development of the OS, and is intended to run as a VMWare guest.
 It includes tools for troubleshooting as well as Docker for running containers.
 User data will be read from a mounted CD-ROM, either from a file named "user-data" or from an OVF file.
+
+### Deprecated variants
+
+#### aws-k8s-1.15: Kubernetes 1.15 node
+
+The [aws-k8s-1.15](aws-k8s-1.15/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.15, 1.16, and 1.17 clusters.
+
+Upstream support for Kubernetes 1.15 has ended and this variant will no longer be supported in Bottlerocket releases.
 
 ## Development
 


### PR DESCRIPTION
**Description of changes:**

I'm also working on the 1.0.8 changelog / release note, and will have some explanation there too, basically just saying how upstream support has ended.  When we further remove 1.15 from the tree, I think we'd remove the text from the models README, and leave the note in the top-level READMEs a bit longer, and maybe the note in the variants README even longer - that can be a separate discussion, but I wanted to clarify why I just did the simpler "(deprecated)" note in the models README.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
