### PR TITLE
Move kernel console settings to variant tomls

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -177,10 +177,10 @@ set default="0"
 set timeout="0"
 
 menuentry "${PRETTY_NAME} ${VERSION_ID}" {
-   linux (\$root)/vmlinuz \\
+   linux (\$root)/vmlinuz root=/dev/dm-0 \\
        ${KERNEL_PARAMETERS} \\
-       root=/dev/dm-0 rootwait ro \\
-       console=tty0 console=ttyS0 random.trust_cpu=on selinux=1 enforcing=1 \\
+       rootwait ro \\
+       random.trust_cpu=on selinux=1 enforcing=1 \\
        systemd.log_target=journal-or-kmsg systemd.log_color=0 net.ifnames=0 \\
        biosdevname=0 dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\
        dm-mod.create="root,,,ro,0 $VERITY_DATA_512B_BLOCKS verity $VERITY_VERSION PARTUUID=\$boot_uuid/PARTNROFF=1 PARTUUID=\$boot_uuid/PARTNROFF=2 \\

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -8,6 +8,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0",
+]
 included-packages = [
 # core
     "release",

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -6,6 +6,10 @@ publish = false
 build = "build.rs"
 
 [package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0",
+]
 included-packages = [
 # core
     "release",

--- a/variants/aws-k8s-1.16/Cargo.toml
+++ b/variants/aws-k8s-1.16/Cargo.toml
@@ -10,6 +10,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0",
+]
 included-packages = [
     "aws-iam-authenticator",
     "cni",

--- a/variants/aws-k8s-1.17/Cargo.toml
+++ b/variants/aws-k8s-1.17/Cargo.toml
@@ -10,6 +10,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0",
+]
 included-packages = [
     "aws-iam-authenticator",
     "cni",

--- a/variants/aws-k8s-1.18/Cargo.toml
+++ b/variants/aws-k8s-1.18/Cargo.toml
@@ -10,6 +10,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0",
+]
 included-packages = [
     "aws-iam-authenticator",
     "cni",

--- a/variants/aws-k8s-1.19/Cargo.toml
+++ b/variants/aws-k8s-1.19/Cargo.toml
@@ -10,6 +10,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0",
+]
 included-packages = [
     "aws-iam-authenticator",
     "cni",

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -10,6 +10,10 @@ exclude = ["README.md"]
 [package.metadata.build-variant]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=ttyS0",
+    "console=tty1",
+]
 included-packages = [
 # core
     "release",


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/1489

**Description of changes:**

This moves console settings like `console=tty0` to variant tomls to allow for different variants to have different console configurations.

**Testing done:**

Built and launched the following variants and checked to see if they still have console messages.

- [x] vmware-dev (x86_64)
- [x] aws-ecs-1 (aarch64)
- [x] aws-k8s-1.16 (aarch64)
- [x] aws-k8s-1.17 (aarch64)
- [x] aws-k8s-1.18 (x86_64)
- [x] aws-k8s-1.19 (x86_64)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
