### PR TITLE
kubelet, pluto: support IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Static pods can be particularly useful when running in standalone mode.
 For Kubernetes variants in AWS and VMware, the following are set for you automatically, but you can override them if you know what you're doing!
 In AWS, [pluto](sources/api/) sets these based on runtime instance information.
 In VMware, Bottlerocket uses [netdog](sources/api/) (for `node-ip`) or relies on [default values](sources/models/src/vmware-k8s-1.21/defaults.d/).
-* `settings.kubernetes.node-ip`: The IPv4 address of this node.
+* `settings.kubernetes.node-ip`: The IP address of this node.
 * `settings.kubernetes.pod-infra-container-image`: The URI of the "pause" container.
 * `settings.kubernetes.kube-reserved`: Resources reserved for node components.
   * Bottlerocket provides default values for the resources by [schnauzer](sources/api/):
@@ -378,7 +378,7 @@ In VMware, Bottlerocket uses [netdog](sources/api/) (for `node-ip`) or relies on
 
 For Kubernetes variants in AWS, the following settings are set for you automatically by [pluto](sources/api/).
 * `settings.kubernetes.max-pods`: The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)
-* `settings.kubernetes.cluster-dns-ip`: Derived from the EKS IPV4 Service CIDR or the CIDR block of the primary network interface.
+* `settings.kubernetes.cluster-dns-ip`: Derived from the EKS Service IP CIDR or the CIDR block of the primary network interface.
 
 #### Amazon ECS settings
 

--- a/packages/kubernetes-1.21/0001-AWS-Include-IPv6-addresses-in-NodeAddresses.patch
+++ b/packages/kubernetes-1.21/0001-AWS-Include-IPv6-addresses-in-NodeAddresses.patch
@@ -1,0 +1,202 @@
+From f8ea814e2d459a900bfb5e6f613dbe521b31515b Mon Sep 17 00:00:00 2001
+From: Angus Lees <gus@inodes.org>
+Date: Thu, 19 Nov 2020 17:34:07 +1100
+Subject: [PATCH] AWS: Include IPv6 addresses in NodeAddresses
+
+---
+ .../k8s.io/legacy-cloud-providers/aws/aws.go  | 52 +++++++++++++++++++
+ .../legacy-cloud-providers/aws/aws_fakes.go   |  8 +++
+ .../legacy-cloud-providers/aws/aws_test.go    | 24 ++++++---
+ 3 files changed, 78 insertions(+), 6 deletions(-)
+
+diff --git a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+index c74eef1199f..ee773f063cb 100644
+--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
++++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+@@ -24,6 +24,7 @@ import (
+ 	"fmt"
+ 	"io"
+ 	"net"
++	"net/http"
+ 	"path"
+ 	"regexp"
+ 	"sort"
+@@ -1439,6 +1440,17 @@ func (c *Cloud) HasClusterID() bool {
+ 	return len(c.tagging.clusterID()) > 0
+ }
+ 
++// isAWSNotFound returns true if the error was caused by an AWS API 404 response.
++func isAWSNotFound(err error) bool {
++	if err != nil {
++		var aerr awserr.RequestFailure
++		if errors.As(err, &aerr) {
++			return aerr.StatusCode() == http.StatusNotFound
++		}
++	}
++	return false
++}
++
+ // NodeAddresses is an implementation of Instances.NodeAddresses.
+ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
+ 	if c.selfAWSInstance.nodeName == name || len(name) == 0 {
+@@ -1493,6 +1505,27 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
+ 			}
+ 		}
+ 
++		// IPv6. Ordered after IPv4 addresses, so legacy code can continue to just use the "first" address in a dual-stack cluster.
++		for _, macID := range macIDs {
++			ipPath := path.Join("network/interfaces/macs/", macID, "ipv6s")
++			ips, err := c.metadata.GetMetadata(ipPath)
++			if err != nil {
++				if isAWSNotFound(err) {
++					// No IPv6 configured. Not an error, just a disappointment.
++					continue
++				}
++				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipPath, err)
++			}
++
++			for _, ip := range strings.Split(ips, "\n") {
++				if ip == "" {
++					continue
++				}
++				// NB: "Internal" is actually about intra-cluster reachability, and not public vs private.
++				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip})
++			}
++		}
++
+ 		externalIP, err := c.metadata.GetMetadata("public-ipv4")
+ 		if err != nil {
+ 			//TODO: It would be nice to be able to determine the reason for the failure,
+@@ -1582,6 +1615,25 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
+ 		}
+ 	}
+ 
++	// IPv6. Ordered after IPv4 addresses, so legacy code can continue to just use the "first" address.
++	for _, networkInterface := range instance.NetworkInterfaces {
++		// skip network interfaces that are not currently in use
++		if aws.StringValue(networkInterface.Status) != ec2.NetworkInterfaceStatusInUse {
++			continue
++		}
++
++		for _, addr6 := range networkInterface.Ipv6Addresses {
++			if ipAddress := aws.StringValue(addr6.Ipv6Address); ipAddress != "" {
++				ip := net.ParseIP(ipAddress)
++				if ip == nil {
++					return nil, fmt.Errorf("EC2 instance had invalid IPv6 address: %s (%q)", aws.StringValue(instance.InstanceId), ipAddress)
++				}
++				// NB: "Internal" is actually about intra-cluster reachability, and not public vs private.
++				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
++			}
++		}
++	}
++
+ 	// TODO: Other IP addresses (multiple ips)?
+ 	publicIPAddress := aws.StringValue(instance.PublicIpAddress)
+ 	if publicIPAddress != "" {
+diff --git a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+index 0113c55554f..500a81a696a 100644
+--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
++++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+@@ -39,6 +39,7 @@ type FakeAWSServices struct {
+ 	selfInstance                *ec2.Instance
+ 	networkInterfacesMacs       []string
+ 	networkInterfacesPrivateIPs [][]string
++	networkInterfacesIPv6s      [][]string
+ 	networkInterfacesVpcIDs     []string
+ 
+ 	ec2      FakeEC2
+@@ -374,6 +375,13 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
+ 				}
+ 			}
+ 		}
++		if len(keySplit) == 5 && keySplit[4] == "ipv6s" {
++			for i, macElem := range m.aws.networkInterfacesMacs {
++				if macParam == macElem {
++					return strings.Join(m.aws.networkInterfacesIPv6s[i], "/\n"), nil
++				}
++			}
++		}
+ 
+ 		return "", nil
+ 	}
+diff --git a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+index 56fd43dd12c..40c570d7bf6 100644
+--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
++++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+@@ -583,7 +583,7 @@ func testHasNodeAddress(t *testing.T, addrs []v1.NodeAddress, addressType v1.Nod
+ 	t.Errorf("Did not find expected address: %s:%s in %v", addressType, address, addrs)
+ }
+ 
+-func makeInstance(num int, privateIP, publicIP, privateDNSName, publicDNSName string, setNetInterface bool) ec2.Instance {
++func makeInstance(num int, privateIP, publicIP, ipv6IP, privateDNSName, publicDNSName string, setNetInterface bool) ec2.Instance {
+ 	var tag ec2.Tag
+ 	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
+ 	tag.Value = aws.String(TestClusterID)
+@@ -613,6 +613,14 @@ func makeInstance(num int, privateIP, publicIP, privateDNSName, publicDNSName st
+ 				},
+ 			},
+ 		}
++
++		if ipv6IP != "" {
++			instance.NetworkInterfaces[0].Ipv6Addresses = []*ec2.InstanceIpv6Address{
++				{
++					Ipv6Address: aws.String(ipv6IP),
++				},
++			}
++		}
+ 	}
+ 	return instance
+ }
+@@ -620,9 +628,9 @@ func makeInstance(num int, privateIP, publicIP, privateDNSName, publicDNSName st
+ func TestNodeAddresses(t *testing.T) {
+ 	// Note instance0 and instance1 have the same name
+ 	// (we test that this produces an error)
+-	instance0 := makeInstance(0, "192.168.0.1", "1.2.3.4", "instance-same.ec2.internal", "instance-same.ec2.external", true)
+-	instance1 := makeInstance(1, "192.168.0.2", "", "instance-same.ec2.internal", "", false)
+-	instance2 := makeInstance(2, "192.168.0.1", "1.2.3.4", "instance-other.ec2.internal", "", false)
++	instance0 := makeInstance(0, "192.168.0.1", "1.2.3.4", "2001:db8::1", "instance-same.ec2.internal", "instance-same.ec2.external", true)
++	instance1 := makeInstance(1, "192.168.0.2", "", "", "instance-same.ec2.internal", "", false)
++	instance2 := makeInstance(2, "192.168.0.1", "1.2.3.4", "", "instance-other.ec2.internal", "", false)
+ 	instances := []*ec2.Instance{&instance0, &instance1, &instance2}
+ 
+ 	aws1, _ := mockInstancesResp(&instance0, []*ec2.Instance{&instance0})
+@@ -644,23 +652,25 @@ func TestNodeAddresses(t *testing.T) {
+ 	if err3 != nil {
+ 		t.Errorf("Should not error when instance found")
+ 	}
+-	if len(addrs3) != 5 {
++	if len(addrs3) != 6 {
+ 		t.Errorf("Should return exactly 5 NodeAddresses")
+ 	}
+ 	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "192.168.0.1")
+ 	testHasNodeAddress(t, addrs3, v1.NodeExternalIP, "1.2.3.4")
++	testHasNodeAddress(t, addrs3, v1.NodeInternalIP, "2001:db8::1")
+ 	testHasNodeAddress(t, addrs3, v1.NodeExternalDNS, "instance-same.ec2.external")
+ 	testHasNodeAddress(t, addrs3, v1.NodeInternalDNS, "instance-same.ec2.internal")
+ 	testHasNodeAddress(t, addrs3, v1.NodeHostName, "instance-same.ec2.internal")
+ }
+ 
+ func TestNodeAddressesWithMetadata(t *testing.T) {
+-	instance := makeInstance(0, "", "2.3.4.5", "instance.ec2.internal", "", false)
++	instance := makeInstance(0, "", "2.3.4.5", "", "instance.ec2.internal", "", false)
+ 	instances := []*ec2.Instance{&instance}
+ 	awsCloud, awsServices := mockInstancesResp(&instance, instances)
+ 
+ 	awsServices.networkInterfacesMacs = []string{"0a:77:89:f3:9c:f6", "0a:26:64:c4:6a:48"}
+ 	awsServices.networkInterfacesPrivateIPs = [][]string{{"192.168.0.1"}, {"192.168.0.2"}}
++	awsServices.networkInterfacesIPv6s = [][]string{{"2001:db8:1::1"}, {"2001:db8:1::2"}}
+ 	addrs, err := awsCloud.NodeAddresses(context.TODO(), "")
+ 	if err != nil {
+ 		t.Errorf("unexpected error: %v", err)
+@@ -668,6 +678,8 @@ func TestNodeAddressesWithMetadata(t *testing.T) {
+ 	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.1")
+ 	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.2")
+ 	testHasNodeAddress(t, addrs, v1.NodeExternalIP, "2.3.4.5")
++	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "2001:db8:1::1")
++	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "2001:db8:1::2")
+ 	var index1, index2 int
+ 	for i, addr := range addrs {
+ 		if addr.Type == v1.NodeInternalIP && addr.Address == "192.168.0.1" {
+-- 
+2.17.1
+

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -36,6 +36,8 @@ Source8: kubernetes-tmpfiles.conf
 Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 
+Patch0001: 0001-AWS-Include-IPv6-addresses-in-NodeAddresses.patch
+
 BuildRequires: git
 BuildRequires: rsync
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -28,6 +28,12 @@ net.ipv4.ip_default_ttl = 255
 # Enable IPv4 forwarding for container networking.
 net.ipv4.conf.all.forwarding = 1
 
+# Enable IPv6 forwarding for container networking.
+net.ipv6.conf.all.forwarding = 1
+
+# Accept router advertisement (RA) packets even if IPv6 forwarding is enabled on eth0
+net.ipv6.conf.eth0.accept_ra = 2
+
 # This is generally considered a safe ephemeral port range
 net.ipv4.ip_local_port_range = 32768 60999
 

--- a/sources/api/pluto/README.md
+++ b/sources/api/pluto/README.md
@@ -15,7 +15,7 @@ It uses IMDS to get information such as:
 
 It uses EKS to get information such as:
 
-- Service IPV4 CIDR
+- Service IP CIDR
 
 It uses the Bottlerocket API to get information such as:
 

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -105,7 +105,7 @@ pub use variant::*;
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 use crate::modeled_types::{
     BootstrapContainerMode, CpuManagerPolicy, DNSDomain, ECSAgentLogLevel, ECSAttributeKey,
@@ -162,9 +162,9 @@ struct KubernetesSettings {
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.
     max_pods: u32,
-    cluster_dns_ip: Ipv4Addr,
+    cluster_dns_ip: IpAddr,
     cluster_domain: DNSDomain,
-    node_ip: Ipv4Addr,
+    node_ip: IpAddr,
     pod_infra_container_image: SingleLineString,
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes https://github.com/bottlerocket-os/bottlerocket/issues/1696

**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Sep 13 15:59:59 2021 -0700

    kubernetes-1.21: patch kubelet to support ipv6 with AWS
    
    This adds a patch to the in-tree AWS cloud provider code to make kubelet
    append IPv6 addresses to the list of NodeAddresses.

```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Aug 9 12:27:23 2021 -0700

    pluto: support IPv6
    
    This adds support for retrieving IPv6 node IP address for IPv6 EKS
    clusters


```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Aug 13 11:00:47 2021 -0700

    release: enable IPv6 forwarding

```

The testing below has been done with IPv6 changes in aws-vpc-cni that has yet to be formally released: https://github.com/aws/amazon-vpc-cni-k8s/pull/1587

**Testing done:**

**Testing for IPv6 EKS Clusters:**
Created an AMI off of the built images and launched an EC2 instance in my IPv6 EKS cluster.
The node is able to get an IPv6 internal IP address:
```
$ kubectl get nodes -o wide
NAME                                          STATUS   ROLES    AGE   VERSION   INTERNAL-IP                              EXTERNAL-IP      OS-IMAGE                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-3-236.us-west-2.compute.internal   Ready    <none>   26m   v1.21.3   2600:1f13:8ff:6600:6a76:135f:ee92:3395   54.188.180.229   Bottlerocket OS 1.2.0   5.10.50          containerd://1.4.8+bottlerocket
```

Can run pods without problem. The pods get IPv6 addresses assigned without problem. I can ping external ipv4 and ipv6 addresses without problem.


**Testing for IPv4 EKS Clusters:**
Launched node with AMI in IPv4 cluster.
Node becomes Ready with the correct `node-ip` and `cluster-dns-ip`:
```
$ kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE   VERSION   INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-1-232.us-west-2.compute.internal    Ready    <none>   28s   v1.21.3   192.168.1.232    54.190.54.101   Bottlerocket OS 1.2.0   5.10.50          containerd://1.4.8+bottlerocket
```
Can run pods without problem.

Ran conformance tests with an IPv6 cluster and all tests passed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
