### PR TITLE
Add support for uploading OVAs to VMware

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -64,6 +64,15 @@ REPO_METADATA_EXPIRING_WITHIN = "3 days"
 # You can use ALLOW_CLOBBER=true with the `ssm` task to make it overwrite existing values.
 # (This is not required with `promote-ssm` because the intent of promotion is overwriting.)
 
+# This can be overridden to provide a custom import spec for a VMware OVA.
+# Using configuration from Infra.toml, we substitute the correct value for
+# network, and whether or not to mark a VM as a template
+VMWARE_IMPORT_SPEC_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/support/vmware/import_spec.template"
+
+# You can set VMWARE_DATACENTERS to override the list of datacenters from
+# Infra.toml for VMware commands; it's a comma-separated list like
+# "datacenter1,datacenter2"
+
 # Disallow pulling directly Upstream URLs when lookaside cache results in MISSes as a fallback.
 # To use the upstream source as fallback, override this on the command line and set it to 'true'
 BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"
@@ -119,6 +128,9 @@ BUILDSYS_KMOD_KIT_PATH = "${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_KMOD_KIT}"
 BUILDSYS_OVA = "${BUILDSYS_NAME_VARIANT}-v${BUILDSYS_VERSION_IMAGE}.ova"
 BUILDSYS_OVA_PATH = "${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_OVA}"
 BUILDSYS_OVF_TEMPLATE = "${BUILDSYS_ROOT_DIR}/variants/${BUILDSYS_VARIANT}/template.ovf"
+
+# The default name of uploaded OVAs; override by setting VMWARE_VM_NAME
+VMWARE_VM_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
 
 [tasks.setup]
 script = [
@@ -936,6 +948,56 @@ pubsys \
    ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"}
 '''
 ]
+
+[tasks._upload-ova-base]
+# Rather than depend on "build", which currently rebuilds images each run, we
+# depend on publish-tools and check for the image files below to save time.
+# This does mean that `cargo make` must be run before 
+# `cargo make _upload-ova-base`.
+dependencies = ["setup-build", "publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+ova_path="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.ova"
+if [ ! -s "${ova_path}" ]; then
+   echo "An OVA doesn't exist for the current version/commit - ${BUILDSYS_VERSION_FULL} - please run 'cargo make'" >&2
+   exit 1
+fi
+
+vm_name="${VMWARE_VM_NAME:-${VMWARE_VM_NAME_DEFAULT}}"
+
+pubsys \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   \
+   upload-ova \
+   \
+   --ova "${ova_path}" \
+   --spec "${VMWARE_IMPORT_SPEC_PATH}" \
+   --name "${vm_name}" \
+   \
+   ${MARK_OVA_AS_TEMPLATE:+--mark-as-template} \
+   \
+   ${VMWARE_DATACENTERS:+--datacenters "${VMWARE_DATACENTERS}"}
+'''
+]
+
+# This task runs `_upload-ova-base` which will upload the OVA and *not* mark it
+# as a template
+[tasks.upload-ova]
+script_runner = "bash"
+extend = "_upload-ova-base"
+
+# This task runs `_upload-ova-base` with the environment variable
+# `MARK_OVA_AS_TEMPLATE` set, which will upload the OVA *and* mark it as a
+# template
+[tasks.vmware-template]
+script_runner = "bash"
+env = { "MARK_OVA_AS_TEMPLATE" = "true" }
+extend = "_upload-ova-base"
 
 [tasks.clean]
 dependencies = [

--- a/PUBLISHING-AWS.md
+++ b/PUBLISHING-AWS.md
@@ -1,0 +1,142 @@
+# Publishing Bottlerocket on AWS
+
+This guide will walk you through some AWS-specific details around publishing an AMI, granting access to said AMI, as well as making it easy for others to find your AMI via SSM parameters.
+
+### Register an AMI
+
+The [BUILDING](BUILDING.md#register-an-ami) guide covers the process of making an AMI, and has you specify `PUBLISH_REGIONS` to decide where the AMI will live.
+You can also specify this in your `Infra.toml` file:
+
+```toml
+[aws]
+regions = ["us-west-2", "us-east-1", "us-east-2"]
+```
+
+If you specify multiple regions, an AMI will be registered in the first region and then copied to the other regions.
+
+After putting this in `Infra.toml`, you can make an AMI more easily:
+
+```shell
+cargo make ami
+```
+
+If you want to change the name or description of your AMI, you can add on `-e PUBLISH_AMI_NAME=my-name` or `-e PUBLISH_AMI_DESCRIPTION=my-desc`.
+
+> Note: the AMI registration process creates a JSON file describing the AMIs in a directory under `build/images/`.
+> This file is used by the steps below when granting access to the AMIs or setting parameters in SSM.
+
+### Granting access to your AMI
+
+If you use different accounts to make and test your AMIs, you can grant access to specific accounts like this:
+
+```shell
+cargo make grant-ami -e GRANT_TO_USERS=0123456789,9876543210
+```
+
+(Later, if you need to revoke access, you can do this:)
+
+```shell
+cargo make revoke-ami -e REVOKE_FROM_USERS=0123456789,9876543210
+```
+
+> Note: similar to `cargo make ami`, you can specify `PUBLISH_REGIONS` on the command line if you don't want to make an `Infra.toml` config.
+
+### Making your AMIs discoverable with SSM parameters
+
+After you've made AMIs and a repo, you may want to make it easier to find your AMIs, particularly as you make new versions over time.
+
+One way to do this is to store the AMI IDs in [AWS SSM Parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).
+These are simple names like `/my/ami/id` that you can use in many places instead of specific AMI IDs.
+For example, you can launch EC2 instances using [RunInstances](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html) or [in a CloudFormation stack](https://aws.amazon.com/blogs/mt/integrating-aws-cloudformation-with-aws-systems-manager-parameter-store/) using a parameter name rather than an AMI ID.
+You can also use the same parameter names across regions, so you don't have to deal with region-specific AMI IDs.
+
+> Note: SSM parameters are private to your account.
+> They let you use consistent names instead of tracking AMI IDs, but they don't currently let you share with other accounts.
+
+The `cargo make ssm` task can set SSM parameters based on the AMIs you built [above](#register-an-ami).
+For this to work, you have to specify a parameter prefix in your `Infra.toml`.
+This setting lives in the same `[aws]` section you used above to list the regions where you want to register AMIs.
+(The same region list will be used to determine where to publish SSM parameters.)
+
+Here's an example configuration for regions and the SSM prefix:
+
+```toml
+[aws]
+regions = ["us-west-2", "us-east-1", "us-east-2"]
+ssm_prefix = "/your/prefix/here"
+```
+
+This prefix forms the start of the name of each SSM parameter we set.
+The rest of the name comes from parameter templates.
+
+Parameter templates determine the name and value of each parameter we want to set for each AMI we've built.
+The [default template](tools/pubsys/policies/ssm/defaults.toml) creates parameters that let users find the AMI ID and the image version for each of your AMIs.
+The templates have access to the name of the current variant, architecture, etc., so they can create unique parameter names for each build.
+For more information on how templates work, check out [their documentation](tools/pubsys/policies/ssm/).
+
+If you're happy with the default template, you can set SSM parameters like this:
+
+```shell
+cargo make ssm
+```
+
+This will create versioned parameters, meaning that the parameter name has the image version in it.
+This isn't very discoverable yet, but it's useful for testing.
+
+As an example, a parameter might look like this:
+
+```
+/your/prefix/here/aws-k8s-1.19/x86_64/1.0.1-dafe3b16/image_id
+```
+
+Once you're satisfied with your image and parameters, you can promote the parameters to simpler names (for example, "latest") using the [instructions below](#promoting-ssm-parameters).
+
+Note: if you want to customize the SSM parameters that get set, you can copy and modify the existing template file, then point to your file like this:
+
+```shell
+cargo make ssm -e PUBLISH_SSM_TEMPLATES_PATH=/my/template/path
+```
+
+### Making your AMIs public
+
+We talked about [granting AMI access](#granting-access-to-your-ami) to specific AWS accounts.
+This is useful for testing, and for sharing private AMIs with specific accounts.
+
+If you want to make your AMIs public to the world, there's a shortcut:
+
+```
+cargo make ami-public
+```
+
+(Later, if you need to make the AMIs private again, you can do this.
+ The AMIs will then only be accessible to account IDs you've specifically granted.)
+
+```shell
+cargo make ami-private
+```
+
+### Promoting SSM parameters
+
+[Above](#making-your-amis-discoverable-with-ssm-parameters), we set SSM parameters based on our AMIs.
+The SSM parameter names include version numbers, which is handy for testing, but makes them hard to find.
+Once we're satisfied, we can promote the SSM parameters to simpler names.
+
+```shell
+cargo make promote-ssm -e SSM_TARGET=latest
+```
+
+This will copy the fully versioned parameter from earlier, something like:
+
+```
+/your/prefix/here/aws-k8s-1.19/x86_64/1.0.1-dafe3b16/image_id
+```
+
+...to a simpler parameter name:
+```
+/your/prefix/here/aws-k8s-1.19/x86_64/latest/image_id
+```
+
+You can then use this parameter name to get the latest AMI ID.
+
+> Note: if you use a custom parameter template, you need to have an `{image_version}` component in the parameter name for promotion to work.
+> The `SSM_TARGET` you specify above becomes the `image_version` in the template.

--- a/PUBLISHING-VMWARE.md
+++ b/PUBLISHING-VMWARE.md
@@ -1,0 +1,75 @@
+# Publishing a Bottlerocket OVA on VMware
+
+This guide will walk through some VMware specific details around making your OVA available as a VM or VM template in one or more software defined datacenters.
+
+### Configuration details
+
+As mentioned in the [PUBLISHING](PUBLISHING.md) guide, the process uses a configuration file called `Infra.toml`.
+For VMware, you can specify details about your various vSphere instances and datacenters in `Infra.toml`, as well as configuration that may be common between datacenters.
+
+It's important to note that we use [`govc`](https://github.com/vmware/govmomi/tree/master/govc) under the hood for interactions with vSphere, so at runtime **all datacenter configuration in `Infra.toml` is overridden by `GOVC_` environment variables.**
+`govc` is run in a container, so you do not need to install it on your machine.
+We first check for environment variables, then use `Infra.toml` for datacenter specific configuration, and finally common configuration.
+The following `GOVC_` environment variables are supported:
+* `GOVC_URL`
+* `GOVC_DATACENTER`
+* `GOVC_DATASTORE`
+* `GOVC_NETWORK`
+* `GOVC_FOLDER`
+* `GOVC_RESOURCE_POOL`
+* `GOVC_USERNAME`
+* `GOVC_PASSWORD`
+
+Credentials for your various datacenters may be stored at `~/.config/pubsys/vsphere-credentials.toml`.
+The format of the file is below; each datacenter gets its own `[datacenter.NAME]` block, where `NAME` corresponds to a datacenter name in `Infra.toml`
+Similar to other datacenter configuration, at runtime we first check for the environment variables `GOVC_USERNAME` and `GOVC_PASSWORD` and use one or both of them if they are set.
+
+```toml
+[datacenter.foo]
+username = "username"
+password = "password"
+
+[datacenter.bar]
+username = "bar"
+password = "baz"
+```
+
+### Uploading a Bottlerocket OVA
+
+You can specify the datacenters to which you would like to upload your OVA in `Infra.toml`.
+
+```toml
+[vmware]
+datacenters = ["foo", "bar"]
+```
+
+Then you can easily upload your OVA, specifying the variant you wish to upload (currently only VMware variants).
+
+```shell
+cargo make upload-ova -e BUILDSYS_VARIANT=vmware-k8s-1.20
+```
+
+If you would like to upload your OVA as a VM template, you can do this in a single step:
+
+```shell
+cargo make vmware-template -e BUILDSYS_VARIANT=vmware-k8s-1.20
+```
+
+You can override the list of datacenters to upload to by specifying `VMWARE_DATACENTERS`:
+
+```shell
+cargo make vmware-template \
+  -e BUILDSYS_VARIANT=vmware-k8s-1.20 \
+  -e VMWARE_DATACENTERS="foo,bar"
+```
+
+If you would like to override the name of the VM, you can add on `-e VMWARE_VM_NAME=my-name`.
+
+You can also override the import spec used when uploading the OVA by specifying `VMWARE_IMPORT_SPEC_PATH`.
+Our [import spec template](tools/pubsys/support/vmware/import_spec.template) can be used as a starting point for further customization.
+
+```shell
+cargo make vmware-template \
+  -e BUILDSYS_VARIANT=vmware-k8s-1.20 \
+  -e VMWARE_IMPORT_SPEC_PATH=/path/to/my/spec.toml
+```

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,7 +1,7 @@
 # Publishing Bottlerocket
 
 This guide will walk you through deploying a Bottlerocket image, and if desired, sharing it with others.
-It currently focuses on deploying to AWS, though the tooling is built to support other platforms in the future.
+It currently focuses on deploying to AWS and VMware, though the tooling is built to support other platforms in the future.
 
 Remember to look at the [TRADEMARKS](TRADEMARKS.md) guide to understand naming concerns.
 You can pass `-e BUILDSYS_NAME=my-name` to `cargo make` commands to change the default "short" name, which is used in file and AMI names.
@@ -38,44 +38,9 @@ cargo make -e BUILDSYS_VARIANT=my-variant -e BUILDSYS_ARCH=my-arch
 cargo make repo -e BUILDSYS_VARIANT=my-variant -e BUILDSYS_ARCH=my-arch
 ```
 
-## Register an AMI
+## Publishing your image
 
-The [BUILDING](BUILDING.md#register-an-ami) guide covers the process of making an AMI, and has you specify `PUBLISH_REGIONS` to decide where the AMI will live.
-You can also specify this in your `Infra.toml` file:
-
-```toml
-[aws]
-regions = ["us-west-2", "us-east-1", "us-east-2"]
-```
-
-If you specify multiple regions, an AMI will be registered in the first region and then copied to the other regions.
-
-After putting this in `Infra.toml`, you can make an AMI more easily:
-
-```shell
-cargo make ami
-```
-
-If you want to change the name or description of your AMI, you can add on `-e PUBLISH_AMI_NAME=my-name` or `-e PUBLISH_AMI_DESCRIPTION=my-desc`.
-
-> Note: the AMI registration process creates a JSON file describing the AMIs in a directory under `build/images/`.
-> This file is used by the steps below when granting access to the AMIs or setting parameters in SSM.
-
-## Granting access to your AMI
-
-If you use different accounts to make and test your AMIs, you can grant access to specific accounts like this:
-
-```shell
-cargo make grant-ami -e GRANT_TO_USERS=0123456789,9876543210
-```
-
-(Later, if you need to revoke access, you can do this:)
-
-```shell
-cargo make revoke-ami -e REVOKE_FROM_USERS=0123456789,9876543210
-```
-
-> Note: similar to `cargo make ami`, you can specify `PUBLISH_REGIONS` on the command line if you don't want to make an `Infra.toml` config.
+For details on publishing your image on AWS or VMware, please see the respective [PUBLISHING-AWS](PUBLISHING-AWS.md) or [PUBLISHING-VMWARE](PUBLISHING-VMWARE.md) guides.
 
 ## Build a repo
 
@@ -307,103 +272,3 @@ If you forget, your hosts won't be able to talk to the repo until you update it.
 
 Currently, to refresh an existing repo, you would use the [tuftool update](https://github.com/awslabs/tough/tree/develop/tuftool) command without specifying any new targets.
 We're working on ways to make this easier, and integrated into the `cargo make` system.
-
-## Making your AMIs discoverable with SSM parameters
-
-After you've made AMIs and a repo, you may want to make it easier to find your AMIs, particularly as you make new versions over time.
-
-One way to do this is to store the AMI IDs in [AWS SSM Parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).
-These are simple names like `/my/ami/id` that you can use in many places instead of specific AMI IDs.
-For example, you can launch EC2 instances using [RunInstances](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html) or [in a CloudFormation stack](https://aws.amazon.com/blogs/mt/integrating-aws-cloudformation-with-aws-systems-manager-parameter-store/) using a parameter name rather than an AMI ID.
-You can also use the same parameter names across regions, so you don't have to deal with region-specific AMI IDs.
-
-> Note: SSM parameters are private to your account.
-> They let you use consistent names instead of tracking AMI IDs, but they don't currently let you share with other accounts.
-
-The `cargo make ssm` task can set SSM parameters based on the AMIs you built [above](#register-an-ami).
-For this to work, you have to specify a parameter prefix in your `Infra.toml`.
-This setting lives in the same `[aws]` section you used above to list the regions where you want to register AMIs.
-(The same region list will be used to determine where to publish SSM parameters.)
-
-Here's an example configuration for regions and the SSM prefix:
-
-```toml
-[aws]
-regions = ["us-west-2", "us-east-1", "us-east-2"]
-ssm_prefix = "/your/prefix/here"
-```
-
-This prefix forms the start of the name of each SSM parameter we set.
-The rest of the name comes from parameter templates.
-
-Parameter templates determine the name and value of each parameter we want to set for each AMI we've built.
-The [default template](tools/pubsys/policies/ssm/defaults.toml) creates parameters that let users find the AMI ID and the image version for each of your AMIs.
-The templates have access to the name of the current variant, architecture, etc., so they can create unique parameter names for each build.
-For more information on how templates work, check out [their documentation](tools/pubsys/policies/ssm/).
-
-If you're happy with the default template, you can set SSM parameters like this:
-
-```shell
-cargo make ssm
-```
-
-This will create versioned parameters, meaning that the parameter name has the image version in it.
-This isn't very discoverable yet, but it's useful for testing.
-
-As an example, a parameter might look like this:
-
-```
-/your/prefix/here/aws-k8s-1.19/x86_64/1.0.1-dafe3b16/image_id
-```
-
-Once you're satisfied with your image and parameters, you can promote the parameters to simpler names (for example, "latest") using the [instructions below](#promoting-ssm-parameters).
-
-Note: if you want to customize the SSM parameters that get set, you can copy and modify the existing template file, then point to your file like this:
-
-```shell
-cargo make ssm -e PUBLISH_SSM_TEMPLATES_PATH=/my/template/path
-```
-
-## Making your AMIs public
-
-We talked about [granting AMI access](#granting-access-to-your-ami) to specific AWS accounts.
-This is useful for testing, and for sharing private AMIs with specific accounts.
-
-If you want to make your AMIs public to the world, there's a shortcut:
-
-```
-cargo make ami-public
-```
-
-(Later, if you need to make the AMIs private again, you can do this.
- The AMIs will then only be accessible to account IDs you've specifically granted.)
-
-```shell
-cargo make ami-private
-```
-
-## Promoting SSM parameters
-
-[Above](#making-your-amis-discoverable-with-ssm-parameters), we set SSM parameters based on our AMIs.
-The SSM parameter names include version numbers, which is handy for testing, but makes them hard to find.
-Once we're satisfied, we can promote the SSM parameters to simpler names.
-
-```shell
-cargo make promote-ssm -e SSM_TARGET=latest
-```
-
-This will copy the fully versioned parameter from earlier, something like:
-
-```
-/your/prefix/here/aws-k8s-1.19/x86_64/1.0.1-dafe3b16/image_id
-```
-
-...to a simpler parameter name:
-```
-/your/prefix/here/aws-k8s-1.19/x86_64/latest/image_id
-```
-
-You can then use this parameter name to get the latest AMI ID.
-
-> Note: if you use a custom parameter template, you need to have an `{image_version}` component in the parameter name for promotion to work.
-> The `SSM_TARGET` you specify above becomes the `image_version` in the template.

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -664,6 +664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1164,9 @@ name = "pubsys-config"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "home",
+ "lazy_static",
+ "log",
  "parse-datetime",
  "serde",
  "snafu",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1125,6 +1125,7 @@ dependencies = [
  "chrono",
  "clap",
  "coldsnap",
+ "duct",
  "futures",
  "indicatif",
  "lazy_static",

--- a/tools/pubsys-config/Cargo.toml
+++ b/tools/pubsys-config/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 
 [dependencies]
 chrono = "0.4"
+home = "0.5"
+lazy_static = "1.4"
+log = "0.4"
 parse-datetime = { path = "../../sources/parse-datetime" }
 serde = { version = "1.0", features = ["derive"]  }
 snafu = "0.6"

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -1,5 +1,7 @@
 //! The config module owns the definition and loading process for our configuration sources.
+pub mod vmware;
 
+use crate::vmware::VmwareConfig;
 use chrono::Duration;
 use parse_datetime::parse_offset;
 use serde::{Deserialize, Deserializer};
@@ -19,6 +21,9 @@ pub struct InfraConfig {
 
     // Config for AWS specific subcommands
     pub aws: Option<AwsConfig>,
+
+    // Config for VMware specific subcommands
+    pub vmware: Option<VmwareConfig>,
 }
 
 impl InfraConfig {
@@ -168,6 +173,9 @@ mod error {
             path: PathBuf,
             source: toml::de::Error,
         },
+
+        #[snafu(display("Missing config: {}", what))]
+        MissingConfig { what: String },
     }
 }
 pub use error::Error;

--- a/tools/pubsys-config/src/vmware.rs
+++ b/tools/pubsys-config/src/vmware.rs
@@ -1,0 +1,221 @@
+//! The vmware module owns the definition and loading process for our VMware configuration sources.
+use lazy_static::lazy_static;
+use log::debug;
+use serde::Deserialize;
+use snafu::{OptionExt, ResultExt};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+lazy_static! {
+    /// Determine the full path to the Vsphere credentials at runtime.  This is an Option because it is
+    /// possible (however unlikely) that `home_dir()` is unable to find the home directory of the
+    /// current user
+    pub static ref VMWARE_CREDS_PATH: Option<PathBuf> = home::home_dir().map(|home| home
+        .join(".config")
+        .join("pubsys")
+        .join("vsphere-credentials.toml"));
+}
+
+const GOVC_USERNAME: &str = "GOVC_USERNAME";
+const GOVC_PASSWORD: &str = "GOVC_PASSWORD";
+const GOVC_URL: &str = "GOVC_URL";
+const GOVC_DATACENTER: &str = "GOVC_DATACENTER";
+const GOVC_DATASTORE: &str = "GOVC_DATASTORE";
+const GOVC_NETWORK: &str = "GOVC_NETWORK";
+const GOVC_RESOURCE_POOL: &str = "GOVC_RESOURCE_POOL";
+const GOVC_FOLDER: &str = "GOVC_FOLDER";
+
+/// VMware-specific infrastructure configuration
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VmwareConfig {
+    #[serde(default)]
+    pub datacenters: Vec<String>,
+    #[serde(default)]
+    pub datacenter: HashMap<String, DatacenterBuilder>,
+    pub common: Option<DatacenterBuilder>,
+}
+
+/// VMware datacenter-specific configuration.
+///
+/// Fields are optional here because this struct is used to gather environment variables, common
+/// config, and datacenter-specific configuration, each of which may not have the complete set of
+/// fields.  It is used to build a complete datacenter configuration (hence the "Builder" name).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DatacenterBuilder {
+    pub vsphere_url: Option<String>,
+    pub datacenter: Option<String>,
+    pub datastore: Option<String>,
+    pub network: Option<String>,
+    pub folder: Option<String>,
+    pub resource_pool: Option<String>,
+}
+
+/// Helper macro for retrieving a field from another struct if the field in `self` is `None`
+macro_rules! field_or {
+    ($self:expr, $field:ident, $other:expr) => {
+        $self
+            .$field
+            .as_ref()
+            .or($other.and_then(|o| o.$field.as_ref()))
+            .cloned()
+    };
+}
+
+impl DatacenterBuilder {
+    /// Create a DatacenterBuilder from environment variables
+    pub fn from_env() -> Self {
+        Self {
+            vsphere_url: get_env(GOVC_URL),
+            datacenter: get_env(GOVC_DATACENTER),
+            datastore: get_env(GOVC_DATASTORE),
+            network: get_env(GOVC_NETWORK),
+            folder: get_env(GOVC_FOLDER),
+            resource_pool: get_env(GOVC_RESOURCE_POOL),
+        }
+    }
+
+    /// Creates a new DatacenterBuilder, merging fields from another (Optional)
+    /// DatacenterBuilder if the field in `self` is None
+    pub fn take_missing_from(&self, other: Option<&Self>) -> Self {
+        Self {
+            vsphere_url: field_or!(self, vsphere_url, other),
+            datacenter: field_or!(self, datacenter, other),
+            datastore: field_or!(self, datastore, other),
+            network: field_or!(self, network, other),
+            folder: field_or!(self, folder, other),
+            resource_pool: field_or!(self, resource_pool, other),
+        }
+    }
+
+    /// Attempts to create a `Datacenter`, consuming `self` and ensuring that each field contains a
+    /// value.
+    pub fn build(self) -> Result<Datacenter> {
+        let get_or_err =
+            |opt: Option<String>, what: &str| opt.context(error::MissingConfig { what });
+
+        Ok(Datacenter {
+            vsphere_url: get_or_err(self.vsphere_url, "vSphere URL")?,
+            datacenter: get_or_err(self.datacenter, "vSphere datacenter")?,
+            datastore: get_or_err(self.datastore, "vSphere datastore")?,
+            network: get_or_err(self.network, "vSphere network")?,
+            folder: get_or_err(self.folder, "vSphere folder")?,
+            resource_pool: get_or_err(self.resource_pool, "vSphere resource pool")?,
+        })
+    }
+}
+
+/// A fully configured VMware datacenter, i.e. no optional fields
+#[derive(Debug)]
+pub struct Datacenter {
+    pub vsphere_url: String,
+    pub datacenter: String,
+    pub datastore: String,
+    pub network: String,
+    pub folder: String,
+    pub resource_pool: String,
+}
+
+/// VMware infrastructure credentials for all datacenters
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DatacenterCredsConfig {
+    #[serde(default)]
+    pub datacenter: HashMap<String, DatacenterCredsBuilder>,
+}
+
+impl DatacenterCredsConfig {
+    /// Deserializes a DatacenterCredsConfig from a given path
+    pub fn from_path<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        let creds_config_str = fs::read_to_string(path).context(error::File { path })?;
+        toml::from_str(&creds_config_str).context(error::InvalidToml { path })
+    }
+}
+
+/// VMware datacenter-specific credentials.  Fields are optional here since this struct is used to
+/// gather environment variables as well as fields from file, either of which may or may not exist.
+/// It is used to build a complete credentials configuration (hence the "Builder" name).
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DatacenterCredsBuilder {
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+impl DatacenterCredsBuilder {
+    /// Create a DatacenterCredsBuilder from environment variables
+    pub fn from_env() -> Self {
+        Self {
+            username: get_env(GOVC_USERNAME),
+            password: get_env(GOVC_PASSWORD),
+        }
+    }
+
+    /// Creates a new DatacenterCredsBuilder, merging fields from another (Optional)
+    /// DatacenterCredsBuilder if the field in `self` is None
+    pub fn take_missing_from(&self, other: Option<&Self>) -> Self {
+        Self {
+            username: field_or!(self, username, other),
+            password: field_or!(self, password, other),
+        }
+    }
+    /// Attempts to create a `DatacenterCreds`, consuming `self` and ensuring that each field
+    /// contains a value
+    pub fn build(self) -> Result<DatacenterCreds> {
+        let get_or_err =
+            |opt: Option<String>, what: &str| opt.context(error::MissingConfig { what });
+
+        Ok(DatacenterCreds {
+            username: get_or_err(self.username, "vSphere username")?,
+            password: get_or_err(self.password, "vSphere password")?,
+        })
+    }
+}
+
+/// Fully configured datacenter credentials, i.e. no optional fields
+#[derive(Debug)]
+pub struct DatacenterCreds {
+    pub username: String,
+    pub password: String,
+}
+
+/// Attempt to retrieve an environment variable, returning None if it doesn't exist
+fn get_env(var: &str) -> Option<String> {
+    match env::var(var) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            debug!("Unable to read environment variable '{}': {}", var, e);
+            None
+        }
+    }
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::io;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub enum Error {
+        #[snafu(display("Failed to read '{}': {}", path.display(), source))]
+        File { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Invalid config file at '{}': {}", path.display(), source))]
+        InvalidToml {
+            path: PathBuf,
+            source: toml::de::Error,
+        },
+
+        #[snafu(display("Missing config: {}", what))]
+        MissingConfig { what: String },
+    }
+}
+pub use error::Error;
+pub type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1.36"
 chrono = "0.4"
 clap = "2.33"
 coldsnap = { version = "0.3", default-features = false, features = ["rusoto-rustls"]}
+duct = "0.13.0"
 pubsys-config = { path = "../pubsys-config/" }
 futures = "0.3.5"
 indicatif = "0.16.0"

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -50,3 +50,35 @@ ssm_prefix = "/your/prefix/here"
 # If specified, we assume this role before making any API calls in this region.
 # (This is assumed after the "global" aws.role, if that is also specified.)
 role = "arn:aws:iam::012345678901:role/assume-regional"
+
+[vmware]
+# A list of datacenter names to which you would like to upload an OVA.  These
+# are "friendly" names, and do not need to be the actual name of the
+# software-defined datacenter, but can be.  For example, you may have have
+# multiple vSphere instances with datacenters that still carry the default
+# "SDDC-Datacenter" name; this field allows you to differentiate them.
+datacenters = ["north", "south"]
+
+# ***
+# GOVC_* environment variables set in the current environment override any
+# configuration set in the sections below!
+# ***
+
+# Optional common configuration
+# This configuration allow values to be set in a single place if they are common in 
+# multiple datacenters.  They can be overridden in the datacenter's block below.
+[vmware.common]
+network = "a_network"
+
+# Datacenter specific configuration
+# This specifies all of the values necessary to communicate with this
+# datacenter via `govc`.  Each value maps directly to the GOVC_* environment
+# variable in the corresponding comment.  If any of these values is missing and
+# isn't in the environment, we will look for them in `vmware.common`.
+[vmware.datacenter.north]
+vsphere_url = "https://vcenter.1234.vmwarevmc.com" # GOVC_URL
+datacenter = "SDDC-Datacenter" # GOVC_DATACENTER
+datastore = "WorkloadDatastore" # GOVC_DATASTORE
+network = "sddc-cgw-network-1" # GOVC_NETWORK
+folder = "my_folder" # GOVC_FOLDER
+resource_pool = "/SDDC-Datacenter/host/Cluster/Resources/Compute-ResourcePool" # GOVC_RESOURCE_POOL

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -25,6 +25,7 @@ Configuration comes from:
 
 mod aws;
 mod repo;
+mod vmware;
 
 use semver::Version;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
@@ -77,6 +78,9 @@ fn run() -> Result<()> {
                     .context(error::PromoteSsm)
             })
         }
+        SubCommand::UploadOva(ref upload_args) => {
+            vmware::upload_ova::run(&args, &upload_args).context(error::UploadOva)
+        }
     }
 }
 
@@ -115,6 +119,8 @@ enum SubCommand {
 
     Ssm(aws::ssm::SsmArgs),
     PromoteSsm(aws::promote_ssm::PromoteArgs),
+
+    UploadOva(vmware::upload_ova::UploadArgs),
 }
 
 /// Parses a SemVer, stripping a leading 'v' if present
@@ -173,6 +179,11 @@ mod error {
 
         #[snafu(display("Failed to update SSM: {}", source))]
         Ssm { source: crate::aws::ssm::Error },
+
+        #[snafu(display("Failed to upload OVA: {}", source))]
+        UploadOva {
+            source: crate::vmware::upload_ova::Error,
+        },
     }
 }
 type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/vmware/govc.rs
+++ b/tools/pubsys/src/vmware/govc.rs
@@ -1,0 +1,177 @@
+//! The govc module handles the process of building and executing the calls to Docker in order to
+//! run specific `govc` commands.
+use duct::cmd;
+use log::trace;
+use pubsys_config::vmware::{Datacenter, DatacenterCreds};
+use snafu::ResultExt;
+use std::env;
+use std::path::Path;
+use std::process::Output;
+
+pub(crate) struct Govc {
+    env_config: Vec<String>,
+}
+
+impl Govc {
+    const GOVC: &'static str = "govc";
+
+    /// Make a new instance of `Govc`, creating all of the environment variables required to run
+    /// `govc` as Docker `--env` arguments
+    pub(crate) fn new(dc: Datacenter, creds: DatacenterCreds) -> Self {
+        let mut env_config = Vec::new();
+        env_config.env_arg("GOVC_USERNAME", creds.username);
+        env_config.env_arg("GOVC_PASSWORD", creds.password);
+        env_config.env_arg("GOVC_URL", dc.vsphere_url);
+        env_config.env_arg("GOVC_DATACENTER", dc.datacenter);
+        env_config.env_arg("GOVC_DATASTORE", dc.datastore);
+        env_config.env_arg("GOVC_NETWORK", dc.network);
+        env_config.env_arg("GOVC_RESOURCE_POOL", dc.resource_pool);
+        env_config.env_arg("GOVC_FOLDER", dc.folder);
+
+        Self { env_config }
+    }
+
+    /// Run `govc import.ova` using Docker.
+    ///
+    /// Using the given name, OVA path, and import spec path, this function builds the `govc
+    /// import.ova` command as it will be used in the container.  It also builds the necessary bind
+    /// mount arguments to mount the import spec and OVA into the container.  Finally, it calls
+    /// `govc` via `docker run` invocation using these arguments.
+    pub(crate) fn upload_ova<S, P1, P2>(
+        self,
+        name: S,
+        ova_path: P1,
+        import_spec_path: P2,
+    ) -> Result<Output>
+    where
+        S: AsRef<str>,
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+    {
+        let name = name.as_ref();
+        let ova_host_path = ova_path.as_ref();
+        let import_spec_host_path = import_spec_path.as_ref();
+
+        // Define the paths to the OVA and import spec we will use for the bind mounts into the
+        // container
+        let ova_container_path = "/tmp/bottlerocket.ova";
+        let import_spec_container_path = "/tmp/import.spec";
+
+        //--mount type=bind,source="path/to/thing",target=/tmp/thing,readonly
+        let mount_config = &[
+            // Mount the import spec file
+            "--mount",
+            &format!(
+                "type=bind,source={},target={},readonly",
+                import_spec_host_path.display(),
+                import_spec_container_path
+            ),
+            // Mount the OVA
+            "--mount",
+            &format!(
+                "type=bind,source={},target={},readonly",
+                ova_host_path.display(),
+                ova_container_path
+            ),
+        ];
+
+        // govc import.ova -options=/path/to/spec -name bottlerocket_vm_name /path/to/ova
+        let govc_cmd = &[
+            Self::GOVC,
+            "import.ova",
+            &format!("-options={}", import_spec_container_path),
+            "-name",
+            &name,
+            ova_container_path,
+        ];
+
+        let env_config: Vec<&str> = self.env_config.iter().map(|s| s.as_ref()).collect();
+
+        docker_run(&env_config, Some(mount_config), govc_cmd)
+    }
+}
+
+/// Execute `docker run` using the SDK container with the specified environment, mount, and command
+/// arguments.
+///
+/// This builds the entire `docker run` command string using a list of Docker `--env FOO=BAR`
+/// strings, an optional list of `--mount` strings, and a list of strings meant to be the command
+/// to run in the container.
+// The arguments are `&[&str]` in an attempt to be as flexible as possible for the caller
+fn docker_run(docker_env: &[&str], mount: Option<&[&str]>, command: &[&str]) -> Result<Output> {
+    let sdk = env::var("BUILDSYS_SDK_IMAGE").context(error::Environment {
+        var: "BUILDSYS_SDK_IMAGE",
+    })?;
+    trace!("SDK image: {}", sdk);
+
+    let mut args = vec!["run"];
+    args.push("--net=host");
+    args.extend(docker_env);
+
+    if let Some(mount_cfg) = mount {
+        args.extend(mount_cfg)
+    }
+
+    args.push(&sdk);
+    args.extend(command);
+
+    let output = cmd("docker", args)
+        .stderr_to_stdout()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .context(error::CommandStart)?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    trace!("{}", stdout);
+    if output.status.success() {
+        Ok(output)
+    } else {
+        error::Docker { output: stdout }.fail()
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// Helper trait for constructing Docker `--env` arguments
+trait EnvArg {
+    fn env_arg<S1, S2>(&mut self, key: S1, value: S2)
+    where
+        S1: AsRef<str>,
+        S2: AsRef<str>;
+}
+
+impl EnvArg for Vec<String> {
+    fn env_arg<S1, S2>(&mut self, key: S1, value: S2)
+    where
+        S1: AsRef<str>,
+        S2: AsRef<str>,
+    {
+        self.push("--env".to_string());
+        self.push(format!("{}={}", key.as_ref(), value.as_ref()))
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+pub(crate) mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Failed to start command: {}", source))]
+        CommandStart { source: std::io::Error },
+
+        #[snafu(display("Docker invocation failed: {}", output))]
+        Docker { output: String },
+
+        #[snafu(display("Missing environment variable '{}'", var))]
+        Environment {
+            var: String,
+            source: std::env::VarError,
+        },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/vmware/mod.rs
+++ b/tools/pubsys/src/vmware/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod govc;
+pub(crate) mod upload_ova;

--- a/tools/pubsys/src/vmware/upload_ova/mod.rs
+++ b/tools/pubsys/src/vmware/upload_ova/mod.rs
@@ -1,0 +1,245 @@
+//! The upload_ova module owns the 'upload_ova' subcommand and is responsible for collating all of
+//! the config necessary to upload an OVA bundle to VMware datacenters.
+use crate::vmware::govc::Govc;
+use crate::Args;
+use log::{debug, info, trace};
+use pubsys_config::vmware::{
+    Datacenter, DatacenterBuilder, DatacenterCreds, DatacenterCredsBuilder, DatacenterCredsConfig,
+    VMWARE_CREDS_PATH,
+};
+use pubsys_config::InfraConfig;
+use serde::Serialize;
+use snafu::{ensure, OptionExt, ResultExt};
+use std::fs;
+use std::path::PathBuf;
+use structopt::StructOpt;
+use tempfile::NamedTempFile;
+use tinytemplate::TinyTemplate;
+
+const SPEC_TEMPLATE_NAME: &str = "spec_template";
+
+/// Uploads a Bottlerocket OVA to VMware datacenters
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct UploadArgs {
+    /// Path to the OVA image
+    #[structopt(short = "o", long, parse(from_os_str))]
+    ova: PathBuf,
+
+    /// Path to the import spec
+    #[structopt(short = "s", long, parse(from_os_str))]
+    spec: PathBuf,
+
+    /// The desired VM name
+    #[structopt(short = "n", long)]
+    name: String,
+
+    /// Make the uploaded OVA a VM template
+    #[structopt(long)]
+    mark_as_template: bool,
+
+    /// Datacenters to which you want to upload the OVA
+    #[structopt(long, use_delimiter = true)]
+    datacenters: Vec<String>,
+}
+
+/// Common entrypoint from main()
+pub(crate) fn run(args: &Args, upload_args: &UploadArgs) -> Result<()> {
+    // Get infra config
+    info!(
+        "Checking for infra config at path: {}",
+        args.infra_config_path.display()
+    );
+    let infra_config =
+        InfraConfig::from_path_or_default(&args.infra_config_path).context(error::InfraConfig)?;
+    trace!("Using infra config: {:?}", infra_config);
+
+    let vmware = infra_config
+        .vmware
+        .context(error::MissingConfig { missing: "vmware" })?;
+
+    // If the user gave an override list of datacenters, use it, otherwise use what's in the config
+    let upload_datacenters = if !upload_args.datacenters.is_empty() {
+        &upload_args.datacenters
+    } else {
+        &vmware.datacenters
+    };
+    ensure!(
+        !upload_datacenters.is_empty(),
+        error::MissingConfig {
+            missing: "vmware.datacenters"
+        }
+    );
+
+    // Retrieve credentials from GOVC_ environment variables
+    let creds_env = DatacenterCredsBuilder::from_env();
+    // Retrieve credentials from file. The `home` crate is used to construct the VMWARE_CREDS_PATH,
+    // and it's possible (however unlikely) that it is unable to determine the user's home folder.
+    let creds_file = if let Some(ref creds_file) = *VMWARE_CREDS_PATH {
+        if creds_file.exists() {
+            info!("Using vSphere credentials file at {}", creds_file.display());
+            DatacenterCredsConfig::from_path(creds_file).context(error::VmwareConfig)?
+        } else {
+            info!("vSphere credentials file not found, will attempt to use environment");
+            DatacenterCredsConfig::default()
+        }
+    } else {
+        info!("Unable to determine vSphere credentials file location, will attempt to use environment");
+        DatacenterCredsConfig::default()
+    };
+
+    // Retrieve datacenter-related GOVC_ environment variables and any common configuration given
+    // via Infra.toml
+    let dc_env = DatacenterBuilder::from_env();
+    let dc_common = vmware.common.as_ref();
+
+    // Read the import spec as a template
+    let import_spec_str = fs::read_to_string(&upload_args.spec).context(error::File {
+        action: "read",
+        path: &upload_args.spec,
+    })?;
+    let mut tt = TinyTemplate::new();
+    tt.add_template(SPEC_TEMPLATE_NAME, &import_spec_str)
+        .context(error::AddTemplate {
+            path: &upload_args.spec,
+        })?;
+
+    info!(
+        "Uploading to datacenters: {}",
+        &upload_datacenters.join(", ")
+    );
+    for dc in upload_datacenters {
+        debug!("Building config for {}", &dc);
+        // If any specific configuration exists for this datacenter, retrieve it from VMware
+        // config.  Then build out a complete datacenter config with all values necessary to
+        // interact with VMware.  Environment variables trump all others, so start with those, then
+        // fill in any missing items with datacenter-specific configuration and any common
+        // configuration.
+        let dc_config = vmware.datacenter.get(dc);
+        trace!("{} config: {:?}", &dc, &dc_config);
+        let datacenter: Datacenter = dc_env
+            .take_missing_from(dc_config)
+            .take_missing_from(dc_common)
+            .build()
+            .context(error::DatacenterBuild)?;
+
+        // Use a similar pattern here for credentials; start with environment variables and fill in
+        // any missing items with the datacenter-specific credentials from file.
+        let dc_creds = creds_file.datacenter.get(dc);
+        let creds: DatacenterCreds = creds_env
+            .take_missing_from(dc_creds)
+            .build()
+            .context(error::CredsBuild)?;
+
+        // Render the import spec with this datacenter's details and write to temp file
+        let rendered_spec = render_spec(&tt, &datacenter.network, upload_args.mark_as_template)?;
+        let import_spec = NamedTempFile::new().context(error::TempFile)?;
+        fs::write(import_spec.path(), &rendered_spec).context(error::File {
+            action: "write",
+            path: import_spec.path(),
+        })?;
+        trace!("Import spec: {}", &rendered_spec);
+
+        if upload_args.mark_as_template {
+            info!(
+                "Uploading OVA to datacenter '{}' as template with name: '{}'",
+                &dc, &upload_args.name
+            );
+        } else {
+            info!(
+                "Uploading OVA to datacenter '{}' with name '{}'",
+                &dc, &upload_args.name
+            );
+        }
+
+        Govc::new(datacenter, creds)
+            .upload_ova(&upload_args.name, &upload_args.ova, import_spec)
+            .context(error::UploadOva)?;
+    }
+
+    Ok(())
+}
+
+/// Render the import spec template given the current network and template setting.
+// This exists primarily to abstract the creation of the Context struct that is required by
+// TinyTemplate; it's pretty ugly to do inline with the rest of the code.
+fn render_spec<S>(tt: &TinyTemplate<'_>, network: S, mark_as_template: bool) -> Result<String>
+where
+    S: AsRef<str>,
+{
+    #[derive(Debug, Serialize)]
+    struct Context {
+        network: String,
+        mark_as_template: bool,
+    }
+
+    let context = Context {
+        network: network.as_ref().to_string(),
+        mark_as_template,
+    };
+
+    Ok(tt
+        .render(SPEC_TEMPLATE_NAME, &context)
+        .context(error::RenderTemplate)?)
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::io;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(crate) enum Error {
+        #[snafu(display("Error building template from '{}': {}", path.display(), source))]
+        AddTemplate {
+            path: PathBuf,
+            source: tinytemplate::error::Error,
+        },
+
+        #[snafu(display("Unable to build datacenter credentials: {}", source))]
+        CredsBuild {
+            source: pubsys_config::vmware::Error,
+        },
+
+        #[snafu(display("Unable to build datacenter config: {}", source))]
+        DatacenterBuild {
+            source: pubsys_config::vmware::Error,
+        },
+
+        #[snafu(display("Missing environment variable '{}'", var))]
+        Environment {
+            var: String,
+            source: std::env::VarError,
+        },
+
+        #[snafu(display("Failed to {} '{}': {}", action, path.display(), source))]
+        File {
+            action: String,
+            path: PathBuf,
+            source: io::Error,
+        },
+
+        #[snafu(display("Error reading config: {}", source))]
+        InfraConfig { source: pubsys_config::Error },
+
+        #[snafu(display("Infra.toml is missing {}", missing))]
+        MissingConfig { missing: String },
+
+        #[snafu(display("Error rendering template: {}", source))]
+        RenderTemplate { source: tinytemplate::error::Error },
+
+        #[snafu(display("Failed to create temporary file: {}", source))]
+        TempFile { source: io::Error },
+
+        #[snafu(display("Error reading config: {}", source))]
+        VmwareConfig {
+            source: pubsys_config::vmware::Error,
+        },
+
+        #[snafu(display("Failed to upload OVA: {}", source))]
+        UploadOva { source: crate::vmware::govc::Error },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/support/vmware/import_spec.template
+++ b/tools/pubsys/support/vmware/import_spec.template
@@ -1,0 +1,16 @@
+\{
+  "DiskProvisioning": "flat",
+  "IPAllocationPolicy": "dhcpPolicy",
+  "IPProtocol": "IPv4",
+  "NetworkMapping": [
+    \{
+      "Name": "VM Network",
+      "Network": "{ network }"
+    }
+  ],
+  "MarkAsTemplate": { mark_as_template },
+  "PowerOn": false,
+  "InjectOvfEnv": false,
+  "WaitForIP": false,
+  "Name": null
+}


### PR DESCRIPTION
**Issue number:**
Implements #1605 


**Description of changes:**

It's probably easiest to read through the PR by commit.
```
pubsys-config: Add VMware support
     
    This adds everything needed to support VMware specific configuration,
    including credentials.
```
```
pubsys: Add VMware 'upload-ova' subcommand
    
    This adds the subcommand `upload-ova` to `pubsys`.  This subcommand is
    meant to be used via `cargo make` and allow a user to upload an OVA to
    one or more VMware datacenters, optionally marking the VM as a template.
    Under the hood, it accomplishes this by running `govc` in the SDK
    container via Docker invocation, similar to how `buildsys` accomplishes
    its task.
    
    Like the rest of `pubsys`, it gets much of its configuration from
    `Infra.toml`.  The configuration details all of the values needed to
    communicate with a vSphere instance, and allows for users to specify
    "common" configuration that multiple datacenters share.  Credentials for
    different datacenters can be specified in a file located at
    `~/.config/pubsys/vsphere-credentials.toml`.  Because we use `govc`
    under the hood, at runtime we check for GOVC_* environment variables and
    allow them to override VMware datacenter config in `Infra.toml` or
    `vsphere-credentials.toml`
    
    The subcommand allows a user to override the name of the resulting VM,
    import spec, and specify a subset of datacenters than what's specified
    in config.
```
```
Makefile: Add `upload-ova` and `vmware-template` targets
    
    This change adds the ability to upload a built OVA to one or more VMware
    software defined datacenters.  The `vmware-template` target uploads the
    OVA and marks it as a VM template using the import spec.  Multiple
    environment variables allow a user to override the VM name, list of
    datacenters to upload to, and the import spec used to upload.
```
```
PUBLISHING: Split relevent AWS/VMware details into their own guides.
    
    This change splits `PUBLISHING.md` into multiple files to account for
    the differences in publishing Bottlerocket on AWS and VMware.  The
    `PUBLISHING-AWS.md` guide covers publishing and granting access to AMIs,
    and details around SSM parameters.  The `PUBLISHING-VMWARE.md` guide
    covers the configuration details and process for uploading an OVA to one
    or more VMware SDDC's.  The main `PUBLISHING.md` still covers all
    general information around configuration, repos, etc.
```

**Testing done:**

I performed the test steps with varying configuration setups:
*   _only_ environment variables (no datacenter-specific details in `Infra.toml` or creds file)
*  _only_ datacenter config/credentials file (no environment variables)
* datacenter config/creds file with values missing but populated in the environment
* environment variables with values missing but populated in the files
* all config populated in the `[vmware.common]` section
* various values populated in `common`, `Infra.toml` and environment to ensure the values cascade as expected

Testing steps:
* Upload an OVA
* Upload an OVA as template
* Override VM name, import_spec, and datacenters.  (I don't have multiple datacenters to push to so I populated the same details for multiple datacenters and ensured that pubsys attempts to upload to them both, failing the second time because a VM already exists)
* Attempt to re-upload the same OVA, fails as expected with a nice message:
```
[INFO] Uploading OVA to datacenter 'main' with name 'bottlerocket-vmware-k8s-1.20-x86_64-v1.1.1-5bf37a18-dirty'                                                                      
Failed to upload OVA: Docker invocation failed: /usr/bin/govc: The name 'bottlerocket-vmware-k8s-1.20-x86_64-v1.1.1-5bf37a18-dirty' already exists
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
