### PR TITLE
avoid wildcard for applying rp_filter to interfaces

### DIFF
--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -35,6 +35,10 @@ net.ipv4.ip_local_port_range = 32768 60999
 net.netfilter.nf_conntrack_max = 1048576
 net.netfilter.nf_conntrack_generic_timeout = 120
 
+# Enable loose mode for reverse path filter
+net.ipv4.conf.eth0.rp_filter = 2
+net.ipv4.conf.lo.rp_filter = 2
+
 ## Kernel hardening settings
 ## Settings & descriptions sourced from the KSPP wiki, see
 ## https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings#sysctls

--- a/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
@@ -1,7 +1,7 @@
-From 91604d466e49e8529482336a979b990a9588b722 Mon Sep 17 00:00:00 2001
+From f244800c56fb8daa7de89ed4edb085fe0e6ffc47 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 17 Sep 2019 01:35:51 +0000
-Subject: [PATCH 9001/9008] use absolute path for /var/run symlink
+Subject: [PATCH 9001/9009] use absolute path for /var/run symlink
 
 Otherwise the symlink may be broken if /var is a bind mount from
 somewhere else.
@@ -25,5 +25,5 @@ index 0e2c509..6716540 100644
  d /var/log 0755 - - -
  m4_ifdef(`ENABLE_UTMP',
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
+++ b/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
@@ -1,7 +1,7 @@
-From 6931413055f6f9a70f906f6a2df8a24e901a47e5 Mon Sep 17 00:00:00 2001
+From 916d64e020a4f1bd8fffebad15410d232de1190d Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 10 Mar 2020 20:30:10 +0000
-Subject: [PATCH 9002/9008] core: add separate timeout for system shutdown
+Subject: [PATCH 9002/9009] core: add separate timeout for system shutdown
 
 There is an existing setting for this (DefaultTimeoutStopUSec), but
 changing it has no effect because `reset_arguments()` is called just
@@ -62,5 +62,5 @@ index a280b75..de946a0 100644
          arg_default_timeout_abort_set = false;
          arg_default_start_limit_interval = DEFAULT_START_LIMIT_INTERVAL;
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9003-repart-always-use-random-UUIDs.patch
+++ b/packages/systemd/9003-repart-always-use-random-UUIDs.patch
@@ -1,7 +1,7 @@
-From de6bf41d3da21515ff34152c8a9fb6ae23a028c2 Mon Sep 17 00:00:00 2001
+From 129c0ceeab9874ef5f2116a581a132e13d43b896 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 16 Apr 2020 15:10:41 +0000
-Subject: [PATCH 9003/9008] repart: always use random UUIDs
+Subject: [PATCH 9003/9009] repart: always use random UUIDs
 
 We would like to avoid adding OpenSSL to the base OS, and for our use
 case we do not need the UUIDs assigned to disks or partitions to be
@@ -22,10 +22,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  2 files changed, 14 insertions(+), 92 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index f406d59..c16b50c 100644
+index f0e28cc..8be80c9 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1374,8 +1374,7 @@ substs.set('DEFAULT_LLMNR_MODE', default_llmnr)
+@@ -1380,8 +1380,7 @@ substs.set('DEFAULT_LLMNR_MODE', default_llmnr)
  
  want_repart = get_option('repart')
  if want_repart != 'false'
@@ -36,7 +36,7 @@ index f406d59..c16b50c 100644
                  error('repart support was requested, but dependencies are not available')
          endif
 diff --git a/src/partition/repart.c b/src/partition/repart.c
-index 6db413e..f771c33 100644
+index b11f43c..023a00e 100644
 --- a/src/partition/repart.c
 +++ b/src/partition/repart.c
 @@ -13,9 +13,6 @@
@@ -49,7 +49,7 @@ index 6db413e..f771c33 100644
  #include "sd-id128.h"
  
  #include "alloc-util.h"
-@@ -1347,28 +1344,18 @@ static int fdisk_set_disklabel_id_by_uuid(struct fdisk_context *c, sd_id128_t id
+@@ -1350,28 +1347,18 @@ static int fdisk_set_disklabel_id_by_uuid(struct fdisk_context *c, sd_id128_t id
  }
  
  static int derive_uuid(sd_id128_t base, const char *token, sd_id128_t *ret) {
@@ -85,7 +85,7 @@ index 6db413e..f771c33 100644
          return 0;
  }
  
-@@ -2810,83 +2797,19 @@ static int context_mkfs(Context *context) {
+@@ -2818,83 +2805,19 @@ static int context_mkfs(Context *context) {
  }
  
  static int partition_acquire_uuid(Context *context, Partition *p, sd_id128_t *ret) {
@@ -176,5 +176,5 @@ index 6db413e..f771c33 100644
  }
  
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen-and-VM.patch
+++ b/packages/systemd/9004-machine-id-setup-generate-stable-ID-under-Xen-and-VM.patch
@@ -1,7 +1,7 @@
-From 59744095bbd3fa229fabae98ee11c4e5e6502a8b Mon Sep 17 00:00:00 2001
+From 3b74d210606fc150e1a6173c463c08a9cc85f1e4 Mon Sep 17 00:00:00 2001
 From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 Date: Tue, 7 Jul 2020 22:38:20 +0000
-Subject: [PATCH 9004/9008] machine-id-setup: generate stable ID under Xen and
+Subject: [PATCH 9004/9009] machine-id-setup: generate stable ID under Xen and
  VMWare
 
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
@@ -76,5 +76,5 @@ index 6d15f9c..16f8b8c 100644
          }
  
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9005-core-mount-etc-with-specific-label.patch
+++ b/packages/systemd/9005-core-mount-etc-with-specific-label.patch
@@ -1,7 +1,7 @@
-From 02a6f0a9c8f4dd758eb0754bae2dadb5579f0a2f Mon Sep 17 00:00:00 2001
+From f27f7f0d1be1b4c580d07f8025268c0ab72260e8 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 9 Jul 2020 20:00:36 +0000
-Subject: [PATCH 9005/9008] core: mount /etc with specific label
+Subject: [PATCH 9005/9009] core: mount /etc with specific label
 
 The filesystem is mounted after we load the SELinux policy, so we can
 apply the label we need to restrict access.
@@ -25,5 +25,5 @@ index 915b101..38c1a29 100644
            NULL,          MNT_FATAL|MNT_IN_CONTAINER },
          { "devpts",      "/dev/pts",                  "devpts",     "mode=620,gid=" STRINGIFY(TTY_GID),        MS_NOSUID|MS_NOEXEC,
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9006-journal-disable-keyed-hashes-for-compatibility.patch
+++ b/packages/systemd/9006-journal-disable-keyed-hashes-for-compatibility.patch
@@ -1,7 +1,7 @@
-From e01966709aa6beeb85df234be0e75eb9722778ba Mon Sep 17 00:00:00 2001
+From 22f287486b107994fd9105d539821056cf708407 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 12 Nov 2020 16:18:15 +0000
-Subject: [PATCH 9006/9008] journal: disable keyed hashes for compatibility
+Subject: [PATCH 9006/9009] journal: disable keyed hashes for compatibility
 
 Otherwise the journal is not readable by older versions of systemd.
 
@@ -14,10 +14,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src/journal/journal-file.c b/src/journal/journal-file.c
-index 1dbe818..531b9df 100644
+index 6bee5da..791145e 100644
 --- a/src/journal/journal-file.c
 +++ b/src/journal/journal-file.c
-@@ -3383,13 +3383,12 @@ int journal_file_open(
+@@ -3463,13 +3463,12 @@ int journal_file_open(
  #endif
          };
  
@@ -34,5 +34,5 @@ index 1dbe818..531b9df 100644
                  f->keyed_hash = r;
  
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9007-pkg-config-stop-hardcoding-prefix-to-usr.patch
+++ b/packages/systemd/9007-pkg-config-stop-hardcoding-prefix-to-usr.patch
@@ -1,7 +1,7 @@
-From f15c27de1ba9c3f841359f25d945d67a9eb8c396 Mon Sep 17 00:00:00 2001
+From 52940a257782a1dca2e72f210675f89f99c33bc0 Mon Sep 17 00:00:00 2001
 From: Erikson Tung <etung@amazon.com>
 Date: Wed, 27 Jan 2021 14:43:47 -0800
-Subject: [PATCH 9007/9008] pkg-config: stop hardcoding prefix to /usr
+Subject: [PATCH 9007/9009] pkg-config: stop hardcoding prefix to /usr
 
 While we ensure /usr points to the sys-root at runtime, for Bottlerocket's
 packaging we need to be careful to avoid dependencies on the host OS so
@@ -11,7 +11,7 @@ the prefix needs to be configurable.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
-index f2c0455..c50821b 100644
+index b5cc8f9..ec4992b 100644
 --- a/src/core/systemd.pc.in
 +++ b/src/core/systemd.pc.in
 @@ -11,7 +11,7 @@
@@ -24,5 +24,5 @@ index f2c0455..c50821b 100644
  rootprefix=${root_prefix}
  sysconf_dir=@sysconfdir@
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9008-virt-add-Amazon-EC2-to-dmi-vendor-table.patch
+++ b/packages/systemd/9008-virt-add-Amazon-EC2-to-dmi-vendor-table.patch
@@ -1,7 +1,7 @@
-From 7dd380c3c32d7c3c3bd90d494dbbb9fa0e3ab1fb Mon Sep 17 00:00:00 2001
+From 1610fcd97af2b9a2533e74fb4223b5feb2960a9f Mon Sep 17 00:00:00 2001
 From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 Date: Wed, 21 Apr 2021 00:46:32 +0000
-Subject: [PATCH 9008/9008] virt: add "Amazon EC2" to dmi vendor table
+Subject: [PATCH 9008/9009] virt: add "Amazon EC2" to dmi vendor table
 
 Systemd fails to detect the dmi vendor for ARM EC2 instances, and uses
 the random machine id generator instead of a consistent ID after each
@@ -15,7 +15,7 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/src/basic/virt.c b/src/basic/virt.c
-index 1b90f4b..364e7c6 100644
+index 7d78a40..36b470e 100644
 --- a/src/basic/virt.c
 +++ b/src/basic/virt.c
 @@ -158,6 +158,7 @@ static int detect_vm_dmi(void) {
@@ -27,5 +27,5 @@ index 1b90f4b..364e7c6 100644
          unsigned i;
          int r;
 -- 
-2.30.2
+2.21.3
 

--- a/packages/systemd/9009-sysctl-do-not-set-rp_filter-via-wildcard.patch
+++ b/packages/systemd/9009-sysctl-do-not-set-rp_filter-via-wildcard.patch
@@ -1,0 +1,36 @@
+From 54b88070572372af16bd6c372ea1f4fe90d2b46d Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Mon, 21 Jun 2021 20:53:47 +0000
+Subject: [PATCH 9009/9009] sysctl: do not set rp_filter via wildcard
+
+The wildcard matches existing interfaces when `systemd-sysctl` runs
+at startup, but also applies to new interfaces when it is invoked by
+a udev rule in `99-systemd.rules`.
+
+This effectively makes `net.ipv4.conf.default` useless for setting a
+default value for rp_filter, since the wildcard will also match and
+clobber the value.
+
+It also interferes with CNI plugins that attempt to configure the
+rp_filter value for newly created interfaces.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ sysctl.d/50-default.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/sysctl.d/50-default.conf b/sysctl.d/50-default.conf
+index 3baa922..8b4fc0b 100644
+--- a/sysctl.d/50-default.conf
++++ b/sysctl.d/50-default.conf
+@@ -23,7 +23,6 @@ kernel.core_uses_pid = 1
+ 
+ # Source route verification
+ net.ipv4.conf.default.rp_filter = 2
+-net.ipv4.conf.*.rp_filter = 2
+ -net.ipv4.conf.all.rp_filter
+ 
+ # Do not accept source routing
+-- 
+2.21.3
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -43,6 +43,9 @@ Patch9007: 9007-pkg-config-stop-hardcoding-prefix-to-usr.patch
 # so it can generate the correct machine id
 Patch9008: 9008-virt-add-Amazon-EC2-to-dmi-vendor-table.patch
 
+# Local patch to stop overriding rp_filter defaults with wildcard values.
+Patch9009: 9009-sysctl-do-not-set-rp_filter-via-wildcard.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**
Fixes #1367


**Description of changes:**
Stop using wildcards to apply `rp_filter = 2` in systemd, and set the previous default values for `eth0` and `lo`.

This fixes Cilium, which wants to disable the reverse path filter checks for interfaces it creates. It's also more in line with our goals for the host OS, where we expect to manage `eth0` and other interfaces should be configured by containers or the orchestrator agent.


**Testing done:**
For the aws-k8s-1.21 variant, all the settings in `/proc/sys/net/conf/ipv4/*/rp_filter` were the same before and after this change, and the same after a reboot. Interfaces created by the amazon-vpc-cni-k8s plugin had `rp_filter = 2`.

For the aws-ecs-1 variant, all the settings in `/proc/sys/net/conf/ipv4/*/rp_filter` were the same before and after this change. Interfaces created for a task using `awsvpc` mode had `rp_filter = 2`. After a reboot, the interface was removed since the task was no longer running.

For the vmware-k8s-1.20 variant, all the interfaces created by Cilium had `rp_filter = 0`, which is what it needs to function properly. `eth0` and `lo` still had `rp_filter = 2`. After a reboot, the Cilium interfaces were recreated, and still had the expected values.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
