### PR TITLE
Update ca-certificates to 2021.09.30

### DIFF
--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -12,5 +12,5 @@ path = "pkg.rs"
 releases-url = "https://curl.se/docs/caextract.html"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2021-07-05.pem"
-sha512 = "881183c7fed512cab763a6145f0e07c5bcdc143589baf433f7ba92223d215f18f48782fcfc04860db0671849e2ceeecedf6704f77148f588e17c4cd9a34cc8f8"
+url = "https://curl.haxx.se/ca/cacert-2021-09-30.pem"
+sha512 = "52cbf96a7d108df3a6338f076fb2d012d33cea18176c2dfb0dfcee3786ecb510b40c53b1f2f841bacf384533d190e87eff1db33b54d0561a1e97f6049b3f3203"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2021.07.05
+Version: 2021.09.30
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2021-07-05.pem
+Source0: https://curl.haxx.se/ca/cacert-2021-09-30.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description


### PR DESCRIPTION
**Description of changes:**

Updated to the latest CA certificates (2021-09-30).

**Testing done:**

- [x] Built aws-ecs-1 (aarch64).
- [x] Built aws-k8s-1.20 (x86_64).
- [x] Built vmware-k8s-1.20 (x86_64).
- [x] Confirmed that pods/tasks run OK on all of the above variants.
- [x] Confirmed `/pki/tls/certs/ca-bundle.crt` had the correct number of certs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
