### PR TITLE
SDK bump v0.22.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - run: rustup toolchain install 1.51.0 && rustup default 1.51.0
+      - run: rustup toolchain install 1.53.0 && rustup default 1.53.0
       - run: cargo install --version 0.30.0 cargo-make
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} -e BUILDSYS_ARCH=${{ matrix.arch }} -e BUILDSYS_JOBS=12

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,7 +26,7 @@ BUILDSYS_NAME = "bottlerocket"
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.21.0"
+BUILDSYS_SDK_VERSION="v0.22.0"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 


### PR DESCRIPTION
**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket/issues/1605.

**Description of changes:**

Update to a newer SDK that contains `govc`, **Rust 1.53**, and [more](https://github.com/bottlerocket-os/bottlerocket-sdk/pull/56)!

**Testing done:**

_See https://github.com/bottlerocket-os/bottlerocket-sdk/pull/56_.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
