### PR TITLE
release: do not acquire a IPv6 lease on eth0

### DIFF
--- a/packages/release/eth0.xml
+++ b/packages/release/eth0.xml
@@ -17,9 +17,4 @@
   <ipv4:dhcp>
     <enabled>true</enabled>
   </ipv4:dhcp>
-
-  <ipv6:dhcp>
-    <enabled>true</enabled>
-    <defer-timeout>1</defer-timeout>
-  </ipv6:dhcp>
 </interface>


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1351 


**Description of changes:**
```
Author: Sanika <shasanik@amazon.com>
Date:   Mon Apr 19 23:18:14 2021 +0000

    release: do not acquire a IPv6 lease on eth0
    
    If IPv6 is not enabled in the EC2 VPC subnet, we can wait up to 30
    seconds before it times out.
    
    Our various helper programs such as `netdog` and `early-boot-config`
    only expect to deal with IPv4 leases, and we do nothing with the IPv6
    address today.
 ```


**Testing done:**
Launched `aws-k8s-1.19-x86_64` ami and checked `wicked ifstatus eth0`
```
bash-5.0# wicked ifstatus eth0
eth0            up
      link:     #2, state up, mtu 9001
      type:     ethernet, hwaddr 0e:c6:cc:30:78:dd
      config:   wicked:xml:/etc/wicked/ifconfig/eth0.xml
      leases:   ipv4 dhcp granted
      addr:     ipv4 192.168.66.23/19 [dhcp]
      route:    ipv4 default via 192.168.64.1 proto dhcp
```
Executed following macis tests for aws-ecs-1
```
PASS: TestV4TaskEndpointAWSVPCNetworkModeWithIPV6
PASS: TestIPv6ConnectivityAwsvpcNetworkMode 
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
