### PR TITLE
logdog: include `/var/log/kdump` in the logdog tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,14 +642,14 @@ sudo sheltie
 logdog
 ```
 
-This will write an archive of the logs to `/tmp/bottlerocket-logs.tar.gz`.
+This will write an archive of the logs to `/var/log/support/bottlerocket-logs.tar.gz`.
 You can use SSH to retrieve the file.
 Once you have exited from the Bottlerocket host, run a command like:
 
 ```bash
 ssh -i YOUR_KEY_FILE \
     ec2-user@YOUR_HOST \
-    "cat /.bottlerocket/rootfs/tmp/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
+    "cat /.bottlerocket/rootfs/var/log/support/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
 ```
 
 For a list of what is collected, see the logdog [command list](sources/logdog/src/log_request.rs).

--- a/packages/release/release-tmpfiles.conf
+++ b/packages/release/release-tmpfiles.conf
@@ -3,3 +3,5 @@ C /etc/nsswitch.conf - - - -
 C /etc/wicked/ifconfig/eth0.xml - - - -
 d /var/log/kdump 0700 root root -
 T /var/log/kdump - - - - security.selinux=system_u:object_r:secret_t:s0
+d /var/log/support 0755 root root -
+T /var/log/support - - - - security.selinux=system_u:object_r:secret_t:s0

--- a/sources/logdog/README.md
+++ b/sources/logdog/README.md
@@ -10,7 +10,7 @@ into a tarball for easy export.
 Usage example:
 ```rust
 $ logdog
-logs are at: /tmp/bottlerocket-logs.tar.gz
+logs are at: /var/log/support/bottlerocket-logs.tar.gz
 ```
 
 ## Logs

--- a/sources/logdog/conf/logdog.common.conf
+++ b/sources/logdog/conf/logdog.common.conf
@@ -14,3 +14,4 @@ exec settings.json apiclient --method GET --uri /
 exec signpost signpost status
 exec wicked wicked show all
 file os-release /etc/os-release
+glob /var/log/kdump/*

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -7,7 +7,7 @@ into a tarball for easy export.
 Usage example:
 ```
 $ logdog
-logs are at: /tmp/bottlerocket-logs.tar.gz
+logs are at: /var/log/support/bottlerocket-logs.tar.gz
 ```
 
 # Logs
@@ -39,6 +39,7 @@ use tempfile::TempDir;
 
 const ERROR_FILENAME: &str = "logdog.errors";
 const OUTPUT_FILENAME: &str = "bottlerocket-logs.tar.gz";
+const OUTPUT_DIRNAME: &str = "/var/log/support";
 const TARBALL_DIRNAME: &str = "bottlerocket-logs";
 
 /// Prints a usage message in the event a bad arg is passed.
@@ -77,7 +78,7 @@ fn parse_args(args: env::Args) -> PathBuf {
 
     match output_arg {
         Some(path) => PathBuf::from(path),
-        None => env::temp_dir().as_path().join(OUTPUT_FILENAME),
+        None => PathBuf::from(OUTPUT_DIRNAME).join(OUTPUT_FILENAME),
     }
 }
 


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**

```
51cb5257 logdog: include `/var/log/kdump` in the logdog taball
```

This commit adds `/var/log/kdump` so that logdog collects crash kernel dumps when they exist.

```
61402201 logdog: change default output directory for tarball
```

This commit changes the default output directory for the tarball created by logdog, from  `/tmp` to `/var/log/support`.


**Testing done:**

In aws-dev, which has kdump support enabled: I verified that the files generated by `prairiedog` were collected by `logdog`:

```sh
tar --list -f /.bottlerocket/rootfs/var/log/support/bottlerocket-logs.tar.gz | grep var:
bottlerocket-logs/var
bottlerocket-logs/var/log
bottlerocket-logs/var/log/kdump
bottlerocket-logs/var/log/kdump/dmesg.log
bottlerocket-logs/var/log/kdump/vmcore.dump
bottlerocket-logs/var/log/kdump/prairiedog.log
``` 

In aws-ecs-1, which doesn't have kdump support enabled, I verified that `logdog` still works:

```sh
tar --list -f /.bottlerocket/rootfs/var/log/support/bottlerocket-logs.tar.gz
bottlerocket-logs/
bottlerocket-logs/logdog.errors
bottlerocket-logs/containerd-config
bottlerocket-logs/containerd-config-host
bottlerocket-logs/df
bottlerocket-logs/df-inodes
bottlerocket-logs/dmesg
bottlerocket-logs/iptables-filter
bottlerocket-logs/iptables-nat
bottlerocket-logs/journalctl-boots
bottlerocket-logs/journalctl.errors
bottlerocket-logs/journalctl.log
bottlerocket-logs/proc-mounts
bottlerocket-logs/settings.json
bottlerocket-logs/signpost
bottlerocket-logs/wicked
bottlerocket-logs/os-release
bottlerocket-logs/docker-info
bottlerocket-logs/docker-daemon.json
bottlerocket-logs/ecs-config.json
bottlerocket-logs/ecs-tasks

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
