### PR TITLE
netdog: remove IP string formatting when setting as hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ For [host-container](#host-containers-settings) and [bootstrap-container](#boots
 
 Most users don't need to change this setting as the following defaults work for the majority of use cases.
 If this setting isn't set we attempt to use DNS reverse lookup for the hostname.
-If the lookup is unsuccessful, the IP of the node is used in the format `ip-X-X-X-X`.
+If the lookup is unsuccessful, the IP of the node is used.
 
 ##### Proxy settings
 

--- a/sources/api/netdog/README.md
+++ b/sources/api/netdog/README.md
@@ -10,8 +10,7 @@ file.
 
 It contains two subcommands meant for use as settings generators:
 * `node-ip`: returns the node's current IP address in JSON format
-* `generate-hostname`: returns the node's hostname in JSON format (it is the resolved IP or the IP
-  in format "ip-x-x-x-x" if resolving fails)
+* `generate-hostname`: returns the node's hostname in JSON format. If the lookup is unsuccessful, the IP of the node is used.
 
 The subcommand `set-hostname` sets the hostname for the system.
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Aug 3 17:50:05 2021 -0700

    netdog: remove ip string formatting when setting as hostname
    
    This removes the "ip-X-X-X-X" formatting of the IP address when we're
    using it to set as our hostname. This fixes upgrades and downgrades to
    and from versions of Bottlerocket that uses their plain IP as their
    hostname when registering with the K8s control plane.

```


**Testing done:**
Built OVAs for vmware-k8s-1.20, vmware-k8s-1.21 fine.
Launched VMs and observed that the hostnames were being set to the VM IP address as expected:
```
bash-5.0# apiclient -u /settings?keys=settings.network.hostname
{"network":{"hostname":"198.19.32.14"}}
```

Tried upgrading from a v1.1.4 VM and the VM comes back fine. Node shows up in cluster fine. 
Ran upgrade downgrading testing on the VMs, the quick tests pass.
```
* Phase 2a: launch Bottlerocket v1.1.4 instances
Importing OVA and creating a template out of it...
Launching 3 Bottlerocket v1.1.4 nodes
Cloning VM for worker node '1-20-test-updown-node-1'...
Powering on VirtualMachine:vm-1206... OK
Cloning VM for worker node '1-20-test-updown-node-2'...
Powering on VirtualMachine:vm-1207... OK
Cloning VM for worker node '1-20-test-updown-node-3'...
Powering on VirtualMachine:vm-1208... OK
Waiting for launched Bottlerocket nodes to become 'Ready' in 1-20-test cluster
198.19.128.59   Ready      <none>   37s   v1.20.8
198.19.128.60   NotReady   <none>   15s   v1.20.8
198.19.64.30    NotReady   <none>   0s    v1.20.8

198.19.128.59   Ready      <none>   43s   v1.20.8
198.19.128.60   Ready      <none>   21s   v1.20.8
198.19.64.30    NotReady   <none>   6s    v1.20.8

198.19.128.59   Ready      <none>   49s   v1.20.8
198.19.128.60   Ready      <none>   27s   v1.20.8
198.19.64.30    NotReady   <none>   12s   v1.20.8

198.19.128.59   Ready      <none>   55s   v1.20.8
198.19.128.60   Ready      <none>   33s   v1.20.8
198.19.64.30    NotReady   <none>   18s   v1.20.8

198.19.128.59   Ready   <none>   61s   v1.20.8
198.19.128.60   Ready   <none>   39s   v1.20.8
198.19.64.30    Ready   <none>   24s   v1.20.8

Waiting for the SSM agent on the nodes to be ready for up to 5 minutes

* Phase 2b: change the update repository
Changing TUF repository endpoints via the Bottlerocket API to the following:
Metadata base url: https://blah.cloudfront.net/migration-testing/vmware-k8s-1.20/x86_64/
Targets base url: https://blah.cloudfront.net/migration-testing/targets/

* Phase 3: Initiate the update to Bottlerocket v1.2.0
Initiating upgrade to v1.2.0 on 'mi-07cfae4d4e9b25d5b mi-0e2c8b8f65a1fd3f3 mi-057bbeee76d209213'
Waiting for the instances to reboot into v1.2.0

* Phase 4: test the instances after the upgrade to version v1.2.0
Waiting for launched Bottlerocket nodes to become 'Ready' in 1-20-test cluster
198.19.128.59   Ready   <none>   2m32s   v1.20.9
198.19.128.60   Ready   <none>   2m10s   v1.20.9
198.19.64.30    Ready   <none>   115s    v1.20.9

```


Built aws-k8s-1.20 AMI and launched an instance with it. Node comes up fine without problem with a resolved hostname:
```
[ec2-user@ip-192-168-15-218 ~]$ apiclient -u /settings?keys=settings.network.hostname
{"network":{"hostname":"ip-192-168-15-218.us-west-2.compute.internal"}}
``` 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
