### PR TITLE
Makefile: make OVF file first in the OVA bundle

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -425,7 +425,12 @@ echo "SHA256(${ovf})= ${ovf_sha256}" >> "${ova_tmp_dir}/${manifest}"
 cp "${root_vmdk_path}" "${ova_tmp_dir}"
 cp "${data_vmdk_path}" "${ova_tmp_dir}"
 
-tar -cf "${ova_tmp_dir}/${BUILDSYS_OVA}" -C "${ova_tmp_dir}" "${manifest}" "${ovf}" "${root_vmdk_path##*/}" "${data_vmdk_path##*/}"
+# According to the OVF spec:
+# https://www.dmtf.org/sites/default/files/standards/documents/DSP0243_2.1.1.pdf,
+# the OVF must be first in the tar bundle.  Manifest is next, and then the
+# files must fall in the same order as listed in the References section of the
+# OVF file
+tar -cf "${ova_tmp_dir}/${BUILDSYS_OVA}" -C "${ova_tmp_dir}" "${ovf}" "${manifest}" "${root_vmdk_path##*/}" "${data_vmdk_path##*/}"
 mv "${ova_tmp_dir}/${BUILDSYS_OVA}" "${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.ova"
 '''
 ]


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
The [OVF spec](https://www.dmtf.org/sites/default/files/standards/documents/DSP0243_2.1.1.pdf) (section 5.3) requires that the OVF is at the beginning of the OVA tar bundle.  

```
This change moves the OVF file to the beginning of the OVA tar bundle to
align with the OVF spec.  Some client software is nice enough to take
care of this for you and upload the OVF first.  vSphere however, will
choke when a user provides a URL to an OVA bundle where the OVF file
isn't first.
```


**Testing done:**
* Upload and run the `vmware-k8s-1.20` OVA successfully from my local machine using `cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.20 upload-ova`
* Upload the `vmware-k8s-1.20` OVA successfully from a private testing endpoint, and observe proper behavior when running it.  The following command instructs vSphere to pull directly from the HTTPS endpoint to a private content library.  I then created a VM from the content library template.
```
govc library.import -k -m -pull -n=test test https://<redacted>/8a28b63fe2d1a7cdb3a2260fab0a38a7c59afd26bddd7c00972486967552484a.bottlerocket-vmware-k8s-1.20-x86_64-v1.2.0.ova
```
* Verified it shows up first in the OVA:
```
$ tar -tf bottlerocket-vmware-k8s-1.20-x86_64-1.2.0-6bc16261.ova
bottlerocket-vmware-k8s-1.20-x86_64-1.2.0-6bc16261.ovf
bottlerocket-vmware-k8s-1.20-x86_64-1.2.0-6bc16261.mf
bottlerocket-vmware-k8s-1.20-x86_64-1.2.0-6bc16261.vmdk
bottlerocket-vmware-k8s-1.20-x86_64-1.2.0-6bc16261-data.vmdk
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
