### PR TITLE
release-tmpfiles: Remove entry for /etc/hosts

### DIFF
--- a/packages/release/release-tmpfiles.conf
+++ b/packages/release/release-tmpfiles.conf
@@ -1,4 +1,3 @@
-C /etc/hosts - - - -
 C /etc/nsswitch.conf - - - -
 C /etc/wicked/ifconfig/eth0.xml - - - -
 d /var/log/kdump 0700 root root -


### PR DESCRIPTION
**Issue number:**
Fixes #1744 


**Description of changes:**
```
release-tmpfiles: Remove entry for /etc/hosts

The /etc/hosts file was removed and replaced with a template in a prior
change (#1713).  This removes the entry from `release-tmpfiles.conf`.
```


**Testing done:**
Boot an `aws-k8s-1.19` AMI, ensure node properly boots, joins the cluster, and the offending log message doesn't appear.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
