### PR TITLE
modify /etc/os-release

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -152,8 +152,10 @@ mv "${ROOT_MOUNT}/boot"/* "${BOOT_MOUNT}"
 
 # Set the Bottlerocket variant, version, and build-id
 SYS_ROOT="${ARCH}-bottlerocket-linux-gnu/sys-root"
+VERSION="${VERSION_ID} (${VARIANT})"
 cat <<EOF >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/lib/os-release"
-PRETTY_NAME="${PRETTY_NAME} ${VERSION_ID}"
+VERSION="${VERSION}"
+PRETTY_NAME="${PRETTY_NAME} ${VERSION}"
 VARIANT_ID=${VARIANT}
 VERSION_ID=${VERSION_ID}
 BUILD_ID=${BUILD_ID}

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -152,10 +152,15 @@ mv "${ROOT_MOUNT}/boot"/* "${BOOT_MOUNT}"
 
 # Set the Bottlerocket variant, version, and build-id
 SYS_ROOT="${ARCH}-bottlerocket-linux-gnu/sys-root"
-echo "PRETTY_NAME=\"${PRETTY_NAME} ${VERSION_ID}\"" >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/lib/os-release"
-echo "VARIANT_ID=${VARIANT}" >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/lib/os-release"
-echo "VERSION_ID=${VERSION_ID}" >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/lib/os-release"
-echo "BUILD_ID=${BUILD_ID}" >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/lib/os-release"
+cat <<EOF >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/lib/os-release"
+PRETTY_NAME="${PRETTY_NAME} ${VERSION_ID}"
+VARIANT_ID=${VARIANT}
+VERSION_ID=${VERSION_ID}
+BUILD_ID=${BUILD_ID}
+HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
+SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
+BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
+EOF
 
 # BOTTLEROCKET-ROOT-A
 mkdir -p "${ROOT_MOUNT}/lost+found"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Adds **HOME_URL**, **SUPPORT_URL**, and **BUG_REPORT_URL** to `/etc/os-release`,
as well as the _variant_ to the **PRETTY_NAME** and a new **VERSION** field.

**OLD**
```
NAME=Bottlerocket
ID=bottlerocket
PRETTY_NAME="Bottlerocket OS 1.2.0"
VARIANT_ID=aws-ecs-1
VERSION_ID=1.2.0
BUILD_ID=ccf1b754
```

**NEW**
```
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.2.0 (aws-ecs-1)"
PRETTY_NAME="Bottlerocket OS 1.2.0 (aws-ecs-1)"
VARIANT_ID=aws-ecs-1
VERSION_ID=1.2.0
BUILD_ID=e0808b0b
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
```

**Testing done:**

Built and launched `aws-k8s-1.20` and `aws-ecs-1` variants. Verified the expected changes via the admin container. Both instances connected to their respective clusters without issue, although the **OS Image** now reports as `Bottlerocket OS 1.2.0 (aws-k8s-1.20)` in EKS.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
