### PR TITLE
models: add lockdown default configuration files

### DIFF
--- a/SECURITY_GUIDANCE.md
+++ b/SECURITY_GUIDANCE.md
@@ -113,10 +113,10 @@ Modifications to the running kernel could bypass or subvert these mechanisms.
 Bottlerocket enables the Lockdown security module and offers settings to choose from one of three modes.
 
 The first mode, "none", effectively disables the protection.
-This is the default in today's [variants](variants/) of Bottlerocket, for compatibility with existing deployments.
+This is the default in older [variants](variants/) of Bottlerocket, for compatibility with existing deployments.
 
 The second mode, "integrity", blocks most ways to overwrite the kernel's memory and modify its code.
-This will become the default in future variants.
+This is the default in newer variants.
 Enabling this mode will prevent unsigned kernel modules from being loaded.
 
 The third mode, "confidentiality", stops most ways of reading the kernel's memory from userspace.

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -94,9 +94,6 @@ affected-services = ["chronyd"]
 
 # Kernel
 
-[settings.kernel]
-lockdown = "none"
-
 [services.sysctl]
 configuration-files = []
 restart-commands = ["/usr/bin/corndog sysctl"]

--- a/sources/models/shared-defaults/lockdown-none.toml
+++ b/sources/models/shared-defaults/lockdown-none.toml
@@ -1,0 +1,3 @@
+# Kernel
+[settings.kernel]
+lockdown = "none"

--- a/sources/models/src/aws-dev/defaults.d/51-lockdown-none.toml
+++ b/sources/models/src/aws-dev/defaults.d/51-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml

--- a/sources/models/src/aws-ecs-1/defaults.d/51-lockdown-integrity.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/51-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/models/src/aws-k8s-1.19/defaults.d/51-lockdown-none.toml
+++ b/sources/models/src/aws-k8s-1.19/defaults.d/51-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml

--- a/sources/models/src/vmware-dev/defaults.d/51-lockdown-none.toml
+++ b/sources/models/src/vmware-dev/defaults.d/51-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml


### PR DESCRIPTION
**Issue number:**
#813 


**Description of changes:**

```
fc416bf1  docs: update security guidance document
```

This commit updates the security guidance document since the default kernel lockdown mode for newer variants is `integrity`

```
4e6b5a5f models: add lockdown default configuration files
```

This commit adds default configuration files for the different values that can be used for the kernel lockdown setting. It also changes the lockdown mode for the ECS variant from `none` to `integrity`.


**Testing done:**
In aws-dev, aws-ecs, k8s 1.16, 1.17, 1.18, 1.19 x86_64:

- Launch nginx container/task/pod
- Check `systemctl status`, no failing units
- Check the expected values of `/sys/kernel/security/lockdown` in each variant:

#### AWS dev:

```shell
cat /sys/kernel/security/lockdown
[none] integrity confidentiality
```

#### AWS ECS:

```shell
cat /sys/kernel/security/lockdown
none [integrity] confidentiality
```

#### AWS k8s 1.19:

```shell
cat /sys/kernel/security/lockdown
[none] integrity confidentiality
```

#### AWS k8s 1.18:

```shell
cat /sys/kernel/security/lockdown
[none] integrity confidentiality
```

#### AWS k8s 1.17:

```shell
cat /sys/kernel/security/lockdown
[none] integrity confidentiality
```

#### AWS k8s 1.16:

```shell
cat /sys/kernel/security/lockdown
[none] integrity confidentiality
```

#### VMWare dev:
![Screenshot from 2021-04-28 10-58-39](https://user-images.githubusercontent.com/6305870/116451091-e92e4980-a810-11eb-94f3-7998193eb19b.png)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
