### PR TITLE
thar-be-settings: silence tokio mut warning

### DIFF
--- a/sources/api/thar-be-settings/src/main.rs
+++ b/sources/api/thar-be-settings/src/main.rs
@@ -245,7 +245,7 @@ fn main() {
         }
     }
 
-    let mut rt = Runtime::new().expect("Failed to create tokio runtime");
+    let rt = Runtime::new().expect("Failed to create tokio runtime");
     if let Err(e) = rt.block_on(async { run(args).await }) {
         eprintln!("{}", e);
         process::exit(1);


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Missed during #1269 / #1479

**Description of changes:**

After tokio v1, runtimes no longer need to be mut and the compiler is
reminding us.

**Testing done:**

`cargo make unit-tests`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
