### PR TITLE
Update default control container to v0.5.2

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -71,4 +71,5 @@ version = "1.2.0"
 "(1.2.0, 1.3.0)" = [
     "migrate_v1.3.0_etc-hosts-service.lz4",
     "migrate_v1.3.0_hostname-affects-etc-hosts.lz4",
+    "migrate_v1.3.0_control-container-v0-5-2.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -670,6 +670,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "control-container-v0-5-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     # "api/migration/migrations/vX.Y.Z/..."
     "api/migration/migrations/v1.3.0/etc-hosts-service",
     "api/migration/migrations/v1.3.0/hostname-affects-etc-hosts",
+    "api/migration/migrations/v1.3.0/control-container-v0-5-2",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.3.0/control-container-v0-5-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.3.0/control-container-v0-5-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "control-container-v0-5-2"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.3.0/control-container-v0-5-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.3.0/control-container-v0-5-2/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.1";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.2";
+
+/// We bumped the version of the default control container from v0.5.1 to v0.5.2
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.1"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.2"

--- a/sources/models/shared-defaults/vmware-host-containers.toml
+++ b/sources/models/shared-defaults/vmware-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.2"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.1"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.2"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates the default control container from v0.5.1 to v0.5.2

**Testing done:**

Using a custom TUF repo, upgraded/downgraded between v1.2.0 and v1.3.0.
In AWS Systems Manager, instance showed agent upgrade/downgrade between 3.0.1209.0 and 3.1.192.0.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
