### PR TITLE
Add constants crate

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -509,6 +509,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bottlerocket-constants"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme",
+]
+
+[[package]]
 name = "bottlerocket-release"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -254,6 +254,7 @@ name = "apiclient"
 version = "0.1.0"
 dependencies = [
  "cargo-readme",
+ "constants",
  "datastore",
  "futures",
  "http",
@@ -489,6 +490,7 @@ dependencies = [
  "apiclient",
  "base64",
  "cargo-readme",
+ "constants",
  "datastore",
  "http",
  "log",
@@ -506,13 +508,6 @@ version = "0.1.0"
 dependencies = [
  "rand",
  "serde_json",
-]
-
-[[package]]
-name = "bottlerocket-constants"
-version = "0.1.0"
-dependencies = [
- "cargo-readme",
 ]
 
 [[package]]
@@ -606,6 +601,7 @@ dependencies = [
  "argh",
  "base64",
  "cargo-readme",
+ "constants",
  "der-parser",
  "http",
  "log",
@@ -667,6 +663,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
+name = "constants"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +697,7 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "cargo-readme",
+ "constants",
  "http",
  "log",
  "models",
@@ -942,6 +946,7 @@ dependencies = [
  "async-trait",
  "base64",
  "cargo-readme",
+ "constants",
  "flate2",
  "hex-literal",
  "http",
@@ -964,6 +969,7 @@ name = "ecs-settings-applier"
 version = "0.1.0"
 dependencies = [
  "cargo-readme",
+ "constants",
  "log",
  "schnauzer",
  "serde",
@@ -1373,6 +1379,7 @@ dependencies = [
  "apiclient",
  "base64",
  "cargo-readme",
+ "constants",
  "http",
  "log",
  "models",
@@ -2255,6 +2262,7 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "cargo-readme",
+ "constants",
  "imdsclient",
  "models",
  "rusoto_core",
@@ -2680,6 +2688,7 @@ dependencies = [
  "base64",
  "bottlerocket-release",
  "cargo-readme",
+ "constants",
  "handlebars",
  "http",
  "lazy_static",
@@ -2845,6 +2854,7 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "cargo-readme",
+ "constants",
  "datastore",
  "http",
  "log",
@@ -2862,6 +2872,7 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "cargo-readme",
+ "constants",
  "http",
  "log",
  "serde",
@@ -3063,6 +3074,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "cargo-readme",
+ "constants",
  "log",
  "models",
  "schnauzer",
@@ -3135,6 +3147,7 @@ version = "0.1.0"
 dependencies = [
  "bottlerocket-release",
  "cargo-readme",
+ "constants",
  "datastore",
  "log",
  "merge-toml",
@@ -3195,6 +3208,7 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "cargo-readme",
+ "constants",
  "datastore",
  "http",
  "log",
@@ -3283,6 +3297,7 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "cargo-readme",
+ "constants",
  "handlebars",
  "http",
  "itertools",
@@ -3305,6 +3320,7 @@ dependencies = [
  "bottlerocket-release",
  "cargo-readme",
  "chrono",
+ "constants",
  "fs2",
  "http",
  "log",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -51,6 +51,8 @@ members = [
     "updater/updog",
 
     "webpki-roots-shim",
+
+    "constants"
 ]
 
 [profile.release]

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+constants = { path = "../../constants" }
 datastore = { path = "../datastore" }
 futures = { version = "0.3", default-features = false }
 http = "0.2"

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -18,8 +18,8 @@ use std::env;
 use std::process;
 use std::str::FromStr;
 use unindent::unindent;
+use constants;
 
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const DEFAULT_METHOD: &str = "GET";
 
 /// Stores user-supplied global arguments.
@@ -33,7 +33,7 @@ impl Default for Args {
     fn default() -> Self {
         Self {
             log_level: LevelFilter::Info,
-            socket_path: DEFAULT_API_SOCKET.to_string(),
+            socket_path: constants::API_SOCKET.to_string(),
         }
     }
 }
@@ -151,7 +151,7 @@ fn usage() -> ! {
 
         update cancel options:
             None."#,
-        socket = DEFAULT_API_SOCKET,
+        socket = constants::API_SOCKET,
         method = DEFAULT_METHOD,
     );
     eprintln!("{}", unindent(msg));

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -6,7 +6,7 @@ mod error;
 pub use error::Error;
 
 use actix_web::{
-    body::Body, error::ResponseError, web, App, BaseHttpResponse, FromRequest, HttpRequest,
+    body::Body, error::ResponseError, web, App, FromRequest, HttpRequest,
     HttpResponse, HttpServer, Responder,
 };
 use bottlerocket_release::BottlerocketRelease;

--- a/sources/api/bootstrap-containers/Cargo.toml
+++ b/sources/api/bootstrap-containers/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 datastore = { path = "../datastore" }
 base64 = "0.13"
 http = "0.2"

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["README.md"]
 apiclient = { path = "../apiclient" }
 argh = "0.1.3"
 base64 = "0.13"
+constants = { path = "../../constants" }
 # x509-parser depends on der-parser ^5.0.  5.1.1 contains breaking changes.
 # The 5.1.1 release isn't in the master branch; those changes are instead in a
 # 6.0.0 release, more clearly implying breaking changes.  Lock to 5.1.0.

--- a/sources/api/certdog/src/main.rs
+++ b/sources/api/certdog/src/main.rs
@@ -20,12 +20,10 @@ use std::io::{BufRead, Seek};
 use std::path::Path;
 use std::process;
 use x509_parser;
+use constants;
 
 use model::modeled_types::Identifier;
 
-// FIXME Get from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
-const API_SETTINGS_URI: &str = "/settings";
 // Read from the source in `/usr/share/factory` not the copy in `/etc`
 const DEFAULT_SOURCE_BUNDLE: &str = "/usr/share/factory/etc/pki/tls/certs/ca-bundle.crt";
 // This file is first created with tmpfilesd configurations
@@ -42,7 +40,7 @@ struct Args {
     #[argh(option, default = "LevelFilter::Info", short = 'l')]
     /// log-level trace|debug|info|warn|error
     log_level: LevelFilter,
-    #[argh(option, default = "DEFAULT_API_SOCKET.to_string()", short = 's')]
+    #[argh(option, default = "constants::API_SOCKET.to_string()", short = 's')]
     /// socket-path path to apiserver socket
     socket_path: String,
     #[argh(option, default = "DEFAULT_TRUSTED_STORE.to_string()", short = 't')]
@@ -67,7 +65,7 @@ where
     debug!("Querying the API for settings");
 
     let method = "GET";
-    let uri = API_SETTINGS_URI;
+    let uri = constants::API_SETTINGS_URI;
     let (_code, response_body) = apiclient::raw_request(&socket_path, uri, method, None)
         .await
         .context(error::APIRequest { method, uri })?;

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 http = "0.2"
 log = "0.4"
 models = { path = "../../models" }

--- a/sources/api/corndog/src/main.rs
+++ b/sources/api/corndog/src/main.rs
@@ -16,8 +16,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::String;
 use std::{env, process};
+use constants;
 
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const SYSCTL_PATH_PREFIX: &str = "/proc/sys";
 const LOCKDOWN_PATH: &str = "/sys/kernel/security/lockdown";
 
@@ -183,7 +183,7 @@ fn usage() -> ! {
         --log-level trace|debug|info|warn|error
 
     Socket path defaults to {}",
-        program_name, DEFAULT_API_SOCKET,
+        program_name, constants::API_SOCKET,
     );
     process::exit(2);
 }
@@ -228,7 +228,7 @@ fn parse_args(args: env::Args) -> Args {
     Args {
         subcommand: subcommand.unwrap_or_else(|| usage_msg("Must specify a subcommand.")),
         log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
-        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }
 

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["README.md"]
 apiclient = { path = "../apiclient" }
 async-trait = "0.1.36"
 base64 = "0.13"
+constants = { path = "../../constants" }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 http = "0.2"
 imdsclient = { path = "../../imdsclient" }

--- a/sources/api/early-boot-config/src/main.rs
+++ b/sources/api/early-boot-config/src/main.rs
@@ -20,6 +20,7 @@ use snafu::{ensure, ResultExt};
 use std::fs;
 use std::str::FromStr;
 use std::{env, process};
+use constants;
 
 mod compression;
 mod provider;
@@ -28,12 +29,6 @@ use crate::provider::{Platform, PlatformDataProvider};
 
 // TODO
 // Tests!
-
-// FIXME Get these from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
-const API_SETTINGS_URI: &str = "/settings";
-// We change settings in the shared transaction used by boot-time services.
-const TRANSACTION: &str = "bottlerocket-launch";
 
 // We only want to run early-boot-config once, at first boot.  Our systemd unit file has a
 // ConditionPathExists that will prevent it from running again if this file exists.
@@ -56,7 +51,7 @@ fn usage() -> ! {
             [ --log-level trace|debug|info|warn|error ]
 
     Socket path defaults to {}",
-        program_name, DEFAULT_API_SOCKET,
+        program_name, constants::API_SOCKET,
     );
     process::exit(2);
 }
@@ -97,7 +92,7 @@ fn parse_args(args: env::Args) -> Args {
 
     Args {
         log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
-        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }
 
@@ -111,7 +106,7 @@ async fn run() -> Result<()> {
     info!("early-boot-config started");
 
     info!("Retrieving platform-specific data");
-    let uri = &format!("{}?tx={}", API_SETTINGS_URI, TRANSACTION);
+    let uri = &format!("{}?tx={}", constants::API_SETTINGS_URI, constants::LAUNCH_TRANSACTION);
     let method = "PATCH";
     for settings_json in Platform
         .platform_data()

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+constants = { path = "../../constants" }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1"
 schnauzer = { path = "../schnauzer" }

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -13,8 +13,8 @@ use snafu::{OptionExt, ResultExt};
 use std::fs;
 use std::path::Path;
 use std::{env, process};
+use constants;
 
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const DEFAULT_ECS_CONFIG_PATH: &str = "/etc/ecs/ecs.config.json";
 const VARIANT_ATTRIBUTE_NAME: &str = "bottlerocket.variant";
 
@@ -153,7 +153,7 @@ fn parse_args(args: env::Args) -> Args {
         }
     }
     Args {
-        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }
 
@@ -171,7 +171,7 @@ fn usage() -> ! {
             [ (-s | --socket-path) PATH ]
 
     Socket path defaults to {}",
-        program_name, DEFAULT_API_SOCKET
+        program_name, constants::API_SOCKET
     );
     process::exit(2);
 }

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["README.md"]
 [dependencies]
 apiclient = { path = "../apiclient" }
 base64 = "0.13"
+constants = { path = "../../constants" }
 http = "0.2"
 log = "0.4"
 models = { path = "../../models" }

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 imdsclient = { path = "../../imdsclient" }
 models = { path = "../../models" }
 rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }

--- a/sources/api/pluto/src/api.rs
+++ b/sources/api/pluto/src/api.rs
@@ -16,10 +16,7 @@ pub(crate) struct AwsK8sInfo {
 mod inner {
     use super::*;
     use snafu::{OptionExt, ResultExt, Snafu};
-
-    // FIXME Get these from configuration in the future
-    const DEFAULT_API_SOCKET: &str = "/run/api.sock";
-    const SETTINGS_URI: &str = "/settings";
+    use constants;
 
     #[derive(Debug, Snafu)]
     pub(crate) enum Error {
@@ -38,10 +35,11 @@ mod inner {
 
     /// Gets the Bottlerocket settings from the API and deserializes them into a struct.
     async fn get_settings() -> Result<model::Settings> {
+        let uri = constants::API_SETTINGS_URI;
         let (_status, response_body) =
-            apiclient::raw_request(DEFAULT_API_SOCKET, SETTINGS_URI, "GET", None)
+            apiclient::raw_request(constants::API_SOCKET, uri, "GET", None)
                 .await
-                .context(ApiClient { uri: SETTINGS_URI })?;
+                .context(ApiClient { uri })?;
 
         serde_json::from_str(&response_body).context(SettingsJson)
     }

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["README.md"]
 [dependencies]
 apiclient = { path = "../apiclient" }
 base64 = "0.13"
+constants = { path = "../../constants" }
 bottlerocket-release = { path = "../../bottlerocket-release" }
 handlebars = "4.1"
 http = "0.2"

--- a/sources/api/schnauzer/src/main.rs
+++ b/sources/api/schnauzer/src/main.rs
@@ -19,9 +19,9 @@ use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::string::String;
 use std::{env, process};
+use constants;
 
 // Setting generators do not require dynamic socket paths at this moment.
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const API_METADATA_URI_BASE: &str = "/metadata/";
 
 mod error {
@@ -91,7 +91,7 @@ type Result<T> = std::result::Result<T, error::Error>;
 async fn get_metadata(key: &str, meta: &str) -> Result<String> {
     let uri = &format!("{}{}?keys={}", API_METADATA_URI_BASE, meta, key);
     let method = "GET";
-    let (code, response_body) = apiclient::raw_request(DEFAULT_API_SOCKET, &uri, method, None)
+    let (code, response_body) = apiclient::raw_request(constants::API_SOCKET, &uri, method, None)
         .await
         .context(error::APIRequest { method, uri })?;
     ensure!(
@@ -147,7 +147,7 @@ async fn run() -> Result<()> {
 
     let registry = schnauzer::build_template_registry().context(error::BuildTemplateRegistry)?;
     let template = get_metadata(&setting_name, "templates").await?;
-    let settings = schnauzer::get_settings(DEFAULT_API_SOCKET)
+    let settings = schnauzer::get_settings(constants::API_SOCKET)
         .await
         .context(error::GetSettings)?;
 

--- a/sources/api/servicedog/Cargo.toml
+++ b/sources/api/servicedog/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 datastore = { path = "../datastore" }
 http = "0.2"
 log = "0.4"

--- a/sources/api/servicedog/src/main.rs
+++ b/sources/api/servicedog/src/main.rs
@@ -24,15 +24,10 @@ use std::env;
 use std::ffi::OsStr;
 use std::process::{self, Command};
 use std::str::FromStr;
+use constants;
 
 use datastore::serialization::to_pairs_with_prefix;
 use datastore::{Key, KeyType};
-
-// FIXME Get from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
-const API_SETTINGS_URI: &str = "/settings";
-
-const SYSTEMCTL_BIN: &str = "/bin/systemctl";
 
 mod error {
     use http::StatusCode;
@@ -148,8 +143,8 @@ where
     let key = Key::new(KeyType::Data, key_str).context(error::InvalidKey { key: key_str })?;
     debug!("Querying the API for setting: {}", key_str);
 
-    let uri = format!("{}?keys={}", API_SETTINGS_URI, key_str);
-    let (code, response_body) = apiclient::raw_request(DEFAULT_API_SOCKET, &uri, "GET", None)
+    let uri = format!("{}?keys={}", constants::API_SETTINGS_URI, key_str);
+    let (code, response_body) = apiclient::raw_request(constants::API_SOCKET, &uri, "GET", None)
         .await
         .context(error::APIRequest {
             method: "GET",
@@ -238,7 +233,7 @@ where
     // a `Command` whereas `.args()` returns a `&mut Command`. We use
     // `Command` in our error reporting, which does not play nice with
     // mutable references.
-    let mut command = Command::new(SYSTEMCTL_BIN);
+    let mut command = Command::new(constants::SYSTEMCTL_BIN);
     command.args(args);
     let output = command
         .output()

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 snafu = "0.6"
 http = "0.2"
 log = "0.4"

--- a/sources/api/settings-committer/src/main.rs
+++ b/sources/api/settings-committer/src/main.rs
@@ -17,12 +17,10 @@ use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::ResultExt;
 use std::str::FromStr;
 use std::{collections::HashMap, env, process};
+use constants;
 
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 const API_PENDING_URI_BASE: &str = "/tx";
 const API_COMMIT_URI_BASE: &str = "/tx/commit";
-// By default we commit settings from a shared transaction used by boot-time services.
-const DEFAULT_TRANSACTION: &str = "bottlerocket-launch";
 
 type Result<T> = std::result::Result<T, error::SettingsCommitterError>;
 
@@ -144,7 +142,7 @@ fn usage() -> ! {
 
     Transaction defaults to {}
     Socket path defaults to {}",
-        program_name, DEFAULT_TRANSACTION, DEFAULT_API_SOCKET
+        program_name, constants::LAUNCH_TRANSACTION, constants::API_SOCKET
     );
     process::exit(2);
 }
@@ -192,9 +190,9 @@ fn parse_args(args: env::Args) -> Args {
     }
 
     Args {
-        transaction: transaction.unwrap_or_else(|| DEFAULT_TRANSACTION.to_string()),
+        transaction: transaction.unwrap_or_else(|| constants::LAUNCH_TRANSACTION.to_string()),
         log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
-        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }
 

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+constants = { path = "../../constants" }
 base64 = "0.13"
 log = "0.4"
 models = { path = "../../models" }

--- a/sources/api/static-pods/src/static_pods.rs
+++ b/sources/api/static-pods/src/static_pods.rs
@@ -23,9 +23,6 @@ use std::process;
 use std::str::FromStr;
 use tempfile::{NamedTempFile, TempDir};
 
-// FIXME Get from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
-
 const STATIC_POD_DIR: &str = "/etc/kubernetes/static-pods";
 const ETC_KUBE_DIR: &str = "/etc/kubernetes";
 
@@ -178,7 +175,7 @@ fn usage() {
             [ --log-level trace|debug|info|warn|error ]
 
     Socket path defaults to {}",
-        program_name, DEFAULT_API_SOCKET,
+        program_name, constants::API_SOCKET,
     );
 }
 
@@ -221,7 +218,7 @@ fn parse_args(args: env::Args) -> Result<Args> {
 
     Ok(Args {
         log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
-        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.into()),
+        socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.into()),
     })
 }
 

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+constants = { path = "../../constants" }
 bottlerocket-release = { path = "../../bottlerocket-release" }
 datastore = { path = "../datastore" }
 log = "0.4"

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -26,8 +26,7 @@ use datastore::serialization::{to_pairs, to_pairs_with_prefix};
 use datastore::{self, DataStore, FilesystemDataStore, ScalarError};
 use model::modeled_types::SingleLineString;
 
-// Shared transaction used by boot-time services.
-const TRANSACTION: &str = "bottlerocket-launch";
+use constants;
 
 mod error {
     use std::io;
@@ -285,7 +284,7 @@ fn populate_default_datastore<P: AsRef<Path>>(
             &settings_to_write
         );
         let pending = datastore::Committed::Pending {
-            tx: TRANSACTION.to_string(),
+            tx: constants::LAUNCH_TRANSACTION.to_string(),
         };
         datastore
             .set_keys(&settings_to_write, &pending)
@@ -456,8 +455,7 @@ fn run() -> Result<()> {
     let args = parse_args(env::args());
 
     // SimpleLogger will send errors to stderr and anything less to stdout.
-    SimpleLogger::init(args.log_level, LogConfig::default())
-        .context(error::Logger)?;
+    SimpleLogger::init(args.log_level, LogConfig::default()).context(error::Logger)?;
 
     info!("Storewolf started");
 

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 datastore = { path = "../datastore" }
 http = "0.2"
 log = "0.4"

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 handlebars = "4.1"
 http = "0.2"
 itertools = "0.10"

--- a/sources/api/thar-be-settings/src/main.rs
+++ b/sources/api/thar-be-settings/src/main.rs
@@ -9,11 +9,9 @@ use std::env;
 use std::process;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
+use constants;
 
 use thar_be_settings::{config, get_changed_settings, service};
-
-// FIXME Get from configuration in the future
-const DEFAULT_API_SOCKET: &str = "/run/api.sock";
 
 mod error {
     use snafu::Snafu;
@@ -70,7 +68,7 @@ fn usage() -> ! {
     process; this is useful to prevent blocking an API call.
 
     Socket path defaults to {}",
-        program_name, DEFAULT_API_SOCKET,
+        program_name, constants::API_SOCKET,
     );
     process::exit(2);
 }
@@ -119,7 +117,7 @@ fn parse_args(args: env::Args) -> Args {
         daemon,
         mode,
         log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
-        socket_path: socket_path.unwrap_or_else(|| DEFAULT_API_SOCKET.to_string()),
+        socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }
 

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 apiclient = { path = "../apiclient" }
+constants = { path = "../../constants" }
 bottlerocket-release = { path = "../../bottlerocket-release" }
 chrono = { version = "0.4.11", features = [ "serde" ] }
 fs2 = "0.4.3"

--- a/sources/constants/Cargo.toml
+++ b/sources/constants/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "constants"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/constants/README.md
+++ b/sources/constants/README.md
@@ -1,0 +1,9 @@
+# constants
+
+Current version: 0.1.0
+
+  This crate contains constants shared across multiple Bottlerocket crates
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/constants/README.tpl
+++ b/sources/constants/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/constants/build.rs
+++ b/sources/constants/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/lib.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/constants/src/lib.rs
+++ b/sources/constants/src/lib.rs
@@ -1,0 +1,15 @@
+/*!
+  This crate contains constants shared across multiple Bottlerocket crates
+*/
+
+// Shared API settings
+pub const API_SOCKET: &str = "/run/api.sock";
+pub const API_SETTINGS_URI: &str = "/settings";
+pub const API_SETTINGS_GENERATORS_URI: &str = "/metadata/setting-generators";
+
+// Shared transaction used by boot time services
+pub const LAUNCH_TRANSACTION: &str = "bottlerocket-launch";
+
+// Shared binaries' locations
+pub const SYSTEMCTL_BIN: &str = "/bin/systemctl";
+pub const HOST_CTR_BIN: &str = "/bin/host-ctr";


### PR DESCRIPTION
**Issue number:**
#123

**Description of changes:**

```
7c3cdbe5 sources: use shared constants crate in crates
5b17ca46 sources: add constants crate
56e97663 sources: remove unused struct from apiserver mod
```

This change adds  the `constants` crate and  updates the following crates to use it:
- apiclient
- bootstrap-containers
- certdog
- corndog
- early-boot-config
- ecs-settings-applier
- host-containers
- pluto
- schnauzer
- service-dog
- settings-commiter
- static-pods
- storewolf
- sundog
- thar-be-settings
- thar-be-updates

As part of this PR, I included a small nit to removed an unused struct imported in `sources/api/apiserver/src/server/mod.rs`.

**Testing done:**

**aws-k8s-1.21, aws-k8s-1.19, aws-ecs-1**:
- I ran an nginx pod/task and called `curl http://localhost` from within the pod/task
- `systemctl status` didn't show any failures
- I let the workloads run for +1 hour and `journalctl -p notice` didn't show any alarming message

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
