### PR TITLE
Document the deprecation of the aws-k8s-1.16 variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ For example, an `x86_64` build of the `aws-k8s-1.19` variant will produce an ima
 
 The following variants support EKS, as described above:
 
-- `aws-k8s-1.16`
 - `aws-k8s-1.17`
 - `aws-k8s-1.18`
 - `aws-k8s-1.19`
@@ -64,8 +63,9 @@ Another variant we have in preview is designed to be a Kubernetes worker node in
 
 - `vmware-k8s-1.20`
 
-The `aws-k8s-1.15` variant is deprecated and will no longer be supported in Bottlerocket releases.
-We recommend users replace `aws-k8s-1.15` nodes with the [latest variant compatible with their cluster](variants/).
+The `aws-k8s-1.16` variant is deprecated and will no longer be supported in Bottlerocket releases after June, 2021.
+The `aws-k8s-1.15` variant is no longer supported.
+We recommend users replace `aws-k8s-1.15` and `aws-k8s-1.16` nodes with the [latest variant compatible with their cluster](variants/).
 
 ## Architectures
 

--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -22,7 +22,7 @@ Entries are sorted by filename, and later entries take precedence.
 
 The `#[model]` attribute on Settings and its sub-structs reduces duplication and adds some required metadata; see [its docs](model-derive/) for details.
 
-### aws-k8s-1.16: Kubernetes 1.16
+### aws-k8s-1.16: Kubernetes 1.16 (deprecated)
 
 * [Model](src/aws-k8s-1.19/mod.rs)
 * [Default settings](src/aws-k8s-1.19/defaults.d/)

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -19,7 +19,7 @@ Entries are sorted by filename, and later entries take precedence.
 
 The `#[model]` attribute on Settings and its sub-structs reduces duplication and adds some required metadata; see [its docs](model-derive/) for details.
 
-## aws-k8s-1.16: Kubernetes 1.16
+## aws-k8s-1.16: Kubernetes 1.16 (deprecated)
 
 * [Model](src/aws-k8s-1.19/mod.rs)
 * [Default settings](src/aws-k8s-1.19/defaults.d/)

--- a/variants/README.md
+++ b/variants/README.md
@@ -24,13 +24,6 @@ Information about API settings for variants can be found in the [models](../sour
 
 ## Variants
 
-### aws-k8s-1.16: Kubernetes 1.16 node
-
-The [aws-k8s-1.16](aws-k8s-1.16/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
-It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
-
-This variant is compatible with Kubernetes 1.16, 1.17, and 1.18 clusters.
-
 ### aws-k8s-1.17: Kubernetes 1.17 node
 
 The [aws-k8s-1.17](aws-k8s-1.17/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
@@ -97,6 +90,15 @@ This variant was compatible with Kubernetes 1.15, 1.16, and 1.17 clusters.
 It reached end-of-life on May 3, 2021.
 
 Upstream support for Kubernetes 1.15 has ended and this variant will no longer be supported in Bottlerocket releases.
+
+### aws-k8s-1.16: Kubernetes 1.16 node
+
+The [aws-k8s-1.16](aws-k8s-1.16/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.16, 1.17, and 1.18 clusters.
+
+Upstream support for Kubernetes 1.16 has ended and this variant will no longer be supported in Bottlerocket releases after June, 2021.
 
 ## Development
 


### PR DESCRIPTION
**Issue number:**

Related to deprecation issue https://github.com/bottlerocket-os/bottlerocket/issues/1552

**Description of changes:**

Similar to https://github.com/bottlerocket-os/bottlerocket/pull/1476 for aws-k8s-1.15, this adds the next step of documentation for the deprecation of aws-k8s-1.16.  It gives a bit of advanced notice so customers start clusters with newer k8s versions now, if possible.  The next step is to remove aws-k8s-1.16 entirely, as with #1487 and #1492, likely tied to a release in July.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
