### PR TITLE
webpki-roots-shim: document version

### DIFF
--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -57,6 +57,7 @@ members = [
 [profile.release]
 debug = true
 
-# This replaces webpki-roots with a shim that reads from the ca-certificates package
+# This replaces webpki-roots with a shim that reads from the ca-certificates package. See
+# webpki-roots-shim/Cargo.toml for more information about using the right version number.
 [patch.crates-io.webpki-roots]
 path = "webpki-roots-shim"

--- a/sources/webpki-roots-shim/Cargo.toml
+++ b/sources/webpki-roots-shim/Cargo.toml
@@ -1,5 +1,14 @@
 [package]
 name = "webpki-roots"
+# This version number is important because it determines whether or not our shim gets used by the
+# patch statement in the sources workspace's Cargo.toml.
+#
+# At the time of this writing, reqwest is the only crate in sources/Cargo.lock that depends on
+# webpki-roots. When reqwest is updated, the version here should be updated to exactly match the one
+# that reqwest is using.
+#
+# You should also double-check sources/Cargo.lock to make sure there aren't two versions of
+# webpki-roots being used (which would mean that one of them came from crates.io instead of here).
 version = "0.21.1"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
**Issue number:**

Closes #1539

**Description of changes:**

We need to be careful with the version number in webpki-roots-shim's
Cargo.toml file. This commit attempts to explain why in comments.

**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
