### PR TITLE
Update third-party package dependencies

### DIFF
--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -9,5 +9,5 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2021-01-19.pem"
-sha512 = "659e8d36bcb65a7fdd299ee008fc4ecd42be87d8ae7d7d15828567b9be44b4ed8a316978f2f7d3d5d7e96a4da0b30bb8bdcfae5202ef099691daa796318a869e"
+url = "https://curl.haxx.se/ca/cacert-2021-04-13.pem"
+sha512 = "df0cd3798e35688e4115c3ffce92b17d37f57af4f973081c8f7e0af3c9f48fc66d2c883481d25c7fbde0f873cc818a2a69490b3965d4f83e9305071cf5344039"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2021.01.09
+Version: 2021.04.13
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2021-01-19.pem
+Source0: https://curl.haxx.se/ca/cacert-2021-04-13.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description

--- a/packages/kernel-5.4/Cargo.toml
+++ b/packages/kernel-5.4/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/c9c16a56ef978680bd95df30d81add144807ffe0c43def257038586bb6b52388/kernel-5.4.105-48.177.amzn2.src.rpm"
-sha512 = "ef506706434bc94df6e845e5262c8d022ebb91ff6bc6a71ac656851c0de66d81392acedb9be39b2be4724f106df21d3b58de71387410e103e4b05a48fa955059"
+url = "https://cdn.amazonlinux.com/blobstore/b5b3738a3efe0842f6b4db451c2bc1bbeafb1857a10ec508081e75b52681f13e/kernel-5.4.110-54.182.amzn2.src.rpm"
+sha512 = "09739ceb8c5923845f76c5c2322243ffce53433fd24fccc0239fa23ee4951a4288752de87db07dbc0a0c5e81b3a6f9537feff0a2149332956216cf2e03527ecd"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.4
-Version: 5.4.105
+Version: 5.4.110
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/c9c16a56ef978680bd95df30d81add144807ffe0c43def257038586bb6b52388/kernel-5.4.105-48.177.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/b5b3738a3efe0842f6b4db451c2bc1bbeafb1857a10ec508081e75b52681f13e/kernel-5.4.110-54.182.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.18"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.18.17/kubernetes-1.18.17.tar.gz"
-sha512 = "5d8ae2fb8a962b8a09b58667d57114a4c75c2b7ae75c9ba0f8b68fccd0f58a3cdb44288a71fbd2f528fe93e280c6b95ea57fe0bbf1b2203aec9fd39fc7fd3f79"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.18.18/kubernetes-1.18.18.tar.gz"
+sha512 = "8305cff40d08a40c6c8e71e9056fac6b76856a6e39ac8d2e3952c155a8c70a9d7c269725d55df180dd906d0ff6d9c8b9e17a58b00a08c86438f1435058163fd3"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.18.17
+%global gover 1.18.18
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.19"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.19.9/kubernetes-1.19.9.tar.gz"
-sha512 = "0aa01de3cf3e7d1b000a422768cc665a0b58eac10045629c5eabae6688a47d19ef36b98f6d1719263b3c9877808f0f13f43cd764f691849bda385f4f96ea92d1"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.19.10/kubernetes-1.19.10.tar.gz"
+sha512 = "7a69062be5a2fd0522f03077edb023e59f4887580f3018e4a3c1726c888d1123e3beb1adce58e7ff4b658bd3f1eb8e650f022f88c2d0abbc561acec164028cf5"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.19.9
+%global gover 1.19.10
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/archive/v4.4.18/libxcrypt-4.4.18.tar.gz"
-sha512 = "66e3afb32ca27b1b00c21d07f0cd3eb3403ebd1732503376e5f85fa79acf078aa2bac54a8920121b3741cd46a807f4ea176de38c6b5b4611c701dc9e6f8d1490"
+url = "https://github.com/besser82/libxcrypt/archive/v4.4.19/libxcrypt-4.4.19.tar.gz"
+sha512 = "f5bd2598b5d0de47f3d805bbd4a045439e456d361a39e8725c40e2e1f32cf392bdc20b51840528f53cec052dff98be1a009fcd70b92e288584bedf06ef94b816"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.18
+Version: 4.4.19
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/5.11/strace-5.11.tar.xz"
-sha512 = "688bec8d620c7ca701561ed7479e42687cc30737f944b82201731d827775cd2864787ecca7c93ba149b06d5d654d9f6bd109a977f8138bab34339cd5930828f0"
+url = "https://strace.io/files/5.12/strace-5.12.tar.xz"
+sha512 = "289cf82da4c69270458953b45d09c8eb05a6624898d3ac493c3ec293cd5ad07205084ad0af021dab2be9c0dc53f0301816113a746d96c78780b79231a185e7c9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 5.11
+Version: 5.12
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later


### PR DESCRIPTION
**Description of changes:**

```
4155adb3 Update ca-certificates to 2021-04-13
b0e8493d Update kernel-5.4 to 5.4.110
25fd8496 Update kubernetes-1.18 to 1.18.18
ca893879 Update kubernetes-1.19 to 1.19.10
bfada7e4 Update libxcrypt to 4.4.19
c1113e49 Update strace to 5.12
```

All pretty minor updates.

Not updated: aws-iam-authenticator; there was a release today, but the Go vendor code wasn't updated, so it doesn't build correctly.  [issue](https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/368)

**Testing done:**

Built aws-k8s-1.18, aws-k8s-1.19, aws-k8s-1.20, and aws-ecs-1 variants, ran a pod/task OK, `systemctl status` `running`, API OK, dmesg OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
