### PR TITLE
netdog: Persist current IP and add subcommand `node-ip` for retrieval

### DIFF
--- a/packages/os/netdog-tmpfiles.conf
+++ b/packages/os/netdog-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /var/lib/netdog 0700 root root -
+Z /var/lib/netdog 0700 root root -

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -42,6 +42,7 @@ Source200: migration-tmpfiles.conf
 Source201: host-containers-tmpfiles.conf
 Source202: thar-be-updates-tmpfiles.conf
 Source203: bootstrap-containers-tmpfiles.conf
+Source204: netdog-tmpfiles.conf
 
 # 3xx sources: udev rules
 Source300: ephemeral-storage.rules
@@ -356,6 +357,7 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.conf
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_tmpfilesdir}/thar-be-updates.conf
 install -p -m 0644 %{S:203} %{buildroot}%{_cross_tmpfilesdir}/bootstrap-containers.conf
+install -p -m 0644 %{S:204} %{buildroot}%{_cross_tmpfilesdir}/netdog.conf
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-storage.rules
@@ -381,6 +383,7 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 
 %files -n %{_cross_os}netdog
 %{_cross_bindir}/netdog
+%{_cross_tmpfilesdir}/netdog.conf
 
 %files -n %{_cross_os}corndog
 %{_cross_bindir}/corndog

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -74,6 +74,8 @@
 (filecon "/var/log/journal/.*" any state)
 (filecon "/var/lib/selinux" any state)
 (filecon "/var/lib/selinux/.*" any state)
+(filecon "/var/lib/netdog" any lease)
+(filecon "/var/lib/netdog/.*" any lease)
 
 ; Label kernel filesystem mounts.
 (filecon "/proc" any any)

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
  "rand 0.8.3",
  "regex",
  "serde",
+ "serde_json",
  "serde_plain",
  "snafu",
 ]

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = "1.2"
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 regex = "1.1"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 serde_plain = "0.3.0"
 snafu = "0.6"
 

--- a/sources/api/netdog/README.md
+++ b/sources/api/netdog/README.md
@@ -4,9 +4,11 @@ Current version: 0.1.0
 
 ## Introduction
 
-netdog is a small helper program for wicked, to apply network settings received from DHCP.
+netdog is a small helper program for wicked, to apply network settings received from DHCP.  It also
+contains a subcommand `node-ip` that returns the node's current IP address in JSON format; this
+subcommand is intended for use as a settings generator.
 
-It generates `/etc/resolv.conf` and sets the hostname.
+It generates `/etc/resolv.conf`, sets the hostname, and persists the current IP to file.
 
 ## Colophon
 


### PR DESCRIPTION
**Issue number:**
Related to #1458 


**Description of changes:**
```
With this change, netdog will persist the node's current IP (read from
it's DHCP leases file) to /var/lib/netdog/current_ip.  It does this as
part of its "install" subcommand, which is run each time that wickedd
receives an update.  A new subcommand has also been added, which
retrieves the current IP from said file and returns it as JSON.  This
subcommand is intended for use as a settings generator.
```

This change is meant to support the VMWare variant #1451, specifically the `kubernetes.node-ip` setting and will receive further exercise with that PR.

**Testing done:**
* Build and run an `aws-dev` variant to ensure that the file containing the IP exists with the correct data and the subcommand works:
```
bash-5.0# ls -lahZ /var/lib/netdog/current_ip 
-rw-r--r--. 1 root root system_u:object_r:lease_t:s0 11 Apr 19 20:15 /var/lib/netdog/current_ip

bash-5.0# cat /var/lib/netdog/current_ip 
10.0.60.220

bash-5.0# netdog node-ip
"10.0.60.220"
```
* Build and run an `aws-k8s-1.19` node, started sheltie and checked files.  Node joins the cluster just fine and I can run pods on it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
