### PR TITLE
k8s: update eni-max-pods

### DIFF
--- a/packages/os/eni-max-pods
+++ b/packages/os/eni-max-pods
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2021-03-16T15:26:13-07:00
+# This file was generated at 2021-08-31T18:22:52Z
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
@@ -134,8 +134,10 @@ g3.4xlarge 234
 g3.8xlarge 234
 g3s.xlarge 58
 g4ad.16xlarge 234
+g4ad.2xlarge 8
 g4ad.4xlarge 29
 g4ad.8xlarge 58
+g4ad.xlarge 8
 g4dn.12xlarge 234
 g4dn.16xlarge 58
 g4dn.2xlarge 29
@@ -265,6 +267,15 @@ m6gd.large 29
 m6gd.medium 8
 m6gd.metal 737
 m6gd.xlarge 58
+m6i.12xlarge 234
+m6i.16xlarge 737
+m6i.24xlarge 737
+m6i.2xlarge 58
+m6i.32xlarge 737
+m6i.4xlarge 234
+m6i.8xlarge 234
+m6i.large 29
+m6i.xlarge 58
 mac1.metal 234
 p2.16xlarge 234
 p2.8xlarge 234
@@ -393,10 +404,14 @@ t4g.micro 4
 t4g.nano 4
 t4g.small 11
 t4g.xlarge 58
+u-12tb1.112xlarge 737
 u-12tb1.metal 147
 u-18tb1.metal 737
 u-24tb1.metal 737
+u-6tb1.112xlarge 737
+u-6tb1.56xlarge 737
 u-6tb1.metal 147
+u-9tb1.112xlarge 737
 u-9tb1.metal 147
 x1.16xlarge 234
 x1.32xlarge 234


### PR DESCRIPTION
Add m6i instance types and others: fetched from https://github.com/awslabs/amazon-eks-ami/pull/749/files

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #1720



**Description of changes:** Update eni-max-pods (add m6i instances)



**Testing done:** (none)



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
