### PR TITLE
Update third-party packages

### DIFF
--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -9,5 +9,5 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2021-05-25.pem"
-sha512 = "dcf1a7ad2c9f49f794fb7b927a4c04dd3d25afcd99fe2f7b89be50c986aa2c7964fb785a6eb053f6639996c8b5b93d2364369b0f68c3e483de132f68299c7f0a"
+url = "https://curl.haxx.se/ca/cacert-2021-07-05.pem"
+sha512 = "881183c7fed512cab763a6145f0e07c5bcdc143589baf433f7ba92223d215f18f48782fcfc04860db0671849e2ceeecedf6704f77148f588e17c4cd9a34cc8f8"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2021.05.25
+Version: 2021.07.05
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2021-05-25.pem
+Source0: https://curl.haxx.se/ca/cacert-2021-07-05.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v20.10.4/cli-20.10.4.tar.gz"
-sha512 = "861f69657ac3eede228983b7d845ce98c81f4b0aa601aab37024d3f21cf1ca73a182d33bdde8fb9ad89e4954c3903dc4ec2b81fcf7364941a7c38a80ea410e34"
+url = "https://github.com/docker/cli/archive/v20.10.7/cli-20.10.7.tar.gz"
+sha512 = "4523ae70cb27d848da119070171af2eb84e974ac39d70be4feee105e37c949487c7f72a9bc30c32ce71bffb0787e27b7b9194ce5a8aeae57bdfeb3f2d730010f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 20.10.4
+%global gover 20.10.7
 %global rpmver %{gover}
-%global gitrev d3cb89ee53287cf9214ad5fbc9a111190f607c72
+%global gitrev f0df35096d5f5e6b559b42c7fde6c65a2909f7c5
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v20.10.4/moby-20.10.4.tar.gz"
-sha512 = "6cbead817d37dc3a4d2686556562d3b52f802ac2cd611a1ff6e373db0464080d8babefd3af31175487b700905fbc876ec8ce235989780b037a4408febdf70985"
+url = "https://github.com/moby/moby/archive/v20.10.7/moby-20.10.7.tar.gz"
+sha512 = "2341faa3ebb903d74fa434712fce45e7acf0423710b97cdca11e3999db2819c4385d9a7fb3850925592f20f02c6261edbade6c9d6a2fefbc32f05a6b44ec3073"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 20.10.4
+%global gover 20.10.7
 %global rpmver %{gover}
-%global gitrev 363e9a88a11be517d9e8c65c998ff56f774eb4dc
+%global gitrev b0f5bc36fea9dfb9672e1e9b1278ebab797b9ee0
 
 %global source_date_epoch 1363394400
 

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.2/e2fsprogs-1.46.2.tar.xz"
-sha512 = "5297a4d7bf944806d8ee77227eac596b5e5efed2c665561d40094c40b9f321616c60975a2716f1499a9f72243df6e3b6e2267b98ec1fdc1dfd646d7be887fc4d"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.3/e2fsprogs-1.46.3.tar.xz"
+sha512 = "27da6e38d3463e7a283dacfb88a3210dd6d8c63f4d990db879f63bdf503aaa5c447ef0ccc566b71526c12a8ab0a7a6529014b1010be300ad56a6ad5ce9066196"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}e2fsprogs
-Version: 1.46.2
+Version: 1.46.3
 Release: 1%{?dist}
 Summary: Tools for managing ext2, ext3, and ext4 file systems
 License: GPL-2.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND BSD-3-Clause

--- a/packages/ecs-agent/0001-bottlerocket-default-filesystem-locations.patch
+++ b/packages/ecs-agent/0001-bottlerocket-default-filesystem-locations.patch
@@ -61,19 +61,32 @@ index 080f18c4d..ef14970ce 100644
  		DataDirOnHost:                       "/var/lib/ecs",
  		DisableMetrics:                      BooleanDefaultFalse{Value: ExplicitlyDisabled},
  		ReservedMemory:                      0,
-diff --git a/agent/ecscni/plugin.go b/agent/ecscni/plugin.go
-index 192cfccaa..93f56f3ae 100644
---- a/agent/ecscni/plugin.go
-+++ b/agent/ecscni/plugin.go
-@@ -36,7 +36,7 @@ const (
- 	currentECSCNIVersion      = "2020.09.0"
- 	currentECSCNIGitHash      = "55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1"
- 	currentVPCCNIGitHash      = "a21d3a41f922e14c19387713df66be3e4ee1e1f6"
--	vpcCNIPluginPath          = "/log/vpc-branch-eni.log"
-+	vpcCNIPluginPath          = "/var/log/ecs/vpc-branch-eni.log"
+diff --git a/agent/ecscni/plugin_linux.go b/agent/ecscni/plugin_linux.go
+index 6fc0111d..d3ef6641 100644
+--- a/agent/ecscni/plugin_linux.go
++++ b/agent/ecscni/plugin_linux.go
+@@ -32,7 +32,7 @@ import (
+ const (
  	vpcCNIPluginInterfaceType = "vlan"
+ 	// vpcCNIPluginPath is the path of the cni plugin's log file.
+-	vpcCNIPluginPath = "/log/vpc-branch-eni.log"
++	vpcCNIPluginPath = "/var/log/ecs/vpc-branch-eni.log"
  )
  
+ // newCNIGuard returns a new instance of CNI guard for the CNI client.
+diff --git a/agent/ecscni/plugin_unsupported.go b/agent/ecscni/plugin_unsupported.go
+index 6289877a..fcebedfe 100644
+--- a/agent/ecscni/plugin_unsupported.go
++++ b/agent/ecscni/plugin_unsupported.go
+@@ -25,7 +25,7 @@ import (
+ 
+ const (
+ 	// vpcCNIPluginPath is the path of the cni plugin's log file.
+-	vpcCNIPluginPath = "/log/vpc-branch-eni.log"
++	vpcCNIPluginPath = "/var/log/ecs/vpc-branch-eni.log"
+ )
+ 
+ // newCNIGuard returns a new instance of CNI guard for the CNI client.
 diff --git a/agent/utils/license.go b/agent/utils/license.go
 index 6eccff6ac..324307cd3 100644
 --- a/agent/utils/license.go

--- a/packages/ecs-agent/0005-bottlerocket-fix-procfs-path-on-host.patch
+++ b/packages/ecs-agent/0005-bottlerocket-fix-procfs-path-on-host.patch
@@ -10,22 +10,22 @@ host's `procfs` at `/host/proc`.  Because Bottlerocket does not run the
 ECS agent in a container, the ECS agent can directly read the host's
 `procfs` at `/proc`.
 ---
- agent/ecscni/types.go | 2 +-
+ agent/ecscni/types_linux.go | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/agent/ecscni/types.go b/agent/ecscni/types.go
-index 8561eb51b..957aa3877 100644
---- a/agent/ecscni/types.go
-+++ b/agent/ecscni/types.go
-@@ -38,7 +38,7 @@ const (
- 	ecsSubnet = "169.254.172.0/22"
- 
+diff --git a/agent/ecscni/types_linux.go b/agent/ecscni/types_linux.go
+index 06a134f4..3705ad24 100644
+--- a/agent/ecscni/types_linux.go
++++ b/agent/ecscni/types_linux.go
+@@ -39,7 +39,7 @@ const (
+ 	// ECSBranchENIPluginName is the binary of the branch-eni plugin
+ 	ECSBranchENIPluginName = "vpc-branch-eni"
  	// NetnsFormat is used to construct the path to cotainer network namespace
 -	NetnsFormat = "/host/proc/%s/ns/net"
 +	NetnsFormat = "/proc/%s/ns/net"
- 	// ECSIPAMPluginName is the binary of the ipam plugin
- 	ECSIPAMPluginName = "ecs-ipam"
- 	// ECSBridgePluginName is the binary of the bridge plugin
+ )
+ 
+ //IPAMNetworkConfig is the config format accepted by the plugin
 -- 
 2.32.0
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -10,8 +10,8 @@ path = "pkg.rs"
 
 # ECS agent
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.53.0/amazon-ecs-agent-v1.53.0.tar.gz"
-sha512 = "9619291b19ed38b423b8788fce11c03be6fc6c28023fe3c7442824347b84b2250890f1c44832d23a5adea8646f57f656920fa20063eab5f3e7b7c235e7b98691"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.54.1/amazon-ecs-agent-v1.54.1.tar.gz"
+sha512 = "b3f92920ce327ff5a6d77268f927882d25097da65813d4f4c60787772109aa49952ec4130f83bfd00bf77ee86af1e60ca0b0967c02276126ccc378c954bc6047"
 
 # The ECS agent repository includes two CNI plugins as git submodules.  git
 # archive does not include submodules, so the tarball above does not include
@@ -22,8 +22,8 @@ url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/55b2ae77ee0bf22321b
 sha512 = "42e2dad0741f02a3b0d675c0f512557a118cef6df7e9d989a35c73d02484912d800453148abbf6d8424c5e40d2662745a9aef4a68cb2f610d9defc976e394f1f"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/a21d3a41f922e14c19387713df66be3e4ee1e1f6/amazon-vpc-cni-plugins.tar.gz"
-sha512 = "86011a1d7a8d4a2fe824c9eea6ad2ef9394059475ffa421c3636afd4f4031d60898992022e34ce2b1e9594fa79766f747a6c239e26be5d71fe96addc46bf7f54"
+url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/199bfc65cced4951cbb6a38e6e828afa8c2b023c/amazon-vpc-cni-plugins.tar.gz"
+sha512 = "ee1c2230c43fa7b8b9a25319bd334abfc08210ea8956ccc4525fe936b48b22b85df778823138d58687e847762b436daa0e0ba69c210a00b173f9b933f656386d"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,9 +2,9 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.53.0
+%global agent_gover 1.54.1
 # git rev-parse --short=8
-%global agent_gitrev 225bc3a5
+%global agent_gitrev 3e20420f
 
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
@@ -14,7 +14,7 @@
 %global vpccni_goproject github.com/aws
 %global vpccni_gorepo amazon-vpc-cni-plugins
 %global vpccni_goimport %{vpccni_goproject}/%{vpccni_gorepo}
-%global vpccni_gitrev a21d3a41f922e14c19387713df66be3e4ee1e1f6
+%global vpccni_gitrev 199bfc65cced4951cbb6a38e6e828afa8c2b023c
 %global vpccni_gover 1.2
 
 # Construct reproducible tar archives

--- a/packages/iputils/1000-skip-ipv6-test.patch
+++ b/packages/iputils/1000-skip-ipv6-test.patch
@@ -1,0 +1,13 @@
+diff --git iputils.orig/ping/meson.build iputils/ping/meson.build
+index 1e678ec..eedd04b 100644
+--- iputils.orig/ping/meson.build
++++ iputils/ping/meson.build
+@@ -35,7 +35,7 @@ endif
+ # https://github.com/actions/virtual-environments/issues/668
+ ipv6_dst = []
+ ipv6_switch = []
+-r = run_command('ip', '-6', 'a')
++r = run_command('/bin/false')
+ if r.stdout().strip().contains('::1')
+   message('IPv6 enabled')
+   ipv6_dst = [ '::1' ]

--- a/packages/iputils/Cargo.toml
+++ b/packages/iputils/Cargo.toml
@@ -9,9 +9,9 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-path = "iputils-20210202.tar.gz"
-url = "https://github.com/iputils/iputils/archive/20210202.tar.gz"
-sha512 = "af600fe74e1b78c0da66c378f55eb468d62206aaae1864693f7ec79833c9c0de95843573d1792627695f08ecfcdb4e79c354065daf178d393fcc6ef9a8a5d526"
+path = "iputils-20210722.tar.gz"
+url = "https://github.com/iputils/iputils/archive/20210722.tar.gz"
+sha512 = "8f85bf468f8ef1e2832e9bbf9009552df4a6d723dd130fa0d5b2aa3bae617c972f936143c2370c3b4ce2ba2499828c91a299ee42cf81fa81aabe10552db2b328"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iputils/iputils.spec
+++ b/packages/iputils/iputils.spec
@@ -1,10 +1,17 @@
 Name: %{_cross_os}iputils
-Version: 20210202
+Version: 20210722
 Release: 1%{?dist}
 Summary: A set of network monitoring tools
 License: GPL-2.0-or-later AND BSD-3-Clause
 URL: https://github.com/iputils/iputils
 Source0: https://github.com/iputils/iputils/archive/%{version}.tar.gz#/iputils-%{version}.tar.gz
+
+# iputils' IPv6 testing requires iproute for 'ip' to check whether IPv6 is
+# enabled, since they switchd to GitHub Actions CI where it's not.  Skip IPv6
+# testing rather than adding an iproute requirement.
+# Note: After version 20210722, this check moved into ping/test/meson.build, so
+# the patch will need to be rebased in the next update.
+Patch1000: 1000-skip-ipv6-test.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libcap-devel

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.19"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.19.12/kubernetes-1.19.12.tar.gz"
-sha512 = "ccef766299c3261fd3839bd2900a7d22c7ca18bd4c4709f2d3c45c71bfcef0a091ecb2cea0ae111613bcd68ac7fb3b8b8e9045215f0419c9a9c588a73c279a7b"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.19.13/kubernetes-1.19.13.tar.gz"
+sha512 = "d5bece5cdc399c5132c959b5f53431427893a2bc37c3f475df73c2f846e4c51b961b092c3099c1f1f42de2cdde782bf62c404b9cc44fc69cecfee2c7765b7509"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.19.12
+%global gover 1.19.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.20/Cargo.toml
+++ b/packages/kubernetes-1.20/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.20"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.20.8/kubernetes-1.20.8.tar.gz"
-sha512 = "172127ec5015bddf763ecdbebd3922c1c77ecb8e976b72f08f9e6d6768132f06b586a639ae0e8cbbe4db3f029d509740b3efa119f468387637dc15fc63d79aac"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.20.9/kubernetes-1.20.9.tar.gz"
+sha512 = "9083589e016f1b9d3432fdab748f296b833c2f3425d6c89299e04f074865a9d2e706f4a8c0f9b90f32fca0c568e841f6a9c85dab5a748cd182f4e0f66c08cc8f"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.20/kubernetes-1.20.spec
+++ b/packages/kubernetes-1.20/kubernetes-1.20.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.20.8
+%global gover 1.20.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.21/Cargo.toml
+++ b/packages/kubernetes-1.21/Cargo.toml
@@ -14,8 +14,8 @@ package-name = "kubernetes-1.21"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.21.2/kubernetes-1.21.2.tar.gz"
-sha512 = "20f81c975d6a5a4e6cbbfcaa2f34e8dd4f96018a8a60004a9fedf13eb9d8d43a14f0b746fb48a1240e378d2a1b8de440104c72269d68239040fa6a690c5115ff"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.21.3/kubernetes-1.21.3.tar.gz"
+sha512 = "d780099814468079eaa9b9b33fb0f48e2c44ebbf304068f44c79281e7dc074cfe8a2f56330f8363282ce6ed07a12125fa4ec6a8a5308d208456231f827c861a0"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.21.2
+%global gover 1.21.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-audit/audit-userspace/archive/v3.0.2/audit-userspace-3.0.2.tar.gz"
-sha512 = "4ea6b2f2fe7006ff44b0bdfdd248e0ecbfc4f0db47f6861f1e339c5e091757c2672ac70e7056454849227065123c87d7891d6c8396b2f61f5f4c8b164a311609"
+url = "https://github.com/linux-audit/audit-userspace/archive/v3.0.3/audit-userspace-3.0.3.tar.gz"
+sha512 = "b248398ed4aa3c52eaf6272ce618d2dcc8d88494d1bf3d530178d61906f4f7dac3c0c56862f5bdafa43d72b5c327898d82e95e83d09057b4fc90e917ba83bfad"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libaudit
-Version: 3.0.2
+Version: 3.0.3
 Release: 1%{?dist}
 Summary: Library for the audit subsystem
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.50.tar.gz"
-sha512 = "ef9659df65875ef4e987666337d99f4b93a6db5f108c9c885d9b835cba49ee750961ec83cd25f497b01158eb063e1a0675cfd451487c7e90936753e669743bbf"
+url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.51.tar.gz"
+sha512 = "032f52468323af68cc5cc1d9adcbf61bae962887d475b995629ea22428fbd6e4722599497394cccdb8443381d257187eb2ce80866b009ae84cd8cd45fd616716"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.50
+Version: 2.51
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause

--- a/packages/libffi/Cargo.toml
+++ b/packages/libffi/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz"
-sha512 = "61513801a156f11420f541d325de697131846487122d6bdcf5491b18b4da788589f5c0bb07e88e396495d3be5830d74e9135595e2b8ddbfe95c448d8597fbd6f"
+url = "https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz"
+sha512 = "31bad35251bf5c0adb998c88ff065085ca6105cf22071b9bd4b5d5d69db4fadf16cadeec9baca944c4bb97b619b035bb8279de8794b922531fddeb0779eb7fb1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libffi/libffi.spec
+++ b/packages/libffi/libffi.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libffi
-Version: 3.3
+Version: 3.4.2
 Release: 1%{?dist}
 Summary: Library for FFI
 License: MIT

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -15,7 +15,6 @@ sha512 = "fb120105c4cb582491a53a0e4c61fe4bdd1f94b279bb7c362afd591369ede50a196c70
 [build-dependencies]
 glibc = { path = "../glibc" }
 libffi = { path = "../libffi" }
-libpcre = { path = "../libpcre" }
 libselinux = { path = "../libselinux" }
 libz = { path = "../libz" }
 util-linux = { path = "../util-linux" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -9,12 +9,10 @@ BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libffi-devel
 BuildRequires: %{_cross_os}libmount-devel
-BuildRequires: %{_cross_os}libpcre-devel
 BuildRequires: %{_cross_os}libselinux-devel
 BuildRequires: %{_cross_os}libz-devel
 Requires: %{_cross_os}libffi
 Requires: %{_cross_os}libmount
-Requires: %{_cross_os}libpcre
 Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}libz
 

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/archive/v4.4.22/libxcrypt-4.4.22.tar.gz"
-sha512 = "360c5df9a8a239c8e63b5edeea4c99f451fe67c0ef3084f7659c9ad4c976486bb09328fa1e731238538d7ea05133078d4f890d11c030aaee7734ea6f4ae28b1c"
+url = "https://github.com/besser82/libxcrypt/archive/v4.4.23/libxcrypt-4.4.23.tar.gz"
+sha512 = "4d5854a082a8c707416507611881c1407f0ea0bda0557c5f7ae6b70d8dd1c7a0828afe29d8f2e7754f5f97b824aaa03671dae6d4dad329fcd131b94b77ddb713"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.22
+Version: 4.4.23
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/vmware/open-vm-tools/releases/download/stable-11.2.5/open-vm-tools-11.2.5-17337674.tar.gz"
-sha512 = "b6d4bc6522418ec7a881752181ad9240e535854df492e758abf3996c6afe245466ffbff60cc1b6cdff5cf731b5769c9f9cb96aed29f0b788d0eef05f91fcf8ab"
+url = "https://github.com/vmware/open-vm-tools/releases/download/stable-11.3.0/open-vm-tools-11.3.0-18090558.tar.gz"
+sha512 = "36fa4fc309e57f49f1000abe8ca48aaf8bda67cd0ef3fd25ed0dfc12e2dd88e5a2bc8dae69abbadb44b2fa5195802f9925681a452f54916daa268adb20e8c8cd"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -1,7 +1,7 @@
-%global buildver 17337674
+%global buildver 18090558
 
 Name: %{_cross_os}open-vm-tools
-Version: 11.2.5
+Version: 11.3.0
 Release: 1%{?dist}
 Summary: Tools for VMware
 License: LGPL-2.1-or-later

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/5.12/strace-5.12.tar.xz"
-sha512 = "289cf82da4c69270458953b45d09c8eb05a6624898d3ac493c3ec293cd5ad07205084ad0af021dab2be9c0dc53f0301816113a746d96c78780b79231a185e7c9"
+url = "https://strace.io/files/5.13/strace-5.13.tar.xz"
+sha512 = "ba8b0eae396fa2b762bf17cbcdcd84b0660b2a5d5e7e9caf098ef3414a87fd28d4140dd10136483f35904560e5044e40be2bf6117462868a360306d62887c8ed"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 5.12
+Version: 5.13
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later

--- a/packages/util-linux/1000-libmount-kernel-compat.patch
+++ b/packages/util-linux/1000-libmount-kernel-compat.patch
@@ -1,0 +1,373 @@
+commit eccd0130d33cf2348f68d8f83c93909e8b50805d
+Author: Tom Kirchner <tjk@amazon.com>
+Date:   Wed Jul 28 15:38:26 2021 -0700
+
+    Revert "libmount: remove read-mountinfo workaround"
+    
+    This reverts commit 57898c3a7ee8fc5933cddd4526bb3980bef85a02.
+
+diff --git a/configure.ac b/configure.ac
+index bc9549daf..1c003585b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -528,6 +528,7 @@ AC_CHECK_FUNCS([ \
+ 	__fpending \
+ 	__fpurge \
+ 	fpurge \
++	fmemopen \
+ 	fsync \
+ 	getdomainname \
+ 	getdtablesize \
+diff --git a/libmount/src/mountP.h b/libmount/src/mountP.h
+index d43a83541..9b40457ab 100644
+--- a/libmount/src/mountP.h
++++ b/libmount/src/mountP.h
+@@ -98,6 +98,7 @@ extern int mnt_valid_tagname(const char *tagname);
+ extern int append_string(char **a, const char *b);
+ 
+ extern const char *mnt_statfs_get_fstype(struct statfs *vfs);
++extern int is_procfs_fd(int fd);
+ extern int is_file_empty(const char *name);
+ 
+ extern int mnt_is_readonly(const char *path)
+@@ -123,6 +124,7 @@ extern void mnt_free_filesystems(char **filesystems);
+ extern char *mnt_get_kernel_cmdline_option(const char *name);
+ extern int mnt_stat_mountpoint(const char *target, struct stat *st);
+ extern int mnt_lstat_mountpoint(const char *target, struct stat *st);
++extern FILE *mnt_get_procfs_memstream(int fd, char **membuf);
+ 
+ /* tab.c */
+ extern int is_mountinfo(struct libmnt_table *tb);
+diff --git a/libmount/src/tab_parse.c b/libmount/src/tab_parse.c
+index 917779ab6..ba90b7087 100644
+--- a/libmount/src/tab_parse.c
++++ b/libmount/src/tab_parse.c
+@@ -696,15 +696,7 @@ static int kernel_fs_postparse(struct libmnt_table *tb,
+ 	return rc;
+ }
+ 
+-/**
+- * mnt_table_parse_stream:
+- * @tb: tab pointer
+- * @f: file stream
+- * @filename: filename used for debug and error messages
+- *
+- * Returns: 0 on success, negative number in case of error.
+- */
+-int mnt_table_parse_stream(struct libmnt_table *tb, FILE *f, const char *filename)
++static int __table_parse_stream(struct libmnt_table *tb, FILE *f, const char *filename)
+ {
+ 	int rc = -1;
+ 	int flags = 0;
+@@ -785,6 +777,40 @@ err:
+ 	return rc;
+ }
+ 
++/**
++ * mnt_table_parse_stream:
++ * @tb: tab pointer
++ * @f: file stream
++ * @filename: filename used for debug and error messages
++ *
++ * Returns: 0 on success, negative number in case of error.
++ */
++int mnt_table_parse_stream(struct libmnt_table *tb, FILE *f, const char *filename)
++{
++	int fd, rc;
++	FILE *memf = NULL;
++	char *membuf = NULL;
++
++	/*
++	 * For /proc/#/{mountinfo,mount} we read all file to memory and use it
++	 * as memory stream. For more details see mnt_read_procfs_file().
++	 */
++	if ((fd = fileno(f)) >= 0
++	    && (tb->fmt == MNT_FMT_GUESS ||
++		tb->fmt == MNT_FMT_MOUNTINFO ||
++		tb->fmt == MNT_FMT_MTAB)
++	    && is_procfs_fd(fd)
++	    && (memf = mnt_get_procfs_memstream(fd, &membuf))) {
++
++		rc = __table_parse_stream(tb, memf, filename);
++		fclose(memf);
++		free(membuf);
++	} else
++		rc = __table_parse_stream(tb, f, filename);
++
++	return rc;
++}
++
+ /**
+  * mnt_table_parse_file:
+  * @tb: tab pointer
+@@ -800,18 +826,49 @@ err:
+ int mnt_table_parse_file(struct libmnt_table *tb, const char *filename)
+ {
+ 	FILE *f;
+-	int rc;
++	int rc, fd = -1;
+ 
+ 	if (!filename || !tb)
+ 		return -EINVAL;
+ 
+-	f = fopen(filename, "r" UL_CLOEXECSTR);
++	/*
++	 * Try to use read()+poll() to realiably read all
++	 * /proc/#/{mount,mountinfo} file to memory
++	 */
++	if (tb->fmt != MNT_FMT_SWAPS
++	    && strncmp(filename, "/proc/", 6) == 0) {
++
++		FILE *memf;
++		char *membuf = NULL;
++
++		fd = open(filename, O_RDONLY|O_CLOEXEC);
++		if (fd < 0) {
++			rc = -errno;
++			goto done;
++		}
++		memf = mnt_get_procfs_memstream(fd, &membuf);
++		if (memf) {
++			rc = __table_parse_stream(tb, memf, filename);
++
++			fclose(memf);
++			free(membuf);
++			close(fd);
++			goto done;
++		}
++		/* else fallback to fopen/fdopen() */
++	}
++
++	if (fd >= 0)
++		f = fdopen(fd, "r" UL_CLOEXECSTR);
++	else
++		f = fopen(filename, "r" UL_CLOEXECSTR);
++
+ 	if (f) {
+-		rc = mnt_table_parse_stream(tb, f, filename);
++		rc = __table_parse_stream(tb, f, filename);
+ 		fclose(f);
+ 	} else
+ 		rc = -errno;
+-
++done:
+ 	DBG(TAB, ul_debugobj(tb, "parsing done [filename=%s, rc=%d]", filename, rc));
+ 	return rc;
+ }
+@@ -868,7 +925,7 @@ static int __mnt_table_parse_dir(struct libmnt_table *tb, const char *dirname)
+ 
+ 		f = fopen_at(dd, d->d_name, O_RDONLY|O_CLOEXEC, "r" UL_CLOEXECSTR);
+ 		if (f) {
+-			mnt_table_parse_stream(tb, f, d->d_name);
++			__table_parse_stream(tb, f, d->d_name);
+ 			fclose(f);
+ 		}
+ 	}
+@@ -909,7 +966,7 @@ static int __mnt_table_parse_dir(struct libmnt_table *tb, const char *dirname)
+ 		f = fopen_at(dirfd(dir), d->d_name,
+ 				O_RDONLY|O_CLOEXEC, "r" UL_CLOEXECSTR);
+ 		if (f) {
+-			mnt_table_parse_stream(tb, f, d->d_name);
++			__table_parse_stream(tb, f, d->d_name);
+ 			fclose(f);
+ 		}
+ 	}
+diff --git a/libmount/src/utils.c b/libmount/src/utils.c
+index 35afce32c..b8dcab235 100644
+--- a/libmount/src/utils.c
++++ b/libmount/src/utils.c
+@@ -19,6 +19,7 @@
+ #include <fcntl.h>
+ #include <pwd.h>
+ #include <grp.h>
++#include <poll.h>
+ #include <blkid.h>
+ 
+ #include "strutils.h"
+@@ -449,6 +450,13 @@ const char *mnt_statfs_get_fstype(struct statfs *vfs)
+ 	return NULL;
+ }
+ 
++int is_procfs_fd(int fd)
++{
++	struct statfs sfs;
++
++	return fstatfs(fd, &sfs) == 0 && sfs.f_type == STATFS_PROC_MAGIC;
++}
++
+ /**
+  * mnt_match_fstype:
+  * @type: filesystem type
+@@ -1168,7 +1176,164 @@ done:
+ 	return 1;
+ }
+ 
++#if defined(HAVE_FMEMOPEN) || defined(TEST_PROGRAM)
++
++/*
++ * This function tries to minimize possible races when we read
++ * /proc/#/{mountinfo,mount} files.
++ *
++ * The idea is to minimize number of read()s and check by poll() that during
++ * the read the mount table has not been modified. If yes, than re-read it
++ * (with some limitations to avoid never ending loop).
++ *
++ * Returns: <0 error, 0 success, 1 too many attempts
++ */
++static int read_procfs_file(int fd, char **buf, size_t *bufsiz)
++{
++	size_t bufmax = 0;
++	int rc = 0, tries = 0, ninters = 0;
++	char *bufptr = NULL;
++
++	assert(buf);
++	assert(bufsiz);
++
++	*bufsiz = 0;
++	*buf = NULL;
++
++	do {
++		ssize_t ret;
++
++		if (!bufptr || bufmax == *bufsiz) {
++			char *tmp;
++
++			bufmax = bufmax ? bufmax * 2 : (16 * 1024);
++			tmp = realloc(*buf, bufmax);
++			if (!tmp)
++				break;
++			*buf = tmp;
++			bufptr = tmp + *bufsiz;
++		}
++
++		errno = 0;
++		ret = read(fd, bufptr, bufmax - *bufsiz);
++
++		if (ret < 0) {
++			/* error */
++			if ((errno == EAGAIN || errno == EINTR) && (ninters++ < 5)) {
++				xusleep(200000);
++				continue;
++			}
++			break;
++
++		} if (ret > 0) {
++			/* success -- verify no event during read */
++			struct pollfd fds[] = {
++				{ .fd = fd, .events = POLLPRI }
++			};
++
++			rc = poll(fds, 1, 0);
++			if (rc < 0)
++				break;		/* poll() error */
++			if (rc > 0) {
++				/* event -- read all again */
++				if (lseek(fd, 0, SEEK_SET) != 0)
++					break;
++				*bufsiz = 0;
++				bufptr = *buf;
++				tries++;
++
++				if (tries > 10)
++					/* busy system? -- wait */
++					xusleep(10000);
++				continue;
++			}
++
++			/* successful read() without active poll() */
++			(*bufsiz) += (size_t) ret;
++			bufptr += ret;
++			tries = ninters = 0;
++		} else {
++			/* end-of-file */
++			goto success;
++		}
++	} while (tries <= 100);
++
++	rc = errno ? -errno : 1;
++	free(*buf);
++	return rc;
++
++success:
++	return 0;
++}
++
++/*
++ * Create FILE stream for data from read_procfs_file()
++ */
++FILE *mnt_get_procfs_memstream(int fd, char **membuf)
++{
++	size_t sz = 0;
++	off_t cur;
++
++	*membuf = NULL;
++
++	/* in case of error, rewind to the original position */
++	cur = lseek(fd, 0, SEEK_CUR);
++
++	if (read_procfs_file(fd, membuf, &sz) == 0 && sz > 0) {
++		FILE *memf = fmemopen(*membuf, sz, "r");
++		if (memf)
++			return memf;	/* success */
++
++		free(*membuf);
++		*membuf = NULL;
++	}
++
++	/* error */
++	if (cur != (off_t) -1)
++		lseek(fd, cur, SEEK_SET);
++	return NULL;
++}
++#else
++FILE *mnt_get_procfs_memstream(int fd __attribute((__unused__)),
++		               char **membuf __attribute((__unused__)))
++{
++	return NULL;
++}
++#endif /* HAVE_FMEMOPEN */
++
++
+ #ifdef TEST_PROGRAM
++static int test_proc_read(struct libmnt_test *ts, int argc, char *argv[])
++{
++	char *buf = NULL;
++	char *filename = argv[1];
++	size_t bufsiz = 0;
++	int rc = 0, fd = open(filename, O_RDONLY);
++
++	if (fd <= 0) {
++		warn("%s: cannot open", filename);
++		return -errno;
++	}
++
++	rc = read_procfs_file(fd, &buf, &bufsiz);
++	close(fd);
++
++	switch (rc) {
++	case 0:
++		fwrite(buf, 1, bufsiz, stdout);
++		free(buf);
++		break;
++	case 1:
++		warnx("too many attempts");
++		break;
++	default:
++		warn("%s: cannot read", filename);
++		break;
++	}
++
++	return rc;
++}
++
+ static int test_match_fstype(struct libmnt_test *ts, int argc, char *argv[])
+ {
+ 	char *type = argv[1];
+@@ -1350,6 +1515,7 @@ int main(int argc, char *argv[])
+ 	{ "--guess-root",    test_guess_root,      "[<maj:min>]" },
+ 	{ "--mkdir",         test_mkdir,           "<path>" },
+ 	{ "--statfs-type",   test_statfs_type,     "<path>" },
++	{ "--read-procfs",   test_proc_read,       "<path>" },
+ 
+ 	{ NULL }
+ 	};

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.36/util-linux-2.36.tar.xz"
-sha512 = "cbb4975da8d99a1edd45514171d59ea7b019ce0f77a81e88b447a733f725e91c53540d9dc78bc626dc011dca129b8b150aaf9e64ccf62a4202ae816581acf4fd"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.37/util-linux-2.37.1.tar.xz"
+sha512 = "ec300c830869e10a0d7f8c0b99e9bb46e0b88fc51f3c6c6a4d9752a89f035e8d69d81f25fd103ef8d7d253e81440695ef3f5d72dccc94815ec8d5f6f949f7555"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -1,10 +1,20 @@
+%global majorminor 2.37
+%global version %{majorminor}.1
+
 Name: %{_cross_os}util-linux
-Version: 2.36
+Version: %{version}
 Release: 1%{?dist}
 Summary: A collection of basic system utilities
 License: BSD-3-Clause AND BSD-4-Clause-UC AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
 URL: http://en.wikipedia.org/wiki/Util-linux
-Source0: https://www.kernel.org/pub/linux/utils/util-linux/v%{version}/util-linux-%{version}.tar.xz
+Source0: https://www.kernel.org/pub/linux/utils/util-linux/v%{majorminor}/util-linux-%{version}.tar.xz
+
+# Note: remove the autogen.sh call when we no longer patch anything in the
+# build system.
+
+# Retain compatibility with kernels <5.8
+Patch1000: 1000-libmount-kernel-compat.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libacl-devel
 BuildRequires: %{_cross_os}libselinux-devel
@@ -106,6 +116,9 @@ Requires: %{_cross_os}libuuid
 cp Documentation/licenses/COPYING.* .
 
 %build
+# We have patches that touch the build system, so we need to regenerate
+./autogen.sh
+
 %cross_configure \
   --disable-makeinstall-chown \
   --disable-nls \
@@ -185,6 +198,7 @@ done
 %{_cross_bindir}/renice
 %{_cross_bindir}/setsid
 %{_cross_bindir}/taskset
+%{_cross_bindir}/uclampset
 %{_cross_bindir}/umount
 %{_cross_bindir}/unshare
 %{_cross_bindir}/uuidgen

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -432,7 +432,6 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "libffi",
- "libpcre",
  "libselinux",
  "libz",
  "util-linux",


### PR DESCRIPTION
**Description of changes:**

```
209ad3da Update ca-certificates to 2021.07.05
344c99ed Update docker-cli to 20.10.7
1927d17c Update docker-engine to 20.10.7
85c0c1dc Update e2fsprogs to 1.46.3
91dee5d3 Update ecs-agent to 1.54.1
c934b4d3 Update iputils to 20210722
9c0527a0 Update kubernetes-1.19 to 1.19.13
1ac45499 Update kubernetes-1.20 to 1.20.9
dff2c920 Update kubernetes-1.21 to 1.21.3
11dac819 Update libaudit to 3.0.3
f2c9a88a Update libcap to 2.51
79e67837 Update libffi to 3.4.2
b79bb6d2 Update libxcrypt to 4.4.23
3883d35b Update open-vm-tools to 11.3.0
fcfc9182 Update strace to 5.13
d1f24ecc Update util-linux to 2.37.1
5a9a35bd Remove glib dependency on pcre, it uses an internal copy
```

Note: this is the change in libmount for which I added a revert patch so we can maintain kernel compatibility <5.8: https://github.com/karelzak/util-linux/commit/57898c3a7ee8fc5933cddd4526bb3980bef85a02

Not updated: [bash](https://github.com/bottlerocket-os/bottlerocket/issues/1613), [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/368), grub (eek), [systemd](https://github.com/bottlerocket-os/bottlerocket/issues/1671), [containerd](https://github.com/bottlerocket-os/bottlerocket/issues/1670), [runc](https://github.com/bottlerocket-os/bottlerocket/issues/1674), [glib](https://github.com/bottlerocket-os/bottlerocket/issues/1675)

**Testing done:**

* Built aws-1.21, 1.20, 1.19, 1.17, ecs (x86 and arm) and aws-dev, vmware-1.21 (x86)
* Confirmed that pods/tasks run OK
* Confirmed API get/set OK, system services healthy, journal OK
* Confirmed that vmtoolsd was healthy and vSphere showed open-vm-tools info the same as before
* Confirmed 'ping' still works in aws-dev

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
