### PR TITLE
buildsys: retry builds on "unexpected EOF" error

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -147,8 +147,10 @@ version = "0.1.0"
 dependencies = [
  "duct",
  "hex",
+ "lazy_static",
  "nonzero_ext",
  "rand",
+ "regex",
  "reqwest",
  "serde",
  "serde_plain",

--- a/tools/buildsys/Cargo.toml
+++ b/tools/buildsys/Cargo.toml
@@ -11,7 +11,9 @@ exclude = ["README.md"]
 [dependencies]
 duct = "0.13.0"
 hex = "0.4.0"
+lazy_static = "1.4"
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+regex = "1"
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_plain = "0.3.0"


### PR DESCRIPTION
**Issue number:**

#1095

**Description of changes:**

This is an alternate approach to #1545 that uses regexes to give us a little more control over how we match messages.  In particular, it at least lets us make sure that "unexpected EOF" is on a line of its own, and not embedded in any other build message.

**Testing done:**

* Confirmed a normal build is still OK.
* Confirmed the "failed to solve" error message is retried 10 times; I just echoed it from a spec file.
* Confirmed the "unexpected EOF" error message is retried only if on a line of its own, not otherwise.
  * I had to modify the captured `stdout` to test this, because RPM prefixes every line of output and it wouldn't match as a full line otherwise.
* Confirmed it doesn't retry after a normal failure without either message.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
