### PR TITLE
restrict bootstrap container user data

### DIFF
--- a/packages/os/bootstrap-containers-tmpfiles.conf
+++ b/packages/os/bootstrap-containers-tmpfiles.conf
@@ -1,3 +1,3 @@
 d /etc/bootstrap-containers 0750 root root -
 d /local/bootstrap-containers 0700 root root -
-T /local/bootstrap-containers - - - - security.selinux=system_u:object_r:state_t:s0
+T /local/bootstrap-containers - - - - security.selinux=system_u:object_r:secret_t:s0

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -64,6 +64,8 @@
 ; Label local state directories.
 (filecon "/local/host-containers" any secret)
 (filecon "/local/host-containers/.*" any secret)
+(filecon "/local/bootstrap-containers" any secret)
+(filecon "/local/bootstrap-containers/.*" any secret)
 (filecon "/var/lib/chrony" any measure)
 (filecon "/var/lib/chrony/.*" any measure)
 (filecon "/var/lib/systemd" any state)

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -101,9 +101,10 @@
 ; ... docker's image layers
 (typetransition runtime_t local_t dir "overlay2" cache_t)
 
-; If a system process creates a directory for host container state, it
-; receives the "secret_t" label.
+; If a system process creates a directory for host or bootstrap container
+; state, it receives the "secret_t" label.
 (typetransition system_t local_t dir "host-containers" secret_t)
+(typetransition system_t local_t dir "bootstrap-containers" secret_t)
 
 ; The socket for the API server gets the "api_socket_t" label.
 (typetransition api_t any_t sock_file "api.sock" api_socket_t)


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This is a follow-up ea35f1bb, which added similar restrictions to host container user data.


**Testing done:**
Confirmed that a bootstrap container's user data had the expected label:
```
# ls -latrZ /local/bootstrap-containers/boot-label/user-data
-rw-r--r--. 1 root root system_u:object_r:secret_t:s0 11 Apr 16 18:36 /local/bootstrap-containers/boot-label/user-data
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
