### PR TITLE
Fix VMware spelling and document user data sources

### DIFF
--- a/sources/api/early-boot-config/src/provider/vmware.rs
+++ b/sources/api/early-boot-config/src/provider/vmware.rs
@@ -1,4 +1,4 @@
-//! The vmware module implements the `PlatformDataProvider` trait for gathering userdata on VMWare
+//! The vmware module implements the `PlatformDataProvider` trait for gathering userdata on VMware
 //! via mounted CDRom or the guestinfo interface
 
 use super::{PlatformDataProvider, SettingsJson};
@@ -97,7 +97,7 @@ impl VmwareDataProvider {
     }
 
     /// Read and base64 decode user data contained in an OVF file
-    // In VMWare, user data is supplied to the host via an XML file.  Within
+    // In VMware, user data is supplied to the host via an XML file.  Within
     // the XML file, there is a `PropertySection` that contains `Property` elements
     // with attributes.  User data is base64 encoded inside a `Property` element with
     // the attribute "user-data".
@@ -143,7 +143,7 @@ impl VmwareDataProvider {
     fn guestinfo_user_data() -> Result<Option<SettingsJson>> {
         info!("Attempting to retrieve user data via guestinfo interface");
 
-        // It would be extremely odd to get here and not be on VMWare, but check anyway
+        // It would be extremely odd to get here and not be on VMware, but check anyway
         ensure!(vmw_backdoor::is_vmware_cpu(), error::NotVmware);
 
         // `guestinfo.userdata.encoding` informs us how to handle the data in the
@@ -209,7 +209,7 @@ impl VmwareDataProvider {
 
     /// Request a key's value from guestinfo
     fn backdoor_get_bytes(key: &str) -> Result<Option<Vec<u8>>> {
-        // Probe and access the VMWare backdoor.  `kernel lockdown(7)` may block "privileged"
+        // Probe and access the VMware backdoor.  `kernel lockdown(7)` may block "privileged"
         // mode because of its use of `iopl()`.  According the the bug report below, in theory
         // "privileged" mode is more reliable than "unprivileged" but both provide access to
         // the same data so we fall back to "unprivileged" if the first call fails.
@@ -337,7 +337,7 @@ mod error {
         },
 
         #[snafu(display(
-            "Unable to read user data from guestinfo, this is not a VMWare virtual CPU"
+            "Unable to read user data from guestinfo, this is not a VMware virtual CPU"
         ))]
         NotVmware,
 

--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -57,7 +57,7 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-dev/mod.rs)
 * [Default settings](src/aws-dev/defaults.d/)
 
-### vmware-dev: VMWare development build
+### vmware-dev: VMware development build
 
 * [Model](src/vmware-dev/mod.rs)
 * [Default settings](src/vmware-dev/defaults.d/)

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -54,7 +54,7 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-dev/mod.rs)
 * [Default settings](src/aws-dev/defaults.d/)
 
-## vmware-dev: VMWare development build
+## vmware-dev: VMware development build
 
 * [Model](src/vmware-dev/mod.rs)
 * [Default settings](src/vmware-dev/defaults.d/)

--- a/variants/README.md
+++ b/variants/README.md
@@ -70,9 +70,9 @@ The [aws-dev](aws-dev/Cargo.toml) variant has useful packages for local developm
 It includes tools for troubleshooting as well as Docker for running containers.
 User data will be read from IMDS.
 
-### vmware-dev: VMWare development build
+### vmware-dev: VMware development build
 
-The [vmware-dev](vmware-dev/Cargo.toml) variant has useful packages for local development of the OS, and is intended to run as a VMWare guest.
+The [vmware-dev](vmware-dev/Cargo.toml) variant has useful packages for local development of the OS, and is intended to run as a VMware guest.
 It includes tools for troubleshooting as well as Docker for running containers.
 User data will be read from a mounted CD-ROM, either from a file named "user-data" or from an OVF file.
 

--- a/variants/README.md
+++ b/variants/README.md
@@ -74,7 +74,8 @@ User data will be read from IMDS.
 
 The [vmware-dev](vmware-dev/Cargo.toml) variant has useful packages for local development of the OS, and is intended to run as a VMware guest.
 It includes tools for troubleshooting as well as Docker for running containers.
-User data will be read from a mounted CD-ROM, either from a file named "user-data" or from an OVF file.
+User data will be read from a mounted CD-ROM (from a file named "user-data" or from an OVF file), and from VMware's guestinfo interface.
+If user data exists at both places, settings read from guestinfo will override identical settings from CD-ROM.
 
 ### Deprecated variants
 


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This change fixes the spelling of VMware and documents user data sources for `vmware-dev`
```
commit 1c9409ee145729b6966441acefe18c5432e086d8
    early-boot-config: Fix VMware spelling

commit 3ecb33d7252d503bd439012a2870ee307ea8f421
    vmware-dev: Document user data sources

commit 012712a79bbd799fe80dea6f884e08c1f787625a
    vmware-dev: Fix VMware spelling
```


**Testing done:**
Booted a `vmware-dev` VM with user data to ensure nothing is broken there.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
