### PR TITLE
Revert "aws-k8s-1.20: enable unified cgroup hierarchy"

### DIFF
--- a/variants/aws-k8s-1.20/Cargo.toml
+++ b/variants/aws-k8s-1.20/Cargo.toml
@@ -21,7 +21,6 @@ included-packages = [
 kernel-parameters = [
     "console=tty0",
     "console=ttyS0",
-    "systemd.unified_cgroup_hierarchy=1",
 ]
 
 [lib]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Apr 28 14:18:54 2021 -0700

    Revert "aws-k8s-1.20: enable unified cgroup hierarchy"
    
    This reverts commit 07f5e84dd8e3643c09f6cc9c19af21dd48b82956.
    
    k8s+containerd with cgroup v2 is currently not working correctly
    due to https://github.com/opencontainers/runc/issues/2366

```


**Testing done:**
Launched node, joins cluster fine, can run pods


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
