### PR TITLE
Add region flag to aws-iam-authenticator command

### DIFF
--- a/packages/kubernetes-1.17/kubelet-kubeconfig
+++ b/packages/kubernetes-1.17/kubelet-kubeconfig
@@ -26,6 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+      {{#if settings.aws.region}}
+      - "--region"
+      - "{{settings.aws.region}}"
+      {{/if}}
 {{/if}}
 {{/if}}
 {{#if (eq settings.kubernetes.authentication-mode "tls")}}

--- a/packages/kubernetes-1.18/kubelet-kubeconfig
+++ b/packages/kubernetes-1.18/kubelet-kubeconfig
@@ -26,6 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+      {{#if settings.aws.region}}
+      - "--region"
+      - "{{settings.aws.region}}"
+      {{/if}}      
 {{/if}}
 {{/if}}
 {{#if (eq settings.kubernetes.authentication-mode "tls")}}

--- a/packages/kubernetes-1.19/kubelet-kubeconfig
+++ b/packages/kubernetes-1.19/kubelet-kubeconfig
@@ -26,6 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+      {{#if settings.aws.region}}
+      - "--region"
+      - "{{settings.aws.region}}"
+      {{/if}}
 {{/if}}
 {{/if}}
 {{#if (eq settings.kubernetes.authentication-mode "tls")}}

--- a/packages/kubernetes-1.20/kubelet-kubeconfig
+++ b/packages/kubernetes-1.20/kubelet-kubeconfig
@@ -26,6 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+      {{#if settings.aws.region}}
+      - "--region"
+      - "{{settings.aws.region}}"
+      {{/if}}
 {{/if}}
 {{/if}}
 {{#if (eq settings.kubernetes.authentication-mode "tls")}}

--- a/packages/kubernetes-1.21/kubelet-kubeconfig
+++ b/packages/kubernetes-1.21/kubelet-kubeconfig
@@ -26,6 +26,10 @@ users:
       - token
       - "-i"
       - "{{settings.kubernetes.cluster-name}}"
+      {{#if settings.aws.region}}
+      - "--region"
+      - "{{settings.aws.region}}"
+      {{/if}}
 {{/if}}
 {{/if}}
 {{#if (eq settings.kubernetes.authentication-mode "tls")}}


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Adds `--region` flag to `aws-iam-authenticator` command to reflect AL2 EKS changes to support additional regions. 


**Testing done:**
Created EKS Clusters for the following variants: 
* aws-k8s-1.17
* aws-k8s-1.18
* aws-k8s-1.19
* aws-k8s-1.20
* aws-k8s-1.21

Confirmed updates to `kubelet-kubeconfig` allowed Bottlerocket nodes for each cluster to join successfully and deploy pods. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
