### PR TITLE
Add ECR account IDs for ap-northeast-3: Osaka

### DIFF
--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -63,7 +63,6 @@ lazy_static! {
         m.insert("eu-central-1", "602401143452");
         m.insert("eu-north-1", "602401143452");
         m.insert("eu-south-1", "590381155156");
-        m.insert("eu-south-1", "590381155156");
         m.insert("eu-west-1", "602401143452");
         m.insert("eu-west-2", "602401143452");
         m.insert("eu-west-3", "602401143452");

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -53,6 +53,7 @@ lazy_static! {
         m.insert("ap-east-1", "800184023465");
         m.insert("ap-northeast-1", "602401143452");
         m.insert("ap-northeast-2", "602401143452");
+        m.insert("ap-northeast-3", "602401143452");
         m.insert("ap-south-1", "602401143452");
         m.insert("ap-southeast-1", "602401143452");
         m.insert("ap-southeast-2", "602401143452");

--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -20,6 +20,7 @@ lazy_static! {
         m.insert("ap-east-1", "375569722642");
         m.insert("ap-northeast-1", "328549459982");
         m.insert("ap-northeast-2", "328549459982");
+        m.insert("ap-northeast-3", "328549459982");
         m.insert("ap-south-1", "328549459982");
         m.insert("ap-southeast-1", "328549459982");
         m.insert("ap-southeast-2", "328549459982");


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

This is the main bit for #1474 but it won't be done until we perform a release and update the docs accordingly.

**Description of changes:**

```
60924ea8 Add ECR account IDs for ap-northeast-3: Osaka
c7a7f1a9 pluto: remove duplicate eu-south-1 region entry
```

**Testing done:**

I made a temporary change to pluto to force the ap-northeast-3 region instead of using IMDS or the fallback.  (I'm working on a separate change to use settings.aws.region instead of IMDS so we can test more easily.)  It fetched the containers from ap-northeast-3 OK, from an instance in us-west-2:

```
host-ctr[3724]: time="2021-04-19T23:08:02Z" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:ap-northeast-3:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3533]: time="2021-04-19T23:08:02Z" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:ap-northeast-3:328549459982:repository/bottlerocket-control:v0.5.0"
host-ctr[3518]: time="2021-04-19T23:08:02Z" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:ap-northeast-3:328549459982:repository/bottlerocket-admin:v0.7.0"
host-ctr[3724]: time="2021-04-19T23:08:04Z" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:ap-northeast-3:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3724]: time="2021-04-19T23:08:04Z" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:ap-northeast-3:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3724]: time="2021-04-19T23:08:04Z" level=info msg="tagging image" img="602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/pause-amd64:3.1"
host-ctr[3518]: time="2021-04-19T23:08:10Z" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:ap-northeast-3:328549459982:repository/bottlerocket-admin:v0.7.0"
host-ctr[3518]: time="2021-04-19T23:08:10Z" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:ap-northeast-3:328549459982:repository/bottlerocket-admin:v0.7.0"
host-ctr[3533]: time="2021-04-19T23:08:10Z" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:ap-northeast-3:328549459982:repository/bottlerocket-control:v0.5.0"
host-ctr[3533]: time="2021-04-19T23:08:10Z" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:ap-northeast-3:328549459982:repository/bottlerocket-control:v0.5.0"
host-ctr[3518]: time="2021-04-19T23:08:15Z" level=info msg="tagging image" img="328549459982.dkr.ecr.ap-northeast-3.amazonaws.com/bottlerocket-admin:v0.7.0"
host-ctr[3533]: time="2021-04-19T23:08:15Z" level=info msg="tagging image" img="328549459982.dkr.ecr.ap-northeast-3.amazonaws.com/bottlerocket-control:v0.5.0"
```

Still ran a pod OK, admin and control containers worked OK, `systemctl status` `running`, API OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
