### PR TITLE
packages: add grep to all variants

### DIFF
--- a/packages/grep/Cargo.toml
+++ b/packages/grep/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "grep"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://mirrors.kernel.org/gnu/grep/grep-3.6.tar.xz"
+sha512 = "8934544a19ded61344d83ff2cab501e86f17f8ae338892e0c36c2d2d8e63c76817840a0071ef5e3fcbca9115eba8a1aae0e4c46b024e75cd9a2e3bd05f933d90"
+
+[dependencies]
+libpcre = { path = "../libpcre" }
+
+[build-dependencies]
+libpcre = { path = "../libpcre" }
+glibc = { path = "../glibc" }

--- a/packages/grep/build.rs
+++ b/packages/grep/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/grep/grep.spec
+++ b/packages/grep/grep.spec
@@ -1,0 +1,34 @@
+Name: %{_cross_os}grep
+Version: 3.6
+Release: 1%{?dist}
+Summary: GNU grep utility
+URL: https://www.gnu.org/software/grep/
+License: GPL-3.0-or-later
+Source: https://mirrors.kernel.org/gnu/grep/grep-%{version}.tar.xz
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libpcre-devel
+Requires: %{_cross_os}libpcre
+
+%description
+%{summary}.
+
+%prep
+%setup -n grep-%{version}
+
+%build
+%cross_configure --without-included-regex --disable-silent-rules
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING
+%{_cross_bindir}/grep
+%{_cross_attribution_file}
+# Exclude fgrep and egrep because they are shell scripts
+%exclude %{_cross_bindir}/fgrep
+%exclude %{_cross_bindir}/egrep
+%exclude %{_cross_infodir}
+%exclude %{_cross_localedir}
+%exclude %{_cross_mandir}

--- a/packages/grep/pkg.rs
+++ b/packages/grep/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -22,6 +22,7 @@ dbus-broker = { path = "../dbus-broker" }
 e2fsprogs = { path = "../e2fsprogs" }
 filesystem = { path = "../filesystem" }
 glibc = { path = "../glibc" }
+grep = { path = "../grep" }
 grub = { path = "../grub" }
 iproute = { path = "../iproute" }
 libaudit = { path = "../libaudit" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -49,6 +49,7 @@ Requires: %{_cross_os}e2fsprogs
 Requires: %{_cross_os}libgcc
 Requires: %{_cross_os}libstd-rust
 Requires: %{_cross_os}filesystem
+Requires: %{_cross_os}grep
 Requires: %{_cross_os}glibc
 Requires: %{_cross_os}grub
 Requires: %{_cross_os}iproute

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -259,6 +259,14 @@ name = "glibc"
 version = "0.1.0"
 
 [[package]]
+name = "grep"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libpcre",
+]
+
+[[package]]
 name = "grub"
 version = "0.1.0"
 dependencies = [
@@ -659,6 +667,7 @@ dependencies = [
  "e2fsprogs",
  "filesystem",
  "glibc",
+ "grep",
  "grub",
  "iproute",
  "libaudit",


### PR DESCRIPTION
**Issue number:**
#1414


**Description of changes:**

```
43821e5c packages: add grep to all variants
```

This PR adds grep to all the variants

**Testing done:**

aws-dev/aws-ecs-1/aws-k8s-1.16/aws-k8s-1.19 x86_64:

* Validated `grep` is available and used with `-E` for extended regular expressions

aws-dev/aws-ecs-1 aarch64:

* Validated `grep` is available and used with `-E` for extended regular expressions


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
