### PR TITLE
Support for zstd compressed kernel and modules

### DIFF
--- a/packages/kernel-5.10/2000-kbuild-move-module-strip-compression-code-into-scrip.patch
+++ b/packages/kernel-5.10/2000-kbuild-move-module-strip-compression-code-into-scrip.patch
@@ -1,0 +1,184 @@
+From 4fc601b61092b4a7608a3d79d32663d9d167caf4 Mon Sep 17 00:00:00 2001
+From: Masahiro Yamada <masahiroy@kernel.org>
+Date: Wed, 31 Mar 2021 22:38:08 +0900
+Subject: [PATCH 2000/2001] kbuild: move module strip/compression code into
+ scripts/Makefile.modinst
+
+Both mod_strip_cmd and mod_compress_cmd are only used in
+scripts/Makefile.modinst, hence there is no good reason to define them
+in the top Makefile. Move the relevant code to scripts/Makefile.modinst.
+
+Also, show separate log messages for each of install, strip, sign, and
+compress.
+
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+(cherry picked from commit 65ce9c38326e2588fcd1a3a4817c14b4660f430b)
+[fixed a merge conflict in Makefile and script/Makefile.modinst while cherry-picking]
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile                 | 32 -------------
+ scripts/Makefile.modinst | 98 +++++++++++++++++++++++++++++++++-------
+ 2 files changed, 81 insertions(+), 49 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 2931104182e7..bf6f6e3074da 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1028,38 +1028,6 @@ export INSTALL_DTBS_PATH ?= $(INSTALL_PATH)/dtbs/$(KERNELRELEASE)
+ MODLIB	= $(INSTALL_MOD_PATH)/lib/modules/$(KERNELRELEASE)
+ export MODLIB
+ 
+-#
+-# INSTALL_MOD_STRIP, if defined, will cause modules to be
+-# stripped after they are installed.  If INSTALL_MOD_STRIP is '1', then
+-# the default option --strip-debug will be used.  Otherwise,
+-# INSTALL_MOD_STRIP value will be used as the options to the strip command.
+-
+-ifdef INSTALL_MOD_STRIP
+-ifeq ($(INSTALL_MOD_STRIP),1)
+-mod_strip_cmd = $(STRIP) --strip-debug
+-else
+-mod_strip_cmd = $(STRIP) $(INSTALL_MOD_STRIP)
+-endif # INSTALL_MOD_STRIP=1
+-else
+-mod_strip_cmd = true
+-endif # INSTALL_MOD_STRIP
+-export mod_strip_cmd
+-
+-# CONFIG_MODULE_COMPRESS, if defined, will cause module to be compressed
+-# after they are installed in agreement with CONFIG_MODULE_COMPRESS_GZIP
+-# or CONFIG_MODULE_COMPRESS_XZ.
+-
+-mod_compress_cmd = true
+-ifdef CONFIG_MODULE_COMPRESS
+-  ifdef CONFIG_MODULE_COMPRESS_GZIP
+-    mod_compress_cmd = $(KGZIP) -n -f
+-  endif # CONFIG_MODULE_COMPRESS_GZIP
+-  ifdef CONFIG_MODULE_COMPRESS_XZ
+-    mod_compress_cmd = $(XZ) -f
+-  endif # CONFIG_MODULE_COMPRESS_XZ
+-endif # CONFIG_MODULE_COMPRESS
+-export mod_compress_cmd
+-
+ ifdef CONFIG_MODULE_SIG_ALL
+ $(eval $(call config_filename,MODULE_SIG_KEY))
+ 
+diff --git a/scripts/Makefile.modinst b/scripts/Makefile.modinst
+index 5a4579e76485..84696ef99df7 100644
+--- a/scripts/Makefile.modinst
++++ b/scripts/Makefile.modinst
+@@ -6,30 +6,94 @@
+ PHONY := __modinst
+ __modinst:
+ 
+-include scripts/Kbuild.include
++include include/config/auto.conf
++include $(srctree)/scripts/Kbuild.include
+ 
+-modules := $(sort $(shell cat $(if $(KBUILD_EXTMOD),$(KBUILD_EXTMOD)/)modules.order))
++modules := $(sort $(shell cat $(MODORDER)))
++
++ifeq ($(KBUILD_EXTMOD),)
++dst := $(MODLIB)/kernel
++else
++INSTALL_MOD_DIR ?= extra
++dst := $(MODLIB)/$(INSTALL_MOD_DIR)
++endif
++
++suffix-y				:=
++suffix-$(CONFIG_MODULE_COMPRESS_GZIP)	:= .gz
++suffix-$(CONFIG_MODULE_COMPRESS_XZ)	:= .xz
++
++modules := $(patsubst $(extmod_prefix)%, $(dst)/%$(suffix-y), $(modules))
+ 
+-PHONY += $(modules)
+ __modinst: $(modules)
+ 	@:
+ 
+-# Don't stop modules_install if we can't sign external modules.
+-quiet_cmd_modules_install = INSTALL $@
+-      cmd_modules_install = \
+-    mkdir -p $(2) ; \
+-    cp $@ $(2) ; \
+-    $(mod_strip_cmd) $(2)/$(notdir $@) ; \
+-    $(mod_sign_cmd) $(2)/$(notdir $@) $(patsubst %,|| true,$(KBUILD_EXTMOD)) ; \
+-    $(mod_compress_cmd) $(2)/$(notdir $@)
++quiet_cmd_none =
++      cmd_none = :
+ 
+-# Modules built outside the kernel source tree go into extra by default
+-INSTALL_MOD_DIR ?= extra
+-ext-mod-dir = $(INSTALL_MOD_DIR)$(subst $(patsubst %/,%,$(KBUILD_EXTMOD)),,$(@D))
++#
++# Installation
++#
++quiet_cmd_install = INSTALL $@
++      cmd_install = mkdir -p $(dir $@); cp $< $@
++
++# Strip
++#
++# INSTALL_MOD_STRIP, if defined, will cause modules to be stripped after they
++# are installed. If INSTALL_MOD_STRIP is '1', then the default option
++# --strip-debug will be used. Otherwise, INSTALL_MOD_STRIP value will be used
++# as the options to the strip command.
++ifdef INSTALL_MOD_STRIP
++
++ifeq ($(INSTALL_MOD_STRIP),1)
++strip-option := --strip-debug
++else
++strip-option := $(INSTALL_MOD_STRIP)
++endif
++
++quiet_cmd_strip = STRIP   $@
++      cmd_strip = $(STRIP) $(strip-option) $@
++
++else
++
++quiet_cmd_strip =
++      cmd_strip = :
++
++endif
++
++#
++# Signing
++# Don't stop modules_install even if we can't sign external modules.
++#
++ifeq ($(CONFIG_MODULE_SIG_ALL),y)
++quiet_cmd_sign = SIGN    $@
++$(eval $(call config_filename,MODULE_SIG_KEY))
++      cmd_sign = scripts/sign-file $(CONFIG_MODULE_SIG_HASH) $(MODULE_SIG_KEY_SRCPREFIX)$(CONFIG_MODULE_SIG_KEY) certs/signing_key.x509 $@ \
++                 $(if $(KBUILD_EXTMOD),|| true)
++else
++quiet_cmd_sign :=
++      cmd_sign := :
++endif
++
++$(dst)/%.ko: $(extmod_prefix)%.ko FORCE
++	$(call cmd,install)
++	$(call cmd,strip)
++	$(call cmd,sign)
++
++#
++# Compression
++#
++quiet_cmd_gzip = GZIP    $@
++      cmd_gzip = $(KGZIP) -n -f $<
++quiet_cmd_xz = XZ      $@
++      cmd_xz = $(XZ) --lzma2=dict=2MiB -f $<
++
++$(dst)/%.ko.gz: $(dst)/%.ko FORCE
++	$(call cmd,gzip)
+ 
+-modinst_dir = $(if $(KBUILD_EXTMOD),$(ext-mod-dir),kernel/$(@D))
++$(dst)/%.ko.xz: $(dst)/%.ko FORCE
++	$(call cmd,xz)
+ 
+-$(modules):
+-	$(call cmd,modules_install,$(MODLIB)/$(modinst_dir))
++PHONY += FORCE
++FORCE:
+ 
+ .PHONY: $(PHONY)
+-- 
+2.30.2
+

--- a/packages/kernel-5.10/2001-kbuild-add-support-for-zstd-compressed-modules.patch
+++ b/packages/kernel-5.10/2001-kbuild-add-support-for-zstd-compressed-modules.patch
@@ -1,0 +1,82 @@
+From 35822be50c3068a660331b82a6d37db42bc78126 Mon Sep 17 00:00:00 2001
+From: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Date: Wed, 7 Apr 2021 18:09:27 +0200
+Subject: [PATCH 2001/2001] kbuild: add support for zstd compressed modules
+
+kmod 28 supports modules compressed in zstd format so let's add this
+possibility to kernel.
+
+Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Reviewed-by: Oleksandr Natalenko <oleksandr@natalenko.name>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+(cherry picked from commit c3d7ef377eb2564b165b1e8fdb4646952c90ac17)
+[fixed a merge conflict in init/Kconfig]
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ init/Kconfig             | 11 +++++++++--
+ scripts/Makefile.modinst |  6 ++++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/init/Kconfig b/init/Kconfig
+index fc4c9f416fad..113481826737 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -2234,8 +2234,9 @@ config MODULE_COMPRESS
+ 	  Out-of-tree kernel modules installed using Kbuild will also be
+ 	  compressed upon installation.
+ 
+-	  Note: for modules inside an initrd or initramfs, it's more efficient
+-	  to compress the whole initrd or initramfs instead.
++	  Please note that the tool used to load modules needs to support the
++	  corresponding algorithm. module-init-tools MAY support gzip, and kmod
++	  MAY support gzip, xz and zstd.
+ 
+ 	  Note: This is fully compatible with signed modules.
+ 
+@@ -2257,6 +2258,12 @@ config MODULE_COMPRESS_GZIP
+ config MODULE_COMPRESS_XZ
+ 	bool "XZ"
+ 
++config MODULE_COMPRESS_ZSTD
++	bool "ZSTD"
++	help
++	  Compress modules with ZSTD. The installed modules are suffixed
++	  with .ko.zst.
++
+ endchoice
+ 
+ config MODULE_ALLOW_MISSING_NAMESPACE_IMPORTS
+diff --git a/scripts/Makefile.modinst b/scripts/Makefile.modinst
+index 84696ef99df7..59f613aa08b4 100644
+--- a/scripts/Makefile.modinst
++++ b/scripts/Makefile.modinst
+@@ -21,6 +21,7 @@ endif
+ suffix-y				:=
+ suffix-$(CONFIG_MODULE_COMPRESS_GZIP)	:= .gz
+ suffix-$(CONFIG_MODULE_COMPRESS_XZ)	:= .xz
++suffix-$(CONFIG_MODULE_COMPRESS_ZSTD)	:= .zst
+ 
+ modules := $(patsubst $(extmod_prefix)%, $(dst)/%$(suffix-y), $(modules))
+ 
+@@ -86,6 +87,8 @@ quiet_cmd_gzip = GZIP    $@
+       cmd_gzip = $(KGZIP) -n -f $<
+ quiet_cmd_xz = XZ      $@
+       cmd_xz = $(XZ) --lzma2=dict=2MiB -f $<
++quiet_cmd_zstd = ZSTD    $@
++      cmd_zstd = $(ZSTD) -T0 --rm -f -q $<
+ 
+ $(dst)/%.ko.gz: $(dst)/%.ko FORCE
+ 	$(call cmd,gzip)
+@@ -93,6 +96,9 @@ $(dst)/%.ko.gz: $(dst)/%.ko FORCE
+ $(dst)/%.ko.xz: $(dst)/%.ko FORCE
+ 	$(call cmd,xz)
+ 
++$(dst)/%.ko.zst: $(dst)/%.ko FORCE
++	$(call cmd,zstd)
++
+ PHONY += FORCE
+ FORCE:
+ 
+-- 
+2.30.2
+

--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -61,3 +61,14 @@ CONFIG_DEBUG_INFO_BTF=y
 # We don't want to extend the kernel command line with any upstream defaults;
 # Bottlerocket uses a fairly custom setup that needs tight control over it.
 CONFIG_CMDLINE_EXTEND=n
+
+# Enable ZSTD kernel image compression
+CONFIG_HAVE_KERNEL_ZSTD=y
+CONFIG_KERNEL_ZSTD=y
+CONFIG_ZSTD_COMPRESS=y
+CONFIG_ZSTD_DECOMPRESS=y
+CONFIG_DECOMPRESS_ZSTD=y
+
+# Enable ZSTD modules compression
+CONFIG_MODULE_COMPRESS=y
+CONFIG_MODULE_COMPRESS_ZSTD=y

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -12,6 +12,9 @@ Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
+# Add zstd support for compressed kernel modules
+Patch2000: 2000-kbuild-move-module-strip-compression-code-into-scrip.patch
+Patch2001: 2001-kbuild-add-support-for-zstd-compressed-modules.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-5.4/2000-lib-Prepare-zstd-for-preboot-environment-improve-per.patch
+++ b/packages/kernel-5.4/2000-lib-Prepare-zstd-for-preboot-environment-improve-per.patch
@@ -1,0 +1,101 @@
+From bd475ee90b2b4ce6eae2ccbb5ef214557e937145 Mon Sep 17 00:00:00 2001
+From: Nick Terrell <terrelln@fb.com>
+Date: Thu, 30 Jul 2020 12:08:34 -0700
+Subject: [PATCH 2000/2007] lib: Prepare zstd for preboot environment, improve
+ performance
+
+These changes are necessary to get the build to work in the preboot
+environment, and to get reasonable performance:
+
+- Remove a double definition of the CHECK_F macro when the zstd
+  library is amalgamated.
+
+- Switch ZSTD_copy8() to __builtin_memcpy(), because in the preboot
+  environment on x86 gcc can't inline `memcpy()` otherwise.
+
+- Limit the gcc hack in ZSTD_wildcopy() to the broken gcc version. See
+  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81388.
+
+ZSTD_copy8() and ZSTD_wildcopy() are in the core of the zstd hot loop.
+So outlining these calls to memcpy(), and having an extra branch are very
+detrimental to performance.
+
+Signed-off-by: Nick Terrell <terrelln@fb.com>
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Link: https://lore.kernel.org/r/20200730190841.2071656-2-nickrterrell@gmail.com
+(cherry picked from commit 6d25a633ea68a103c7293d16eb69a7d4689075ad)
+---
+ lib/zstd/fse_decompress.c |  9 +--------
+ lib/zstd/zstd_internal.h  | 14 ++++++++++++--
+ 2 files changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/lib/zstd/fse_decompress.c b/lib/zstd/fse_decompress.c
+index a84300e5a013..0b353530fb3f 100644
+--- a/lib/zstd/fse_decompress.c
++++ b/lib/zstd/fse_decompress.c
+@@ -47,6 +47,7 @@
+ ****************************************************************/
+ #include "bitstream.h"
+ #include "fse.h"
++#include "zstd_internal.h"
+ #include <linux/compiler.h>
+ #include <linux/kernel.h>
+ #include <linux/string.h> /* memcpy, memset */
+@@ -60,14 +61,6 @@
+ 		enum { FSE_static_assert = 1 / (int)(!!(c)) }; \
+ 	} /* use only *after* variable declarations */
+ 
+-/* check and forward error code */
+-#define CHECK_F(f)                  \
+-	{                           \
+-		size_t const e = f; \
+-		if (FSE_isError(e)) \
+-			return e;   \
+-	}
+-
+ /* **************************************************************
+ *  Templates
+ ****************************************************************/
+diff --git a/lib/zstd/zstd_internal.h b/lib/zstd/zstd_internal.h
+index 1a79fab9e13a..dac753397f86 100644
+--- a/lib/zstd/zstd_internal.h
++++ b/lib/zstd/zstd_internal.h
+@@ -127,7 +127,14 @@ static const U32 OF_defaultNormLog = OF_DEFAULTNORMLOG;
+ *  Shared functions to include for inlining
+ *********************************************/
+ ZSTD_STATIC void ZSTD_copy8(void *dst, const void *src) {
+-	memcpy(dst, src, 8);
++	/*
++	 * zstd relies heavily on gcc being able to analyze and inline this
++	 * memcpy() call, since it is called in a tight loop. Preboot mode
++	 * is compiled in freestanding mode, which stops gcc from analyzing
++	 * memcpy(). Use __builtin_memcpy() to tell gcc to analyze this as a
++	 * regular memcpy().
++	 */
++	__builtin_memcpy(dst, src, 8);
+ }
+ /*! ZSTD_wildcopy() :
+ *   custom version of memcpy(), can copy up to 7 bytes too many (8 bytes if length==0) */
+@@ -137,13 +144,16 @@ ZSTD_STATIC void ZSTD_wildcopy(void *dst, const void *src, ptrdiff_t length)
+ 	const BYTE* ip = (const BYTE*)src;
+ 	BYTE* op = (BYTE*)dst;
+ 	BYTE* const oend = op + length;
+-	/* Work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81388.
++#if defined(GCC_VERSION) && GCC_VERSION >= 70000 && GCC_VERSION < 70200
++	/*
++	 * Work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81388.
+ 	 * Avoid the bad case where the loop only runs once by handling the
+ 	 * special case separately. This doesn't trigger the bug because it
+ 	 * doesn't involve pointer/integer overflow.
+ 	 */
+ 	if (length <= 8)
+ 		return ZSTD_copy8(dst, src);
++#endif
+ 	do {
+ 		ZSTD_copy8(op, ip);
+ 		op += 8;
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/2001-lib-Add-zstd-support-to-decompress.patch
+++ b/packages/kernel-5.4/2001-lib-Add-zstd-support-to-decompress.patch
@@ -1,0 +1,460 @@
+From 30ff8b18827f5fc6c31808a5868324867688cbdd Mon Sep 17 00:00:00 2001
+From: Nick Terrell <terrelln@fb.com>
+Date: Thu, 30 Jul 2020 12:08:35 -0700
+Subject: [PATCH 2001/2007] lib: Add zstd support to decompress
+
+- Add unzstd() and the zstd decompress interface.
+
+- Add zstd support to decompress_method().
+
+The decompress_method() and unzstd() functions are used to decompress
+the initramfs and the initrd. The __decompress() function is used in
+the preboot environment to decompress a zstd compressed kernel.
+
+The zstd decompression function allows the input and output buffers to
+overlap because that is used by x86 kernel decompression.
+
+Signed-off-by: Nick Terrell <terrelln@fb.com>
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Link: https://lore.kernel.org/r/20200730190841.2071656-3-nickrterrell@gmail.com
+(cherry picked from commit 4963bb2b89884bbdb7e33e6a09c159551e9627aa)
+---
+ include/linux/decompress/unzstd.h |  11 +
+ lib/Kconfig                       |   4 +
+ lib/Makefile                      |   1 +
+ lib/decompress.c                  |   5 +
+ lib/decompress_unzstd.c           | 345 ++++++++++++++++++++++++++++++
+ 5 files changed, 366 insertions(+)
+ create mode 100644 include/linux/decompress/unzstd.h
+ create mode 100644 lib/decompress_unzstd.c
+
+diff --git a/include/linux/decompress/unzstd.h b/include/linux/decompress/unzstd.h
+new file mode 100644
+index 000000000000..56d539ae880f
+--- /dev/null
++++ b/include/linux/decompress/unzstd.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef LINUX_DECOMPRESS_UNZSTD_H
++#define LINUX_DECOMPRESS_UNZSTD_H
++
++int unzstd(unsigned char *inbuf, long len,
++	   long (*fill)(void*, unsigned long),
++	   long (*flush)(void*, unsigned long),
++	   unsigned char *output,
++	   long *pos,
++	   void (*error_fn)(char *x));
++#endif
+diff --git a/lib/Kconfig b/lib/Kconfig
+index 3321d04dfa5a..ad33691e129c 100644
+--- a/lib/Kconfig
++++ b/lib/Kconfig
+@@ -329,6 +329,10 @@ config DECOMPRESS_LZ4
+ 	select LZ4_DECOMPRESS
+ 	tristate
+ 
++config DECOMPRESS_ZSTD
++	select ZSTD_DECOMPRESS
++	tristate
++
+ #
+ # Generic allocator support is selected if needed
+ #
+diff --git a/lib/Makefile b/lib/Makefile
+index 6bf453fb731d..f948c1f6534d 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -157,6 +157,7 @@ lib-$(CONFIG_DECOMPRESS_LZMA) += decompress_unlzma.o
+ lib-$(CONFIG_DECOMPRESS_XZ) += decompress_unxz.o
+ lib-$(CONFIG_DECOMPRESS_LZO) += decompress_unlzo.o
+ lib-$(CONFIG_DECOMPRESS_LZ4) += decompress_unlz4.o
++lib-$(CONFIG_DECOMPRESS_ZSTD) += decompress_unzstd.o
+ 
+ obj-$(CONFIG_TEXTSEARCH) += textsearch.o
+ obj-$(CONFIG_TEXTSEARCH_KMP) += ts_kmp.o
+diff --git a/lib/decompress.c b/lib/decompress.c
+index 857ab1af1ef3..ab3fc90ffc64 100644
+--- a/lib/decompress.c
++++ b/lib/decompress.c
+@@ -13,6 +13,7 @@
+ #include <linux/decompress/inflate.h>
+ #include <linux/decompress/unlzo.h>
+ #include <linux/decompress/unlz4.h>
++#include <linux/decompress/unzstd.h>
+ 
+ #include <linux/types.h>
+ #include <linux/string.h>
+@@ -37,6 +38,9 @@
+ #ifndef CONFIG_DECOMPRESS_LZ4
+ # define unlz4 NULL
+ #endif
++#ifndef CONFIG_DECOMPRESS_ZSTD
++# define unzstd NULL
++#endif
+ 
+ struct compress_format {
+ 	unsigned char magic[2];
+@@ -52,6 +56,7 @@ static const struct compress_format compressed_formats[] __initconst = {
+ 	{ {0xfd, 0x37}, "xz", unxz },
+ 	{ {0x89, 0x4c}, "lzo", unlzo },
+ 	{ {0x02, 0x21}, "lz4", unlz4 },
++	{ {0x28, 0xb5}, "zstd", unzstd },
+ 	{ {0, 0}, NULL, NULL }
+ };
+ 
+diff --git a/lib/decompress_unzstd.c b/lib/decompress_unzstd.c
+new file mode 100644
+index 000000000000..0ad2c15479ed
+--- /dev/null
++++ b/lib/decompress_unzstd.c
+@@ -0,0 +1,345 @@
++// SPDX-License-Identifier: GPL-2.0
++
++/*
++ * Important notes about in-place decompression
++ *
++ * At least on x86, the kernel is decompressed in place: the compressed data
++ * is placed to the end of the output buffer, and the decompressor overwrites
++ * most of the compressed data. There must be enough safety margin to
++ * guarantee that the write position is always behind the read position.
++ *
++ * The safety margin for ZSTD with a 128 KB block size is calculated below.
++ * Note that the margin with ZSTD is bigger than with GZIP or XZ!
++ *
++ * The worst case for in-place decompression is that the beginning of
++ * the file is compressed extremely well, and the rest of the file is
++ * uncompressible. Thus, we must look for worst-case expansion when the
++ * compressor is encoding uncompressible data.
++ *
++ * The structure of the .zst file in case of a compresed kernel is as follows.
++ * Maximum sizes (as bytes) of the fields are in parenthesis.
++ *
++ *    Frame Header: (18)
++ *    Blocks: (N)
++ *    Checksum: (4)
++ *
++ * The frame header and checksum overhead is at most 22 bytes.
++ *
++ * ZSTD stores the data in blocks. Each block has a header whose size is
++ * a 3 bytes. After the block header, there is up to 128 KB of payload.
++ * The maximum uncompressed size of the payload is 128 KB. The minimum
++ * uncompressed size of the payload is never less than the payload size
++ * (excluding the block header).
++ *
++ * The assumption, that the uncompressed size of the payload is never
++ * smaller than the payload itself, is valid only when talking about
++ * the payload as a whole. It is possible that the payload has parts where
++ * the decompressor consumes more input than it produces output. Calculating
++ * the worst case for this would be tricky. Instead of trying to do that,
++ * let's simply make sure that the decompressor never overwrites any bytes
++ * of the payload which it is currently reading.
++ *
++ * Now we have enough information to calculate the safety margin. We need
++ *   - 22 bytes for the .zst file format headers;
++ *   - 3 bytes per every 128 KiB of uncompressed size (one block header per
++ *     block); and
++ *   - 128 KiB (biggest possible zstd block size) to make sure that the
++ *     decompressor never overwrites anything from the block it is currently
++ *     reading.
++ *
++ * We get the following formula:
++ *
++ *    safety_margin = 22 + uncompressed_size * 3 / 131072 + 131072
++ *                 <= 22 + (uncompressed_size >> 15) + 131072
++ */
++
++/*
++ * Preboot environments #include "path/to/decompress_unzstd.c".
++ * All of the source files we depend on must be #included.
++ * zstd's only source dependeny is xxhash, which has no source
++ * dependencies.
++ *
++ * When UNZSTD_PREBOOT is defined we declare __decompress(), which is
++ * used for kernel decompression, instead of unzstd().
++ *
++ * Define __DISABLE_EXPORTS in preboot environments to prevent symbols
++ * from xxhash and zstd from being exported by the EXPORT_SYMBOL macro.
++ */
++#ifdef STATIC
++# define UNZSTD_PREBOOT
++# include "xxhash.c"
++# include "zstd/entropy_common.c"
++# include "zstd/fse_decompress.c"
++# include "zstd/huf_decompress.c"
++# include "zstd/zstd_common.c"
++# include "zstd/decompress.c"
++#endif
++
++#include <linux/decompress/mm.h>
++#include <linux/kernel.h>
++#include <linux/zstd.h>
++
++/* 128MB is the maximum window size supported by zstd. */
++#define ZSTD_WINDOWSIZE_MAX	(1 << ZSTD_WINDOWLOG_MAX)
++/*
++ * Size of the input and output buffers in multi-call mode.
++ * Pick a larger size because it isn't used during kernel decompression,
++ * since that is single pass, and we have to allocate a large buffer for
++ * zstd's window anyway. The larger size speeds up initramfs decompression.
++ */
++#define ZSTD_IOBUF_SIZE		(1 << 17)
++
++static int INIT handle_zstd_error(size_t ret, void (*error)(char *x))
++{
++	const int err = ZSTD_getErrorCode(ret);
++
++	if (!ZSTD_isError(ret))
++		return 0;
++
++	switch (err) {
++	case ZSTD_error_memory_allocation:
++		error("ZSTD decompressor ran out of memory");
++		break;
++	case ZSTD_error_prefix_unknown:
++		error("Input is not in the ZSTD format (wrong magic bytes)");
++		break;
++	case ZSTD_error_dstSize_tooSmall:
++	case ZSTD_error_corruption_detected:
++	case ZSTD_error_checksum_wrong:
++		error("ZSTD-compressed data is corrupt");
++		break;
++	default:
++		error("ZSTD-compressed data is probably corrupt");
++		break;
++	}
++	return -1;
++}
++
++/*
++ * Handle the case where we have the entire input and output in one segment.
++ * We can allocate less memory (no circular buffer for the sliding window),
++ * and avoid some memcpy() calls.
++ */
++static int INIT decompress_single(const u8 *in_buf, long in_len, u8 *out_buf,
++				  long out_len, long *in_pos,
++				  void (*error)(char *x))
++{
++	const size_t wksp_size = ZSTD_DCtxWorkspaceBound();
++	void *wksp = large_malloc(wksp_size);
++	ZSTD_DCtx *dctx = ZSTD_initDCtx(wksp, wksp_size);
++	int err;
++	size_t ret;
++
++	if (dctx == NULL) {
++		error("Out of memory while allocating ZSTD_DCtx");
++		err = -1;
++		goto out;
++	}
++	/*
++	 * Find out how large the frame actually is, there may be junk at
++	 * the end of the frame that ZSTD_decompressDCtx() can't handle.
++	 */
++	ret = ZSTD_findFrameCompressedSize(in_buf, in_len);
++	err = handle_zstd_error(ret, error);
++	if (err)
++		goto out;
++	in_len = (long)ret;
++
++	ret = ZSTD_decompressDCtx(dctx, out_buf, out_len, in_buf, in_len);
++	err = handle_zstd_error(ret, error);
++	if (err)
++		goto out;
++
++	if (in_pos != NULL)
++		*in_pos = in_len;
++
++	err = 0;
++out:
++	if (wksp != NULL)
++		large_free(wksp);
++	return err;
++}
++
++static int INIT __unzstd(unsigned char *in_buf, long in_len,
++			 long (*fill)(void*, unsigned long),
++			 long (*flush)(void*, unsigned long),
++			 unsigned char *out_buf, long out_len,
++			 long *in_pos,
++			 void (*error)(char *x))
++{
++	ZSTD_inBuffer in;
++	ZSTD_outBuffer out;
++	ZSTD_frameParams params;
++	void *in_allocated = NULL;
++	void *out_allocated = NULL;
++	void *wksp = NULL;
++	size_t wksp_size;
++	ZSTD_DStream *dstream;
++	int err;
++	size_t ret;
++
++	if (out_len == 0)
++		out_len = LONG_MAX; /* no limit */
++
++	if (fill == NULL && flush == NULL)
++		/*
++		 * We can decompress faster and with less memory when we have a
++		 * single chunk.
++		 */
++		return decompress_single(in_buf, in_len, out_buf, out_len,
++					 in_pos, error);
++
++	/*
++	 * If in_buf is not provided, we must be using fill(), so allocate
++	 * a large enough buffer. If it is provided, it must be at least
++	 * ZSTD_IOBUF_SIZE large.
++	 */
++	if (in_buf == NULL) {
++		in_allocated = large_malloc(ZSTD_IOBUF_SIZE);
++		if (in_allocated == NULL) {
++			error("Out of memory while allocating input buffer");
++			err = -1;
++			goto out;
++		}
++		in_buf = in_allocated;
++		in_len = 0;
++	}
++	/* Read the first chunk, since we need to decode the frame header. */
++	if (fill != NULL)
++		in_len = fill(in_buf, ZSTD_IOBUF_SIZE);
++	if (in_len < 0) {
++		error("ZSTD-compressed data is truncated");
++		err = -1;
++		goto out;
++	}
++	/* Set the first non-empty input buffer. */
++	in.src = in_buf;
++	in.pos = 0;
++	in.size = in_len;
++	/* Allocate the output buffer if we are using flush(). */
++	if (flush != NULL) {
++		out_allocated = large_malloc(ZSTD_IOBUF_SIZE);
++		if (out_allocated == NULL) {
++			error("Out of memory while allocating output buffer");
++			err = -1;
++			goto out;
++		}
++		out_buf = out_allocated;
++		out_len = ZSTD_IOBUF_SIZE;
++	}
++	/* Set the output buffer. */
++	out.dst = out_buf;
++	out.pos = 0;
++	out.size = out_len;
++
++	/*
++	 * We need to know the window size to allocate the ZSTD_DStream.
++	 * Since we are streaming, we need to allocate a buffer for the sliding
++	 * window. The window size varies from 1 KB to ZSTD_WINDOWSIZE_MAX
++	 * (8 MB), so it is important to use the actual value so as not to
++	 * waste memory when it is smaller.
++	 */
++	ret = ZSTD_getFrameParams(&params, in.src, in.size);
++	err = handle_zstd_error(ret, error);
++	if (err)
++		goto out;
++	if (ret != 0) {
++		error("ZSTD-compressed data has an incomplete frame header");
++		err = -1;
++		goto out;
++	}
++	if (params.windowSize > ZSTD_WINDOWSIZE_MAX) {
++		error("ZSTD-compressed data has too large a window size");
++		err = -1;
++		goto out;
++	}
++
++	/*
++	 * Allocate the ZSTD_DStream now that we know how much memory is
++	 * required.
++	 */
++	wksp_size = ZSTD_DStreamWorkspaceBound(params.windowSize);
++	wksp = large_malloc(wksp_size);
++	dstream = ZSTD_initDStream(params.windowSize, wksp, wksp_size);
++	if (dstream == NULL) {
++		error("Out of memory while allocating ZSTD_DStream");
++		err = -1;
++		goto out;
++	}
++
++	/*
++	 * Decompression loop:
++	 * Read more data if necessary (error if no more data can be read).
++	 * Call the decompression function, which returns 0 when finished.
++	 * Flush any data produced if using flush().
++	 */
++	if (in_pos != NULL)
++		*in_pos = 0;
++	do {
++		/*
++		 * If we need to reload data, either we have fill() and can
++		 * try to get more data, or we don't and the input is truncated.
++		 */
++		if (in.pos == in.size) {
++			if (in_pos != NULL)
++				*in_pos += in.pos;
++			in_len = fill ? fill(in_buf, ZSTD_IOBUF_SIZE) : -1;
++			if (in_len < 0) {
++				error("ZSTD-compressed data is truncated");
++				err = -1;
++				goto out;
++			}
++			in.pos = 0;
++			in.size = in_len;
++		}
++		/* Returns zero when the frame is complete. */
++		ret = ZSTD_decompressStream(dstream, &out, &in);
++		err = handle_zstd_error(ret, error);
++		if (err)
++			goto out;
++		/* Flush all of the data produced if using flush(). */
++		if (flush != NULL && out.pos > 0) {
++			if (out.pos != flush(out.dst, out.pos)) {
++				error("Failed to flush()");
++				err = -1;
++				goto out;
++			}
++			out.pos = 0;
++		}
++	} while (ret != 0);
++
++	if (in_pos != NULL)
++		*in_pos += in.pos;
++
++	err = 0;
++out:
++	if (in_allocated != NULL)
++		large_free(in_allocated);
++	if (out_allocated != NULL)
++		large_free(out_allocated);
++	if (wksp != NULL)
++		large_free(wksp);
++	return err;
++}
++
++#ifndef UNZSTD_PREBOOT
++STATIC int INIT unzstd(unsigned char *buf, long len,
++		       long (*fill)(void*, unsigned long),
++		       long (*flush)(void*, unsigned long),
++		       unsigned char *out_buf,
++		       long *pos,
++		       void (*error)(char *x))
++{
++	return __unzstd(buf, len, fill, flush, out_buf, 0, pos, error);
++}
++#else
++STATIC int INIT __decompress(unsigned char *buf, long len,
++			     long (*fill)(void*, unsigned long),
++			     long (*flush)(void*, unsigned long),
++			     unsigned char *out_buf, long out_len,
++			     long *pos,
++			     void (*error)(char *x))
++{
++	return __unzstd(buf, len, fill, flush, out_buf, out_len, pos, error);
++}
++#endif
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/2002-init-Add-support-for-zstd-compressed-kernel.patch
+++ b/packages/kernel-5.4/2002-init-Add-support-for-zstd-compressed-kernel.patch
@@ -1,0 +1,119 @@
+From 306c3246fc07136e55747b9d4016e043bb77b00a Mon Sep 17 00:00:00 2001
+From: Nick Terrell <terrelln@fb.com>
+Date: Thu, 30 Jul 2020 12:08:36 -0700
+Subject: [PATCH 2002/2007] init: Add support for zstd compressed kernel
+
+- Add the zstd and zstd22 cmds to scripts/Makefile.lib
+
+- Add the HAVE_KERNEL_ZSTD and KERNEL_ZSTD options
+
+Architecture specific support is still needed for decompression.
+
+Signed-off-by: Nick Terrell <terrelln@fb.com>
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Link: https://lore.kernel.org/r/20200730190841.2071656-4-nickrterrell@gmail.com
+(cherry picked from commit 48f7ddf785af24aa380f3282d8d4400883d0099e)
+---
+ Makefile             |  3 ++-
+ init/Kconfig         | 15 ++++++++++++++-
+ scripts/Makefile.lib | 22 ++++++++++++++++++++++
+ 3 files changed, 38 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index e51077a8080d..3f593214a087 100644
+--- a/Makefile
++++ b/Makefile
+@@ -448,6 +448,7 @@ KLZOP		= lzop
+ LZMA		= lzma
+ LZ4		= lz4c
+ XZ		= xz
++ZSTD		= zstd
+ 
+ CHECKFLAGS     := -D__linux__ -Dlinux -D__STDC__ -Dunix -D__unix__ \
+ 		  -Wbitwise -Wno-return-void -Wno-unknown-attribute $(CF)
+@@ -496,7 +497,7 @@ CLANG_FLAGS :=
+ export ARCH SRCARCH CONFIG_SHELL BASH HOSTCC KBUILD_HOSTCFLAGS CROSS_COMPILE LD CC
+ export CPP AR NM STRIP OBJCOPY OBJDUMP OBJSIZE READELF PAHOLE LEX YACC AWK INSTALLKERNEL
+ export PERL PYTHON PYTHON3 CHECK CHECKFLAGS MAKE UTS_MACHINE HOSTCXX
+-export KGZIP KBZIP2 KLZOP LZMA LZ4 XZ
++export KGZIP KBZIP2 KLZOP LZMA LZ4 XZ ZSTD
+ export KBUILD_HOSTCXXFLAGS KBUILD_HOSTLDFLAGS KBUILD_HOSTLDLIBS LDFLAGS_MODULE
+ 
+ export KBUILD_CPPFLAGS NOSTDINC_FLAGS LINUXINCLUDE OBJCOPYFLAGS KBUILD_LDFLAGS
+diff --git a/init/Kconfig b/init/Kconfig
+index f23e90d9935f..4dc3ea198a2c 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -159,13 +159,16 @@ config HAVE_KERNEL_LZO
+ config HAVE_KERNEL_LZ4
+ 	bool
+ 
++config HAVE_KERNEL_ZSTD
++	bool
++
+ config HAVE_KERNEL_UNCOMPRESSED
+ 	bool
+ 
+ choice
+ 	prompt "Kernel compression mode"
+ 	default KERNEL_GZIP
+-	depends on HAVE_KERNEL_GZIP || HAVE_KERNEL_BZIP2 || HAVE_KERNEL_LZMA || HAVE_KERNEL_XZ || HAVE_KERNEL_LZO || HAVE_KERNEL_LZ4 || HAVE_KERNEL_UNCOMPRESSED
++	depends on HAVE_KERNEL_GZIP || HAVE_KERNEL_BZIP2 || HAVE_KERNEL_LZMA || HAVE_KERNEL_XZ || HAVE_KERNEL_LZO || HAVE_KERNEL_LZ4 || HAVE_KERNEL_ZSTD || HAVE_KERNEL_UNCOMPRESSED
+ 	help
+ 	  The linux kernel is a kind of self-extracting executable.
+ 	  Several compression algorithms are available, which differ
+@@ -244,6 +247,16 @@ config KERNEL_LZ4
+ 	  is about 8% bigger than LZO. But the decompression speed is
+ 	  faster than LZO.
+ 
++config KERNEL_ZSTD
++	bool "ZSTD"
++	depends on HAVE_KERNEL_ZSTD
++	help
++	  ZSTD is a compression algorithm targeting intermediate compression
++	  with fast decompression speed. It will compress better than GZIP and
++	  decompress around the same speed as LZO, but slower than LZ4. You
++	  will need at least 192 KB RAM or more for booting. The zstd command
++	  line tool is required for compression.
++
+ config KERNEL_UNCOMPRESSED
+ 	bool "None"
+ 	depends on HAVE_KERNEL_UNCOMPRESSED
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index a6d0044328b1..698b58774ed7 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -383,6 +383,28 @@ quiet_cmd_xzkern = XZKERN  $@
+ quiet_cmd_xzmisc = XZMISC  $@
+       cmd_xzmisc = cat $(real-prereqs) | $(XZ) --check=crc32 --lzma2=dict=1MiB > $@
+ 
++# ZSTD
++# ---------------------------------------------------------------------------
++# Appends the uncompressed size of the data using size_append. The .zst
++# format has the size information available at the beginning of the file too,
++# but it's in a more complex format and it's good to avoid changing the part
++# of the boot code that reads the uncompressed size.
++#
++# Note that the bytes added by size_append will make the zstd tool think that
++# the file is corrupt. This is expected.
++#
++# zstd uses a maximum window size of 8 MB. zstd22 uses a maximum window size of
++# 128 MB. zstd22 is used for kernel compression because it is decompressed in a
++# single pass, so zstd doesn't need to allocate a window buffer. When streaming
++# decompression is used, like initramfs decompression, zstd22 should likely not
++# be used because it would require zstd to allocate a 128 MB buffer.
++
++quiet_cmd_zstd = ZSTD    $@
++      cmd_zstd = { cat $(real-prereqs) | $(ZSTD) -19; $(size_append); } > $@
++
++quiet_cmd_zstd22 = ZSTD22  $@
++      cmd_zstd22 = { cat $(real-prereqs) | $(ZSTD) -22 --ultra; $(size_append); } > $@
++
+ # ASM offsets
+ # ---------------------------------------------------------------------------
+ 
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/2003-x86-Bump-ZO_z_extra_bytes-margin-for-zstd.patch
+++ b/packages/kernel-5.4/2003-x86-Bump-ZO_z_extra_bytes-margin-for-zstd.patch
@@ -1,0 +1,50 @@
+From 66cad5025a1bbd5a2dec72f706c293ee6ff59243 Mon Sep 17 00:00:00 2001
+From: Nick Terrell <terrelln@fb.com>
+Date: Thu, 30 Jul 2020 12:08:38 -0700
+Subject: [PATCH 2003/2007] x86: Bump ZO_z_extra_bytes margin for zstd
+
+Bump the ZO_z_extra_bytes margin for zstd.
+
+Zstd needs 3 bytes per 128 KB, and has a 22 byte fixed overhead.
+Zstd needs to maintain 128 KB of space at all times, since that is
+the maximum block size. See the comments regarding in-place
+decompression added in lib/decompress_unzstd.c for details.
+
+The existing code is written so that all the compression algorithms use
+the same ZO_z_extra_bytes. It is taken to be the maximum of the growth
+rate plus the maximum fixed overhead. The comments just above this diff
+state that:
+
+Signed-off-by: Nick Terrell <terrelln@fb.com>
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Link: https://lore.kernel.org/r/20200730190841.2071656-6-nickrterrell@gmail.com
+(cherry picked from commit 0fe4f4ef8cc8e15a8f29f08f4be6128395f125f6)
+---
+ arch/x86/boot/header.S | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/arch/x86/boot/header.S b/arch/x86/boot/header.S
+index 2c11c0f45d49..1382b7bb73d2 100644
+--- a/arch/x86/boot/header.S
++++ b/arch/x86/boot/header.S
+@@ -536,8 +536,14 @@ pref_address:		.quad LOAD_PHYSICAL_ADDR	# preferred load addr
+ # the size-dependent part now grows so fast.
+ #
+ # extra_bytes = (uncompressed_size >> 8) + 65536
++#
++# ZSTD compressed data grows by at most 3 bytes per 128K, and only has a 22
++# byte fixed overhead but has a maximum block size of 128K, so it needs a
++# larger margin.
++#
++# extra_bytes = (uncompressed_size >> 8) + 131072
+ 
+-#define ZO_z_extra_bytes	((ZO_z_output_len >> 8) + 65536)
++#define ZO_z_extra_bytes	((ZO_z_output_len >> 8) + 131072)
+ #if ZO_z_output_len > ZO_z_input_len
+ # define ZO_z_extract_offset	(ZO_z_output_len + ZO_z_extra_bytes - \
+ 				 ZO_z_input_len)
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/2004-x86-Add-support-for-ZSTD-compressed-kernel.patch
+++ b/packages/kernel-5.4/2004-x86-Add-support-for-ZSTD-compressed-kernel.patch
@@ -1,0 +1,175 @@
+From 31714e3795c54f31f7edbfb1bf1808ab12439347 Mon Sep 17 00:00:00 2001
+From: Nick Terrell <terrelln@fb.com>
+Date: Thu, 30 Jul 2020 12:08:39 -0700
+Subject: [PATCH 2004/2007] x86: Add support for ZSTD compressed kernel
+
+- Add support for zstd compressed kernel
+
+- Define __DISABLE_EXPORTS in Makefile
+
+- Remove __DISABLE_EXPORTS definition from kaslr.c
+
+- Bump the heap size for zstd.
+
+- Update the documentation.
+
+Integrates the ZSTD decompression code to the x86 pre-boot code.
+
+Zstandard requires slightly more memory during the kernel decompression
+on x86 (192 KB vs 64 KB), and the memory usage is independent of the
+window size.
+
+__DISABLE_EXPORTS is now defined in the Makefile, which covers both
+the existing use in kaslr.c, and the use needed by the zstd decompressor
+in misc.c.
+
+This patch has been boot tested with both a zstd and gzip compressed
+kernel on i386 and x86_64 using buildroot and QEMU.
+
+Additionally, this has been tested in production on x86_64 devices.
+We saw a 2 second boot time reduction by switching kernel compression
+from xz to zstd.
+
+Signed-off-by: Nick Terrell <terrelln@fb.com>
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Link: https://lore.kernel.org/r/20200730190841.2071656-7-nickrterrell@gmail.com
+(cherry picked from commit fb46d057db824693994b048d3a8c869892afaa3f)
+[fixed merge conflict in arch/x86/boot/compressed/Makefile]
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Documentation/x86/boot.rst        |  6 +++---
+ arch/x86/Kconfig                  |  1 +
+ arch/x86/boot/compressed/Makefile |  6 +++++-
+ arch/x86/boot/compressed/kaslr.c  |  7 -------
+ arch/x86/boot/compressed/misc.c   |  4 ++++
+ arch/x86/include/asm/boot.h       | 11 +++++++++--
+ 6 files changed, 22 insertions(+), 13 deletions(-)
+
+diff --git a/Documentation/x86/boot.rst b/Documentation/x86/boot.rst
+index 08a2f100c0e6..4e6b8ee2978e 100644
+--- a/Documentation/x86/boot.rst
++++ b/Documentation/x86/boot.rst
+@@ -767,9 +767,9 @@ Protocol:	2.08+
+   uncompressed data should be determined using the standard magic
+   numbers.  The currently supported compression formats are gzip
+   (magic numbers 1F 8B or 1F 9E), bzip2 (magic number 42 5A), LZMA
+-  (magic number 5D 00), XZ (magic number FD 37), and LZ4 (magic number
+-  02 21).  The uncompressed payload is currently always ELF (magic
+-  number 7F 45 4C 46).
++  (magic number 5D 00), XZ (magic number FD 37), LZ4 (magic number
++  02 21) and ZSTD (magic number 28 B5). The uncompressed payload is
++  currently always ELF (magic number 7F 45 4C 46).
+ 
+ ============	==============
+ Field name:	payload_length
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index 36a28b9e46cb..9e7067cdebbf 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -179,6 +179,7 @@ config X86
+ 	select HAVE_KERNEL_LZMA
+ 	select HAVE_KERNEL_LZO
+ 	select HAVE_KERNEL_XZ
++	select HAVE_KERNEL_ZSTD
+ 	select HAVE_KPROBES
+ 	select HAVE_KPROBES_ON_FTRACE
+ 	select HAVE_FUNCTION_ERROR_INJECTION
+diff --git a/arch/x86/boot/compressed/Makefile b/arch/x86/boot/compressed/Makefile
+index 292b5bc6e3a3..dfe6782d76db 100644
+--- a/arch/x86/boot/compressed/Makefile
++++ b/arch/x86/boot/compressed/Makefile
+@@ -24,7 +24,7 @@ OBJECT_FILES_NON_STANDARD	:= y
+ KCOV_INSTRUMENT		:= n
+ 
+ targets := vmlinux vmlinux.bin vmlinux.bin.gz vmlinux.bin.bz2 vmlinux.bin.lzma \
+-	vmlinux.bin.xz vmlinux.bin.lzo vmlinux.bin.lz4
++	vmlinux.bin.xz vmlinux.bin.lzo vmlinux.bin.lz4 vmlinux.bin.zst
+ 
+ KBUILD_CFLAGS := -m$(BITS) -O2
+ KBUILD_CFLAGS += -fno-strict-aliasing $(call cc-option, -fPIE, -fPIC)
+@@ -40,6 +40,7 @@ KBUILD_CFLAGS += $(call cc-disable-warning, gnu)
+ KBUILD_CFLAGS += -Wno-pointer-sign
+ # Disable relocation relaxation in case the link is not PIE.
+ KBUILD_CFLAGS += $(call as-option,-Wa$(comma)-mrelax-relocations=no)
++KBUILD_CFLAGS += -D__DISABLE_EXPORTS
+ 
+ KBUILD_AFLAGS  := $(KBUILD_CFLAGS) -D__ASSEMBLY__
+ GCOV_PROFILE := n
+@@ -146,6 +147,8 @@ $(obj)/vmlinux.bin.lzo: $(vmlinux.bin.all-y) FORCE
+ 	$(call if_changed,lzo)
+ $(obj)/vmlinux.bin.lz4: $(vmlinux.bin.all-y) FORCE
+ 	$(call if_changed,lz4)
++$(obj)/vmlinux.bin.zst: $(vmlinux.bin.all-y) FORCE
++	$(call if_changed,zstd22)
+ 
+ suffix-$(CONFIG_KERNEL_GZIP)	:= gz
+ suffix-$(CONFIG_KERNEL_BZIP2)	:= bz2
+@@ -153,6 +156,7 @@ suffix-$(CONFIG_KERNEL_LZMA)	:= lzma
+ suffix-$(CONFIG_KERNEL_XZ)	:= xz
+ suffix-$(CONFIG_KERNEL_LZO) 	:= lzo
+ suffix-$(CONFIG_KERNEL_LZ4) 	:= lz4
++suffix-$(CONFIG_KERNEL_ZSTD)	:= zst
+ 
+ quiet_cmd_mkpiggy = MKPIGGY $@
+       cmd_mkpiggy = $(obj)/mkpiggy $< > $@
+diff --git a/arch/x86/boot/compressed/kaslr.c b/arch/x86/boot/compressed/kaslr.c
+index 2e53c056ba20..ae7e1698587f 100644
+--- a/arch/x86/boot/compressed/kaslr.c
++++ b/arch/x86/boot/compressed/kaslr.c
+@@ -19,13 +19,6 @@
+  */
+ #define BOOT_CTYPE_H
+ 
+-/*
+- * _ctype[] in lib/ctype.c is needed by isspace() of linux/ctype.h.
+- * While both lib/ctype.c and lib/cmdline.c will bring EXPORT_SYMBOL
+- * which is meaningless and will cause compiling error in some cases.
+- */
+-#define __DISABLE_EXPORTS
+-
+ #include "misc.h"
+ #include "error.h"
+ #include "../string.h"
+diff --git a/arch/x86/boot/compressed/misc.c b/arch/x86/boot/compressed/misc.c
+index 9652d5c2afda..39e592d0e0b4 100644
+--- a/arch/x86/boot/compressed/misc.c
++++ b/arch/x86/boot/compressed/misc.c
+@@ -77,6 +77,10 @@ static int lines, cols;
+ #ifdef CONFIG_KERNEL_LZ4
+ #include "../../../../lib/decompress_unlz4.c"
+ #endif
++
++#ifdef CONFIG_KERNEL_ZSTD
++#include "../../../../lib/decompress_unzstd.c"
++#endif
+ /*
+  * NOTE: When adding a new decompressor, please update the analysis in
+  * ../header.S.
+diff --git a/arch/x86/include/asm/boot.h b/arch/x86/include/asm/boot.h
+index 680c320363db..9191280d9ea3 100644
+--- a/arch/x86/include/asm/boot.h
++++ b/arch/x86/include/asm/boot.h
+@@ -24,9 +24,16 @@
+ # error "Invalid value for CONFIG_PHYSICAL_ALIGN"
+ #endif
+ 
+-#ifdef CONFIG_KERNEL_BZIP2
++#if defined(CONFIG_KERNEL_BZIP2)
+ # define BOOT_HEAP_SIZE		0x400000
+-#else /* !CONFIG_KERNEL_BZIP2 */
++#elif defined(CONFIG_KERNEL_ZSTD)
++/*
++ * Zstd needs to allocate the ZSTD_DCtx in order to decompress the kernel.
++ * The ZSTD_DCtx is ~160KB, so set the heap size to 192KB because it is a
++ * round number and to allow some slack.
++ */
++# define BOOT_HEAP_SIZE		 0x30000
++#else
+ # define BOOT_HEAP_SIZE		 0x10000
+ #endif
+ 
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/2005-.gitignore-Add-ZSTD-compressed-files.patch
+++ b/packages/kernel-5.4/2005-.gitignore-Add-ZSTD-compressed-files.patch
@@ -1,0 +1,34 @@
+From 9e5deea6a88d5c1038e7d2562224a2bfd1a083f1 Mon Sep 17 00:00:00 2001
+From: Adam Borowski <kilobyte@angband.pl>
+Date: Thu, 30 Jul 2020 12:08:40 -0700
+Subject: [PATCH 2005/2007] .gitignore: Add ZSTD-compressed files
+
+For now, that's arch/x86/boot/compressed/vmlinux.bin.zst but probably more
+will come, thus let's be consistent with all other compressors.
+
+Signed-off-by: Adam Borowski <kilobyte@angband.pl>
+Signed-off-by: Nick Terrell <terrelln@fb.com>
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Link: https://lore.kernel.org/r/20200730190841.2071656-8-nickrterrell@gmail.com
+(cherry picked from commit 6f3decabaff032e5fcc6cf56f0851ee259359232)
+---
+ .gitignore | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/.gitignore b/.gitignore
+index 70580bdd352c..10faf379482f 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -44,6 +44,7 @@
+ *.tab.[ch]
+ *.tar
+ *.xz
++*.zst
+ Module.symvers
+ modules.builtin
+ modules.order
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/2006-kbuild-move-module-strip-compression-code-into-scrip.patch
+++ b/packages/kernel-5.4/2006-kbuild-move-module-strip-compression-code-into-scrip.patch
@@ -1,0 +1,184 @@
+From 1b82a356860716e14a27bc90cc9755caebbdab0b Mon Sep 17 00:00:00 2001
+From: Masahiro Yamada <masahiroy@kernel.org>
+Date: Wed, 31 Mar 2021 22:38:08 +0900
+Subject: [PATCH 2006/2007] kbuild: move module strip/compression code into
+ scripts/Makefile.modinst
+
+Both mod_strip_cmd and mod_compress_cmd are only used in
+scripts/Makefile.modinst, hence there is no good reason to define them
+in the top Makefile. Move the relevant code to scripts/Makefile.modinst.
+
+Also, show separate log messages for each of install, strip, sign, and
+compress.
+
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+(cherry picked from commit 65ce9c38326e2588fcd1a3a4817c14b4660f430b)
+[fixed a merge conflict in Makefile and script/Makefile.modinst while cherry-picking]
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile                 | 32 -------------
+ scripts/Makefile.modinst | 98 +++++++++++++++++++++++++++++++++-------
+ 2 files changed, 81 insertions(+), 49 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 3f593214a087..ef0da022f0c1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -978,38 +978,6 @@ export INSTALL_DTBS_PATH ?= $(INSTALL_PATH)/dtbs/$(KERNELRELEASE)
+ MODLIB	= $(INSTALL_MOD_PATH)/lib/modules/$(KERNELRELEASE)
+ export MODLIB
+ 
+-#
+-# INSTALL_MOD_STRIP, if defined, will cause modules to be
+-# stripped after they are installed.  If INSTALL_MOD_STRIP is '1', then
+-# the default option --strip-debug will be used.  Otherwise,
+-# INSTALL_MOD_STRIP value will be used as the options to the strip command.
+-
+-ifdef INSTALL_MOD_STRIP
+-ifeq ($(INSTALL_MOD_STRIP),1)
+-mod_strip_cmd = $(STRIP) --strip-debug
+-else
+-mod_strip_cmd = $(STRIP) $(INSTALL_MOD_STRIP)
+-endif # INSTALL_MOD_STRIP=1
+-else
+-mod_strip_cmd = true
+-endif # INSTALL_MOD_STRIP
+-export mod_strip_cmd
+-
+-# CONFIG_MODULE_COMPRESS, if defined, will cause module to be compressed
+-# after they are installed in agreement with CONFIG_MODULE_COMPRESS_GZIP
+-# or CONFIG_MODULE_COMPRESS_XZ.
+-
+-mod_compress_cmd = true
+-ifdef CONFIG_MODULE_COMPRESS
+-  ifdef CONFIG_MODULE_COMPRESS_GZIP
+-    mod_compress_cmd = $(KGZIP) -n -f
+-  endif # CONFIG_MODULE_COMPRESS_GZIP
+-  ifdef CONFIG_MODULE_COMPRESS_XZ
+-    mod_compress_cmd = $(XZ) -f
+-  endif # CONFIG_MODULE_COMPRESS_XZ
+-endif # CONFIG_MODULE_COMPRESS
+-export mod_compress_cmd
+-
+ ifdef CONFIG_MODULE_SIG_ALL
+ $(eval $(call config_filename,MODULE_SIG_KEY))
+ 
+diff --git a/scripts/Makefile.modinst b/scripts/Makefile.modinst
+index 5a4579e76485..84696ef99df7 100644
+--- a/scripts/Makefile.modinst
++++ b/scripts/Makefile.modinst
+@@ -6,30 +6,94 @@
+ PHONY := __modinst
+ __modinst:
+ 
+-include scripts/Kbuild.include
++include include/config/auto.conf
++include $(srctree)/scripts/Kbuild.include
+ 
+-modules := $(sort $(shell cat $(if $(KBUILD_EXTMOD),$(KBUILD_EXTMOD)/)modules.order))
++modules := $(sort $(shell cat $(MODORDER)))
++
++ifeq ($(KBUILD_EXTMOD),)
++dst := $(MODLIB)/kernel
++else
++INSTALL_MOD_DIR ?= extra
++dst := $(MODLIB)/$(INSTALL_MOD_DIR)
++endif
++
++suffix-y				:=
++suffix-$(CONFIG_MODULE_COMPRESS_GZIP)	:= .gz
++suffix-$(CONFIG_MODULE_COMPRESS_XZ)	:= .xz
++
++modules := $(patsubst $(extmod_prefix)%, $(dst)/%$(suffix-y), $(modules))
+ 
+-PHONY += $(modules)
+ __modinst: $(modules)
+ 	@:
+ 
+-# Don't stop modules_install if we can't sign external modules.
+-quiet_cmd_modules_install = INSTALL $@
+-      cmd_modules_install = \
+-    mkdir -p $(2) ; \
+-    cp $@ $(2) ; \
+-    $(mod_strip_cmd) $(2)/$(notdir $@) ; \
+-    $(mod_sign_cmd) $(2)/$(notdir $@) $(patsubst %,|| true,$(KBUILD_EXTMOD)) ; \
+-    $(mod_compress_cmd) $(2)/$(notdir $@)
++quiet_cmd_none =
++      cmd_none = :
+ 
+-# Modules built outside the kernel source tree go into extra by default
+-INSTALL_MOD_DIR ?= extra
+-ext-mod-dir = $(INSTALL_MOD_DIR)$(subst $(patsubst %/,%,$(KBUILD_EXTMOD)),,$(@D))
++#
++# Installation
++#
++quiet_cmd_install = INSTALL $@
++      cmd_install = mkdir -p $(dir $@); cp $< $@
++
++# Strip
++#
++# INSTALL_MOD_STRIP, if defined, will cause modules to be stripped after they
++# are installed. If INSTALL_MOD_STRIP is '1', then the default option
++# --strip-debug will be used. Otherwise, INSTALL_MOD_STRIP value will be used
++# as the options to the strip command.
++ifdef INSTALL_MOD_STRIP
++
++ifeq ($(INSTALL_MOD_STRIP),1)
++strip-option := --strip-debug
++else
++strip-option := $(INSTALL_MOD_STRIP)
++endif
++
++quiet_cmd_strip = STRIP   $@
++      cmd_strip = $(STRIP) $(strip-option) $@
++
++else
++
++quiet_cmd_strip =
++      cmd_strip = :
++
++endif
++
++#
++# Signing
++# Don't stop modules_install even if we can't sign external modules.
++#
++ifeq ($(CONFIG_MODULE_SIG_ALL),y)
++quiet_cmd_sign = SIGN    $@
++$(eval $(call config_filename,MODULE_SIG_KEY))
++      cmd_sign = scripts/sign-file $(CONFIG_MODULE_SIG_HASH) $(MODULE_SIG_KEY_SRCPREFIX)$(CONFIG_MODULE_SIG_KEY) certs/signing_key.x509 $@ \
++                 $(if $(KBUILD_EXTMOD),|| true)
++else
++quiet_cmd_sign :=
++      cmd_sign := :
++endif
++
++$(dst)/%.ko: $(extmod_prefix)%.ko FORCE
++	$(call cmd,install)
++	$(call cmd,strip)
++	$(call cmd,sign)
++
++#
++# Compression
++#
++quiet_cmd_gzip = GZIP    $@
++      cmd_gzip = $(KGZIP) -n -f $<
++quiet_cmd_xz = XZ      $@
++      cmd_xz = $(XZ) --lzma2=dict=2MiB -f $<
++
++$(dst)/%.ko.gz: $(dst)/%.ko FORCE
++	$(call cmd,gzip)
+ 
+-modinst_dir = $(if $(KBUILD_EXTMOD),$(ext-mod-dir),kernel/$(@D))
++$(dst)/%.ko.xz: $(dst)/%.ko FORCE
++	$(call cmd,xz)
+ 
+-$(modules):
+-	$(call cmd,modules_install,$(MODLIB)/$(modinst_dir))
++PHONY += FORCE
++FORCE:
+ 
+ .PHONY: $(PHONY)
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/2007-kbuild-add-support-for-zstd-compressed-modules.patch
+++ b/packages/kernel-5.4/2007-kbuild-add-support-for-zstd-compressed-modules.patch
@@ -1,0 +1,82 @@
+From ddd6d2cff1af4bccee97a7d939e39f64a8965e50 Mon Sep 17 00:00:00 2001
+From: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Date: Wed, 7 Apr 2021 18:09:27 +0200
+Subject: [PATCH 2007/2007] kbuild: add support for zstd compressed modules
+
+kmod 28 supports modules compressed in zstd format so let's add this
+possibility to kernel.
+
+Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Reviewed-by: Oleksandr Natalenko <oleksandr@natalenko.name>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+(cherry picked from commit c3d7ef377eb2564b165b1e8fdb4646952c90ac17)
+[fixed a merge conflict in init/Kconfig]
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ init/Kconfig             | 11 +++++++++--
+ scripts/Makefile.modinst |  6 ++++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/init/Kconfig b/init/Kconfig
+index 4dc3ea198a2c..c6ffb8b7eec6 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -2121,8 +2121,9 @@ config MODULE_COMPRESS
+ 	  Out-of-tree kernel modules installed using Kbuild will also be
+ 	  compressed upon installation.
+ 
+-	  Note: for modules inside an initrd or initramfs, it's more efficient
+-	  to compress the whole initrd or initramfs instead.
++	  Please note that the tool used to load modules needs to support the
++	  corresponding algorithm. module-init-tools MAY support gzip, and kmod
++	  MAY support gzip, xz and zstd.
+ 
+ 	  Note: This is fully compatible with signed modules.
+ 
+@@ -2144,6 +2145,12 @@ config MODULE_COMPRESS_GZIP
+ config MODULE_COMPRESS_XZ
+ 	bool "XZ"
+ 
++config MODULE_COMPRESS_ZSTD
++	bool "ZSTD"
++	help
++	  Compress modules with ZSTD. The installed modules are suffixed
++	  with .ko.zst.
++
+ endchoice
+ 
+ config MODULE_ALLOW_MISSING_NAMESPACE_IMPORTS
+diff --git a/scripts/Makefile.modinst b/scripts/Makefile.modinst
+index 84696ef99df7..59f613aa08b4 100644
+--- a/scripts/Makefile.modinst
++++ b/scripts/Makefile.modinst
+@@ -21,6 +21,7 @@ endif
+ suffix-y				:=
+ suffix-$(CONFIG_MODULE_COMPRESS_GZIP)	:= .gz
+ suffix-$(CONFIG_MODULE_COMPRESS_XZ)	:= .xz
++suffix-$(CONFIG_MODULE_COMPRESS_ZSTD)	:= .zst
+ 
+ modules := $(patsubst $(extmod_prefix)%, $(dst)/%$(suffix-y), $(modules))
+ 
+@@ -86,6 +87,8 @@ quiet_cmd_gzip = GZIP    $@
+       cmd_gzip = $(KGZIP) -n -f $<
+ quiet_cmd_xz = XZ      $@
+       cmd_xz = $(XZ) --lzma2=dict=2MiB -f $<
++quiet_cmd_zstd = ZSTD    $@
++      cmd_zstd = $(ZSTD) -T0 --rm -f -q $<
+ 
+ $(dst)/%.ko.gz: $(dst)/%.ko FORCE
+ 	$(call cmd,gzip)
+@@ -93,6 +96,9 @@ $(dst)/%.ko.gz: $(dst)/%.ko FORCE
+ $(dst)/%.ko.xz: $(dst)/%.ko FORCE
+ 	$(call cmd,xz)
+ 
++$(dst)/%.ko.zst: $(dst)/%.ko FORCE
++	$(call cmd,zstd)
++
+ PHONY += FORCE
+ FORCE:
+ 
+-- 
+2.30.2
+

--- a/packages/kernel-5.4/config-bottlerocket
+++ b/packages/kernel-5.4/config-bottlerocket
@@ -61,3 +61,14 @@ CONFIG_DEBUG_INFO_BTF=y
 # We don't want to extend the kernel command line with any upstream defaults;
 # Bottlerocket uses a fairly custom setup that needs tight control over it.
 CONFIG_CMDLINE_EXTEND=n
+
+# Enable ZSTD kernel image compression
+CONFIG_HAVE_KERNEL_ZSTD=y
+CONFIG_KERNEL_ZSTD=y
+CONFIG_ZSTD_COMPRESS=y
+CONFIG_ZSTD_DECOMPRESS=y
+CONFIG_DECOMPRESS_ZSTD=y
+
+# Enable ZSTD modules compression
+CONFIG_MODULE_COMPRESS=y
+CONFIG_MODULE_COMPRESS_ZSTD=y

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -12,6 +12,7 @@ Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.
 Patch0001: 0001-lustrefsx-Disable-Werror-stringop-overflow.patch
+
 # Required patches for kdump support
 Patch0002: 0002-x86-purgatory-Add-fno-stack-protector.patch
 Patch0003: 0003-arm64-kexec_file-add-crash-dump-support.patch
@@ -19,6 +20,17 @@ Patch0004: 0004-libfdt-include-fdt_addresses.c.patch
 
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
+
+# Add zstd support for compressed kernel
+Patch2000: 2000-lib-Prepare-zstd-for-preboot-environment-improve-per.patch
+Patch2001: 2001-lib-Add-zstd-support-to-decompress.patch
+Patch2002: 2002-init-Add-support-for-zstd-compressed-kernel.patch
+Patch2003: 2003-x86-Bump-ZO_z_extra_bytes-margin-for-zstd.patch
+Patch2004: 2004-x86-Add-support-for-ZSTD-compressed-kernel.patch
+Patch2005: 2005-.gitignore-Add-ZSTD-compressed-files.patch
+# Add zstd support for compressed kernel modules
+Patch2006: 2006-kbuild-move-module-strip-compression-code-into-scrip.patch
+Patch2007: 2007-kbuild-add-support-for-zstd-compressed-modules.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -14,3 +14,4 @@ sha512 = "557cdcaec75e5a1ceea2d10862c944e9a65ef54f6ee9da6dc98ce4582418fdc9958aab
 
 [build-dependencies]
 glibc = { path = "../glibc" }
+libzstd = { path = "../libzstd" }

--- a/packages/kmod/kmod.spec
+++ b/packages/kmod/kmod.spec
@@ -6,6 +6,8 @@ License: GPL-2.0-or-later AND LGPL-2.1-or-later
 URL: http://git.kernel.org/?p=utils/kernel/kmod/kmod.git;a=summary
 Source0: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libzstd-devel
+Requires: %{_cross_os}libzstd
 
 %description
 %{summary}.
@@ -24,6 +26,7 @@ cp tools/COPYING COPYING.GPL
 
 %build
 %cross_configure \
+  --with-zstd \
   --without-openssl \
   --without-zlib \
   --without-xz

--- a/packages/libzstd/Cargo.toml
+++ b/packages/libzstd/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "libzstd"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/facebook/zstd/archive/v1.5.0.tar.gz"
+sha512 = "25b657529a698eec891f92ff4a085d1fd95d2ff938ce52c8a4ff6163eb0b668ec642dd09e0db190652638cd92371006afa01d8e437437762c4097ad301675c33"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libzstd/build.rs
+++ b/packages/libzstd/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/libzstd/libzstd.spec
+++ b/packages/libzstd/libzstd.spec
@@ -1,0 +1,49 @@
+Name: %{_cross_os}libzstd
+Version: 1.5.0
+Release: 1%{?dist}
+Summary: Library for Zstandard compression
+License: BSD-3-Clause AND GPL-2.0-only
+URL: https://github.com/facebook/zstd/
+Source0: https://github.com/faceboot/zstd/archive/v%{version}.tar.gz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for Zstandard compression
+Requires: %{_cross_os}libzstd
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n zstd-%{version}
+
+%global set_env \
+%set_cross_build_flags \\\
+export CC=%{_cross_target}-gcc \\\
+export PREFIX=%{_cross_prefix} \\\
+export DESTDIR=%{buildroot}%{_cross_rootdir} \\\
+%{nil}
+
+%build
+%set_env
+%make_build
+
+%install
+%set_env
+%make_install
+
+%files
+%license COPYING
+%{_cross_libdir}/*.so.*
+%{_cross_attribution_file}
+%exclude %{_cross_bindir}
+%exclude %{_cross_mandir}
+
+%files devel
+%{_cross_includedir}/*.h
+%{_cross_libdir}/*.so
+%{_cross_libdir}/*.a
+%{_cross_libdir}/pkgconfig/*.pc

--- a/packages/libzstd/pkg.rs
+++ b/packages/libzstd/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -329,6 +329,7 @@ name = "kmod"
 version = "0.1.0"
 dependencies = [
  "glibc",
+ "libzstd",
 ]
 
 [[package]]
@@ -595,6 +596,13 @@ dependencies = [
 
 [[package]]
 name = "libz"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "libzstd"
 version = "0.1.0"
 dependencies = [
  "glibc",


### PR DESCRIPTION
**Issue number:**
#1614

**Description of changes:**

```
47032848 packages: add support for ZSTD compression in kernel 5.10
3c3a6399 packages: add support for ZSTD compression in kernel 5.4
9e5ec8eb packages: add support to kmod for zstd compression
85aa7301 packages: add libzstd
```

With these changes, kernel x86_64 images and modules for both arches are compressed using the Zstandard compression algorithm.

**Testing done:**

aws-dev, aws-k8s-1.19, aws-k8s-1.20, aws-ecs-1 (x86_64, aarch64):

- [x] Hosts actually boot
- [x] Launch pod/task/container
- [x] `systemctl status` OK
- [x] `journalctl -p3` OK
- [x] `modinfo fuse` shows module's name with extension `.ko.zst`
- [x] Only x86_64: check kernel image is compressed with a modified version of [this script](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/extract-vmlinux)
- [x] Only k8s: Install falco without `ebpf.enabled`, this will force compiling and loading the falco driver at runtime.
- [x] Compile kernel module with new kmod kit, with Dockerfile:

```dockerfile
FROM amazonlinux:2 as build

WORKDIR /tmp
# Install dependencies and download sources
RUN \
  ulimit -n 1024; yum -y install \
    bc bzip2 cmake3 curl diffutils dwarves elfutils-devel \
    findutils gcc gcc-c++ git kmod make tar ncurses-devel \
    patch xz && \
  git clone https://github.com/falcosecurity/falco.git && \
  curl -OJL https://github.com/openzfs/zfs/releases/download/zfs-2.0.4/zfs-2.0.4.tar.gz

# Add kmod kit in its own layer
FROM build as kmod-kit
ARG VARIANT="aws-dev"
ARG ARCH="x86_64"
ARG VERSION="1.1.4"
ARG KIT="${VARIANT}-${ARCH}-kmod-kit-v${VERSION}"
COPY ./${KIT}.tar.xz /tmp
RUN tar xf ${KIT}.tar.xz

# Compile falco driver
FROM kmod-kit as falco-build
ARG VARIANT="aws-dev"
ARG ARCH="x86_64"
ARG VERSION="1.1.4"
ARG KIT="${VARIANT}-${ARCH}-kmod-kit-v${VERSION}"
ARG KERNELDIR="/tmp/${KIT}/kernel-devel"
ARG CROSS_COMPILE="${ARCH}-bottlerocket-linux-musl-"
ARG INSTALL_MOD_STRIP=1
RUN \
  export PATH="/tmp/${KIT}/toolchain/usr/bin:${PATH}" && \
  mkdir -p falco/build && \
  cd falco/build && \
  cmake3 -DUSE_BUNDLED_DEPS=ON .. && \
  make driver -j8
RUN test -f /tmp/falco/build/driver/falco.ko

# Compile zfs kernel module
FROM kmod-kit as zfs-build
ARG VARIANT="aws-dev"
ARG ARCH="x86_64"
ARG VERSION="1.1.4"
ARG KIT="${VARIANT}-${ARCH}-kmod-kit-v${VERSION}"
ARG KERNELDIR="/tmp/${KIT}/kernel-devel"
ARG CROSS_COMPILE="${ARCH}-bottlerocket-linux-musl-"
ARG INSTALL_MOD_STRIP=1
RUN \
  export PATH="/tmp/${KIT}/toolchain/usr/bin:${PATH}" && \
  tar xf zfs-2.0.4.tar.gz && \
  cd zfs-2.0.4 && \
  ./configure \
    --with-config=kernel \
    --with-linux="${KERNELDIR}" \
    --with-linux-obj="${KERNELDIR}" && \
  make -C module modules -j8
RUN test -f  /tmp/zfs-2.0.4/module/avl/zavl.ko && \
    test -f /tmp/zfs-2.0.4/module/icp/icp.ko && \
    test -f /tmp/zfs-2.0.4/module/lua/zlua.ko && \
    test -f /tmp/zfs-2.0.4/module/nvpair/znvpair.ko && \
    test -f /tmp/zfs-2.0.4/module/spl/spl.ko && \
    test -f /tmp/zfs-2.0.4/module/unicode/zunicode.ko && \
    test -f /tmp/zfs-2.0.4/module/zcommon/zcommon.ko && \
    test -f /tmp/zfs-2.0.4/module/zfs/zfs.ko
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
