### PR TITLE
kubelet: add setting for configuring systemReserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,14 @@ The following settings are optional and allow you to further configure your clus
     ```
     allowed-unsafe-sysctls = ["net.core.somaxconn", "net.ipv4.ip_local_port_range"]
     ```
+* `settings.kubernetes.system-reserved`: Resources reserved for system components.
+  * Example user data for setting up system reserved:
+    ```
+    [settings.kubernetes.system-reserved]
+    cpu = "10m"
+    memory = "100Mi"
+    ephemeral-storage= "1Gi"
+    ```
 * `settings.kubernetes.registry-qps`: The registry pull QPS.
 * `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.
 * `settings.kubernetes.event-qps`: The maximum event creations per second.

--- a/Release.toml
+++ b/Release.toml
@@ -50,4 +50,5 @@ version = "1.1.1"
 "(1.1.0, 1.1.1)" = []
 "(1.1.1, 1.1.2)" = [
     "migrate_v1.1.2_kubelet-container-log.lz4",
+    "migrate_v1.1.2_kubelet-system-reserved.lz4",
 ]

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -68,6 +68,12 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{~#if settings.kubernetes.system-reserved}}
+systemReserved:
+  {{~#each settings.kubernetes.system-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -68,6 +68,12 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{~#if settings.kubernetes.system-reserved}}
+systemReserved:
+  {{~#each settings.kubernetes.system-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -68,6 +68,12 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{~#if settings.kubernetes.system-reserved}}
+systemReserved:
+  {{~#each settings.kubernetes.system-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -68,6 +68,12 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{~#if settings.kubernetes.system-reserved}}
+systemReserved:
+  {{~#each settings.kubernetes.system-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -68,6 +68,12 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{~#if settings.kubernetes.system-reserved}}
+systemReserved:
+  {{~#each settings.kubernetes.system-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 cpuManagerPolicy: "static"
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1555,6 +1555,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-system-reserved"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "api/migration/migrations/v1.1.0/schnauzer-paws",
     "api/migration/migrations/v1.1.0/kubelet-kube-api-qps-kube-api-burst",
     "api/migration/migrations/v1.1.2/kubelet-container-log",
+    "api/migration/migrations/v1.1.2/kubelet-system-reserved",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.2/kubelet-system-reserved/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.2/kubelet-system-reserved/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kubelet-system-reserved"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }
+

--- a/sources/api/migration/migrations/v1.1.2/kubelet-system-reserved/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.2/kubelet-system-reserved/src/main.rs
@@ -1,0 +1,22 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new settings for configuring kubelet, `settings.kubernetes.system-reserved`
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.system-reserved",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -136,6 +136,7 @@ struct KubernetesSettings {
     standalone_mode: bool,
     eviction_hard: HashMap<KubernetesEvictionHardKey, KubernetesThresholdValue>,
     kube_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
+    system_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
     allowed_unsafe_sysctls: Vec<SingleLineString>,
     server_tls_bootstrap: bool,
     cloud_provider: KubernetesCloudProvider,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Part of #1447


**Description of changes:**
Adds a new settings kubernetes.system-reserved for configuring


**Testing done:**
launching instance with the AMI which contains new setting and check if the resources (cpu, memory, storage) have been reserved.
Step1:  Check if configuration is here.
```
cat etc/kubernetes/kubelet/config
systemReserved:
  cpu: "40m"
  ephemeral-storage: "1Gi"
  memory: "1000Mi"
``` 

```
[tianhg@ip-172-31-39-243 ~]$ NODE_NAME="ip-192-168-28-205.us-west-2.compute.internal"
[tianhg@ip-172-31-39-243 ~]$ curl -sSL "http://localhost:8001/api/v1/nodes/${NODE_NAME}/proxy/configz" | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' > kubelet_configz_${NODE_NAME}

ls  kubelet_configz_${NODE_NAME}

  "systemReserved": {
    "cpu": "40m",
    "ephemeral-storage": "1Gi",
    "memory": "1000Mi"
  },
```
Step2:  go to EKS check if the resources (cpu, memory, storage) have been reserved
_NodeAllocatable = NodeCapacity - Kube-reserved - system-reserved - eviction-threshold_

**cpu**

[settings.kubernetes.system-reserved.cpu]
cpu = "40m,"
Allocatable cpu = 4000m (NodeCapacity) - 80m (kube-reserved) -40m ( system-reserved)

EKS
Name | Capacity | Allocatable
-- | -- | --
CPU | 4 | 3880m

**memory**

[settings.kubernetes.system-reserved.memory]
memory = "1000Mi"
Allocatable memory = 16089632Ki (NodeCapacity) - 893Mi (kube-reserved) -1000Mi ( system-reserved)

EKS
Name | Capacity | Allocatable
-- | -- | --
Memory | 16089632Ki | 14048800Ki

**ephemeral-storage**

[settings.kubernetes.system-reserved.ephemeral-storage]
ephemeral-storage = "1Gi"
Allocatable ephemeral-storage = 20624592Ki (NodeCapacity) - 1Gi (kube-reserved) -1Gi ( system-reserved)

```
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         3880m
  ephemeral-storage:           16860140308
```
Test cases 

the case where the new settings are unset

Step1: Check if configuration is here.
```
userdata - no system-reserved setting
....
cluster-name = "bottlerocket"
[settings.host-containers.admin]
enabled = true
....
```
  result 
```
cat etc/kubernetes/kubelet.config
...
kubeReserved:
  cpu: "80m"
  memory: "893Mi"
  ephemeral-storage: "1Gi"
resolvConf: "/etc/resolv.conf"
...
```

```
[tianhg@ip-172-31-39-243 ~]$ NODE_NAME="ip-192-168-17-160.us-west-2.compute.internal"
[tianhg@ip-172-31-39-243 ~]$ curl -sSL "http://localhost:8001/api/v1/nodes/${NODE_NAME}/proxy/configz" | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' > kubelet_configz_${NODE_NAME}

cat  kubelet_configz_${NODE_NAME}

....
  "kubeReserved": {
    "cpu": "80m",
    "ephemeral-storage": "1Gi",
    "memory": "893Mi"
  },
  "enforceNodeAllocatable": [
    "pods"
  ],
....
```
systemReserved has not been configured in kubelet.

Step2:  go to EKS check if the resources (cpu, memory, storage) have been reserved

```
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         4
  ephemeral-storage:           20624592Ki
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      15917600Ki
  pods:                        58
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         3920m
  ephemeral-storage:           17933882132
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      14900768Ki
  pods:                        58

  "evictionHard": {
    "imagefs.available": "15%",
    "memory.available": "100Mi",
    "nodefs.available": "10%",
    "nodefs.inodesFree": "5%"
  },
```
cpu 
Allocatable cpu(3920m) = 4000m (NodeCapacity) - 80m (kube-reserved) - 0 ( system-reserved)

memory
Allocatable memory(14900768Ki) = 15917600Ki (NodeCapacity) - 893Mi/914432Ki (kube-reserved) -0 ( system-reserved) - 100Mi/102400Ki (eviction-hard)

ephemeral-storage
Allocatable ephemeral-storage(17933882132) = 20624592Ki/21119582208 (NodeCapacity) -1Gi/1,073,741,824 (kube-reserved) -0 ( system-reserved) - 10%/2111958220.8 (eviction-hard)


### Migration test:
#### upgrade
Step1: Upgrade to v1.1.2
```
bash-5.0# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.19",
    "arch": "x86_64",
    "version": "1.1.2",
    "max_version": "1.1.2",
.....
bash-5.0# updog update -i 1.1.2 -r -n
Starting update to 1.1.2
```
Step2: Specify new setting `system-reserved`through control container
```
apiclient set -j '{"kubernetes": {"system-reserved": {"memory":"1000Mi", "cpu":"40m", "ephemeral-storage":"1Gi"}}}'
```
```
cat ../<tastore/current/live/settings/kubernetes/system-reserved/
cpu  ephemeral-storage	memory
```

downgrade

Step1: Check migration binary
```
ls -al /var/lib/bottlerocket-migrations
-rw-r--r--.  1 root root 500380 Jun  7 23:20 2b743f2f624ed6f54d459d650482758b953d895c9988e13e0d2372905a2df181.migrate_v1.1.2_kubelet-system-reserved.lz4
-rw-r--r--.  1 root root   3283 Jun  7 23:20 38ca59d14c8b36a1c6734e1f659e2c1f27278c960d29697c9660865cbd1a6bf6.manifest.json
-rw-r--r--.  1 root root 500571 Jun  7 23:20 bf86b87721ad0c57441262a3251ef00ac3b950dfddaf1c782c0c6720213bec24.migrate_v1.1.2_kubelet-container-log.lz4

```
Step2: Downgrade to previous verison
```
signpost rollback-to-inactive
reboot
```

Step3: Check if `system-reserved` have been removed
```
bash-5.0# ls /var/lib/bottlerocket/datastore/current/live/settings/kubernetes
api-server			  max-pods.setting-generator
authentication-mode		  node-ip
cluster-certificate		  node-ip.setting-generator
cluster-dns-ip			  pod-infra-container-image
cluster-dns-ip.setting-generator  pod-infra-container-image.affected-services
cluster-domain			  pod-infra-container-image.setting-generator
cluster-name			  standalone-mode
max-pods			  static-pods.affected-services
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
