### PR TITLE
kubernetes: add symlink for secrets-store-csi-providers

### DIFF
--- a/packages/kubernetes-1.16/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.16/kubernetes-tmpfiles.conf
@@ -1,2 +1,4 @@
 d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
+d /var/lib/kubelet/providers/secrets-store - - - -
+L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store

--- a/packages/kubernetes-1.17/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.17/kubernetes-tmpfiles.conf
@@ -1,2 +1,4 @@
 d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
+d /var/lib/kubelet/providers/secrets-store - - - -
+L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store

--- a/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
@@ -1,2 +1,4 @@
 d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
+d /var/lib/kubelet/providers/secrets-store - - - -
+L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store

--- a/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
@@ -1,2 +1,4 @@
 d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
+d /var/lib/kubelet/providers/secrets-store - - - -
+L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store

--- a/packages/kubernetes-1.20/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.20/kubernetes-tmpfiles.conf
@@ -1,2 +1,4 @@
 d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
+d /var/lib/kubelet/providers/secrets-store - - - -
+L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store


### PR DESCRIPTION
**Issue number:**
Fixes #1524.


**Description of changes:**
Add a symlink to a path where providers can create their socket.


**Testing done:**
Installed the AWS provider for the secrets store CSI driver by following the [usage](https://github.com/aws/secrets-store-csi-driver-provider-aws#usage) instructions. Verified that the pod had access to the secret.

Verified that the sockets were created in the expected paths:
```
bash-5.0# ls -latr /etc/kubernetes/secrets-store-csi-providers
lrwxrwxrwx. 1 root root 40 Apr 30 14:13 /etc/kubernetes/secrets-store-csi-providers -> /var/lib/kubelet/providers/secrets-store

bash-5.0# ls -latr /var/lib/kubelet/providers/secrets-store/aws.sock   
srwxr-xr-x. 1 root root 0 Apr 30 14:16 /var/lib/kubelet/providers/secrets-store/aws.sock

bash-5.0# ls -latr /var/lib/kubelet/providers/secrets-store/aws.sock   
srwxr-xr-x. 1 root root 0 Apr 30 14:15 /var/lib/kubelet/plugins/csi-secrets-store/csi.sock
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
