### PR TITLE
fix various SELinux policy issues

### DIFF
--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -10,7 +10,6 @@ After=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dDATA.device
 Type=oneshot
 Environment=BOTTLEROCKET_DATA=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
 Environment=LOCAL_DIR=/local
-Environment=CONTEXT="system_u:object_r:local_t:s0"
 
 # To "grow" the partition, we delete it and recreate it at the larger size, then
 # write it back to the device. udevd observes the write via inotify, and tells
@@ -28,7 +27,7 @@ ExecStart=/usr/sbin/growpart ${BOTTLEROCKET_DATA}
 # depend on the link, and would immediately transition to the failed state when the
 # link is removed. systemd will create local.mount for us as a side effect.
 ExecStart=/usr/bin/mount \
-    -o defaults,noatime,nosuid,nodev,fscontext="${CONTEXT}",defcontext="${CONTEXT}",rootcontext="${CONTEXT}" \
+    -o defaults,noatime,nosuid,nodev \
     ${BOTTLEROCKET_DATA} ${LOCAL_DIR}
 
 # After the mount is active, we grow the filesystem to fill the resized partition,

--- a/packages/release/usr-src-kernels.mount.in
+++ b/packages/release/usr-src-kernels.mount.in
@@ -8,7 +8,7 @@ Before=local-fs.target umount.target
 What=overlay
 Where=PREFIX/src/kernels
 Type=overlay
-Options=noatime,nosuid,nodev,lowerdir=/var/lib/kernel-devel/lower,upperdir=/var/lib/kernel-devel/upper,workdir=/var/lib/kernel-devel/work,context=system_u:object_r:local_t:s0
+Options=noatime,nosuid,nodev,lowerdir=/var/lib/kernel-devel/lower,upperdir=/var/lib/kernel-devel/upper,workdir=/var/lib/kernel-devel/work,context=system_u:object_r:state_t:s0
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/selinux-policy/base.cil
+++ b/packages/selinux-policy/base.cil
@@ -28,6 +28,13 @@
 (userlevel system_u s0-s0)
 (userrange system_u s0-s0)
 
+; Take the context from the target file rather than the source
+; process when computing the level for new file objects. We can
+; expect the directory where files are created to have the right
+; range of categories applied, but the process creating the file
+; may be privileged and have the full range or no range at all.
+(defaultrange files target low-high)
+
 ; Enable policy to use consolidated network peer controls. This
 ; avoids a function call to the compatibility mode helper, and
 ; will be faster when no network labeling rules are defined.

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -97,7 +97,8 @@
 (filecon "/run/.*" any ())
 
 ; Label external filesystem mounts.
-(filecon "/mnt" any external)
+(filecon "/mnt" any local)
 (filecon "/mnt/.*" any ())
-(filecon "/media" any external)
+(filecon "/media" any local)
+(filecon "/media/cdrom" any local)
 (filecon "/media/.*" any ())

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -26,7 +26,7 @@
 (genfscon debugfs / any)
 (genfscon kvmfs / any)
 (genfscon nsfs / any)
-(genfscon proc / any)
+(genfscon proc / proc)
 (genfscon pstore / any)
 (genfscon ramfs / any)
 (genfscon rootfs / any)
@@ -81,7 +81,7 @@
 (filecon "/var/lib/netdog/.*" any lease)
 
 ; Label kernel filesystem mounts.
-(filecon "/proc" any any)
+(filecon "/proc" any proc)
 (filecon "/proc/.*" any ())
 (filecon "/sys" any any)
 (filecon "/sys/.*" any ())

--- a/packages/selinux-policy/lxc_contexts
+++ b/packages/selinux-policy/lxc_contexts
@@ -6,7 +6,7 @@ process = "system_u:system_r:container_t:s0"
 
 # The 'file' label should always be applied to the container's root
 # filesystem, regardless of privileged status or automatic labeling.
-file = "system_u:object_r:local_t:s0"
+file = "system_u:object_r:data_t:s0"
 
 # The 'ro_file' label is not currently used by the above runtimes.
 ro_file = "system_u:object_r:cache_t:s0"

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -55,15 +55,17 @@
 (roletype object_r etc_t)
 (context etc (system_u object_r etc_t s0))
 
-; Files that have no label, or perhaps an invalid label.
-(type unlabeled_t)
-(roletype object_r unlabeled_t)
-(context unlabeled (system_u object_r unlabeled_t s0))
-
 ; Files created on local storage.
 (type local_t)
 (roletype object_r local_t)
 (context local (system_u object_r local_t s0))
+
+; The "external_t" and "unlabeled_t" types were removed to simplify
+; the policy. Add aliases for backwards compatibility.
+(typealias external_t)
+(typealias unlabeled_t)
+(typealiasactual external_t local_t)
+(typealiasactual unlabeled_t local_t)
 
 ; Alias "container_file_t" to "local_t" for compatibility with
 ; the container-selinux policy.
@@ -110,11 +112,6 @@
 (roletype object_r secret_t)
 (context secret (system_u object_r secret_t s0))
 
-; Files that are mount points for external filesystems.
-(type external_t)
-(roletype object_r external_t)
-(context external (system_u object_r external_t s0))
-
 ; Dynamic objects are files on temporary storage with special rules.
 (typeattribute dynamic_o)
 (typeattributeset dynamic_o (etc_t))
@@ -134,19 +131,16 @@
   os_t init_exec_t api_exec_t clock_exec_t
   network_exec_t bus_exec_t runtime_exec_t))
 
-; Ephemeral objects reside on storage with a different lifecycle
-; from the rest of the OS, such as tmpfs filesystems, EBS volumes,
-; and EFS filesystems.
+; Ephemeral objects reside on tmpfs filesystems.
 (typeattribute ephemeral_o)
-(typeattributeset ephemeral_o (
-  any_t external_t proc_t unlabeled_t))
+(typeattributeset ephemeral_o (any_t proc_t))
 
 ; The set of all objects.
 (typeattribute all_o)
 (typeattributeset all_o (
   os_t init_exec_t api_exec_t clock_exec_t
   network_exec_t bus_exec_t runtime_exec_t
-  any_t etc_t external_t proc_t unlabeled_t
+  any_t etc_t proc_t
   local_t private_t secret_t cache_t
   lease_t measure_t state_t
   api_socket_t))

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -67,8 +67,14 @@
 (typealiasactual external_t local_t)
 (typealiasactual unlabeled_t local_t)
 
-; Alias "container_file_t" to "local_t" for compatibility with
-; the container-selinux policy.
+; Files created by containers, or on their behalf.
+(type data_t)
+(roletype object_r data_t)
+(context data (system_u object_r data_t s0))
+
+; Alias "container_file_t" to "local_t" for compatibility with the
+; container-selinux policy. Ideally it would be aliased to `data_t`
+; but then kubelet applies the wrong label to plugin directories.
 (typealias container_file_t)
 (typealiasactual container_file_t local_t)
 
@@ -116,6 +122,10 @@
 (typeattribute dynamic_o)
 (typeattributeset dynamic_o (etc_t))
 
+; Shared objects are files on local storage for containers.
+(typeattribute shared_o)
+(typeattributeset shared_o (local_t data_t))
+
 ; Protected objects are files on local storage with special rules.
 (typeattribute protected_o)
 (typeattributeset protected_o (
@@ -141,6 +151,6 @@
   os_t init_exec_t api_exec_t clock_exec_t
   network_exec_t bus_exec_t runtime_exec_t
   any_t etc_t proc_t
-  local_t private_t secret_t cache_t
+  local_t data_t private_t secret_t cache_t
   lease_t measure_t state_t
   api_socket_t))

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -39,8 +39,13 @@
 (roletype object_r runtime_exec_t)
 (context runtime_exec (system_u object_r runtime_exec_t s0))
 
+; Files under /proc.
+(type proc_t)
+(roletype object_r proc_t)
+(context proc (system_u object_r proc_t s0))
+
 ; Files where we have no specific policy objectives, such as
-; those on kernel filesystems like /proc and /dev.
+; tmpfs mounts and various kernel filesystems.
 (type any_t)
 (roletype object_r any_t)
 (context any (system_u object_r any_t s0))
@@ -133,14 +138,15 @@
 ; from the rest of the OS, such as tmpfs filesystems, EBS volumes,
 ; and EFS filesystems.
 (typeattribute ephemeral_o)
-(typeattributeset ephemeral_o (any_t external_t unlabeled_t))
+(typeattributeset ephemeral_o (
+  any_t external_t proc_t unlabeled_t))
 
 ; The set of all objects.
 (typeattribute all_o)
 (typeattributeset all_o (
   os_t init_exec_t api_exec_t clock_exec_t
   network_exec_t bus_exec_t runtime_exec_t
-  any_t etc_t unlabeled_t external_t
+  any_t etc_t external_t proc_t unlabeled_t
   local_t private_t secret_t cache_t
   lease_t measure_t state_t
   api_socket_t))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -70,11 +70,11 @@
 ; Runtimes that use the Go SELinux library will override this label
 ; with the "process" label from the `lxc_contexts` when launching
 ; unprivileged containers, unless automatic labeling is disabled.
-(typetransition runtime_t local_t process control_t)
+(typetransition runtime_t data_t process control_t)
 (typetransition runtime_t cache_t process control_t)
 (typetransition runtime_t secret_t process control_t)
 (allow runtime_t container_s (processes (transform)))
-(allow container_s local_t (file (entrypoint)))
+(allow container_s data_t (file (entrypoint)))
 (allow container_s cache_t (file (entrypoint)))
 (allow container_s secret_t (file (entrypoint)))
 
@@ -135,8 +135,8 @@
 (neverallow other_s dynamic_o (files (mutate mount)))
 
 ; Most subjects are allowed to write to and manage mounts for
-; "local" files and directories on /local.
-(allow unconfined_s local_t (files (mutate mount)))
+; most of the files and directories on /local.
+(allow unconfined_s shared_o (files (mutate mount)))
 
 ; Subjects that control the OS, including helpers spawned by apiserver, can
 ; write to and manage mounts for "secret" files and directories on /local.
@@ -154,8 +154,8 @@
 (neverallow unprivileged_s state_t (files (mutate mount)))
 (neverallow unprivileged_s secret_t (files (mutate mount)))
 
-; Confined subjects cannot modify "state", "secret", or "local" files.
-(neverallow confined_s local_t (files (mutate mount)))
+; Confined subjects cannot modify "state", "secret", or "shared" files.
+(neverallow confined_s shared_o (files (mutate mount)))
 (neverallow confined_s state_t (files (mutate mount)))
 (neverallow confined_s secret_t (files (mutate mount)))
 
@@ -203,8 +203,12 @@
 (allow all_o self (filesystem (associate)))
 (allow all_o ephemeral_o (filesystem (associate)))
 
-; Protected object labels can also be used on local storage.
+; Protected object labels can be used on local storage.
 (allow protected_o local_t (filesystem (associate)))
+
+; The data object label can also be used, so that volume types like
+; emptyDir can be relabeled on behalf of containers.
+(allow data_t local_t (filesystem (associate)))
 
 ; Containers are allowed to relax security constraints, since we
 ; don't control what code they run or how it's built.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -57,8 +57,6 @@
 (allow bus_t bus_exec_t (file (entrypoint)))
 
 ; PID 1 starts container runtimes as "runtime_t".
-; The level range is adjusted to span all categories at the same time,
-; to support Docker's use of MCS labels.
 (typetransition init_t runtime_exec_t process runtime_t)
 (allow init_t runtime_t (processes (transform)))
 (allow runtime_t runtime_exec_t (file (entrypoint)))
@@ -77,6 +75,12 @@
 (allow container_s data_t (file (entrypoint)))
 (allow container_s cache_t (file (entrypoint)))
 (allow container_s secret_t (file (entrypoint)))
+
+; Adjust the level range to span all categories, since privileged
+; containers won't get an MCS pair assigned.
+(rangetransition runtime_t data_t process s0-s0)
+(rangetransition runtime_t cache_t process s0-s0)
+(rangetransition runtime_t secret_t process s0-s0)
 
 ; Also allow entry to container domains through `docker-init`, which
 ; is mounted from the root filesystem and used as the init process.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -85,11 +85,6 @@
 ; Allow containers to communicate with runtimes via pipes.
 (allow container_s runtime_t (files (mutate)))
 
-; If a trusted process creates a file or directory when the parent
-; directory has no label, it receives the "local_t" label.
-(typetransition trusted_s unlabeled_t file local_t)
-(typetransition trusted_s unlabeled_t dir local_t)
-
 ; If a runtime process creates a directory for cached container archives
 ; or snapshot layers on local storage, it receives the "cache_t" label.
 ; ... containerd's pristine archives

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -200,6 +200,9 @@
 ; be useful for containers, and we don't use it in the host.
 (neverallow all_s global (files (block)))
 
+; All subject labels can be used for files on /proc.
+(allow all_s proc_t (filesystem (associate)))
+
 ; All object labels can be used for files on filesystems that have
 ; the same label, and for files on ephemeral storage.
 (allow all_o self (filesystem (associate)))

--- a/packages/selinux-policy/sid.cil
+++ b/packages/selinux-policy/sid.cil
@@ -42,10 +42,10 @@
 (sidcontext security kernel)
 (sidcontext devnull kernel)
 
-; Apply the "unlabeled" context for entities with an invalid context,
-; and for files with no context at all, which are treated the same.
-(sidcontext unlabeled unlabeled)
-(sidcontext file unlabeled)
+; Apply the "local" context for entities with an invalid context, and
+; for files with no context at all, which are treated the same.
+(sidcontext unlabeled local)
+(sidcontext file local)
 
 ; Apply the "any" context for entities like sockets, ports, and
 ; network interfaces if they are otherwise unlabeled.

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -622,7 +622,7 @@ func withSuperpowered() oci.SpecOpts {
 		oci.WithParentCgroupDevices,
 		oci.WithPrivileged,
 		oci.WithNewPrivileges,
-		oci.WithSelinuxLabel("system_u:system_r:super_t:s0"),
+		oci.WithSelinuxLabel("system_u:system_r:super_t:s0-s0:c0.c1023"),
 		oci.WithAllDevicesAllowed,
 	)
 }
@@ -634,7 +634,7 @@ func withBootstrap() oci.SpecOpts {
 	return oci.Compose(
 		withPrivilegedMounts(),
 		withRootFsShared(),
-		oci.WithSelinuxLabel("system_u:system_r:control_t:s0"),
+		oci.WithSelinuxLabel("system_u:system_r:control_t:s0-s0:c0.c1023"),
 		// Bootstrap containers don't require all "privileges", we only add the
 		// `CAP_SYS_ADMIN` capability. `WithDefaultProfile` will create the proper
 		// seccomp profile based on the container's capabilities.
@@ -647,7 +647,7 @@ func withBootstrap() oci.SpecOpts {
 // withDefault adds container options for non-privileged containers
 func withDefault() oci.SpecOpts {
 	return oci.Compose(
-		oci.WithSelinuxLabel("system_u:system_r:control_t:s0"),
+		oci.WithSelinuxLabel("system_u:system_r:control_t:s0-s0:c0.c1023"),
 		// Non-privileged containers only have access to a subset of the devices
 		oci.WithDefaultUnixDevices,
 		// No additional capabilities required for non-privileged containers


### PR DESCRIPTION
**Issue number:**
#1617, #1651, #1712

**Description of changes:**
This includes some SELinux policy fixes, as well as some refactoring to pave the way for MCS isolation. More details are available in the commit messages, but at a high level, here's what's changing.

A new `proc_t` object type is added to fix an AVC denial that processes could encounter when writing to `/proc`. This didn't appear to cause any real trouble; as far as I can tell, this wasn't surfaced to programs as an error.

The `unlabeled_t` and `external_t` object types are removed, and aliases are added for `local_t`. The distinction between different types of local files was never very useful and caused problems when creating new filesystems via bootstrap containers, as discussed in #1617. This should also help with #1651.

While cleaning up the `local_t` mount options that are no longer needed, I fixed an oversight with the `/usr/src/kernels` mount, which is not intended to be writable by unprivileged containers.

Finally there are the changes that lay the groundwork for MCS isolation. Adding a distinct type for container files - `data_t` vs. `local_t` - enables us to assert that `data_t` must always follow the isolation rules. Running privileged and host containers with the full MCS range clarifies the policy goal that they are allowed to bypass isolation.

Specifying the default range transition fixes two problems, both caused by using the source context. Privileged containers would create files with the wrong level - either too weak (`s0`) or too strong (`s0-s0:c0.c1023`). Unprivileged containers would add their MCS pairs to object types that aren't meant to be isolated, such as `any_t`.

**Testing done:**
Verified that nodes came up and sonobuoy passed with no SELinux denials. Previously, nodes would sometimes log a denial for `httpd` because of the "associate" issue that's now resolved.

Confirmed that the directories under `/var/lib/{host,}containerd` had the expected labels.

Verified that only `container_t` and `data_t` types use MCS pairs:
```
# find -context '*:s0:c*,c*' ! -context '*:data_t:*' ! -context '*:container_t:*'
<no output>
```

Verified that only `control_t` and `super_t` types use the full MCS range:
```
# find -context '*:s0-s0:c*.c*' ! -context '*:control_t:*' ! -context '*:super_t:*'
<no output>
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
