### PR TITLE
kubelet: make cluster-dns-ip optional

### DIFF
--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -27,8 +27,10 @@ authorization:
     cacheUnauthorizedTTL: 30s
 {{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
+{{~#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~/if}}
 {{~#if settings.kubernetes.eviction-hard}}
 evictionHard:
   {{~#each settings.kubernetes.eviction-hard}}

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -27,8 +27,10 @@ authorization:
     cacheUnauthorizedTTL: 30s
 {{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
+{{~#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~/if}}
 {{~#if settings.kubernetes.eviction-hard}}
 evictionHard:
   {{~#each settings.kubernetes.eviction-hard}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -27,8 +27,10 @@ authorization:
     cacheUnauthorizedTTL: 30s
 {{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
+{{~#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~/if}}
 {{~#if settings.kubernetes.eviction-hard}}
 evictionHard:
   {{~#each settings.kubernetes.eviction-hard}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -27,8 +27,10 @@ authorization:
     cacheUnauthorizedTTL: 30s
 {{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
+{{~#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~/if}}
 {{~#if settings.kubernetes.eviction-hard}}
 evictionHard:
   {{~#each settings.kubernetes.eviction-hard}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -27,8 +27,10 @@ authorization:
     cacheUnauthorizedTTL: 30s
 {{~/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
+{{~#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~/if}}
 {{~#if settings.kubernetes.eviction-hard}}
 evictionHard:
   {{~#each settings.kubernetes.eviction-hard}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/1453


**Description of changes:**
Outside of EKS, we cannot compute a value for this, and there's not a reasonable default. We also need to account for it being optional for kubelet in standalone mode.

**Testing done:**
Since Those changes in different version kube-config are an identical change, and it works the same way in all versions, so we just need build aws-k8s-1.19-x86_64 and aws-k8s-1.19-aarch64 images to do test.

With `cluster-dns-ip` data
`bottlerocket-aws-k8s-1.19-x86_64-v1.0.8-b20d9ca6`
`bottlerocket-aws-k8s-1.19-aarch64-v1.0.8-b20d9ca6`

Launching instances to validate if `clusterDNS` works as expectation. 

```
clusterDNS:
- 10.100.0.10
```

Without `cluster-dns-ip` data (remove `cluster-dns-ip` value in `50-aws-k8s.toml`)
`bottlerocket-aws-k8s-1.19-x86_64-v1.0.8-ad8c4812-dirty`
`bottlerocket-aws-k8s-1.19-aarch64-v1.0.8-ad8c4812-dirty`

Launching instances to validate if `clusterDNS` is not in `kubelet-config`. 

```
clusterDomain: cluster.local
kubeReserved:
```
(no `clusterDNS` value there)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
