### PR TITLE
early-boot-config: Simplify conditional compilation and make `local_file` available to all platforms

### DIFF
--- a/sources/api/early-boot-config/src/main.rs
+++ b/sources/api/early-boot-config/src/main.rs
@@ -43,19 +43,9 @@ const MARKER_FILE: &str = "/var/lib/bottlerocket/early-boot-config.ran";
 /// This function returns the appropriate data provider for this variant. It exists primarily to
 /// keep the ugly bits of conditional compilation out of the main function.
 fn create_provider() -> Result<Box<dyn PlatformDataProvider>> {
-    #[cfg(bottlerocket_platform = "aws")]
+    #[cfg(any(bottlerocket_platform = "aws", bottlerocket_platform = "aws-dev"))]
     {
         Ok(Box::new(provider::aws::AwsDataProvider))
-    }
-
-    #[cfg(bottlerocket_platform = "aws-dev")]
-    {
-        use std::path::Path;
-        if Path::new(provider::local_file::LocalFileDataProvider::USER_DATA_FILE).exists() {
-            Ok(Box::new(provider::local_file::LocalFileDataProvider))
-        } else {
-            Ok(Box::new(provider::aws::AwsDataProvider))
-        }
     }
 
     #[cfg(bottlerocket_platform = "vmware")]

--- a/sources/api/early-boot-config/src/provider.rs
+++ b/sources/api/early-boot-config/src/provider.rs
@@ -3,14 +3,18 @@
 use crate::settings::SettingsJson;
 use async_trait::async_trait;
 
-#[cfg(any(bottlerocket_platform = "aws", bottlerocket_platform = "aws-dev"))]
-pub(crate) mod aws;
-
 #[cfg(bottlerocket_platform = "aws-dev")]
-pub(crate) mod local_file;
+mod local_file;
+
+#[cfg(any(bottlerocket_platform = "aws", bottlerocket_platform = "aws-dev"))]
+mod aws;
+#[cfg(any(bottlerocket_platform = "aws", bottlerocket_platform = "aws-dev"))]
+pub(crate) use aws::AwsDataProvider as Platform;
 
 #[cfg(bottlerocket_platform = "vmware")]
-pub(crate) mod vmware;
+mod vmware;
+#[cfg(bottlerocket_platform = "vmware")]
+pub(crate) use vmware::VmwareDataProvider as Platform;
 
 /// Support for new platforms can be added by implementing this trait.
 #[async_trait]


### PR DESCRIPTION
**Issue number:**
Fixes #1457 


**Description of changes:**
This change simplifies the conditional compilation by re-exporting the appropriate `PlatformDataProvider` as the common name `Platform`.  This allows us to remove all conditional bits from `main` by using `Platform` when retrieving user data.

It also makes `local_file` a common function that all platforms can use, rather than a "platform-like" module in itself.  Currently, we only make use of it in the `aws-dev` variant.
``` 
Previously, `local_file` was an implementor of the
`PlatformDataProvider` trait.  This was a bit awkward, considering local
file is _not_ a platform.  It also meant it was a bit awkward to use
inside another provider.  This change makes `local_file` a function that
all platforms can use and makes use of it inside the `aws` module for
`aws-dev` variants.
```

```
This change uses `cfg` directives inside of `provider.rs` to compile the
appropriate `PlatformDataProvider` for the current variant.  It
re-exports the data provider as `Platform`, meaning that all conditional
compilation details are removed from `main.rs` and it can simply use
`Platform` instead of a specific platform trait implementor.
```

**Testing done:**
* Boot an `aws-dev` variant with and without a local file to ensure local file is read if it exists
* Boot an `aws-k8s-1.19` variant to ensure user data is read properly (and local file isn't attempted).
* Boot a `vmware-k8s-1.20` variant to ensure nothing broke there.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
