### PR TITLE
split SELinux policy rules for trusted subjects

### DIFF
--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -20,11 +20,11 @@
 ; without policy restrictions.
 (allow all_s self (processes (interact)))
 
-; Only trusted components can interact with all processes.
-(allow trusted_s all_s (processes (interact)))
+; Only privileged components can interact with all processes.
+(allow privileged_s all_s (processes (interact)))
 
-; Untrusted components cannot interact with trusted processes.
-(neverallow untrusted_s trusted_s (processes (interact)))
+; Unprivileged components cannot interact with privileged processes.
+(neverallow unprivileged_s privileged_s (processes (interact)))
 
 ; PID 1 starts as "kernel_t" and becomes "init_t".
 (typetransition kernel_t init_exec_t process init_t)
@@ -115,11 +115,11 @@
 ; All subjects can read from anything that's public.
 (allow all_s public (files (load)))
 
-; Trusted subjects can read from anything at all.
-(allow trusted_s global (files (load)))
+; Privileged subjects can read from anything at all.
+(allow privileged_s global (files (load)))
 
-; Untrusted subjects cannot read from restricted objects.
-(neverallow untrusted_s restricted_o (files (load)))
+; Unprivileged subjects cannot read from restricted objects.
+(neverallow unprivileged_s restricted_o (files (load)))
 
 ; All subjects are allowed to write to objects with their own label.
 ; This includes files like the ones under /proc/self.
@@ -155,9 +155,9 @@
 ; files and directories on /local.
 (allow control_s state_t (files (mutate mount)))
 
-; Untrusted subjects cannot modify "state" or "secret" files.
-(neverallow untrusted_s state_t (files (mutate mount)))
-(neverallow untrusted_s secret_t (files (mutate mount)))
+; Unprivileged subjects cannot modify "state" or "secret" files.
+(neverallow unprivileged_s state_t (files (mutate mount)))
+(neverallow unprivileged_s secret_t (files (mutate mount)))
 
 ; Confined subjects cannot modify "state", "secret", or "local" files.
 (neverallow confined_s local_t (files (mutate mount)))
@@ -185,8 +185,8 @@
 (allow api_s api_socket_t (files (mutate)))
 (allow control_s api_socket_t (files (mutate)))
 
-; Untrusted components are not allowed to use the API socket.
-(neverallow untrusted_s api_socket_t (files (mutate)))
+; Unprivileged components are not allowed to use the API socket.
+(neverallow unprivileged_s api_socket_t (files (mutate)))
 
 ; Only trusted components are allowed to relabel files.
 (allow trusted_s global (files (relabel)))

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -75,9 +75,13 @@
   network_t clock_t bus_t runtime_t
   container_t control_t super_t))
 
+; Subjects that are treated as a privileged part of the OS.
+(typeattribute privileged_s)
+(typeattributeset privileged_s (xor (all_s) (unprivileged_s)))
+
 ; Subjects that are treated as a trusted part of the OS.
 (typeattribute trusted_s)
-(typeattributeset trusted_s (xor (all_s) (untrusted_s)))
+(typeattributeset trusted_s (xor (privileged_s) (control_t)))
 
 ; Subjects that are part of the OS, but confined through policy.
 (typeattribute confined_s)
@@ -91,9 +95,13 @@
 (typeattribute other_s)
 (typeattributeset other_s (container_t))
 
+; Subjects that are not treated as a privileged part of the OS.
+(typeattribute unprivileged_s)
+(typeattributeset unprivileged_s (confined_s other_s))
+
 ; Subjects that are not treated as a trusted part of the OS.
 (typeattribute untrusted_s)
-(typeattributeset untrusted_s (confined_s other_s))
+(typeattributeset untrusted_s (xor (all_s) (trusted_s)))
 
 ; Subjects that are started from containers.
 (typeattribute container_s)


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
```
Since 59264b48, privileged containers have received the `control_t`
label by default. This label is treated as a trusted subject, and has
broad powers of system configuration, including the ability to modify
files in /etc or change SELinux labels.

However, because these powers are granted by default, it creates the
risk of accidental misconfiguration, where files in /etc are modified
without realizing that these changes will be lost on reboot. Changing
SELinux labels can also happen unexpectedly, and could interfere with
the operation of the host or the reliability of upgrades.

To fix this, we split the rules for trusted subjects in two, to match
the expected access boundaries between privileged containers and the
underlying host.

Privileged subjects can still interact with all processes and read
all files, but can no longer change SELinux labels or edit files in
/etc. They also cannot unmount system mounts, or interact directly
with systemd or dbus.
```


**Testing done:**
dev, ecs, and k8s variants booted up and ran containers without AVC denials.

Ran a privileged pod:
```
❯ kubectl exec -ti privileged-pod -- bash

bash-4.2# cat /proc/self/attr/current
system_u:system_r:control_t:s0

bash-4.2# apiclient set motd="hello"

bash-4.2# touch /host-root/etc/foo
touch: cannot touch '/host-root/etc/foo': Permission denied
[  309.381083] audit: type=1400 audit(1620158963.124:5): avc:  denied  { write } for  pid=15157 comm="touch" name="/" dev="tmpfs" ino=9325 scontext=system_u:system_r:control_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=0

bash-4.2# ls -latrZ /host-root/local/host-containers
drwxr-xr-x. root root system_u:object_r:local_t:s0     ..
drwx------. root root system_u:object_r:secret_t:s0    .
drwx------. root root system_u:object_r:secret_t:s0    control
drwx------. root root system_u:object_r:secret_t:s0    admin

bash-4.2# setfattr -n security.selinux -v system_u:object_r:any_t:s0 /host-root/tmp/.font-unix/
setfattr: /host-root/tmp/.font-unix/: Permission denied
[ 2455.787311] audit: type=1400 audit(1620161109.479:13): avc:  denied  { relabelfrom } for  pid=46913 comm="setfattr" name=".font-unix" dev="tmpfs" ino=12510 scontext=system_u:system_r:control_t:s0 tcontext=system_u:object_r:any_t:s0 tclass=dir permissive=0
```

Ran an unprivileged pod. It couldn't write to the API socket, modify files in /etc, read restricted directories, or relabel files.
```
❯ kubectl exec -ti unprivileged-pod -- bash

bash-4.2# cat /proc/self/attr/current
system_u:system_r:container_t:s0:c332,c393

bash-4.2# apiclient set motd="hello"
Failed to change settings: Failed PATCH request to '/settings?tx=apiclient-set-yc2lgVzll4pxV4gM': Failed to send request: error trying to connect: Permission denied (os error 13)
[ 1120.216432] audit: type=1400 audit(1620159773.942:8): avc:  denied  { write } for  pid=27440 comm="apiclient" name="api.sock" dev="tmpfs" ino=13828 scontext=system_u:system_r:container_t:s0:c332,c393 tcontext=system_u:object_r:api_socket_t:s0 tclass=sock_file permissive=0

bash-4.2# touch /host-root/etc/foo
touch: cannot touch '/host-root/etc/foo': Permission denied
[ 1144.664059] audit: type=1400 audit(1620159798.389:9): avc:  denied  { write } for  pid=27804 comm="touch" name="/" dev="tmpfs" ino=9325 scontext=system_u:system_r:container_t:s0:c332,c393 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=0

bash-4.2# ls -latrZ /host-root/local/host-containers
setfattr: /host-root/local/host-containers: Permission denied
[ 2278.910547] audit: type=1400 audit(1620160932.607:12): avc:  denied  { read } for  pid=44369 comm="ls" name="host-containers" dev="nvme1n1p1" ino=1046529 scontext=system_u:system_r:container_t:s0:c332,c393 tcontext=system_u:object_r:secret_t:s0 tclass=dir permissive=0

bash-4.2# setfattr -n security.selinux -v system_u:object_r:any_t:s0 /host-root/tmp/.font-unix/
[ 2225.201995] audit: type=1400 audit(1620160878.901:11): avc:  denied  { relabelfrom } for  pid=43535 comm="setfattr" name=".font-unix" dev="tmpfs" ino=12510 scontext=system_u:system_r:container_t:s0:c332,c393 tcontext=system_u:object_r:any_t:s0 tclass=dir permissive=0
```

Ran a superpowered pod, which could do all of the above:
```
❯ kubectl exec -ti admin-pod -- bash

bash-4.2# cat /proc/self/attr/current
system_u:system_r:super_t:s0

bash-4.2# apiclient set motd="hello"

bash-4.2# touch /host-root/etc/foo

bash-4.2# ls -latrZ /host-root/local/host-containers
drwxr-xr-x. root root system_u:object_r:local_t:s0     ..
drwx------. root root system_u:object_r:secret_t:s0    .
drwx------. root root system_u:object_r:secret_t:s0    control
drwx------. root root system_u:object_r:secret_t:s0    admin

bash-4.2# setfattr -n security.selinux -v system_u:object_r:any_t:s0 /host-root/tmp/.font-unix/
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
