### PR TITLE
Add an entry to `/etc/hosts` for the current hostname

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -68,3 +68,7 @@ version = "1.2.0"
     "migrate_v1.2.0_container-registry-config-restarts.lz4",
     "migrate_v1.2.0_admin-container-v0-7-2.lz4",
 ]
+"(1.2.0, 1.2.1)" = [
+    "migrate_v1.2.1_etc-hosts-service.lz4",
+    "migrate_v1.2.1_hostname-affects-etc-hosts.lz4",
+]

--- a/packages/release/hosts.template
+++ b/packages/release/hosts.template
@@ -1,2 +1,3 @@
 127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1 localhost localhost.localdomain localhost6 localhost6.localdomain6
+{{add_unresolvable_hostname settings.network.hostname}}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -6,7 +6,6 @@ Release: 0%{?dist}
 Summary: Bottlerocket release
 License: Apache-2.0 OR MIT
 
-Source10: hosts
 Source11: nsswitch.conf
 Source97: release-sysctl.conf
 Source98: release-systemd-system.conf
@@ -15,6 +14,7 @@ Source99: release-tmpfiles.conf
 Source200: motd.template
 Source201: proxy-env
 Source202: hostname-env
+Source203: hosts.template
 
 Source1000: eth0.xml
 Source1001: multi-user.target
@@ -91,7 +91,7 @@ Requires: %{_cross_os}wicked
 
 %install
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
-install -p -m 0644 %{S:10} %{S:11} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
+install -p -m 0644 %{S:11} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/wicked/ifconfig
 install -p -m 0644 %{S:1000} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/wicked/ifconfig
@@ -135,6 +135,7 @@ install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_templatedir}/hostname-env
+install -p -m 0644 %{S:203} %{buildroot}%{_cross_templatedir}/hosts
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.rules
@@ -142,7 +143,6 @@ install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.r
 ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
 %files
-%{_cross_factorydir}%{_cross_sysconfdir}/hosts
 %{_cross_factorydir}%{_cross_sysconfdir}/nsswitch.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/wicked/ifconfig/eth0.xml
 %{_cross_sysctldir}/80-release.conf
@@ -175,6 +175,7 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %{_cross_templatedir}/motd
 %{_cross_templatedir}/proxy-env
 %{_cross_templatedir}/hostname-env
+%{_cross_templatedir}/hosts
 %{_cross_udevrulesdir}/61-mount-cdrom.rules
 
 %changelog

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1038,6 +1038,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "etc-hosts-service"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1395,13 @@ dependencies = [
  "simplelog",
  "snafu",
  "tokio",
+]
+
+[[package]]
+name = "hostname-affects-etc-hosts"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2689,6 +2689,7 @@ dependencies = [
  "bottlerocket-release",
  "cargo-readme",
  "constants",
+ "dns-lookup",
  "handlebars",
  "http",
  "lazy_static",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -24,8 +24,9 @@ members = [
     "api/migration/migration-helpers",
     "api/shibaken",
 
-    # "api/migration/migrations/vX.Y.Z/...
-    # (all migrations currently archived; replace this line with new ones)
+    # "api/migration/migrations/vX.Y.Z/..."
+    "api/migration/migrations/v1.2.1/etc-hosts-service",
+    "api/migration/migrations/v1.2.1/hostname-affects-etc-hosts",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.2.1/etc-hosts-service/Cargo.toml
+++ b/sources/api/migration/migrations/v1.2.1/etc-hosts-service/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "etc-hosts-service"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.2.1/etc-hosts-service/src/main.rs
+++ b/sources/api/migration/migrations/v1.2.1/etc-hosts-service/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and generator for configuring hostname
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "services.hosts",
+        "configuration-files.hosts",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.2.1/hostname-affects-etc-hosts/Cargo.toml
+++ b/sources/api/migration/migrations/v1.2.1/hostname-affects-etc-hosts/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hostname-affects-etc-hosts"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.2.1/hostname-affects-etc-hosts/src/main.rs
+++ b/sources/api/migration/migrations/v1.2.1/hostname-affects-etc-hosts/src/main.rs
@@ -1,0 +1,30 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{
+    MetadataListReplacement, ReplaceMetadataListsMigration,
+};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the 'affected-services' list metadata for 'settings.network.hostname' to include the
+/// hosts "service" on upgrade, and to remove it on downgrade.
+fn run() -> Result<()> {
+    migrate(ReplaceMetadataListsMigration(vec![
+        MetadataListReplacement {
+            setting: "settings.network.hostname",
+            metadata: "affected-services",
+            old_vals: &["hostname"],
+            new_vals: &["hostname", "hosts"],
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -14,6 +14,7 @@ apiclient = { path = "../apiclient" }
 base64 = "0.13"
 constants = { path = "../../constants" }
 bottlerocket-release = { path = "../../bottlerocket-release" }
+dns-lookup = "1.0"
 handlebars = "4.1"
 http = "0.2"
 lazy_static = "1.4"

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -118,6 +118,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     // but isn't provided in the data given to the renderer
     template_registry.set_strict_mode(true);
 
+    // Prefer snake case for helper names (we accidentally created a few with kabob case)
     template_registry.register_helper("base64_decode", Box::new(helpers::base64_decode));
     template_registry.register_helper("join_map", Box::new(helpers::join_map));
     template_registry.register_helper("default", Box::new(helpers::default));
@@ -130,6 +131,10 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper(
         "kube_reserve_memory",
         Box::new(helpers::kube_reserve_memory),
+    );
+    template_registry.register_helper(
+        "add_unresolvable_hostname",
+        Box::new(helpers::add_unresolvable_hostname),
     );
 
     Ok(template_registry)

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -81,7 +81,7 @@ template-path = "/usr/share/templates/proxy-env"
 affected-services = ["containerd", "host-containerd", "host-containers"]
 
 [metadata.settings.network.hostname]
-affected-services = ["hostname"]
+affected-services = ["hostname", "hosts"]
 setting-generator = "netdog generate-hostname"
 
 [services.hostname]
@@ -91,6 +91,14 @@ restart-commands = ["/bin/systemctl try-restart set-hostname.service"]
 [configuration-files.hostname]
 path = "/etc/network/hostname.env"
 template-path = "/usr/share/templates/hostname-env"
+
+[services.hosts]
+configuration-files = ["hosts"]
+restart-commands = []
+
+[configuration-files.hosts]
+path = "/etc/hosts"
+template-path = "/usr/share/templates/hosts"
 
 # NTP
 


### PR DESCRIPTION
**Issue number:**
Fixes #1700


**Description of changes:**
```
    schnauzer: Add a new template helper: `add_unresolvable_hostname`
    
    This change adds a new template helper `add_unresolvable_hostname` that
    will attempt to resolve the hostname given to it in the template (from
    `settings.network.hostname`).  If the hostname is unresolvable or
    resolves to localhost (127.0.0.1 or ::1), the helper adds an alias to
    the hostname for both the IPv4 and IPv6 addresses
```
```
    Add a hostname entry to `/etc/hosts` if hostname is unresolvable
    
    Previously, `/etc/hosts` was a static file (in the `release` package)
    that we copied into the image when building Bottlerocket.  In order to
    have an entry in the file corresponding to hostname, a new "hosts"
    service was added to the affected services for
    `settings.network.hostname`.  This new "hosts" service has a templated
    configuration file that uses `settings.network.hostname` to populate the
    entry in `/etc/hosts` if the current hostname is unresolvable in DNS.
    The templated configuration file uses the previously added
    `add_unresolvable_hostname` template renderer helper.
```
```
    migrations: Add migrations for `/etc/hosts` "service"
    
    This change includes the 2 migrations necessary to make `/etc/hosts` an
    "affected service" of `settings.network.hostname`: one to add the
    service and configuration file for the hosts service, and another to
    add the hosts service to `settings.network.hostname`.
```

**Testing done:**
Boot an `aws-k8s-1.19` host and observe proper behavior, run a pod, etc.  `/etc/hosts` looks like:
```
bash-5.0# cat /etc/hosts 
127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
::1 localhost localhost.localdomain localhost6 localhost6.localdomain6
```
Upgrade the same host to a version including these changes, observe proper boot and behavior.  `/etc/hosts` looks the same because the hostname resolves in EC2:
```
bash-5.0# cat /etc/hosts 
127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4l
::1 localhost localhost.localdomain localhost6 localhost6.localdomain6

```

I followed the same procedure with a VMware variant.  `/etc/hosts` before the upgrade:
```
bash-5.0# cat /etc/hosts 
127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
::1 localhost localhost.localdomain localhost6 localhost6.localdomain6
```
`/etc/hosts` after the upgrade (`hosts-test` is the hostname of my VM):
```
bash-5.0# cat /etc/hosts 
127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
::1 localhost localhost.localdomain localhost6 localhost6.localdomain6
127.0.0.1 hosts-test
::1 hosts-test
```




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
