### PR TITLE
add MCS constraints to the SELinux policy

### DIFF
--- a/packages/selinux-policy/files.cil
+++ b/packages/selinux-policy/files.cil
@@ -9,8 +9,6 @@
 (classmapping files relabel relabel_blk_file)
 (classmapping files relabel relabel_sock_file)
 (classmapping files relabel relabel_fifo_file)
-(classmapping files relabel relabel_filesystem)
-(classmapping files relabel relabel_kernel_service)
 
 ; Permission group for mounts.
 (classmapping files mount mount_file)
@@ -81,8 +79,6 @@
 (classpermission relabel_blk_file)
 (classpermission relabel_sock_file)
 (classpermission relabel_fifo_file)
-(classpermission relabel_filesystem)
-(classpermission relabel_kernel_service)
 (classpermissionset relabel_file (
   file (relabelfrom relabelto)))
 (classpermissionset relabel_dir (
@@ -97,10 +93,6 @@
   sock_file (relabelfrom relabelto)))
 (classpermissionset relabel_fifo_file (
   fifo_file (relabelfrom relabelto)))
-(classpermissionset relabel_filesystem (
-  filesystem (relabelfrom relabelto)))
-(classpermissionset relabel_kernel_service (
-  kernel_service (create_files_as)))
 
 ; Sets of permissions for mounts.
 (classpermission mount_file)

--- a/packages/selinux-policy/mcs.cil
+++ b/packages/selinux-policy/mcs.cil
@@ -1,0 +1,107 @@
+; SELinux dominance rules are somewhat involved but the usage below
+; is straightforward. A quick summary of the relevant details:
+;
+; * s0:c0,c1 (source) dominates s0:c1 (target) since it has two
+;   categories, one of which is c1
+; * s0:c0.c4 (source) dominates s0:c1 (target) since it has a range of
+;   categories, from c0 to c4, which includes c1
+; * s0:c0,c1 (source) neither dominates or is dominated by s0:c1,c2
+;   (target) since only one of the two categories is shared
+; * s0:c0,c1 (source) likewise does not dominate s0:c2,c3 (target)
+;   since neither of the categories is shared
+;
+; In practice, the container runtime will assign two categories at
+; random to each unprivileged container, such that no container has a
+; level that dominates or is dominated by any other. We refer to the
+; two random categories as an MCS pair.
+
+; All the `(dom h1 h2)` checks below can be read as testing whether
+; an unprivileged process running in a container is interacting with
+; its own processes, or reading and writing to its own files.
+;
+; Privileged containers are left alone by the container runtime and
+; inherit the default level, which covers the range of categories -
+; `s0-s0:c0.1023`. They would also pass the dominance check. However,
+; since we have privileged subjects that run outside of containers,
+; we check for that with `(eq t1 privileged_s)`.
+;
+; The current policy attempts to avoid propagating MCS pairs to types
+; that are not `data_t`, but that was not previously done and we may
+; encounter labels like `system_u:object_r:local_t:s0:cX,cY`. The
+; `(eq t2 unconstrained_o)` check is intended to preserve access to
+; these files after an upgrade.
+;
+; Actions that change the label of a process or file are restricted
+; to trusted processes, unless the new label is identical to the old
+; one. This allows programs that attempt to sync all file attributes
+; to work while preserving the intended access restrictions.
+
+; =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+; Restrict file reads unless one of these conditions is met:
+; * the source dominates the target
+; * the source context is a privileged subject (e.g. `control_t`)
+; * the target context is for a subject (e.g. /proc/<pid>/<file>)
+; * the target context is for an unconstrained object
+
+(mlsconstrain (files (load))
+  (or (dom h1 h2)
+      (or (eq t1 privileged_s)
+          (or (eq t2 all_s)
+              (eq t2 unconstrained_o)))))
+
+; Restrict file writes unless one of these conditions is met:
+; * the source dominates the target
+; * the source context is for a privileged subject (e.g. `control_t`)
+; * the target context is for an unconstrained object
+
+(mlsconstrain (files (mutate))
+  (or (dom h1 h2)
+      (or (eq t1 privileged_s)
+          (eq t2 unconstrained_o))))
+
+; Restrict file transitions unless one of these conditions is met:
+; * the new label exactly matches the old label
+; * the process context is trusted
+
+(mlsvalidatetrans files
+  (or (eq t3 trusted_s)
+      (and (and (and (and
+           (eq u1 u2)
+           (eq r1 r2))
+           (eq t1 t2))
+           (eq h1 h2))
+           (eq l1 l2))))
+
+; =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+; Restrict process interactions unless one of these conditions is met:
+; * the source dominates the target
+; * the source context is for a privileged subject (e.g. `control_t`)
+
+(mlsconstrain (processes (interact))
+  (or (dom h1 h2)
+      (eq t1 privileged_s)))
+
+; Restrict process transitions unless one of these conditions is met:
+; * the new label exactly matches the old label
+; * the source context is for a trusted subject
+
+(mlsconstrain (processes (transform))
+  (or (eq t1 trusted_s)
+      (and (and (and (and
+           (eq u1 u2)
+           (eq r1 r2))
+           (eq t1 t2))
+           (eq h1 h2))
+           (eq l1 l2))))
+
+; =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+; Restrict system interactions unless one of these conditions is met:
+; * the source dominates the target
+; * the source context is for a privileged subject (e.g. `control_t`)
+
+(mlsconstrain (systems (use))
+  (or (dom h1 h2)
+      (eq t1 privileged_s)))

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -126,6 +126,14 @@
 (typeattribute shared_o)
 (typeattributeset shared_o (local_t data_t))
 
+; Constrained objects are files where MCS constraints apply.
+(typeattribute constrained_o)
+(typeattributeset constrained_o (data_t))
+
+; Unconstrained objects are not affected by MCS constraints.
+(typeattribute unconstrained_o)
+(typeattributeset unconstrained_o (xor (all_o) (constrained_o)))
+
 ; Protected objects are files on local storage with special rules.
 (typeattribute protected_o)
 (typeattributeset protected_o (

--- a/packages/selinux-policy/processes.cil
+++ b/packages/selinux-policy/processes.cil
@@ -8,8 +8,6 @@
     setfscreate setkeycreate setsockcreate)))
 (classmapping processes transform (
   process2 (nnp_transition nosuid_transition)))
-(classmapping processes transform (
-  kernel_service (use_as_override)))
 
 (classmapping processes describe (
   process (

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -187,11 +187,17 @@
 ; Unprivileged components are not allowed to use the API socket.
 (neverallow unprivileged_s api_socket_t (files (mutate)))
 
-; Only trusted components are allowed to relabel files.
+; Only trusted components are allowed to relabel all files.
 (allow trusted_s global (files (relabel)))
 
-; Untrusted components are not allowed to relabel files.
-(neverallow untrusted_s global (files (relabel)))
+; Containers are allowed to "relabel" constrained files, but are
+; governed by additional MCS constraints that require the old and
+; new labels to match exactly.
+(allow container_s constrained_o (files (relabel)))
+
+; Untrusted components are not allowed to relabel most files.
+(neverallow untrusted_s all_s (files (relabel)))
+(neverallow untrusted_s unconstrained_o (files (relabel)))
 
 ; No components are allowed to block access to files by using
 ; fanotify permission events. Fanotify only sends events for

--- a/packages/selinux-policy/selinux-policy.spec
+++ b/packages/selinux-policy/selinux-policy.spec
@@ -21,6 +21,7 @@ Source9: networks.cil
 Source10: ipcs.cil
 Source11: systems.cil
 Source12: rules.cil
+Source13: mcs.cil
 
 # Helpers for generating CIL
 Source50: catgen.sh
@@ -42,7 +43,7 @@ BuildRequires: secilc
 cp -p \
   %{S:0} %{S:1} %{S:2} %{S:3} %{S:4} %{S:5} \
   %{S:6} %{S:7} %{S:8} %{S:9} %{S:10} %{S:11} \
-  %{S:12} .
+  %{S:12} %{S:13} .
 
 %build
 %{_sourcedir}/catgen.sh > category.cil

--- a/packages/selinux-policy/systems.cil
+++ b/packages/selinux-policy/systems.cil
@@ -5,6 +5,8 @@
 (classmapping systems manage (capability2 (mac_override mac_admin)))
 (classmapping systems manage (cap2_userns (mac_override mac_admin)))
 (classmapping systems manage (dbus (all)))
+(classmapping systems manage (filesystem (relabelfrom relabelto)))
+(classmapping systems manage (kernel_service (all)))
 (classmapping systems manage (security (all)))
 (classmapping systems manage (service (all)))
 (classmapping systems manage (


### PR DESCRIPTION
**Issue number:**
Fixes #1712
#1569

**Description of changes:**
This adds `mlsconstrain` statements to the SELinux policy so that the MCS category pairs assigned to container processes and files are used for access decisions.

The CIL documentation on [mlsconstrain](https://github.com/SELinuxProject/selinux/blob/master/secilc/docs/cil_constraint_statements.md#mlsconstrain) is helpful to understand what's happening, but briefly:
* `dom` is the dominance test described in the comments
* `h1` is the source "high" context (typically a subject / process)
* `h2` is the target "high" context (either an object / file, or another subject / process)

The "low" context (`l1`, `l2`) should be just `s0` for everything (with no categories), and is not useful for making the access decision.

Some special cases, since it's hard to write useful comments about what's *not* included:
* `(files (load))` has an exception for "subject" files (like `/proc/<pid>/<file>`), so `ps` works for everyone.
* `(files (describe))` does not have a constraint, so `ls` works for everyone.
* `(files (relabel))` and `(processes (transform))` are "relabel" actions; they're not constrained because they're currently reserved for trusted (read: "not container") processes.

**Testing done:**
Tested these scenarios.

| Action | Privileged container | Unprivileged container |
| --- | --- | --- |
| Create files in an `emptyDir` volume | ✅ | ✅ |
| Create files in a `hostPath` volume | ✅ | ✅ |
| Create files in an Amazon EBS volume | ✅ | ✅ |
| Create files in an Amazon EFS volume | ✅ | ✅ |
| Create files in a Docker image volume | ✅ | ✅ |
| Signal processes with a different level | ✅ | ❌ |
| List files in a directory with a different level | ✅ | ❌ |
| Create files in a directory with a different level | ✅ | ❌ |
| Relabel files with the same level | ✅ | ✅ |
| Relabel files with a different level | ❌ | ❌ |
| Relabel processes with the same level | ✅ | ✅ |
| Relabel processes with a different level | ❌ | ❌ |
| List files in host's `/etc` | ✅ | ❌ |
| Create files in host's `/etc` | ❌ | ❌ |
| List files for host's datastore | ✅ | ❌ |
| Create files in host's datastore | ❌  | ❌ |

Verified that `podman` and `pip` can run inside a container without unexpected denials.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
