### PR TITLE
open-vm-tools: add recommended device filters

### DIFF
--- a/packages/open-vm-tools/tools.conf
+++ b/packages/open-vm-tools/tools.conf
@@ -3,3 +3,7 @@ poweron-script=/usr/bin/true
 poweroff-script=/usr/bin/true
 resume-script=/usr/bin/true
 suspend-script=/usr/bin/true
+
+[guestinfo]
+primary-nics=eth0
+exclude-nics=antrea-*,cali*,ovs-system,br*,flannel*,veth*,docker*,virbr*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1568


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jun 3 16:12:42 2021 -0700

    open-vm-tools: add recommended device filters

    Adds the recommended device filters to VMTools config to prevent
    interference from CNI network/device interfaces.

    The list of filters is taken directly from cloud-provider-vsphere.

```


**Testing done:**
Built OVA, launched 3 VMs using said OVA and all of them came up fine. Ran pods fine. The vmtool version shows up in the vcenter UI.

vmtools running fine on the hosts

```
bash-5.0# systemctl status vmtoolsd
● vmtoolsd.service - VMware Tools service
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/vmtoolsd.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2021-06-04 00:16:10 UTC; 1min 17s ago
       Docs: https://github.com/vmware/open-vm-tools
   Main PID: 2797 (vmtoolsd)
      Tasks: 3 (limit: 9525)
     Memory: 3.2M
     CGroup: /system.slice/vmtoolsd.service
             └─2797 /usr/bin/vmtoolsd

Jun 04 00:16:10 198.19.8.9 systemd[1]: Started VMware Tools service.

bash-5.0# cat /etc/vmware-tools/tools.conf
[powerops]
poweron-script=/usr/bin/true
poweroff-script=/usr/bin/true
resume-script=/usr/bin/true
suspend-script=/usr/bin/true

[guestinfo]
primary-nics=eth0
exclude-nics=antrea-*,cali*,ovs-system,br*,flannel*,veth*,docker*,virbr*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????

```

Lemme know if there's anything else I should test.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
