### PR TITLE
Add ap-northeast-3 to supported region list

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -43,6 +43,7 @@ af-south-1
 ap-east-1
 ap-northeast-1
 ap-northeast-2
+ap-northeast-3
 ap-south-1
 ap-southeast-1
 ap-southeast-2

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -104,6 +104,7 @@ af-south-1
 ap-east-1
 ap-northeast-1
 ap-northeast-2
+ap-northeast-3
 ap-south-1
 ap-southeast-1
 ap-southeast-2


### PR DESCRIPTION
**Issue number:**

Fixes #1474 

**Description of changes:**

Now that v1.1.0 is live, Bottlerocket is available in the ap-northeast-3 (Osaka) AWS region.

**Testing done:**

Created EKS and ECS clusters in ap-northeast-3 and successfully used v1.1.0 in each.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
