### PR TITLE
add open-vm-tools and dependencies

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,7 +26,7 @@ BUILDSYS_NAME = "bottlerocket"
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.20.0"
+BUILDSYS_SDK_VERSION="v0.21.0"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -31,6 +31,7 @@ Requires: %{name}
   --disable-ducktype-docs \
   --disable-tests \
   --disable-xml-docs \
+  --disable-selinux \
   --disable-systemd \
   --with-xml=expat \
 

--- a/packages/libffi/Cargo.toml
+++ b/packages/libffi/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "libffi"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz"
+sha512 = "61513801a156f11420f541d325de697131846487122d6bdcf5491b18b4da788589f5c0bb07e88e396495d3be5830d74e9135595e2b8ddbfe95c448d8597fbd6f"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libffi/build.rs
+++ b/packages/libffi/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/libffi/libffi.spec
+++ b/packages/libffi/libffi.spec
@@ -1,0 +1,46 @@
+Name: %{_cross_os}libffi
+Version: 3.3
+Release: 1%{?dist}
+Summary: Library for FFI
+License: MIT
+URL: https://sourceware.org/libffi/
+Source0: https://github.com/libffi/libffi/releases/download/v%{version}/libffi-%{version}.tar.gz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for FFI
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n libffi-%{version} -p1
+
+%build
+%cross_configure \
+  --disable-docs \
+  --disable-multi-os-directory \
+
+%make_build
+
+%install
+%make_install
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+%exclude %{_cross_mandir}
+
+%files devel
+%{_cross_libdir}/*.a
+%{_cross_libdir}/*.so
+%{_cross_includedir}/*.h
+%{_cross_pkgconfigdir}/*.pc
+%exclude %{_cross_libdir}/*.la
+
+%changelog

--- a/packages/libffi/pkg.rs
+++ b/packages/libffi/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "libglib"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://download.gnome.org/sources/glib/2.68/glib-2.68.1.tar.xz"
+sha512 = "f705cda6f1b4b0acc5fe8d21b60994ca0ec6de39c6722f4f01cbe0ece30eacb7271d3cb29067e638e0204a3cefa2df1e535f273b72330455e185b544cebc2ab0"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libffi = { path = "../libffi" }
+libpcre = { path = "../libpcre" }
+libselinux = { path = "../libselinux" }
+libz = { path = "../libz" }
+util-linux = { path = "../util-linux" }

--- a/packages/libglib/build.rs
+++ b/packages/libglib/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,0 +1,70 @@
+Name: %{_cross_os}libglib
+Version: 2.68.1
+Release: 1%{?dist}
+Summary: The GLib libraries
+License: LGPL-2.1-or-later
+URL: https://www.gtk.org/
+Source0: https://download.gnome.org/sources/glib/2.68/glib-%{version}.tar.xz
+BuildRequires: meson
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libffi-devel
+BuildRequires: %{_cross_os}libmount-devel
+BuildRequires: %{_cross_os}libpcre-devel
+BuildRequires: %{_cross_os}libselinux-devel
+BuildRequires: %{_cross_os}libz-devel
+Requires: %{_cross_os}libffi
+Requires: %{_cross_os}libmount
+Requires: %{_cross_os}libpcre
+Requires: %{_cross_os}libselinux
+Requires: %{_cross_os}libz
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the GLib libraries
+Requires: %{name}
+Requires: %{_cross_os}libffi-devel
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n glib-%{version} -p1
+
+%build
+CONFIGURE_OPTS=(
+ -Dlibmount=enabled
+ -Dselinux=enabled
+
+ -Dlibelf=disabled
+ -Dnls=disabled
+
+ -Dman=false
+ -Dtests=false
+)
+
+%cross_meson "${CONFIGURE_OPTS[@]}"
+%cross_meson_build
+
+%install
+%cross_meson_install
+
+%files
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+%exclude %{_cross_datadir}
+
+%files devel
+%{_cross_bindir}/*
+%{_cross_libdir}/*.so
+%dir %{_cross_libdir}/glib-2.0
+%dir %{_cross_libdir}/glib-2.0/include
+%{_cross_libdir}/glib-2.0/include/glibconfig.h
+%dir %{_cross_includedir}/gio-unix-2.0
+%dir %{_cross_includedir}/glib-2.0
+%{_cross_includedir}/gio-unix-2.0/*
+%{_cross_includedir}/glib-2.0/*
+%{_cross_pkgconfigdir}/*.pc
+
+%changelog

--- a/packages/libglib/pkg.rs
+++ b/packages/libglib/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/libtirpc/Cargo.toml
+++ b/packages/libtirpc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "libtirpc"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.1.tar.bz2"
+sha512 = "131f746800ac7280cc3900597018fc8dbc8da50c14e29dbaccf36a6d110eded117351108c6b069eaac90d77cfec17014b08e9afddcf153fda2d780ba64260cbc"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libtirpc/build.rs
+++ b/packages/libtirpc/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/libtirpc/libtirpc.spec
+++ b/packages/libtirpc/libtirpc.spec
@@ -1,0 +1,49 @@
+Name: %{_cross_os}libtirpc
+Version: 1.3.1
+Release: 1%{?dist}
+Summary: Library for RPC
+License: BSD-3-Clause
+URL: http://git.linux-nfs.org/?p=steved/libtirpc.git;a=summary
+Source0: http://downloads.sourceforge.net/libtirpc/libtirpc-%{version}.tar.bz2
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for RPC
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n libtirpc-%{version} -p1
+
+%build
+%cross_configure \
+  --enable-static \
+  --disable-authdes \
+  --disable-gssapi \
+
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+%exclude %{_cross_mandir}
+%exclude %{_cross_sysconfdir}
+
+%files devel
+%{_cross_libdir}/*.a
+%{_cross_libdir}/*.so
+%dir %{_cross_includedir}/tirpc
+%{_cross_includedir}/tirpc/*
+%{_cross_pkgconfigdir}/*.pc
+%exclude %{_cross_libdir}/*.la
+
+%changelog

--- a/packages/libtirpc/pkg.rs
+++ b/packages/libtirpc/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/open-vm-tools/0001-no_cflags_werror.patch
+++ b/packages/open-vm-tools/0001-no_cflags_werror.patch
@@ -1,0 +1,18 @@
+configure.ac: disable -Werror
+
+Disable the mandatory flag -Werror in configure.ac.
+
+Signed-off-by: Karoly Kasza <kaszak@gmail.com>
+
+--- open-vm-tools/configure.ac	2015-06-17 10:02:00.000000000 +0200
++++ open-vm-tools/configure.ac	2015-06-17 10:02:00.000000000 +0200
+@@ -935,7 +935,7 @@
+ 
+ ### General flags / actions
+ CFLAGS="$CFLAGS -Wall"
+-CFLAGS="$CFLAGS -Werror"
++# CFLAGS="$CFLAGS -Werror"
+ 
+ # -Wno-unknown-pragmas is due to gcc not understanding '#pragma ident'
+ # in Xlib.h on OpenSolaris.
+

--- a/packages/open-vm-tools/0002-dont-force-cppflags.patch
+++ b/packages/open-vm-tools/0002-dont-force-cppflags.patch
@@ -1,0 +1,21 @@
+m4: do not force -I/usr/include in CPPFLAGS
+
+This is so horribly broken for cross-compilation. :-(
+
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+
+--- open-vm-tools/m4/vmtools.m4	2015-06-17 10:03:00.000000000 +0200
++++ open-vm-tools/m4/vmtools.m4	2015-06-17 10:03:00.000000000 +0200
+@@ -281,10 +281,10 @@
+       if test "$os" = freebsd; then
+          CUSTOM_$1_CPPFLAGS="-I/usr/local/include"
+       else
+-         CUSTOM_$1_CPPFLAGS="-I/usr/include"
++         CUSTOM_$1_CPPFLAGS=" "
+       fi
+       if test -n "$2"; then
+-         CUSTOM_$1_CPPFLAGS="${CUSTOM_$1_CPPFLAGS}/$2"
++         : CUSTOM_$1_CPPFLAGS="${CUSTOM_$1_CPPFLAGS}/$2"
+       fi
+    fi
+ ])

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "open-vm-tools"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/vmware/open-vm-tools/releases/download/stable-11.2.5/open-vm-tools-11.2.5-17337674.tar.gz"
+sha512 = "b6d4bc6522418ec7a881752181ad9240e535854df492e758abf3996c6afe245466ffbff60cc1b6cdff5cf731b5769c9f9cb96aed29f0b788d0eef05f91fcf8ab"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libglib = { path = "../libglib" }
+libtirpc = { path = "../libtirpc" }
+libxcrypt = { path = "../libxcrypt" }

--- a/packages/open-vm-tools/build.rs
+++ b/packages/open-vm-tools/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/open-vm-tools/open-vm-tools-tmpfiles.conf
+++ b/packages/open-vm-tools/open-vm-tools-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/vmware-tools/tools.conf - - - -

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -1,0 +1,119 @@
+%global buildver 17337674
+
+Name: %{_cross_os}open-vm-tools
+Version: 11.2.5
+Release: 1%{?dist}
+Summary: Tools for VMware
+License: LGPL-2.1-or-later
+URL: https://github.com/vmware/open-vm-tools
+Source0: https://github.com/vmware/open-vm-tools/releases/download/stable-%{version}/open-vm-tools-%{version}-%{buildver}.tar.gz
+Source1: vmtoolsd.service
+Source2: tools.conf
+Source3: open-vm-tools-tmpfiles.conf
+Patch0001: 0001-no_cflags_werror.patch
+Patch0002: 0002-dont-force-cppflags.patch
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libglib-devel
+BuildRequires: %{_cross_os}libtirpc-devel
+BuildRequires: %{_cross_os}libxcrypt-devel
+Requires: %{_cross_os}libglib
+Requires: %{_cross_os}libtirpc
+Requires: %{_cross_os}libxcrypt
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the tools for VMware
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n open-vm-tools-%{version}-%{buildver} -p1
+
+%build
+autoreconf -fi
+%cross_configure \
+  --disable-deploypkg \
+  --disable-docs \
+  --disable-libappmonitor \
+  --disable-multimon \
+  --disable-resolutionkms \
+  --disable-servicediscovery \
+  --disable-tests \
+  --disable-vgauth \
+  --with-tirpc \
+  --with-udev-rules-dir=%{_cross_udevrulesdir} \
+  --without-dnet \
+  --without-gtk2 \
+  --without-gtk3 \
+  --without-gtkmm \
+  --without-gtkmm3 \
+  --without-icu \
+  --without-kernel-modules \
+  --without-pam \
+  --without-ssl \
+  --without-x \
+  --without-xerces \
+  --without-xml2 \
+  --without-xmlsec1 \
+  --without-xmlsecurity \
+
+# "fix" rpath
+sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
+sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+
+%make_build
+
+%install
+%make_install
+
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/vmtoolsd.service
+
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/vmware-tools
+install -p -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/vmware-tools
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:3} %{buildroot}%{_cross_tmpfilesdir}/open-vm-tools.conf
+
+find %{buildroot} -name '*.la' -delete
+
+%files
+%license COPYING LICENSE
+%{_cross_attribution_file}
+%{_cross_bindir}/vmtoolsd
+%{_cross_bindir}/vmware-toolbox-cmd
+%{_cross_unitdir}/vmtoolsd.service
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/vmware-tools
+%{_cross_factorydir}%{_cross_sysconfdir}/vmware-tools/tools.conf
+%{_cross_tmpfilesdir}/open-vm-tools.conf
+
+%{_cross_libdir}/*.so.*
+%dir %{_cross_libdir}/open-vm-tools
+%{_cross_libdir}/open-vm-tools/*
+%dir %{_cross_datadir}/open-vm-tools
+%{_cross_datadir}/open-vm-tools/*
+
+%exclude %{_cross_bindir}/vmware-checkvm
+%exclude %{_cross_bindir}/vmware-namespace-cmd
+%exclude %{_cross_bindir}/vmware-rpctool
+%exclude %{_cross_bindir}/vmware-xferlogs
+%exclude %{_cross_bindir}/vmware-hgfsclient
+%exclude %{_cross_sbindir}/mount.vmhgfs
+%exclude %{_cross_sysconfdir}
+%exclude %{_cross_udevrulesdir}
+
+%exclude %{_bindir}
+%exclude /sbin
+
+%files devel
+%{_cross_libdir}/*.a
+%{_cross_libdir}/*.so
+%dir %{_cross_includedir}/vmGuestLib
+%{_cross_includedir}/vmGuestLib/*
+%{_cross_pkgconfigdir}/*.pc
+
+%changelog

--- a/packages/open-vm-tools/pkg.rs
+++ b/packages/open-vm-tools/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/open-vm-tools/tools.conf
+++ b/packages/open-vm-tools/tools.conf
@@ -1,0 +1,5 @@
+[powerops]
+poweron-script=/usr/bin/true
+poweroff-script=/usr/bin/true
+resume-script=/usr/bin/true
+suspend-script=/usr/bin/true

--- a/packages/open-vm-tools/vmtoolsd.service
+++ b/packages/open-vm-tools/vmtoolsd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=VMware Tools service
+Documentation=https://github.com/vmware/open-vm-tools
+ConditionVirtualization=vmware
+
+[Service]
+ExecStart=/usr/bin/vmtoolsd
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -55,6 +55,7 @@ Requires: %{_cross_os}libfdisk
 %package -n %{_cross_os}libmount
 Summary: Device mounting library
 License: LGPL-2.1-or-later
+Requires: %{_cross_os}libblkid
 Requires: %{_cross_os}libselinux
 
 %description -n %{_cross_os}libmount
@@ -63,6 +64,7 @@ Requires: %{_cross_os}libselinux
 %package -n %{_cross_os}libmount-devel
 Summary: Files for development using the device mounting library
 License: LGPL-2.1-or-later
+Requires: %{_cross_os}libblkid-devel
 Requires: %{_cross_os}libmount
 
 %description -n %{_cross_os}libmount-devel

--- a/sources/models/src/vmware-dev/defaults.d/50-vmware-dev.toml
+++ b/sources/models/src/vmware-dev/defaults.d/50-vmware-dev.toml
@@ -1,7 +1,7 @@
 # Metrics
 [settings.metrics]
 send-metrics = false
-service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "docker"]
+service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "docker", "vmtoolsd"]
 
 # Network
 [metadata.settings.network]

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -603,6 +603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "open-vm-tools"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libglib",
+ "libtirpc",
+ "libxcrypt",
+]
+
+[[package]]
 name = "os"
 version = "0.1.0"
 dependencies = [

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -738,6 +738,7 @@ dependencies = [
  "iputils",
  "kernel-5_10",
  "login",
+ "open-vm-tools",
  "procps",
  "release",
  "strace",

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -432,6 +432,18 @@ name = "libgcc"
 version = "0.1.0"
 
 [[package]]
+name = "libglib"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libffi",
+ "libpcre",
+ "libselinux",
+ "libz",
+ "util-linux",
+]
+
+[[package]]
 name = "libiw"
 version = "0.1.0"
 dependencies = [
@@ -562,6 +574,13 @@ dependencies = [
 
 [[package]]
 name = "libxcrypt"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "libz"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -554,6 +554,13 @@ name = "libstd-rust"
 version = "0.1.0"
 
 [[package]]
+name = "libtirpc"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "libxcrypt"
 version = "0.1.0"
 dependencies = [

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -421,6 +421,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libffi"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "libgcc"
 version = "0.1.0"
 

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -18,6 +18,7 @@ included-packages = [
 # core
     "release",
     "kernel-5.10",
+    "open-vm-tools",
 # docker
     "docker-cli",
     "docker-engine",
@@ -40,6 +41,7 @@ path = "lib.rs"
 # core
 release = { path = "../../packages/release" }
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
+open-vm-tools = { path = "../../packages/open-vm-tools" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }


### PR DESCRIPTION
**Issue number:**
Fixes #1510


**Description of changes:**
Add `open-vm-tools` and its dependencies: glib2, libffi, libtirpc.

Make a minor fix to the `libmount` package in `util-linux` to correctly express development dependencies.

Adjust `libdbus` build to work correctly if `libselinux-devel` is present in the SDK.

Update to a newer SDK that contains `glib-genmarshal` and `genrpc`. 


**Testing done:**
Built the `vmware-dev` image. Verified that the DNS name and IP addresses are visible in vCenter, and that VMWare Tools reports as running.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
