### PR TITLE
release: constrain ip_local_port_range

### DIFF
--- a/packages/ecs-agent/ecs-sysctl.conf
+++ b/packages/ecs-agent/ecs-sysctl.conf
@@ -1,6 +1,2 @@
 # ECS task role endpoint
 net.ipv4.conf.all.route_localnet = 1
-
-# Constrain ephemeral ports to the range documented for ECS
-# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html
-net.ipv4.ip_local_port_range = 32768 60999

--- a/packages/kubernetes-1.20/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.20/kubelet-sysctl.conf
@@ -1,5 +1,2 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
-
-# This is generally considered a safe ephemeral port range
-net.ipv4.ip_local_port_range = 32768 60999

--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -28,8 +28,8 @@ net.ipv4.ip_default_ttl = 255
 # Enable IPv4 forwarding for container networking.
 net.ipv4.conf.all.forwarding = 1
 
-# Have a larger connection range available
-net.ipv4.ip_local_port_range = 1025 65000
+# This is generally considered a safe ephemeral port range
+net.ipv4.ip_local_port_range = 32768 60999
 
 # Connection tracking to prevent dropped connections
 net.netfilter.nf_conntrack_max = 1048576


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1386 more definitively 


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue May 4 15:41:26 2021 -0700

    release: constrain ip_local_port_range
    
    containerd listens on ports in the kernel's ephemeral port range which
    can conflict with fixed ports kubelet needs when it starts up.
    
    This limits the ephemeral port range for all Bottlerocket variants
    and not just aws-ecs-1 and aws-k8s-1.20.

```


**Testing done:**

Build aws-k8s-1.19 image and launched instance. Checked sysctl and saw that the ephemeral port range is set correctly.
```
$ sudo sysctl -a | grep net.ipv4.ip_local_port_range
net.ipv4.ip_local_port_range = 32768	60999

```

Ports being used:
```
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 127.0.0.1:50051         0.0.0.0:*               LISTEN      4865/./aws-k8s-agen 
tcp        0      0 127.0.0.1:43591         0.0.0.0:*               LISTEN      3353/containerd     
tcp        0      0 127.0.0.1:10248         0.0.0.0:*               LISTEN      3600/kubelet        
tcp        0      0 127.0.0.1:10249         0.0.0.0:*               LISTEN      4448/kube-proxy     
tcp        0      0 127.0.0.1:61679         0.0.0.0:*               LISTEN      4865/./aws-k8s-agen 
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      4120/sshd           
tcp6       0      0 :::10250                :::*                    LISTEN      3600/kubelet        
tcp6       0      0 :::61678                :::*                    LISTEN      4865/./aws-k8s-agen 
tcp6       0      0 :::9808                 :::*                    LISTEN      4749/livenessprobe  
tcp6       0      0 :::10256                :::*                    LISTEN      4448/kube-proxy     
tcp6       0      0 :::22                   :::*                    LISTEN      4120/sshd   
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
