### PR TITLE
Improve restart commands by passing changed settings

### DIFF
--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -1,3 +1,4 @@
+use crate::service::Services;
 use crate::{error, Result};
 use itertools::join;
 use snafu::ResultExt;
@@ -28,11 +29,11 @@ where
 
 /// Given a map of Service objects, return a HashSet of
 /// affected configuration file names
-pub fn get_config_file_names(services: &model::Services) -> HashSet<String> {
+pub fn get_config_file_names(services: &Services) -> HashSet<String> {
     debug!("Building set of affected configuration file names");
     let mut config_file_set = HashSet::new();
-    for service in services.values() {
-        for file in service.configuration_files.iter() {
+    for service in services.0.values() {
+        for file in &service.model.configuration_files {
             config_file_set.insert(file.to_string());
         }
     }
@@ -117,6 +118,7 @@ impl RenderedConfigFile {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::service::Services;
     use maplit::{hashmap, hashset};
     use std::convert::TryInto;
 
@@ -132,9 +134,10 @@ mod test {
                 restart_commands: vec!["echo hi".to_string()]
             },
         );
+        let services = Services::from_model_services(input_map, None);
 
         let expected_output = hashset! {"file1".to_string(), "file2".to_string() };
 
-        assert_eq!(get_config_file_names(&input_map), expected_output)
+        assert_eq!(get_config_file_names(&services), expected_output)
     }
 }

--- a/sources/api/thar-be-settings/src/main.rs
+++ b/sources/api/thar-be-settings/src/main.rs
@@ -189,7 +189,7 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             let services =
                 service::get_affected_services(&args.socket_path, Some(changed_settings)).await?;
             trace!("Found services: {:?}", services);
-            if services.is_empty() {
+            if services.0.is_empty() {
                 info!("No services are affected, exiting...");
                 process::exit(0)
             }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1389 



**Description of changes:**
Pass a space separated string of changed settings to the restart command
Here, I have added a function to return a map of `service, list of changed settings`  so that we get the list of changed settings for a particular service and that list can be passed as a env to the restart command fo that service. Here I have used `env` because some commands are `systemctl` based and passing them as arguments to them wouldn't be right.

```
Author: Sanika <shasanik@amazon.com>
Date:   Sat Apr 10 00:29:23 2021 +0000

    thar-be-settings: pass changed settings to restart commands
    
    When the changed settings affect any services, the changed settings are passed to the restart command of that service.
    The changed settings are passed as space separated strings to the env of the restart command.
    The env is only set when there are any changed settings that affects the service.
```
Handle the changed settings for host-containers. Handle only the host-containers whose setting is changed. 

```
Author: Sanika <shasanik@amazon.com>
Date:   Sat Apr 10 00:43:09 2021 +0000

    host-containers: handle host-containers based on changed settings passed to the restart command
    
    if there are no changed settings passed, say during startup, handle all the host containers.
    if the settings are changed for a particular host container, handle only that host container.
    if the settings are not host-container settings, but do affect host-containers, handle all the host-containers.
```


**Testing done:**
1. Verified that on startup, all the host containers are handled
```
Apr 29 19:29:50 ip-172-31-44-44.us-west-2.compute.internal thar-be-settings[3581]: 19:29:50 [INFO] Command stdout: 19:29:50 [INFO] host-containers started
Apr 29 19:29:50 ip-172-31-44-44.us-west-2.compute.internal thar-be-settings[3581]: 19:29:50 [INFO] Handling host container 'control' during full configuration process
Apr 29 19:29:50 ip-172-31-44-44.us-west-2.compute.internal thar-be-settings[3581]: 19:29:50 [INFO] Host container 'control' is enabled: true, superpowered: false, with source: 328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.5.0
Apr 29 19:29:50 ip-172-31-44-44.us-west-2.compute.internal thar-be-settings[3581]: 19:29:50 [INFO] Handling host container 'admin' during full configuration process
Apr 29 19:29:50 ip-172-31-44-44.us-west-2.compute.internal thar-be-settings[3581]: 19:29:50 [INFO] Host container 'admin' is enabled: true, superpowered: true, with source: 328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.0

```
2. Verified that if a particular host-container setting is changed, only that host-container is handled
```
apiclient set  settings.host-containers.admin.source=328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.0
 
Apr 29 19:33:10 ip-172-31-44-44.us-west-2.compute.internal apiserver[4784]: 19:33:10 [TRACE] (1) thar_be_settings: [api/thar-be-settings/src/main.rs:191] Found services: Services({"host-containers": Service { changed_settings: Some({"settings.host-containers.admin.source"}), model: Service { configuration_files: [], restart_commands: ["/usr/bin/host-containers"] } }})

Apr 29 19:33:10 ip-172-31-44-44.us-west-2.compute.internal apiserver[4784]: 19:33:10 [INFO] Command stdout: 19:33:10 [INFO] host-containers started
Apr 29 19:33:10 ip-172-31-44-44.us-west-2.compute.internal apiserver[4784]: 19:33:10 [INFO] Handling host container 'admin' because it's directly affected by changed setting 'settings.host-containers.admin.source' (and maybe others)
Apr 29 19:33:10 ip-172-31-44-44.us-west-2.compute.internal apiserver[4784]: 19:33:10 [INFO] Host container 'admin' is enabled: true, superpowered: true, with source: 328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.0
Apr 29 19:33:10 ip-172-31-44-44.us-west-2.compute.internal apiserver[4784]: 19:33:10 [INFO] Not handling host container 'control', no changed settings affect it


apiclient set  settings.host-containers.control.enabled=true

Apr 29 19:34:18 ip-172-31-44-44.us-west-2.compute.internal apiserver[4811]: 19:34:18 [TRACE] (1) thar_be_settings: [api/thar-be-settings/src/main.rs:191] Found services: Services({"host-containers": Service { changed_settings: Some({"settings.host-containers.control.enabled"}), model: Service { configuration_files: [], restart_commands: ["/usr/bin/host-containers"] } }})

Apr 29 19:34:18 ip-172-31-44-44.us-west-2.compute.internal apiserver[4811]: 19:34:18 [INFO] Command stdout: 19:34:18 [INFO] host-containers started
Apr 29 19:34:18 ip-172-31-44-44.us-west-2.compute.internal apiserver[4811]: 19:34:18 [INFO] Handling host container 'control' because it's directly affected by changed setting 'settings.host-containers.control.enabled' (and maybe others)
Apr 29 19:34:18 ip-172-31-44-44.us-west-2.compute.internal apiserver[4811]: 19:34:18 [INFO] Host container 'control' is enabled: true, superpowered: false, with source: 328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.5.0
Apr 29 19:34:18 ip-172-31-44-44.us-west-2.compute.internal apiserver[4811]: 19:34:18 [INFO] Not handling host container 'admin', no changed settings affect it

```

3. Verified that if a setting that doesn't belong to `settings.host-containers` but affects the host-containers, all the host-containers are handled
```
apiclient set settings.network.https-proxy="0.0.0.0:9898"

Apr 29 19:34:57 ip-172-31-44-44.us-west-2.compute.internal apiserver[4836]: 19:34:57 [TRACE] (1) thar_be_settings: [api/thar-be-settings/src/main.rs:191] Found services: Services({"docker": Service { changed_settings: Some({"settings.network.https-proxy"}), model: Service { configuration_files: [SingleLineString { inner: "proxy-env" }], restart_commands: ["/bin/systemctl try-restart docker.service"] } }, "host-containers": Service { changed_settings: Some({"settings.network.https-proxy"}), model: Service { configuration_files: [], restart_commands: ["/usr/bin/host-containers"] } }, "containerd": Service { changed_settings: Some({"settings.network.https-proxy"}), model: Service { configuration_files: [SingleLineString { inner: "containerd-config-toml" }, SingleLineString { inner: "proxy-env" }], restart_commands: ["/bin/systemctl try-restart containerd.service"] } }, "host-containerd": Service { changed_settings: Some({"settings.network.https-proxy"}), model: Service { configuration_files: [SingleLineString { inner: "proxy-env" }], restart_commands: ["/bin/systemctl try-restart host-containerd.service"] } }, "ecs": Service { changed_settings: Some({"settings.network.https-proxy"}), model: Service { configuration_files: [SingleLineString { inner: "ecs-config" }], restart_commands: ["/usr/bin/ecs-settings-applier", "/bin/systemctl try-reload-or-restart ecs.service"] } }})

Apr 29 19:34:59 ip-172-31-44-44.us-west-2.compute.internal apiserver[4836]: 19:34:59 [INFO] Command stdout: 19:34:58 [INFO] host-containers started
Apr 29 19:34:59 ip-172-31-44-44.us-west-2.compute.internal apiserver[4836]: 19:34:58 [INFO] Handling host container 'admin' because it's indirectly affected by changed setting 'settings.network.https-proxy' (and maybe others)
Apr 29 19:34:59 ip-172-31-44-44.us-west-2.compute.internal apiserver[4836]: 19:34:58 [INFO] Host container 'admin' is enabled: true, superpowered: true, with source: 328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.0
Apr 29 19:34:59 ip-172-31-44-44.us-west-2.compute.internal apiserver[4836]: 19:34:58 [INFO] Handling host container 'control' because it's indirectly affected by changed setting 'settings.network.https-proxy' (and maybe others)
Apr 29 19:34:59 ip-172-31-44-44.us-west-2.compute.internal apiserver[4836]: 19:34:58 [INFO] Host container 'control' is enabled: true, superpowered: false, with source: 328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.5.0
```

4. Verified that code doesn't break if we pass in setting that has no affected services

```
 apiclient set settings.metrics.metrics-url=https://metrics.bottlerocket.aws/v1/metrics

Apr 29 19:36:48 ip-172-31-44-44.us-west-2.compute.internal apiserver[6307]: 19:36:48 [TRACE] (1) thar_be_settings: [api/thar-be-settings/src/main.rs:191] Found services: Services({})
Apr 29 19:36:48 ip-172-31-44-44.us-west-2.compute.internal apiserver[6307]: 19:36:48 [INFO] No services are affected, exiting...

```
5. Verified that corresponding services are handled, if we pass in a list of changed_settings that affects different services

```
apiclient set settings.host-containers.admin.source=328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.0 settings.motd="helllo"

Apr 29 00:03:45 ip-172-31-33-3.us-west-2.compute.internal apiserver[4812]: 00:03:45 [TRACE] (1) thar_be_settings: [api/thar-be-settings/src/main.rs:191] Found services: Services({"motd": Service { changed_settings: Some({"settings.motd"}), model: Service { configuration_files: [SingleLineString { inner: "motd" }], restart_commands: [] } }, "host-containers": Service { changed_settings: Some({"settings.host-containers.admin.source"}), model: Service { configuration_files: [], restart_commands: ["/usr/bin/host-containers"] } }})

Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [INFO] Restarting affected services...
Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [DEBUG] (1) thar_be_settings::service: Checking for restart-commands for host-containers
Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [INFO] restart commands ["/usr/bin/host-containers"]
Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [DEBUG] (1) thar_be_settings::service: Restart command: "/usr/bin/host-containers"

Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [INFO] Command stdout: 19:37:03 [INFO] host-containers started
Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [INFO] Handling host container 'admin' because it's directly affected by changed setting 'settings.host-containers.admin.source' (and maybe others)
Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [INFO] Host container 'admin' is enabled: true, superpowered: true, with source: 328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.0
Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [INFO] Not handling host container 'control', no changed settings affect it

Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [DEBUG] (1) thar_be_settings::service: Checking for restart-commands for motd
Apr 29 19:37:03 ip-172-31-44-44.us-west-2.compute.internal apiserver[6316]: 19:37:03 [INFO] restart commands []

```
6. Ran upgrade downgrade testing for k8s variants to verify the instances boot up correctly after upgrade/downgrade
7. Verified the above 5 usecases on k8s and ecs variants both.

**Terms of contributiaon:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.