### PR TITLE
VMware: OVF template changes to support the vSphere CSI driver

### DIFF
--- a/variants/vmware-dev/template.ovf
+++ b/variants/vmware-dev/template.ovf
@@ -82,6 +82,8 @@
       <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
       <vmw:ExtraConfig ovf:required="false" vmw:key="disk.enableUUID" vmw:value="true"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="bios.bootOrder" vmw:value="hdd"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="bios.hddOrder" vmw:value="nvme0:1"/>
     </VirtualHardwareSection>
   </VirtualSystem>
 </Envelope>

--- a/variants/vmware-dev/template.ovf
+++ b/variants/vmware-dev/template.ovf
@@ -81,6 +81,7 @@
       </Item>
       <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="disk.enableUUID" vmw:value="true"/>
     </VirtualHardwareSection>
   </VirtualSystem>
 </Envelope>

--- a/variants/vmware-dev/template.ovf
+++ b/variants/vmware-dev/template.ovf
@@ -26,7 +26,7 @@
       <System>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
-        <vssd:VirtualSystemType>vmx-14</vssd:VirtualSystemType>
+        <vssd:VirtualSystemType>vmx-15</vssd:VirtualSystemType>
       </System>
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
These changes to the OVF template file are meant to support the [vSphere CSI driver prerequisites](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/prerequisites.html).  Additional details are in the commit messages below:

```
 The vSphere CSI driver requires that the hardware version for VMs is at
 least 15.  This commit updates the value in the OVF template.
```
```
The vSphere CSI driver requires that the `disk.EnableUUID` parameter be set to
TRUE.  This is necessary so VMDKs always present a consistent UUID to the VM so
it is properly mounted.
```
```
The vSphere CSI driver recommends the VMware Paravirtual SCSI
controller, and uses SCSI when attaching disks to VMs.  We observed the
BIOS prioritizes SCSI over NVME, so if a SCSI drive was attached using
this CSI driver and the machine was rebooted, it would attempt to boot
via the SCSI drive which obviously won't work.  This change forces the
BIOS to prioritize hdd nvme0:1 first
```


**Testing done:**
* Added a SCSI drive to a `vmware-k8s-1.20` node, booted to BIOS and observed the SCSI device comes before NVME in the boot order.  Exited BIOS and the machine fell through to PXE, failing to boot.
* Added an OVA containing this change, attached a SCSI drive to it, booted the node to BIOS and observed that NVME came before SCSI in the boot order.  Exited BIOS and observed the machine boot.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
