### PR TITLE
update SDK to 0.20.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: cargo install --version 0.30.0 cargo-make
-      - run: cargo install --version 0.6.6 cargo-deny --no-default-features
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} -e BUILDSYS_ARCH=${{ matrix.arch }} -e BUILDSYS_JOBS=12

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,12 +43,10 @@ We recommend you install the latest stable Rust using [rustup](https://rustup.rs
 Rust 1.51.0 or higher is required.
 
 To organize build tasks, we use [cargo-make](https://sagiegurari.github.io/cargo-make/).
-We also use [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) during the build process.
-To get these, run:
+To get it, run:
 
 ```
 cargo install cargo-make
-cargo install cargo-deny --version 0.6.2
 ```
 
 #### Docker

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,9 +27,9 @@ BUILDSYS_NAME = "bottlerocket"
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="0.15.0"
+BUILDSYS_SDK_VERSION="v0.20.0"
 # Site for fetching the SDK
-BUILDSYS_SDK_SITE="cache.bottlerocket.aws"
+BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 
 # These can be overridden with -e to change configuration for pubsys (`cargo
 # make repo`).  In addition, you can set RELEASE_START_TIME to determine when
@@ -86,9 +86,9 @@ DOCKER_BUILDKIT = "1"
 # Certain variables are defined here to allow us to override a component value
 # on the command line.
 
-# Depends on ${BUILDSYS_ARCH} and ${BUILDSYS_SDK_VERSION}.
-BUILDSYS_SDK_IMAGE = { script = [ "echo bottlerocket/sdk-${BUILDSYS_ARCH}:v${BUILDSYS_SDK_VERSION}-$(uname -m)" ] }
-BUILDSYS_TOOLCHAIN = { script = [ "echo bottlerocket/toolchain-${BUILDSYS_ARCH}:v${BUILDSYS_SDK_VERSION}-${BUILDSYS_ARCH}" ] }
+# Depends on ${BUILDSYS_REGISTRY}, ${BUILDSYS_ARCH} and ${BUILDSYS_SDK_VERSION}.
+BUILDSYS_SDK_IMAGE = { script = [ "echo ${BUILDSYS_REGISTRY}/bottlerocket-sdk-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
+BUILDSYS_TOOLCHAIN = { script = [ "echo ${BUILDSYS_REGISTRY}/bottlerocket-toolchain-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"
@@ -145,7 +145,7 @@ mkdir -p ${GO_MOD_CACHE}
 dependencies = ["setup"]
 script = [
 '''
-for cmd in curl docker gunzip lz4; do
+for cmd in docker gzip lz4; do
   if ! command -v ${cmd} >/dev/null 2>&1 ; then
     echo "required program '${cmd}' not found" >&2
     exit 1
@@ -157,6 +157,7 @@ done
 [tasks.fetch]
 dependencies = [
   "fetch-sdk",
+  "fetch-toolchain",
   "fetch-sources",
   "fetch-vendored",
 ]
@@ -166,15 +167,40 @@ dependencies = ["setup-build"]
 script_runner = "bash"
 script = [
 '''
-set -o pipefail
-if ! docker image inspect ${BUILDSYS_SDK_IMAGE} >/dev/null 2>&1 ; then
-  # Let curl resolve the certificates instead of the tasks resolved bundle.
-  unset SSL_CERT_FILE SSL_CERT_DIR
-  if ! curl --silent --fail --show-error https://${BUILDSYS_SDK_SITE}/${BUILDSYS_SDK_IMAGE}.tar.gz \
-       | gunzip | docker load ; then
-    echo "failed to load '${BUILDSYS_SDK_IMAGE}'" >&2
+if ! docker image inspect "${BUILDSYS_SDK_IMAGE}" >/dev/null 2>&1 ; then
+  if ! docker pull "${BUILDSYS_SDK_IMAGE}" ; then
+    echo "failed to pull '${BUILDSYS_SDK_IMAGE}'" >&2
     exit 1
   fi
+fi
+'''
+]
+
+[tasks.fetch-toolchain]
+dependencies = ["setup-build"]
+script_runner = "bash"
+script = [
+'''
+if docker image inspect "${BUILDSYS_TOOLCHAIN}-${BUILDSYS_ARCH}" >/dev/null 2>&1 ; then
+  exit 0
+fi
+
+case "${BUILDSYS_ARCH}" in
+  x86_64) docker_arch="amd64" ;;
+  aarch64) docker_arch="arm64" ;;
+esac
+
+# We want the image with the target's native toolchain, rather than one that matches the
+# host architecture.
+if ! docker pull --platform "${docker_arch}" "${BUILDSYS_TOOLCHAIN}" ; then
+  echo "could not pull '${BUILDSYS_TOOLCHAIN}' for ${docker_arch}" >&2
+  exit 1
+fi
+
+# Apply a tag to distinguish the image from other architectures.
+if ! docker tag "${BUILDSYS_TOOLCHAIN}" "${BUILDSYS_TOOLCHAIN}-${BUILDSYS_ARCH}" ; then
+  echo "could not tag '${BUILDSYS_TOOLCHAIN}-${BUILDSYS_ARCH}'" >&2
+  exit 1
 fi
 '''
 ]
@@ -320,6 +346,24 @@ script = [
 '''
 mkdir -p "${BUILDSYS_ARCHIVES_DIR}"
 
+toolchain="toolchain-${BUILDSYS_SDK_VERSION}.${BUILDSYS_ARCH}.tar.gz"
+if [ ! -s "${BUILDSYS_ARCHIVES_DIR}/${toolchain}" ] ; then
+  if ! docker create --name "${toolchain}" \
+      ${BUILDSYS_TOOLCHAIN}-${BUILDSYS_ARCH} true >/dev/null 2>&1 ; then
+    echo "could not create toolchain container" >&2
+    exit 1
+  fi
+  if ! docker cp "${toolchain}":toolchain - \
+      | gzip --fast > "${BUILDSYS_ARCHIVES_DIR}/${toolchain}" ; then
+    echo "could not extract toolchain from container" >&2
+    exit 1
+  fi
+  if ! docker rm -f "${toolchain}" >/dev/null 2>&1 ; then
+    echo "could not remove toolchain container" >&2
+    exit 1
+  fi
+fi
+
 # Find the most recent kernel archive. If we have more than one, we want the
 # last one that was built.
 kernel_archive="$(find "${BUILDSYS_PACKAGES_DIR}" \
@@ -343,8 +387,6 @@ mkdir -p /tmp/kit/${BUILDSYS_KMOD_KIT} /tmp/extract
 
 # Retrieve the toolchain and kernel archives.
 pushd /tmp/extract >/dev/null
-curl --silent --fail --show-error --output /tmp/kit/${BUILDSYS_KMOD_KIT}/toolchain.tar.xz \
-  https://${BUILDSYS_SDK_SITE}/${BUILDSYS_TOOLCHAIN}.tar.xz
 find /tmp/rpms -name "${kernel_archive##*/}" \
   -exec rpm2cpio {} \; | cpio -idmu --quiet
 find -name 'kernel-devel.tar.xz' -exec mv {} /tmp/kit/${BUILDSYS_KMOD_KIT} \;
@@ -354,8 +396,7 @@ popd >/dev/null
 pushd /tmp/kit/${BUILDSYS_KMOD_KIT} >/dev/null
 tar xf kernel-devel.tar.xz
 rm kernel-devel.tar.xz
-tar xf toolchain.tar.xz
-rm toolchain.tar.xz
+tar xf /tmp/archives/${toolchain}
 popd >/dev/null
 
 # Merge them together into a unified archive.
@@ -468,10 +509,22 @@ mv "${ova_tmp_dir}/${BUILDSYS_OVA}" "${BUILDSYS_ARCHIVES_DIR}"
 dependencies = ["fetch"]
 script = [
 '''
-[ "${BUILDSYS_ALLOW_FAILED_LICENSE_CHECK}" = "true" ] && set +e
-(cd sources && cargo deny check --disable-fetch licenses)
-(cd tools && cargo deny check --disable-fetch licenses)
-set -e
+run_cargo_deny="
+(cd /tmp/sources && cargo deny check --disable-fetch licenses)
+(cd /tmp/tools && cargo deny check --disable-fetch licenses)
+"
+set +e
+docker run --rm \
+  --network=none \
+  --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
+  -e CARGO_HOME="/tmp/.cargo" \
+  -v "${CARGO_HOME}":/tmp/.cargo \
+  -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
+  -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
+  "${BUILDSYS_SDK_IMAGE}" \
+  bash -c "${run_cargo_deny}"
+[ "${?}" -eq 0 ] || [ "${BUILDSYS_ALLOW_FAILED_LICENSE_CHECK}" = "true" ]
 '''
 ]
 

--- a/macros/shared
+++ b/macros/shared
@@ -180,6 +180,7 @@ CROSS_COMPILATION_CONF_EOF\
   GOFLAGS="-mod=vendor"; export GOFLAGS ; \
   GOPROXY="off"; export GOPROXY ; \
   GOSUMDB="off"; export GOSUMDB ; \
+  GO111MODULE="auto"; export GO111MODULE ; \
 
 %cross_go_setup() \
   mkdir -p GOPATH/src/%2 ; \

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -119,14 +119,14 @@ grub2-mkimage \
   -O "%{_cross_grub_tuple}" \
   -o "%{buildroot}%{_cross_grubdir}/%{_cross_grub_image}" \
   -p "%{_cross_grub_prefix}" \
-%if %{_cross_arch} == x86_64
+%if "%{_cross_arch}" == "x86_64"
   biosdisk \
 %else
   efi_gop \
 %endif
   configfile echo ext2 gptprio linux normal part_gpt reboot sleep
 
-%if %{_cross_arch} == x86_64
+%if "%{_cross_arch}" == "x86_64"
 install -m 0644 ./grub-core/boot.img \
   %{buildroot}%{_cross_grubdir}/boot.img
 %endif
@@ -135,7 +135,7 @@ install -m 0644 ./grub-core/boot.img \
 %license COPYING COPYING.unicode
 %{_cross_attribution_file}
 %dir %{_cross_grubdir}
-%if %{_cross_arch} == x86_64
+%if "%{_cross_arch}" == "x86_64"
 %{_cross_grubdir}/boot.img
 %endif
 %{_cross_grubdir}/%{_cross_grub_image}

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -1,5 +1,5 @@
 %global debug_package %{nil}
-%global __strip %{_bindir}/strip
+%global __strip %{_bindir}/true
 
 Name: %{_cross_os}grub
 Version: 2.04

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/archive/v4.4.17/libxcrypt-4.4.17.tar.gz"
-sha512 = "94aaba6ccf9b6d1a32f9a571ee32261cecd393d5b8d8c6f18d740dc7bb29ac0fbd381124e7f0d84882559bb634208c08151b3dc05c9138fa0a229c4ba20fb6f7"
+url = "https://github.com/besser82/libxcrypt/archive/v4.4.18/libxcrypt-4.4.18.tar.gz"
+sha512 = "66e3afb32ca27b1b00c21d07f0cd3eb3403ebd1732503376e5f85fa79acf078aa2bac54a8920121b3741cd46a807f4ea176de38c6b5b4611c701dc9e6f8d1490"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.17
+Version: 4.4.18
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later


### PR DESCRIPTION
**Issue number:**
Fixes #1455, fixes #582

**Description of changes:**
Update to the latest SDK, with new versions of GCC, Rust, and Go.

Retrieve the SDK and toolchain as containers from ECR, rather than archives from S3.

Fix minor issues related to the new Fedora base image and the new version of Go.

Use `cargo deny` from the SDK.

**Testing done:**
Verified that local builds of `aws-dev` worked under KVM for both arches.

For `aws-ecr-1` and `aws-k8s-1.19`, confirmed that:
* x86_64 builds for both x86_64 and aarch64 build and run containers
* aarch64 builds for both x86_64 and aarch64 build and run containers

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
