### PR TITLE
aws-ecs-1: use kernel 5.10

### DIFF
--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "docker-init",
  "docker-proxy",
  "ecs-agent",
- "kernel-5_4",
+ "kernel-5_10",
  "release",
 ]
 

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -13,7 +13,7 @@ kernel-parameters = [
 included-packages = [
 # core
     "release",
-    "kernel-5.4",
+    "kernel-5.10",
 # docker
     "docker-cli",
     "docker-engine",
@@ -29,7 +29,7 @@ path = "lib.rs"
 [build-dependencies]
 # core
 release = { path = "../../packages/release" }
-kernel-5_4 = { path = "../../packages/kernel-5.4" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Update the `aws-ecs-1` variant build to `kernel-5.10` (from `kernel-5.4`).

**Testing done:**

Pending.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
