### PR TITLE
systemd: generate stable machine IDS for ARM KVM guests

### DIFF
--- a/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
@@ -1,7 +1,7 @@
-From 14dc71e93ad0c704369de133446f8d67a8c37fad Mon Sep 17 00:00:00 2001
+From 6504eb5947e0896d9f35147597509895d752bc0e Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 17 Sep 2019 01:35:51 +0000
-Subject: [PATCH 9001/9007] use absolute path for /var/run symlink
+Subject: [PATCH 9001/9008] use absolute path for /var/run symlink
 
 Otherwise the symlink may be broken if /var is a bind mount from
 somewhere else.
@@ -25,5 +25,5 @@ index 0e2c509..6716540 100644
  d /var/log 0755 - - -
  m4_ifdef(`ENABLE_UTMP',
 -- 
-2.21.3
+2.30.2
 

--- a/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
+++ b/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
@@ -1,7 +1,7 @@
-From 386b8c116963192875ad4d97e38c8becb5408da7 Mon Sep 17 00:00:00 2001
+From e28a86ad4928509953dea794e61020c14996858c Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 10 Mar 2020 20:30:10 +0000
-Subject: [PATCH 9002/9007] core: add separate timeout for system shutdown
+Subject: [PATCH 9002/9008] core: add separate timeout for system shutdown
 
 There is an existing setting for this (DefaultTimeoutStopUSec), but
 changing it has no effect because `reset_arguments()` is called just
@@ -62,5 +62,5 @@ index a280b75..de946a0 100644
          arg_default_timeout_abort_set = false;
          arg_default_start_limit_interval = DEFAULT_START_LIMIT_INTERVAL;
 -- 
-2.21.3
+2.30.2
 

--- a/packages/systemd/9003-repart-always-use-random-UUIDs.patch
+++ b/packages/systemd/9003-repart-always-use-random-UUIDs.patch
@@ -1,7 +1,7 @@
-From 4a649efbfabfffba80924646b5bbbe46be12549f Mon Sep 17 00:00:00 2001
+From f59750b48ee9dfc33a451629add411eba967e643 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 16 Apr 2020 15:10:41 +0000
-Subject: [PATCH 9003/9007] repart: always use random UUIDs
+Subject: [PATCH 9003/9008] repart: always use random UUIDs
 
 We would like to avoid adding OpenSSL to the base OS, and for our use
 case we do not need the UUIDs assigned to disks or partitions to be
@@ -36,7 +36,7 @@ index 580964c..781b0a2 100644
                  error('repart support was requested, but dependencies are not available')
          endif
 diff --git a/src/partition/repart.c b/src/partition/repart.c
-index 6db413e..f771c33 100644
+index 6d7e519..dfc2c79 100644
 --- a/src/partition/repart.c
 +++ b/src/partition/repart.c
 @@ -13,9 +13,6 @@
@@ -176,5 +176,5 @@ index 6db413e..f771c33 100644
  }
  
 -- 
-2.21.3
+2.30.2
 

--- a/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen.patch
+++ b/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen.patch
@@ -1,7 +1,7 @@
-From f201fcb17276d84a22332cde915f8c3ffac63c51 Mon Sep 17 00:00:00 2001
+From ee634296cdf5470521bddee3ce082b848696fc62 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 7 Jul 2020 22:38:20 +0000
-Subject: [PATCH 9004/9007] machine-id-setup: generate stable ID under Xen
+Subject: [PATCH 9004/9008] machine-id-setup: generate stable ID under Xen
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 ---
@@ -45,5 +45,5 @@ index 6d15f9c..aa9609f 100644
          }
  
 -- 
-2.21.3
+2.30.2
 

--- a/packages/systemd/9005-core-mount-etc-with-specific-label.patch
+++ b/packages/systemd/9005-core-mount-etc-with-specific-label.patch
@@ -1,7 +1,7 @@
-From 71d1fce8c9c3f1787add39625221bfe09140a572 Mon Sep 17 00:00:00 2001
+From 1da3740ea90f03f8357c165e8e409e4ff2f48830 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 9 Jul 2020 20:00:36 +0000
-Subject: [PATCH 9005/9007] core: mount /etc with specific label
+Subject: [PATCH 9005/9008] core: mount /etc with specific label
 
 The filesystem is mounted after we load the SELinux policy, so we can
 apply the label we need to restrict access.
@@ -25,5 +25,5 @@ index 915b101..38c1a29 100644
            NULL,          MNT_FATAL|MNT_IN_CONTAINER },
          { "devpts",      "/dev/pts",                  "devpts",     "mode=620,gid=" STRINGIFY(TTY_GID),        MS_NOSUID|MS_NOEXEC,
 -- 
-2.21.3
+2.30.2
 

--- a/packages/systemd/9006-journal-disable-keyed-hashes-for-compatibility.patch
+++ b/packages/systemd/9006-journal-disable-keyed-hashes-for-compatibility.patch
@@ -1,7 +1,7 @@
-From f504b52791a80b07c1d2d835614532ff6eb0060f Mon Sep 17 00:00:00 2001
+From 4aa9be06f1765b7c5f74447aad09b888127b6429 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 12 Nov 2020 16:18:15 +0000
-Subject: [PATCH 9006/9007] journal: disable keyed hashes for compatibility
+Subject: [PATCH 9006/9008] journal: disable keyed hashes for compatibility
 
 Otherwise the journal is not readable by older versions of systemd.
 
@@ -34,5 +34,5 @@ index 6bee5da..791145e 100644
                  f->keyed_hash = r;
  
 -- 
-2.21.3
+2.30.2
 

--- a/packages/systemd/9007-pkg-config-stop-hardcoding-prefix-to-usr.patch
+++ b/packages/systemd/9007-pkg-config-stop-hardcoding-prefix-to-usr.patch
@@ -1,7 +1,7 @@
-From 247d2b76343f839cf7c03d58f7e08b608ad6d402 Mon Sep 17 00:00:00 2001
+From 0551622158173ffd60367805b7e1dbd75b2ead0f Mon Sep 17 00:00:00 2001
 From: Erikson Tung <etung@amazon.com>
 Date: Wed, 27 Jan 2021 14:43:47 -0800
-Subject: [PATCH 9007/9007] pkg-config: stop hardcoding prefix to /usr
+Subject: [PATCH 9007/9008] pkg-config: stop hardcoding prefix to /usr
 
 While we ensure /usr points to the sys-root at runtime, for Bottlerocket's
 packaging we need to be careful to avoid dependencies on the host OS so
@@ -24,5 +24,5 @@ index b5cc8f9..ec4992b 100644
  rootprefix=${root_prefix}
  sysconf_dir=@sysconfdir@
 -- 
-2.21.3
+2.30.2
 

--- a/packages/systemd/9008-virt-add-Amazon-EC2-to-dmi-vendor-table.patch
+++ b/packages/systemd/9008-virt-add-Amazon-EC2-to-dmi-vendor-table.patch
@@ -1,0 +1,31 @@
+From be47b1641896bd83c571925c8ad6b8119cffbc3b Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Wed, 21 Apr 2021 00:46:32 +0000
+Subject: [PATCH 9008/9008] virt: add "Amazon EC2" to dmi vendor table
+
+Systemd fails to detect the dmi vendor for ARM EC2 instances, and uses
+the random machine id generator instead of a consistent ID after each
+boot. To fix the problem, this commit adds "Amazon EC2" key to the dmi
+vendor table, and maps it to `VIRTUALIZATION_KVM`, so that a consistent
+machine ID is used after reboots.
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ src/basic/virt.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/basic/virt.c b/src/basic/virt.c
+index 7d78a40..36b470e 100644
+--- a/src/basic/virt.c
++++ b/src/basic/virt.c
+@@ -158,6 +158,7 @@ static int detect_vm_dmi(void) {
+                 { "Parallels",           VIRTUALIZATION_PARALLELS },
+                 /* https://wiki.freebsd.org/bhyve */
+                 { "BHYVE",               VIRTUALIZATION_BHYVE     },
++                { "Amazon EC2",          VIRTUALIZATION_KVM       },
+         };
+         unsigned i;
+         int r;
+-- 
+2.30.2
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -39,6 +39,10 @@ Patch9006: 9006-journal-disable-keyed-hashes-for-compatibility.patch
 # dependencies on the host OS.
 Patch9007: 9007-pkg-config-stop-hardcoding-prefix-to-usr.patch
 
+# Local patch to let systemd recognize ARM EC2 instances as `VIRTUALIZATION_KVM`,
+# so it can generate the correct machine id
+Patch9008: 9008-virt-add-Amazon-EC2-to-dmi-vendor-table.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**
#1493


**Description of changes:**

```
49c17f96 systemd: generate stable machine IDs for ARM KVM guests
```

Systemd doesn't recognize Amazon EC2 as a valid dmi vendor. The vendor is used to detect the virtualization type, which then is used to generate the machine ID. Since no dmi vendor is detected, systemd defaults to use the random machine ID generator, which results in a different machine ID after each boot. This patch extends the list of valid dmi vendors, and adds `Amazon EC2` as a new vendor.

**Testing done:**

In k8s 1.19, ecs and dev aarch64/x86_64:

- Run `systemctl status` to check that no units were failing
- Reboot and check that `journalctl --list-boots` shows two entries
- Run nginx pod/task/container and successfully call `curl http://localhost` within the pod/task/container
- Run images with the `systemd.log_level` kernel parameter as `debug` to validate the correct virtualization type was selected for both XEN and KVM:

**ECS**

**aarch64 (t4g.medium)**

```
Apr 20 17:01:26 localhost systemd[1]: Found VM virtualization kvm
Apr 20 17:01:26 localhost systemd[1]: Detected virtualization kvm.
Apr 20 17:01:26 localhost systemd[1]: Detected architecture arm64.
```

**x86_64**

XEN (c4.large)

```
Apr 20 17:02:04 localhost systemd[1]: Virtualization Xen found in DMI (/sys/class/d
Apr 20 17:02:04 localhost systemd[1]: Virtualization XEN, found /sys/hypervisor/pro
Apr 20 17:02:04 localhost systemd[1]: Found VM virtualization xen
Apr 20 17:02:04 localhost systemd[1]: Detected virtualization xen.
Apr 20 17:02:04 localhost systemd[1]: Detected architecture x86-64.
```

KVM (m5.xlarge)

```
Apr 20 17:01:57 localhost systemd[1]: Virtualization Amazon EC2 found in DMI (/sys/
Apr 20 17:01:57 localhost systemd[1]: UML virtualization not found in /proc/cpuinfo
Apr 20 17:01:57 localhost systemd[1]: Virtualization found, CPUID=KVMKVMKVM
Apr 20 17:01:57 localhost systemd[1]: Found VM virtualization kvm
Apr 20 17:01:57 localhost systemd[1]: Detected virtualization kvm.
Apr 20 17:01:57 localhost systemd[1]: Detected architecture x86-64.
Apr 20 17:01:57 localhost systemd[1]: Detected first boot.
```

**k8s 1.19**

**aarch64**

```
Apr 20 00:46:10 localhost systemd[1]: Virtualization Amazon EC2 found in DMI (/sys/class/dmi/id/sys_vendor)
Apr 20 00:46:10 localhost systemd[1]: UML virtualization not found in /proc/cpuinfo.
Apr 20 00:46:10 localhost systemd[1]: No virtualization found in CPUID
Apr 20 00:46:10 localhost systemd[1]: Found VM virtualization kvm
Apr 20 00:46:10 localhost systemd[1]: Detected virtualization kvm.
Apr 20 00:46:10 localhost systemd[1]: Detected architecture arm64.
```

**x86_64**

XEN (c4.large)

```
Apr 20 16:55:32 localhost systemd[1]: Virtualization Xen found in DMI (/sys/class/dmi/id/sys_vendor)
Apr 20 16:55:32 localhost systemd[1]: Virtualization XEN, found /sys/hypervisor/properties/features with value 00000705, XENFEAT_dom0 (indicating the 'hardware domain')
Apr 20 16:55:32 localhost systemd[1]: Found VM virtualization xen
Apr 20 16:55:32 localhost systemd[1]: Detected virtualization xen.
Apr 20 16:55:32 localhost systemd[1]: Detected architecture x86-64.
```

KVM (m5.xlarge)

```
Apr 20 16:55:22 localhost systemd[1]: Virtualization Amazon EC2 found in DMI (/sys/class/dmi/id/sys_vendor)
Apr 20 16:55:22 localhost systemd[1]: UML virtualization not found in /proc/cpuinfo.
Apr 20 16:55:22 localhost systemd[1]: Virtualization found, CPUID=KVMKVMKVM
Apr 20 16:55:22 localhost systemd[1]: Found VM virtualization kvm
Apr 20 16:55:22 localhost systemd[1]: Detected virtualization kvm.
Apr 20 16:55:22 localhost systemd[1]: Detected architecture x86-64.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
