### PR TITLE
packages: build zlib and zlib-devel

### DIFF
--- a/packages/libz/Cargo.toml
+++ b/packages/libz/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "libz"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://www.zlib.net/zlib-1.2.11.tar.xz"
+sha512 = "b7f50ada138c7f93eb7eb1631efccd1d9f03a5e77b6c13c8b757017b2d462e19d2d3e01c50fad60a4ae1bc86d431f6f94c72c11ff410c25121e571953017cb67"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libz/build.rs
+++ b/packages/libz/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/libz/libz.spec
+++ b/packages/libz/libz.spec
@@ -1,0 +1,50 @@
+Name: %{_cross_os}libz
+Version: 1.2.11
+Release: 1%{?dist}
+Summary: Library for zlib compression
+URL: https://www.zlib.net/
+License: Zlib
+Source: https://www.zlib.net/zlib-%{version}.tar.xz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for zlib compression
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%setup -n zlib-%{version}
+
+# Sets cross build flags, target cross compiler, and env variables
+# required to `make install` libz
+%global set_env \
+%set_cross_build_flags \\\
+export CROSS_PREFIX="%{_cross_target}-" \\\
+%{nil}
+
+%build
+%set_env
+# zlib only reads prefix from this argument, not the environment
+./configure --prefix='%{_cross_prefix}'
+%make_build
+
+%install
+%set_env
+%make_install
+
+%files
+%license README
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+%exclude %{_cross_mandir}
+
+%files devel
+%{_cross_libdir}/*.so
+%{_cross_includedir}/*.h
+%{_cross_libdir}/*.a
+%{_cross_pkgconfigdir}/*.pc

--- a/packages/libz/pkg.rs
+++ b/packages/libz/pkg.rs
@@ -1,0 +1,1 @@
+// not used


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**
```
6bd13fa5 packages: build zlib and zlib-devel
```

This commit adds zlib runtime libraries and development headers

**Testing done:**
- Build vmware-dev variant and confirm the new libraries are in `/usr/lib`, the snapshot is the output of a VMWare host:

![image](https://user-images.githubusercontent.com/6305870/116148034-4604f500-a695-11eb-92a5-de74cfaf4f37.png)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
