### PR TITLE
Fixed a misleading typo for setting Labels/Taints

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ You should [specify them in user data](#using-user-data).
 * `settings.kubernetes.cluster-certificate`: This is the base64-encoded certificate authority of the cluster.
 * `settings.kubernetes.api-server`: This is the cluster's Kubernetes API endpoint.
 
-The following settings can be optionally set to customize the node labels and taints.
+The following settings can be optionally set to customize the node labels and taints. Remember to quote keys (since they often contain ".") and to quote all values.
 * `settings.kubernetes.node-labels`: [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) in the form of key, value pairs added when registering the node in the cluster.
 * `settings.kubernetes.node-taints`: [Taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) in the form of key, value and effect entries added when registering the node in the cluster.
   * Example user data for setting up labels and taints:

--- a/README.md
+++ b/README.md
@@ -299,11 +299,11 @@ The following settings can be optionally set to customize the node labels and ta
   * Example user data for setting up labels and taints:
     ```
     [settings.kubernetes.node-labels]
-    label1 = "foo"
-    label2 = "bar"
+    "label1" = "foo"
+    "label2" = "bar"
     [settings.kubernetes.node-taints]
-    dedicated = "experimental:PreferNoSchedule"
-    special = "true:NoSchedule"
+    "dedicated" = "experimental:PreferNoSchedule"
+    "special" = "true:NoSchedule"
     ```
 
 The following settings are optional and allow you to further configure your cluster.


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Labels and taints do not work if the keys aren't wrapped in strings. My nodes never connect to the cluster. There may be other places in this codebase where this issue exists.

**Testing done:**
N/A

**Terms of contribution:**
By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
