### PR TITLE
pubsys: allow refresh-repo to use default key path

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -664,6 +664,7 @@ pubsys \
    --variant "${BUILDSYS_VARIANT}" \
    \
    --root-role-path "${PUBLISH_REPO_ROOT_JSON}" \
+   --default-key-path "${PUBLISH_REPO_KEY}" \
    --repo-expiration-policy-path "${PUBLISH_EXPIRATION_POLICY_PATH}" \
    ${REPO_UNSAFE_REFRESH_ARG} \
    --outdir "${PUBLISH_REPO_OUTPUT_DIR}"


### PR DESCRIPTION
**Description of changes:**

This copies the logic from repo.rs into refresh-repo so we can refresh local repos with the default, generated key.  I admit this probably isn't super useful in any production setting, but it's at least good for testing!

**Testing done:**

Local key:
```
[cargo-make] INFO - Running Task: refresh-repo
17:17:10 [INFO] Using infra config from path: /home/tjk/work/bottlerocket/Infra.toml
17:17:10 [INFO] Using repo expiration policy from path: /home/tjk/work/bottlerocket/tools/pubsys/policies/repo-expiration/2w-2w-1w.toml
17:17:10 [INFO] Loaded TUF repo: file:///home/tjk/work/bottlerocket/build/repos/default/latest/aws-k8s-1.19/x86_64
17:17:10 [INFO] Setting non-root metadata expiration times:
        snapshot:  2021-05-28 17:17:10.423431799 UTC
        targets:   2021-05-28 17:17:10.423431799 UTC
        timestamp: 2021-05-21 17:17:10.423431799 UTC
17:17:10 [INFO] Writing repo metadata to: /home/tjk/work/bottlerocket/build/repos/default/bottlerocket-1.1.0-64b14ebb/aws-k8s-1.19/x86_64
[cargo-make] INFO - Build Done in 29.06 seconds.
```

KMS key:
```
[cargo-make] INFO - Running Task: refresh-repo
17:36:41 [INFO] Using infra config from path: /home/tjk/work/bottlerocket/Infra.toml
17:36:41 [INFO] Using repo expiration policy from path: /home/tjk/work/bottlerocket/tools/pubsys/policies/repo-expiration/2w-2w-1w.toml
17:36:41 [INFO] Loaded TUF repo: file:///home/tjk/work/bottlerocket/build/repos/default/latest/aws-k8s-1.19/x86_64
17:36:41 [INFO] Setting non-root metadata expiration times:
        snapshot:  2021-05-28 17:36:41.487717816 UTC
        targets:   2021-05-28 17:36:41.487717816 UTC
        timestamp: 2021-05-21 17:36:41.487717816 UTC
17:36:41 [INFO] Writing repo metadata to: /home/tjk/work/bottlerocket/build/repos/default/bottlerocket-1.1.0-64b14ebb-dirty/aws-k8s-1.19/x86_64
[cargo-make] INFO - Build Done in 1.65 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
