### PR TITLE
makefile: check cargo version

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -266,9 +266,31 @@ cargo install \
 '''
 ]
 
+# We need Cargo version 1.51 or higher in order to build a workspace's
+# dependency during build-package
+[tasks.check-cargo-version]
+script_runner = "bash"
+script = [
+'''
+set -euo pipefail
+cargo_version=$(cargo --version | awk '{print $2}')
+strarr=(${cargo_version//./ })
+cargo_major="${strarr[0]}"
+cargo_minor="${strarr[1]}"
+if [ "${cargo_major}" -gt "1" ] ; then
+  # cargo is version 2 or higher, so it's higher than 1.51
+  exit 0
+fi
+if [ "${cargo_minor}" -lt "51" ] ; then
+  echo "Error: Cargo 1.51.0 or greater is required, your version is ${cargo_version}" >&2
+  exit 1
+fi
+'''
+]
+
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["build-tools", "publish-setup"]
+dependencies = ["check-cargo-version", "build-tools", "publish-setup"]
 script_runner = "bash"
 script = [
 '''


### PR DESCRIPTION

**Issue number:**

Follow up to #1408
Follow up to #1361 

**Description of changes:**

    makefile: check cargo version

    For the build-package target (used by cargo make repo), we need Cargo
    version 1.51 or higher to build a dependency of the variants workspace.
    To make this clear, we check the Cargo version before build-package and
    provide a clear error message.

**Testing done:**

```sh
rustup default 1.50.0
cargo make repo
# Error: Cargo 1.51.0 or greater is required, your version is 1.50.0
# [cargo-make] ERROR - Error while executing command, exit code: 1
# [cargo-make] WARN - Build Failed.
# FAIL: 1
```

```sh
rustup default 1.51.0
cargo make repo
# Works!
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
