### PR TITLE
Update Kubernetes for CVE-2021-25741

### DIFF
--- a/packages/kubernetes-1.17/0050-k8s-1.17-CVE-2021-25741.patch
+++ b/packages/kubernetes-1.17/0050-k8s-1.17-CVE-2021-25741.patch
@@ -1,0 +1,892 @@
+From ac51f2f6a3f70fde8fa709374f9405eb782ba36d Mon Sep 17 00:00:00 2001
+From: Manu Gupta <mgpta@amazon.com>
+Date: Wed, 25 Aug 2021 08:27:33 -0700
+Subject: [PATCH] -- EKS Patch -- Pass additional flags to subpath mount to
+ avoid flakes in certain conditions
+
+https://github.com/kubernetes/kubernetes/pull/104340
+
+Backport upstream fix to 1.17.
+
+Several definitions were not present in the vendored package for
+k8s.io/utils/mount. So, I copied the missing definition from 1.18 to
+1.17 from upstream code. I have mentioned the code that is copied from
+upstream in the comments of the code.  This was added to the
+pkg/volume/util/subpath.
+
+There were some missing mutex (this is an internal level detail from the
+vendored package that was exposed), which were then also acquired
+at the subpath volume level.
+
+---
+ cmd/kubelet/app/server.go                     |   3 +-
+ pkg/volume/util/subpath/BUILD                 |  21 +-
+ .../util/subpath/subpath_fake_mounter.go      | 109 ++++++++++
+ pkg/volume/util/subpath/subpath_linux.go      |   9 +-
+ pkg/volume/util/subpath/subpath_linux_test.go |   6 +-
+ pkg/volume/util/subpath/subpath_mount.go      | 135 ++++++++++++
+ .../util/subpath/subpath_mount_linux.go       | 202 ++++++++++++++++++
+ .../util/subpath/subpath_mount_unsupported.go |  48 +++++
+ .../util/subpath/subpath_mount_windows.go     | 170 +++++++++++++++
+ 9 files changed, 682 insertions(+), 21 deletions(-)
+ create mode 100644 pkg/volume/util/subpath/subpath_fake_mounter.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount_linux.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount_unsupported.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount_windows.go
+
+diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
+index 62bd759ffc6..918b8ba7fd3 100644
+--- a/cmd/kubelet/app/server.go
++++ b/cmd/kubelet/app/server.go
+@@ -371,7 +371,8 @@ func UnsecuredDependencies(s *options.KubeletServer, featureGate featuregate.Fea
+ 	}
+ 
+ 	mounter := mount.New(s.ExperimentalMounterPath)
+-	subpather := subpath.New(mounter)
++	subPathMounter := subpath.NewMounter(mounter, s.ExperimentalMounterPath)
++	subpather := subpath.New(subPathMounter)
+ 	hu := hostutil.NewHostUtil()
+ 	var pluginRunner = exec.New()
+ 
+diff --git a/pkg/volume/util/subpath/BUILD b/pkg/volume/util/subpath/BUILD
+index 3830dc9ae00..564db078c3f 100644
+--- a/pkg/volume/util/subpath/BUILD
++++ b/pkg/volume/util/subpath/BUILD
+@@ -4,62 +4,57 @@ go_library(
+     name = "go_default_library",
+     srcs = [
+         "subpath.go",
++        "subpath_fake_mounter.go",
+         "subpath_linux.go",
++        "subpath_mount.go",
++        "subpath_mount_linux.go",
++        "subpath_mount_unsupported.go",
++        "subpath_mount_windows.go",
+         "subpath_unsupported.go",
+         "subpath_windows.go",
+     ],
+     importpath = "k8s.io/kubernetes/pkg/volume/util/subpath",
+     visibility = ["//visibility:public"],
+-    deps = select({
++    deps = [
++        "//vendor/k8s.io/utils/mount:go_default_library",
++    ] + select({
+         "@io_bazel_rules_go//go/platform:android": [
+             "//vendor/golang.org/x/sys/unix:go_default_library",
+             "//vendor/k8s.io/klog:go_default_library",
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:darwin": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:dragonfly": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:freebsd": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:ios": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:linux": [
+             "//vendor/golang.org/x/sys/unix:go_default_library",
+             "//vendor/k8s.io/klog:go_default_library",
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:nacl": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:netbsd": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:openbsd": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:plan9": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:solaris": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:windows": [
+             "//vendor/k8s.io/klog:go_default_library",
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "//conditions:default": [],
+diff --git a/pkg/volume/util/subpath/subpath_fake_mounter.go b/pkg/volume/util/subpath/subpath_fake_mounter.go
+new file mode 100644
+index 00000000000..d49b571b0d4
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_fake_mounter.go
+@@ -0,0 +1,109 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	"k8s.io/klog"
++	mountutils "k8s.io/utils/mount"
++	"path/filepath"
++	"sync"
++)
++
++// FakeMounter implements MountInterface for tests.
++type FakeMounter struct {
++	*mountutils.FakeMounter
++
++	// mutex is pulled out from vendor because it is private to the vendored package;
++	// so that we can create a lock when MountSensitive is called.
++	mutex sync.Mutex
++	// mutext is pulled out from vendor because it is private to the vendored package;
++	// so that we can create a lock when MountSensitive is called.
++	log []mountutils.FakeAction
++}
++
++var _ MountInterface = &FakeMounter{}
++
++// NewFakeMounter returns a FakeMounter struct that implements Interface and is
++// suitable for testing purposes.
++func NewFakeMounter(mps []mountutils.MountPoint) *FakeMounter {
++	return &FakeMounter{
++		FakeMounter: &mountutils.FakeMounter{
++			MountPoints: mps,
++		},
++		mutex: sync.Mutex{},
++		log:   []mountutils.FakeAction{},
++	}
++}
++
++// MountSensitiveWithFlags records the mount event and updates the in-memory mount points for FakeMounter
++// sensitiveOptions to be passed in a separate parameter from the normal
++// mount options and ensures the sensitiveOptions are never logged. This
++// method should be used by callers that pass sensitive material (like
++// passwords) as mount options.
++func (f *FakeMounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	return f.MountSensitive(source, target, fstype, options, sensitiveOptions)
++}
++
++
++// MountSensitive records the mount event and updates the in-memory mount points for FakeMounter
++// sensitiveOptions to be passed in a separate parameter from the normal
++// mount options and ensures the sensitiveOptions are never logged. This
++// method should be used by callers that pass sensitive material (like
++// passwords) as mount options.
++// Reqd for patch
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/fake_mounter.go
++func (f *FakeMounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
++	f.mutex.Lock()
++	defer f.mutex.Unlock()
++
++	opts := []string{}
++
++	for _, option := range options {
++		// find 'bind' option
++		if option == "bind" {
++			// This is a bind-mount. In order to mimic linux behaviour, we must
++			// use the original device of the bind-mount as the real source.
++			// E.g. when mounted /dev/sda like this:
++			//      $ mount /dev/sda /mnt/test
++			//      $ mount -o bind /mnt/test /mnt/bound
++			// then /proc/mount contains:
++			// /dev/sda /mnt/test
++			// /dev/sda /mnt/bound
++			// (and not /mnt/test /mnt/bound)
++			// I.e. we must use /dev/sda as source instead of /mnt/test in the
++			// bind mount.
++			for _, mnt := range f.MountPoints {
++				if source == mnt.Path {
++					source = mnt.Device
++					break
++				}
++			}
++		}
++		// reuse MountPoint.Opts field to mark mount as readonly
++		opts = append(opts, option)
++	}
++
++	// If target is a symlink, get its absolute path
++	absTarget, err := filepath.EvalSymlinks(target)
++	if err != nil {
++		absTarget = target
++	}
++	f.MountPoints = append(f.MountPoints, mountutils.MountPoint{Device: source, Path: absTarget, Type: fstype, Opts: append(opts, sensitiveOptions...)})
++	klog.V(5).Infof("Fake mounter: mounted %s to %s", source, absTarget)
++	f.log = append(f.log, mountutils.FakeAction{Action: mountutils.FakeActionMount, Target: absTarget, Source: source, FSType: fstype})
++	return nil
++}
+\ No newline at end of file
+diff --git a/pkg/volume/util/subpath/subpath_linux.go b/pkg/volume/util/subpath/subpath_linux.go
+index 0663a72c50d..e72050d076d 100644
+--- a/pkg/volume/util/subpath/subpath_linux.go
++++ b/pkg/volume/util/subpath/subpath_linux.go
+@@ -43,11 +43,11 @@ const (
+ )
+ 
+ type subpath struct {
+-	mounter mount.Interface
++	mounter MountInterface
+ }
+ 
+ // New returns a subpath.Interface for the current system
+-func New(mounter mount.Interface) Interface {
++func New(mounter MountInterface) Interface {
+ 	return &subpath{
+ 		mounter: mounter,
+ 	}
+@@ -147,7 +147,7 @@ func getSubpathBindTarget(subpath Subpath) string {
+ 	return filepath.Join(subpath.PodDir, containerSubPathDirectoryName, subpath.VolumeName, subpath.ContainerName, strconv.Itoa(subpath.VolumeMountIndex))
+ }
+ 
+-func doBindSubPath(mounter mount.Interface, subpath Subpath) (hostPath string, err error) {
++func doBindSubPath(mounter MountInterface, subpath Subpath) (hostPath string, err error) {
+ 	// Linux, kubelet runs on the host:
+ 	// - safely open the subpath
+ 	// - bind-mount /proc/<pid of kubelet>/fd/<fd> to subpath target
+@@ -196,8 +196,9 @@ func doBindSubPath(mounter mount.Interface, subpath Subpath) (hostPath string, e
+ 
+ 	// Do the bind mount
+ 	options := []string{"bind"}
++	mountFlags := []string{"--no-canonicalize"}
+ 	klog.V(5).Infof("bind mounting %q at %q", mountSource, bindPathTarget)
+-	if err = mounter.Mount(mountSource, bindPathTarget, "" /*fstype*/, options); err != nil {
++	if err = mounter.MountSensitiveWithFlags(mountSource, bindPathTarget, "" /*fstype*/, options, nil /* sensitiveOptions */, mountFlags); err != nil {
+ 		return "", fmt.Errorf("error mounting %s: %s", subpath.Path, err)
+ 	}
+ 	success = true
+diff --git a/pkg/volume/util/subpath/subpath_linux_test.go b/pkg/volume/util/subpath/subpath_linux_test.go
+index 154d761e6bf..ca4dd5331d4 100644
+--- a/pkg/volume/util/subpath/subpath_linux_test.go
++++ b/pkg/volume/util/subpath/subpath_linux_test.go
+@@ -611,7 +611,7 @@ func TestCleanSubPaths(t *testing.T) {
+ 			t.Fatalf("failed to prepare test %q: %v", test.name, err.Error())
+ 		}
+ 
+-		fm := mount.NewFakeMounter(mounts)
++		fm := NewFakeMounter(mounts)
+ 		fm.UnmountFunc = test.unmount
+ 
+ 		err = doCleanSubPaths(fm, base, testVol)
+@@ -636,12 +636,12 @@ var (
+ 	testSubpath   = 1
+ )
+ 
+-func setupFakeMounter(testMounts []string) *mount.FakeMounter {
++func setupFakeMounter(testMounts []string) *FakeMounter {
+ 	mounts := []mount.MountPoint{}
+ 	for _, mountPoint := range testMounts {
+ 		mounts = append(mounts, mount.MountPoint{Device: "/foo", Path: mountPoint})
+ 	}
+-	return mount.NewFakeMounter(mounts)
++	return NewFakeMounter(mounts)
+ }
+ 
+ func getTestPaths(base string) (string, string) {
+diff --git a/pkg/volume/util/subpath/subpath_mount.go b/pkg/volume/util/subpath/subpath_mount.go
+new file mode 100644
+index 00000000000..09f42260bea
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount.go
+@@ -0,0 +1,135 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++// TODO(thockin): This whole pkg is pretty linux-centric.  As soon as we have
++// an alternate platform, we will need to abstract further.
++
++package subpath
++
++import (
++	"k8s.io/utils/mount"
++	"strings"
++)
++
++// Log message where sensitive mount options were removed
++// Reqd. for subpath patch.
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount.go#L34-L35
++const sensitiveOptionsRemoved = "<masked>"
++
++// MountInterface defines the set of methods to allow for mount operations on a system.
++type MountInterface interface {
++	mount.Interface
++
++	// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags
++	MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error
++}
++
++// Compile-time check to ensure all Mounter implementations satisfy
++// the mount interface.
++var _ MountInterface = &Mounter{}
++
++// MakeBindOptsSensitive is the same as MakeBindOpts but this method allows
++// sensitiveOptions to be passed in a separate parameter from the normal mount
++// options and ensures the sensitiveOptions are never logged. This method should
++// be used by callers that pass sensitive material (like passwords) as mount
++// options.
++// Required for subpath patch.
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount.go#L316-L328
++func MakeBindOptsSensitive(options []string, sensitiveOptions []string) (bool, []string, []string, []string) {
++	// Because we have an FD opened on the subpath bind mount, the "bind" option
++	// needs to be included, otherwise the mount target will error as busy if you
++	// remount as readonly.
++	//
++	// As a consequence, all read only bind mounts will no longer change the underlying
++	// volume mount to be read only.
++	bindRemountOpts := []string{"bind", "remount"}
++	bindRemountSensitiveOpts := []string{}
++	bind := false
++	bindOpts := []string{"bind"}
++
++	// _netdev is a userspace mount option and does not automatically get added when
++	// bind mount is created and hence we must carry it over.
++	if checkForNetDev(options, sensitiveOptions) {
++		bindOpts = append(bindOpts, "_netdev")
++	}
++
++	for _, option := range options {
++		switch option {
++		case "bind":
++			bind = true
++			break
++		case "remount":
++			break
++		default:
++			bindRemountOpts = append(bindRemountOpts, option)
++		}
++	}
++
++	for _, sensitiveOption := range sensitiveOptions {
++		switch sensitiveOption {
++		case "bind":
++			bind = true
++			break
++		case "remount":
++			break
++		default:
++			bindRemountSensitiveOpts = append(bindRemountSensitiveOpts, sensitiveOption)
++		}
++	}
++
++	return bind, bindOpts, bindRemountOpts, bindRemountSensitiveOpts
++}
++
++// Required for subpath patch:
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount.go#L316-L328
++func checkForNetDev(options []string, sensitiveOptions []string) bool {
++	for _, option := range options {
++		if option == "_netdev" {
++			return true
++		}
++	}
++	for _, sensitiveOption := range sensitiveOptions {
++		if sensitiveOption == "_netdev" {
++			return true
++		}
++	}
++	return false
++}
++
++// sanitizedOptionsForLogging will return a comma seperated string containing
++// options and sensitiveOptions. Each entry in sensitiveOptions will be
++// replaced with the string sensitiveOptionsRemoved
++// e.g. o1,o2,<masked>,<masked>
++// Reqd for subpath patch
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount.go#L349-L370
++func sanitizedOptionsForLogging(options []string, sensitiveOptions []string) string {
++	seperator := ""
++	if len(options) > 0 && len(sensitiveOptions) > 0 {
++		seperator = ","
++	}
++
++	sensitiveOptionsStart := ""
++	sensitiveOptionsEnd := ""
++	if len(sensitiveOptions) > 0 {
++		sensitiveOptionsStart = strings.Repeat(sensitiveOptionsRemoved+",", len(sensitiveOptions)-1)
++		sensitiveOptionsEnd = sensitiveOptionsRemoved
++	}
++
++	return strings.Join(options, ",") +
++		seperator +
++		sensitiveOptionsStart +
++		sensitiveOptionsEnd
++}
+diff --git a/pkg/volume/util/subpath/subpath_mount_linux.go b/pkg/volume/util/subpath/subpath_mount_linux.go
+new file mode 100644
+index 00000000000..a227c15a88d
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount_linux.go
+@@ -0,0 +1,202 @@
++// +build linux
++
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	"fmt"
++	"k8s.io/klog"
++	"os/exec"
++	"strings"
++
++	mountutils "k8s.io/utils/mount"
++)
++
++const (
++	// Default mount command if mounter path is not specified.
++	defaultMountCommand = "mount"
++)
++
++// Mounter provides the subpath implementation of mount.Interface
++// for the linux platform.  This implementation assumes that the
++// kubelet is running in the host's root mount namespace.
++type Mounter struct {
++	mountutils.Interface
++	mounterPath string
++	withSystemd bool
++}
++
++// NewMounter returns a MountInterface for the current system.
++// It provides options to override the default mounter behavior.
++// mounterPath allows using an alternative to `/bin/mount` for mounting.
++func NewMounter(mounter mountutils.Interface, mounterPath string) MountInterface {
++	return &Mounter{
++		Interface:   mounter,
++		mounterPath: mounterPath,
++		withSystemd: detectSystemd(),
++	}
++}
++
++// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags
++func (mounter *Mounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	// Path to mounter binary if containerized mounter is needed. Otherwise, it is set to empty.
++	// All Linux distros are expected to be shipped with a mount utility that a support bind mounts.
++	mounterPath := ""
++	bind, bindOpts, bindRemountOpts, bindRemountOptsSensitive := MakeBindOptsSensitive(options, sensitiveOptions)
++	if bind {
++		err := mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, bindOpts, bindRemountOptsSensitive, mountFlags)
++		if err != nil {
++			return err
++		}
++		return mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, bindRemountOpts, bindRemountOptsSensitive, mountFlags)
++	}
++	// The list of filesystems that require containerized mounter on GCI image cluster
++	fsTypesNeedMounter := map[string]struct{}{
++		"nfs":       {},
++		"glusterfs": {},
++		"ceph":      {},
++		"cifs":      {},
++	}
++	if _, ok := fsTypesNeedMounter[fstype]; ok {
++		mounterPath = mounter.mounterPath
++	}
++	return mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, options, sensitiveOptions, mountFlags)
++}
++
++// doMount runs the mount command. mounterPath is the path to mounter binary if containerized mounter is used.
++// sensitiveOptions is an extension of options except they will not be logged (because they may contain sensitive material)
++// mountFlags are additional flags used in the mount command that are not related with fstype and mount options
++func (mounter *Mounter) doMount(mounterPath string, mountCmd string, source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	mountArgs, mountArgsLogStr := makeMountArgsSensitiveWithMountFlags(source, target, fstype, options, sensitiveOptions, mountFlags)
++	if len(mounterPath) > 0 {
++		mountArgs = append([]string{mountCmd}, mountArgs...)
++		mountArgsLogStr = mountCmd + " " + mountArgsLogStr
++		mountCmd = mounterPath
++	}
++
++	if mounter.withSystemd {
++		// Try to run mount via systemd-run --scope. This will escape the
++		// service where kubelet runs and any fuse daemons will be started in a
++		// specific scope. kubelet service than can be restarted without killing
++		// these fuse daemons.
++		//
++		// Complete command line (when mounterPath is not used):
++		// systemd-run --description=... --scope -- mount -t <type> <what> <where>
++		//
++		// Expected flow:
++		// * systemd-run creates a transient scope (=~ cgroup) and executes its
++		//   argument (/bin/mount) there.
++		// * mount does its job, forks a fuse daemon if necessary and finishes.
++		//   (systemd-run --scope finishes at this point, returning mount's exit
++		//   code and stdout/stderr - thats one of --scope benefits).
++		// * systemd keeps the fuse daemon running in the scope (i.e. in its own
++		//   cgroup) until the fuse daemon dies (another --scope benefit).
++		//   Kubelet service can be restarted and the fuse daemon survives.
++		// * When the fuse daemon dies (e.g. during unmount) systemd removes the
++		//   scope automatically.
++		//
++		// systemd-mount is not used because it's too new for older distros
++		// (CentOS 7, Debian Jessie).
++		mountCmd, mountArgs, mountArgsLogStr = AddSystemdScopeSensitive("systemd-run", target, mountCmd, mountArgs, mountArgsLogStr)
++		// } else {
++		// No systemd-run on the host (or we failed to check it), assume kubelet
++		// does not run as a systemd service.
++		// No code here, mountCmd and mountArgs are already populated.
++	}
++
++	// Logging with sensitive mount options removed.
++	klog.V(4).Infof("Mounting cmd (%s) with arguments (%s)", mountCmd, mountArgsLogStr)
++	command := exec.Command(mountCmd, mountArgs...)
++	output, err := command.CombinedOutput()
++	if err != nil {
++		klog.Errorf("Mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s\n", err, mountCmd, mountArgsLogStr, string(output))
++		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s",
++			err, mountCmd, mountArgsLogStr, string(output))
++	}
++	return err
++}
++
++// detectSystemd returns true if OS runs with systemd as init. When not sure
++// (permission errors, ...), it returns false.
++// There may be different ways how to detect systemd, this one makes sure that
++// systemd-runs (needed by Mount()) works.
++func detectSystemd() bool {
++	if _, err := exec.LookPath("systemd-run"); err != nil {
++		klog.V(2).Infof("Detected OS without systemd")
++		return false
++	}
++	// Try to run systemd-run --scope /bin/true, that should be enough
++	// to make sure that systemd is really running and not just installed,
++	// which happens when running in a container with a systemd-based image
++	// but with different pid 1.
++	cmd := exec.Command("systemd-run", "--description=Kubernetes systemd probe", "--scope", "true")
++	output, err := cmd.CombinedOutput()
++	if err != nil {
++		klog.V(2).Infof("Cannot run systemd-run, assuming non-systemd OS")
++		klog.V(4).Infof("systemd-run failed with: %v", err)
++		klog.V(4).Infof("systemd-run output: %s", string(output))
++		return false
++	}
++	klog.V(2).Infof("Detected OS with systemd")
++	return true
++}
++
++// makeMountArgsSensitiveWithMountFlags makes the arguments to the mount(8) command.
++// sensitiveOptions is an extension of options except they will not be logged (because they may contain sensitive material)
++// mountFlags are additional mount flags that are not related with the fstype and mount options
++func makeMountArgsSensitiveWithMountFlags(source, target, fstype string, options []string, sensitiveOptions []string, mountFlags []string) (mountArgs []string, mountArgsLogStr string) {
++	// Build mount command as follows:
++	//   mount [$mountFlags] [-t $fstype] [-o $options] [$source] $target
++	mountArgs = []string{}
++	mountArgsLogStr = ""
++
++	mountArgs = append(mountArgs, mountFlags...)
++	mountArgsLogStr += strings.Join(mountFlags, " ")
++
++	if len(fstype) > 0 {
++		mountArgs = append(mountArgs, "-t", fstype)
++		mountArgsLogStr += strings.Join(mountArgs, " ")
++	}
++	if len(options) > 0 || len(sensitiveOptions) > 0 {
++		combinedOptions := []string{}
++		combinedOptions = append(combinedOptions, options...)
++		combinedOptions = append(combinedOptions, sensitiveOptions...)
++		mountArgs = append(mountArgs, "-o", strings.Join(combinedOptions, ","))
++		// exclude sensitiveOptions from log string
++		mountArgsLogStr += " -o " + sanitizedOptionsForLogging(options, sensitiveOptions)
++	}
++	if len(source) > 0 {
++		mountArgs = append(mountArgs, source)
++		mountArgsLogStr += " " + source
++	}
++	mountArgs = append(mountArgs, target)
++	mountArgsLogStr += " " + target
++
++	return mountArgs, mountArgsLogStr
++}
++
++// AddSystemdScopeSensitive adds "system-run --scope" to given command line
++// It also accepts takes a sanitized string containing mount arguments, mountArgsLogStr,
++// and returns the string appended to the systemd command for logging.
++// Reqd for subPath patch.
++// https://github.com/kubernetes/kubernetes/blob/0f3e6609388defe7d0149216cb0409531f8d33b3/vendor/k8s.io/utils/mount/mount_linux.go#L227-L234
++func AddSystemdScopeSensitive(systemdRunPath, mountName, command string, args []string, mountArgsLogStr string) (string, []string, string) {
++	descriptionArg := fmt.Sprintf("--description=Kubernetes transient mount for %s", mountName)
++	systemdRunArgs := []string{descriptionArg, "--scope", "--", command}
++	return systemdRunPath, append(systemdRunArgs, args...), strings.Join(systemdRunArgs, " ") + " " + mountArgsLogStr
++}
+\ No newline at end of file
+diff --git a/pkg/volume/util/subpath/subpath_mount_unsupported.go b/pkg/volume/util/subpath/subpath_mount_unsupported.go
+new file mode 100644
+index 00000000000..16dcd053396
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount_unsupported.go
+@@ -0,0 +1,48 @@
++// +build !linux,!windows
++
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	"errors"
++
++	"k8s.io/utils/mount"
++)
++
++// Mounter implements mount.Interface for unsupported platforms
++type Mounter struct {
++	mount.Interface
++	mounterPath string
++}
++
++var errUtilsMountUnsupported = errors.New("utils/mount on this platform is not supported")
++
++// NewMounter returns a MountInterface for the current system.
++// It provides options to override the default mounter behavior.
++// mounterPath allows using an alternative to `/bin/mount` for mounting.
++func NewMounter(mounter mount.Interface, mounterPath string) MountInterface {
++	return &Mounter{
++		Interface:   mounter,
++		mounterPath: mounterPath,
++	}
++}
++
++// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags
++func (mounter *Mounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	return errUtilsMountUnsupported
++}
+diff --git a/pkg/volume/util/subpath/subpath_mount_windows.go b/pkg/volume/util/subpath/subpath_mount_windows.go
+new file mode 100644
+index 00000000000..aa5a4315c61
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount_windows.go
+@@ -0,0 +1,170 @@
++// +build windows
++
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	"fmt"
++	"k8s.io/klog"
++	"k8s.io/utils/keymutex"
++	"k8s.io/utils/mount"
++	"os"
++	"os/exec"
++	"path/filepath"
++	"strings"
++)
++
++var getSMBMountMutex = keymutex.NewHashed(0);
++
++// Mounter provides the subpath implementation of mount.Interface
++// for the windows platform.  This implementation assumes that the
++// kubelet is running in the host's root mount namespace.
++type Mounter struct {
++	mount.Interface
++	mounterPath string
++}
++
++// NewMounter returns a MountInterface for the current system.
++// It provides options to override the default mounter behavior.
++// mounterPath allows using an alternative to `/bin/mount` for mounting.
++func NewMounter(mounter mount.Interface, mounterPath string) MountInterface {
++	return &Mounter{
++		Interface:   mounter,
++		mounterPath: mounterPath,
++	}
++}
++
++// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags but
++// because mountFlags are linux mount(8) flags this method is the same as MountSensitive() in Windows
++func (mounter *Mounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	return mounter.MountSensitive(source, target, fstype, options, sensitiveOptions)
++}
++
++// MountSensitive is the same as Mount() but this method allows
++// sensitiveOptions to be passed in a separate parameter from the normal
++// mount options and ensures the sensitiveOptions are never logged. This
++// method should be used by callers that pass sensitive material (like
++// passwords) as mount options.
++// Reqd for SubPath patch
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount_windows.go#L59-L124
++func (mounter *Mounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
++	target = mount.NormalizeWindowsPath(target)
++	sanitizedOptionsForLogging := sanitizedOptionsForLogging(options, sensitiveOptions)
++
++	if source == "tmpfs" {
++		klog.V(3).Infof("mounting source (%q), target (%q), with options (%q)", source, target, sanitizedOptionsForLogging)
++		return os.MkdirAll(target, 0755)
++	}
++
++	parentDir := filepath.Dir(target)
++	if err := os.MkdirAll(parentDir, 0755); err != nil {
++		return err
++	}
++
++	klog.V(4).Infof("mount options(%q) source:%q, target:%q, fstype:%q, begin to mount",
++		sanitizedOptionsForLogging, source, target, fstype)
++	bindSource := source
++
++	if bind, _, _, _ := MakeBindOptsSensitive(options, sensitiveOptions); bind {
++		bindSource = mount.NormalizeWindowsPath(source)
++	} else {
++		allOptions := []string{}
++		allOptions = append(allOptions, options...)
++		allOptions = append(allOptions, sensitiveOptions...)
++		if len(allOptions) < 2 {
++			klog.Warningf("mount options(%q) command number(%d) less than 2, source:%q, target:%q, skip mounting",
++				sanitizedOptionsForLogging, len(allOptions), source, target)
++			return nil
++		}
++
++		// currently only cifs mount is supported
++		if strings.ToLower(fstype) != "cifs" {
++			return fmt.Errorf("only cifs mount is supported now, fstype: %q, mounting source (%q), target (%q), with options (%q)", fstype, source, target, sanitizedOptionsForLogging)
++		}
++
++		// lock smb mount for the same source
++		getSMBMountMutex.LockKey(source)
++		defer getSMBMountMutex.UnlockKey(source)
++
++		if output, err := newSMBMapping(allOptions[0], allOptions[1], source); err != nil {
++			if isSMBMappingExist(source) {
++				klog.V(2).Infof("SMB Mapping(%s) already exists, now begin to remove and remount", source)
++				if output, err := removeSMBMapping(source); err != nil {
++					return fmt.Errorf("Remove-SmbGlobalMapping failed: %v, output: %q", err, output)
++				}
++				if output, err := newSMBMapping(allOptions[0], allOptions[1], source); err != nil {
++					return fmt.Errorf("New-SmbGlobalMapping remount failed: %v, output: %q", err, output)
++				}
++			} else {
++				return fmt.Errorf("New-SmbGlobalMapping failed: %v, output: %q", err, output)
++			}
++		}
++	}
++
++	if output, err := exec.Command("cmd", "/c", "mklink", "/D", target, bindSource).CombinedOutput(); err != nil {
++		klog.Errorf("mklink failed: %v, source(%q) target(%q) output: %q", err, bindSource, target, string(output))
++		return err
++	}
++
++	return nil
++}
++
++// do the SMB mount with username, password, remotepath
++// return (output, error)
++// Reqd for subPath patch.
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount_windows.go#L126-L146
++func newSMBMapping(username, password, remotepath string) (string, error) {
++	if username == "" || password == "" || remotepath == "" {
++		return "", fmt.Errorf("invalid parameter(username: %s, password: %s, remoteapth: %s)", username, sensitiveOptionsRemoved, remotepath)
++	}
++
++	// use PowerShell Environment Variables to store user input string to prevent command line injection
++	// https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-5.1
++	cmdLine := `$PWord = ConvertTo-SecureString -String $Env:smbpassword -AsPlainText -Force` +
++		`;$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Env:smbuser, $PWord` +
++		`;New-SmbGlobalMapping -RemotePath $Env:smbremotepath -Credential $Credential`
++	// Import OS/exec rather than kutil exec because that is what is in the original code.
++	cmd := exec.Command("powershell", "/c", cmdLine)
++	cmd.Env = append(os.Environ(),
++		fmt.Sprintf("smbuser=%s", username),
++		fmt.Sprintf("smbpassword=%s", password),
++		fmt.Sprintf("smbremotepath=%s", remotepath))
++
++	output, err := cmd.CombinedOutput()
++	return string(output), err
++}
++
++// check whether remotepath is already mounted
++// Reqd for subpath patch
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount_windows.go#L148-L154
++func isSMBMappingExist(remotepath string) bool {
++	cmd := exec.Command("powershell", "/c", `Get-SmbGlobalMapping -RemotePath $Env:smbremotepath`)
++	cmd.Env = append(os.Environ(), fmt.Sprintf("smbremotepath=%s", remotepath))
++	_, err := cmd.CombinedOutput()
++	return err == nil
++}
++
++// remove SMB mapping
++// Reqd for subpath patch
++// Ref: https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/k8s.io/utils/mount/mount_windows.go#L156-L162
++func removeSMBMapping(remotepath string) (string, error) {
++	cmd := exec.Command("powershell", "/c", `Remove-SmbGlobalMapping -RemotePath $Env:smbremotepath -Force`)
++	cmd.Env = append(os.Environ(), fmt.Sprintf("smbremotepath=%s", remotepath))
++	output, err := cmd.CombinedOutput()
++	return string(output), err
++}
+\ No newline at end of file
+-- 
+2.33.0
+

--- a/packages/kubernetes-1.17/kubernetes-1.17.spec
+++ b/packages/kubernetes-1.17/kubernetes-1.17.spec
@@ -26,6 +26,7 @@ Source8: kubernetes-tmpfiles.conf
 Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
+Patch50: 0050-k8s-1.17-CVE-2021-25741.patch
 
 # Update aws-sdk-go for IMDSv2 support
 Patch100: aws-sdk-go-1.28.2_k8s-1.17.8.patch.bz2

--- a/packages/kubernetes-1.18/0050-k8s-1.18-CVE-2021-25741.patch
+++ b/packages/kubernetes-1.18/0050-k8s-1.18-CVE-2021-25741.patch
@@ -1,0 +1,624 @@
+From db8a9200fc396b83a693ef0ff2e6baff6b1eaea9 Mon Sep 17 00:00:00 2001
+From: Manu Gupta <mgpta@amazon.com>
+Date: Mon, 23 Aug 2021 16:01:52 -0700
+Subject: [PATCH] -- EKS Patch -- Pass additional flags to subpath mount to
+ avoid flakes in certain conditions
+
+PR: https://github.com/kubernetes/kubernetes/pull/104340
+
+Backport upstream fix to 1.18.
+
+In-compatible change:
+1. klog/v2 is not present in EKS 1.18; so klog v1 is used.
+
+Other notes:
+1. In volume, a new MounterInterface is introduced and this is
+used for subPaths.
+2. When sensitive options are provided, the MounterInterface's
+MountSensitiveWithFlags is called for both systemd and non-systemd
+related services.
+3. A fakeMounter is introduced for testing and ensuring that the build
+   does not break.
+4. The scope of the CR is limited to windows and linux. It will throw
+an errUtilsMountUnsupported Error for other operating sytems.
+
+Signed-off-by: Jackson West <jgw@amazon.com>
+---
+ cmd/kubelet/app/server.go                     |   3 +-
+ pkg/volume/util/subpath/BUILD                 |  21 +-
+ .../util/subpath/subpath_fake_mounter.go      |  47 ++++
+ pkg/volume/util/subpath/subpath_linux.go      |   9 +-
+ pkg/volume/util/subpath/subpath_linux_test.go |   6 +-
+ pkg/volume/util/subpath/subpath_mount.go      |  36 +++
+ .../util/subpath/subpath_mount_linux.go       | 216 ++++++++++++++++++
+ .../util/subpath/subpath_mount_unsupported.go |  48 ++++
+ .../util/subpath/subpath_mount_windows.go     |  47 ++++
+ 9 files changed, 412 insertions(+), 21 deletions(-)
+ create mode 100644 pkg/volume/util/subpath/subpath_fake_mounter.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount_linux.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount_unsupported.go
+ create mode 100644 pkg/volume/util/subpath/subpath_mount_windows.go
+
+diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
+index e49381d3bee..3b2e75b6299 100644
+--- a/cmd/kubelet/app/server.go
++++ b/cmd/kubelet/app/server.go
+@@ -372,7 +372,8 @@ func UnsecuredDependencies(s *options.KubeletServer, featureGate featuregate.Fea
+ 	}
+ 
+ 	mounter := mount.New(s.ExperimentalMounterPath)
+-	subpather := subpath.New(mounter)
++	subPathMounter := subpath.NewMounter(mounter, s.ExperimentalMounterPath)
++	subpather := subpath.New(subPathMounter)
+ 	hu := hostutil.NewHostUtil()
+ 	var pluginRunner = exec.New()
+ 
+diff --git a/pkg/volume/util/subpath/BUILD b/pkg/volume/util/subpath/BUILD
+index 3830dc9ae00..564db078c3f 100644
+--- a/pkg/volume/util/subpath/BUILD
++++ b/pkg/volume/util/subpath/BUILD
+@@ -4,62 +4,57 @@ go_library(
+     name = "go_default_library",
+     srcs = [
+         "subpath.go",
++        "subpath_fake_mounter.go",
+         "subpath_linux.go",
++        "subpath_mount.go",
++        "subpath_mount_linux.go",
++        "subpath_mount_unsupported.go",
++        "subpath_mount_windows.go",
+         "subpath_unsupported.go",
+         "subpath_windows.go",
+     ],
+     importpath = "k8s.io/kubernetes/pkg/volume/util/subpath",
+     visibility = ["//visibility:public"],
+-    deps = select({
++    deps = [
++        "//vendor/k8s.io/utils/mount:go_default_library",
++    ] + select({
+         "@io_bazel_rules_go//go/platform:android": [
+             "//vendor/golang.org/x/sys/unix:go_default_library",
+             "//vendor/k8s.io/klog:go_default_library",
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:darwin": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:dragonfly": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:freebsd": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:ios": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:linux": [
+             "//vendor/golang.org/x/sys/unix:go_default_library",
+             "//vendor/k8s.io/klog:go_default_library",
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:nacl": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:netbsd": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:openbsd": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:plan9": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:solaris": [
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "@io_bazel_rules_go//go/platform:windows": [
+             "//vendor/k8s.io/klog:go_default_library",
+-            "//vendor/k8s.io/utils/mount:go_default_library",
+             "//vendor/k8s.io/utils/nsenter:go_default_library",
+         ],
+         "//conditions:default": [],
+diff --git a/pkg/volume/util/subpath/subpath_fake_mounter.go b/pkg/volume/util/subpath/subpath_fake_mounter.go
+new file mode 100644
+index 00000000000..cf54209f5ff
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_fake_mounter.go
+@@ -0,0 +1,47 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	mountutils "k8s.io/utils/mount"
++)
++
++// FakeMounter implements MountInterface for tests.
++type FakeMounter struct {
++	*mountutils.FakeMounter
++}
++
++var _ MountInterface = &FakeMounter{}
++
++// NewFakeMounter returns a FakeMounter struct that implements Interface and is
++// suitable for testing purposes.
++func NewFakeMounter(mps []mountutils.MountPoint) *FakeMounter {
++	return &FakeMounter{
++		FakeMounter: &mountutils.FakeMounter{
++			MountPoints: mps,
++		},
++	}
++}
++
++// MountSensitiveWithFlags records the mount event and updates the in-memory mount points for FakeMounter
++// sensitiveOptions to be passed in a separate parameter from the normal
++// mount options and ensures the sensitiveOptions are never logged. This
++// method should be used by callers that pass sensitive material (like
++// passwords) as mount options.
++func (f *FakeMounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	return f.MountSensitive(source, target, fstype, options, sensitiveOptions)
++}
+diff --git a/pkg/volume/util/subpath/subpath_linux.go b/pkg/volume/util/subpath/subpath_linux.go
+index 0663a72c50d..e72050d076d 100644
+--- a/pkg/volume/util/subpath/subpath_linux.go
++++ b/pkg/volume/util/subpath/subpath_linux.go
+@@ -43,11 +43,11 @@ const (
+ )
+ 
+ type subpath struct {
+-	mounter mount.Interface
++	mounter MountInterface
+ }
+ 
+ // New returns a subpath.Interface for the current system
+-func New(mounter mount.Interface) Interface {
++func New(mounter MountInterface) Interface {
+ 	return &subpath{
+ 		mounter: mounter,
+ 	}
+@@ -147,7 +147,7 @@ func getSubpathBindTarget(subpath Subpath) string {
+ 	return filepath.Join(subpath.PodDir, containerSubPathDirectoryName, subpath.VolumeName, subpath.ContainerName, strconv.Itoa(subpath.VolumeMountIndex))
+ }
+ 
+-func doBindSubPath(mounter mount.Interface, subpath Subpath) (hostPath string, err error) {
++func doBindSubPath(mounter MountInterface, subpath Subpath) (hostPath string, err error) {
+ 	// Linux, kubelet runs on the host:
+ 	// - safely open the subpath
+ 	// - bind-mount /proc/<pid of kubelet>/fd/<fd> to subpath target
+@@ -196,8 +196,9 @@ func doBindSubPath(mounter mount.Interface, subpath Subpath) (hostPath string, e
+ 
+ 	// Do the bind mount
+ 	options := []string{"bind"}
++	mountFlags := []string{"--no-canonicalize"}
+ 	klog.V(5).Infof("bind mounting %q at %q", mountSource, bindPathTarget)
+-	if err = mounter.Mount(mountSource, bindPathTarget, "" /*fstype*/, options); err != nil {
++	if err = mounter.MountSensitiveWithFlags(mountSource, bindPathTarget, "" /*fstype*/, options, nil /* sensitiveOptions */, mountFlags); err != nil {
+ 		return "", fmt.Errorf("error mounting %s: %s", subpath.Path, err)
+ 	}
+ 	success = true
+diff --git a/pkg/volume/util/subpath/subpath_linux_test.go b/pkg/volume/util/subpath/subpath_linux_test.go
+index 154d761e6bf..ca4dd5331d4 100644
+--- a/pkg/volume/util/subpath/subpath_linux_test.go
++++ b/pkg/volume/util/subpath/subpath_linux_test.go
+@@ -611,7 +611,7 @@ func TestCleanSubPaths(t *testing.T) {
+ 			t.Fatalf("failed to prepare test %q: %v", test.name, err.Error())
+ 		}
+ 
+-		fm := mount.NewFakeMounter(mounts)
++		fm := NewFakeMounter(mounts)
+ 		fm.UnmountFunc = test.unmount
+ 
+ 		err = doCleanSubPaths(fm, base, testVol)
+@@ -636,12 +636,12 @@ var (
+ 	testSubpath   = 1
+ )
+ 
+-func setupFakeMounter(testMounts []string) *mount.FakeMounter {
++func setupFakeMounter(testMounts []string) *FakeMounter {
+ 	mounts := []mount.MountPoint{}
+ 	for _, mountPoint := range testMounts {
+ 		mounts = append(mounts, mount.MountPoint{Device: "/foo", Path: mountPoint})
+ 	}
+-	return mount.NewFakeMounter(mounts)
++	return NewFakeMounter(mounts)
+ }
+ 
+ func getTestPaths(base string) (string, string) {
+diff --git a/pkg/volume/util/subpath/subpath_mount.go b/pkg/volume/util/subpath/subpath_mount.go
+new file mode 100644
+index 00000000000..a8ad8c228a1
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount.go
+@@ -0,0 +1,36 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++// TODO(thockin): This whole pkg is pretty linux-centric.  As soon as we have
++// an alternate platform, we will need to abstract further.
++
++package subpath
++
++import (
++	"k8s.io/utils/mount"
++)
++
++// MountInterface defines the set of methods to allow for mount operations on a system.
++type MountInterface interface {
++	mount.Interface
++
++	// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags
++	MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error
++}
++
++// Compile-time check to ensure all Mounter implementations satisfy
++// the mount interface.
++var _ MountInterface = &Mounter{}
+diff --git a/pkg/volume/util/subpath/subpath_mount_linux.go b/pkg/volume/util/subpath/subpath_mount_linux.go
+new file mode 100644
+index 00000000000..f7f03ad1fa7
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount_linux.go
+@@ -0,0 +1,216 @@
++// +build linux
++
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	"fmt"
++	"k8s.io/klog"
++	"os/exec"
++	"strings"
++
++	mountutils "k8s.io/utils/mount"
++)
++
++const (
++	// Default mount command if mounter path is not specified.
++	defaultMountCommand = "mount"
++	// Log message where sensitive mount options were removed
++	sensitiveOptionsRemoved = "<masked>"
++)
++
++// Mounter provides the subpath implementation of mount.Interface
++// for the linux platform.  This implementation assumes that the
++// kubelet is running in the host's root mount namespace.
++type Mounter struct {
++	mountutils.Interface
++	mounterPath string
++	withSystemd bool
++}
++
++// NewMounter returns a MountInterface for the current system.
++// It provides options to override the default mounter behavior.
++// mounterPath allows using an alternative to `/bin/mount` for mounting.
++func NewMounter(mounter mountutils.Interface, mounterPath string) MountInterface {
++	return &Mounter{
++		Interface:   mounter,
++		mounterPath: mounterPath,
++		withSystemd: detectSystemd(),
++	}
++}
++
++// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags
++func (mounter *Mounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	// Path to mounter binary if containerized mounter is needed. Otherwise, it is set to empty.
++	// All Linux distros are expected to be shipped with a mount utility that a support bind mounts.
++	mounterPath := ""
++	bind, bindOpts, bindRemountOpts, bindRemountOptsSensitive := mountutils.MakeBindOptsSensitive(options, sensitiveOptions)
++	if bind {
++		err := mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, bindOpts, bindRemountOptsSensitive, mountFlags)
++		if err != nil {
++			return err
++		}
++		return mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, bindRemountOpts, bindRemountOptsSensitive, mountFlags)
++	}
++	// The list of filesystems that require containerized mounter on GCI image cluster
++	fsTypesNeedMounter := map[string]struct{}{
++		"nfs":       {},
++		"glusterfs": {},
++		"ceph":      {},
++		"cifs":      {},
++	}
++	if _, ok := fsTypesNeedMounter[fstype]; ok {
++		mounterPath = mounter.mounterPath
++	}
++	return mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, options, sensitiveOptions, mountFlags)
++}
++
++// doMount runs the mount command. mounterPath is the path to mounter binary if containerized mounter is used.
++// sensitiveOptions is an extension of options except they will not be logged (because they may contain sensitive material)
++// mountFlags are additional flags used in the mount command that are not related with fstype and mount options
++func (mounter *Mounter) doMount(mounterPath string, mountCmd string, source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	mountArgs, mountArgsLogStr := makeMountArgsSensitiveWithMountFlags(source, target, fstype, options, sensitiveOptions, mountFlags)
++	if len(mounterPath) > 0 {
++		mountArgs = append([]string{mountCmd}, mountArgs...)
++		mountArgsLogStr = mountCmd + " " + mountArgsLogStr
++		mountCmd = mounterPath
++	}
++
++	if mounter.withSystemd {
++		// Try to run mount via systemd-run --scope. This will escape the
++		// service where kubelet runs and any fuse daemons will be started in a
++		// specific scope. kubelet service than can be restarted without killing
++		// these fuse daemons.
++		//
++		// Complete command line (when mounterPath is not used):
++		// systemd-run --description=... --scope -- mount -t <type> <what> <where>
++		//
++		// Expected flow:
++		// * systemd-run creates a transient scope (=~ cgroup) and executes its
++		//   argument (/bin/mount) there.
++		// * mount does its job, forks a fuse daemon if necessary and finishes.
++		//   (systemd-run --scope finishes at this point, returning mount's exit
++		//   code and stdout/stderr - thats one of --scope benefits).
++		// * systemd keeps the fuse daemon running in the scope (i.e. in its own
++		//   cgroup) until the fuse daemon dies (another --scope benefit).
++		//   Kubelet service can be restarted and the fuse daemon survives.
++		// * When the fuse daemon dies (e.g. during unmount) systemd removes the
++		//   scope automatically.
++		//
++		// systemd-mount is not used because it's too new for older distros
++		// (CentOS 7, Debian Jessie).
++		mountCmd, mountArgs, mountArgsLogStr = mountutils.AddSystemdScopeSensitive("systemd-run", target, mountCmd, mountArgs, mountArgsLogStr)
++		// } else {
++		// No systemd-run on the host (or we failed to check it), assume kubelet
++		// does not run as a systemd service.
++		// No code here, mountCmd and mountArgs are already populated.
++	}
++
++	// Logging with sensitive mount options removed.
++	klog.V(4).Infof("Mounting cmd (%s) with arguments (%s)", mountCmd, mountArgsLogStr)
++	command := exec.Command(mountCmd, mountArgs...)
++	output, err := command.CombinedOutput()
++	if err != nil {
++		klog.Errorf("Mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s\n", err, mountCmd, mountArgsLogStr, string(output))
++		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s",
++			err, mountCmd, mountArgsLogStr, string(output))
++	}
++	return err
++}
++
++// detectSystemd returns true if OS runs with systemd as init. When not sure
++// (permission errors, ...), it returns false.
++// There may be different ways how to detect systemd, this one makes sure that
++// systemd-runs (needed by Mount()) works.
++func detectSystemd() bool {
++	if _, err := exec.LookPath("systemd-run"); err != nil {
++		klog.V(2).Infof("Detected OS without systemd")
++		return false
++	}
++	// Try to run systemd-run --scope /bin/true, that should be enough
++	// to make sure that systemd is really running and not just installed,
++	// which happens when running in a container with a systemd-based image
++	// but with different pid 1.
++	cmd := exec.Command("systemd-run", "--description=Kubernetes systemd probe", "--scope", "true")
++	output, err := cmd.CombinedOutput()
++	if err != nil {
++		klog.V(2).Infof("Cannot run systemd-run, assuming non-systemd OS")
++		klog.V(4).Infof("systemd-run failed with: %v", err)
++		klog.V(4).Infof("systemd-run output: %s", string(output))
++		return false
++	}
++	klog.V(2).Infof("Detected OS with systemd")
++	return true
++}
++
++// makeMountArgsSensitiveWithMountFlags makes the arguments to the mount(8) command.
++// sensitiveOptions is an extension of options except they will not be logged (because they may contain sensitive material)
++// mountFlags are additional mount flags that are not related with the fstype and mount options
++func makeMountArgsSensitiveWithMountFlags(source, target, fstype string, options []string, sensitiveOptions []string, mountFlags []string) (mountArgs []string, mountArgsLogStr string) {
++	// Build mount command as follows:
++	//   mount [$mountFlags] [-t $fstype] [-o $options] [$source] $target
++	mountArgs = []string{}
++	mountArgsLogStr = ""
++
++	mountArgs = append(mountArgs, mountFlags...)
++	mountArgsLogStr += strings.Join(mountFlags, " ")
++
++	if len(fstype) > 0 {
++		mountArgs = append(mountArgs, "-t", fstype)
++		mountArgsLogStr += strings.Join(mountArgs, " ")
++	}
++	if len(options) > 0 || len(sensitiveOptions) > 0 {
++		combinedOptions := []string{}
++		combinedOptions = append(combinedOptions, options...)
++		combinedOptions = append(combinedOptions, sensitiveOptions...)
++		mountArgs = append(mountArgs, "-o", strings.Join(combinedOptions, ","))
++		// exclude sensitiveOptions from log string
++		mountArgsLogStr += " -o " + sanitizedOptionsForLogging(options, sensitiveOptions)
++	}
++	if len(source) > 0 {
++		mountArgs = append(mountArgs, source)
++		mountArgsLogStr += " " + source
++	}
++	mountArgs = append(mountArgs, target)
++	mountArgsLogStr += " " + target
++
++	return mountArgs, mountArgsLogStr
++}
++
++// sanitizedOptionsForLogging will return a comma separated string containing
++// options and sensitiveOptions. Each entry in sensitiveOptions will be
++// replaced with the string sensitiveOptionsRemoved
++// e.g. o1,o2,<masked>,<masked>
++func sanitizedOptionsForLogging(options []string, sensitiveOptions []string) string {
++	separator := ""
++	if len(options) > 0 && len(sensitiveOptions) > 0 {
++		separator = ","
++	}
++
++	sensitiveOptionsStart := ""
++	sensitiveOptionsEnd := ""
++	if len(sensitiveOptions) > 0 {
++		sensitiveOptionsStart = strings.Repeat(sensitiveOptionsRemoved+",", len(sensitiveOptions)-1)
++		sensitiveOptionsEnd = sensitiveOptionsRemoved
++	}
++
++	return strings.Join(options, ",") +
++		separator +
++		sensitiveOptionsStart +
++		sensitiveOptionsEnd
++}
+diff --git a/pkg/volume/util/subpath/subpath_mount_unsupported.go b/pkg/volume/util/subpath/subpath_mount_unsupported.go
+new file mode 100644
+index 00000000000..16dcd053396
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount_unsupported.go
+@@ -0,0 +1,48 @@
++// +build !linux,!windows
++
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	"errors"
++
++	"k8s.io/utils/mount"
++)
++
++// Mounter implements mount.Interface for unsupported platforms
++type Mounter struct {
++	mount.Interface
++	mounterPath string
++}
++
++var errUtilsMountUnsupported = errors.New("utils/mount on this platform is not supported")
++
++// NewMounter returns a MountInterface for the current system.
++// It provides options to override the default mounter behavior.
++// mounterPath allows using an alternative to `/bin/mount` for mounting.
++func NewMounter(mounter mount.Interface, mounterPath string) MountInterface {
++	return &Mounter{
++		Interface:   mounter,
++		mounterPath: mounterPath,
++	}
++}
++
++// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags
++func (mounter *Mounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	return errUtilsMountUnsupported
++}
+diff --git a/pkg/volume/util/subpath/subpath_mount_windows.go b/pkg/volume/util/subpath/subpath_mount_windows.go
+new file mode 100644
+index 00000000000..b8feefc8c6a
+--- /dev/null
++++ b/pkg/volume/util/subpath/subpath_mount_windows.go
+@@ -0,0 +1,47 @@
++// +build windows
++
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package subpath
++
++import (
++	"k8s.io/utils/mount"
++)
++
++// Mounter provides the subpath implementation of mount.Interface
++// for the windows platform.  This implementation assumes that the
++// kubelet is running in the host's root mount namespace.
++type Mounter struct {
++	mount.Interface
++	mounterPath string
++}
++
++// NewMounter returns a MountInterface for the current system.
++// It provides options to override the default mounter behavior.
++// mounterPath allows using an alternative to `/bin/mount` for mounting.
++func NewMounter(mounter mount.Interface, mounterPath string) MountInterface {
++	return &Mounter{
++		Interface:   mounter,
++		mounterPath: mounterPath,
++	}
++}
++
++// MountSensitiveWithFlags is the same as MountSensitive() with additional mount flags but
++// because mountFlags are linux mount(8) flags this method is the same as MountSensitive() in Windows
++func (mounter *Mounter) MountSensitiveWithFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
++	return mounter.MountSensitive(source, target, fstype, options, sensitiveOptions)
++}
+-- 
+2.33.0
+

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -26,6 +26,7 @@ Source8: kubernetes-tmpfiles.conf
 Source9: kubelet-sysctl.conf
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
+Patch50: 0050-k8s-1.18-CVE-2021-25741.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.19/Cargo.toml
+++ b/packages/kubernetes-1.19/Cargo.toml
@@ -15,8 +15,8 @@ package-name = "kubernetes-1.19"
 releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.19.13/kubernetes-1.19.13.tar.gz"
-sha512 = "d5bece5cdc399c5132c959b5f53431427893a2bc37c3f475df73c2f846e4c51b961b092c3099c1f1f42de2cdde782bf62c404b9cc44fc69cecfee2c7765b7509"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.19.15/kubernetes-1.19.15.tar.gz"
+sha512 = "cdef25ab050df79a5fce824721920fedead8326b83b5134ef534a8b8671b58a122bd49598981cd86bdd6ab46fdc8b55ccee5fd9e4c725ddf261bf4178f264e0a"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.19.13
+%global gover 1.19.15
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.20/Cargo.toml
+++ b/packages/kubernetes-1.20/Cargo.toml
@@ -15,8 +15,8 @@ package-name = "kubernetes-1.20"
 releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.20.9/kubernetes-1.20.9.tar.gz"
-sha512 = "9083589e016f1b9d3432fdab748f296b833c2f3425d6c89299e04f074865a9d2e706f4a8c0f9b90f32fca0c568e841f6a9c85dab5a748cd182f4e0f66c08cc8f"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.20.11/kubernetes-1.20.11.tar.gz"
+sha512 = "eddf4690ec034c6b09c13e939d172e96072e131416b137022ed664ad5604446c8ca95038ff2f622b41a6d000900b836b0d708f75ac6c9574a7d1b262f73bba1a"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.20/kubernetes-1.20.spec
+++ b/packages/kubernetes-1.20/kubernetes-1.20.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.20.9
+%global gover 1.20.11
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.21/Cargo.toml
+++ b/packages/kubernetes-1.21/Cargo.toml
@@ -15,8 +15,8 @@ package-name = "kubernetes-1.21"
 releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.21.3/kubernetes-1.21.3.tar.gz"
-sha512 = "d780099814468079eaa9b9b33fb0f48e2c44ebbf304068f44c79281e7dc074cfe8a2f56330f8363282ce6ed07a12125fa4ec6a8a5308d208456231f827c861a0"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.21.5/kubernetes-1.21.5.tar.gz"
+sha512 = "bef73a90b31ea9c72070efc52c4e2c6aed1fde5bb0c2b391394148a394cf020071793b368a429e3d11f3e1afa24a3da9ec82b5ba64d61e2fd00209c796d5b7b3"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.21.3
+%global gover 1.21.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Description of changes:**

```
a600323a Update kubernetes-1.21 to 1.21.5
bc8c0ec4 Update kubernetes-1.20 to 1.20.11
8d6e6a6e Update kubernetes-1.19 to 1.19.15
3c279cee Add patch for CVE-2021-25741 for kubernetes-1.18
84944182 Add patch for CVE-2021-25741 for kubernetes-1.17
```

More details here: https://github.com/kubernetes/kubernetes/issues/104980

The 1.18 patch matches [EKS-D](https://github.com/aws/eks-distro/pull/553); the 1.17 patch is similarly backported.

**Testing done:**

Confirmed patches are applying cleanly for 1.17 and 1.18.

Built and ran all of AWS 1.17 - 1.21 for x86_64 and aarch64, and VMware x86 1.20 and 1.21.  Confirmed that pods run OK, API get/set OK, system services healthy, journal OK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
