### PR TITLE
aws-k8s: get cluster dns cidr from eks

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -329,6 +329,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +604,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
 name = "corndog"
 version = "0.1.0"
 dependencies = [
@@ -651,6 +678,25 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
 ]
 
 [[package]]
@@ -732,6 +778,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -925,6 +992,7 @@ checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -946,6 +1014,17 @@ name = "futures-core"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1167,6 +1246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "host-containers"
 version = "0.1.0"
 dependencies = [
@@ -1269,10 +1358,12 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
+ "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -1518,6 +1609,12 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1841,6 +1938,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,11 +2103,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pluto"
 version = "0.1.0"
 dependencies = [
+ "apiclient",
  "cargo-readme",
- "lazy_static",
+ "models",
  "reqwest",
+ "rusoto_core",
+ "rusoto_eks",
  "serde_json",
  "snafu",
+ "tokio",
 ]
 
 [[package]]
@@ -2123,6 +2230,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2325,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_core"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aff20978970d47630f08de5f0d04799497818d16cafee5aec90c4b4d0806cf"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "lazy_static",
+ "log",
+ "rusoto_credential",
+ "rusoto_signature",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91e4c25ea8bfa6247684ff635299015845113baaa93ba8169b9e565701b58e"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs-next",
+ "futures",
+ "hyper",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "rusoto_eks"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d7e1e577d4102a9d80d5eafc0547064d3e8817d094f00e95ae45d03ae3accb"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5486e6b1673ab3e0ba1ded284fb444845fe1b7f41d13989a54dd60f62a7b2baa"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac",
+ "http",
+ "hyper",
+ "log",
+ "md5",
+ "percent-encoding",
+ "pin-project-lite",
+ "rusoto_credential",
+ "rustc_version",
+ "serde",
+ "sha2",
+ "time 0.2.26",
+ "tokio",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2436,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]
@@ -2300,6 +2522,29 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2464,6 +2709,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "shared-containerd-configs"
 version = "0.1.0"
 dependencies = [
@@ -2491,6 +2749,12 @@ dependencies = [
  "simplelog",
  "snafu",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
@@ -2726,6 +2990,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "sundog"
@@ -3377,3 +3647,9 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -10,10 +10,14 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-lazy_static = "1.4"
-reqwest = { version = "0.11.1", default-features = false, features = ["blocking"]}
+apiclient = { path = "../apiclient" }
+models = { path = "../../models" }
+reqwest = { version = "0.11.1", default-features = false }
+rusoto_core = { version = "0.46", default-features = false, features = ["rustls"] }
+rusoto_eks = { version = "0.46", default-features = false, features = ["rustls"] }
 serde_json = "1"
 snafu = "0.6"
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/api/pluto/README.md
+++ b/sources/api/pluto/README.md
@@ -6,12 +6,32 @@ Current version: 0.1.0
 
 pluto is called by sundog to generate settings required by Kubernetes.
 This is done dynamically because we require access to dynamic networking
-setup information.
+and cluster setup information.
 
-It makes calls to IMDS to get meta data:
+It uses IMDS to get information such as:
 
-- Cluster DNS
+- Instance Type
 - Node IP
+
+It uses EKS to get information such as:
+
+- Service IPV4 CIDR
+
+It uses the Bottlerocket API to get information such as:
+
+- Kubernetes Cluster Name
+- AWS Region
+
+## Interface
+
+Pluto takes the name of the setting that it is to generate as its first
+argument.
+It returns the generated setting to stdout as a JSON document.
+Any other output is returned to stderr.
+
+Pluto returns a special exit code of 2 to inform `sundog` that a setting should be skipped. For
+example, if `max-pods` cannot be generated, we want `sundog` to skip it without failing since a
+reasonable default is available.
 
 ## Colophon 
 

--- a/sources/api/pluto/build.rs
+++ b/sources/api/pluto/build.rs
@@ -6,6 +6,15 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
+    // TODO: Replace this approach when the build system supports ideas like "variant
+    // tags": https://github.com/bottlerocket-os/bottlerocket/issues/1260
+    println!("cargo:rerun-if-env-changed=VARIANT");
+    if let Ok(variant) = env::var("VARIANT") {
+        if variant.starts_with("aws-k8s") {
+            println!("cargo:rustc-cfg=aws_k8s_variant");
+        }
+    }
+
     // Check for environment variable "SKIP_README". If it is set,
     // skip README generation
     if env::var_os("SKIP_README").is_some() {

--- a/sources/api/pluto/src/api.rs
+++ b/sources/api/pluto/src/api.rs
@@ -1,0 +1,92 @@
+pub(super) use inner::{get_aws_k8s_info, Error};
+
+/// The result type for the [`api`] module.
+pub(super) type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Default)]
+pub(crate) struct AwsK8sInfo {
+    pub(crate) region: String,
+    pub(crate) cluster_name: String,
+}
+
+/// This code is the 'actual' implementation compiled when the `sources` workspace is being compiled
+/// for `aws-k8s-*` variants.
+// TODO - find a better way https://github.com/bottlerocket-os/bottlerocket/issues/1260
+#[cfg(aws_k8s_variant)]
+mod inner {
+    use super::*;
+    use snafu::{OptionExt, ResultExt, Snafu};
+
+    // FIXME Get these from configuration in the future
+    const DEFAULT_API_SOCKET: &str = "/run/api.sock";
+    const SETTINGS_URI: &str = "/settings";
+
+    #[derive(Debug, Snafu)]
+    pub(crate) enum Error {
+        #[snafu(display("Error calling Bottlerocket API: {}", source))]
+        ApiClient {
+            source: apiclient::Error,
+            uri: String,
+        },
+
+        #[snafu(display("The '{}' setting is missing", setting))]
+        Missing { setting: String },
+
+        #[snafu(display("Unable to deserialize Bottlerocket settings: {}", source))]
+        SettingsJson { source: serde_json::Error },
+    }
+
+    /// Gets the Bottlerocket settings from the API and deserializes them into a struct.
+    async fn get_settings() -> Result<model::Settings> {
+        let (_status, response_body) =
+            apiclient::raw_request(DEFAULT_API_SOCKET, SETTINGS_URI, "GET", None)
+                .await
+                .context(ApiClient { uri: SETTINGS_URI })?;
+
+        serde_json::from_str(&response_body).context(SettingsJson)
+    }
+
+    /// Gets the info that we need to know about the EKS cluster from the Bottlerocket API.
+    pub(crate) async fn get_aws_k8s_info() -> Result<AwsK8sInfo> {
+        let settings = get_settings().await?;
+        Ok(AwsK8sInfo {
+            region: settings
+                .aws
+                .context(Missing { setting: "aws" })?
+                .region
+                .context(Missing { setting: "region" })?
+                .into(),
+            cluster_name: settings
+                .kubernetes
+                .context(Missing {
+                    setting: "kubernetes",
+                })?
+                .cluster_name
+                .context(Missing {
+                    setting: "cluster-name",
+                })?
+                .into(),
+        })
+    }
+}
+
+/// This dummy code is compiled when the `sources` workspace is being compiled for non `aws-k8s-*`
+/// variants.
+// TODO - find a better way https://github.com/bottlerocket-os/bottlerocket/issues/1260
+#[cfg(not(aws_k8s_variant))]
+mod inner {
+    use super::*;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    pub(crate) enum Error {
+        #[snafu(display(
+            "The get_aws_k8s_info function is only compatible with aws-k8s variants"
+        ))]
+        WrongVariant,
+    }
+
+    pub(crate) async fn get_aws_k8s_info() -> Result<AwsK8sInfo> {
+        WrongVariant.fail()
+    }
+}

--- a/sources/api/pluto/src/eks.rs
+++ b/sources/api/pluto/src/eks.rs
@@ -1,0 +1,48 @@
+use rusoto_core::region::ParseRegionError;
+use rusoto_core::{Region, RusotoError};
+use rusoto_eks::{DescribeClusterError, Eks, EksClient};
+use snafu::{OptionExt, ResultExt, Snafu};
+use std::str::FromStr;
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display("Error describing cluster: {}", source))]
+    DescribeCluster {
+        source: RusotoError<DescribeClusterError>,
+    },
+
+    #[snafu(display("Missing field '{}' EKS response", field))]
+    Missing { field: &'static str },
+
+    #[snafu(display("Unable to parse '{}' as a region: {}", region, source))]
+    RegionParse {
+        region: String,
+        source: ParseRegionError,
+    },
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Returns the cluster's [serviceIPv4CIDR] DNS IP by calling the EKS API.
+/// (https://docs.aws.amazon.com/eks/latest/APIReference/API_KubernetesNetworkConfigRequest.html)
+pub(super) async fn get_cluster_cidr(region: &str, cluster: &str) -> Result<String> {
+    let parsed_region = Region::from_str(region).context(RegionParse { region })?;
+    let client = EksClient::new(parsed_region);
+    let describe_cluster = rusoto_eks::DescribeClusterRequest {
+        name: cluster.to_owned(),
+    };
+    client
+        .describe_cluster(describe_cluster)
+        .await
+        .context(DescribeCluster {})?
+        .cluster
+        .context(Missing { field: "cluster" })?
+        .kubernetes_network_config
+        .context(Missing {
+            field: "kubernetes_network_config",
+        })?
+        .service_ipv_4_cidr
+        .context(Missing {
+            field: "service_ipv_4_cidr",
+        })
+}


### PR DESCRIPTION
## Issue number:

Closes #1197

## Description of changes:

We previously assumed that an EKS cluster DNS IP was either 10.100.0.10 or 172.20.0.10. This may be incorrect when the cluster has a custom serviceIPv4CIDR setting.

Now we get the serviceIPv4CIDR from EKS describe-cluster so that we can calculate the correct cluster DNS IP in the presence of serviceIPv4CIDR.

Notes 
- this requires rusoto v0.46 because the serviceIPv4CIDR is fairly new to the API 
- rusoto v0.46 relies on tokio v1
- We needed to switch from `reqwest::blocking` to `reqwest` async for the IMDS calls because we need a runtime for rusoto.

## Testing done:

#### Reproducing the issue before fixing it:

After reading [this](https://unofficial-kubernetes.readthedocs.io/en/latest/concepts/services-networking/dns-pod-service/)

- I created a cluster with a custom CIDR: `10.31.32.0/24`.
- I ran a production 1.18 AMI and verified that it had the wrong Cluster DNS: `10.100.0.10`.
- I ran a pod like this (there was some nslookup bug with busybox so I used ubuntu and installed dnsutils on the healthy pod. I couldn't apt-get install anything on the unhealthy pod which further proves DNS was broken. For the unhealthy pod I used busybox):
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
- Inside the pod I ran `nslookup kubernetes.default`, which returned

```
/ # nslookup kubernetes.default
;; connection timed out; no servers could be reached
```

In a healthy, non-custom-CIDR cluster, the above produces:

```
root@ubuntu:/# nslookup kubernetes.default
Server:   10.100.0.10
Address:  10.100.0.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.100.0.1
```

Thus we have proven that Bottlerocket does not work correctly with a custom `serviceIPv4CIDR`.

#### Testing this PR

**Custom CIDR Cluster**

- I ran a node in a cluster with `serviceIPv4CIDR: '10.31.32.0/24'`
- I logged in and checked the Cluster DNS IP
  - `apiclient -u /settings?keys=settings.kubernetes.cluster-dns-ip`
  - `{"kubernetes":{"cluster-dns-ip":"10.31.32.10"}}`
- I ran a pod:
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
  - `nslookup kubernetes.default`

The result shows that cluster DNS resolution is working:

```text
Server:   10.31.32.10
Address:  10.31.32.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.31.32.1
```

**Non-Custom CIDR Cluster**

- I ran a node in a cluster with no `serviceIPv4CIDR` configuration.
- I logged in and checked the Cluster DNS IP
  - `apiclient -u /settings?keys=settings.kubernetes.cluster-dns-ip`
  - `{"kubernetes":{"cluster-dns-ip":"10.100.0.10"}}`
- I ran a pod:
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
  - `nslookup kubernetes.default`

The result shows that cluster DNS resolution is working:

```text
Server:   10.100.0.10
Address:  10.100.0.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.100.0.1
```

**Without Describe Cluster Permissions**

- I ran a node in a cluster with no `serviceIPv4CIDR` configuration and with DescribeCluster removed from the Node's instance role.
- I logged in and checked some tracing in the journal.
  - Saw this: `Unable to determine CIDR from EKS, falling back to default cluster DNS IP: Error describing cluster: Request ID: Some("9753370c-9443-455c-91b4-a182491bcf1e") Body: {"message":"User: arn:aws:sts::xxx:assumed-role/ [...] is not authorized to perform: eks:DescribeCluster on resource: [..."}`
  - `apiclient -u /settings?keys=settings.kubernetes.cluster-dns-ip`
  - `{"kubernetes":{"cluster-dns-ip":"10.100.0.10"}}`
- I ran a pod:
  - `kubectl run -i -t ubuntu --image=ubuntu --restart=Never --command=true -- bash`
  - `nslookup kubernetes.default`

The result shows that cluster DNS resolution is working despite failure to call the EKS API and describe-cluster:

```text
Server:   10.100.0.10
Address:  10.100.0.10#53

Name: kubernetes.default.svc.cluster.local
Address: 10.100.0.1
```

## Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
