### PR TITLE
netdog: Add IP validation to `node_ip()`

### DIFF
--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -257,10 +257,13 @@ fn remove(args: RemoveArgs) -> Result<()> {
 
 /// Return the current IP address as JSON (intended for use as a settings generator)
 fn node_ip() -> Result<()> {
-    let ip =
+    let ip_string =
         fs::read_to_string(CURRENT_IP).context(error::CurrentIpReadFailed { path: CURRENT_IP })?;
+    // Validate that we read a proper IP address
+    let _ = IpAddr::from_str(&ip_string).context(error::IpFromString { ip: &ip_string })?;
+
     // sundog expects JSON-serialized output
-    Ok(print_json(ip)?)
+    Ok(print_json(ip_string)?)
 }
 
 /// Attempt to resolve assigned IP address, if unsuccessful use "ip-X-X-X-X" where X's are the


### PR DESCRIPTION
**Issue number:**
Requested in #1664 


**Description of changes:**
```
Previously the `node-ip` subcommand, which runs the `node_ip()`
function, would read the current IP from file and return it directly as
JSON.  This change validates what we read from the file is an actual
proper IP address.
```


**Testing done:**
* Run an `aws-k8s-1.19` node, it joins the cluster and runs a pod just fine.
* Manually change `/var/lib/netdog/current_ip` to an invalid IP `1.2.3`, run `netdog node-ip` by hand and (correctly) receive an error.
```
bash-5.0# netdog node-ip
Invalid IP address '1.2.3': invalid IP address syntax
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
