### PR TITLE
kubelet: add setting for configuring eventRecordQPS and eventBurst

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ The following settings are optional and allow you to further configure your clus
     ```
 * `settings.kubernetes.registry-qps`: The registry pull QPS.
 * `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.
+* `settings.kubernetes.event-burst`: The maximum size of a burst of event creations.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ The following settings are optional and allow you to further configure your clus
     ```
 * `settings.kubernetes.registry-qps`: The registry pull QPS.
 * `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.
+* `settings.kubernetes.event-qps`: The maximum event creations per second.
 * `settings.kubernetes.event-burst`: The maximum size of a burst of event creations.
 
 You can also optionally specify static pods for your node with the following settings.

--- a/Release.toml
+++ b/Release.toml
@@ -43,4 +43,5 @@ version = "1.0.8"
     "migrate_v1.1.0_kubelet-cloud-provider.lz4",
     "migrate_v1.1.0_kubelet-registry-qps-registry-burst.lz4",
     "migrate_v1.1.0_shared-containerd-configs.lz4",
+    "migrate_v1.1.0_kubelet-event-qps-event-burst.lz4",
 ]

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -40,10 +40,10 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-qps}}
+{{~#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-burst}}
+{{~#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
 {{~#if settings.kubernetes.event-qps includeZero=true}}

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-burst includeZero=true}}
+eventBurst: {{settings.kubernetes.event-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-qps includeZero=true}}
+eventRecordQPS: {{settings.kubernetes.event-qps}}
+{{~/if}}
 {{~#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{~/if}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -40,10 +40,10 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-qps}}
+{{~#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-burst}}
+{{~#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
 {{~#if settings.kubernetes.event-qps includeZero=true}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-burst includeZero=true}}
+eventBurst: {{settings.kubernetes.event-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-qps includeZero=true}}
+eventRecordQPS: {{settings.kubernetes.event-qps}}
+{{~/if}}
 {{~#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{~/if}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -40,10 +40,10 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-qps}}
+{{~#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-burst}}
+{{~#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
 {{~#if settings.kubernetes.event-qps includeZero=true}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-burst includeZero=true}}
+eventBurst: {{settings.kubernetes.event-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-qps includeZero=true}}
+eventRecordQPS: {{settings.kubernetes.event-qps}}
+{{~/if}}
 {{~#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{~/if}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -40,10 +40,10 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-qps}}
+{{~#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-burst}}
+{{~#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
 {{~#if settings.kubernetes.event-qps includeZero=true}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-burst includeZero=true}}
+eventBurst: {{settings.kubernetes.event-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-qps includeZero=true}}
+eventRecordQPS: {{settings.kubernetes.event-qps}}
+{{~/if}}
 {{~#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{~/if}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -40,10 +40,10 @@ evictionHard:
 {{~#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-qps}}
+{{~#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~/if}}
-{{~#if settings.kubernetes.registry-burst}}
+{{~#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
 {{~#if settings.kubernetes.event-qps includeZero=true}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-burst includeZero=true}}
+eventBurst: {{settings.kubernetes.event-burst}}
+{{~/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{~#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -46,6 +46,9 @@ registryPullQPS: {{settings.kubernetes.registry-qps}}
 {{~#if settings.kubernetes.registry-burst}}
 registryBurst: {{settings.kubernetes.registry-burst}}
 {{~/if}}
+{{~#if settings.kubernetes.event-qps includeZero=true}}
+eventRecordQPS: {{settings.kubernetes.event-qps}}
+{{~/if}}
 {{~#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{~/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1390,6 +1390,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-event-qps-event-burst"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-registry-qps-registry-burst"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "api/migration/migrations/v1.1.0/kubelet-cloud-provider",
     "api/migration/migrations/v1.1.0/kubelet-registry-qps-registry-burst",
     "api/migration/migrations/v1.1.0/shared-containerd-configs",
+    "api/migration/migrations/v1.1.0/kubelet-event-qps-event-burst",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.0/kubelet-event-qps-event-burst/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-event-qps-event-burst/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-event-qps-event-burst"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.0/kubelet-event-qps-event-burst/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-event-qps-event-burst/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added two new settings for configuring kubelet, `settings.kubernetes.event-qps`
+/// and `settings.kubernetes.event-burst`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.event-qps",
+        "settings.kubernetes.event-burst",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -136,6 +136,7 @@ struct KubernetesSettings {
     cloud_provider: KubernetesCloudProvider,
     registry_qps: i32,
     registry_burst: i32,
+    event_qps: i32,
     event_burst: i32,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -136,6 +136,7 @@ struct KubernetesSettings {
     cloud_provider: KubernetesCloudProvider,
     registry_qps: i32,
     registry_burst: i32,
+    event_burst: i32,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1495


**Description of changes:**
Adds two new settings `kubernetes.event-qps` and `kubernetes.event-burst` for configuring


**Testing done:**
#### `event-qps`
Creating large amount of events at same time, and check how many relevant events have been logged.
Compare two argument values (smaller value and larger value ), the number of event that has been logged by smaller value will smaller than by larger value.

Step1: `event-qps = 0` unlimited (larger value)
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml;
kubectl delete -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml --force;
```
Result:  63 events have been captured and logged. 


Step2: `event-qps = 1` lowest value (smaller value)
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml;
kubectl delete -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml --force;
```
Result:  42 events have been captured and logged. 

Test result: The number of events by  `event-qps = 1` is smaller than by `event-qps = 0`, which means setting `kubernetes.event-qps` works.

#### `event-burst`
Creating large amount of events at same time, and check how many relevant events have been logged.
Compare two argument values (smaller value and larger value ), the number of event that has been logged by smaller value will smaller than by larger value.

Step1: `event-burst = 100` (larger value)
Run command Twice immediately.
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml;
kubectl delete -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml --force;
```
Result:  119 events have been captured and logged. 

Step2: `event-burst = 1` lowest value (smaller value)
Run command Twice immediately.
```
kubectl apply -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml;
kubectl delete -f amazonlinux.yaml -f debian.yaml -f ubuntu.yaml -f nginx.yaml -f python.yaml -f busybox.yaml -f golang.yaml -f httpd.yaml -f node.yaml -f redis.yaml -f mysql.yaml -f postgres.yaml --force;
```
Result:  64 events have been captured and logged. 

Test result: The number of events by  `event-burst = 1` is smaller than by `event-burst = 100`, which means setting `kubernetes.event-burst` works.

### Migration test:
#### upgrade
Step1: Upgrade to v1.1.0
```
bash-5.0# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.19",
    "arch": "x86_64",
    "version": "1.1.0",
    "max_version": "1.1.0",
.....
bash-5.0# updog update -i 1.1.0 -r -n
Starting update to 1.1.0
```
Step2: Specify new setting `event-qps` and `event-burst` through control container
```
apiclient set -j '{"kubernetes": {"event-qps": 50, "event-burst": 100}}
```
```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/event-qps
50
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/event-burst
100
```

downgrade

Step1: Check migration binary
```
ls -al /var/lib/bottlerocket-migrations
total 1980
drwx------.  2 root root   4096 Apr 29 22:19 .
drwxr-xr-x. 15 root root   4096 Apr 29 22:20 ..
-rw-r--r--.  1 root root 500376 Apr 29 22:19 20bf88b0fc969d079323303636d59f7dee19334d5330ca4d98f03e83dd0768bc.migrate_v1.1.0_kubelet-server-tls-bootstrap.lz4
-rw-r--r--.  1 root root 500611 Apr 29 22:19 2efee01e95b64359eb0a3be08b6be219ba9401b0e5dd724a6c08551cc09fe72f.migrate_v1.1.0_kubelet-event-qps-event-burst.lz4
-rw-r--r--.  1 root root 500441 Apr 29 22:19 4a5d86d8b8342b562e43ad8aae876bf71249510ec6e1a83b52df998e7180299e.migrate_v1.1.0_kubelet-registry-qps-registry-burst.lz4
-rw-r--r--.  1 root root 500460 Apr 29 22:19 81d7535ebd76e9307766c658f1aaffdba91f227d31acb2421058a9d7ba7a53cb.migrate_v1.1.0_kubelet-cloud-provider.lz4
-rw-r--r--.  1 root root   2964 Apr 29 22:19 f77deadeecd4baa00a7f8182477306f55f9ab6458f77adf336b6e172599f5428.manifest.json

```
Step2: Downgrade to previous verison
```
signpost rollback-to-inactive
reboot
```

Step3: Check if `event-qps` and `event-burst` have been removed
```
bash-5.0# ls /var/lib/bottlerocket/datastore/current/live/settings/kubernetes
api-server			  max-pods.setting-generator
authentication-mode		  node-ip
cluster-certificate		  node-ip.setting-generator
cluster-dns-ip			  pod-infra-container-image
cluster-dns-ip.setting-generator  pod-infra-container-image.affected-services
cluster-domain			  pod-infra-container-image.setting-generator
cluster-name			  standalone-mode
max-pods			  static-pods.affected-services
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
