### PR TITLE
imdsclient: return options for all IMDS fetch functions

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1430,7 +1430,6 @@ dependencies = [
  "httptest",
  "log",
  "reqwest",
- "serde",
  "serde_json",
  "simplelog",
  "snafu",

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -117,11 +117,12 @@ type Result<T> = std::result::Result<T, PlutoError>;
 
 async fn get_max_pods(client: &mut ImdsClient) -> Result<String> {
     let instance_type = client
-        .fetch_identity_document()
+        .fetch_instance_type()
         .await
         .context(error::ImdsRequest)?
-        .instance_type()
-        .to_string();
+        .context(error::ImdsNone {
+            what: "instance_type",
+        })?;
 
     // Find the corresponding maximum number of pods supported by this instance type
     let file = BufReader::new(
@@ -208,6 +209,9 @@ async fn get_cluster_dns_from_imds_mac(client: &mut ImdsClient) -> Result<String
         .fetch_mac_addresses()
         .await
         .context(error::ImdsRequest)?
+        .context(error::ImdsNone {
+            what: "mac addresses",
+        })?
         .first()
         .context(error::ImdsNone {
             what: "mac addresses",
@@ -219,6 +223,9 @@ async fn get_cluster_dns_from_imds_mac(client: &mut ImdsClient) -> Result<String
         .fetch_cidr_blocks_for_mac(&mac)
         .await
         .context(error::ImdsRequest)?
+        .context(error::ImdsNone {
+            what: "CIDR blocks",
+        })?
         .first()
         .context(error::ImdsNone {
             what: "CIDR blocks",
@@ -239,7 +246,8 @@ async fn get_node_ip(client: &mut ImdsClient) -> Result<String> {
     client
         .fetch_local_ipv4_address()
         .await
-        .context(error::ImdsRequest)
+        .context(error::ImdsRequest)?
+        .context(error::ImdsNone { what: "node ip" })
 }
 
 /// Print usage message.

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -43,10 +43,12 @@ impl UserData {
 async fn fetch_public_keys_from_imds() -> Result<Vec<String>> {
     info!("Connecting to IMDS");
     let mut client = ImdsClient::new().await.context(error::ImdsClient)?;
-    client
+    let public_keys = client
         .fetch_public_ssh_keys()
         .await
-        .context(error::ImdsClient)
+        .context(error::ImdsClient)?
+        .unwrap_or_else(Vec::new);
+    Ok(public_keys)
 }
 
 /// Store the args we receive on the command line.

--- a/sources/imdsclient/Cargo.toml
+++ b/sources/imdsclient/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["README.md"]
 http = "0.2"
 log = "0.4"
 reqwest = { version = "0.11.1", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"
 snafu = "0.6"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This commit changes the return type for the IMDS fetch functions to
options returning None when a 404 is encountered. This makes it easier
for the caller to decide what to do when a 404 occurs and is closer to
the behavior before imdsclient was written.

`fetch_identity_document` and its associated `IdentityDocument` struct
were removed in favor of separate `fetch_region` and
`fetch_instance_type` functions. Instance-type is now fetched via IMDS
meta-data as opposed to the identity document. We are returning to the
original behavior as it is possible that the identity document can be
absent in certain situations.

Changes were also made to shibaken, pluto, and early-boot-config to
accommodate the options detailed above.

**Testing done:**

- Built `aws-k8s-1.19` ami and launched instance.
- Instance connected to eks cluster.
- Connected to control container via ssm session.
- Verified that `host-containers.admin.user-data` contained a base64-encoded block.
- Connected to admin container via ssh.
- Verified that `/.bottlerocket/host-containers/admin/user-data` contained JSON.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.
- Ran `pluto` with it's sub-commands to verify functionality.

**Other testing:**
- [x] `aws-ecs-1` with no user data set.
- [x] `aws-dev` with no user data set. _(tested by @arnaldo2792)_
- [x] `vmware-k8s-1.20` with user data from guestinfo interface.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
