### PR TITLE
update runc to 1.0.2

### DIFF
--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -9,9 +9,9 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.0.1/runc.tar.xz"
-path = "runc-v1.0.1.tar.xz"
-sha512 = "1db35ec91ab59b7bc3c863231e0f610000526859df2a792675fbe5917ade18e2c5df26a613897f0cefa90ba4d4f590e55ec6df84958a44384379e693f9b65b10"
+url = "https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.tar.xz"
+path = "runc-v1.0.2.tar.xz"
+sha512 = "2feae69e7680c55de4dc9bb7d77e8275b47b58f5549b061bd6ceef493cb16a5505e0077cf36fea4b0ec799327143aa9f5f46572d55007270ac93fa87aaadd530"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -1,15 +1,14 @@
 %global goproject github.com/opencontainers
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
-%global commit 4144b63817ebcc5b358fc2c8ef95f7cddd709aa7
-%global shortcommit 4144b63
-%global gover 1.0.1
+%global commit 52b36a2dd837e8462de8e01458bf02cf9eea47dd
+%global gover 1.0.2
 
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}%{gorepo}
 Version: %{gover}
-Release: 1.%{shortcommit}%{?dist}
+Release: 1%{?dist}
 Summary: CLI for running Open Containers
 License: Apache-2.0
 URL: https://%{goimport}


### PR DESCRIPTION
**Issue number:**
Fixes #1674


**Description of changes:**
Update runc to 1.0.2.


**Testing done:**
Tested `aws-k8s-1.21`, `aws-ecs-1` for both architectures. Pods and tasks ran fine. `sonobuoy` runs passed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
