### PR TITLE
docs: update references to the ECS variant for GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 With this release, the aws-ecs-1 variant has graduated from preview status and is now generally available.
 It's been updated to include Docker 20.10.
+The new [Bottlerocket ECS Updater](https://github.com/bottlerocket-os/bottlerocket-ecs-updater/) is available to help provide automated updates.
 :tada:
 
 ## OS Changes

--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -1,9 +1,5 @@
 # Using a Bottlerocket AMI with Amazon ECS
 
-> The [ECS variant](variants/README.md#aws-ecs-1-amazon-ecs-container-instance) of Bottlerocket is currently in a developer preview phase and we're looking for your
-> [feedback](https://github.com/bottlerocket-os/bottlerocket#contact-us).
-> We'd love for you to try it out!
-
 [Amazon Elastic Container Service (Amazon ECS)](https://ecs.aws) is a highly scalable, fast container management service that makes it easy to run, stop, and manage containers on a cluster.
 Your containers are defined in a task definition which you use to run individual tasks or as a service.
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ The following variants support EKS, as described above:
 - `aws-k8s-1.20`
 - `aws-k8s-1.21`
 
-We also have a variant designed to work with ECS, currently in preview:
+The following variant supports ECS:
 
 - `aws-ecs-1`
 
-Other variants we have in preview are designed to be Kubernetes worker nodes in VMware:
+We also have variants in preview status that are designed to be Kubernetes worker nodes in VMware:
 
 - `vmware-k8s-1.20`
 - `vmware-k8s-1.21`
@@ -175,11 +175,13 @@ For more details, see the [update system documentation](sources/updater/).
 ### Update methods
 
 There are several ways of updating your Bottlerocket hosts.
+We provide tools for automatically updating hosts, as well as an API for direct control of updates.
+
+#### Automated updates
 
 For EKS variants of Bottlerocket, we recommend using the [Bottlerocket update operator](https://github.com/bottlerocket-os/bottlerocket-update-operator) for automated updates.
-You can also use one of the methods below for direct control of updates.
 
-For the ECS preview variant of Bottlerocket, we recommend updating hosts using one of the methods below, until further automation is ready.
+For the ECS variant of Bottlerocket, we recommend using the [Bottlerocket ECS updater](https://github.com/bottlerocket-os/bottlerocket-ecs-updater/) for automated updates.
 
 #### Update API
 
@@ -212,10 +214,6 @@ apiclient update apply --check --reboot
 ```
 
 See the [apiclient documentation](sources/api/apiclient/) for more details.
-
-#### Bottlerocket Update Operator
-
-If you are running the Kubernetes variant of Bottlerocket, you can use the [Bottlerocket update operator](https://github.com/bottlerocket-os/bottlerocket-update-operator) to automate Bottlerocket updates.
 
 ### Update rollback
 

--- a/SECURITY_FEATURES.md
+++ b/SECURITY_FEATURES.md
@@ -41,12 +41,24 @@ Using partition sets and modeled settings removes the dependency on correct loca
 There is no package manager database or shared filesystem tree that can become corrupted and make the process non-deterministic.
 
 Our philosophy for variants is that the right time for an unexpected major version update to the kernel or orchestrator agent is "never".
+
+#### Kubernetes variants
+
 Each Kubernetes variant will be supported for approximately one year after it is first released.
 This follows the [Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) support policy.
 Newer LTS releases of the kernel may be introduced in newer variants, but not in older ones.
 
 We provide [a Kubernetes operator](https://github.com/bottlerocket-os/bottlerocket-update-operator) for automated updates to Bottlerocket.
 We recommend deploying it on your Kubernetes clusters.
+
+#### ECS variant
+
+We currently have a single variant for Amazon ECS.
+Newer LTS releases of the kernel may be introduced in newer variants, but not in the current one.
+
+We provide [an updater](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) for automated updates to Bottlerocket.
+We recommend deploying it on your ECS clusters.
+
 
 ### Immutable rootfs backed by dm-verity
 

--- a/SECURITY_GUIDANCE.md
+++ b/SECURITY_GUIDANCE.md
@@ -29,8 +29,11 @@ Bottlerocket includes many [security features](SECURITY_FEATURES.md) to mitigate
 These countermeasures serve to reduce the reliability of exploits and to raise their cost.
 However, it is always better to patch vulnerabilities than to rely on mitigations alone.
 
-We provide [a Kubernetes operator](https://github.com/bottlerocket-os/bottlerocket-update-operator) for automated updates to Bottlerocket.
+For our Kubernetes variants, we provide [a Kubernetes operator](https://github.com/bottlerocket-os/bottlerocket-update-operator) for automated updates to Bottlerocket.
 We recommend deploying it on your Kubernetes clusters.
+
+For our ECS variant, we provide [an updater](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) for automated updates to Bottlerocket.
+We recommend deploying it on your ECS clusters.
 
 ### Avoid containers with elevated privileges
 

--- a/sources/updater/README.md
+++ b/sources/updater/README.md
@@ -6,7 +6,8 @@ This document describes the Bottlerocket update system and its components, namel
 - [apiclient](../api/apiclient/README.md): automates interactions with the update API
 - [updog](#whats-updog): low-level client that interfaces with a TUF repository to find and apply updates
 - [signpost](#signpost): helper tool to update partition priority flags
-- [Bottlerocket update operator (brupop)](https://github.com/bottlerocket-os/bottlerocket-update-operator): an optional component that coordinates node updates with the rest of the cluster
+- [Bottlerocket update operator (brupop)](https://github.com/bottlerocket-os/bottlerocket-update-operator): an optional component that coordinates node updates with the rest of the Kubernetes cluster
+- [Bottlerocket ECS updater](https://github.com/bottlerocket-os/bottlerocket-ecs-updater): an optional component that coordinates container instance updates with the rest of the ECS cluster
 
 ![Update overview](update-system.png)
 ## TUF and tough


### PR DESCRIPTION
**Description of changes:**
The ECS variant is no longer in preview.  We've also launched a new optional Bottlerocket ECS Updater, similar to the Bottlerocket Update Operator for Kubernetes, which helps automate Bottlerocket updates.


**Testing done:**
No testing for doc updates.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
