### PR TITLE
packages: add release URLs

### DIFF
--- a/packages/acpid/Cargo.toml
+++ b/packages/acpid/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://downloads.sourceforge.net/acpid2"
+
 [[package.metadata.build-package.external-files]]
 url = "http://downloads.sourceforge.net/acpid2/acpid-2.0.32.tar.xz"
 sha512 = "c7afffdf9818504e1ac03b0ad693a05f772bfd07af9808262b3b6bb82ca4dabe6253c94e6dc59e5be6f0da9e815e8bcf2d3e16f02b23d0248b6bad4509e78be7"

--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.5.2/aws-iam-authenticator-0.5.2.tar.gz"
 sha512 = "a16a630096ed3223d156e1586f02ffcfcf256f12530ba565f5f1f649c83418cd71ea66c554c9e1edd1b44dd745d9393f4ed4c63c62677ae973e9bd9a1a24fe5b"

--- a/packages/bash/Cargo.toml
+++ b/packages/bash/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://ftp.gnu.org/gnu/bash"
+
 [[package.metadata.build-package.external-files]]
 url = "https://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz"
 sha512 = "bb4519f06e278f271d08722b531e49d2e842cc3e0b02a6b3eee422e2efcb5b6226111af43f5e5eae56beb85ac8bfebcd6a4aacbabb8f609e529aa4d571890864"

--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://curl.se/docs/caextract.html"
+
 [[package.metadata.build-package.external-files]]
 url = "https://curl.haxx.se/ca/cacert-2021-07-05.pem"
 sha512 = "881183c7fed512cab763a6145f0e07c5bcdc143589baf433f7ba92223d215f18f48782fcfc04860db0671849e2ceeecedf6704f77148f588e17c4cd9a34cc8f8"

--- a/packages/chrony/Cargo.toml
+++ b/packages/chrony/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://download.tuxfamily.org/chrony"
+
 [[package.metadata.build-package.external-files]]
 url = "https://download.tuxfamily.org/chrony/chrony-4.1.tar.gz"
 sha512 = "5e283d6a56e6852606c681a7c29c5786b102d584178cbd7033ebbc95a8e95533605631363b850a3087cca438a5878db7a317f120aab2fd856487d02fccfbcb1f"

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/containernetworking/plugins/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/containernetworking/plugins/archive/v0.9.1/plugins-0.9.1.tar.gz"
 sha512 = "24e8fcedbff2ae7a83aa96085b546b164de6a0884d593e3b5386e9d2de3c4d9a215db9e9405332020cc45c371709a32b600e263e4f8dee62c51adafdc0180f24"

--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/containernetworking/cni/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/containernetworking/cni/archive/v0.8.1/cni-0.8.1.tar.gz"
 sha512 = "b869e76806c6e259743715831ddf5754a56e79fa7f25435e54e3f0648700e473e5778630e592f5c5d181058e74c7542aeac5c4f3d8cd26b83f7758bb186f43e9"

--- a/packages/conntrack-tools/Cargo.toml
+++ b/packages/conntrack-tools/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://www.netfilter.org/projects/conntrack-tools/files"
+
 [[package.metadata.build-package.external-files]]
 url = "https://www.netfilter.org/projects/conntrack-tools/files/conntrack-tools-1.4.6.tar.bz2"
 sha512 = "a48260308a12b11b584fcf4658ec2c4c1adb2801c9cf9a73fc259e5c30d2fbe401aca21e931972413f03e415f98fbf9bd678d2126faa6c6d5748e8a652e58f1a"

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/containerd/containerd/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/containerd/containerd/archive/v1.5.5/containerd-1.5.5.tar.gz"
 sha512 = "8ee5aa1d35e76238fd8707bff6b7eedb7931e6489d49b6907a8e190b076fe6fd95ae5e85ecea1605adb7fcd4f3ae0e926696f1d2f3c0d12b61e6df906929b9eb"

--- a/packages/coreutils/Cargo.toml
+++ b/packages/coreutils/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://ftp.gnu.org/gnu/coreutils"
+
 [[package.metadata.build-package.external-files]]
 url = "https://ftp.gnu.org/gnu/coreutils/coreutils-8.32.tar.xz"
 sha512 = "1c8f3584efd61b4b02e7ac5db8e103b63cfb2063432caaf1e64cb2dcc56d8c657d1133bbf10bd41468d6a1f31142e6caa81d16ae68fa3e6e84075c253613a145"

--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/bus1/dbus-broker/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/bus1/dbus-broker/releases/download/v29/dbus-broker-29.tar.xz"
 sha512 = "ef0b59cacef2918cb94bdf8d91a1211a8f635f9059416938248febc67bfd82a3a2a32517af81df56590b1c742aeac2a22ad656153293012ecad4667588df0b1c"

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/docker/cli/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/docker/cli/archive/v20.10.7/cli-20.10.7.tar.gz"
 sha512 = "4523ae70cb27d848da119070171af2eb84e974ac39d70be4feee105e37c949487c7f72a9bc30c32ce71bffb0787e27b7b9194ce5a8aeae57bdfeb3f2d730010f"

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/moby/moby/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/moby/moby/archive/v20.10.7/moby-20.10.7.tar.gz"
 sha512 = "2341faa3ebb903d74fa434712fce45e7acf0423710b97cdca11e3999db2819c4385d9a7fb3850925592f20f02c6261edbade6c9d6a2fefbc32f05a6b44ec3073"

--- a/packages/docker-init/Cargo.toml
+++ b/packages/docker-init/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/krallin/tini/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/krallin/tini/archive/v0.19.0/tini-0.19.0.tar.gz"
 sha512 = "1fa85b56e2c6085ea474f251928e7a40510d92aeef60b3c145b0496969c1b5df86835d143cb91ef5b4bf4da63fa8a56947cc39a4276e4b72faa57276d432b292"

--- a/packages/docker-proxy/Cargo.toml
+++ b/packages/docker-proxy/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/docker/libnetwork/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/docker/libnetwork/archive/fa125a3512ee0f6187721c88582bf8c4378bd4d7/libnetwork-fa125a3512ee0f6187721c88582bf8c4378bd4d7.tar.gz"
 sha512 = "dd583218fbeba8aeac2e4143369ad55a3e6c15d64f198f73e3656a80d0281a4374fb3be7bc05b01425461bf830762aa2c950da68ed0e3ae5884643e9d178c69e"

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs"
+
 [[package.metadata.build-package.external-files]]
 url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.3/e2fsprogs-1.46.3.tar.xz"
 sha512 = "27da6e38d3463e7a283dacfb88a3210dd6d8c63f4d990db879f63bdf503aaa5c447ef0ccc566b71526c12a8ab0a7a6529014b1010be300ad56a6ad5ce9066196"

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -9,6 +9,9 @@ build = "build.rs"
 path = "pkg.rs"
 
 # ECS agent
+[package.metadata.build-package]
+releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/aws/amazon-ecs-agent/archive/v1.54.1/amazon-ecs-agent-v1.54.1.tar.gz"
 sha512 = "b3f92920ce327ff5a6d77268f927882d25097da65813d4f4c60787772109aa49952ec4130f83bfd00bf77ee86af1e60ca0b0967c02276126ccc378c954bc6047"

--- a/packages/findutils/Cargo.toml
+++ b/packages/findutils/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://ftp.gnu.org/pub/gnu/findutils"
+
 [[package.metadata.build-package.external-files]]
 url = "https://ftp.gnu.org/pub/gnu/findutils/findutils-4.8.0.tar.xz"
 sha512 = "eaa2da304dbeb2cd659b9210ac37da1bde4cd665c12a818eca98541c5ed5cba1050641fc0c39c0a446a5a7a87a8d654df0e0e6b0cee21752ea485188c9f1071e"

--- a/packages/glibc/Cargo.toml
+++ b/packages/glibc/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://ftp.gnu.org/gnu/glibc"
+
 [[package.metadata.build-package.external-files]]
 url = "https://ftp.gnu.org/gnu/glibc/glibc-2.33.tar.xz"
 sha512 = "4cb5777b68b22b746cc51669e0e9282b43c83f6944e42656e6db7195ebb68f2f9260f130fdeb4e3cfc64efae4f58d96c43d388f52be1eb024ca448084684abdb"

--- a/packages/grep/Cargo.toml
+++ b/packages/grep/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://mirrors.kernel.org/gnu/grep"
+
 [[package.metadata.build-package.external-files]]
 url = "https://mirrors.kernel.org/gnu/grep/grep-3.6.tar.xz"
 sha512 = "8934544a19ded61344d83ff2cab501e86f17f8ae338892e0c36c2d2d8e63c76817840a0071ef5e3fcbca9115eba8a1aae0e4c46b024e75cd9a2e3bd05f933d90"

--- a/packages/iproute/Cargo.toml
+++ b/packages/iproute/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://kernel.org/pub/linux/utils/net/iproute2"
+
 [[package.metadata.build-package.external-files]]
 url = "http://kernel.org/pub/linux/utils/net/iproute2/iproute2-5.9.0.tar.xz"
 sha512 = "bce59b0e8d876f10f94926be7f2a7cda0de15db04fabedfe938649d486ca6d6d222523d1661b8b36ea50e35369a4730938d6ebeb80577ac0522a3432037bcd50"

--- a/packages/iptables/Cargo.toml
+++ b/packages/iptables/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://www.netfilter.org/projects/iptables/files"
+
 [[package.metadata.build-package.external-files]]
 url = "http://www.netfilter.org/projects/iptables/files/iptables-1.8.7.tar.bz2"
 sha512 = "c0a33fafbf1139157a9f52860938ebedc282a1394a68dcbd58981159379eb525919f999b25925f2cb4d6b18089bd99a94b00b3e73cff5cb0a0e47bdff174ed75"

--- a/packages/iputils/Cargo.toml
+++ b/packages/iputils/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/iputils/iputils/releases"
+
 [[package.metadata.build-package.external-files]]
 path = "iputils-20210722.tar.gz"
 url = "https://github.com/iputils/iputils/archive/20210722.tar.gz"

--- a/packages/kexec-tools/Cargo.toml
+++ b/packages/kexec-tools/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://kernel.org/pub/linux/utils/kernel/kexec"
+
 [[package.metadata.build-package.external-files]]
 url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.22.tar.xz"
 sha512 = "7580860f272eee5af52139809f12961e5a5d3a65f4e191183ca9c845410425d25818945ac14ed04a60e6ce474dc2656fc6a14041177b0bf703f450820c7d6aba"

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod"
+
 [[package.metadata.build-package.external-files]]
 url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-29.tar.xz"
 sha512 = "557cdcaec75e5a1ceea2d10862c944e9a65ef54f6ee9da6dc98ce4582418fdc9958aab2e14a84807db61daf36ec4fcdc23a36376c39d5dc31d1823ca7cd47998"

--- a/packages/kubernetes-1.17/Cargo.toml
+++ b/packages/kubernetes-1.17/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 publish = false
 build = "build.rs"
 
-[package.metadata.build-package]
-package-name = "kubernetes-1.17"
-
 [lib]
 path = "pkg.rs"
+
+[package.metadata.build-package]
+package-name = "kubernetes-1.17"
+releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/kubernetes/kubernetes/archive/v1.17.17/kubernetes-1.17.17.tar.gz"

--- a/packages/kubernetes-1.18/Cargo.toml
+++ b/packages/kubernetes-1.18/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 publish = false
 build = "build.rs"
 
-[package.metadata.build-package]
-package-name = "kubernetes-1.18"
-
 [lib]
 path = "pkg.rs"
+
+[package.metadata.build-package]
+package-name = "kubernetes-1.18"
+releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/kubernetes/kubernetes/archive/v1.18.20/kubernetes-1.18.20.tar.gz"

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 publish = false
 build = "build.rs"
 
-[package.metadata.build-package]
-package-name = "kubernetes-1.19"
-
 [lib]
 path = "pkg.rs"
+
+[package.metadata.build-package]
+package-name = "kubernetes-1.19"
+releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/kubernetes/kubernetes/archive/v1.19.13/kubernetes-1.19.13.tar.gz"

--- a/packages/kubernetes-1.20/Cargo.toml
+++ b/packages/kubernetes-1.20/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 publish = false
 build = "build.rs"
 
-[package.metadata.build-package]
-package-name = "kubernetes-1.20"
-
 [lib]
 path = "pkg.rs"
+
+[package.metadata.build-package]
+package-name = "kubernetes-1.20"
+releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/kubernetes/kubernetes/archive/v1.20.9/kubernetes-1.20.9.tar.gz"

--- a/packages/kubernetes-1.21/Cargo.toml
+++ b/packages/kubernetes-1.21/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 publish = false
 build = "build.rs"
 
-[package.metadata.build-package]
-package-name = "kubernetes-1.21"
-
 [lib]
 path = "pkg.rs"
+
+[package.metadata.build-package]
+package-name = "kubernetes-1.21"
+releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/kubernetes/kubernetes/archive/v1.21.3/kubernetes-1.21.3.tar.gz"

--- a/packages/libacl/Cargo.toml
+++ b/packages/libacl/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://download-mirror.savannah.gnu.org/releases/acl"
+
 [[package.metadata.build-package.external-files]]
 url = "https://download-mirror.savannah.gnu.org/releases/acl/acl-2.2.53.tar.gz"
 sha512 = "176b7957fe0e7618e0b7bf2ac5071f7fa29417df718cce977661a576fa184e4af9d303b591c9d556b6ba8923e799457343afa401f5a9f7ecd9022185a4e06716"

--- a/packages/libattr/Cargo.toml
+++ b/packages/libattr/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://download-mirror.savannah.gnu.org/releases/attr"
+
 [[package.metadata.build-package.external-files]]
 url = "https://download-mirror.savannah.gnu.org/releases/attr/attr-2.5.1.tar.xz"
 sha512 = "9e5555260189bb6ef2440c76700ebb813ff70582eb63d446823874977307d13dfa3a347dfae619f8866943dfa4b24ccf67dadd7e3ea2637239fdb219be5d2932"

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/linux-audit/audit-userspace/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/linux-audit/audit-userspace/archive/v3.0.3/audit-userspace-3.0.3.tar.gz"
 sha512 = "b248398ed4aa3c52eaf6272ce618d2dcc8d88494d1bf3d530178d61906f4f7dac3c0c56862f5bdafa43d72b5c327898d82e95e83d09057b4fc90e917ba83bfad"

--- a/packages/libbzip2/Cargo.toml
+++ b/packages/libbzip2/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://sourceware.org/pub/bzip2"
+
 [[package.metadata.build-package.external-files]]
 url = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
 sha512 = "083f5e675d73f3233c7930ebe20425a533feedeaaa9d8cc86831312a6581cefbe6ed0d08d2fa89be81082f2a5abdabca8b3c080bf97218a1bd59dc118a30b9f3"

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://sites.google.com/site/fullycapable/release-notes-for-libcap"
+
 [[package.metadata.build-package.external-files]]
 url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.51.tar.gz"
 sha512 = "032f52468323af68cc5cc1d9adcbf61bae962887d475b995629ea22428fbd6e4722599497394cccdb8443381d257187eb2ce80866b009ae84cd8cd45fd616716"

--- a/packages/libdbus/Cargo.toml
+++ b/packages/libdbus/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://dbus.freedesktop.org/releases/dbus"
+
 [[package.metadata.build-package.external-files]]
 url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.12.20.tar.gz"
 sha512 = "0964683bc6859374cc94e42e1ec0cdb542cca67971c205fcba4352500b6c0891665b0718e7d85eb060c81cb82e3346c313892bc02384da300ddd306c7eef0056"

--- a/packages/libelf/Cargo.toml
+++ b/packages/libelf/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://sourceware.org/elfutils/ftp/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://sourceware.org/elfutils/ftp/0.185/elfutils-0.185.tar.bz2"
 sha512 = "34de0de1355b11740e036e0fc64f2fc063587c8eb121b19216ee5548d3f0f268d8fc3995176c47190466b9d881007cfa11a9d01e9a50e38af6119492bf8bb47f"

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/libexpat/libexpat/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.xz"
 sha512 = "9dc760dbf701f75e55c4479d81417622f8c750d8473498458a382a4c2932a2976a059cb3589f88855188e5173ec7868d285c4601428e0ca625df7a59cf975191"

--- a/packages/libffi/Cargo.toml
+++ b/packages/libffi/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/libffi/libffi/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz"
 sha512 = "31bad35251bf5c0adb998c88ff065085ca6105cf22071b9bd4b5d5d69db4fadf16cadeec9baca944c4bb97b619b035bb8279de8794b922531fddeb0779eb7fb1"

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://download.gnome.org/sources/glib"
+
 [[package.metadata.build-package.external-files]]
 url = "https://download.gnome.org/sources/glib/2.68/glib-2.68.3.tar.xz"
 sha512 = "fb120105c4cb582491a53a0e4c61fe4bdd1f94b279bb7c362afd591369ede50a196c706375564ededf3550d4062a285b038e20b605e6d5dfe36f5d208f4bad3f"

--- a/packages/libiw/Cargo.toml
+++ b/packages/libiw/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://hewlettpackard.github.io/wireless-tools/Tools.html"
+
 [[package.metadata.build-package.external-files]]
 url = "https://hewlettpackard.github.io/wireless-tools/wireless_tools.29.tar.gz"
 sha512 = "c169e29d53353e3d65913a5a5ba219752218968b0c036d4bfb25e7f3a9e31fe1e6adfcdbb410116e9c161c99aa3a7314fdc889ba36ba63f002d11ff9dba6974d"

--- a/packages/libmnl/Cargo.toml
+++ b/packages/libmnl/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://netfilter.org/projects/libmnl/files"
+
 [[package.metadata.build-package.external-files]]
 url = "http://netfilter.org/projects/libmnl/files/libmnl-1.0.4.tar.bz2"
 sha512 = "e2bbfb688fe41913d53c74ba7ec95b4e88ee2c52b556b8608185f2fcbd629665423a3b37f877f84426ba257cf6040fa701539d67166b00b8e3e2dfde6831a2f9"

--- a/packages/libnetfilter_conntrack/Cargo.toml
+++ b/packages/libnetfilter_conntrack/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://netfilter.org/projects/libnetfilter_conntrack/files"
+
 [[package.metadata.build-package.external-files]]
 url = "https://netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-1.0.8.tar.bz2"
 sha512 = "ddc70e7e3f2d764ed1e115e4a03fe8848b8c04bd69eea0952e63131dd4dae3c23f33b8be518673e1ec3b5dbf708f5f86eac97be46fe265d95386a5e902bd0b82"

--- a/packages/libnetfilter_cthelper/Cargo.toml
+++ b/packages/libnetfilter_cthelper/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://netfilter.org/projects/libnetfilter_cthelper/files"
+
 [[package.metadata.build-package.external-files]]
 url = "https://netfilter.org/projects/libnetfilter_cthelper/files/libnetfilter_cthelper-1.0.0.tar.bz2"
 sha512 = "f0372daee0edbf4c27ee80eadd4ce786a4b67b39c0b9d22e88bc9adcbdffd6676eb9df01b933ee64d2fcea9c05a9ca9070c94e907277d69acbd22ae9a3c74e45"

--- a/packages/libnetfilter_cttimeout/Cargo.toml
+++ b/packages/libnetfilter_cttimeout/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://netfilter.org/projects/libnetfilter_cttimeout/files"
+
 [[package.metadata.build-package.external-files]]
 url = "https://netfilter.org/projects/libnetfilter_cttimeout/files/libnetfilter_cttimeout-1.0.0.tar.bz2"
 sha512 = "d64f592be022d02b6e6627470f9aed75114b0c7177012d31d868ee7eb39fca330a7638c9a209ff489d4a8c0549b8fcfd33582c6d36ee519b920cf27429301c85"

--- a/packages/libnetfilter_queue/Cargo.toml
+++ b/packages/libnetfilter_queue/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://netfilter.org/projects/libnetfilter_queue/files"
+
 [[package.metadata.build-package.external-files]]
 url = "https://netfilter.org/projects/libnetfilter_queue/files/libnetfilter_queue-1.0.5.tar.bz2"
 sha512 = "732a44b602e5efaa4f5582ea25ff8f5ec8f4dca5c0e725cd93fe2d441db80416b25c6018147be90acb262d7428eb5b21b3f7b5920e612d115061ec6a19d67f85"

--- a/packages/libnfnetlink/Cargo.toml
+++ b/packages/libnfnetlink/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://netfilter.org/projects/libnfnetlink/files"
+
 [[package.metadata.build-package.external-files]]
 url = "http://netfilter.org/projects/libnfnetlink/files/libnfnetlink-1.0.1.tar.bz2"
 sha512 = "2ec2cd389c04e21c8a02fb3f6d6f326fc33ca9589577f1739c23d883fe2ee9feaa16e83b6ed09063ad886432e49565dc3256277d035260aca5aab17954b46104"

--- a/packages/libnftnl/Cargo.toml
+++ b/packages/libnftnl/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://netfilter.org/projects/libnftnl/files"
+
 [[package.metadata.build-package.external-files]]
 url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.2.0.tar.bz2"
 sha512 = "2a068e7eab308442bbfba5325f3aebeb874c142b029ff5906cadf63a1f879b20930bc55cd9554c5d256a0642f0f5a6d36177d9ae88cf507ab5dfc7fabffbb380"

--- a/packages/libnl/Cargo.toml
+++ b/packages/libnl/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/thom311/libnl/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/thom311/libnl/archive/libnl3_5_0.tar.gz"
 sha512 = "2b762419a21b4560f7d488791a9d7aec0d1c6eac0cd2839ceec0bef5562f130ce44b826691276e1301b9e239f684063037959207474cefec4b46efc32039615d"

--- a/packages/libpcap/Cargo.toml
+++ b/packages/libpcap/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://www.tcpdump.org/release"
+
 [[package.metadata.build-package.external-files]]
 url = "http://www.tcpdump.org/release/libpcap-1.10.1.tar.gz"
 sha512 = "56c314f19c2b857742bf8abcb1e78066986aaa95cec339b75a3c8b70a9fa2b5167da98708352f9ec97a1cea2700cfb4e040bda108d58ac46cec9b7deab88d171"

--- a/packages/libpcre/Cargo.toml
+++ b/packages/libpcre/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://ftp.pcre.org/pub/pcre"
+
 [[package.metadata.build-package.external-files]]
 url = "https://ftp.pcre.org/pub/pcre/pcre2-10.37.tar.bz2"
 sha512 = "69f4bf4736b986e0fc855eedb292efe72a0df2e803bc0e61a6cf47775eed433bb1b2f28d7e641591ef4603d47beb543a64ed0eef9538d00f0746bc3435c143ec"

--- a/packages/libseccomp/Cargo.toml
+++ b/packages/libseccomp/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/seccomp/libseccomp/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/seccomp/libseccomp/releases/download/v2.5.1/libseccomp-2.5.1.tar.gz"
 sha512 = "2be80a6323f9282dbeae8791724e5778b32e2382b2a3d1b0f77366371ec4072ea28128204f675cce101c091c0420d12c497e1a9ccbb7dc5bcbf61bfd777160af"

--- a/packages/libselinux/Cargo.toml
+++ b/packages/libselinux/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/SELinuxProject/selinux/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/libselinux-3.2.tar.gz"
 sha512 = "18129ac0b9936e1f66021f1b311cf1c1e27a01e50cb70f08a3e1c642c5251e4538aec25a8427778569dfecf5333cf1fb84f1a59afdce8019328d0cff7e5833c5"

--- a/packages/libsemanage/Cargo.toml
+++ b/packages/libsemanage/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/SELinuxProject/selinux/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/libsemanage-3.2.tar.gz"
 sha512 = "6ad670bb298b1bab506217b12a3fda5d2209f4387a11410f0c1b65f765ffb579b0d70795dee19048909e0b72ef904fc318be60d5a01f80ab12742ce07647a084"

--- a/packages/libsepol/Cargo.toml
+++ b/packages/libsepol/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/SELinuxProject/selinux/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/libsepol-3.2.tar.gz"
 sha512 = "1a6b3489ff766958a4b444b9be63a794267243aed303d3e7d87278f11be492dbf603a0c8181c4c5e01cb0e1ceb43810a77f738f0b9bd1d7d2be67053f9c67a6f"

--- a/packages/libtirpc/Cargo.toml
+++ b/packages/libtirpc/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://sourceforge.net/projects/libtirpc/files/libtirpc/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.2.tar.bz2"
 sha512 = "8664d5c4f842ee5acf83b9c1cadb7871f17b8157a7c4500e2236dcfb3a25768cab39f7c5123758dcd7381e30eb028ddfa26a28f458283f2dcea3426c9878c255"

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/besser82/libxcrypt/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/besser82/libxcrypt/archive/v4.4.23/libxcrypt-4.4.23.tar.gz"
 sha512 = "4d5854a082a8c707416507611881c1407f0ea0bda0557c5f7ae6b70d8dd1c7a0828afe29d8f2e7754f5f97b824aaa03671dae6d4dad329fcd131b94b77ddb713"

--- a/packages/libz/Cargo.toml
+++ b/packages/libz/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://www.zlib.net"
+
 [[package.metadata.build-package.external-files]]
 url = "https://www.zlib.net/zlib-1.2.11.tar.xz"
 sha512 = "b7f50ada138c7f93eb7eb1631efccd1d9f03a5e77b6c13c8b757017b2d462e19d2d3e01c50fad60a4ae1bc86d431f6f94c72c11ff410c25121e571953017cb67"

--- a/packages/libzstd/Cargo.toml
+++ b/packages/libzstd/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/facebook/zstd/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/facebook/zstd/archive/v1.5.0.tar.gz"
 sha512 = "25b657529a698eec891f92ff4a085d1fd95d2ff938ce52c8a4ff6163eb0b668ec642dd09e0db190652638cd92371006afa01d8e437437762c4097ad301675c33"

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/makedumpfile/makedumpfile/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/makedumpfile/makedumpfile/archive/1.6.9/makedumpfile-1.6.9.tar.gz"
 sha512 = "9982985498ae641d390c3b87d92aecd263a502f1a4a9e96e145d86d8778b9e778e4ee98034ef4dbe12ed5586c57278917ea5f3c9ae2989ad1ac051215e03b3d9"

--- a/packages/ncurses/Cargo.toml
+++ b/packages/ncurses/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://invisible-mirror.net/ncurses/announce.html"
+
 [[package.metadata.build-package.external-files]]
 url = "https://invisible-mirror.net/archives/ncurses/ncurses-6.2.tar.gz"
 sha512 = "4c1333dcc30e858e8a9525d4b9aefb60000cfc727bc4a1062bace06ffc4639ad9f6e54f6bdda0e3a0e5ea14de995f96b52b3327d9ec633608792c99a1e8d840d"

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/vmware/open-vm-tools/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/vmware/open-vm-tools/releases/download/stable-11.3.0/open-vm-tools-11.3.0-18090558.tar.gz"
 sha512 = "36fa4fc309e57f49f1000abe8ca48aaf8bda67cd0ef3fd25ed0dfc12e2dd88e5a2bc8dae69abbadb44b2fa5195802f9925681a452f54916daa268adb20e8c8cd"

--- a/packages/policycoreutils/Cargo.toml
+++ b/packages/policycoreutils/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/SELinuxProject/selinux/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/SELinuxProject/selinux/releases/download/3.2/policycoreutils-3.2.tar.gz"
 sha512 = "d16781d2d61b8b78d6fc242f2b5c3a03f47ea524fb61655823b6b0f0327ff376c65fe7bdf7a53f5863c01e599cf4a7050f21fda0fe6a8f2c2c16f89b156a4346"

--- a/packages/procps/Cargo.toml
+++ b/packages/procps/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://gitlab.com/procps-ng/procps/-/tags"
+
 [[package.metadata.build-package.external-files]]
 url = "https://gitlab.com/procps-ng/procps/-/archive/v3.3.17/procps-v3.3.17.tar.gz"
 sha512 = "070076cf6bbbd8b6b342af361035f11d9c7381c5d1e2e430a5f2584ff55656254e8f863a40ca75a38870a5007d1b22a0d452bef13fa0ab89e4bf9676826fd788"

--- a/packages/readline/Cargo.toml
+++ b/packages/readline/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://ftp.gnu.org/gnu/readline"
+
 [[package.metadata.build-package.external-files]]
 url = "https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz"
 sha512 = "27790d0461da3093a7fee6e89a51dcab5dc61928ec42e9228ab36493b17220641d5e481ea3d8fee5ee0044c70bf960f55c7d3f1a704cf6b9c42e5c269b797e00"

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/opencontainers/runc/releases/"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.tar.xz"
 path = "runc-v1.0.2.tar.xz"

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://strace.io/files"
+
 [[package.metadata.build-package.external-files]]
 url = "https://strace.io/files/5.13/strace-5.13.tar.xz"
 sha512 = "ba8b0eae396fa2b762bf17cbcdcd84b0660b2a5d5e7e9caf098ef3414a87fd28d4140dd10136483f35904560e5044e40be2bf6117462868a360306d62887c8ed"

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/systemd/systemd-stable/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/systemd/systemd-stable/archive/v247.8/systemd-stable-247.8.tar.gz"
 sha512 = "ac6c9e9b1642f14971551585b25b0b69733a76577154baa701d9879349844913535859d1ef440d20b4d55d8bcc7c34b9d413710f3e49e4cc295d1e5ebb48102c"

--- a/packages/tcpdump/Cargo.toml
+++ b/packages/tcpdump/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "http://www.tcpdump.org/release"
+
 [[package.metadata.build-package.external-files]]
 url = "http://www.tcpdump.org/release/tcpdump-4.99.1.tar.gz"
 sha512 = "53d31355e1a6ef5a65bb3bf72454169fc80adf973a327a5768840e6ccf0550fbeb3c8a41f959635076d871df0619680321910a3a97879607f481cdaa8b7ceda7"

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"
+
 [[package.metadata.build-package.external-files]]
 url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.37/util-linux-2.37.1.tar.xz"
 sha512 = "ec300c830869e10a0d7f8c0b99e9bb46e0b88fc51f3c6c6a4d9752a89f035e8d69d81f25fd103ef8d7d253e81440695ef3f5d72dccc94815ec8d5f6f949f7555"

--- a/packages/wicked/Cargo.toml
+++ b/packages/wicked/Cargo.toml
@@ -8,6 +8,9 @@ build = "build.rs"
 [lib]
 path = "pkg.rs"
 
+[package.metadata.build-package]
+releases-url = "https://github.com/openSUSE/wicked/releases"
+
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/openSUSE/wicked/archive/version-0.6.66.tar.gz"
 sha512 = "4898e065a77c3158702b1a32e2317a97821df2bc54a9df52e6b3626e4787602771983717a90eb999d7e4a119e4705bfeeb213de8361877fae2a6cda178c329bd"

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -51,6 +51,13 @@ reads BUILDSYS_VARIANT.)
 variant-sensitive = true
 ```
 
+`releases-url` is ignored by buildsys, but can be used by packager maintainers
+to indicate a good URL for checking whether the software has had a new release.
+```
+[package.metadata.build-package]
+releases-url = "https://www.example.com/releases"
+```
+
 ## Metadata for variants
 
 `included-packages` is a list of packages that should be included in a variant.
@@ -187,6 +194,7 @@ struct Metadata {
 pub(crate) struct BuildPackage {
     pub(crate) external_files: Option<Vec<ExternalFile>>,
     pub(crate) package_name: Option<String>,
+    pub(crate) releases_url: Option<String>,
     pub(crate) source_groups: Option<Vec<PathBuf>>,
     pub(crate) variant_sensitive: Option<bool>,
 }


### PR DESCRIPTION
**Description of changes:**

I was working on updating third-party packages and got annoyed by needing to hack up the download URLs to find URLs where I could check for new releases.

This change adds a key to packages/*/Cargo.toml that lets us give a URL useful for checking for updates.  A grep for releases-url should be all that's needed when updating packages.

For software on GitHub, it's the standard releases page; for others, it's the page I found best for accuracy and friendliness.

**Testing done:**

Checked all the URLs.  Built packages to confirm buildsys doesn't care.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
