### PR TITLE
Revert der-parser update and lock to working version

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "argh",
  "base64",
  "cargo-readme",
+ "der-parser",
  "http",
  "log",
  "models",
@@ -868,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "5.1.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc78bc286418c19333af99233e74abe9d38254d51d8dcc4f571aeb11d25ad194"
+checksum = "120842c2385dea19347e2f6e31caa5dced5ba8afdfacaac16c59465fdd1168f2"
 dependencies = [
  "der-oid-macro",
  "nom",

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -13,6 +13,10 @@ exclude = ["README.md"]
 apiclient = { path = "../apiclient" }
 argh = "0.1.3"
 base64 = "0.13"
+# x509-parser depends on der-parser ^5.0.  5.1.1 contains breaking changes.
+# The 5.1.1 release isn't in the master branch; those changes are instead in a
+# 6.0.0 release, more clearly implying breaking changes.  Lock to 5.1.0.
+der-parser = "=5.1.0"
 http = "0.2"
 log = "0.4"
 models = { path = "../../models" }


### PR DESCRIPTION
**Description of changes:**

After the merges of #1654 and #1683, we would get errors on startup from certdog saying there were invalid certificates and boot would fail.  I must have done insufficient re-testing after rebasing #1683.

I bisected and found that der-parser is specifically the crate update that causes the failure.  As mentioned in the comment below:
```
# x509-parser depends on der-parser ^5.0.  5.1.1 contains breaking changes.
# The 5.1.1 release isn't in the master branch; those changes are instead in a
# 6.0.0 release, more clearly implying breaking changes.  Lock to 5.1.0.
```

@arnaldo2792 offered to dive deeper on exactly which change in 5.1.1 is breaking, and communicate upstream or fix our code as necessary.  For now, locking this version fixes our issue.

**Testing done:**

This resolves the certificate error on startup, and the node is otherwise healthy as well.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
