### PR TITLE
release: mark ipv6 lease as optional for eth0

### DIFF
--- a/packages/release/eth0.xml
+++ b/packages/release/eth0.xml
@@ -21,5 +21,8 @@
   <ipv6:dhcp>
     <enabled>true</enabled>
     <defer-timeout>1</defer-timeout>
+    <flags>
+      <optional />
+    </flags>
   </ipv6:dhcp>
 </interface>


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1351


**Description of changes:**
```
uthor: Erikson Tung <etung@amazon.com>
Date:   Thu Jun 3 12:47:44 2021 -0700

    release: mark ipv6 lease as optional for eth0

    This marks the DHCPv6 as optional in the network interface configuration
    file for eth0.

    When wicked reads the network interface configuration, it knows not to
    wait for an ipv6 address lease. Wicked no longer waits the full 30
    seconds for an ipv6 address lease when there is no ipv6 support.


```


**Testing done:**
Launched 10 instances in an subnet without ipv6 address assignment, all of them get initialized much quicker than before. Wicked no longer waits the full 30 seconds for an ipv6 address assignment.

```
bash-5.0# systemd-analyze blame
7.300s activate-multi-user.service                                                
7.036s kubelet.service                                                            
2.148s systemd-tmpfiles-setup.service                                             
1.838s wicked.service              
...

```

```
bash-5.0# wicked ifstatus eth0
...
eth0            up
      link:     #2, state up, mtu 9001
      type:     ethernet, hwaddr 02:64:19:14:01:f3
      config:   wicked:xml:/etc/wicked/ifconfig/eth0.xml
      leases:   ipv4 dhcp granted
      leases:   ipv6 dhcp requesting
      addr:     ipv4 192.168.25.30/19 [dhcp]
      route:    ipv4 default via 192.168.0.1 proto dhcp
wicked: Exit with status: 0

```

Then I enabled IPv6 address assignment for a subnet and launched an instance into it, wicked comes up fine, the host gets both an ipv4 address and ipv6 address without problem:
```
bash-5.0# systemd-analyze blame
8.869s activate-multi-user.service                                                
8.639s kubelet.service                                                            
7.965s systemd-tmpfiles-setup.service                                             
3.523s wicked.service                 
```

```
bash-5.0# wicked ifstatus eth0
eth0            up
      link:     #2, state up, mtu 9001
      type:     ethernet, hwaddr 02:f8:6d:24:d5:d1
      config:   wicked:xml:/etc/wicked/ifconfig/eth0.xml
      leases:   ipv4 dhcp granted
      leases:   ipv6 dhcp granted
      addr:     ipv4 192.168.18.82/19 [dhcp]
      addr:     ipv6 2600:1f14:326:5500:8a3a:6b96:f3ae:a87e/64 [dhcp]
      route:    ipv4 default via 192.168.0.1 proto dhcp
      route:    ipv6 default via fe80::cc:7cff:feec:c0f1 metric 1024 proto ra
wicked: Exit with status: 0

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
