### PR TITLE
Add resize2fs binary to sbin

### DIFF
--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -38,6 +38,7 @@ Requires: %{_cross_os}e2fsprogs-libs
   --enable-elf-shlibs \
   --enable-symlink-install \
   --enable-relative-symlinks \
+  --enable-resizer \
   --disable-backtrace \
   --disable-debugfs \
   --disable-defrag \
@@ -48,7 +49,6 @@ Requires: %{_cross_os}e2fsprogs-libs
   --disable-libblkid \
   --disable-libuuid \
   --disable-nls \
-  --disable-resizer \
   --disable-rpath \
   --disable-tdb \
   --disable-uuidd \
@@ -84,6 +84,7 @@ install -p -m 0644 %{S:11} %{buildroot}%{_cross_tmpfilesdir}/e2fsprogs.conf
 %{_cross_sbindir}/mkfs.ext2
 %{_cross_sbindir}/mkfs.ext3
 %{_cross_sbindir}/mkfs.ext4
+%{_cross_sbindir}/resize2fs
 %{_cross_sbindir}/tune2fs
 %{_cross_factorydir}%{_cross_sysconfdir}/mke2fs.conf
 %{_cross_tmpfilesdir}/e2fsprogs.conf


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
resolves #1518

**Description of changes:**
Add resize2fs binary to sbin - this makes ebs pvcs can be extended.

**Testing done:**
I tested this code with a private cluster and verified this patch works.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
