### PR TITLE
actions: pin rust toolchain to v1.51.0 temporarily

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+      - run: rustup toolchain install 1.51.0 && rustup default 1.51.0
       - run: cargo install --version 0.30.0 cargo-make
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} -e BUILDSYS_ARCH=${{ matrix.arch }} -e BUILDSYS_JOBS=12


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Github actions is failing due to a difference in rust toolchain versions
in the bottlerocket-sdk and the CI host


**Testing done:**
See build checks below


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
