### PR TITLE
open-vm-tools: add cilium device filters

### DIFF
--- a/packages/open-vm-tools/tools.conf
+++ b/packages/open-vm-tools/tools.conf
@@ -6,4 +6,4 @@ suspend-script=/usr/bin/true
 
 [guestinfo]
 primary-nics=eth0
-exclude-nics=antrea-*,cali*,ovs-system,br*,flannel*,veth*,docker*,virbr*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????
+exclude-nics=antrea-*,cali*,cilium*,lxc*,ovs-system,br*,flannel*,veth*,docker*,virbr*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????


### PR DESCRIPTION
**Issue number:**

#1715

**Description of changes:**

Adds cilium devices to the **exclude-nics** list.

The same change was made in the kubernetes-sigs/image-builder project:
https://github.com/kubernetes-sigs/image-builder/pull/669

**Testing done:**

Launched two Bottlerocket `vmware-k8s-1.21` instances (one with the fix and one without) and compared the number of IP addresses in vCenter. The un-patched instance reported 15 IP addresses, whereas the patched instance only reported 2.

The cluster was running Cilium 1.10.3 and passed the [connectivity check](https://raw.githubusercontent.com/cilium/cilium/v1.10/examples/kubernetes/connectivity-check/connectivity-check.yaml).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
