### PR TITLE
Enable metrics for vmware-dev variant

### DIFF
--- a/packages/os/metricdog-toml
+++ b/packages/os/metricdog-toml
@@ -1,7 +1,11 @@
 metrics_url = "{{settings.metrics.metrics-url}}"
 send_metrics = {{settings.metrics.send-metrics}}
 service_checks = [{{join_array ", " settings.metrics.service-checks}}]
-region = "{{settings.aws.region}}"
 seed = {{settings.updates.seed}}
 version_lock = "{{settings.updates.version-lock}}"
 ignore_waves = {{settings.updates.ignore-waves}}
+{{~#if settings.aws.region}}
+region = "{{settings.aws.region}}"
+{{~else}}
+region = "global"
+{{~/if}}

--- a/sources/models/src/vmware-dev/defaults.d/30-metrics.toml
+++ b/sources/models/src/vmware-dev/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootstrapContainer, HostContainer, KernelSettings, NetworkSettings, NtpSettings,
-    UpdatesSettings,
+    BootstrapContainer, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -19,4 +19,5 @@ struct Settings {
     ntp: NtpSettings,
     network: NetworkSettings,
     kernel: KernelSettings,
+    metrics: MetricsSettings,
 }


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/1452


**Description of changes:**

This adds a conditional for the region. If an aws region is not available, the region is set to global. This is required to enable metrics on non-aws variants like `vmware-dev`.

This also enables metrics on the `vmware-dev` variant by adding the `metrics.toml` to the variant's `defaults.d` directory and adding`MetricsSettings` to the `mod.rs`.

**Testing done:**

- [x] Built vmware-dev variant.
- [x] Built OVA.
- [x] Imported into vSphere.
- [x] Set motd in user data.
- [x] Started VM.
- [x] Logged into console and ran `metricdog --log-level debug send-health-ping`.
- [x] Checked for health ping record.
- [x] Verified the data inside the health ping record was correct _(ie. region = global)_.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
