### PR TITLE
Add two kubelet settings - topologyManagerPolicy and topologyManagerScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.container-log-max-files`: The maximum number of container log files that can be present for a container.
 * `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`. If you want to allow pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node, you can set this setting to `static`. You should reboot if you change this setting after startup - try `apiclient reboot`.
 * `settings.kubernetes.cpu-manager-reconcile-period`: Specifies the CPU manager reconcile period, which controls how often updated CPU assignments are written to cgroupfs. The value is a duration like `30s` for 30 seconds or `1h5m` for 1 hour and 5 minutes.
+* `settings.kubernetes.topology-manager-policy`: Specifies the topology manager policy. Possible values are `none`, `restricted`, `best-effort`, and `single-numa-node`. Defaults to `none`.
 * `settings.kubernetes.topology-manager-scope`: Specifies the topology manager scope. Possible values are `container` and `pod`. Defaults to `container`. If you want to group all containers in a pod to a common set of NUMA nodes, you can set this setting to `pod`.
 
 You can also optionally specify static pods for your node with the following settings.

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.container-log-max-files`: The maximum number of container log files that can be present for a container.
 * `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`. If you want to allow pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node, you can set this setting to `static`. You should reboot if you change this setting after startup - try `apiclient reboot`.
 * `settings.kubernetes.cpu-manager-reconcile-period`: Specifies the CPU manager reconcile period, which controls how often updated CPU assignments are written to cgroupfs. The value is a duration like `30s` for 30 seconds or `1h5m` for 1 hour and 5 minutes.
+* `settings.kubernetes.topology-manager-scope`: Specifies the topology manager scope. Possible values are `container` and `pod`. Defaults to `container`. If you want to group all containers in a pod to a common set of NUMA nodes, you can set this setting to `pod`.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -63,4 +63,5 @@ version = "1.1.4"
     "migrate_v1.2.0_hostname-setting.lz4",
     "migrate_v1.2.0_hostname-setting-metadata.lz4",
     "migrate_v1.2.0_add-custom-certificates.lz4",
+    "migrate_v1.2.0_kubelet-topology-manager.lz4",
 ]

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -81,6 +81,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-policy}}
+topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -78,6 +78,9 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-scope}}
+topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -81,6 +81,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-policy}}
+topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -78,6 +78,9 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-scope}}
+topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -81,6 +81,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-policy}}
+topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -78,6 +78,9 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-scope}}
+topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -81,6 +81,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-policy}}
+topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -78,6 +78,9 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-scope}}
+topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -81,6 +81,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-policy}}
+topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -78,6 +78,9 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{~/if}}
+{{~#if settings.kubernetes.topology-manager-scope}}
+topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1691,6 +1691,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-topology-manager"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "api/migration/migrations/v1.2.0/hostname-setting",
     "api/migration/migrations/v1.2.0/hostname-setting-metadata",
     "api/migration/migrations/v1.2.0/add-custom-certificates",
+    "api/migration/migrations/v1.2.0/kubelet-topology-manager",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.2.0/kubelet-topology-manager/Cargo.toml
+++ b/sources/api/migration/migrations/v1.2.0/kubelet-topology-manager/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-topology-manager"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.2.0/kubelet-topology-manager/src/main.rs
+++ b/sources/api/migration/migrations/v1.2.0/kubelet-topology-manager/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added two new settings for configuring kubelet, `settings.kubernetes.topology-manager-policy`
+/// and `settings.kubernetes.topology-manager-scope`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.topology-manager-scope",
+        "settings.kubernetes.topology-manager-policy",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -114,7 +114,7 @@ use crate::modeled_types::{
     KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
     KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
     KubernetesThresholdValue, Lockdown, PemCertificateString, SingleLineString, SysctlKey, Url,
-    ValidBase64, ValidLinuxHostname,
+    ValidBase64, ValidLinuxHostname, TopologyManagerScope,
 };
 
 // Kubernetes static pod manifest settings
@@ -156,6 +156,7 @@ struct KubernetesSettings {
     container_log_max_files: i32,
     cpu_manager_policy: CpuManagerPolicy,
     cpu_manager_reconcile_period: KubernetesDurationValue,
+    topology_manager_scope: TopologyManagerScope,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -114,7 +114,7 @@ use crate::modeled_types::{
     KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
     KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
     KubernetesThresholdValue, Lockdown, PemCertificateString, SingleLineString, SysctlKey, Url,
-    ValidBase64, ValidLinuxHostname, TopologyManagerScope,
+    ValidBase64, ValidLinuxHostname, TopologyManagerPolicy, TopologyManagerScope,
 };
 
 // Kubernetes static pod manifest settings
@@ -157,6 +157,7 @@ struct KubernetesSettings {
     cpu_manager_policy: CpuManagerPolicy,
     cpu_manager_reconcile_period: KubernetesDurationValue,
     topology_manager_scope: TopologyManagerScope,
+    topology_manager_policy: TopologyManagerPolicy,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -890,3 +890,52 @@ mod test_kubernetes_duration_value {
         }
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// TopologyManagerScope represents a string that contains a valid topology management scope. Default: container
+/// https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct TopologyManagerScope {
+    inner: String,
+}
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ValidTopologyManagerScope {
+    Container,
+    Pod,
+}
+
+impl TryFrom<&str> for TopologyManagerScope {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<ValidTopologyManagerScope>(&input).context(
+            error::InvalidTopologyManagerScope { input })?;
+        Ok(TopologyManagerScope {
+            inner: input.to_string(),
+        })
+    }
+}
+string_impls_for!(TopologyManagerScope, "TopologyManagerScope");
+
+#[cfg(test)]
+mod test_topology_manager_scope {
+    use super::TopologyManagerScope;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_topology_manager_scope() {
+        for ok in &["container", "pod"] {
+            TopologyManagerScope::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_topology_manager_scope() {
+        for err in &["", "bad", "100", &"a".repeat(64)] {
+            TopologyManagerScope::try_from(*err).unwrap_err();
+        }
+    }
+}

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -107,6 +107,12 @@ pub mod error {
             input: String,
             source: serde_plain::Error,
         },
+
+        #[snafu(display("Invalid topology manager policy '{}'", input))]
+        InvalidTopologyManagerPolicy {
+            input: String,
+            source: serde_plain::Error,
+        },
     }
 }
 

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -101,6 +101,12 @@ pub mod error {
 
         #[snafu(display("No valid certificate found in bundle"))]
         NoCertificatesFound {},
+
+        #[snafu(display("Invalid topology manager scope '{}'", input))]
+        InvalidTopologyManagerScope {
+            input: String,
+            source: serde_plain::Error,
+        },
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1597

**Description of changes:**
Pass two new arguments to kubelet `topologyManagerPolicy` and `topologyManagerScope`

- [x] expose `kubernetes.topology-manager-policy` as a setting
- [x] expose `kubernetes.topology-manager-scope` as a setting
- [x] add migration for `kubernetes.topology-manager-policy` and `kubernetes.topology-manager-scope` 

**Testing done:**

- [x] Test behavioral effect of new setting `topology-manager-policy`
- [x] Test behavioral effect of new setting `topology-manager-scope`
- [x] Test migration process - `cpu-manager-policy` `cpu-manager-reconcile-policy`

#### `topology-manager-policy`
launching instance with the AMI which contains new setting and check if `topology-manager-policy` has been configured expectantly.

Step1 check if `topology-manager-policy` has been configured expectantly:

Test with `topology-manager-policy= none`
```
1737 container_manager_linux.go:314] "Initializing Topology Manager" policy="none" scope="container"
```
Test with default ("none")
```
1737 container_manager_linux.go:314] "Initializing Topology Manager" policy="none" scope="container"
```
Test with `topology-manager-policy= best-effort`
```
1730 container_manager_linux.go:314] "Initializing Topology Manager" policy="best-effort" scope="container"
```
Test with `topology-manager-policy= restricted`
```
1729 container_manager_linux.go:314] "Initializing Topology Manager" policy="restricted" scope="container"
```
Test with `topology-manager-policy= single-numa-node`
```
1736 container_manager_linux.go:314] "Initializing Topology Manager" policy="single-numa-node" scope="container"
```
Step2: Launched nginx pods/containers 
 
#### `topology-manager-scope`
launching instance with the AMI which contains new setting and check if `topology-manager-scope` has been configured expectantly.

Step1 check if `topology-manager-scope` has been configured expectantly:

Test with `topology-manager-scope = container`
```
1726 container_manager_linux.go:314] "Initializing Topology Manager" policy="none" scope="container"
```
Test with `topology-manager-scope = pod`
```
1725 container_manager_linux.go:314] "Initializing Topology Manager" policy="none" scope="pod"
```
Test with default
```
1737 container_manager_linux.go:314] "Initializing Topology Manager" policy="none" scope="container"
```

Step2: Launched nginx pods/containers 

#### Migration test:
upgrade
Step1: Upgrade to v1.2.0
```
bash-5.0# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.21",
    "arch": "x86_64",
    "version": "1.2.0",
    "max_version": "1.2.0",
.....

bash-5.0# updog update -i 1.2.0 -r -n
Starting update to 1.2.0
```
Step2: Specify new setting `topology-manager-policy` and `topology-manager-scope` through control container
```
apiclient set -j '{"kubernetes": {"topology-manager-policy": "restricted"}}'
apiclient set -j '{"kubernetes": {"topology-manager-scope": "pod"}}'
```

```
<atastore/current/live/settings/kubernetes/topology-manager-policy
"restricted"
<e/current/live/settings/kubernetes/topology-manager-scope
"pod"

```

```
journalctl -u kubelet
4488 container_manager_linux.go:314] "Initializing Topology Manager" policy="restricted" scope="pod"
```

downgrade
Step1: Check migration binary
```
ls -al /var/lib/bottlerocket-migrations
-rw-r--r--.  1 root root 477627 Jul 20 00:18 e9968ee60b449f1767b025034356dfca9c37ffe34e6a97fa8c176f169b698af1.migrate_v1.2.0_kubelet-topology-manager.lz4
```
Step2: Downgrade to previous verison
```
signpost rollback-to-inactive
reboot
```

Step3: Check if `topology-manager-policy` and `topology-manager-scope` have been removed
```
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/topology-manager-policy
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/topology-manager-policy: No such file or directory
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/topology-manager-scope
cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/topology-manager-scope: No such file or directory
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
