### PR TITLE
refactor package and variant dependencies

### DIFF
--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -18,4 +18,5 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-iptables = { path = "../iptables" }
+# `iptables` is only needed at runtime, and is pulled in by `release`.
+# iptables = { path = "../iptables" }

--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -18,4 +18,5 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-iptables = { path = "../iptables" }
+# `iptables` is only needed at runtime, and is pulled in by `release`.
+# iptables = { path = "../iptables" }

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -15,7 +15,6 @@ sha512 = "f09930d19f53381d86cf522954458ecc949f15a0c6a49f990bdb61fe19afee07535633
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }
-libseccomp = { path = "../libseccomp" }
 
 # RPM Requires
 [dependencies]

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -20,4 +20,3 @@ glibc = { path = "../glibc" }
 [dependencies]
 cni-plugins = { path = "../cni-plugins" }
 runc = { path = "../runc" }
-systemd = { path = "../systemd" }

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -18,5 +18,4 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-cni-plugins = { path = "../cni-plugins" }
 runc = { path = "../runc" }

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -32,9 +32,7 @@ Patch1003: 1003-cri-relabel-volumes-after-copying-source-files.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
-BuildRequires: %{_cross_os}libseccomp-devel
 Requires: %{_cross_os}cni-plugins
-Requires: %{_cross_os}libseccomp
 Requires: %{_cross_os}runc
 Requires: %{_cross_os}systemd
 
@@ -47,7 +45,7 @@ Requires: %{_cross_os}systemd
 
 %build
 %cross_go_configure %{goimport}
-export BUILDTAGS="no_btrfs seccomp selinux"
+export BUILDTAGS="no_btrfs selinux"
 export LD_VERSION="-X github.com/containerd/containerd/version.Version=%{gover}+bottlerocket"
 export LD_REVISION="-X github.com/containerd/containerd/version.Revision=%{gitrev}"
 for bin in \

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -32,7 +32,6 @@ Patch1003: 1003-cri-relabel-volumes-after-copying-source-files.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{_cross_os}cni-plugins
 Requires: %{_cross_os}runc
 
 %description

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -34,7 +34,6 @@ BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}cni-plugins
 Requires: %{_cross_os}runc
-Requires: %{_cross_os}systemd
 
 %description
 %{summary}.

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -20,7 +20,8 @@ systemd = { path = "../systemd" }
 
 # RPM Requires
 [dependencies]
-# `containerd` is only needed at runtime, and is pulled in by `release`.
+# `containerd` and `iptables` are only needed at runtime, and are pulled in by
+# `release`.
 # containerd = { path = "../containerd" }
-iptables = { path = "../iptables" }
+# iptables = { path = "../iptables" }
 procps = { path = "../procps" }

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -20,6 +20,7 @@ systemd = { path = "../systemd" }
 
 # RPM Requires
 [dependencies]
-containerd = { path = "../containerd" }
+# `containerd` is only needed at runtime, and is pulled in by `release`.
+# containerd = { path = "../containerd" }
 iptables = { path = "../iptables" }
 procps = { path = "../procps" }

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -20,8 +20,8 @@ systemd = { path = "../systemd" }
 
 # RPM Requires
 [dependencies]
-# `containerd` and `iptables` are only needed at runtime, and are pulled in by
-# `release`.
+# `containerd`, `iptables`, and `procps` are only needed at runtime, and are
+# pulled in by `release`.
 # containerd = { path = "../containerd" }
 # iptables = { path = "../iptables" }
-procps = { path = "../procps" }
+# procps = { path = "../procps" }

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -31,6 +31,8 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-docker-engine = { path = "../docker-engine" }
+# `docker-engine` is only needed at runtime, and is included in the variant
+# definition.
+# docker-engine = { path = "../docker-engine" }
 # `iptables` is only needed at runtime, and is pulled in by `release`.
 # iptables = { path = "../iptables" }

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -32,4 +32,5 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 docker-engine = { path = "../docker-engine" }
-iptables = { path = "../iptables" }
+# `iptables` is only needed at runtime, and is pulled in by `release`.
+# iptables = { path = "../iptables" }

--- a/packages/host-ctr/Cargo.toml
+++ b/packages/host-ctr/Cargo.toml
@@ -17,4 +17,5 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-containerd = { path = "../containerd" }
+# `containerd` is only needed at runtime, and is pulled in by `release`.
+# containerd = { path = "../containerd" }

--- a/packages/kubernetes-1.16/Cargo.toml
+++ b/packages/kubernetes-1.16/Cargo.toml
@@ -32,6 +32,7 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` is only needed at runtime, and is pulled in by `release`.
+# `containerd` and `findutils` are only needed at runtime, and are pulled in by
+# `release`.
 # containerd = { path = "../containerd" }
-findutils = { path = "../findutils" }
+# findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.16/Cargo.toml
+++ b/packages/kubernetes-1.16/Cargo.toml
@@ -32,5 +32,6 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-containerd = { path = "../containerd" }
+# `containerd` is only needed at runtime, and is pulled in by `release`.
+# containerd = { path = "../containerd" }
 findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.16/Cargo.toml
+++ b/packages/kubernetes-1.16/Cargo.toml
@@ -31,8 +31,8 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` and `findutils` are only needed at runtime, and are pulled in by
-# `release`.
+# `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
+# and are pulled in by `release`.
+# conntrack-tools = { path = "../conntrack-tools" }
 # containerd = { path = "../containerd" }
 # findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.17/Cargo.toml
+++ b/packages/kubernetes-1.17/Cargo.toml
@@ -32,6 +32,7 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` is only needed at runtime, and is pulled in by `release`.
+# `containerd` and `findutils` are only needed at runtime, and are pulled in by
+# `release`.
 # containerd = { path = "../containerd" }
-findutils = { path = "../findutils" }
+# findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.17/Cargo.toml
+++ b/packages/kubernetes-1.17/Cargo.toml
@@ -32,5 +32,6 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-containerd = { path = "../containerd" }
+# `containerd` is only needed at runtime, and is pulled in by `release`.
+# containerd = { path = "../containerd" }
 findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.17/Cargo.toml
+++ b/packages/kubernetes-1.17/Cargo.toml
@@ -31,8 +31,8 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` and `findutils` are only needed at runtime, and are pulled in by
-# `release`.
+# `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
+# and are pulled in by `release`.
+# conntrack-tools = { path = "../conntrack-tools" }
 # containerd = { path = "../containerd" }
 # findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -24,5 +24,6 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-containerd = { path = "../containerd" }
+# `containerd` is only needed at runtime, and is pulled in by `release`.
+# containerd = { path = "../containerd" }
 findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -24,6 +24,7 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` is only needed at runtime, and is pulled in by `release`.
+# `containerd` and `findutils` are only needed at runtime, and are pulled in by
+# `release`.
 # containerd = { path = "../containerd" }
-findutils = { path = "../findutils" }
+# findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -23,8 +23,8 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` and `findutils` are only needed at runtime, and are pulled in by
-# `release`.
+# `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
+# and are pulled in by `release`.
+# conntrack-tools = { path = "../conntrack-tools" }
 # containerd = { path = "../containerd" }
 # findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -24,5 +24,6 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-containerd = { path = "../containerd" }
+# `containerd` is only needed at runtime, and is pulled in by `release`.
+# containerd = { path = "../containerd" }
 findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -24,6 +24,7 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` is only needed at runtime, and is pulled in by `release`.
+# `containerd` and `findutils` are only needed at runtime, and are pulled in by
+# `release`.
 # containerd = { path = "../containerd" }
-findutils = { path = "../findutils" }
+# findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -23,8 +23,8 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` and `findutils` are only needed at runtime, and are pulled in by
-# `release`.
+# `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
+# and are pulled in by `release`.
+# conntrack-tools = { path = "../conntrack-tools" }
 # containerd = { path = "../containerd" }
 # findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.20/Cargo.toml
+++ b/packages/kubernetes-1.20/Cargo.toml
@@ -24,5 +24,6 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-containerd = { path = "../containerd" }
+# `containerd` is only needed at runtime, and is pulled in by `release`.
+# containerd = { path = "../containerd" }
 findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.20/Cargo.toml
+++ b/packages/kubernetes-1.20/Cargo.toml
@@ -24,6 +24,7 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` is only needed at runtime, and is pulled in by `release`.
+# `containerd` and `findutils` are only needed at runtime, and are pulled in by
+# `release`.
 # containerd = { path = "../containerd" }
-findutils = { path = "../findutils" }
+# findutils = { path = "../findutils" }

--- a/packages/kubernetes-1.20/Cargo.toml
+++ b/packages/kubernetes-1.20/Cargo.toml
@@ -23,8 +23,8 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-conntrack-tools = { path = "../conntrack-tools" }
-# `containerd` and `findutils` are only needed at runtime, and are pulled in by
-# `release`.
+# `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
+# and are pulled in by `release`.
+# conntrack-tools = { path = "../conntrack-tools" }
 # containerd = { path = "../containerd" }
 # findutils = { path = "../findutils" }

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -29,4 +29,6 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-host-ctr = { path = "../host-ctr" }
+# We depend on `host-ctr` for host containers functionality, but only need it
+# at runtime, and expect it to be pulled in by way of the `release` package.
+# host-ctr = { path = "../host-ctr" }

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -17,6 +17,7 @@ path = "pkg.rs"
 acpid = { path = "../acpid" }
 ca-certificates = { path = "../ca-certificates" }
 chrony = { path = "../chrony" }
+conntrack-tools = { path = "../conntrack-tools" }
 containerd = { path = "../containerd" }
 coreutils = { path = "../coreutils" }
 dbus-broker = { path = "../dbus-broker" }

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -24,6 +24,7 @@ filesystem = { path = "../filesystem" }
 glibc = { path = "../glibc" }
 grep = { path = "../grep" }
 grub = { path = "../grub" }
+host-ctr = { path = "../host-ctr" }
 iproute = { path = "../iproute" }
 libaudit = { path = "../libaudit" }
 libgcc = { path = "../libgcc" }

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -22,6 +22,7 @@ coreutils = { path = "../coreutils" }
 dbus-broker = { path = "../dbus-broker" }
 e2fsprogs = { path = "../e2fsprogs" }
 filesystem = { path = "../filesystem" }
+findutils = { path = "../findutils" }
 glibc = { path = "../glibc" }
 grep = { path = "../grep" }
 grub = { path = "../grub" }

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -27,6 +27,7 @@ grep = { path = "../grep" }
 grub = { path = "../grub" }
 host-ctr = { path = "../host-ctr" }
 iproute = { path = "../iproute" }
+iptables = { path = "../iptables" }
 libaudit = { path = "../libaudit" }
 libgcc = { path = "../libgcc" }
 libstd-rust = { path = "../libstd-rust" }

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -17,6 +17,7 @@ path = "pkg.rs"
 acpid = { path = "../acpid" }
 ca-certificates = { path = "../ca-certificates" }
 chrony = { path = "../chrony" }
+containerd = { path = "../containerd" }
 coreutils = { path = "../coreutils" }
 dbus-broker = { path = "../dbus-broker" }
 e2fsprogs = { path = "../e2fsprogs" }

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -34,6 +34,7 @@ libgcc = { path = "../libgcc" }
 libstd-rust = { path = "../libstd-rust" }
 os = { path = "../os" }
 policycoreutils = { path = "../policycoreutils" }
+procps = { path = "../procps" }
 selinux-policy = { path = "../selinux-policy" }
 systemd = { path = "../systemd" }
 util-linux = { path = "../util-linux" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -43,6 +43,7 @@ Requires: %{_cross_os}acpid
 Requires: %{_cross_os}audit
 Requires: %{_cross_os}ca-certificates
 Requires: %{_cross_os}chrony
+Requires: %{_cross_os}containerd
 Requires: %{_cross_os}coreutils
 Requires: %{_cross_os}dbus-broker
 Requires: %{_cross_os}e2fsprogs

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -52,6 +52,7 @@ Requires: %{_cross_os}filesystem
 Requires: %{_cross_os}grep
 Requires: %{_cross_os}glibc
 Requires: %{_cross_os}grub
+Requires: %{_cross_os}host-ctr
 Requires: %{_cross_os}iproute
 Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}policycoreutils

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -55,6 +55,7 @@ Requires: %{_cross_os}glibc
 Requires: %{_cross_os}grub
 Requires: %{_cross_os}host-ctr
 Requires: %{_cross_os}iproute
+Requires: %{_cross_os}iptables
 Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}policycoreutils
 Requires: %{_cross_os}systemd

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -50,8 +50,9 @@ Requires: %{_cross_os}e2fsprogs
 Requires: %{_cross_os}libgcc
 Requires: %{_cross_os}libstd-rust
 Requires: %{_cross_os}filesystem
-Requires: %{_cross_os}grep
+Requires: %{_cross_os}findutils
 Requires: %{_cross_os}glibc
+Requires: %{_cross_os}grep
 Requires: %{_cross_os}grub
 Requires: %{_cross_os}host-ctr
 Requires: %{_cross_os}iproute

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -59,6 +59,7 @@ Requires: %{_cross_os}iproute
 Requires: %{_cross_os}iptables
 Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}policycoreutils
+Requires: %{_cross_os}procps
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}wicked

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -43,6 +43,7 @@ Requires: %{_cross_os}acpid
 Requires: %{_cross_os}audit
 Requires: %{_cross_os}ca-certificates
 Requires: %{_cross_os}chrony
+Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}coreutils
 Requires: %{_cross_os}dbus-broker

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -16,7 +16,6 @@ dependencies = [
  "docker-engine",
  "docker-init",
  "docker-proxy",
- "findutils",
  "iputils",
  "kernel-5_10",
  "login",
@@ -321,7 +320,6 @@ name = "kubernetes-1_16"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "findutils",
  "glibc",
 ]
 
@@ -330,7 +328,6 @@ name = "kubernetes-1_17"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "findutils",
  "glibc",
 ]
 
@@ -339,7 +336,6 @@ name = "kubernetes-1_18"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "findutils",
  "glibc",
 ]
 
@@ -348,7 +344,6 @@ name = "kubernetes-1_19"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "findutils",
  "glibc",
 ]
 
@@ -357,7 +352,6 @@ name = "kubernetes-1_20"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "findutils",
  "glibc",
 ]
 
@@ -652,6 +646,7 @@ dependencies = [
  "dbus-broker",
  "e2fsprogs",
  "filesystem",
+ "findutils",
  "glibc",
  "grep",
  "grub",
@@ -731,7 +726,6 @@ dependencies = [
  "docker-engine",
  "docker-init",
  "docker-proxy",
- "findutils",
  "iputils",
  "kernel-5_10",
  "login",

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -163,7 +163,6 @@ dependencies = [
 name = "containerd"
 version = "0.1.0"
 dependencies = [
- "cni-plugins",
  "glibc",
  "runc",
 ]

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -166,7 +166,6 @@ dependencies = [
  "cni-plugins",
  "glibc",
  "runc",
- "systemd",
 ]
 
 [[package]]

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -622,7 +622,6 @@ name = "os"
 version = "0.1.0"
 dependencies = [
  "glibc",
- "host-ctr",
 ]
 
 [[package]]
@@ -666,6 +665,7 @@ dependencies = [
  "glibc",
  "grep",
  "grub",
+ "host-ctr",
  "iproute",
  "libaudit",
  "libgcc",

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -135,7 +135,6 @@ name = "cni"
 version = "0.1.0"
 dependencies = [
  "glibc",
- "iptables",
 ]
 
 [[package]]
@@ -143,7 +142,6 @@ name = "cni-plugins"
 version = "0.1.0"
 dependencies = [
  "glibc",
- "iptables",
 ]
 
 [[package]]
@@ -201,7 +199,6 @@ name = "docker-engine"
 version = "0.1.0"
 dependencies = [
  "glibc",
- "iptables",
  "libseccomp",
  "procps",
  "systemd",
@@ -235,7 +232,6 @@ version = "0.1.0"
 dependencies = [
  "docker-engine",
  "glibc",
- "iptables",
 ]
 
 [[package]]
@@ -661,6 +657,7 @@ dependencies = [
  "grub",
  "host-ctr",
  "iproute",
+ "iptables",
  "libaudit",
  "libgcc",
  "libstd-rust",

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -200,7 +200,6 @@ dependencies = [
 name = "docker-engine"
 version = "0.1.0"
 dependencies = [
- "containerd",
  "glibc",
  "iptables",
  "libseccomp",
@@ -274,7 +273,6 @@ dependencies = [
 name = "host-ctr"
 version = "0.1.0"
 dependencies = [
- "containerd",
  "glibc",
 ]
 
@@ -327,7 +325,6 @@ name = "kubernetes-1_16"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "containerd",
  "findutils",
  "glibc",
 ]
@@ -337,7 +334,6 @@ name = "kubernetes-1_17"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "containerd",
  "findutils",
  "glibc",
 ]
@@ -347,7 +343,6 @@ name = "kubernetes-1_18"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "containerd",
  "findutils",
  "glibc",
 ]
@@ -357,7 +352,6 @@ name = "kubernetes-1_19"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "containerd",
  "findutils",
  "glibc",
 ]
@@ -367,7 +361,6 @@ name = "kubernetes-1_20"
 version = "0.1.0"
 dependencies = [
  "conntrack-tools",
- "containerd",
  "findutils",
  "glibc",
 ]
@@ -658,6 +651,7 @@ dependencies = [
  "acpid",
  "ca-certificates",
  "chrony",
+ "containerd",
  "coreutils",
  "dbus-broker",
  "e2fsprogs",

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -165,7 +165,6 @@ version = "0.1.0"
 dependencies = [
  "cni-plugins",
  "glibc",
- "libseccomp",
  "runc",
  "systemd",
 ]

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -227,7 +227,6 @@ dependencies = [
 name = "ecs-agent"
 version = "0.1.0"
 dependencies = [
- "docker-engine",
  "glibc",
 ]
 

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "iputils",
  "kernel-5_10",
  "login",
- "procps",
  "release",
  "strace",
  "tcpdump",
@@ -199,7 +198,6 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "libseccomp",
- "procps",
  "systemd",
 ]
 
@@ -658,6 +656,7 @@ dependencies = [
  "libstd-rust",
  "os",
  "policycoreutils",
+ "procps",
  "selinux-policy",
  "systemd",
  "util-linux",
@@ -730,7 +729,6 @@ dependencies = [
  "kernel-5_10",
  "login",
  "open-vm-tools",
- "procps",
  "release",
  "strace",
  "tcpdump",

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -317,7 +317,6 @@ dependencies = [
 name = "kubernetes-1_16"
 version = "0.1.0"
 dependencies = [
- "conntrack-tools",
  "glibc",
 ]
 
@@ -325,7 +324,6 @@ dependencies = [
 name = "kubernetes-1_17"
 version = "0.1.0"
 dependencies = [
- "conntrack-tools",
  "glibc",
 ]
 
@@ -333,7 +331,6 @@ dependencies = [
 name = "kubernetes-1_18"
 version = "0.1.0"
 dependencies = [
- "conntrack-tools",
  "glibc",
 ]
 
@@ -341,7 +338,6 @@ dependencies = [
 name = "kubernetes-1_19"
 version = "0.1.0"
 dependencies = [
- "conntrack-tools",
  "glibc",
 ]
 
@@ -349,7 +345,6 @@ dependencies = [
 name = "kubernetes-1_20"
 version = "0.1.0"
 dependencies = [
- "conntrack-tools",
  "glibc",
 ]
 
@@ -639,6 +634,7 @@ dependencies = [
  "acpid",
  "ca-certificates",
  "chrony",
+ "conntrack-tools",
  "containerd",
  "coreutils",
  "dbus-broker",

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -22,7 +22,6 @@ included-packages = [
     "docker-init",
     "docker-proxy",
 # tools
-    "findutils",
     "login",
     "iputils",
     "procps",
@@ -44,7 +43,6 @@ docker-engine = { path = "../../packages/docker-engine" }
 docker-init = { path = "../../packages/docker-init" }
 docker-proxy = { path = "../../packages/docker-proxy" }
 # tools
-findutils = { path = "../../packages/findutils" }
 login = { path = "../../packages/login" }
 iputils = { path = "../../packages/iputils" }
 procps = { path = "../../packages/procps" }

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -24,7 +24,6 @@ included-packages = [
 # tools
     "login",
     "iputils",
-    "procps",
     "strace",
     "tcpdump",
     "chrony-tools",
@@ -45,7 +44,6 @@ docker-proxy = { path = "../../packages/docker-proxy" }
 # tools
 login = { path = "../../packages/login" }
 iputils = { path = "../../packages/iputils" }
-procps = { path = "../../packages/procps" }
 strace = { path = "../../packages/strace" }
 tcpdump = { path = "../../packages/tcpdump" }
 chrony = { path = "../../packages/chrony" }

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -27,7 +27,6 @@ included-packages = [
 # tools
     "login",
     "iputils",
-    "procps",
     "strace",
     "tcpdump",
     "chrony-tools",
@@ -49,7 +48,6 @@ docker-proxy = { path = "../../packages/docker-proxy" }
 # tools
 login = { path = "../../packages/login" }
 iputils = { path = "../../packages/iputils" }
-procps = { path = "../../packages/procps" }
 strace = { path = "../../packages/strace" }
 tcpdump = { path = "../../packages/tcpdump" }
 chrony = { path = "../../packages/chrony" }

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -25,7 +25,6 @@ included-packages = [
     "docker-init",
     "docker-proxy",
 # tools
-    "findutils",
     "login",
     "iputils",
     "procps",
@@ -48,7 +47,6 @@ docker-engine = { path = "../../packages/docker-engine" }
 docker-init = { path = "../../packages/docker-init" }
 docker-proxy = { path = "../../packages/docker-proxy" }
 # tools
-findutils = { path = "../../packages/findutils" }
 login = { path = "../../packages/login" }
 iputils = { path = "../../packages/iputils" }
 procps = { path = "../../packages/procps" }


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This shifts some commonly used packages into the set installed by "release". `find`, `ps`, and `conntrack` will now be available on all variants, instead of some on `aws-k8s-*` and others on `aws-ecs-1`.

"host-ctr" and "containerd" are also promoted to the "release" package set. They end up installed regardless because of our host containers feature, and moving the dependency allows us to start building the "os" package sooner.

Most of the dependencies of Go packages have been eliminated, since those aren't needed at build time. The notable exception is the "runc" dependency on "libseccomp".


**Testing done:**
Built all variants locally.

Confirmed that `aws-k8s-1.18` and `aws-ecs-1` worked as expected:
* host containers came up
* orchestrated containers came up
* `find`, `ps`, and `conntrack` were present
* k8s build had the CNI binaries
* ecs build had Docker


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
