### PR TITLE
packages: update 5.4 and 5.10 kernels

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,5 +13,5 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/e02ea3dba6fd0e1fedb847a6bf67a4c990c3d23e128cf632af472d38ce05b3cd/kernel-5.10.35-31.135.amzn2.src.rpm"
-sha512 = "7c02f472045321ab92e13d6348ed3e6c879d4423cff87770889718c9974c8871c35a3d7caae1e5ea185d53d9fd71b83e3d0f189c7f01633b33682dfc67654df8"
+url = "https://cdn.amazonlinux.com/blobstore/ffdc72c6cf8a4fcebfe8a3175a3f618f42f6ff2b00a36c0da6e04cf00d258daf/kernel-5.10.50-44.132.amzn2.src.rpm"
+sha512 = "ff548cfb49be98f1180c30f0c4f13846a690fb162a09be17a910267ac301b9efafacacbc5d873d699e250d8d1962bb48d7095509b6de3ce36ebf1b930efa92d8"

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.35
+Version: 5.10.50
 Release: 2%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/e02ea3dba6fd0e1fedb847a6bf67a4c990c3d23e128cf632af472d38ce05b3cd/kernel-5.10.35-31.135.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/ffdc72c6cf8a4fcebfe8a3175a3f618f42f6ff2b00a36c0da6e04cf00d258daf/kernel-5.10.50-44.132.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.4/Cargo.toml
+++ b/packages/kernel-5.4/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/3166b2c4af7dbb50ef04eedc98aff0020ea1570892d7e01a9dab885e04168afc/kernel-5.4.117-58.216.amzn2.src.rpm"
-sha512 = "0d86948018725b4590622a49f27fa7dae03ce06fcef11d39883f7fc421087442fea54c30603c997bd6f519606be596f1e46f33727213c34bd78a85076a47eeef"
+url = "https://cdn.amazonlinux.com/blobstore/d10a345f3b99842f109529ef5520232b1eba2349b667a7a0a18b1f86cb3eebbd/kernel-5.4.129-63.229.amzn2.src.rpm"
+sha512 = "852a1ece96a9f7cf65f81848291a00a43f7e2ae426e65b38b72125a627970f9d7e1a5ab60cbd570d17d63911fa4644aff9a1aa84f8f3096b9ca596a90fa99fc1"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.4
-Version: 5.4.117
+Version: 5.4.129
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/3166b2c4af7dbb50ef04eedc98aff0020ea1570892d7e01a9dab885e04168afc/kernel-5.4.117-58.216.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/d10a345f3b99842f109529ef5520232b1eba2349b667a7a0a18b1f86cb3eebbd/kernel-5.4.129-63.229.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**

```
48aa7088 packages: update 5.10 kernel
2b4c73fc packages: update 5.4 kernel
```

**Testing done:**
aws-k8s-1.19 / aws-k8s-1.20 / aws-ecs-1, x86_64/aarch64:

- Launched nginx pod/task/container
- `systemctl status` OK
- `journalctl -p3` didn't show errors in k8s variants, and the ecs variant it showed expected errors related to CNI tmpfiles

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
