### PR TITLE
metricdog and updog: remove reqwest proxy workaround

### DIFF
--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -471,25 +471,6 @@ fn set_https_proxy_environment_variables(
         _ => return Ok(()),
     };
 
-    // TODO - remove this workaround, https://github.com/bottlerocket-os/bottlerocket/issues/1332
-    // reqwest needs a URL protocol scheme to be present, but other implementations assume
-    // `http://` as the scheme when none is present. We need to check the `HTTPS_PROXY` env and
-    // reset it with `http://` when no scheme is present. This workaround will no longer be needed
-    // when both bottlerocket and tough are using reqwest >= 0.11.1.
-    let proxy = if Url::parse(&proxy).is_ok() {
-        // the proxy value is OK, it has a scheme
-        debug!("setting HTTPS_PROXY={}", proxy);
-        proxy
-    } else {
-        // try prepending the default scheme
-        let prepended = format!("http://{}", proxy);
-        // now we expect a valid URL
-        let _ = Url::parse(&prepended).context(error::Proxy { proxy })?;
-        // now we know we have a string that will work with reqwest
-        debug!("prepended https:// and setting HTTPS_PROXY={}", prepended);
-        prepended
-    };
-
     std::env::set_var("HTTPS_PROXY", &proxy);
     if let Some(no_proxy) = no_proxy {
         if !no_proxy.is_empty() {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #1332

**Description of changes:**

Before reqwest 11.1 we needed to check HTTPS_PROXY and, if it had no protocol, prepend the default (`http://`). After 11.1 this behavior is provided by reqwest.

**Testing done:**

I ran a tinyproxy server and gave Bottlerocket this in its userdata:

```toml
[settings.network]
https-proxy = "192.168.57.178:8888"
```

I ran Bottlerocket and observed that `updog check-update` and `metricdog` were functioning properly and I could see their traffic going through the tinyproxy server.

Prior to https://github.com/seanmonstar/reqwest/pull/1178, this would not have worked because reqwest did not default to `http://` in the absence of a protocol.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
