### PR TITLE
Supported file pattern for logdog log files

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1357,6 +1357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "globset"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,12 +1821,14 @@ version = "0.1.0"
 dependencies = [
  "cargo-readme",
  "flate2",
+ "glob",
  "reqwest",
  "shell-words",
  "snafu",
  "tar",
  "tempfile",
  "url",
+ "walkdir",
 ]
 
 [[package]]

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -10,12 +10,14 @@ exclude = ["README.md"]
 
 [dependencies]
 flate2 = "1.0"
+glob = "0.3"
 reqwest = { version = "0.10.1", default-features = false, features = ["blocking", "rustls-tls"] }
 shell-words = "1.0.0"
 snafu = { version = "0.6", features = ["backtraces-impl-backtrace-crate"] }
 tar = { version = "0.4", default-features = false }
 tempfile = { version = "3.1.0", default-features = false }
 url = "2.1.1"
+walkdir = "2.3"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/logdog/conf/logdog.aws-ecs-1.conf
+++ b/sources/logdog/conf/logdog.aws-ecs-1.conf
@@ -3,5 +3,6 @@ file docker-daemon.json /etc/docker/daemon.json
 file ecs-agent-state.json /var/lib/ecs/data/ecs_agent_data.json
 file ecs-config.json /etc/ecs/ecs.config.json
 http ecs-tasks http://localhost:51678/v1/tasks
-file ecs-cni-bridge-plugin.log /var/log/ecs/ecs-cni-bridge-plugin.log
-file ecs-cni-eni-plugin.log /var/log/ecs/ecs-cni-eni-plugin.log
+glob /var/log/ecs/ecs-cni-bridge-plugin.log*
+glob /var/log/ecs/ecs-cni-eni-plugin.log*
+glob /var/log/ecs/vpc-branch-eni.log*

--- a/sources/logdog/src/error.rs
+++ b/sources/logdog/src/error.rs
@@ -124,6 +124,15 @@ pub(crate) enum Error {
     #[snafu(display("Empty command."))]
     ModeMissing {},
 
+    #[snafu(display("Error parsing glob pattern '{}': {}", pattern, source))]
+    ParseGlobPattern {
+        pattern: String,
+        source: glob::PatternError,
+    },
+
+    #[snafu(display("The logdog configuration has a 'glob' line with no glob instructions."))]
+    PatternMissing {},
+
     #[snafu(display("Cannot write to / as a file."))]
     RootAsFile { backtrace: Backtrace },
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1481 


**Description of changes:**
 Ecs variant awsvpc mode feature's log file has dynamic names, so it was difficult to export such files with current `logdog` capabilities. This change extends logdog to support a new request type `glob`, which takes pattern for file matching. For this case, destination filename and path in tarball will be same as source file.


**Testing done:**
1. Added unit tests to test different combination of patterns.
2. Tested `logdog` in an image:
     * Build an ecs variant image
     * Launced ami in ECS cluster
     * Started eni trunking task to generate `ecs-cni-eni-plugin.log`, `ecs-cni-bridge-plugin.log` and `vpc-branch-eni.log` log files. 
     * Waited an hour and re-ran task so that timestamp are attached to log files.
     * Followed steps [here](https://github.com/bottlerocket-os/bottlerocket#logs) to export log files.
     * verified all the log files are present in expected directory. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
