### PR TITLE
pubsys: validate-repo without tokio runtime

### DIFF
--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -44,12 +44,7 @@ fn run() -> Result<()> {
     match args.subcommand {
         SubCommand::Repo(ref repo_args) => repo::run(&args, &repo_args).context(error::Repo),
         SubCommand::ValidateRepo(ref validate_repo_args) => {
-            let rt = Runtime::new().context(error::Runtime)?;
-            rt.block_on(async {
-                repo::validate_repo::run(&args, &validate_repo_args)
-                    .await
-                    .context(error::ValidateRepo)
-            })
+            repo::validate_repo::run(&args, &validate_repo_args).context(error::ValidateRepo)
         }
         SubCommand::CheckRepoExpirations(ref check_expirations_args) => {
             repo::check_expirations::run(&args, &check_expirations_args)


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**



**Description of changes:**

We were seeing `pubsys validate-repo` hang and we believe it was because of multiple tokio runtimes. Although it's not clear why `tokio::spawn` was working before, re-implementing this to use `std::thread::spawn` instead has fixed the problem.

**Testing done:**

Created an Infra.toml like this:

```toml
[repo.2020-07-07]
metadata_base_url = "https://updates.bottlerocket.aws/2020-07-07/"
targets_url = "https://updates.bottlerocket.aws/targets/"
root_role_url = "https://cache.bottlerocket.aws/root.json"
root_role_sha512 = "90393204232a1ad6b0a45528b1f7df1a3e37493b1e05b1c149f081849a292c8dafb4ea5f7ee17bcc664e35f66e37e4cfa4aae9de7a2a28aa31ae6ac3d9bea4d5"
```

And this a few times:

```sh
cargo make validate-repo \
    -e PUBLISH_REPO=2020-07-07 \
    -e BUILDSYS_VARIANT=aws-k8s-1.15 \
    -e BUILDSYS_ARCH=x86_64 \
    -e PUBLISH_INFRA_CONFIG_PATH="${INFRA_TOML}"
```

I also edited a target in a repo and verified that the program errors out when the repo is bad:

```
Failed to validate repository: Failed to download and write target 'migrate_v1.0.6_metricdog-init.lz4': Hash mismatch for https://somewhere.amazonaws.com/somewhere/targets/17a0a6e4f95471734b77091212ccabf564d3312062fc98c995002df2fbf7c6db.migrate_v1.0.6_metricdog-init.lz4: calculated 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae, expected 17a0a6e4f95471734b77091212ccabf564d3312062fc98c995002df2fbf7c6db
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
