### PR TITLE
Store build artifacts per architecture

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -325,7 +325,13 @@ if [ -z "${PACKAGE}" ]; then
     echo "cargo make build-package -e PACKAGE=kernel"
     exit 1
 fi
+
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+# Save built artifacts for each architecture.  We don't set this everywhere
+# because we build host tools with cargo as well, like buildsys and pubsys.
+export CARGO_TARGET_DIR=${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}
+
 cargo build \
   ${CARGO_BUILD_ARGS} \
   ${CARGO_MAKE_CARGO_ARGS} \
@@ -339,6 +345,11 @@ dependencies = ["build-tools", "publish-setup"]
 script = [
 '''
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+# Save built artifacts for each architecture.  We don't set this everywhere
+# because we build host tools with cargo as well, like buildsys and pubsys.
+export CARGO_TARGET_DIR=${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}
+
 cargo build \
   ${CARGO_BUILD_ARGS} \
   ${CARGO_MAKE_CARGO_ARGS} \

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -103,7 +103,7 @@ impl PackageBuilder {
             arch = arch,
         );
 
-        build(BuildType::Package, &package, args, &tag, &output_dir)?;
+        build(BuildType::Package, &package, &arch, args, &tag, &output_dir)?;
 
         Ok(Self)
     }
@@ -160,7 +160,7 @@ impl VariantBuilder {
             arch = arch
         );
 
-        build(BuildType::Variant, &variant, args, &tag, &output_dir)?;
+        build(BuildType::Variant, &variant, &arch, args, &tag, &output_dir)?;
 
         Ok(Self)
     }
@@ -177,6 +177,7 @@ enum BuildType {
 fn build(
     kind: BuildType,
     what: &str,
+    arch: &str,
     build_args: Vec<String>,
     tag: &str,
     output_dir: &PathBuf,
@@ -200,7 +201,7 @@ fn build(
     let nocache = rand::thread_rng().gen::<u32>();
 
     // Create a directory for tracking outputs before we move them into position.
-    let build_dir = create_build_dir(&kind, &what)?;
+    let build_dir = create_build_dir(&kind, &what, &arch)?;
 
     // Clean up any previous outputs we have tracked.
     clean_build_files(&build_dir, &output_dir)?;
@@ -318,13 +319,13 @@ enum Retry<'a> {
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 /// Create a directory for build artifacts.
-fn create_build_dir(kind: &BuildType, name: &str) -> Result<PathBuf> {
+fn create_build_dir(kind: &BuildType, name: &str, arch: &str) -> Result<PathBuf> {
     let prefix = match kind {
         BuildType::Package => "packages",
         BuildType::Variant => "variants",
     };
 
-    let path = [&getenv("BUILDSYS_STATE_DIR")?, prefix, name]
+    let path = [&getenv("BUILDSYS_STATE_DIR")?, arch, prefix, name]
         .iter()
         .collect();
 


### PR DESCRIPTION
**Description of changes:**

```
Previously, switching between architectures would rebuild all artifacts, which
can make building and testing changes painful.

This change makes cargo and buildsys store their state in arch-specific
directories, so when you switch, they can find the last artifacts they built
for that arch.
```

*Note* because it originally confused me: we don't need to change anything about the RPM builds or the Rust/cargo used inside package builds, because the cache mount used in package builds is already arch-specific.

**Testing done:**

There's a relatively high blast radius for relatively few lines of code, so let me know if you can think of other tests to run.

* Build x86_64 aws-k8s-1.20 from scratch.  Confirm health.
* Check `build/state/`; here's an example of a marker for a package and for a variant artifact.
```
   662017      0 -rw-r--r--   1 tjk      tjk             0 Jun 24 09:56 x86_64/packages/grep/bottlerocket-x86_64-grep-debugsource-3.6-1.x86_64.rpm.buildsys_marker
   923063      0 -rw-r--r--   1 tjk      tjk             0 Jun 24 10:10 x86_64/variants/aws-k8s-1.20/bottlerocket-aws-k8s-1.20-x86_64-1.1.2-18c6be33-root.verity.lz4.buildsys_marker
```
* Build x86_64 again.  Artifacts are reused, build is fast.  (Only variant artifact state is changed, no packages.)  Confirm health.
* Build aarch64 from scratch.  Confirm health.
* Check `build/state`; x86 state isn't touched.  Example ARM markers:
```
   923418      0 -rw-r--r--   1 tjk      tjk             0 Jun 24 10:20 aarch64/packages/grep/bottlerocket-aarch64-grep-debuginfo-3.6-1.x86_64.rpm.buildsys_marker
  1054430      0 -rw-r--r--   1 tjk      tjk             0 Jun 24 10:26 aarch64/variants/aws-k8s-1.20/bottlerocket-aws-k8s-1.20-aarch64-1.1.2-18c6be33.img.lz4.buildsys_marker
```
* Build aarch64 again; build is fast.  Confirm health.
* Build x86_64 again; ***build is fast***.  aarch64 state isn't touched, only x86 variant artifacts.  Confirm health.
* Build aarch64 again; ***build is fast***.  x86 state isn't touched, only aarch64 variant artifacts.  Confirm health.
* Build aws-ecs-1 variant for x86 just to confirm nothing funny is going on between variants.  It builds the ECS-specific packages and updates their state markers, reuses the rest.  Confirm health.
* Touch storewolf/src/main.rs, build x86_64, confirm it rebuilds os, build aarch64, confirm it rebuilds os again.

The (top-level) cargo fingerprint/cache is separated correctly; example package:
```
drwxr-xr-x. 2 tjk tjk 4.0K 06-24 10:18 variants/target/aarch64/debug/.fingerprint/acpid-eb8670ac655d56a0/
drwxr-xr-x. 2 tjk tjk 4.0K 06-24 09:54 variants/target/x86_64/debug/.fingerprint/acpid-eb8670ac655d56a0/
```
(Before, it was like that, but minus the $arch level.)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
