### PR TITLE
Add *.src.rpm to packages/.gitignore

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,1 +1,2 @@
 *.patch.bz2
+*.src.rpm

--- a/packages/kernel-5.10/.gitignore
+++ b/packages/kernel-5.10/.gitignore
@@ -1,1 +1,0 @@
-kernel-*.src.rpm

--- a/packages/kernel-5.4/.gitignore
+++ b/packages/kernel-5.4/.gitignore
@@ -1,1 +1,0 @@
-kernel-*.src.rpm


### PR DESCRIPTION
**Description of changes:**

This replaces the need for individual SRPM gitignores in the kernel and GRUB packages.

**Testing done:**

Confirmed that there were no untracked SRPMs after build.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
