### PR TITLE
pubsys: raise messages to 'warn' if AMI exists or repo doesn't

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -10,7 +10,7 @@ use crate::aws::{client::build_client, parse_arch, region_from_string};
 use crate::Args;
 use futures::future::{join, lazy, ready, FutureExt};
 use futures::stream::{self, StreamExt};
-use log::{error, info, trace};
+use log::{error, info, trace, warn};
 use pubsys_config::{AwsConfig, InfraConfig};
 use register::{get_ami_id, register_image, RegisteredIds};
 use rusoto_core::{Region, RusotoError};
@@ -149,7 +149,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     })?;
 
     let (ids_of_image, already_registered) = if let Some(found_id) = maybe_id {
-        info!(
+        warn!(
             "Found '{}' already registered in {}: {}",
             ami_args.name,
             base_region.name(),

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -7,7 +7,7 @@ pub(crate) mod validate_repo;
 use crate::{friendly_version, Args};
 use chrono::{DateTime, Utc};
 use lazy_static::lazy_static;
-use log::{debug, info, trace};
+use log::{debug, info, trace, warn};
 use parse_datetime::parse_datetime;
 use pubsys_config::{InfraConfig, RepoConfig, RepoExpirationPolicy, SigningKeyConfig};
 use semver::Version;
@@ -460,7 +460,7 @@ pub(crate) fn run(args: &Args, repo_args: &RepoArgs) -> Result<()> {
         match load_editor_and_manifest(&repo_args.root_role_path, &metadata_url, &targets_url)? {
             Some((editor, manifest)) => (editor, manifest),
             None => {
-                info!(
+                warn!(
                     "Did not find repo at '{}', starting a new one",
                     metadata_url
                 );


### PR DESCRIPTION
**Description of changes:**

```
During development, if you make changes without committing, pubsys will
see that an AMI exists for your (-dirty) commit and not register a new
one.  Similarly, if you have a repo configured in Infra.toml and expect
to be updating it, but it doesn't exist, pubsys will create a new one.
You may not want to continue testing in these cases if you thought a new
AMI was going to be built, or an existing repo updated, with your recent
changes.  Raise these to 'warn' level so they're more obvious.
```

**Testing done:**

First `cargo make ami` OK:
```
21:26:19 [INFO] Registered AMI 'bottlerocket-aws-k8s-1.21-x86_64-v1.2.0-74af19f7' in us-west-2: ami-001e3...
```

Second `cargo make ami` WARN:
```
21:26:55 [WARN] Found 'bottlerocket-aws-k8s-1.21-x86_64-v1.2.0-74af19f7' already registered in us-west-2: ami-001e3...
```

If a configured repo doesn't exist to update in `cargo make repo`:
```
16:54:01 [WARN] Did not find repo at 'file:///home/me/work/bottlerocket/build/repos/default/latest/aws-k8s-1.21/x86_64', starting a new one
```

If it does exist:
```
16:57:22 [INFO] Found metadata and target URLs, loading existing repository
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
