### PR TITLE
docs: fix kernel lockdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Here are the metrics settings:
 #### Kernel settings
 
 * `settings.kernel.lockdown`: This allows further restrictions on what the Linux kernel will allow, for example preventing the loading of unsigned modules.
-  May be set to "none" (the default), "integrity", or "confidentiality".
+  May be set to "none" (the default in older [variants](variants/), up through aws-k8s-1.19), "integrity" (the default for newer [variants](variants/)), or "confidentiality".
   **Important note:** this setting cannot be lowered (toward 'none') at runtime.
   You must reboot for a change to a lower level to take effect.
 * `settings.kernel.sysctl`: Key/value pairs representing Linux kernel parameters.

--- a/SECURITY_GUIDANCE.md
+++ b/SECURITY_GUIDANCE.md
@@ -116,7 +116,7 @@ Modifications to the running kernel could bypass or subvert these mechanisms.
 Bottlerocket enables the Lockdown security module and offers settings to choose from one of three modes.
 
 The first mode, "none", effectively disables the protection.
-This is the default in older [variants](variants/) of Bottlerocket, for compatibility with existing deployments.
+This is the default in older [variants](variants/) of Bottlerocket up through aws-k8s-1.19, for compatibility with existing deployments.
 
 The second mode, "integrity", blocks most ways to overwrite the kernel's memory and modify its code.
 This is the default in newer variants.


### PR DESCRIPTION


**Issue number:**
N/A

**Description of changes:**

```
1c0f4d2d docs: fix kernel lockdown documentation
```

This fixes the kernel lockdown's documentation, since the default values changed in newer variants.

**Testing done:**
Documentation change, no testing required (other than just verify the render).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.