### PR TITLE
sources: update to handlebars v4

### DIFF
--- a/packages/containerd/containerd-config-toml_k8s
+++ b/packages/containerd/containerd-config-toml_k8s
@@ -30,9 +30,9 @@ SystemdCgroup = true
 bin_dir = "/opt/cni/bin"
 conf_dir = "/etc/cni/net.d"
 
-{{~#if settings.container-registry.mirrors}}
-{{~#each settings.container-registry.mirrors}}
+{{#if settings.container-registry.mirrors}}
+{{#each settings.container-registry.mirrors}}
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{@key}}"]
 endpoint = [{{join_array ", " this }}]
-{{~/each}}
-{{~/if}}
+{{/each}}
+{{/if}}

--- a/packages/docker-engine/daemon-json
+++ b/packages/docker-engine/daemon-json
@@ -7,7 +7,7 @@
   "data-root": "/var/lib/docker",
   "selinux-enabled": true,
   "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 1024, "Hard": 4096 } }
-  {{~#if settings.container-registry.mirrors.[docker.io]}},
+  {{#if settings.container-registry.mirrors.[docker.io]}},
   "registry-mirrors": [{{join_array ", " settings.container-registry.mirrors.[docker.io]}}]
-  {{~/if}}
+  {{/if}}
 }

--- a/packages/kubernetes-1.17/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.17/kubelet-bootstrap-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,7 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if settings.kubernetes.bootstrap-token}}
+{{#if settings.kubernetes.bootstrap-token}}
   user:
     token: "{{settings.kubernetes.bootstrap-token}}"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -1,7 +1,7 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
-{{~#if settings.kubernetes.standalone-mode}}
+{{#if settings.kubernetes.standalone-mode}}
 address: 127.0.0.1
 authentication:
   anonymous:
@@ -10,7 +10,7 @@ authentication:
     enabled: false
 authorization:
   mode: AlwaysAllow
-{{~else}}
+{{else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -25,67 +25,67 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-{{~/if}}
+{{/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
-{{~#if settings.kubernetes.cluster-dns-ip}}
+{{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
-{{~/if}}
-{{~#if settings.kubernetes.eviction-hard}}
+{{/if}}
+{{#if settings.kubernetes.eviction-hard}}
 evictionHard:
-  {{~#each settings.kubernetes.eviction-hard}}
+  {{#each settings.kubernetes.eviction-hard}}
   {{@key}}: "{{this}}"
-  {{~/each}}
-{{~/if}}
-{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.event-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-qps includeZero=true}}
 eventRecordQPS: {{settings.kubernetes.event-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.event-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
 kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
 kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{~/if}}
+{{/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
-  {{~#if settings.kubernetes.kube-reserved.memory}}
+  {{#if settings.kubernetes.kube-reserved.memory}}
   memory: "{{settings.kubernetes.kube-reserved.memory}}"
-  {{~else}}
-  {{~#if settings.kubernetes.max-pods}}
+  {{else}}
+  {{#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
-  {{~/if}}
-  {{~/if}}
+  {{/if}}
+  {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 kubeReservedCgroup: "/runtime"
-{{~#if settings.kubernetes.system-reserved}}
+{{#if settings.kubernetes.system-reserved}}
 systemReserved:
-  {{~#each settings.kubernetes.system-reserved}}
+  {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
-  {{~/each}}
+  {{/each}}
 systemReservedCgroup: "/system"
-{{~/if}}
+{{/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
-{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+{{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-scope}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-policy}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
-{{~/if}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0
@@ -103,9 +103,9 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
-{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+{{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
-{{~/if}}
-{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.17/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.17/kubelet-exec-start-conf
@@ -1,15 +1,15 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
-{{~#unless settings.kubernetes.standalone-mode}}
+{{#unless settings.kubernetes.standalone-mode}}
     --cloud-provider {{default "external" settings.kubernetes.cloud-provider}} \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
     --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
-{{~/if}}
-{{~else}}
+{{/if}}
+{{else}}
     --cloud-provider "" \
-{{~/unless}}
+{{/unless}}
     --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \

--- a/packages/kubernetes-1.17/kubelet-kubeconfig
+++ b/packages/kubernetes-1.17/kubelet-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,8 +16,8 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
-{{~#if settings.kubernetes.cluster-name}}
+{{#if (eq settings.kubernetes.authentication-mode "aws")}}
+{{#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -26,10 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
-{{~/if}}
-{{~/if}}
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{/if}}
+{{/if}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
   user:
     client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
     client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.18/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.18/kubelet-bootstrap-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,7 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if settings.kubernetes.bootstrap-token}}
+{{#if settings.kubernetes.bootstrap-token}}
   user:
     token: "{{settings.kubernetes.bootstrap-token}}"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -1,7 +1,7 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
-{{~#if settings.kubernetes.standalone-mode}}
+{{#if settings.kubernetes.standalone-mode}}
 address: 127.0.0.1
 authentication:
   anonymous:
@@ -10,7 +10,7 @@ authentication:
     enabled: false
 authorization:
   mode: AlwaysAllow
-{{~else}}
+{{else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -25,67 +25,67 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-{{~/if}}
+{{/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
-{{~#if settings.kubernetes.cluster-dns-ip}}
+{{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
-{{~/if}}
-{{~#if settings.kubernetes.eviction-hard}}
+{{/if}}
+{{#if settings.kubernetes.eviction-hard}}
 evictionHard:
-  {{~#each settings.kubernetes.eviction-hard}}
+  {{#each settings.kubernetes.eviction-hard}}
   {{@key}}: "{{this}}"
-  {{~/each}}
-{{~/if}}
-{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.event-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-qps includeZero=true}}
 eventRecordQPS: {{settings.kubernetes.event-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.event-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
 kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
 kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{~/if}}
+{{/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
-  {{~#if settings.kubernetes.kube-reserved.memory}}
+  {{#if settings.kubernetes.kube-reserved.memory}}
   memory: "{{settings.kubernetes.kube-reserved.memory}}"
-  {{~else}}
-  {{~#if settings.kubernetes.max-pods}}
+  {{else}}
+  {{#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
-  {{~/if}}
-  {{~/if}}
+  {{/if}}
+  {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 kubeReservedCgroup: "/runtime"
-{{~#if settings.kubernetes.system-reserved}}
+{{#if settings.kubernetes.system-reserved}}
 systemReserved:
-  {{~#each settings.kubernetes.system-reserved}}
+  {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
-  {{~/each}}
+  {{/each}}
 systemReservedCgroup: "/system"
-{{~/if}}
+{{/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
-{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+{{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-scope}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-policy}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
-{{~/if}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0
@@ -103,9 +103,9 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
-{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+{{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
-{{~/if}}
-{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.18/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.18/kubelet-exec-start-conf
@@ -1,15 +1,15 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
-{{~#unless settings.kubernetes.standalone-mode}}
+{{#unless settings.kubernetes.standalone-mode}}
     --cloud-provider {{default "external" settings.kubernetes.cloud-provider}} \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
     --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
-{{~/if}}
-{{~else}}
+{{/if}}
+{{else}}
     --cloud-provider "" \
-{{~/unless}}
+{{/unless}}
     --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \

--- a/packages/kubernetes-1.18/kubelet-kubeconfig
+++ b/packages/kubernetes-1.18/kubelet-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,8 +16,8 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
-{{~#if settings.kubernetes.cluster-name}}
+{{#if (eq settings.kubernetes.authentication-mode "aws")}}
+{{#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -26,10 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
-{{~/if}}
-{{~/if}}
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{/if}}
+{{/if}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
   user:
     client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
     client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.19/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.19/kubelet-bootstrap-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,7 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if settings.kubernetes.bootstrap-token}}
+{{#if settings.kubernetes.bootstrap-token}}
   user:
     token: "{{settings.kubernetes.bootstrap-token}}"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -1,7 +1,7 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
-{{~#if settings.kubernetes.standalone-mode}}
+{{#if settings.kubernetes.standalone-mode}}
 address: 127.0.0.1
 authentication:
   anonymous:
@@ -10,7 +10,7 @@ authentication:
     enabled: false
 authorization:
   mode: AlwaysAllow
-{{~else}}
+{{else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -25,67 +25,67 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-{{~/if}}
+{{/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
-{{~#if settings.kubernetes.cluster-dns-ip}}
+{{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
-{{~/if}}
-{{~#if settings.kubernetes.eviction-hard}}
+{{/if}}
+{{#if settings.kubernetes.eviction-hard}}
 evictionHard:
-  {{~#each settings.kubernetes.eviction-hard}}
+  {{#each settings.kubernetes.eviction-hard}}
   {{@key}}: "{{this}}"
-  {{~/each}}
-{{~/if}}
-{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.event-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-qps includeZero=true}}
 eventRecordQPS: {{settings.kubernetes.event-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.event-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
 kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
 kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{~/if}}
+{{/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
-  {{~#if settings.kubernetes.kube-reserved.memory}}
+  {{#if settings.kubernetes.kube-reserved.memory}}
   memory: "{{settings.kubernetes.kube-reserved.memory}}"
-  {{~else}}
-  {{~#if settings.kubernetes.max-pods}}
+  {{else}}
+  {{#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
-  {{~/if}}
-  {{~/if}}
+  {{/if}}
+  {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 kubeReservedCgroup: "/runtime"
-{{~#if settings.kubernetes.system-reserved}}
+{{#if settings.kubernetes.system-reserved}}
 systemReserved:
-  {{~#each settings.kubernetes.system-reserved}}
+  {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
-  {{~/each}}
+  {{/each}}
 systemReservedCgroup: "/system"
-{{~/if}}
+{{/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
-{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+{{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-scope}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-policy}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
-{{~/if}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0
@@ -104,9 +104,9 @@ tlsCipherSuites:
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
-{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+{{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
-{{~/if}}
-{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.19/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.19/kubelet-exec-start-conf
@@ -1,15 +1,15 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
-{{~#unless settings.kubernetes.standalone-mode}}
+{{#unless settings.kubernetes.standalone-mode}}
     --cloud-provider {{default "external" settings.kubernetes.cloud-provider}} \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
     --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
-{{~/if}}
-{{~else}}
+{{/if}}
+{{else}}
     --cloud-provider "" \
-{{~/unless}}
+{{/unless}}
     --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \

--- a/packages/kubernetes-1.19/kubelet-kubeconfig
+++ b/packages/kubernetes-1.19/kubelet-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,8 +16,8 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
-{{~#if settings.kubernetes.cluster-name}}
+{{#if (eq settings.kubernetes.authentication-mode "aws")}}
+{{#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -26,10 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
-{{~/if}}
-{{~/if}}
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{/if}}
+{{/if}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
   user:
     client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
     client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.20/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.20/kubelet-bootstrap-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,7 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if settings.kubernetes.bootstrap-token}}
+{{#if settings.kubernetes.bootstrap-token}}
   user:
     token: "{{settings.kubernetes.bootstrap-token}}"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -1,7 +1,7 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
-{{~#if settings.kubernetes.standalone-mode}}
+{{#if settings.kubernetes.standalone-mode}}
 address: 127.0.0.1
 authentication:
   anonymous:
@@ -10,7 +10,7 @@ authentication:
     enabled: false
 authorization:
   mode: AlwaysAllow
-{{~else}}
+{{else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -25,67 +25,67 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-{{~/if}}
+{{/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
-{{~#if settings.kubernetes.cluster-dns-ip}}
+{{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
-{{~/if}}
-{{~#if settings.kubernetes.eviction-hard}}
+{{/if}}
+{{#if settings.kubernetes.eviction-hard}}
 evictionHard:
-  {{~#each settings.kubernetes.eviction-hard}}
+  {{#each settings.kubernetes.eviction-hard}}
   {{@key}}: "{{this}}"
-  {{~/each}}
-{{~/if}}
-{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.event-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-qps includeZero=true}}
 eventRecordQPS: {{settings.kubernetes.event-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.event-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
 kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
 kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{~/if}}
+{{/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
-  {{~#if settings.kubernetes.kube-reserved.memory}}
+  {{#if settings.kubernetes.kube-reserved.memory}}
   memory: "{{settings.kubernetes.kube-reserved.memory}}"
-  {{~else}}
-  {{~#if settings.kubernetes.max-pods}}
+  {{else}}
+  {{#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
-  {{~/if}}
-  {{~/if}}
+  {{/if}}
+  {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 kubeReservedCgroup: "/runtime"
-{{~#if settings.kubernetes.system-reserved}}
+{{#if settings.kubernetes.system-reserved}}
 systemReserved:
-  {{~#each settings.kubernetes.system-reserved}}
+  {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
-  {{~/each}}
+  {{/each}}
 systemReservedCgroup: "/system"
-{{~/if}}
+{{/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
-{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+{{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-scope}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-policy}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
-{{~/if}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0
@@ -104,9 +104,9 @@ tlsCipherSuites:
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
-{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+{{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
-{{~/if}}
-{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.20/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.20/kubelet-exec-start-conf
@@ -1,15 +1,15 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
-{{~#unless settings.kubernetes.standalone-mode}}
+{{#unless settings.kubernetes.standalone-mode}}
     --cloud-provider {{default "external" settings.kubernetes.cloud-provider}} \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
     --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
-{{~/if}}
-{{~else}}
+{{/if}}
+{{else}}
     --cloud-provider "" \
-{{~/unless}}
+{{/unless}}
     --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \

--- a/packages/kubernetes-1.20/kubelet-kubeconfig
+++ b/packages/kubernetes-1.20/kubelet-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,8 +16,8 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
-{{~#if settings.kubernetes.cluster-name}}
+{{#if (eq settings.kubernetes.authentication-mode "aws")}}
+{{#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -26,10 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
-{{~/if}}
-{{~/if}}
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{/if}}
+{{/if}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
   user:
     client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
     client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.21/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.21/kubelet-bootstrap-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,7 +16,7 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if settings.kubernetes.bootstrap-token}}
+{{#if settings.kubernetes.bootstrap-token}}
   user:
     token: "{{settings.kubernetes.bootstrap-token}}"
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -1,7 +1,7 @@
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
-{{~#if settings.kubernetes.standalone-mode}}
+{{#if settings.kubernetes.standalone-mode}}
 address: 127.0.0.1
 authentication:
   anonymous:
@@ -10,7 +10,7 @@ authentication:
     enabled: false
 authorization:
   mode: AlwaysAllow
-{{~else}}
+{{else}}
 address: 0.0.0.0
 authentication:
   anonymous:
@@ -25,67 +25,67 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-{{~/if}}
+{{/if}}
 clusterDomain: {{settings.kubernetes.cluster-domain}}
-{{~#if settings.kubernetes.cluster-dns-ip}}
+{{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
-{{~/if}}
-{{~#if settings.kubernetes.eviction-hard}}
+{{/if}}
+{{#if settings.kubernetes.eviction-hard}}
 evictionHard:
-  {{~#each settings.kubernetes.eviction-hard}}
+  {{#each settings.kubernetes.eviction-hard}}
   {{@key}}: "{{this}}"
-  {{~/each}}
-{{~/if}}
-{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-qps includeZero=true}}
 registryPullQPS: {{settings.kubernetes.registry-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.registry-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.registry-burst includeZero=true}}
 registryBurst: {{settings.kubernetes.registry-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.event-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-qps includeZero=true}}
 eventRecordQPS: {{settings.kubernetes.event-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.event-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-qps includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
 kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{~/if}}
-{{~#if settings.kubernetes.kube-api-burst includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
 kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{~/if}}
+{{/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
-  {{~#if settings.kubernetes.kube-reserved.memory}}
+  {{#if settings.kubernetes.kube-reserved.memory}}
   memory: "{{settings.kubernetes.kube-reserved.memory}}"
-  {{~else}}
-  {{~#if settings.kubernetes.max-pods}}
+  {{else}}
+  {{#if settings.kubernetes.max-pods}}
   memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
-  {{~/if}}
-  {{~/if}}
+  {{/if}}
+  {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
 kubeReservedCgroup: "/runtime"
-{{~#if settings.kubernetes.system-reserved}}
+{{#if settings.kubernetes.system-reserved}}
 systemReserved:
-  {{~#each settings.kubernetes.system-reserved}}
+  {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
-  {{~/each}}
+  {{/each}}
 systemReservedCgroup: "/system"
-{{~/if}}
+{{/if}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
-{{~#if settings.kubernetes.cpu-manager-reconcile-period}}
+{{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-scope}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
-{{~/if}}
-{{~#if settings.kubernetes.topology-manager-policy}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
-{{~/if}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0
@@ -104,9 +104,9 @@ tlsCipherSuites:
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"
-{{~#if settings.kubernetes.container-log-max-size includeZero=true}}
+{{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
-{{~/if}}
-{{~#if settings.kubernetes.container-log-max-files includeZero=true}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
-{{~/if}}
+{{/if}}

--- a/packages/kubernetes-1.21/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.21/kubelet-exec-start-conf
@@ -1,15 +1,15 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \
-{{~#unless settings.kubernetes.standalone-mode}}
+{{#unless settings.kubernetes.standalone-mode}}
     --cloud-provider {{default "external" settings.kubernetes.cloud-provider}} \
     --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
     --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
-{{~/if}}
-{{~else}}
+{{/if}}
+{{else}}
     --cloud-provider "" \
-{{~/unless}}
+{{/unless}}
     --config /etc/kubernetes/kubelet/config \
     --container-runtime=remote \
     --container-runtime-endpoint=unix:///run/dockershim.sock \

--- a/packages/kubernetes-1.21/kubelet-kubeconfig
+++ b/packages/kubernetes-1.21/kubelet-kubeconfig
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-{{~#if settings.kubernetes.api-server}}
+{{#if settings.kubernetes.api-server}}
     certificate-authority: "/etc/kubernetes/pki/ca.crt"
     server: "{{settings.kubernetes.api-server}}"
-{{~/if}}
+{{/if}}
   name: kubernetes
 contexts:
 - context:
@@ -16,8 +16,8 @@ contexts:
 current-context: kubelet
 users:
 - name: kubelet
-{{~#if (eq settings.kubernetes.authentication-mode "aws")}}
-{{~#if settings.kubernetes.cluster-name}}
+{{#if (eq settings.kubernetes.authentication-mode "aws")}}
+{{#if settings.kubernetes.cluster-name}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
@@ -26,10 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
-{{~/if}}
-{{~/if}}
-{{~#if (eq settings.kubernetes.authentication-mode "tls")}}
+{{/if}}
+{{/if}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
   user:
     client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
     client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
-{{~/if}}
+{{/if}}

--- a/packages/os/host-ctr-toml
+++ b/packages/os/host-ctr-toml
@@ -1,6 +1,6 @@
-{{~#if settings.container-registry.mirrors}}
-{{~#each settings.container-registry.mirrors}}
+{{#if settings.container-registry.mirrors}}
+{{#each settings.container-registry.mirrors}}
 [mirrors."{{@key}}"]
 endpoints = [{{join_array ", " this }}]
-{{~/each}}
-{{~/if}}
+{{/each}}
+{{/if}}

--- a/packages/os/metricdog-toml
+++ b/packages/os/metricdog-toml
@@ -4,8 +4,8 @@ service_checks = [{{join_array ", " settings.metrics.service-checks}}]
 seed = {{settings.updates.seed}}
 version_lock = "{{settings.updates.version-lock}}"
 ignore_waves = {{settings.updates.ignore-waves}}
-{{~#if settings.aws.region}}
+{{#if settings.aws.region}}
 region = "{{settings.aws.region}}"
-{{~else}}
+{{else}}
 region = "global"
-{{~/if}}
+{{/if}}

--- a/packages/os/updog-toml
+++ b/packages/os/updog-toml
@@ -3,9 +3,9 @@ targets_base_url = "{{settings.updates.targets-base-url}}"
 seed = {{settings.updates.seed}}
 version_lock = "{{settings.updates.version-lock}}"
 ignore_waves = {{settings.updates.ignore-waves}}
-{{~#if settings.network.https-proxy}}
+{{#if settings.network.https-proxy}}
 https_proxy="{{settings.network.https-proxy}}"
-{{~/if}}
-{{~#if settings.network.no-proxy}}
+{{/if}}
+{{#if settings.network.no-proxy}}
 no_proxy=[{{join_array ", " settings.network.no-proxy}}]
-{{~/if}}
+{{/if}}

--- a/packages/release/proxy-env
+++ b/packages/release/proxy-env
@@ -2,5 +2,5 @@
 HTTPS_PROXY={{settings.network.https-proxy}}
 https_proxy={{settings.network.https-proxy}}
 {{/if}}
-NO_PROXY={{#each settings.network.no-proxy}}{{this}},{{/each}}localhost,127.0.0.1{{#if settings.kubernetes.api-server}},{{host settings.kubernetes.api-server}}{{/if}}{{#if settings.kubernetes.cluster-domain}},.{{settings.kubernetes.cluster-domain}}{{/if}}
-no_proxy={{#each settings.network.no-proxy}}{{this}},{{/each}}localhost,127.0.0.1{{#if settings.kubernetes.api-server}},{{host settings.kubernetes.api-server}}{{/if}}{{#if settings.kubernetes.cluster-domain}},.{{settings.kubernetes.cluster-domain}}{{/if}}
+NO_PROXY={{#each settings.network.no-proxy}}{{this}},{{else}}{{/each}}localhost,127.0.0.1{{#if settings.kubernetes.api-server}},{{host settings.kubernetes.api-server}}{{/if}}{{#if settings.kubernetes.cluster-domain}},.{{settings.kubernetes.cluster-domain}}{{/if}}
+no_proxy={{#each settings.network.no-proxy}}{{this}},{{else}}{{/each}}localhost,127.0.0.1{{#if settings.kubernetes.api-server}},{{host settings.kubernetes.api-server}}{{/if}}{{#if settings.kubernetes.cluster-domain}},.{{settings.kubernetes.cluster-domain}}{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1301,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.5.5"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+checksum = "72a0ffab8c36d0436114310c7e10b59b3307e650ddfabf6d006028e29a70c6e6"
 dependencies = [
  "log",
  "pest",

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["README.md"]
 [dependencies]
 bottlerocket-release = { path = "../../../bottlerocket-release" }
 datastore = { path = "../../datastore" }
-handlebars = "3.0.1"
+handlebars = "4.1"
 schnauzer = { path = "../../schnauzer" }
 serde = "1.0.104"
 serde_json = "1.0"

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -69,7 +69,7 @@ pub enum Error {
     #[snafu(display("Unable to render template string '{}': {}", template, source))]
     RenderTemplate {
         template: String,
-        source: handlebars::TemplateRenderError,
+        source: handlebars::RenderError,
     },
 
     #[snafu(display("'{}' is set to non-string value", setting))]

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["README.md"]
 apiclient = { path = "../apiclient" }
 base64 = "0.13"
 bottlerocket-release = { path = "../../bottlerocket-release" }
-handlebars = "3.0"
+handlebars = "4.1"
 http = "0.2"
 lazy_static = "1.4"
 log = "0.4"

--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -957,13 +957,13 @@ fn kube_cpu_helper(num_cores: usize) -> Result<String, TemplateHelperError>{
 #[cfg(test)]
 mod test_base64_decode {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1011,13 +1011,13 @@ mod test_base64_decode {
 #[cfg(test)]
 mod test_join_map {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1108,13 +1108,13 @@ mod test_join_map {
 #[cfg(test)]
 mod test_default {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1200,13 +1200,13 @@ mod test_default {
 #[cfg(test)]
 mod test_ecr_registry {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1262,13 +1262,13 @@ mod test_ecr_registry {
 #[cfg(test)]
 mod test_pause_registry {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1323,13 +1323,13 @@ mod test_pause_registry {
 #[cfg(test)]
 mod test_host {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1382,13 +1382,13 @@ mod test_host {
 #[cfg(test)]
 mod test_goarch {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1425,13 +1425,13 @@ mod test_goarch {
 #[cfg(test)]
 mod test_join_array {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1493,13 +1493,13 @@ mod test_join_array {
 #[cfg(test)]
 mod test_kube_reserve_memory {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {
@@ -1550,13 +1550,13 @@ mod test_kube_reserve_memory {
 #[cfg(test)]
 mod test_kube_reserve_cpu {
     use super::*;
-    use handlebars::TemplateRenderError;
+    use handlebars::RenderError;
     use serde::Serialize;
     use serde_json::json;
 
     // A thin wrapper around the handlebars render_template method that includes
     // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, TemplateRenderError>
+    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
     where
         T: Serialize,
     {

--- a/sources/api/schnauzer/src/main.rs
+++ b/sources/api/schnauzer/src/main.rs
@@ -80,7 +80,7 @@ mod error {
         RenderTemplate {
             setting_name: String,
             template: String,
-            source: handlebars::TemplateRenderError,
+            source: handlebars::RenderError,
         },
     }
 }

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
-handlebars = "3.0"
+handlebars = "4.1"
 http = "0.2"
 itertools = "0.10"
 log = "0.4"

--- a/sources/api/thar-be-settings/src/main.rs
+++ b/sources/api/thar-be-settings/src/main.rs
@@ -29,7 +29,7 @@ mod error {
         TemplateRegister {
             name: String,
             path: PathBuf,
-            source: handlebars::TemplateFileError,
+            source: handlebars::TemplateError,
         },
     }
 }


### PR DESCRIPTION
**Description of changes:**

I left handlebars out of #1683 because there were fairly substantial changes required.  The relevant change in handlebars is [this](https://github.com/sunng87/handlebars-rust/pull/404) which means `Empty lines around block helpers are now stripped`.  Essentially, before, we had to use `~` in many places to remove whitespace before/after `{{}}` blocks, even where they're not required in "standard" mustache.  There were several issues with the initial upstream change, so we had to wait for the 4.1 release for fixes.

So, you'll see a lot of `~` removal in the diff.  The only significant change in templates is the `else` clause added to the `proxy-env` configuration. handlebars v4 (in strict mode) no longer allows `each` if the referenced variable is missing, unless there's an `else`. Everywhere else, we have `each` in a conditional that checks that the referenced variable is populated.  (Outside of templates, they changed an error variant name, but that's it.)

The only place I left the `~` is in kubernetes-ca-crt files, since I think they would be invalid with any whitespace, and we wouldn't have any other data in those files anyway.

**Testing done:**

Unit tests pass.  k8s and ecs AMIs are healthy.

There's a lot of potential for small changes in behavior here, so I made a little pipeline to confirm there were no changes in rendered output.  I modified thar-be-settings to save rendered files locally and not restart services, which wouldn't exist on my laptop.  I created a default data store, rendered before and after, and diffed the directories.  I then set clusters of settings, going through all k8s settings, registry mirrors, and proxy settings, to cover everything affected in the templated files.  I set settings.kubernetes.authentication-mode to aws and tls and checked both, since they cause different branches in templates.  No differences.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
