### PR TITLE
kubelet: add setting for configuring registryPullQPS and registryBurst 

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ The following settings are optional and allow you to further configure your clus
     ```
     allowed-unsafe-sysctls = ["net.core.somaxconn", "net.ipv4.ip_local_port_range"]
     ```
+* `settings.kubernetes.registry-qps`: The registry pull QPS.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ The following settings are optional and allow you to further configure your clus
     allowed-unsafe-sysctls = ["net.core.somaxconn", "net.ipv4.ip_local_port_range"]
     ```
 * `settings.kubernetes.registry-qps`: The registry pull QPS.
+* `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -41,4 +41,5 @@ version = "1.0.8"
 "(1.0.8, 1.1.0)" = [
     "migrate_v1.1.0_kubelet-server-tls-bootstrap.lz4",
     "migrate_v1.1.0_kubelet-cloud-provider.lz4",
+    "migrate_v1.1.0_kubelet-registry-qps-registry-burst.lz4",
 ]

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -43,6 +43,9 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~#if settings.kubernetes.registry-qps}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-burst}}
+registryBurst: {{settings.kubernetes.registry-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -40,6 +40,9 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-qps}}
+registryPullQPS: {{settings.kubernetes.registry-qps}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -43,6 +43,9 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~#if settings.kubernetes.registry-qps}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-burst}}
+registryBurst: {{settings.kubernetes.registry-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -40,6 +40,9 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-qps}}
+registryPullQPS: {{settings.kubernetes.registry-qps}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -43,6 +43,9 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~#if settings.kubernetes.registry-qps}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-burst}}
+registryBurst: {{settings.kubernetes.registry-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -40,6 +40,9 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-qps}}
+registryPullQPS: {{settings.kubernetes.registry-qps}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -43,6 +43,9 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~#if settings.kubernetes.registry-qps}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-burst}}
+registryBurst: {{settings.kubernetes.registry-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -40,6 +40,9 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-qps}}
+registryPullQPS: {{settings.kubernetes.registry-qps}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -43,6 +43,9 @@ allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~#if settings.kubernetes.registry-qps}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-burst}}
+registryBurst: {{settings.kubernetes.registry-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -40,6 +40,9 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
+{{~#if settings.kubernetes.registry-qps}}
+registryPullQPS: {{settings.kubernetes.registry-qps}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1745,6 +1745,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-registry-qps-registry-burst"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-server-tls-bootstrap"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "api/migration/migrations/v1.0.8/add-bootstrap-containers",
     "api/migration/migrations/v1.1.0/kubelet-server-tls-bootstrap",
     "api/migration/migrations/v1.1.0/kubelet-cloud-provider",
+    "api/migration/migrations/v1.1.0/kubelet-registry-qps-registry-burst",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.0/kubelet-registry-qps-registry-burst/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-registry-qps-registry-burst/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-registry-qps-registry-burst"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.0/kubelet-registry-qps-registry-burst/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-registry-qps-registry-burst/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added two new settings for configuring kubelet, `settings.kubernetes.registry-qps`
+/// and `settings.kubernetes.registry-burst`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.registry-qps",
+        "settings.kubernetes.registry-burst",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -134,6 +134,7 @@ struct KubernetesSettings {
     allowed_unsafe_sysctls: Vec<SingleLineString>,
     server_tls_bootstrap: bool,
     cloud_provider: KubernetesCloudProvider,
+    registry_qps: i32,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -135,6 +135,7 @@ struct KubernetesSettings {
     server_tls_bootstrap: bool,
     cloud_provider: KubernetesCloudProvider,
     registry_qps: i32,
+    registry_burst: i32,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1495


**Description of changes:**
Adds two new settings `kubernetes.registry-qps` and `kubernetes.resgitry-burst` for configuring


**Testing done:**
#### `registry-qps`

Setting `registry-qps` to lowest value (1). and lauching/pulling a number of pods/containers that exceed the image pulling QPS to trigger Error `ErrImagePull - pull QPS exceeded`

Fist step: Test Default value (5)
Test with default value to make sure test result only can be affected by `registry-qps`

Lauching 12 pods/containers simultaneously
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml
			  -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml
			  -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml
			  -f postgres.yaml
```
All pods/containers have been created succesfully, which is expected.
```
[tianhg@ip-172-31-35-96 ~]$ kubectl get pods
NAME                READY   STATUS             RESTARTS   AGE
amazonlinux-96gg7   1/1     Running            1          63m
busybox-k4pp7       1/1     Running            0          63m
debian-2qpwt        1/1     Running            1          63m
....
```

Second step: Test Lowest value (1)
Test with lowest value (1) to makre sure Error `ErrImagePull - pull QPS exceeded` will be triggered because of inadequate QPS value 

Setting `registry-qps` to lowest value, which is 1. 
```
Userdata
[settings.kubernetes]
registry-qps = 1
```

Lauching 12 pods/containers simultaneously
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml 
			  -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml
			  -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml
			  -f postgres.yaml 
```

Error `ErrImagePull - pull QPS exceeded` has been triggerred, which means `registry-qps = 1` succussfully limits pulling images. 
```
redis-vl72j         0/1     ErrImagePull        0          13s
httpd-d7mtb         0/1     ContainerCreating   0          13s
node-9xvzk          0/1     ContainerCreating   0          14s
mysql-86jwv         0/1     ContainerCreating   0          13s
```
```
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  44s                default-scheduler  Successfully assigned default/redis-bjz2x to ip-192-168-4-68.us-west-2.compute.internal
  Warning  Failed     36s                kubelet            Failed to pull image "redis:5.0.12": pull QPS exceeded
  Warning  Failed     36s                kubelet            Error: ErrImagePull
```

#### `registry-burst`

Setting `registry-burst` to lowest value (1). and lauching/pulling a number of pods/containers that exceed the image pulling QPS to trigger Error `ErrImagePull - pull QPS exceeded`

Fist step: Test Default value (10)
Test with default value to make sure test result only can be affected by `registry-burst`

Lauching 7 pods/containers simultaneously
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f redis.yaml -f ubuntu.yaml
			  -f nginx.yaml -f python.yaml -f busybox.yaml
```
All pods/containers have been created succesfully, which is expected.
```
NAME                READY   STATUS    RESTARTS   AGE
amazonlinux-dmc2j   1/1     Running   0          2m28s
amazonlinux-q5qhj   1/1     Running   0          2m28s
busybox-7mr77       1/1     Running   0          2m28s
busybox-bccx9       1/1     Running   0          2m28s
....
```

Second step: Test Lowest value (1)
Test with lowest value (1) to makre sure Error `ErrImagePull - pull QPS exceeded` will be triggered because of inadequate QPS value 

Setting `registry-burst` to lowest value, which is 1. 
```
Userdata
[settings.kubernetes]
registry-burst = 1
```

Lauching 7 pods/containers simultaneously
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f redis.yaml -f ubuntu.yaml
			  -f nginx.yaml -f python.yaml -f busybox.yaml 
```

Error `ErrImagePull - pull QPS exceeded` has been triggerred, which means `registry-burst = 1` succussfully limits pulling images. 
```
redis-lr7lg         0/1     ErrImagePull        0          7s
debian-tdgj2        0/1     ErrImagePull        0          8s
redis-2b4zg         0/1     ErrImagePull        0          8s
amazonlinux-55s6b   0/1     ErrImagePull        0          9s
debian-rcf2k        0/1     ErrImagePull        0          10s
```
```
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Scheduled  20s               default-scheduler  Successfully assigned default/debian-tdgj2 to ip-192-168-12-158.us-west-2.compute.internal
  Warning  Failed     18s               kubelet            Failed to pull image "debian:latest": pull QPS exceeded
  Warning  Failed     18s               kubelet            Error: ErrImagePull
  Normal   BackOff    18s               kubelet            Back-off pulling image "debian:latest"
```
### Migration test
upgrade and downgrade

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
