### PR TITLE
Update default admin container to v0.7.2

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -66,4 +66,5 @@ version = "1.1.4"
     "migrate_v1.2.0_kubelet-topology-manager.lz4",
     "migrate_v1.2.0_container-registry-mirrors.lz4",
     "migrate_v1.2.0_container-registry-config-restarts.lz4",
+    "migrate_v1.2.0_admin-container-v0-7-2.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -229,6 +229,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "admin-container-v0-7-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "api/migration/migrations/v1.2.0/kubelet-topology-manager",
     "api/migration/migrations/v1.2.0/container-registry-mirrors",
     "api/migration/migrations/v1.2.0/container-registry-config-restarts",
+    "api/migration/migrations/v1.2.0/admin-container-v0-7-2",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.2.0/admin-container-v0-7-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.2.0/admin-container-v0-7-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "admin-container-v0-7-2"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.2.0/admin-container-v0-7-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.2.0/admin-container-v0-7-2/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.1";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.2";
+
+/// We bumped the version of the default admin container from v0.7.1 to v0.7.2
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.1"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.2"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"

--- a/sources/models/shared-defaults/vmware-host-containers.toml
+++ b/sources/models/shared-defaults/vmware-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.1"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.2"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates the default admin container from v0.7.1 to v0.7.2

**Testing done:**

Using a custom TUF repo, upgraded and downgraded between v1.1.4 and v1.2.0.

_Note: Cherry-picked the commit and used the v1.1.4 release as a base._

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
