### PR TITLE
host-containers: default "enabled" and "superpowered" to false

### DIFF
--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -363,14 +363,8 @@ where
         name,
         field: "source",
     })?;
-    let enabled = image_details.enabled.context(error::MissingField {
-        name,
-        field: "enabled",
-    })?;
-    let superpowered = image_details.superpowered.context(error::MissingField {
-        name,
-        field: "superpowered",
-    })?;
+    let enabled = image_details.enabled.unwrap_or(false);
+    let superpowered = image_details.superpowered.unwrap_or(false);
 
     info!("Host container '{}' is enabled: {}, superpowered: {}, with source: {}",
           name, enabled, superpowered, source);


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Partially addresses https://github.com/bottlerocket-os/bottlerocket/issues/1385


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon May 17 16:37:52 2021 -0700

    host-containers: default "enabled" and "superpowered" to false
    
    Defaults "enabled" and "superpowered" to false when not defined.

```


**Testing done:**
Launched instance with the following userdata.
`self-terminator` doesn't have either `enabled` or `superpowered` specified
```
[settings.host-containers.admin]
enabled = true

[settings.host-containers.control]
enabled = true

[settings.host-containers.self-terminator]
source="snip.dkr.ecr.us-west-2.amazonaws.com/self-terminator:latest"
```

The host was able to come up fine and the settings are as expected:
```
   "host-containers":{
      ...,
      "self-terminator":{
         "source":"snip.dkr.ecr.us-west-2.amazonaws.com/self-terminator:latest"
      }
   },
```

Then checking the host-container's environment variables, both `enabled` and `superpowered` are defaulted to false.
```
bash-5.0# cat /etc/host-containers/self-terminator.env 
CTR_SUPERPOWERED=false
CTR_SOURCE=snip.dkr.ecr.us-west-2.amazonaws.com/self-terminator:latest

# Just for reference; service is enabled or disabled by host-containers service
# CTR_ENABLED=false

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
