### PR TITLE
kubelet: add setting for configuring containerLogMaxFiles and MaxSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.event-burst`: The maximum size of a burst of event creations.
 * `settings.kubernetes.kube-api-qps`: The QPS to use while talking with kubernetes apiserver.
 * `settings.kubernetes.kube-api-burst`: The burst to allow while talking with kubernetes.
+* `settings.kubernetes.container-log-max-size`: The maximum size of container log file before it is rotated.
+* `settings.kubernetes.container-log-max-files`: The maximum number of container log files that can be present for a container.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -48,3 +48,6 @@ version = "1.1.1"
     "migrate_v1.1.0_kubelet-kube-api-qps-kube-api-burst.lz4",
 ]
 "(1.1.0, 1.1.1)" = []
+"(1.1.1, 1.1.2)" = [
+    "migrate_v1.1.2_kubelet-container-log.lz4",
+]

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -84,3 +84,9 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
+{{~/if}}
+{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
+{{~/if}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -85,3 +85,9 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
+{{~/if}}
+{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
+{{~/if}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -85,3 +85,9 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
+{{~/if}}
+{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
+{{~/if}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -86,3 +86,9 @@ tlsCipherSuites:
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
+{{~/if}}
+{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
+{{~/if}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -87,3 +87,9 @@ tlsCipherSuites:
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
+{{~/if}}
+{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
+{{~/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1481,6 +1481,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-container-log"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-event-qps-event-burst"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "api/migration/migrations/v1.1.0/kubelet-event-qps-event-burst",
     "api/migration/migrations/v1.1.0/schnauzer-paws",
     "api/migration/migrations/v1.1.0/kubelet-kube-api-qps-kube-api-burst",
+    "api/migration/migrations/v1.1.2/kubelet-container-log",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.2/kubelet-container-log/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.2/kubelet-container-log/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-container-log"
+version = "0.1.0"
+authors = ["Sungwon Cho <samjo.nyang@gmail.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.2/kubelet-container-log/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.2/kubelet-container-log/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new settings for configuring kubelet, `settings.kubernetes.container-log-max-size`
+/// and `settings.kubernetes.container-log-max-files`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.container-log-max-size",
+        "settings.kubernetes.container-log-max-files",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -145,6 +145,8 @@ struct KubernetesSettings {
     event_burst: i32,
     kube_api_qps: i32,
     kube_api_burst: i32,
+    container_log_max_size: KubernetesQuantityValue,
+    container_log_max_files: i32,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
**Description of changes:**
Add containerLogMaxFiles and containerLogMaxSize to kubelet configuration.
FYI: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/


**Testing done:**
This patch is currently use for our infrastructure.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
