### PR TITLE
Move pod-infra-container-image generation to schnauzer template helpers

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -44,4 +44,5 @@ version = "1.0.8"
     "migrate_v1.1.0_kubelet-registry-qps-registry-burst.lz4",
     "migrate_v1.1.0_shared-containerd-configs.lz4",
     "migrate_v1.1.0_kubelet-event-qps-event-burst.lz4",
+    "migrate_v1.1.0_schnauzer-paws.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2272,6 +2272,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "schnauzer-paws"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "api/migration/migrations/v1.1.0/kubelet-registry-qps-registry-burst",
     "api/migration/migrations/v1.1.0/shared-containerd-configs",
     "api/migration/migrations/v1.1.0/kubelet-event-qps-event-burst",
+    "api/migration/migrations/v1.1.0/schnauzer-paws",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.0/schnauzer-paws/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.0/schnauzer-paws/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "schnauzer-paws"
+version = "0.1.0"
+authors = ["Tom Kirchner <tjk@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }
+serde_json = "1.0"

--- a/sources/api/migration/migrations/v1.1.0/schnauzer-paws/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.0/schnauzer-paws/src/main.rs
@@ -1,0 +1,131 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use std::process;
+
+const SETTING: &str = "settings.kubernetes.pod-infra-container-image";
+const OLD_SETTING_GENERATOR: &str = "pluto pod-infra-container-image";
+const NEW_SETTING_GENERATOR: &str = "schnauzer settings.kubernetes.pod-infra-container-image";
+const NEW_TEMPLATE: &str =
+    "{{ pause-prefix settings.aws.region }}/eks/pause-{{ goarch os.arch }}:3.1";
+
+/// We moved from using pluto to schnauzer for generating the pause container image URL, since it
+/// lets us reuse the existing region and arch settings, improving reliability and allowing for
+/// testing new regions through settings overrides.
+pub struct SchnauzerPaws;
+
+impl Migration for SchnauzerPaws {
+    fn forward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        // Check if we have this setting at all.
+        if let Some(metadata) = input.metadata.get_mut(SETTING) {
+            if let Some(metadata_value) = metadata.get_mut("setting-generator") {
+                // Make sure the value is what we expect.
+                match metadata_value {
+                    serde_json::Value::String(string) => {
+                        if string == OLD_SETTING_GENERATOR {
+                            // Happy path.  Update the generator.
+                            *metadata_value = NEW_SETTING_GENERATOR.into();
+                            println!(
+                                "Changed setting-generator for '{}' from {:?} to {:?} on upgrade",
+                                SETTING, OLD_SETTING_GENERATOR, NEW_SETTING_GENERATOR
+                            );
+
+                            // Set the associated template.  We didn't have a template for this
+                            // setting before, and metadata can't be changed by the user, so we can
+                            // just set it.
+                            metadata.insert("template".to_string(), NEW_TEMPLATE.into());
+                            println!(
+                                "Set 'template' metadata on '{}' to '{}'",
+                                SETTING, NEW_TEMPLATE
+                            );
+                        } else {
+                            println!(
+                                "setting-generator for '{}' is not set to {:?}, leaving alone",
+                                SETTING, OLD_SETTING_GENERATOR
+                            );
+                        }
+                    }
+                    _ => {
+                        println!(
+                            "setting-generator for '{}' is set to non-string value '{}'; SchnauzerPaws only handles strings",
+                            SETTING, metadata_value
+                        );
+                    }
+                }
+            } else {
+                println!("Found no setting-generator for '{}'", SETTING);
+            }
+        } else {
+            println!("Found no metadata for '{}'", SETTING);
+        }
+
+        Ok(input)
+    }
+
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        // Check if we have this setting at all.
+        if let Some(metadata) = input.metadata.get_mut(SETTING) {
+            if let Some(metadata_value) = metadata.get_mut("setting-generator") {
+                // Make sure the value is what we expect.
+                match metadata_value {
+                    serde_json::Value::String(string) => {
+                        if string == NEW_SETTING_GENERATOR {
+                            // Happy path.  Update the generator.
+                            *metadata_value = OLD_SETTING_GENERATOR.into();
+                            println!(
+                                "Changed setting-generator for '{}' from {:?} to {:?} on downgrade",
+                                SETTING, NEW_SETTING_GENERATOR, OLD_SETTING_GENERATOR
+                            );
+
+                            // Remove the associated template.  We didn't have a template for this
+                            // setting before, and metadata can't be changed by the user, so we can
+                            // just remove it.
+                            if let Some(metadata_value) = metadata.remove("template") {
+                                println!(
+                                    "Removed 'template' metadata on '{}', which was set to '{}'",
+                                    SETTING, metadata_value
+                                );
+                            } else {
+                                println!(
+                                    "Found no 'template' metadata to remove on setting '{}'",
+                                    SETTING
+                                );
+                            }
+                        } else {
+                            println!(
+                                "setting-generator for '{}' is not set to {:?}, leaving alone",
+                                SETTING, NEW_SETTING_GENERATOR
+                            );
+                        }
+                    }
+                    _ => {
+                        println!(
+                            "setting-generator for '{}' is set to non-string value '{}'; SchnauzerPaws only handles strings",
+                            SETTING, metadata_value
+                        );
+                    }
+                }
+            } else {
+                println!("Found no setting-generator for '{}'", SETTING);
+            }
+        } else {
+            println!("Found no metadata for '{}'", SETTING);
+        }
+
+        Ok(input)
+    }
+}
+
+fn run() -> Result<()> {
+    migrate(SchnauzerPaws)
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/pluto/README.md
+++ b/sources/api/pluto/README.md
@@ -12,7 +12,6 @@ It makes calls to IMDS to get meta data:
 
 - Cluster DNS
 - Node IP
-- POD Infra Container Image
 
 ## Colophon 
 

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -122,7 +122,9 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("join_map", Box::new(helpers::join_map));
     template_registry.register_helper("default", Box::new(helpers::default));
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
+    template_registry.register_helper("pause-prefix", Box::new(helpers::pause_prefix));
     template_registry.register_helper("host", Box::new(helpers::host));
+    template_registry.register_helper("goarch", Box::new(helpers::goarch));
     template_registry.register_helper("join_array", Box::new(helpers::join_array));
     template_registry.register_helper("kube_reserve_cpu", Box::new(helpers::kube_reserve_cpu));
     template_registry.register_helper(

--- a/sources/models/shared-defaults/kubernetes-aws.toml
+++ b/sources/models/shared-defaults/kubernetes-aws.toml
@@ -12,7 +12,8 @@ node-ip.setting-generator = "pluto node-ip"
 affected-services = ["kubernetes"]
 
 [metadata.settings.kubernetes.pod-infra-container-image]
-setting-generator = "pluto pod-infra-container-image"
+setting-generator = "schnauzer settings.kubernetes.pod-infra-container-image"
+template = "{{ pause-prefix settings.aws.region }}/eks/pause-{{ goarch os.arch }}:3.1"
 affected-services = ["kubernetes", "containerd"]
 
 [settings.metrics]


### PR DESCRIPTION
**Description of changes:**

```
Move pod-infra-container-image generation to schnauzer template helpers

Previously, pluto talked to IMDS to get the current region so it could generate
the right pause container URL.  This was added before we had the
settings.aws.region setting, so that was the only way.  However, it means extra
IMDS traffic, and it means you can't override the region of the image, which is
useful when testing new regions.  (It also means you can't override the image
arch, though that's less useful.)

This creates a 'pause-prefix' helper, like the existing ecr-prefix helper, that
can be used in schnauzer templates.

This also adds a 'goarch' helper, to convert Bottlerocket-standard architecture
names like x86_64 to "Go-like" architecture names like amd64, as used in the
pause container.
```
```
Add migration for pluto -> schnauzer migration for pause container URL
```

I made the pause-prefix code very similar to the existing ecr-prefix code, so if you expand the diff a little you'll see a good example.  The regions/accounts were just a plain move, of course.

**Testing done:**

Before, the pause container ignored settings.aws.region.  I launched a us-west-2 instance with settings.aws.region=ap-northeast-3 user data, and it still pulled from us-west-2.
```
host-ctr[3545]: time="2021-04-26T21:05:29Z" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:us-west-2:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3545]: time="2021-04-26T21:05:30Z" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:us-west-2:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3545]: time="2021-04-26T21:05:30Z" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:us-west-2:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3545]: time="2021-04-26T21:05:30Z" level=info msg="tagging image" img="602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1"
```
After, it used my setting for ap-northeast-3, even though the instance was in us-west-2:
```
host-ctr[3719]: time="2021-04-30T23:41:49Z" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:ap-northeast-3:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3719]: time="2021-04-30T23:41:51Z" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:ap-northeast-3:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3719]: time="2021-04-30T23:41:51Z" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:ap-northeast-3:602401143452:repository/eks/pause-amd64:3.1"
host-ctr[3719]: time="2021-04-30T23:41:51Z" level=info msg="tagging image" img="602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/pause-amd64:3.1"
```

You can see that it generated the value correctly, and can see the new setting-generator and template:

```
# apiclient -u /settings?prefix=kubernetes.pod
{"kubernetes":{"pod-infra-container-image":"602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/pause-amd64:3.1"}}
# apiclient -u /metadata/setting-generators
{"settings.kubernetes.pod-infra-container-image":"schnauzer settings.kubernetes.pod-infra-container-image",...}
# apiclient -u /metadata/templates?keys=settings.kubernetes.pod-infra-container-image
{"settings.kubernetes.pod-infra-container-image":"{{ pause-prefix settings.aws.region }}/eks/pause-{{ goarch os.arch }}:3.1"}
```

(also tested normal health of instance)

**Migration:**

To test the migration, I started with a v1.0.8 instance built from a recent commit.  (I didn't use the ap-northeast-3 user data when testing the migration.)  You can see the original pause container, plus the setting-generator and (lack of) template:
```
$ apiclient -u /settings?prefix=kubernetes.pod
{"kubernetes":{"pod-infra-container-image":"602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1"}}
$ apiclient -u /metadata/setting-generators
{...,"settings.kubernetes.pod-infra-container-image":"pluto pod-infra-container-image",...}
$ apiclient -u /metadata/templates?keys=settings.kubernetes.pod-infra-container-image
{}
```
I updated to a v1.1.0 build that included this change.  The migration worked, fixing the setting-generator and adding the template:
```
# apiclient -u /settings?prefix=kubernetes.pod
{"kubernetes":{"pod-infra-container-image":"602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1"}}
# apiclient -u /metadata/setting-generators
{...,"settings.kubernetes.pod-infra-container-image":"schnauzer settings.kubernetes.pod-infra-container-image",...}
# apiclient -u /metadata/templates?keys=settings.kubernetes.pod-infra-container-image
{"settings.kubernetes.pod-infra-container-image":"{{ pause-prefix settings.aws.region }}/eks/pause-{{ goarch os.arch }}:3.1"}
```

I downgraded back to v1.0.8 and you can see the setting-generator was reverted and the template removed:
```
# apiclient -u /settings?prefix=kubernetes.pod
{"kubernetes":{"pod-infra-container-image":"602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-amd64:3.1"}}
# apiclient -u /metadata/setting-generators
{...,"settings.kubernetes.pod-infra-container-image":"pluto pod-infra-container-image",...}
# apiclient -u /metadata/templates?keys=settings.kubernetes.pod-infra-container-image
{}
```

(I tested the health of the instance at all three points)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
