### PR TITLE
README: add details about the two default bottlerocket volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,3 +652,10 @@ See [Settings](#settings) above for examples and to understand what you can conf
 The server and client are the user-facing components of the API system, but there are a number of other components that work together to make sure your settings are applied, and that they survive upgrades of Bottlerocket.
 
 For more details, see the [API system documentation](sources/api/).
+
+### Default Volumes
+
+Bottlerocket operates with two default storage volumes. 
+* The root device, `/dev/xvda`, holds the active and passive [partition sets](#updates-1).
+  It also contains the bootloader, the dm-verity hash tree for verifying the [immutable root filesystem](SECURITY_FEATURES.md#immutable-rootfs-backed-by-dm-verity), and the data store for the Bottlerocket API.
+* The data device, `/dex/xvdb`, is used as persistent storage for container images, container orchestration, [host-containers](#Custom-host-containers), and [bootstrap containers](#Bootstrap-containers-settings).


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses https://github.com/bottlerocket-os/bottlerocket/issues/1203


**Description of changes:**
This documents the uses of the two default Bottlerocket volumes.


**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
