### PR TITLE
sources: update httptest

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1447,9 +1447,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "httptest"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c2365a7fb6261670a6bba56577393002429769138605771113bf3b2599c272"
+checksum = "5858cc7b673d0397ffd4cdee93f11eb2fa08a2b0b5e35ae03d6b480a4abe171d"
 dependencies = [
  "bstr",
  "bytes",

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -366,7 +366,7 @@ mod error {
     #[snafu(visibility = "pub(super)")]
 
     pub enum Error {
-        #[snafu(display("Response '{}' from '{}': {}", get_status_code(&source), uri, source))]
+        #[snafu(display("Response '{}' from '{}': {}", get_status_code(source), uri, source))]
         BadResponse { uri: String, source: reqwest::Error },
 
         #[snafu(display("IMDS fetch failed after {} attempts", attempt))]
@@ -426,8 +426,7 @@ mod test {
     #[tokio::test]
     async fn new_imds_client() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         server.expect(
             Expectation::matching(request::method_path("PUT", "/latest/api/token"))
@@ -445,8 +444,7 @@ mod test {
     #[tokio::test]
     async fn fetch_imds() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let schema_version = "latest";
         let target = "meta-data/instance-type";
@@ -484,8 +482,7 @@ mod test {
     #[tokio::test]
     async fn fetch_imds_notfound() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let schema_version = "latest";
         let target = "meta-data/instance-type";
@@ -520,8 +517,7 @@ mod test {
     #[tokio::test]
     async fn fetch_imds_unauthorized() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let schema_version = "latest";
         let target = "meta-data/instance-type";
@@ -555,8 +551,7 @@ mod test {
     #[tokio::test]
     async fn fetch_imds_timeout() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let schema_version = "latest";
         let target = "meta-data/instance-type";
@@ -590,8 +585,7 @@ mod test {
     #[tokio::test]
     async fn fetch_string() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let end_target = "meta-data/instance-type";
         let response_code = 200;
@@ -625,8 +619,7 @@ mod test {
     #[tokio::test]
     async fn fetch_bytes() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let end_target = "dynamic/instance-identity/document";
         let response_code = 200;
@@ -660,8 +653,7 @@ mod test {
     #[tokio::test]
     async fn fetch_userdata() {
         let server = Server::run();
-        let port = server.addr().port();
-        let base_uri = format!("http://localhost:{}", port);
+        let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let response_code = 200;
         let response_body = r#"settings.motd = "Welcome to Bottlerocket!""#;

--- a/sources/metricdog/src/metricdog_test.rs
+++ b/sources/metricdog/src/metricdog_test.rs
@@ -60,10 +60,10 @@ fn send_healthy_ping() {
         request::query(url_decoded(contains(("is_healthy", "true")))),
     ];
     server.expect(Expectation::matching(matcher).respond_with(status_code(200)));
-    let port = server.addr().port();
+    let metrics_url = server.url_str("/metrics");
     let metricdog = Metricdog::from_parts(
         Config {
-            metrics_url: format!("http://localhost:{}/metrics", port),
+            metrics_url,
             send_metrics: true,
             service_checks: vec![
                 String::from("service_a"),
@@ -101,10 +101,10 @@ fn send_unhealthy_ping() {
         request::query(url_decoded(contains(("is_healthy", "false")))),
     ];
     server.expect(Expectation::matching(matcher).respond_with(status_code(200)));
-    let port = server.addr().port();
+    let metrics_url = server.url_str("/metrics");
     let metricdog = Metricdog::from_parts(
         Config {
-            metrics_url: format!("http://localhost:{}/metrics", port),
+            metrics_url,
             send_metrics: true,
             // note that these are out-of-order sort order to ensure that failed services are sorted
             // in the url.
@@ -139,10 +139,10 @@ fn send_boot_success() {
         request::query(url_decoded(contains(("seed", "2041")))),
     ];
     server.expect(Expectation::matching(matcher).respond_with(status_code(200)));
-    let port = server.addr().port();
+    let metrics_url = server.url_str("/metrics");
     let metricdog = Metricdog::from_parts(
         Config {
-            metrics_url: format!("http://localhost:{}/metrics", port),
+            metrics_url,
             send_metrics: true,
             service_checks: vec![
                 String::from("service_afail2"),


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Update to httptest 0.15.3.

Removes references to 'http://localhost' in tests for imdsclient and
metricdog as changes in 0.15.3 triggered CI failures on actions runners.

Also fixed a few small cargo clippy warnings in imdsclient and metricdog.

**Testing done:**

Ran unit tests locally and on actions runners.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
