### PR TITLE
Revert "release: do not acquire a IPv6 lease on eth0"

### DIFF
--- a/packages/release/eth0.xml
+++ b/packages/release/eth0.xml
@@ -17,4 +17,9 @@
   <ipv4:dhcp>
     <enabled>true</enabled>
   </ipv4:dhcp>
+
+  <ipv6:dhcp>
+    <enabled>true</enabled>
+    <defer-timeout>1</defer-timeout>
+  </ipv6:dhcp>
 </interface>


### PR DESCRIPTION
This reverts commit 62c57670289aa99ae8a77c265add61c712af63ff.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
NA


**Description of changes:**
One of the ecs tests for ipv6 connectivity failed because of the change as it breaks containers using host networking and expecting IPv6 support, thus reverted.


**Testing done:**
Tested `aws-ecs-1` variant. Reverting this commit passes the failed test for ipv6 connectivity. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
