### PR TITLE
Use runtime.slice and system.slice cgroup settings in k8s variants

### DIFF
--- a/packages/containerd/containerd.service
+++ b/packages/containerd/containerd.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network-online.target configured.target
-Wants=network-online.target configured.target
+After=network-online.target configured.target runtime.slice
+Wants=network-online.target configured.target runtime.slice
 
 [Service]
+Slice=runtime.slice
 EnvironmentFile=/etc/network/proxy.env
 ExecStart=/usr/bin/containerd
 Type=notify

--- a/packages/containerd/containerd.service
+++ b/packages/containerd/containerd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network-online.target configured.target runtime.slice
-Wants=network-online.target configured.target runtime.slice
+After=network-online.target configured.target
+Wants=network-online.target configured.target
 
 [Service]
 Slice=runtime.slice

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{~#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+systemReservedCgroup: "/system"
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -68,6 +68,7 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+kubeReservedCgroup: "/runtime"
 {{~#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{~#each settings.kubernetes.system-reserved}}

--- a/packages/kubernetes-1.17/kubelet.service
+++ b/packages/kubernetes-1.17/kubelet.service
@@ -6,6 +6,7 @@ Wants=configured.target
 BindsTo=containerd.service
 
 [Service]
+Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{~#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+systemReservedCgroup: "/system"
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -68,6 +68,7 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+kubeReservedCgroup: "/runtime"
 {{~#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{~#each settings.kubernetes.system-reserved}}

--- a/packages/kubernetes-1.18/kubelet.service
+++ b/packages/kubernetes-1.18/kubelet.service
@@ -6,6 +6,7 @@ Wants=configured.target
 BindsTo=containerd.service
 
 [Service]
+Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{~#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+systemReservedCgroup: "/system"
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -68,6 +68,7 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+kubeReservedCgroup: "/runtime"
 {{~#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{~#each settings.kubernetes.system-reserved}}

--- a/packages/kubernetes-1.19/kubelet.service
+++ b/packages/kubernetes-1.19/kubelet.service
@@ -6,6 +6,7 @@ Wants=configured.target
 BindsTo=containerd.service
 
 [Service]
+Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{~#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+systemReservedCgroup: "/system"
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -68,6 +68,7 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+kubeReservedCgroup: "/runtime"
 {{~#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{~#each settings.kubernetes.system-reserved}}

--- a/packages/kubernetes-1.20/kubelet.service
+++ b/packages/kubernetes-1.20/kubelet.service
@@ -6,6 +6,7 @@ Wants=configured.target
 BindsTo=containerd.service
 
 [Service]
+Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -74,6 +74,7 @@ systemReserved:
   {{~#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+systemReservedCgroup: "/system"
 {{~/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{~#if settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -68,6 +68,7 @@ kubeReserved:
   {{~/if}}
   {{~/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+kubeReservedCgroup: "/runtime"
 {{~#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{~#each settings.kubernetes.system-reserved}}

--- a/packages/kubernetes-1.21/kubelet.service
+++ b/packages/kubernetes-1.21/kubelet.service
@@ -6,6 +6,7 @@ Wants=configured.target
 BindsTo=containerd.service
 
 [Service]
+Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env

--- a/packages/release/release-tmpfiles.conf
+++ b/packages/release/release-tmpfiles.conf
@@ -2,4 +2,6 @@ C /etc/hosts - - - -
 C /etc/nsswitch.conf - - - -
 C /etc/wicked/ifconfig/eth0.xml - - - -
 d /var/log/kdump 0700 root root -
+d /sys/fs/cgroup/cpuset/runtime.slice 0755 root root -
+d /sys/fs/cgroup/hugetlb/runtime.slice 0755 root root -
 T /var/log/kdump - - - - security.selinux=system_u:object_r:secret_t:s0

--- a/packages/release/release-tmpfiles.conf
+++ b/packages/release/release-tmpfiles.conf
@@ -4,4 +4,6 @@ C /etc/wicked/ifconfig/eth0.xml - - - -
 d /var/log/kdump 0700 root root -
 d /sys/fs/cgroup/cpuset/runtime.slice 0755 root root -
 d /sys/fs/cgroup/hugetlb/runtime.slice 0755 root root -
+d /sys/fs/cgroup/cpuset/system.slice 0755 root root -
+d /sys/fs/cgroup/hugetlb/system.slice 0755 root root -
 T /var/log/kdump - - - - security.selinux=system_u:object_r:secret_t:s0

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -49,6 +49,9 @@ Source1060: capture-kernel-dump.service
 Source1061: disable-kexec-load.service
 Source1062: load-crash-kernel.service
 
+# systemd cgroups/slices
+Source1080: runtime.slice
+
 BuildArch: noarch
 Requires: %{_cross_os}acpid
 Requires: %{_cross_os}audit
@@ -111,7 +114,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} \
   %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} %{S:1011} \
-  %{S:1015} %{S:1040} %{S:1041} %{S:1060} %{S:1061} %{S:1062} \
+  %{S:1015} %{S:1040} %{S:1041} %{S:1060} %{S:1061} %{S:1062} %{S:1080} \
   %{buildroot}%{_cross_unitdir}
 
 LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/lower)
@@ -166,6 +169,7 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %{_cross_unitdir}/*-kernels.mount
 %{_cross_unitdir}/*-licenses.mount
 %{_cross_unitdir}/var-lib-bottlerocket.mount
+%{_cross_unitdir}/runtime.slice
 %{_cross_unitdir}/set-hostname.service
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/motd

--- a/packages/release/runtime.slice
+++ b/packages/release/runtime.slice
@@ -1,0 +1,4 @@
+[Unit]
+Description=Kubernetes and container runtime slice
+Documentation=man:systemd.special(7)
+Before=slices.target


### PR DESCRIPTION
**Issue number:**

#1681

**Description of changes:**

```
Follow documented best practices (https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/node-allocatable.md#recommended-cgroups-setup) by running runtime components (containerd, kubelet) within their own cgroup. Separate from system components.

This allows setting of kubeReserved and systemReserved to be enforced.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
