### PR TITLE
release: add new udev rules for mounting CD-ROMs

### DIFF
--- a/packages/release/media-cdrom.mount
+++ b/packages/release/media-cdrom.mount
@@ -3,7 +3,7 @@ Description=CD-ROM mount (/media/cdrom)
 # Only run this unit if /dev/cdrom exists and is tracked via systemd. (systemd
 # ships with a udev rule to tag and symlink the first suspected cdrom device to
 # /dev/cdrom)
-Requires=dev-cdrom.device
+BindsTo=dev-cdrom.device
 After=dev-cdrom.device
 DefaultDependencies=no
 Conflicts=umount.target
@@ -13,9 +13,4 @@ Before=local-fs.target umount.target
 What=/dev/cdrom
 Where=/media/cdrom
 Type=iso9660
-Options=defaults,noexec
-
-[Install]
-# This dependency ensures that systemd attempts to run this unit if the device
-# exists.
-WantedBy=dev-cdrom.device
+Options=ro,defaults,noexec

--- a/packages/release/mount-cdrom.rules
+++ b/packages/release/mount-cdrom.rules
@@ -1,0 +1,8 @@
+ACTION!="change", GOTO="mount_cdrom_end"
+SUBSYSTEM!="block", GOTO="mount_cdrom_end"
+KERNEL!="sr[0-9]*|vdisk*|xvd*", GOTO="mount_cdrom_end"
+ENV{DEVTYPE}!="disk", GOTO="mount_cdrom_end"
+# If media is present, we want to mount the CD-ROM.
+ENV{ID_CDROM}=="1", ENV{ID_CDROM_MEDIA}=="1", ENV{ID_FS_TYPE}=="iso9660", \
+  ENV{SYSTEMD_WANTS}="media-cdrom.mount"
+LABEL="mount_cdrom_end"

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -29,8 +29,9 @@ Source1008: opt.mount
 Source1009: var-lib-bottlerocket.mount
 Source1010: etc-cni.mount
 
-# CD-ROM mount
+# CD-ROM mount & associated udev rules
 Source1015: media-cdrom.mount
+Source1016: mount-cdrom.rules
 
 # Mounts that require build-time edits.
 Source1020: var-lib-kernel-devel-lower.mount.in
@@ -113,6 +114,9 @@ install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
 
+install -d %{buildroot}%{_cross_udevrulesdir}
+install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.rules
+
 ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
 %files
@@ -141,5 +145,6 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/motd
 %{_cross_templatedir}/proxy-env
+%{_cross_udevrulesdir}/61-mount-cdrom.rules
 
 %changelog


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1427


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Apr 14 17:03:22 2021 -0700

    release: add new udev rules for mounting cdroms
    
    Adds new udev rules for activating the media-cdrom.mount unit whenever
    we detect media in the CD drive. Removes `WantedBy=` from the mount unit
    as it's no longer needed.
```


**Testing done:**
Build OVA and created VM in vSphere.

Booting the VM with a CD-Drive connected with datastore stored on a CD-ROM works as expected. The CD-ROM gets mounted correctly, `early-boot-config` is able to read user-data from it.:
![boot-with-cdrom](https://user-images.githubusercontent.com/52762042/115796231-590e8100-a386-11eb-9d3b-4017f76ce098.png)

If I remove the CD-ROM from the CD-drive afterwards, the `media-cdrom.mount` goes inactive as does `dev-cdrom.device`:
![remove-cd-after](https://user-images.githubusercontent.com/52762042/115796332-8824f280-a386-11eb-931d-3b32d14f1204.png)

Next, if I boot the VM with no CD-ROM in the drive. The host comes up fine with both `media-cdrom.mount` and `dev-cdrom.device` inactive. If I insert a CD-ROM afterwards, they become active as expected and the CD-ROM is mounted successfully at `/media/cdrom`.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
