### PR TITLE
host-containers: allow mount propagations from privileged containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,10 @@ Bootstrap containers are host containers that can be used to "bootstrap" the hos
 
 Bootstrap containers are very similar to normal host containers; they come with persistent storage and with optional user data.
 Unlike normal host containers, bootstrap containers can't be treated as `superpowered` containers.
-However, these containers have access to the underlying root filesystem on `/.bottlerocket/rootfs`.
+However, bootstrap containers do have additional permissions that normal host containers do not have.
+Bootstrap containers have access to the underlying root filesystem on `/.bottlerocket/rootfs` as well as to all the devices in the host, and they are set up with the `CAP_SYS_ADMIN` capability.
+This allows bootstrap containers to create files, directories, and mounts that are visible to the host.
+
 Bootstrap containers are set up to run after the systemd `configured.target` unit is active.
 The containers' systemd unit depends on this target (and not on any of the bootstrap containers' peers) which means that bootstrap containers will not execute in a deterministic order
 The boot process will "wait" for as long as the bootstrap containers run.
@@ -557,6 +560,11 @@ source = "MY-CONTAINER-URI"
 mode = "once"
 essential = true
 ```
+
+##### Mount propagations in bootstrap and superpowered containers
+Both bootstrap and superpowered host containers are configured with the `/.bottlerocket/rootfs/mnt` bind mount that points to `/mnt` in the host, which itself is a bind mount of `/local/mnt`.
+This bind mount is set up with shared propagations, so any new mount point created underneath `/.bottlerocket/rootfs/mnt` in any bootstrap or superpowered host container will propagate across mount namespaces.
+You can use this feature to configure ephemeral disks attached to your hosts that you may want to use on your workloads.
 
 #### Platform-specific settings
 

--- a/packages/release/mnt.mount
+++ b/packages/release/mnt.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Mnt Directory (/mnt)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+Wants=prepare-local.service
+After=prepare-local.service
+
+[Mount]
+What=/local/mnt
+Where=/mnt
+Type=none
+Options=rbind,rshared
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -34,7 +34,7 @@ ExecStart=/usr/bin/mount \
 # After the mount is active, we grow the filesystem to fill the resized partition,
 # and ensure that it has the directories we need for subsequent mounts.
 ExecStart=/usr/lib/systemd/systemd-growfs ${LOCAL_DIR}
-ExecStart=/usr/bin/mkdir -p ${LOCAL_DIR}/var ${LOCAL_DIR}/opt
+ExecStart=/usr/bin/mkdir -p ${LOCAL_DIR}/var ${LOCAL_DIR}/opt ${LOCAL_DIR}/mnt
 
 # Create the directories we need to set up a read-write overlayfs for the kernel
 # development sources.

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -27,6 +27,7 @@ Source1006: var.mount
 Source1007: opt.mount
 Source1008: var-lib-bottlerocket.mount
 Source1009: etc-cni.mount
+Source1010: mnt.mount
 
 # CD-ROM mount & associated udev rules
 Source1015: media-cdrom.mount
@@ -107,8 +108,8 @@ EOF
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} \
-  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1015} \
-  %{S:1040} %{S:1041} %{S:1060} %{S:1061} %{S:1062} \
+  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} \
+  %{S:1015} %{S:1040} %{S:1041} %{S:1060} %{S:1061} %{S:1062} \
   %{buildroot}%{_cross_unitdir}
 
 LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/lower)
@@ -155,6 +156,7 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %{_cross_unitdir}/prepare-local.service
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount
+%{_cross_unitdir}/mnt.mount
 %{_cross_unitdir}/etc-cni.mount
 %{_cross_unitdir}/media-cdrom.mount
 %{_cross_unitdir}/*-lower.mount


### PR DESCRIPTION
**Issue number:**
#1209 

**Description of changes:**

```
e8936fc5 host-containers: allow mount propagations from privileged containers
```

This commit adds support to propagate mount points created in bootstrap and superpowered containers, across mount peer groups.

The root filesystem of bootstrap and superpowered containers is setup with the `rshared` configuration to allow mounts propagations across peer groups. All mount points attached to the containers are configured as `rprivate` (except for the `mnt` mount). This prevents bootstrap and superpowered containers from remounting directories in the host's root filesystem.

The `/.bottlerocket/rootfs/mnt` mount point was added to bootstrap and superpowered containers. This mount point is a bind mount that points to `/mnt` in the host, which itself is a bind mount of `/local/mnt`. This is required to let users create mount points underneath `/mnt`. This mount point is setup with the `rshared` configuration to allow propagations across peer groups. This is the only mount point from which propagations are allowed across peer groups.

With this change, bootstrap containers now have access to all the devices in the host. Also, they now have the `CAP_SYS_ADMIN` capability to let users manage ephemeral disks. The logic to build the container specs was refactored to provide a better understanding of what options are set for the containers' spec.

**Testing done:**
- Admin and control containers are still working as expected and can make calls using the `apiclient`
- Non-superpowered containers don't have access to `/dev`, `/.bottlerocket/rootfs/mnt` or the host's root filesystem
- I launched a `c5d.2xlarge` instance, which has one ephemeral disk attached to it. I created a bootstrap container with the following settings:

```toml
[settings.bootstrap-containers.ephemeral]
mode = "once"
source = "<SOURCE>"
essential = false
```

Where `setup-ephemeral-disk` is defined as

```Dockerfile
FROM alpine
RUN apk add e2fsprogs bash parted
ADD script ./
RUN chmod +x ./script
ENTRYPOINT ["sh", "script"]
```
And with `script` as:

```bash
#!/usr/bin/env bash
set -ex

DISK=/.bottlerocket/rootfs/dev/nvme2n1
PERSISTENT_DIR=/.bottlerocket/bootstrap-containers/current
PARTITIONS_CREATED=/.bottlerocket/bootstrap-containers/current/created
BASE_MOUNT_POINT=/.bottlerocket/rootfs/mnt

if [ ! -f $PARTITIONS_CREATED ]; then
  parted -s $DISK mklabel gpt 1>/dev/null
  parted -s $DISK mkpart primary ext4 0% 50% 1>/dev/null
  parted -s $DISK mkpart primary ext4 50% 100% 1>/dev/null
  mkfs.ext4 -F ${DISK}p1
  mkfs.ext4 -F ${DISK}p2
  touch $PARTITIONS_CREATED
fi

mkdir -p $BASE_MOUNT_POINT/part1
mkdir -p $BASE_MOUNT_POINT/part2

mount ${DISK}p1 $BASE_MOUNT_POINT/part1
mount ${DISK}p2 $BASE_MOUNT_POINT/part2
```

I confirmed that the partitions were mounted and propagated:

```bash
# From the admin container
[ec2-user@ip-172-31-5-108 ~]$ lsblk
# ...
├─nvme2n1p1  259:14   0  93.1G  0 part /.bottlerocket/rootfs/mnt/part1
└─nvme2n1p2  259:15   0  93.1G  0 part /.bottlerocket/rootfs/mnt/part2

# From the host
bash-5.0# lsblk
# ...
|-nvme2n1p1  259:14   0  93.1G  0 part /local/mnt/part1
|-nvme2n1p2  259:15   0  93.1G  0 part /local/mnt/part2
```

From the admin container I ran:

```bash
[ec2-user@ip-172-31-12-31 ~]$ sudo su
bash-4.2# umount /.bottlerocket/rootfs/mnt/part1
bash-4.2# mount /dev/nvme2n1p1 /.bottlerocket/rootfs/etc/
bash-4.2# ls /.bottlerocket/rootfs/etc/
lost+found
``` 

And confirmed that the mount point didn't propagate:
```bash
# From the host
bash-5.0# lsblk
# ...
nvme2n1      259:0    0 186.3G  0 disk
|-nvme2n1p1  259:14   0  93.1G  0 part
|-nvme2n1p2  259:15   0  93.1G  0 part /local/mnt/part2

bash-5.0# ls /etc/
bootstrap-containers  ...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
