### PR TITLE
Docker update

### DIFF
--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v19.03.15/cli-19.03.15.tar.gz"
-sha512 = "163f67a11b1d976eb91c84e59eb1fabf3f26b360ac726bb0bedb9a1532ef807b665f7461f52f6b236cb8af955af042466070800cd4d09b7a6b90092daf718b41"
+url = "https://github.com/docker/cli/archive/v20.10.4/cli-20.10.4.tar.gz"
+sha512 = "861f69657ac3eede228983b7d845ce98c81f4b0aa601aab37024d3f21cf1ca73a182d33bdde8fb9ad89e4954c3903dc4ec2b81fcf7364941a7c38a80ea410e34"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 19.03.15
+%global gover 20.10.4
 %global rpmver %{gover}
-%global gitrev eeec7e566a2d8e9c30b141bad529d54f2d46c71c
+%global gitrev d3cb89ee53287cf9214ad5fbc9a111190f607c72
 
 %global source_date_epoch 1492525740
 
@@ -16,7 +16,7 @@ Release: 1%{?dist}
 Summary: Docker CLI
 License: Apache-2.0
 URL: https://%{goimport}
-Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
+Source0: https://%{goimport}/archive/v%{gover}/cli-%{gover}.tar.gz
 Source1000: clarify.toml
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v19.03.15/moby-19.03.15.tar.gz"
-sha512 = "20e2a418e95f4575081afb2f898d9a6d37812a4c2976a8adff52c186672282cb3fdef1dd126fb2e90cbb09a559f719150e8e94fbf2a160e49bb64448872b5653"
+url = "https://github.com/moby/moby/archive/v20.10.4/moby-20.10.4.tar.gz"
+sha512 = "6cbead817d37dc3a4d2686556562d3b52f802ac2cd611a1ff6e373db0464080d8babefd3af31175487b700905fbc876ec8ce235989780b037a4408febdf70985"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 19.03.15
+%global gover 20.10.4
 %global rpmver %{gover}
-%global gitrev 420b1d36250f9cfdc561f086f25a213ecb669b6f
+%global gitrev 363e9a88a11be517d9e8c65c998ff56f774eb4dc
 
 %global source_date_epoch 1363394400
 
@@ -44,7 +44,7 @@ Requires: %{_cross_os}procps
 
 %build
 %cross_go_configure %{goimport}
-BUILDTAGS="autogen journald selinux seccomp"
+BUILDTAGS="journald selinux seccomp"
 BUILDTAGS+=" exclude_graphdriver_btrfs"
 BUILDTAGS+=" exclude_graphdriver_devicemapper"
 BUILDTAGS+=" exclude_graphdriver_vfs"
@@ -54,9 +54,8 @@ export VERSION=%{gover}
 export GITCOMMIT=%{gitrev}
 export BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 export PLATFORM="Docker Engine - Community"
-chmod +x ./hack/make/.go-autogen
-./hack/make/.go-autogen
-go build -buildmode=pie -ldflags=-linkmode=external -tags="${BUILDTAGS}" -o dockerd %{goimport}/cmd/dockerd
+source ./hack/make/.go-autogen
+go build -buildmode=pie -ldflags="-linkmode=external ${LDFLAGS}" -tags="${BUILDTAGS}" -o dockerd %{goimport}/cmd/dockerd
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/docker-proxy/Cargo.toml
+++ b/packages/docker-proxy/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/libnetwork/archive/55e924b8a84231a065879156c0de95aefc5f5435/libnetwork-55e924b8a84231a065879156c0de95aefc5f5435.tar.gz"
-sha512 = "3d81ba20a91517e14da7e75a24d4e2eeb04c1dcb9c1bfe1115247982dbdb55d2fd72d0130093e9597363b742a20f2647f229c870da9a1cbdefc69aef65f02250"
+url = "https://github.com/docker/libnetwork/archive/fa125a3512ee0f6187721c88582bf8c4378bd4d7/libnetwork-fa125a3512ee0f6187721c88582bf8c4378bd4d7.tar.gz"
+sha512 = "dd583218fbeba8aeac2e4143369ad55a3e6c15d64f198f73e3656a80d0281a4374fb3be7bc05b01425461bf830762aa2c950da68ed0e3ae5884643e9d178c69e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -3,12 +3,12 @@
 %global goimport %{goproject}/%{gorepo}
 # Use the libnetwork commit listed in this file for the docker version we ship:
 # https://github.com/moby/moby/blob/DOCKER-VERSION-HERE/vendor.conf
-%global commit 55e924b8a84231a065879156c0de95aefc5f5435
+%global commit fa125a3512ee0f6187721c88582bf8c4378bd4d7
 
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}docker-proxy
-Version: 19.03.15
+Version: 20.10.04
 Release: 1%{?dist}
 Summary: Docker CLI
 # mostly Apache-2.0, client/mflag is BSD-3-Clause


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**

```
b03d2cf2 packages: update docker-proxy
0ba73bff packages: update docker-engine
badba994 packages: update docker-cli
```

Update docker to 20.10.4. In [docker's deprecation page](https://docs.docker.com/engine/deprecated/) they list a few feature that were removed in the 20.10 series. I think none of those affected the ECS variant's behavior since the conformance testing is passing. 

**Testing done:**

In x86_64/aarch64:
- [x] Run container in aws-dev variant
- [x] Run task in aws-ecs variant

In x86_64:
- [x] Run conformance testing for ecs variant

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
