### PR TITLE
Add wave definition for slow deployment

### DIFF
--- a/sources/updater/waves/slow-roll.toml
+++ b/sources/updater/waves/slow-roll.toml
@@ -1,0 +1,32 @@
+# The following represents a set of update waves that rolls out more slowly
+# than default. The deployment lasts for 13 days, and gradually increases the
+# nodes updated at once.
+[[waves]]
+start_after = '1 hour'
+fleet_percentage = 1
+
+[[waves]]
+start_after = '1 day'
+fleet_percentage = 5
+
+[[waves]]
+start_after = '3 days'
+fleet_percentage = 15
+
+[[waves]]
+start_after = '7 days'
+fleet_percentage = 40
+
+[[waves]]
+start_after = '9 days'
+fleet_percentage = 60
+
+[[waves]]
+start_after = '12 days'
+fleet_percentage = 90
+
+# Last 10 percent of the hosts will update immediately after 13 days since the start of
+# deployment. Unlike the other waves, there will be no velocity control.
+[[waves]]
+start_after = '13 days'
+fleet_percentage = 100


### PR DESCRIPTION
This adds a new wave schedule for changes we want to deploy extra carefully over ~2 weeks.  It uses the same percentages as default, just shifted later.  Here's how it looks in comparison to the existing schedules:

![waves](https://user-images.githubusercontent.com/13994/132920334-7dc7b35a-29ea-48a4-af35-842db74931ce.png)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
