### PR TITLE
kubelet: add setting for configuring cpuManagerPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.container-log-max-size`: The maximum size of container log file before it is rotated.
 * `settings.kubernetes.container-log-max-files`: The maximum number of container log files that can be present for a container.
 * `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`. If you want to allow pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node, you can set this setting to `static`. You should reboot if you change this setting after startup - try `apiclient reboot`.
+* `settings.kubernetes.cpu-manager-reconcile-period`: Specifies the CPU manager reconcile period, which controls how often updated CPU assignments are written to cgroupfs. The value is a duration like `30s` for 30 seconds or `1h5m` for 1 hour and 5 minutes.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.kube-api-burst`: The burst to allow while talking with kubernetes.
 * `settings.kubernetes.container-log-max-size`: The maximum size of container log file before it is rotated.
 * `settings.kubernetes.container-log-max-files`: The maximum number of container log files that can be present for a container.
+* `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`. If you want to allow pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node, you can set this setting to `static`. You should reboot if you change this setting after startup - try `apiclient reboot`.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -54,3 +54,6 @@ version = "1.1.2"
     "migrate_v1.1.2_admin-container-v0-7-1.lz4",
     "migrate_v1.1.2_control-container-v0-5-1.lz4",
 ]
+"(1.1.2, 1.1.3)" = [
+    "migrate_v1.1.3_kubelet-cpu-manager-state.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -56,4 +56,5 @@ version = "1.1.2"
 ]
 "(1.1.2, 1.1.3)" = [
     "migrate_v1.1.3_kubelet-cpu-manager-state.lz4",
+    "migrate_v1.1.3_kubelet-cpu-manager.lz4",
 ]

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -75,6 +75,9 @@ systemReserved:
   {{~/each}}
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.16/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.16/kubernetes-tmpfiles.conf
@@ -2,3 +2,4 @@ d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -75,6 +75,9 @@ systemReserved:
   {{~/each}}
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.17/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.17/kubernetes-tmpfiles.conf
@@ -2,3 +2,4 @@ d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -75,6 +75,9 @@ systemReserved:
   {{~/each}}
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
@@ -2,3 +2,4 @@ d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -75,6 +75,9 @@ systemReserved:
   {{~/each}}
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
@@ -2,3 +2,4 @@ d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -75,6 +75,9 @@ systemReserved:
   {{~/each}}
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -74,7 +74,7 @@ systemReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
-cpuManagerPolicy: "static"
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.20/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.20/kubernetes-tmpfiles.conf
@@ -2,3 +2,4 @@ d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -75,6 +75,9 @@ systemReserved:
   {{~/each}}
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -74,7 +74,7 @@ systemReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
-cpuManagerPolicy: "static"
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.21/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.21/kubernetes-tmpfiles.conf
@@ -2,3 +2,4 @@ d /etc/kubernetes/static-pods - - - -
 L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1544,6 +1544,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-cpu-manager-state"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "snafu",
+]
+
+[[package]]
 name = "kubelet-event-qps-event-burst"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1544,6 +1544,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-cpu-manager"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-cpu-manager-state"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "api/migration/migrations/v1.1.2/kubelet-system-reserved",
     "api/migration/migrations/v1.1.2/admin-container-v0-7-1",
     "api/migration/migrations/v1.1.2/control-container-v0-5-1",
+    "api/migration/migrations/v1.1.3/kubelet-cpu-manager-state",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "api/migration/migrations/v1.1.2/admin-container-v0-7-1",
     "api/migration/migrations/v1.1.2/control-container-v0-5-1",
     "api/migration/migrations/v1.1.3/kubelet-cpu-manager-state",
+    "api/migration/migrations/v1.1.3/kubelet-cpu-manager",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -1,6 +1,7 @@
 //! Contains the Error and Result types used by the migration helper functions and migrations.
 
 use snafu::Snafu;
+use std::path::PathBuf;
 
 /// Error contains the errors that can happen in the migration helper functions and in migrations.
 #[derive(Debug, Snafu)]
@@ -98,6 +99,12 @@ pub enum Error {
         setting: String,
         metadata: String,
         data: Vec<serde_json::Value>,
+    },
+
+    #[snafu(display("Failed to delete file '{}': '{}'", path.display(), source))]
+    RemoveFile {
+        path: PathBuf,
+        source: std::io::Error,
     },
 }
 

--- a/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager-state/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager-state/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kubelet-cpu-manager-state"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }
+snafu = "0.6"

--- a/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager-state/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager-state/src/main.rs
@@ -1,0 +1,54 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{error, migrate, Migration, MigrationData, Result};
+use snafu::ResultExt;
+use std::fs;
+use std::io;
+use std::process;
+
+const CPU_MANAGER_POLICY_CHECKPOINT: &str = "/var/lib/kubelet/cpu_manager_state";
+
+/// forward - We always remove the state file on boot, therefore we don't need to explicitly
+/// remove the file during forward migration.
+/// backward - We remove cpu manager policy checkpoint value on downgrade, since older versions did not
+/// clean up this state file on boot.
+pub struct CpuManagerPolicyCleaner;
+
+impl Migration for CpuManagerPolicyCleaner {
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("CpuManagerPolicyCleaner has no work to do on upgrade.");
+        Ok(input)
+    }
+
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        // removing existing cpu_manager_policy_state file
+        println!(
+            "Deleting existing cpu manager policy checkpoint: '{}'",
+            CPU_MANAGER_POLICY_CHECKPOINT
+        );
+        if let Err(e) = fs::remove_file(CPU_MANAGER_POLICY_CHECKPOINT) {
+            if e.kind() != io::ErrorKind::NotFound {
+                return Err(e).context(error::RemoveFile {
+                    path: CPU_MANAGER_POLICY_CHECKPOINT,
+                });
+            } else {
+                println!("NotFound: '{}'", CPU_MANAGER_POLICY_CHECKPOINT)
+            }
+        }
+        Ok(input)
+    }
+}
+/// We changed the default for CPU manager policy and need to handle kubelet's state file.
+fn run() -> Result<()> {
+    migrate(CpuManagerPolicyCleaner)
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-cpu-manager"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.3/kubelet-cpu-manager/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added two new settings for configuring kubelet, `settings.kubernetes.cpu-manager-reconcile-period`
+/// and `settings.kubernetes.cpu-manager-policy`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.cpu-manager-policy",
+        "settings.kubernetes.cpu-manager-reconcile-period",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -113,7 +113,7 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    BootstrapContainerMode, DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
+    BootstrapContainerMode, CpuManagerPolicy, DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
     FriendlyVersion, Identifier, KubernetesAuthenticationMode, KubernetesBootstrapToken,
     KubernetesCloudProvider, KubernetesClusterName, KubernetesEvictionHardKey, KubernetesLabelKey,
     KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
@@ -158,6 +158,7 @@ struct KubernetesSettings {
     kube_api_burst: i32,
     container_log_max_size: KubernetesQuantityValue,
     container_log_max_files: i32,
+    cpu_manager_policy: CpuManagerPolicy,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -115,7 +115,7 @@ use std::net::Ipv4Addr;
 use crate::modeled_types::{
     BootstrapContainerMode, CpuManagerPolicy, DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
     FriendlyVersion, Identifier, KubernetesAuthenticationMode, KubernetesBootstrapToken,
-    KubernetesCloudProvider, KubernetesClusterName, KubernetesEvictionHardKey, KubernetesLabelKey,
+    KubernetesCloudProvider, KubernetesClusterName, KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey,
     KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
     KubernetesTaintValue, KubernetesThresholdValue, Lockdown, SingleLineString, SysctlKey, Url,
     ValidBase64,
@@ -159,6 +159,7 @@ struct KubernetesSettings {
     container_log_max_size: KubernetesQuantityValue,
     container_log_max_files: i32,
     cpu_manager_policy: CpuManagerPolicy,
+    cpu_manager_reconcile_period: KubernetesDurationValue,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -817,3 +817,76 @@ mod test_cpu_manager_policy {
         }
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// KubernetesDurationValue represents a string that contains a valid Kubernetes duration value.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct KubernetesDurationValue {
+    inner: String,
+}
+
+lazy_static! {
+    pub(crate) static ref KUBERNETES_DURATION_VALUE: Regex = Regex::new(
+        r"^(([0-9]+\.)?[0-9]+h)?(([0-9]+\.)?[0-9]+m)?(([0-9]+\.)?[0-9]+s)?(([0-9]+\.)?[0-9]+ms)?$"
+    )
+    .unwrap();
+}
+
+impl TryFrom<&str> for KubernetesDurationValue {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        ensure!(
+            !input.is_empty(),
+            error::InvalidKubernetesDurationValue { input }
+        );
+        ensure!(
+            KUBERNETES_DURATION_VALUE.is_match(input),
+            error::InvalidKubernetesDurationValue { input }
+        );
+        Ok(KubernetesDurationValue {
+            inner: input.to_string(),
+        })
+    }
+}
+
+string_impls_for!(KubernetesDurationValue, "KubernetesDurationValue");
+
+#[cfg(test)]
+mod test_kubernetes_duration_value {
+    use super::KubernetesDurationValue;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_tokens() {
+        for ok in &[
+            "9ms",
+            "99s",
+            "20m",
+            "1h",
+            "1h2m3s10ms",
+            "4m5s10ms",
+            "2h3s10ms",
+            "1.5h3.5m",
+        ] {
+            KubernetesDurationValue::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_names() {
+        for err in &[
+            "",
+            "100",
+            "...3ms",
+            "1..5s",
+            "ten second",
+            "1m2h",
+            "9ns",
+            &"a".repeat(23),
+        ] {
+            KubernetesDurationValue::try_from(*err).unwrap_err();
+        }
+    }
+}

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -768,3 +768,52 @@ mod test_kubernetes_cloud_provider {
         }
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// CpuManagerPolicy represents a string that contains a valid cpu management policy. Default: none
+/// https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct CpuManagerPolicy {
+    inner: String,
+}
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ValidCpuManagerPolicy {
+    Static,
+    None,
+}
+
+impl TryFrom<&str> for CpuManagerPolicy {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<ValidCpuManagerPolicy>(&input).context(
+            error::InvalidCpuManagerPolicy { input })?;
+        Ok(CpuManagerPolicy {
+            inner: input.to_string(),
+        })
+    }
+}
+string_impls_for!(CpuManagerPolicy, "CpuManagerPolicy");
+
+#[cfg(test)]
+mod test_cpu_manager_policy {
+    use super::CpuManagerPolicy;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_cpu_manager_policy() {
+        for ok in &["static", "none"] {
+            CpuManagerPolicy::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_cpu_manager_policy() {
+        for err in &["", "bad", "100", &"a".repeat(64)] {
+            CpuManagerPolicy::try_from(*err).unwrap_err();
+        }
+    }
+}

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -74,6 +74,12 @@ pub mod error {
             input: String,
             source: std::num::ParseFloatError,
         },
+
+        #[snafu(display("Invalid Cpu Manager policy '{}'", input))]
+        InvalidCpuManagerPolicy {
+            input: String,
+            source: serde_plain::Error,
+        },
     }
 }
 

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -80,6 +80,9 @@ pub mod error {
             input: String,
             source: serde_plain::Error,
         },
+
+        #[snafu(display("Invalid Kubernetes duration value '{}'", input))]
+        InvalidKubernetesDurationValue { input: String },
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Part of #1628

**Description of changes:**
Fluent-bit does not work with `cpuPolicyManager: static`, and it does work with `cpuPolicyManager: none`. We expose `kubernetes.cpu-manager-policy` as a setting, so customers can specify `cpuManagerPolicy` to `none` and not be blocked by this issue while running fluent bit.

- [x] expose `kubernetes.cpu-manager-policy` as a setting
- [x] expose `kubernetes.cpu-manager-reconcile-policy` as a setting
- [x] add migration for cpu-manager-manager-policy - deal with the issue that changing the CPU manager policy caused issues on upgrade/downgrade ( from none to static and from static to none)
- [x] add migration for cpu-manager-reconcile-period

#### Solution about deal with the issue that changing the CPU manager policy caused issues on upgrade/downgrade
error
```
2028 cpu_manager.go:203] [cpumanager] could not initialize checkpoint manager: could not restore state from checkpoint: configured policy "static" differs from state checkpoint policy "none", please drain this node and delete the CPU manager checkpoint file "/var/lib/kubelet/cpu_manager_state" before restarting Kubelet, please drain node and remove policy state file
```

The reason why upgrade/downgrade of CPU manager policy migration is configured policy "static" differs from state checkpoint policy "none". Therefore, I use migration tool to delete cpu-manager-policy checkpoint for every migration process. No orchestrated workload would be running when the migrator is running, so it should be safe to delete that file before kubelet starts.

**Testing done:**

- [x] Test behavioral effect of new setting `cpu-manager-policy`
- [x] Test behavioral effect of new setting `cpu-manager-reconcile-policy`
- [x] Test migration process - `cpu-manager-policy`
- [x] Test migration process - `cpu-manager-reconcile-policy`

#### `cpu-manager-policy`
launching instance with the AMI which contains new setting and check if `cpu-manager-policy` has been configured expectantly. Meanwhile,  configure it as `none` and test if fluent-bit pod work as expected.

Step1 check if `cpu-manager-policy` has been configured expectantly:

Test with `cpu-manager-policy= "none"`
```
1726 policy_none.go:43] [cpumanager] none policy: Start
```
Test with default ("none")
```
1737 cpu_manager.go:193] [cpumanager] starting with none policy
```
Test with `cpu-manager-policy= "static"`
```
1723 cpu_manager.go:193] [cpumanager] starting with static policy
```

Step2 configure it as `none` and test if fluent-bit pod work as expected:
1. kubectl run --image public.ecr.aws/aws-observability/aws-for-fluent-bit:2.16.0 --command -- sh
2. kubectl exec -ti sh -- sh
3. /fluent-bit/bin/fluent-bit -H -i cpu -o null 
4. while curl localhost:2020; do echo pass; done

result (web server works perfectly ):
```
COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
fluent-bi   1 root   19u  IPv4  20229      0t0  TCP *:24224 (LISTEN)
fluent-bi  36 root   30u  IPv4  19367      0t0  TCP *:2020 (LISTEN)
```

#### Migration test:
upgrade
Step1: Upgrade to v1.1.3
```
bash-5.0# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.20",
    "arch": "x86_64",
    "version": "1.1.3",
    "max_version": "1.1.3",
.....

```
cat var/lib/kubelet/cpu_manager_state
{"policyName":"static","defaultCpuSet":"0-3","checksum":611748604}

```
bash-5.0# updog update -i 1.1.3 -r -n
Starting update to 1.1.3
```

Step2: check if cpu-manager-policy works as expected after upgrading
```
cat var/lib/kubelet/cpu_manager_state
{"policyName":"none","defaultCpuSet":"","checksum":1353318690}
```

```
journalctl - u kubelet
1701 policy_none.go:43] [cpumanager] none policy: Start
```

Step3: Specify new setting `cpu-manage-policy`through control container
```
apiclient set -j '{"kubernetes": {"cpu-manager-policy": "none"}}'
```
```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-policy
"none"
```

downgrade

Step1: Check migration binary
```
ls -al /var/lib/bottlerocket-migrations
total 492
drwx------.  2 root root   4096 Jun 29 21:51 .
drwxr-xr-x. 14 root root   4096 Jun 29 22:22 ..
-rw-r--r--.  1 root root 488744 Jun 29 22:21 0b168f448fed442fc3be61059256d4c12a423aa6afba5ec825596522dd015d41.migrate_v1.1.3_cpu-manager-policy.lz4

```

Step2: Downgrade to previous verison
```
signpost rollback-to-inactive
reboot
```

Step3: check if cpu-manager-policy works as expected after downgrading
```
cat var/lib/kubelet/cpu_manager_state
{"policyName":"static","defaultCpuSet":"0-3","checksum":611748604}
```

```
journalctl - u kubelet
1700 cpu_manager.go:193] [cpumanager] starting with static policy
```

Step4: Check if `cpu-manager-policy` have been removed
```
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-policy
cat: /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-policy: No such file or directory
```

#### `cpu-manager-reconcile-period`
launching instance with the AMI which contains new setting and check if `cpu-manager-reconcile-period` has been configured expectantly.

Step1 check if `cpu-manager-reconcile-period` has been configured expectantly:

Test with `cpu-manager-reconcile-period = 100s`
```
cpu_manager.go:194] [cpumanager] reconciling every 100s
```
Test with `cpu-manager-reconcile-period = 10m`
```
1730 cpu_manager.go:194] [cpumanager] reconciling every 10m0s
```
Test with `cpu-manager-reconcile-period = 1h`
```
1736 cpu_manager.go:194] [cpumanager] reconciling every 1h0m0s
```
Test with `cpu-manager-reconcile-period = 1h0m20s`
```
cpu_manager.go:194] [cpumanager] reconciling every 1h0m20s
```
Test with `cpu-manager-reconcile-period = 10m20s`
```
1726 cpu_manager.go:194] [cpumanager] reconciling every 10m20s
```
Test with `cpu-manager-reconcile-period = 1h10m2s`
```
1727 cpu_manager.go:194] [cpumanager] reconciling every 1h10m2s
```
#### Migration test:
upgrade
Step1: Upgrade to v1.1.3
```
bash-5.0# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.20",
    "arch": "x86_64",
    "version": "1.1.3",
    "max_version": "1.1.3",
.....

bash-5.0# updog update -i 1.1.3 -r -n
Starting update to 1.1.3
```
Step2: Specify new setting `cpu-manager-reconcile-period`through control container
```
apiclient set -j '{"kubernetes": {"cpu-manager-reconcile-period": "10m"}}'
apiclient set -j '{"kubernetes": {"cpu-manager-policy": "none"}}'
```

```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-reconcile-period
"10m"
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-policy
"none"
```

```
journalctl -u kubelet
cpu_manager.go:194] [cpumanager] start with none policy
cpu_manager.go:194] [cpumanager] reconciling every 10m0s
```

downgrade
Step1: Check migration binary
```
ls -al /var/lib/bottlerocket-migrations
0b168f448fed442fc3be61059256d4c12a423aa6afba5ec825596522dd015d41.migrate_v1.1.3_cpu-manager-reconcile-period.lz4
0b168f448fed442fc3be61059256d4c12a423aa6afba5ec825596522dd015d41.migrate_v1.1.3_cpu-manager-policy.lz4

```
Step2: Downgrade to previous verison
```
signpost rollback-to-inactive
reboot
```

Step3: Check if `cpu-manager-policy` have been removed
```
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-reconcile-period
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-reconcile-period: No such file or directory
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-policy
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/cpu-manager-policy: No such file or directory
```

```
journalctl -u kubelet
cpu_manager.go:194] [cpumanager] start with static policy
1702 cpu_manager.go:194] [cpumanager] reconciling every 10s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
