### PR TITLE
[NETDOG] Fixes #1645 : make dns_search a Vec to avoid comma separated search domains in resolv.conf file.

### DIFF
--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -146,7 +146,7 @@ struct LeaseInfo {
     #[serde(rename = "dnsdomain")]
     dns_domain: Option<String>,
     #[serde(rename = "dnssearch")]
-    dns_search: Option<String>,
+    dns_search: Option<Vec<String>>,
 }
 
 /// Informs the user about proper usage of the program and exits.
@@ -275,11 +275,11 @@ where
 }
 
 /// Write resolver configuration for libc.
-fn write_resolv_conf(dns_servers: &[&IpAddr], dns_search: &Option<String>) -> Result<()> {
+fn write_resolv_conf(dns_servers: &[&IpAddr], dns_search: &Option<Vec<String>>) -> Result<()> {
     let mut output = String::new();
 
     if let Some(s) = dns_search {
-        writeln!(output, "search {}", s).context(error::ResolvConfBuildFailed)?;
+        writeln!(output, "search {}", s.join(" ")).context(error::ResolvConfBuildFailed)?;
     }
 
     for n in dns_servers {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
1645


**Description of changes:**
In netdog, make dns_search a Vec


**Testing done:**
Yes locally. The resolv.conf file is now valid.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
