### PR TITLE
Update kernels

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,5 +13,5 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/fa04b98fc067a4943beac60d0c2971e2fbef1a29faed4bac1c4096abe4ad4c12/kernel-5.10.29-27.126.amzn2.src.rpm"
-sha512 = "47341f4a1c13ba7e5ea72bad13fe689eefd22cc7547aea08a08fe47238b4a3fe1659786a406b84a1d1508143be20d9be2fae6fe3e7a6924bc85043bf61d4bfce"
+url = "https://cdn.amazonlinux.com/blobstore/9d3856424e8b2b45e2871c0fd558641435e81650c01a70c2c27c0115c86f04c5/kernel-5.10.29-27.128.amzn2.src.rpm"
+sha512 = "372b4fa3f69cea03469b4305adfea13b4f67eece27a5a1847fd12913fd1f42a2c7dccc4569c5781573db6a7044b5e073f32ad57e9954bc0290c5ee1d90fe5640"

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -2,12 +2,12 @@
 
 Name: %{_cross_os}kernel-5.10
 Version: 5.10.29
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/fa04b98fc067a4943beac60d0c2971e2fbef1a29faed4bac1c4096abe4ad4c12/kernel-5.10.29-27.126.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/9d3856424e8b2b45e2871c0fd558641435e81650c01a70c2c27c0115c86f04c5/kernel-5.10.29-27.128.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.4/Cargo.toml
+++ b/packages/kernel-5.4/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/b5b3738a3efe0842f6b4db451c2bc1bbeafb1857a10ec508081e75b52681f13e/kernel-5.4.110-54.182.amzn2.src.rpm"
-sha512 = "09739ceb8c5923845f76c5c2322243ffce53433fd24fccc0239fa23ee4951a4288752de87db07dbc0a0c5e81b3a6f9537feff0a2149332956216cf2e03527ecd"
+url = "https://cdn.amazonlinux.com/blobstore/30c599278ce31259b6ad8fcfb05d25c9bdbbdce8398f0ca686e70c36e7b4986b/kernel-5.4.110-54.189.amzn2.src.rpm"
+sha512 = "ad38a02ec569dcd088e4013f2c9aa50ddf50775b4ded9da5ca367ae19cd141a7d7cd539c986cdcd70656a17e3e9fe874332942bdb027462ef0e029ac1c5fc38b"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -2,12 +2,12 @@
 
 Name: %{_cross_os}kernel-5.4
 Version: 5.4.110
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/b5b3738a3efe0842f6b4db451c2bc1bbeafb1857a10ec508081e75b52681f13e/kernel-5.4.110-54.182.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/30c599278ce31259b6ad8fcfb05d25c9bdbbdce8398f0ca686e70c36e7b4986b/kernel-5.4.110-54.189.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.


### PR DESCRIPTION
**Description of changes:**

```
90ed20e2 Update kernel-5.4 to 5.4.110-54.189
2adc92c9 Update kernel-5.10 to 5.10.29-27.128
```

**Testing done:**

Built aws-k8s-1.19 (for 5.4) and aws-k8s-1.20 (for 5.10) and confirmed the health of pods, services, API, and dmesg.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
