### PR TITLE
Update systemd to 247.8

### DIFF
--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd-stable/archive/v247.7/systemd-stable-247.7.tar.gz"
-sha512 = "749420285eb06487a251beee4df4b91a6ab2b327f58cc9448378880abc4b5deaca301f0746f61e04355dce0408f982260c43968fae1b8ba66f4c4adac878c824"
+url = "https://github.com/systemd/systemd-stable/archive/v247.8/systemd-stable-247.8.tar.gz"
+sha512 = "ac6c9e9b1642f14971551585b25b0b69733a76577154baa701d9879349844913535859d1ef440d20b4d55d8bcc7c34b9d413710f3e49e4cc295d1e5ebb48102c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,7 +2,7 @@
 %global _cross_allow_rpath 1
 
 Name: %{_cross_os}systemd
-Version: 247.7
+Version: 247.8
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later


### PR DESCRIPTION
**Testing done:**

I built an aws-k8s-1.20 AMI to confirm that systemctl and journal are still healthy, no new errors in journal, API reads and changes work OK, and a pod runs OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
