### PR TITLE
CloudFormation signal program (issue #1581)

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,13 @@ These settings can be changed at any time.
   Supported values are `debug`, `info`, `warn`, `error`, and `crit`, and the default is `info`.
 * `settings.ecs.enable-spot-instance-draining`: If the instance receives a spot termination notice, the agent will set the instance's state to `DRAINING`, so the workload can be moved gracefully before the instance is removed. Defaults to `false`.
 
+#### CloudFormation signal helper settings
+
+For AWS variants, these settings allow you to set up CloudFormation signaling to indicate whether Bottlerocket hosts running in EC2 have been successfully created or updated:
+* `settings.cloudformation.should-signal`: Whether to check status and send signal. Defaults to `false`. If set to `true`, both `stack-name` and `logical-resource-id` need to be specified.
+* `settings.cloudformation.stack-name`: Name of the CloudFormation Stack to signal.
+* `settings.cloudformation.logical-resource-id`: The logical ID of the AutoScalingGroup resource that you want to signal.
+
 #### OCI Hooks settings
 
 Bottlerocket allows you to opt-in to use additional [OCI hooks](https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#lifecycle) for your orchestrated containers.

--- a/Release.toml
+++ b/Release.toml
@@ -101,3 +101,6 @@ version = "1.6.1"
     "migrate_v1.6.0_public-control-container-v0-5-5.lz4",
 ]
 "(1.6.0, 1.6.1)" = []
+"(1.6.1, 1.6.2)" = [
+    "migrate_v1.6.2_add-cfsignal.lz4",
+]

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -22,7 +22,8 @@ source-groups = [
     "imdsclient",
     "retry-read",
     "shimpei",
-    "driverdog"
+    "driverdog",
+    "cfsignal",
 ]
 
 [lib]

--- a/packages/os/cfsignal-toml
+++ b/packages/os/cfsignal-toml
@@ -1,0 +1,3 @@
+should_signal = {{settings.cloudformation.should-signal}}
+stack_name = "{{settings.cloudformation.stack-name}}"
+logical_resource_id = "{{settings.cloudformation.logical-resource-id}}"

--- a/packages/os/cfsignal.service
+++ b/packages/os/cfsignal.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Send signal to CloudFormation Stack
+After=network-online.target settings-applier.service
+Requires=settings-applier.service
+Wants=network-online.target
+# We only want to run once, at first boot. This file is created by cfsignal
+# after a successful run.
+ConditionPathExists=!/var/lib/bottlerocket/cfsignal.ran
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/cfsignal
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -26,6 +26,7 @@ Source5: updog-toml
 Source6: metricdog-toml
 Source7: host-ctr-toml
 Source8: oci-default-hooks-json
+Source9: cfsignal-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -42,6 +43,7 @@ Source113: send-boot-success.service
 Source114: bootstrap-containers@.service
 Source115: link-kernel-modules.service
 Source116: load-kernel-modules.service
+Source117: cfsignal.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -88,6 +90,7 @@ Requires: %{_cross_os}static-pods
 
 %if %{_is_aws_variant}
 Requires: %{_cross_os}shibaken
+Requires: %{_cross_os}cfsignal
 %endif
 
 %if "%{_cross_variant}" == "aws-ecs-1"
@@ -249,6 +252,11 @@ Summary: Manages user-defined K8S static pods
 Summary: Setting generator for populating admin container user-data from IMDS.
 %description -n %{_cross_os}shibaken
 %{summary}.
+
+%package -n %{_cross_os}cfsignal
+Summary: Bottlerocket CloudFormation Stack signaler
+%description -n %{_cross_os}cfsignal
+%{summary}.
 %endif
 
 %package -n %{_cross_os}shimpei
@@ -336,6 +344,7 @@ echo "** Output from non-static builds:"
 %endif
 %if %{_is_aws_variant}
     -p shibaken \
+    -p cfsignal \
 %endif
 %if %{_is_k8s_variant}
 %if %{_is_aws_variant}
@@ -372,6 +381,7 @@ for p in \
 %endif
 %if %{_is_aws_variant}
   shibaken \
+  cfsignal \
 %endif
 %if %{_is_k8s_variant}
 %if %{_is_aws_variant}
@@ -438,6 +448,11 @@ install -p -m 0644 \
   %{S:115} %{S:116} \
 %endif
   %{buildroot}%{_cross_unitdir}
+
+%if %{_is_aws_variant}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:117} %{buildroot}%{_cross_unitdir}
+%endif
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_tmpfilesdir}/migration.conf
@@ -554,6 +569,12 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %if %{_is_aws_variant}
 %files -n %{_cross_os}shibaken
 %{_cross_bindir}/shibaken
+
+%files -n %{_cross_os}cfsignal
+%{_cross_bindir}/cfsignal
+%dir %{_cross_templatedir}
+%{_cross_templatedir}/cfsignal-toml
+%{_cross_unitdir}/cfsignal.service
 %endif
 
 %if %{_is_k8s_variant}

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -44,6 +44,7 @@
 (filecon "/.*/usr/bin/early-boot-config" file api_exec)
 (filecon "/.*/usr/bin/migrator" file api_exec)
 (filecon "/.*/usr/bin/storewolf" file api_exec)
+(filecon "/.*/usr/bin/cfsignal" file api_exec)
 (filecon "/.*/usr/bin/dbus-broker.*" file bus_exec)
 (filecon "/.*/usr/sbin/chronyd" file clock_exec)
 (filecon "/.*/usr/sbin/wicked.*" file network_exec)

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -216,6 +216,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-cfsignal"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +654,23 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfsignal"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme",
+ "hyper",
+ "imdsclient",
+ "log",
+ "rusoto_cloudformation",
+ "rusoto_core",
+ "serde",
+ "simplelog",
+ "snafu",
+ "tokio",
+ "toml",
+]
 
 [[package]]
 name = "chrono"
@@ -2656,6 +2680,20 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rusoto_cloudformation"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00db4cfcfc14725c720d881443f2c17607bd80aa20fecd1382a5936cc2db05d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded",
+ "xml-rs",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "api/migration/migrations/v1.6.0/aws-control-container-v0-5-5",
     "api/migration/migrations/v1.6.0/public-admin-container-v0-7-4",
     "api/migration/migrations/v1.6.0/public-control-container-v0-5-5",
+    "api/migration/migrations/v1.6.2/add-cfsignal",
 
     "bottlerocket-release",
 
@@ -54,6 +55,8 @@ members = [
     "prairiedog",
 
     "metricdog",
+
+    "cfsignal",
 
     "logdog",
 

--- a/sources/api/migration/migrations/v1.6.2/add-cfsignal/Cargo.toml
+++ b/sources/api/migration/migrations/v1.6.2/add-cfsignal/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "add-cfsignal"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.6.2/add-cfsignal/src/main.rs
+++ b/sources/api/migration/migrations/v1.6.2/add-cfsignal/src/main.rs
@@ -1,0 +1,25 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a set of settings for configuring service cfsignal.
+/// Remove the whole `settings.cloudformation` prefix if we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.cloudformation",
+        "services.cfsignal",
+        "configuration-files.cfsignal-toml",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/cfsignal/Cargo.toml
+++ b/sources/cfsignal/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cfsignal"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+simplelog = "0.11"
+snafu = { version = "0.7" }
+toml = "0.5.1"
+tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }
+rusoto_core = { version = "0.47.0", default-features = false, features = ["rustls"] }
+rusoto_cloudformation = { version = "0.47.0", default-features = false, features = ["rustls"] }
+imdsclient = { path = "../imdsclient", version = "0.1.0" }
+hyper = "=0.14.2"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/cfsignal/README.md
+++ b/sources/cfsignal/README.md
@@ -1,0 +1,22 @@
+# cfsignal
+
+Current version: 0.1.0
+
+### Introduction
+
+Cfsignal is similar to [cfn-signal](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-signal.html).
+
+When creating an Auto Scaling Group, CloudFormation can be configured to wait for the expected number of signals from instances before considering the ASG successfully created. See [CreationPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-creationpolicy.html) and [UpdatePolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html) for more details.
+
+Cfsignal uses `systemctl is-system-running` to determine whether the boot has succeeded or failed, and sends the corresponding signal to the CloudFormation stack.
+
+### Configuration
+
+Configuration is read from a TOML file, which is generated from Bottlerocket settings:
+* `should_signal`: Whether to check system status and send signal.
+* `stack_name`: Name of the CFN stack to signal.
+* `logical_resource_id`: The logical ID of the AutoScalingGroup resource that you want to signal.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/cfsignal/README.tpl
+++ b/sources/cfsignal/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/cfsignal/build.rs
+++ b/sources/cfsignal/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/cfsignal/src/cloudformation.rs
+++ b/sources/cfsignal/src/cloudformation.rs
@@ -1,0 +1,61 @@
+use crate::error::{self, Result};
+use imdsclient::ImdsClient;
+use log::info;
+use rusoto_cloudformation::{CloudFormation, CloudFormationClient, SignalResourceInput};
+use rusoto_core::Region;
+use snafu::{OptionExt, ResultExt};
+use std::str::FromStr;
+
+/// Signals Cloudformation stack resource
+pub async fn signal_resource(
+    stack_name: String,
+    logical_resource_id: String,
+    status: String,
+) -> Result<()> {
+    info!("Connecting to IMDS");
+    let mut client = ImdsClient::new();
+    let instance_id = get_instance_id(&mut client).await?;
+    let region = get_region(&mut client).await?;
+
+    info!(
+        "Region: {:?} - InstanceID: {:?} - Signal: {:?}",
+        region, instance_id, status
+    );
+
+    let client = CloudFormationClient::new(
+        Region::from_str(&region).context(error::RegionParseSnafu { region })?,
+    );
+    let signal_resource_input = SignalResourceInput {
+        stack_name,
+        logical_resource_id,
+        status,
+        unique_id: instance_id,
+    };
+
+    client
+        .signal_resource(signal_resource_input)
+        .await
+        .context(error::SignalResourceSnafu)?;
+
+    Ok(())
+}
+
+/// Returns the instanceId
+async fn get_instance_id(client: &mut ImdsClient) -> Result<String> {
+    client
+        .fetch_instance_id()
+        .await
+        .context(error::ImdsRequestSnafu)?
+        .context(error::ImdsNoneSnafu {
+            what: "instance-id",
+        })
+}
+
+/// Returns the region
+async fn get_region(client: &mut ImdsClient) -> Result<String> {
+    client
+        .fetch_region()
+        .await
+        .context(error::ImdsRequestSnafu)?
+        .context(error::ImdsNoneSnafu { what: "region" })
+}

--- a/sources/cfsignal/src/config.rs
+++ b/sources/cfsignal/src/config.rs
@@ -1,0 +1,20 @@
+use crate::error::{self, Result};
+use serde::Deserialize;
+use snafu::ResultExt;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Config {
+    pub(crate) should_signal: bool,
+    pub(crate) stack_name: String,
+    pub(crate) logical_resource_id: String,
+}
+
+impl Config {
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let s = fs::read_to_string(path).context(error::ConfigReadSnafu { path })?;
+        toml::from_str(&s).context(error::ConfigParseSnafu { path })
+    }
+}

--- a/sources/cfsignal/src/error.rs
+++ b/sources/cfsignal/src/error.rs
@@ -1,0 +1,46 @@
+//! Provides the list of errors for `cfsignal`.
+
+use snafu::Snafu;
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+pub enum Error {
+    #[snafu(display("Command '{}' with args '{:?}' failed: {}", command, args, source))]
+    Command {
+        command: String,
+        args: Vec<String>,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]
+    ConfigParse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[snafu(display("Failed to read config file {}: {}", path.display(), source))]
+    ConfigRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("IMDS request failed: {}", source))]
+    ImdsRequest { source: imdsclient::Error },
+
+    #[snafu(display("IMDS request failed: No '{}' found", what))]
+    ImdsNone { what: String },
+
+    #[snafu(display("SignalResource request failed: {}", source))]
+    SignalResource {
+        source: rusoto_core::RusotoError<rusoto_cloudformation::SignalResourceError>,
+    },
+
+    #[snafu(display("Unable to parse '{}' as a region: {}", region, source))]
+    RegionParse {
+        region: String,
+        source: rusoto_core::region::ParseRegionError,
+    },
+}

--- a/sources/cfsignal/src/main.rs
+++ b/sources/cfsignal/src/main.rs
@@ -1,0 +1,92 @@
+#![deny(rust_2018_idioms, unused_imports)]
+
+/*!
+## Introduction
+
+Cfsignal is similar to [cfn-signal](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-signal.html).
+
+When creating an Auto Scaling Group, CloudFormation can be configured to wait for the expected number of signals from instances before considering the ASG successfully created. See [CreationPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-creationpolicy.html) and [UpdatePolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html) for more details.
+
+Cfsignal uses `systemctl is-system-running` to determine whether the boot has succeeded or failed, and sends the corresponding signal to the CloudFormation stack.
+
+## Configuration
+
+Configuration is read from a TOML file, which is generated from Bottlerocket settings:
+* `should_signal`: Whether to check system status and send signal.
+* `stack_name`: Name of the CFN stack to signal.
+* `logical_resource_id`: The logical ID of the AutoScalingGroup resource that you want to signal.
+*/
+
+#![deny(rust_2018_idioms)]
+
+mod cloudformation;
+mod config;
+mod error;
+mod system_check;
+
+use crate::config::Config;
+use crate::error::Result;
+use crate::system_check::SystemCheck;
+use cloudformation::signal_resource;
+use log::LevelFilter;
+use log::{error, info, warn};
+use simplelog::{Config as LogConfig, SimpleLogger};
+use std::fs;
+use std::process;
+
+// We only want to run cfsignal once, at first boot.  Our systemd unit file has a
+// ConditionPathExists that will prevent it from running again if this file exists.
+// We create it after running successfully.
+const MARKER_FILE: &str = "/var/lib/bottlerocket/cfsignal.ran";
+const CFSIGNAL_TOML: &str = "/etc/cfsignal.toml";
+
+/// pub(crate) for testing.
+async fn run() -> Result<()> {
+    SimpleLogger::init(LevelFilter::Info, LogConfig::default())
+        .expect("unable to configure logger");
+
+    // load the cfsignal config file
+    let config = Config::from_file(CFSIGNAL_TOML)?;
+
+    let mut signal_status = "FAILURE";
+    let system_check = Box::new(SystemCheck {});
+    let system_status = system_check.system_running()?;
+    info!(
+        "System status is: {} [{}]",
+        system_status.status, system_status.exit_code
+    );
+
+    // run only if the opt-in flag is set
+    if config.should_signal {
+        if system_status.is_healthy {
+            signal_status = "SUCCESS";
+        }
+
+        if let Err(err) = signal_resource(
+            config.stack_name,
+            config.logical_resource_id,
+            signal_status.to_owned(),
+        )
+        .await
+        {
+            error!("Error while sending signal: {}", err);
+        }
+    }
+
+    fs::write(MARKER_FILE, "").unwrap_or_else(|e| {
+        warn!(
+            "Failed to create marker file '{}', may unexpectedly run again: '{}'",
+            MARKER_FILE, e
+        )
+    });
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/cfsignal/src/system_check.rs
+++ b/sources/cfsignal/src/system_check.rs
@@ -1,0 +1,62 @@
+use crate::error::{self, Result};
+use log::trace;
+use snafu::ResultExt;
+use std::process::Command;
+
+const SYSTEMCTL: &str = "/usr/bin/systemctl";
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct SystemHealth {
+    /// Whether or not the system is healthy.
+    pub(crate) is_healthy: bool,
+    /// The system status description.
+    pub(crate) status: String,
+    /// The system status code.
+    pub(crate) exit_code: i32,
+}
+
+pub(crate) struct SystemCheck {}
+
+impl SystemCheck {
+    pub fn system_running(&self) -> Result<SystemHealth> {
+        let mut result = is_system_running()?;
+        // remove trailing newline
+        result.stdout.pop();
+        Ok(SystemHealth {
+            is_healthy: result.is_success(),
+            status: result.stdout,
+            exit_code: result.exit,
+        })
+    }
+}
+
+struct Outcome {
+    exit: i32,
+    stdout: String,
+}
+
+impl Outcome {
+    fn is_success(&self) -> bool {
+        self.exit == 0
+    }
+}
+
+fn systemctl(args: &[&str]) -> Result<Outcome> {
+    trace!("calling systemctl with '{:?}'", args);
+    let output = Command::new(SYSTEMCTL)
+        .args(args)
+        .output()
+        .with_context(|_| error::CommandSnafu {
+            command: SYSTEMCTL,
+            args: args.iter().map(|&s| s.to_owned()).collect::<Vec<String>>(),
+        })?;
+    Ok(Outcome {
+        exit: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(output.stdout.as_slice()).into(),
+    })
+}
+
+fn is_system_running() -> Result<Outcome> {
+    let outcome = systemctl(&["--wait", "is-system-running"])?;
+    Ok(outcome)
+}

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -157,6 +157,12 @@ impl ImdsClient {
         self.fetch_string(&instance_type_target).await
     }
 
+    /// Gets the instance-id from instance metadata.
+    pub async fn fetch_instance_id(&mut self) -> Result<Option<String>> {
+        let instance_type_target = "meta-data/instance-id";
+        self.fetch_string(&instance_type_target).await
+    }
+
     /// Returns a list of public ssh keys skipping any keys that do not start with 'ssh'.
     pub async fn fetch_public_ssh_keys(&mut self) -> Result<Option<Vec<String>>> {
         info!("Fetching list of available public keys from IMDS");

--- a/sources/models/shared-defaults/cf-signal.toml
+++ b/sources/models/shared-defaults/cf-signal.toml
@@ -1,0 +1,15 @@
+[settings.cloudformation]
+should-signal = false
+stack-name = ""
+logical-resource-id = ""
+
+[services.cfsignal]
+configuration-files = ["cfsignal-toml"]
+restart-commands = ["/bin/systemctl try-restart cfsignal.service"]
+
+[configuration-files.cfsignal-toml]
+path = "/etc/cfsignal.toml"
+template-path = "/usr/share/templates/cfsignal-toml"
+
+[metadata.settings.cloudformation]
+affected-services = ["cfsignal"]

--- a/sources/models/src/aws-dev/defaults.d/25-cf-signal.toml
+++ b/sources/models/src/aws-dev/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -4,8 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    AwsSettings, BootstrapContainer, CloudFormationSettings, HostContainer, KernelSettings,
+    MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
+    UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -24,4 +25,5 @@ struct Settings {
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
+    cloudformation: CloudFormationSettings,
 }

--- a/sources/models/src/aws-ecs-1/defaults.d/25-cf-signal.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,8 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, ECSSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    AwsSettings, BootstrapContainer, CloudFormationSettings, ECSSettings, HostContainer,
+    KernelSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
+    RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -25,4 +26,5 @@ struct Settings {
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
+    cloudformation: CloudFormationSettings,
 }

--- a/sources/models/src/aws-k8s-1.19/defaults.d/25-cf-signal.toml
+++ b/sources/models/src/aws-k8s-1.19/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/models/src/aws-k8s-1.21-nvidia/defaults.d/25-cf-signal.toml
+++ b/sources/models/src/aws-k8s-1.21-nvidia/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/models/src/aws-k8s-1.21-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.21-nvidia/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    AwsSettings, BootstrapContainer, CloudFormationSettings, HostContainer, KernelSettings,
+    KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
+    RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -26,4 +26,5 @@ struct Settings {
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
+    cloudformation: CloudFormationSettings,
 }

--- a/sources/models/src/aws-k8s-1.21/defaults.d/25-cf-signal.toml
+++ b/sources/models/src/aws-k8s-1.21/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/models/src/aws-k8s-1.21/mod.rs
+++ b/sources/models/src/aws-k8s-1.21/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    AwsSettings, BootstrapContainer, CloudFormationSettings, HostContainer, KernelSettings,
+    KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
+    RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -26,4 +26,5 @@ struct Settings {
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
+    cloudformation: CloudFormationSettings,
 }

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -270,6 +270,14 @@ struct MetricsSettings {
     service_checks: Vec<String>,
 }
 
+// CloudFormation settings
+#[model]
+struct CloudFormationSettings {
+    should_signal: bool,
+    stack_name: SingleLineString,
+    logical_resource_id: SingleLineString,
+}
+
 ///// Internal services
 
 // Note: Top-level objects that get returned from the API should have a "rename" attribute


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1581

**Description of changes:**
Created a new rust program, cfsignal to send signal to CloudFormation
Stack.
Program is a sort of cfn-signal
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-signal.html
but as cfn-signal need python cannot be used by bottlerocket.

cfsignal read configuration from a cfsignal.toml file configured reading
user-data, so it depends on settings-applier.service.
It cannot send a signal for a failure happening before
settings-applier.service and network-online.target are started.

It is able to send a failure signal for any other service starting from
(included):
activate-multi-user.service

It use systemctl action is-system-running with --wait option.
This way we can know if any service, after systemd boot process
finished, is in a failure status.

***Detail***
I have created a new setting named `cloudformation`.
It support the keys:
```
signal: boolean
stack_name: string
logical_resource_id: string
```

If signal is false (default) program do nothing.
Other way it excute `systemctl --wait is-system-running` to find out the system state.
Then it send the relative signal to the the _stack_name_ stack.

**Testing done:**
Created and updated and AutoScalingGroup configured to wait signaling by created instances.
Tested that instance send SUCCESS signal if all service started successfully.
```
bash-5.0# systemctl status cfsignal
● cfsignal.service - Send signal to CloudFormation Stack
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/cfsignal.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Thu 2022-02-24 03:20:40 UTC; 10min ago
    Process: 1578 ExecStart=/usr/bin/cfsignal (code=exited, status=0/SUCCESS)
   Main PID: 1578 (code=exited, status=0/SUCCESS)

Feb 24 03:20:40 ip-192-168-16-4.us-west-2.compute.internal cfsignal[1578]: 03:20:40 [INFO] System status is: running [0]
Feb 24 03:20:40 ip-192-168-16-4.us-west-2.compute.internal cfsignal[1578]: 03:20:40 [INFO] Connecting to IMDS
Feb 24 03:20:40 ip-192-168-16-4.us-west-2.compute.internal cfsignal[1578]: 03:20:40 [INFO] Received meta-data/instance-id
Feb 24 03:20:40 ip-192-168-16-4.us-west-2.compute.internal cfsignal[1578]: 03:20:40 [INFO] Received dynamic/instance-identity/document
Feb 24 03:20:40 ip-192-168-16-4.us-west-2.compute.internal cfsignal[1578]: 03:20:40 [INFO] Region: "us-west-2" - InstanceID: "i-051f097c469cd6a7f" - Signal: "SUCCESS"
Feb 24 03:20:40 ip-192-168-16-4.us-west-2.compute.internal systemd[1]: cfsignal.service: Succeeded.
```

Tested that instance send FAILURE signal if a service after `activate-multi-user.service` fail.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
