### PR TITLE
Add a new setting for configuring hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,13 @@ These settings can be changed at any time.
 
 #### Network settings
 
+* `settings.network.hostname`: The desired hostname of the system.
+  **Important note for all Kubernetes variants:** Changing this setting at runtime (not via user data) can cause issues with kubelet registration, as hostname is closely tied to the identity of the system for both registration and certificates/authorization purposes.
+
+Most users don't need to change this setting as the following defaults work for the majority of use cases.
+If this setting isn't set we attempt to use DNS reverse lookup for the hostname.
+If the lookup is unsuccessful, the IP of the node is used in the format `ip-X-X-X-X`.
+
 ##### Proxy settings
 
 These settings will configure the proxying behavior of the following services:

--- a/Release.toml
+++ b/Release.toml
@@ -59,3 +59,7 @@ version = "1.1.4"
     "migrate_v1.1.3_kubelet-cpu-manager.lz4",
 ]
 "(1.1.3, 1.1.4)" = []
+"(1.1.4, 1.1.5)" = [
+    "migrate_v1.1.5_hostname-setting.lz4",
+    "migrate_v1.1.5_hostname-setting-metadata.lz4",
+]

--- a/packages/release/hostname-env
+++ b/packages/release/hostname-env
@@ -1,0 +1,1 @@
+HOSTNAME={{settings.network.hostname}}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -14,6 +14,7 @@ Source99: release-tmpfiles.conf
 
 Source200: motd.template
 Source201: proxy-env
+Source202: hostname-env
 
 Source1000: eth0.xml
 Source1001: multi-user.target
@@ -21,6 +22,7 @@ Source1002: configured.target
 Source1003: preconfigured.target
 Source1004: activate-configured.service
 Source1005: activate-multi-user.service
+Source1011: set-hostname.service
 
 # Mounts for writable local storage.
 Source1006: var.mount
@@ -108,7 +110,7 @@ EOF
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} \
-  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} \
+  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} %{S:1011} \
   %{S:1015} %{S:1040} %{S:1041} %{S:1060} %{S:1061} %{S:1062} \
   %{buildroot}%{_cross_unitdir}
 
@@ -129,6 +131,7 @@ install -p -m 0644 ${LICENSEPATH}.mount %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
+install -p -m 0644 %{S:202} %{buildroot}%{_cross_templatedir}/hostname-env
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.rules
@@ -163,9 +166,11 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %{_cross_unitdir}/*-kernels.mount
 %{_cross_unitdir}/*-licenses.mount
 %{_cross_unitdir}/var-lib-bottlerocket.mount
+%{_cross_unitdir}/set-hostname.service
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/motd
 %{_cross_templatedir}/proxy-env
+%{_cross_templatedir}/hostname-env
 %{_cross_udevrulesdir}/61-mount-cdrom.rules
 
 %changelog

--- a/packages/release/set-hostname.service
+++ b/packages/release/set-hostname.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sets the hostname
+After=settings-applier.service
+Requires=settings-applier.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/network/hostname.env
+ExecStart=/usr/bin/netdog set-hostname '${HOSTNAME}'
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+WantedBy=preconfigured.target

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1314,6 +1314,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname-setting"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "hostname-setting-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1853,6 +1853,7 @@ dependencies = [
 name = "netdog"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "cargo-readme",
  "dns-lookup",
  "envy",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -37,6 +37,8 @@ members = [
     "api/migration/migrations/v1.1.2/control-container-v0-5-1",
     "api/migration/migrations/v1.1.3/kubelet-cpu-manager-state",
     "api/migration/migrations/v1.1.3/kubelet-cpu-manager",
+    "api/migration/migrations/v1.1.5/hostname-setting",
+    "api/migration/migrations/v1.1.5/hostname-setting-metadata",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hostname-setting-metadata"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and generator for configuring hostname
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["setting-generator", "affected-services"],
+        setting: "settings.network.hostname",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hostname-setting"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and generator for configuring hostname
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.network.hostname",
+        "services.hostname",
+        "configuration-files.hostname",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
+argh = "0.1.4"
 dns-lookup = "1.0"
 ipnet = { version = "2.0", features = ["serde"] }
 envy = "0.4"

--- a/sources/api/netdog/README.md
+++ b/sources/api/netdog/README.md
@@ -5,7 +5,8 @@ Current version: 0.1.0
 ## Introduction
 
 netdog is a small helper program for wicked, to apply network settings received from DHCP.  It
-generates `/etc/resolv.conf`, generates and sets the hostname, and persists the current IP to file.
+generates `/etc/resolv.conf`, generates and sets the hostname, and persists the current IP to a
+file.
 
 It contains two subcommands meant for use as settings generators:
 * `node-ip`: returns the node's current IP address in JSON format

--- a/sources/api/netdog/README.md
+++ b/sources/api/netdog/README.md
@@ -12,6 +12,8 @@ It contains two subcommands meant for use as settings generators:
 * `generate-hostname`: returns the node's hostname in JSON format (it is the resolved IP or the IP
   in format "ip-x-x-x-x" if resolving fails)
 
+The subcommand `set-hostname` sets the hostname for the system.
+
 ## Colophon
 
 This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/netdog/README.md
+++ b/sources/api/netdog/README.md
@@ -4,11 +4,13 @@ Current version: 0.1.0
 
 ## Introduction
 
-netdog is a small helper program for wicked, to apply network settings received from DHCP.  It also
-contains a subcommand `node-ip` that returns the node's current IP address in JSON format; this
-subcommand is intended for use as a settings generator.
+netdog is a small helper program for wicked, to apply network settings received from DHCP.  It
+generates `/etc/resolv.conf`, generates and sets the hostname, and persists the current IP to file.
 
-It generates `/etc/resolv.conf`, sets the hostname, and persists the current IP to file.
+It contains two subcommands meant for use as settings generators:
+* `node-ip`: returns the node's current IP address in JSON format
+* `generate-hostname`: returns the node's hostname in JSON format (it is the resolved IP or the IP
+  in format "ip-x-x-x-x" if resolving fails)
 
 ## Colophon
 

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -76,6 +76,18 @@ template-path = "/usr/share/templates/proxy-env"
 [metadata.settings.network]
 affected-services = ["containerd", "host-containerd", "host-containers"]
 
+[metadata.settings.network.hostname]
+affected-services = ["hostname"]
+setting-generator = "netdog generate-hostname"
+
+[services.hostname]
+configuration-files = ["hostname"]
+restart-commands = ["/bin/systemctl try-restart set-hostname.service"]
+
+[configuration-files.hostname]
+path = "/etc/network/hostname.env"
+template-path = "/usr/share/templates/hostname-env"
+
 # NTP
 
 [settings.ntp]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -108,12 +108,13 @@ use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use crate::modeled_types::{
-    BootstrapContainerMode, CpuManagerPolicy, DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
-    FriendlyVersion, Identifier, KubernetesAuthenticationMode, KubernetesBootstrapToken,
-    KubernetesCloudProvider, KubernetesClusterName, KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey,
-    KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
-    KubernetesTaintValue, KubernetesThresholdValue, Lockdown, SingleLineString, SysctlKey, Url,
-    ValidBase64,
+    BootstrapContainerMode, CpuManagerPolicy, DNSDomain, ECSAgentLogLevel, ECSAttributeKey,
+    ECSAttributeValue, FriendlyVersion, Identifier, KubernetesAuthenticationMode,
+    KubernetesBootstrapToken, KubernetesCloudProvider, KubernetesClusterName,
+    KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
+    KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
+    KubernetesThresholdValue, Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
+    ValidLinuxHostname,
 };
 
 // Kubernetes static pod manifest settings
@@ -199,6 +200,7 @@ struct HostContainer {
 // Network settings. These settings will affect host service components' network behavior
 #[model]
 struct NetworkSettings {
+    hostname: ValidLinuxHostname,
     https_proxy: Url,
     // We allow some flexibility in NO_PROXY values because different services support different formats.
     no_proxy: Vec<SingleLineString>,

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -54,6 +54,9 @@ pub mod error {
         #[snafu(display("Invalid domain name '{}': {}", input, msg))]
         InvalidDomainName { input: String, msg: String },
 
+        #[snafu(display("Invalid hostname '{}': {}", input, msg))]
+        InvalidLinuxHostname { input: String, msg: String },
+
         #[snafu(display("Invalid Linux lockdown mode '{}'", input))]
         InvalidLockdown { input: String },
 


### PR DESCRIPTION
**Issue number:**
Fixes #1608 


**Description of changes:**
Reading through this PR by commit will probably be easiest.

> **IMPORTANT NOTE**
> As mentioned in #1608, kubelet uses the hostname when registering itself and for certificate/authorization purposes.  Given that fact, changing the hostname after the host's initial boot (and by extension, kubelet's initial registration) may cause issues with the kubelet.  We don't currently have a method in the API server for "write once, read many" situations but considered the setting useful enough to move forward.  #1663 tracks thoughts on the "write once, read many" API server functionality.

Previously, hostname was written directly to disk by `netdog` called by `wicked` early in boot.  At the point in the boot sequence when `wicked` calls `netdog`, the API server isn't up yet.  Rather than rework the boot sequence (which would be tricky as this point in boot) and add the ability to netdog to talk to the API, we opted to add a subcommand to `netdog` as a settings generator for the new `settings.network.hostname` setting.  The setting is used in a template file, which is an env file for a new systemd unit that calls `netdog set-hostname`.  This command is what will write the hostname to disk at `/proc/sys/kernel/hostname`.

This means that at boot time, if a user has the `hostname` setting in their user data, we will use it, otherwise we will set the hostname using largely the same logic as was in the program previously.  (The only change is that if the DNS reverse lookup fails, we use the IP in the format "ip-x-x-x" as the hostname). 

`netdog` was reworked to use `argh` for argument parsing since our custom logic was starting to get unwieldy with the addition of more subcommands with their own arguments.



**Testing done:**
* `/etc/resolv.conf` is populated in all cases
* Migrations work correctly and the setting and its metadata are correctly populated on upgrade, and nonexistent on downgrade
* I tested that you can set this setting via `apiclient` at runtime.  `kubelet` logs some errors.  I can't speak to what will happen to the kubelet or if it will continue to function or for how long.

No `settings.network.hostname` in user data:
* Boot `aws-k8s-1.19`: it starts, gets a correct hostname, and connects to the cluster just fine and runs a pod
* Boot `vmware-k8s-1.20`: it starts, gets the string `ip-x-x-x-x` as its hostname, connects to the cluster, runs a pod

`settings.network.hostname="br-test-1"` in user data:
* Boot `aws-k8s-1.10`: it boots, gets the hostname from user data, but (correctly) doesn't ever become ready in the cluster.
* Boot `vmware-k8s-1.20`: it boots, gets hostname from user data, and shows up neatly in the cluster, runs a pod.
```
> kubectl get nodes
NAME                STATUS   ROLES                  AGE     VERSION
br-test-1           Ready    <none>                 6h19m   v1.20.8
mrowicki-qs-xx6l2   Ready    control-plane,master   6h41m   v1.20.8
```





**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
