### PR TITLE
packages: fix permissions for /var/lib/systemd/random-seed

### DIFF
--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -70,6 +70,7 @@
 (filecon "/var/lib/chrony/.*" any measure)
 (filecon "/var/lib/systemd" any state)
 (filecon "/var/lib/systemd/.*" any state)
+(filecon "/var/lib/systemd/random-seed" any secret)
 (filecon "/var/lib/wicked" any lease)
 (filecon "/var/lib/wicked/.*" any lease)
 (filecon "/var/log/journal" any state)

--- a/packages/systemd/var-run-tmpfiles.conf
+++ b/packages/systemd/var-run-tmpfiles.conf
@@ -2,3 +2,4 @@ d /run/cache 0755 root root -
 d /run/lock 0755 root root -
 L /var/lock - - - - /run/lock
 Z /var/lib/systemd 0755 root root -
+z /var/lib/systemd/random-seed 600 root root -


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**
```
1176e7dc packages: fix permissions for /var/lib/systemd/random-seed
```

This commit changes the permissions on `/var/lib/systemd/random-seed` from `755` to `600`, and SELinux label from `state_t` to `secret_t`, so that only the root user can read from the file.

**Testing done:**
- Verified  the permissions changed:

```sh
# previous permissions
bash-5.0# ls -lZ /var/lib/systemd
drwxr-xr-x. 2 root root system_u:object_r:state_t:s0 4096 Jul 14 21:22 catalog
drwxr-xr-x. 2 root root system_u:object_r:state_t:s0 4096 Jul 14 21:22 coredump
drwxr-xr-x. 2 root root system_u:object_r:state_t:s0 4096 Jul 14 21:22 pstore
-rwxr-xr-x. 1 root root system_u:object_r:state_t:s0  512 Jul 14 21:22 random-seed
```

```sh
# new permissions
bash-5.0# ls -lZ /var/lib/systemd/
total 20
drwxr-xr-x. 2 root root system_u:object_r:state_t:s0  4096 Jul 16 03:27 catalog
drwxr-xr-x. 2 root root system_u:object_r:state_t:s0  4096 Jul 16 03:27 coredump
drwxr-xr-x. 2 root root system_u:object_r:state_t:s0  4096 Jul 16 03:27 pstore
-rw-------. 1 root root system_u:object_r:secret_t:s0  512 Jul 16 03:27 random-seed
```

- [x] Launch task in x86_64 aws-ecs-1
- [x] Launch pod in x86_64 aws-k8s-1.19, -1.20

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
