### PR TITLE
kubelet: add setting for configuring serverTLSBootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.cluster-domain`: The DNS domain for this cluster, allowing all Kubernetes-run containers to search this domain before the host's search domains.  Defaults to `cluster.local`.
 * `settings.kubernetes.standalone-mode`: Whether to run the kubelet in standalone mode, without connecting to an API server.  Defaults to `false`.
 * `settings.kubernetes.authentication-mode`: Which authentication method the kubelet should use to connect to the API server, and for incoming requests.  Defaults to `aws` for AWS variants, and `tls` for other variants.
+* `settings.kubernetes.server-tls-bootstrap`: Enables or disables server certificate bootstrap.  When enabled, the kubelet will request a certificate from the certificates.k8s.io API.  This requires an approver to approve the certificate signing requests (CSR).  Defaults to `true`.
 * `settings.kubernetes.bootstrap-token`: The token to use for [TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).  This is only used with the `tls` authentication mode, and is otherwise ignored.
 * `settings.kubernetes.eviction-hard`: The signals and thresholds that trigger pod eviction.
   Remember to quote signals (since they all contain ".") and to quote all values.

--- a/Release.toml
+++ b/Release.toml
@@ -38,3 +38,6 @@ version = "1.0.8"
     "migrate_v1.0.8_admin-container-v0-7-0.lz4",
     "migrate_v1.0.8_add-bootstrap-containers.lz4"
 ]
+"(1.0.8, 1.1.0)" = [
+    "migrate_v1.1.0_kubelet-server-tls-bootstrap.lz4",
+]

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -60,7 +60,7 @@ featureGates:
   RotateKubeletServerCertificate: true
 protectKernelDefaults: true
 serializeImagePulls: false
-serverTLSBootstrap: true
+serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -61,7 +61,7 @@ featureGates:
   CSIMigration: false
 protectKernelDefaults: true
 serializeImagePulls: false
-serverTLSBootstrap: true
+serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -61,7 +61,7 @@ featureGates:
   CSIMigration: false
 protectKernelDefaults: true
 serializeImagePulls: false
-serverTLSBootstrap: true
+serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -61,7 +61,7 @@ featureGates:
   CSIMigration: false
 protectKernelDefaults: true
 serializeImagePulls: false
-serverTLSBootstrap: true
+serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1733,6 +1733,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-server-tls-bootstrap"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-standalone-tls-services"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -53,6 +53,7 @@ members = [
     "api/migration/migrations/v1.0.8/control-container-v0-5-0",
     "api/migration/migrations/v1.0.8/admin-container-v0-7-0",
     "api/migration/migrations/v1.0.8/add-bootstrap-containers",
+    "api/migration/migrations/v1.1.0/kubelet-server-tls-bootstrap",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.0/kubelet-server-tls-bootstrap/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-server-tls-bootstrap/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kubelet-server-tls-bootstrap"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.0/kubelet-server-tls-bootstrap/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-server-tls-bootstrap/src/main.rs
@@ -1,0 +1,22 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring kubelet, `kubernetes.server-tls-bootstrap`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.server-tls-bootstrap",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/aws-k8s-1.19/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.19/defaults.d/50-aws-k8s.toml
@@ -58,6 +58,7 @@ affected-services = ["kubernetes", "containerd"]
 cluster-domain = "cluster.local"
 standalone-mode = false
 authentication-mode = "aws"
+server-tls-bootstrap = true
 
 # Metrics
 [settings.metrics]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -126,6 +126,7 @@ struct KubernetesSettings {
     eviction_hard: HashMap<KubernetesEvictionHardKey, KubernetesThresholdValue>,
     kube_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
     allowed_unsafe_sysctls: Vec<SingleLineString>,
+    server_tls_bootstrap: bool,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1467


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Apr 13 13:58:05 2021 -0700

    migrations: add migration for adding `kubernetes.server-tls-bootstrap`
    
    Adds a migration for the new `kubernetes.server-tls-bootstrap` setting.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Apr 13 13:40:59 2021 -0700

    k8s: add setting for configuring serverTLSBootstrap
    
    Adds a new setting `kubernetes.server-tls-bootstrap` for configuring
    whether to enable server certificate bootstrap for the kubelet.

```

**Testing done:**
Built x86 aws-k8s-1.19 image and launched instance with said image. Was able to toggle `kubernetes.server-tls-bootstrap` setting and see kubelet-config update accordingly, kubelet was able to restart successfully after each settings change. Node is still ready and can still run pods.

Launching the instance with userdata that sets `kubernetes.server-tls-bootstrap` to `false` also works. The node comes up fine and can run pods.

When the instance is launched with `kubernetes.server-tls-bootstrap` to `false`. `kubectl get csr` does not show any CSRs from the launched node. When I toggle the setting to true, `kubectl get csr` shows the node requesting a new CSR.

When the instance is launched with `kubernetes.server-tls-bootstrap` to `true`. `kubectl get csr` does show a CSR from the launched node.

Tested migration by upgrading from the release image to the image with the setting and saw that I was able to toggle the new setting as expected. Downgraded back to the release version and the setting no longer exists as expected and `serverTLSBootstrap` is set to true by default as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
