### PR TITLE
model-derive: add derive attributes at start of list

### DIFF
--- a/sources/models/model-derive/src/lib.rs
+++ b/sources/models/model-derive/src/lib.rs
@@ -130,7 +130,10 @@ impl VisitMut for ModelHelper {
             } else {
                 parse_quote!(#[derive(Debug, PartialEq, Serialize, Deserialize)])
             };
-            node.attrs.push(attr);
+            // Rust 1.52 added a legacy_derive_helpers warning (soon to be an error) that yells if
+            // you use an attribute macro before the derive macro that introduces it.  We should
+            // always put derive macros at the start of the list to avoid this.
+            node.attrs.insert(0, attr);
         }
 
         // Let the default implementation do its thing, recursively.


### PR DESCRIPTION
**Description of changes:**

```
model-derive: add derive attributes at start of list

Rust 1.52 added a legacy_derive_helpers warning (soon to be an error) that
yells if you use an attribute macro before the derive macro that introduces it.
We should always put derive macros at the start of the list to avoid this.

Reference: https://github.com/rust-lang/rust/issues/79202
```

Fixes the warnings in the model crate showing up with Rust 1.52:

```
warning: derive helper attribute is used before it is introduced
   --> models/src/lib.rs:261:1
    |
261 | #[model]
    | ^^^^^^^^ the attribute is introduced here
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
    = note: this warning originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

**Testing done:**

^ Those are all gone.  Confirmed I still get a healthy image where the API works fine, pod OK, etc.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
