### PR TITLE
actions: cache tools on develop

### DIFF
--- a/.github/cache_bust
+++ b/.github/cache_bust
@@ -1,0 +1,4 @@
+# This file provides a manual way to clear out the github actions cache.
+# Any change to this file will cause the cache to miss. increment the number below by 1 if
+# you need to clear the cache.
+0

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,47 @@
+# This workflow caches build artifacts for cargo tools and Bottlerocket tools so other workflows won't have to build them
+# every time.
+# The cache should only be inherited by workflows initiated from pull-requests against the develop branch.
+name: Cache
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '.github/**'
+      - 'tools/buildsys/**'
+      - 'tools/pubsys*/**'
+      - '!tools/pubsys/policies/**'
+      - '!tools/pubsys/**.example'
+      - '!tools/pubsys/**.template'
+      - 'tools/Cargo.lock'
+jobs:
+  cache:
+    runs-on: [self-hosted, linux, x64]
+    continue-on-error: true
+    steps:
+      - run: |
+          echo "OS_ARCH=`uname -m`" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo
+            tools/bin
+            tools/.crates.toml
+            tools/.crates2.json
+            tools/target
+          # You can edit the .github/cache_bust file if you need to clear the cache
+          key: ${{ hashFiles('.github/cache_bust') }}-${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
+          restore-keys: |
+            key: ${{ hashFiles('.github/cache_bust') }}-${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-
+      - run: rustup toolchain install 1.53.0 && rustup default 1.53.0
+      - run: cargo install --locked --version 0.30.0 cargo-make
+      - run: cargo install --locked --version 0.6.3 --no-default-features --features ci-autoclean cargo-cache
+      - run: cargo install --locked --version 0.6.2 cargo-sweep
+      - run: |
+          cargo sweep -i -r tools/
+          cargo sweep -t 7 -r tools/
+      - run: cargo make publish-setup-tools
+      - run: cargo make publish-tools
+      - run: cargo make build-tools
+      # This cleans the cargo cache in ~/.cargo
+      - run: cargo-cache

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -263,7 +263,7 @@ ${BUILDSYS_TOOLS_DIR}/docker-go \
 ]
 
 [tasks.build-tools]
-dependencies = ["fetch"]
+dependencies = ["setup", "fetch-sources"]
 script = [
 '''
 cargo install \
@@ -327,7 +327,7 @@ fi
 
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["check-cargo-version", "build-tools", "publish-setup"]
+dependencies = ["check-cargo-version", "fetch-sdk", "build-tools", "publish-setup"]
 script_runner = "bash"
 script = [
 '''
@@ -353,7 +353,7 @@ cargo build \
 ]
 
 [tasks.build-variant]
-dependencies = ["build-tools", "publish-setup"]
+dependencies = ["fetch-sdk", "build-tools", "publish-setup"]
 script = [
 '''
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A but needed for https://github.com/bottlerocket-os/bottlerocket/pull/1653

**Description of changes:**

```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jul 19 17:13:46 2021 -0700

    actions: new caching workflow for develop
    
    Adds a new github actions workflow for caching bottlerocket build and
    publish tools so newly open PRs' workflow won't have to spend as much
    time building them.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jul 19 16:02:34 2021 -0700

    Makefile: simplify build-tools task dep
    
    We don't have a hard dependency on the bottlerocket-sdk for building
    buildsys. Removed `fetch-sdk` from `build-tools` dependencies and filled
    them in places where `build-tools` is an dependency.
    
    This makes it faster for us to build and cache buildsys for CI purposes

```

A caveat is that we can't mix github-hosted runners and self-hosted runners for our workflows because the cache is not shared between them for whatever reason. 

The cache key might resolve to the same value but the cache created for one type of runner would result in a cache miss for another workflow that uses a different type of runner.

**Testing done:**

Tested in a separate github repository and the caching works as expected.

Develop cache workflow:

First run, cache miss
```
Run actions/cache@v2
  with:
    path: ~/.cargo
  tools/bin
  tools/.crates.toml
  tools/.crates2.json
  tools/target
  
    key: ba609f44f8c6f4dd178688080572c0ff95ba010489e47e7ef6e719fa98c6f80b-Linux-x86_64-e7144e7cc06bcd77397ed25b1911937dcfedd426002e1c9476c82983caed5e8f-9e191d765d4a2da17477129db998e0c546569fb485570647afef2a38c5892f5f
  env:
    OS_ARCH: x86_64
Cache not found for input keys: ba609f44f8c6f4dd178688080572c0ff95ba010489e47e7ef6e719fa98c6f80b-Linux-x86_64-e7144e7cc06bcd77397ed25b1911937dcfedd426002e1c9476c82983caed5e8f-9e191d765d4a2da17477129db998e0c546569fb485570647afef2a38c5892f5f
...

Post job cleanup.
/usr/bin/tar --posix -z -cf cache.tgz -P -C /home/ec2-user/_work/... --files-from manifest.txt
Cache Size: ~385 MB (403248130 B)
Cache saved successfully
Cache saved with key: ba609f44f8c6f4dd178688080572c0ff95ba010489e47e7ef6e719fa98c6f80b-Linux-x86_64-e7144e7cc06bcd77397ed25b1911937dcfedd426002e1c9476c82983caed5e8f-9e191d765d4a2da17477129db998e0c546569fb485570647afef2a38c5892f5f
```

subsequent runs:
```
Run actions/cache@v2
Received 0 of 403248130 (0.0%), 0.0 MBs/sec
Received 37748736 of 403248130 (9.4%), 18.0 MBs/sec
Received 121634816 of 403248130 (30.2%), 38.7 MBs/sec
Received 197132288 of 403248130 (48.9%), 47.0 MBs/sec
Received 285212672 of 403248130 (70.7%), 54.4 MBs/sec
Received 373293056 of 403248130 (92.6%), 59.3 MBs/sec
Received 403248130 of 403248130 (100.0%), 58.6 MBs/sec
Cache Size: ~385 MB (403248130 B)
/usr/bin/tar -z -xf /home/ec2-user/_work/_temp/c79a0ead-64a0-4bec-8b30-02dc67257053/cache.tgz -P -C /home/ec2-user/_work/...
Cache restored successfully
Cache restored from key: ba609f44f8c6f4dd178688080572c0ff95ba010489e47e7ef6e719fa98c6f80b-Linux-x86_64-e7144e7cc06bcd77397ed25b1911937dcfedd426002e1c9476c82983caed5e8f-9e191d765d4a2da17477129db998e0c546569fb485570647afef2a38c5892f5f
```

A new PR with the default branch as the base branch, expecting cache to be inherited:
```
Received 0 of 403248130 (0.0%), 0.0 MBs/sec
Received 46137344 of 403248130 (11.4%), 22.0 MBs/sec
Received 134217728 of 403248130 (33.3%), 42.6 MBs/sec
Received 226492416 of 403248130 (56.2%), 53.9 MBs/sec
Received 318767104 of 403248130 (79.0%), 60.7 MBs/sec
Received 403248130 of 403248130 (100.0%), 63.3 MBs/sec
Cache Size: ~385 MB (403248130 B)
/usr/bin/tar -z -xf /home/ec2-user/_work/_temp/305cadba-d452-4c16-8c95-21e0ed2f38e0/cache.tgz -P -C /home/ec2-user/_work/...
Cache restored successfully
Cache restored from key: ba609f44f8c6f4dd178688080572c0ff95ba010489e47e7ef6e719fa98c6f80b-Linux-x86_64-e7144e7cc06bcd77397ed25b1911937dcfedd426002e1c9476c82983caed5e8f-9e191d765d4a2da17477129db998e0c546569fb485570647afef2a38c5892f5f
```
cargo-make is cached too
```
Run cargo install --version 0.30.0 cargo-make
     Ignored package `cargo-make v0.30.0` is already installed, use --force to override
```

Then at the end of the workflow it creates its own cache for subsequent revisions to the PR (note the new cache key):
```
Post job cleanup.
/usr/bin/tar --posix -z -cf cache.tgz -P -C /home/ec2-user/_work/... --files-from manifest.txt
Cache Size: ~418 MB (438131338 B)
Cache saved successfully
Cache saved with key: ba609f44f8c6f4dd178688080572c0ff95ba010489e47e7ef6e719fa98c6f80b-Linux-x86_64-e7144e7cc06bcd77397ed25b1911937dcfedd426002e1c9476c82983caed5e8f-9e191d765d4a2da17477129db998e0c546569fb485570647afef2a38c5892f5f-test-cache-a
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
