### PR TITLE
Update default host containers

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -52,4 +52,5 @@ version = "1.1.1"
     "migrate_v1.1.2_kubelet-container-log.lz4",
     "migrate_v1.1.2_kubelet-system-reserved.lz4",
     "migrate_v1.1.2_admin-container-v0-7-1.lz4",
+    "migrate_v1.1.2_control-container-v0-5-1.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -51,4 +51,5 @@ version = "1.1.1"
 "(1.1.1, 1.1.2)" = [
     "migrate_v1.1.2_kubelet-container-log.lz4",
     "migrate_v1.1.2_kubelet-system-reserved.lz4",
+    "migrate_v1.1.2_admin-container-v0-7-1.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -213,6 +213,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "admin-container-v0-7-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -626,6 +626,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076a6803b0dacd6a88cfe64deba628b01533ff5ef265687e6938280c1afd0a28"
 
 [[package]]
+name = "control-container-v0-5-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "api/migration/migrations/v1.1.0/kubelet-kube-api-qps-kube-api-burst",
     "api/migration/migrations/v1.1.2/kubelet-container-log",
     "api/migration/migrations/v1.1.2/kubelet-system-reserved",
+    "api/migration/migrations/v1.1.2/admin-container-v0-7-1",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "api/migration/migrations/v1.1.2/kubelet-container-log",
     "api/migration/migrations/v1.1.2/kubelet-system-reserved",
     "api/migration/migrations/v1.1.2/admin-container-v0-7-1",
+    "api/migration/migrations/v1.1.2/control-container-v0-5-1",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.2/admin-container-v0-7-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.2/admin-container-v0-7-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "admin-container-v0-7-1"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.2/admin-container-v0-7-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.2/admin-container-v0-7-1/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.0";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.1";
+
+/// We bumped the version of the default admin container from v0.7.0 to v0.7.1
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.1.2/control-container-v0-5-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.2/control-container-v0-5-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "control-container-v0-5-1"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.2/control-container-v0-5-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.2/control-container-v0-5-1/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.0";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.1";
+
+/// We bumped the version of the default control container from v0.5.0 to v0.5.1
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.0"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.1"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.0"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.1"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"

--- a/sources/models/shared-defaults/vmware-host-containers.toml
+++ b/sources/models/shared-defaults/vmware-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.1"
 
 [settings.host-containers.control]
 enabled = false

--- a/sources/models/shared-defaults/vmware-host-containers.toml
+++ b/sources/models/shared-defaults/vmware-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.1"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.1"


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/1595
https://github.com/bottlerocket-os/bottlerocket/issues/1607

**Description of changes:**

This updates the default admin container from v0.7.0 to v0.7.1
and the default control container from v0.5.0. to v0.5.1.

**Testing done:**

Using a custom TUF repo, upgraded and downgraded between 1.1.1 and 1.1.2 and verified both container changes.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
