### PR TITLE
Update third-party packages

### DIFF
--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.3/e2fsprogs-1.46.3.tar.xz"
-sha512 = "27da6e38d3463e7a283dacfb88a3210dd6d8c63f4d990db879f63bdf503aaa5c447ef0ccc566b71526c12a8ab0a7a6529014b1010be300ad56a6ad5ce9066196"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.46.4/e2fsprogs-1.46.4.tar.xz"
+sha512 = "7d9cfdf00ed58e66049585e8382fe4977088956421a0fb8155900c69afd8857309ad2b9301b3f74c9c0afa7287a0ddba2fd1538fcf57858b37a9ab712390016d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}e2fsprogs
-Version: 1.46.3
+Version: 1.46.4
 Release: 1%{?dist}
 Summary: Tools for managing ext2, ext3, and ext4 file systems
 License: GPL-2.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND BSD-3-Clause

--- a/packages/ecs-agent/0001-bottlerocket-default-filesystem-locations.patch
+++ b/packages/ecs-agent/0001-bottlerocket-default-filesystem-locations.patch
@@ -43,16 +43,20 @@ diff --git a/agent/config/config_unix.go b/agent/config/config_unix.go
 index 080f18c4d..ef14970ce 100644
 --- a/agent/config/config_unix.go
 +++ b/agent/config/config_unix.go
-@@ -27,7 +27,7 @@ const (
+@@ -27,10 +27,10 @@ const (
  	// AgentCredentialsAddress is used to serve the credentials for tasks.
  	AgentCredentialsAddress = "" // this is left blank right now for net=bridge
  	// defaultAuditLogFile specifies the default audit log filename
 -	defaultCredentialsAuditLogFile = "/log/audit.log"
 +	defaultCredentialsAuditLogFile = "/var/log/ecs/audit.log"
+ 
+ 	// defaultRuntimeStatsLogFile stores the path where the golang runtime stats are periodically logged
+-	defaultRuntimeStatsLogFile = `/log/agent-runtime-stats.log`
++	defaultRuntimeStatsLogFile = `/var/log/ecs/agent-runtime-stats.log`
+ 
  	// DefaultTaskCgroupPrefix is default cgroup prefix for ECS tasks
  	DefaultTaskCgroupPrefix = "/ecs"
- 
-@@ -52,7 +52,7 @@ func DefaultConfig() Config {
+@@ -56,7 +56,7 @@ func DefaultConfig() Config {
  		DockerEndpoint:                      "unix:///var/run/docker.sock",
  		ReservedPorts:                       []uint16{SSHPort, DockerReservedPort, DockerReservedSSLPort, AgentIntrospectionPort, AgentCredentialsPort},
  		ReservedPortsUDP:                    []uint16{},

--- a/packages/ecs-agent/0003-bottlerocket-bind-introspection-to-localhost.patch
+++ b/packages/ecs-agent/0003-bottlerocket-bind-introspection-to-localhost.patch
@@ -8,18 +8,18 @@ Subject: [PATCH 3/5] bottlerocket: bind introspection to localhost
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/agent/handlers/introspection_server_setup.go b/agent/handlers/introspection_server_setup.go
-index 07f138a22..bda910f7f 100644
+index 3ca0ecc7..b7f70e92 100644
 --- a/agent/handlers/introspection_server_setup.go
 +++ b/agent/handlers/introspection_server_setup.go
-@@ -56,7 +56,7 @@ func introspectionServerSetup(containerInstanceArn *string, taskEngine handlersu
- 	loggingServeMux.Handle("/", LoggingHandler{serverMux})
- 
+@@ -88,7 +88,7 @@ func introspectionServerSetup(containerInstanceArn *string, taskEngine handlersu
+ 		wTimeout = writeTimeoutForPprof
+ 	}
  	server := &http.Server{
 -		Addr:         ":" + strconv.Itoa(config.AgentIntrospectionPort),
 +		Addr:         "127.0.0.1:" + strconv.Itoa(config.AgentIntrospectionPort),
  		Handler:      loggingServeMux,
  		ReadTimeout:  readTimeout,
- 		WriteTimeout: writeTimeout,
+ 		WriteTimeout: wTimeout,
 -- 
 2.32.0
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.54.1/amazon-ecs-agent-v1.54.1.tar.gz"
-sha512 = "b3f92920ce327ff5a6d77268f927882d25097da65813d4f4c60787772109aa49952ec4130f83bfd00bf77ee86af1e60ca0b0967c02276126ccc378c954bc6047"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.55.2/amazon-ecs-agent-v1.55.2.tar.gz"
+sha512 = "683b9612751b1c5f6507688fc3335eab0410ac09381f073316cec8c92113b895b8f7667df6e6431c8c8714c90aeb29c37b84e237192852534a51bd01e9113d90"
 
 # The ECS agent repository includes two CNI plugins as git submodules.  git
 # archive does not include submodules, so the tarball above does not include

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,9 +2,9 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.54.1
+%global agent_gover 1.55.2
 # git rev-parse --short=8
-%global agent_gitrev 3e20420f
+%global agent_gitrev 50274232
 
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins

--- a/packages/grep/Cargo.toml
+++ b/packages/grep/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://mirrors.kernel.org/gnu/grep"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.kernel.org/gnu/grep/grep-3.6.tar.xz"
-sha512 = "8934544a19ded61344d83ff2cab501e86f17f8ae338892e0c36c2d2d8e63c76817840a0071ef5e3fcbca9115eba8a1aae0e4c46b024e75cd9a2e3bd05f933d90"
+url = "https://mirrors.kernel.org/gnu/grep/grep-3.7.tar.xz"
+sha512 = "e9e45dcd40af8367f819f2b93c5e1b4e98a251a9aa251841fa67a875380fae52cfa27c68c6dbdd6a4dde1b1017ee0f6b9833ef6dd6e419d32d71b6df5e972b82"
 
 [dependencies]
 libpcre = { path = "../libpcre" }

--- a/packages/grep/grep.spec
+++ b/packages/grep/grep.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}grep
-Version: 3.6
+Version: 3.7
 Release: 1%{?dist}
 Summary: GNU grep utility
 URL: https://www.gnu.org/software/grep/

--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,5 +13,5 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/ffdc72c6cf8a4fcebfe8a3175a3f618f42f6ff2b00a36c0da6e04cf00d258daf/kernel-5.10.50-44.132.amzn2.src.rpm"
-sha512 = "ff548cfb49be98f1180c30f0c4f13846a690fb162a09be17a910267ac301b9efafacacbc5d873d699e250d8d1962bb48d7095509b6de3ce36ebf1b930efa92d8"
+url = "https://cdn.amazonlinux.com/blobstore/67866b408c9bc8889fd8b86dab6fe79e697ac5ef31d321f173b028bf26dcf266/kernel-5.10.59-52.142.amzn2.src.rpm"
+sha512 = "bbd90bd9793218f9410ca5d953a718fc00ed212953ea7de889698f66388314ecff4f145b2beb90ebff0bac6e961c6b3b71ca18948dc83194dd2e70feba7cf1db"

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.50
+Version: 5.10.59
 Release: 2%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/ffdc72c6cf8a4fcebfe8a3175a3f618f42f6ff2b00a36c0da6e04cf00d258daf/kernel-5.10.50-44.132.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/67866b408c9bc8889fd8b86dab6fe79e697ac5ef31d321f173b028bf26dcf266/kernel-5.10.59-52.142.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.4/Cargo.toml
+++ b/packages/kernel-5.4/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/d10a345f3b99842f109529ef5520232b1eba2349b667a7a0a18b1f86cb3eebbd/kernel-5.4.129-63.229.amzn2.src.rpm"
-sha512 = "852a1ece96a9f7cf65f81848291a00a43f7e2ae426e65b38b72125a627970f9d7e1a5ab60cbd570d17d63911fa4644aff9a1aa84f8f3096b9ca596a90fa99fc1"
+url = "https://cdn.amazonlinux.com/blobstore/9e8b76ee271c50b0190e45d6b3fb69263afc7c8be8c1c3aafc4e663f997a0232/kernel-5.4.141-67.229.amzn2.src.rpm"
+sha512 = "2f980b006579d3297481e0e8f8b636501648b05ae50e48a90ac1b576a47745dd9ab45fa92c7c094f7bff6931c502da2af1a3588f96e362a624d33767601d03b6"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.4
-Version: 5.4.129
+Version: 5.4.141
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/d10a345f3b99842f109529ef5520232b1eba2349b667a7a0a18b1f86cb3eebbd/kernel-5.4.129-63.229.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/9e8b76ee271c50b0190e45d6b3fb69263afc7c8be8c1c3aafc4e663f997a0232/kernel-5.4.141-67.229.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Make Lustre FSx work with a newer GCC.

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/linux-audit/audit-userspace/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-audit/audit-userspace/archive/v3.0.3/audit-userspace-3.0.3.tar.gz"
-sha512 = "b248398ed4aa3c52eaf6272ce618d2dcc8d88494d1bf3d530178d61906f4f7dac3c0c56862f5bdafa43d72b5c327898d82e95e83d09057b4fc90e917ba83bfad"
+url = "https://github.com/linux-audit/audit-userspace/archive/v3.0.5/audit-userspace-3.0.5.tar.gz"
+sha512 = "df37176e698e57ab997b9af17f00e1b5ee7b8d6afaaf792bc67d12b655700e6518aea3f6ed9fc85cc374583fd5309a3bb026e518ac02eb1f9b5ea6d9937dee3d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libaudit
-Version: 3.0.3
+Version: 3.0.5
 Release: 1%{?dist}
 Summary: Library for the audit subsystem
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/libcap/9001-dont-test-during-install.patch
+++ b/packages/libcap/9001-dont-test-during-install.patch
@@ -1,6 +1,6 @@
-diff -ru libcap-2.42.orig/Makefile libcap-2.42/Makefile
---- libcap-2.42.orig/Makefile	2020-08-01 18:41:45.000000000 -0700
-+++ libcap-2.42/Makefile	2020-08-06 20:05:07.354210736 -0700
+diff -Nurd libcap-2.57.orig/Makefile libcap-2.57/Makefile
+--- libcap-2.57.orig/Makefile	2021-09-09 13:57:36.000000000 -0700
++++ libcap-2.57/Makefile	2021-09-17 14:47:21.493628663 -0700
 @@ -17,7 +17,6 @@
  	$(MAKE) -C go $@
  	rm -f cap/go.sum
@@ -8,4 +8,4 @@ diff -ru libcap-2.42.orig/Makefile libcap-2.42/Makefile
 -	$(MAKE) -C tests $@
  	$(MAKE) -C progs $@
  	$(MAKE) -C doc $@
- 	$(MAKE) -C kdebug $@
+ 

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://sites.google.com/site/fullycapable/release-notes-for-libcap"
 
 [[package.metadata.build-package.external-files]]
-url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.51.tar.gz"
-sha512 = "032f52468323af68cc5cc1d9adcbf61bae962887d475b995629ea22428fbd6e4722599497394cccdb8443381d257187eb2ce80866b009ae84cd8cd45fd616716"
+url = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.57.tar.gz"
+sha512 = "3935443a1d1cafe09f96599970337f7aa15fabf48d280ca73141b116ea8bb2af55c5922adcdd7f5c192f629b7c90c3d7ad20ad2c4b44698071deffa7168deb63"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.51
+Version: 2.57
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause
@@ -28,7 +28,8 @@ Requires: %{name}
 
 %build
 make \
-  CC="%{_cross_target}-gcc" CFLAGS="%{_cross_cflags}" \
+  CC="%{_cross_target}-gcc" \
+  CFLAGS="%{_cross_cflags} -fPIC" \
   BUILD_CC="gcc" BUILD_CFLAGS="%{optflags}" \
   prefix=%{_cross_prefix} lib=%{_cross_lib} \
   LIBDIR=%{_cross_libdir} SBINDIR=%{_cross_sbindir} \

--- a/packages/libseccomp/Cargo.toml
+++ b/packages/libseccomp/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/seccomp/libseccomp/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/seccomp/libseccomp/releases/download/v2.5.1/libseccomp-2.5.1.tar.gz"
-sha512 = "2be80a6323f9282dbeae8791724e5778b32e2382b2a3d1b0f77366371ec4072ea28128204f675cce101c091c0420d12c497e1a9ccbb7dc5bcbf61bfd777160af"
+url = "https://github.com/seccomp/libseccomp/releases/download/v2.5.2/libseccomp-2.5.2.tar.gz"
+sha512 = "b2a95152cb274d6b35753596fd825406dae20c4a48b2f4076f835f977ecf324de38a3fe02e789dc20b49ecf6b4eb67f03e7733e92d40f5e20f25874307f1c2ac"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libseccomp/libseccomp.spec
+++ b/packages/libseccomp/libseccomp.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libseccomp
-Version: 2.5.1
+Version: 2.5.2
 Release: 1%{?dist}
 Summary: Library for enhanced seccomp
 License: LGPL-2.1-only

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/besser82/libxcrypt/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/archive/v4.4.23/libxcrypt-4.4.23.tar.gz"
-sha512 = "4d5854a082a8c707416507611881c1407f0ea0bda0557c5f7ae6b70d8dd1c7a0828afe29d8f2e7754f5f97b824aaa03671dae6d4dad329fcd131b94b77ddb713"
+url = "https://github.com/besser82/libxcrypt/archive/v4.4.26/libxcrypt-4.4.26.tar.gz"
+sha512 = "fd58e397c59fd8f227a0006ed1039ef1d89e033f792f186a8c352fddc0741616fabe9784eb081aecac4db945741dd730f6cef36e6354f252fd934ce0866fdb2a"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.23
+Version: 4.4.26
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/5.13/strace-5.13.tar.xz"
-sha512 = "ba8b0eae396fa2b762bf17cbcdcd84b0660b2a5d5e7e9caf098ef3414a87fd28d4140dd10136483f35904560e5044e40be2bf6117462868a360306d62887c8ed"
+url = "https://strace.io/files/5.14/strace-5.14.tar.xz"
+sha512 = "3e147521773d900167809db9feeb148e8ba116f90dd634311941ea335eb7bd8b73ab9e641bd2dcfe899ab41c19a841e203dc771ec3000ae01452d22ecdc43c5a"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 5.13
+Version: 5.14
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/systemd/systemd-stable/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd-stable/archive/v247.8/systemd-stable-247.8.tar.gz"
-sha512 = "ac6c9e9b1642f14971551585b25b0b69733a76577154baa701d9879349844913535859d1ef440d20b4d55d8bcc7c34b9d413710f3e49e4cc295d1e5ebb48102c"
+url = "https://github.com/systemd/systemd-stable/archive/v247.9/systemd-stable-247.9.tar.gz"
+sha512 = "61cd36bec931a3550c9d25abd86d12b031d55cebf3c31eb08805947484aa93d215e3d12227cd41131a26c2a6024a74b1fef5cd4929e6240f916279bfbfc67116"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,7 +2,7 @@
 %global _cross_allow_rpath 1
 
 Name: %{_cross_os}systemd
-Version: 247.8
+Version: 247.9
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.37/util-linux-2.37.1.tar.xz"
-sha512 = "ec300c830869e10a0d7f8c0b99e9bb46e0b88fc51f3c6c6a4d9752a89f035e8d69d81f25fd103ef8d7d253e81440695ef3f5d72dccc94815ec8d5f6f949f7555"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.37/util-linux-2.37.2.tar.xz"
+sha512 = "38f0fe820445e3bfa79550e6581c230f98c7661566ccc4daa51c7208a5f972c61b4e57dfc86bed074fdbc7c40bc79f856be8f6a05a8860c1c0cecc4208e8b81d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -1,5 +1,5 @@
 %global majorminor 2.37
-%global version %{majorminor}.1
+%global version %{majorminor}.2
 
 Name: %{_cross_os}util-linux
 Version: %{version}

--- a/sources/logdog/conf/logdog.aws-ecs-1.conf
+++ b/sources/logdog/conf/logdog.aws-ecs-1.conf
@@ -3,6 +3,7 @@ file docker-daemon.json /etc/docker/daemon.json
 file ecs-agent-state.json /var/lib/ecs/data/ecs_agent_data.json
 file ecs-config.json /etc/ecs/ecs.config.json
 http ecs-tasks http://localhost:51678/v1/tasks
+glob /var/log/ecs/agent-runtime-stats.log*
 glob /var/log/ecs/ecs-cni-bridge-plugin.log*
 glob /var/log/ecs/ecs-cni-eni-plugin.log*
 glob /var/log/ecs/vpc-branch-eni.log*


### PR DESCRIPTION
**Description of changes:**

```
74f090e6 Update e2fsprogs to 1.46.4
78d494cf Update ecs-agent to 1.55.2
a40b2276 Add agent-runtime-stats to aws-ecs-1 logdog config
901a763e Update grep to 3.7
68fe357d Update kernel-5.4 to 5.4.141
ef1132b8 Update kernel-5.10 to 5.10.59
fc753157 Update libaudit to 3.0.5
59fdc25c Update libcap to 2.57
87638ec7 Update libseccomp to 2.5.2
1e84cf1e Update libxcrypt to 4.4.26
73a55186 Update strace to 5.14
7cd88863 Update systemd to 247.9
9106932d Update util-linux to 2.37.2
```
Reviewer notes:
* libcap now requires -fPIC, or you get relocation errors that recommend fPIC.
* rebased ecs-agent and libcap patches.

**Testing done:**

Built and ran aws-k8s-1.21 x86, aws-ecs-1 x86, aws-k8s-1.17 aarch64, aws-dev x86, and vmware-k8s-1.21 x86.  Confirmed that pods/tasks run OK.  Confirmed API get/set OK, system services healthy, and journal OK.  Confirmed on aws-dev that strace-ing bash works and is fun.  Confirmed that /var/log/ecs has the new agent-runtime-stats file, when that feature is enabled, and that logdog output includes it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.