### PR TITLE
sources/lockfile: update vmw_backdoor dependency

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3737,12 +3737,12 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vmw_backdoor"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782273e25af43e3b255d00a72a22311feacabf9482bcbab26a8a03aae9197867"
+checksum = "59dadb264325fd034df77ba88c2ddd1650d78ec8e7548af3003ecdc598dfe0b3"
 dependencies = [
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "errno",
  "libc",
  "log",


### PR DESCRIPTION
This updates `vmw_backdoor` to latest version.

Signed-off-by: Luca BRUNO <lucab@debian.org>
Ref: https://github.com/lucab/vmw_backdoor-rs/releases/tag/v0.2.1
Fixes: https://github.com/bottlerocket-os/bottlerocket/issues/1484

---

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
