### PR TITLE
Apply patches for CVE-2021-41089, CVE-2021-41091, CVE-2021-41092, and CVE-2021-41103

### DIFF
--- a/packages/containerd/0001-v2-runtime-reduce-permissions-for-bundle-dir.patch
+++ b/packages/containerd/0001-v2-runtime-reduce-permissions-for-bundle-dir.patch
@@ -1,0 +1,353 @@
+From 235b5815e5c6f462c67bbb931d1dcd23f7e89e3c Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Mon, 20 Sep 2021 16:20:26 -0700
+Subject: [PATCH 1/3] v2 runtime: reduce permissions for bundle dir
+
+Bundle directory permissions should be 0700 by default.  On Linux with
+user namespaces enabled, the remapped root also needs access to the
+bundle directory.  In this case, the bundle directory is modified to
+0710 and group ownership is changed to the remapped root group.
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ runtime/v2/bundle.go            |   5 +-
+ runtime/v2/bundle_default.go    |  24 +++++
+ runtime/v2/bundle_linux.go      |  74 ++++++++++++++
+ runtime/v2/bundle_linux_test.go | 166 ++++++++++++++++++++++++++++++++
+ runtime/v2/bundle_test.go       |  23 +++++
+ 5 files changed, 291 insertions(+), 1 deletion(-)
+ create mode 100644 runtime/v2/bundle_default.go
+ create mode 100644 runtime/v2/bundle_linux.go
+ create mode 100644 runtime/v2/bundle_linux_test.go
+ create mode 100644 runtime/v2/bundle_test.go
+
+diff --git a/runtime/v2/bundle.go b/runtime/v2/bundle.go
+index 1a58e627b..954163b0f 100644
+--- a/runtime/v2/bundle.go
++++ b/runtime/v2/bundle.go
+@@ -72,7 +72,10 @@ func NewBundle(ctx context.Context, root, state, id string, spec []byte) (b *Bun
+ 	if err := os.MkdirAll(filepath.Dir(b.Path), 0711); err != nil {
+ 		return nil, err
+ 	}
+-	if err := os.Mkdir(b.Path, 0711); err != nil {
++	if err := os.Mkdir(b.Path, 0700); err != nil {
++		return nil, err
++	}
++	if err := prepareBundleDirectoryPermissions(b.Path, spec); err != nil {
+ 		return nil, err
+ 	}
+ 	paths = append(paths, b.Path)
+diff --git a/runtime/v2/bundle_default.go b/runtime/v2/bundle_default.go
+new file mode 100644
+index 000000000..2be40c825
+--- /dev/null
++++ b/runtime/v2/bundle_default.go
+@@ -0,0 +1,24 @@
++//go:build !linux
++// +build !linux
++
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++// prepareBundleDirectoryPermissions prepares the permissions of the bundle
++// directory according to the needs of the current platform.
++func prepareBundleDirectoryPermissions(path string, spec []byte) error { return nil }
+diff --git a/runtime/v2/bundle_linux.go b/runtime/v2/bundle_linux.go
+new file mode 100644
+index 000000000..5f1915d77
+--- /dev/null
++++ b/runtime/v2/bundle_linux.go
+@@ -0,0 +1,74 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++import (
++	"encoding/json"
++	"os"
++
++	"github.com/opencontainers/runtime-spec/specs-go"
++)
++
++// prepareBundleDirectoryPermissions prepares the permissions of the bundle
++// directory according to the needs of the current platform.
++// On Linux when user namespaces are enabled, the permissions are modified to
++// allow the remapped root GID to access the bundle.
++func prepareBundleDirectoryPermissions(path string, spec []byte) error {
++	gid, err := remappedGID(spec)
++	if err != nil {
++		return err
++	}
++	if gid == 0 {
++		return nil
++	}
++	if err := os.Chown(path, -1, int(gid)); err != nil {
++		return err
++	}
++	return os.Chmod(path, 0710)
++}
++
++// ociSpecUserNS is a subset of specs.Spec used to reduce garbage during
++// unmarshal.
++type ociSpecUserNS struct {
++	Linux *linuxSpecUserNS
++}
++
++// linuxSpecUserNS is a subset of specs.Linux used to reduce garbage during
++// unmarshal.
++type linuxSpecUserNS struct {
++	GIDMappings []specs.LinuxIDMapping
++}
++
++// remappedGID reads the remapped GID 0 from the OCI spec, if it exists. If
++// there is no remapping, remappedGID returns 0. If the spec cannot be parsed,
++// remappedGID returns an error.
++func remappedGID(spec []byte) (uint32, error) {
++	var ociSpec ociSpecUserNS
++	err := json.Unmarshal(spec, &ociSpec)
++	if err != nil {
++		return 0, err
++	}
++	if ociSpec.Linux == nil || len(ociSpec.Linux.GIDMappings) == 0 {
++		return 0, nil
++	}
++	for _, mapping := range ociSpec.Linux.GIDMappings {
++		if mapping.ContainerID == 0 {
++			return mapping.HostID, nil
++		}
++	}
++	return 0, nil
++}
+diff --git a/runtime/v2/bundle_linux_test.go b/runtime/v2/bundle_linux_test.go
+new file mode 100644
+index 000000000..617b10594
+--- /dev/null
++++ b/runtime/v2/bundle_linux_test.go
+@@ -0,0 +1,166 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++import (
++	"context"
++	"encoding/json"
++	"fmt"
++	"io/ioutil"
++	"os"
++	"path/filepath"
++	"strconv"
++	"syscall"
++	"testing"
++
++	"github.com/containerd/containerd/namespaces"
++	"github.com/containerd/containerd/oci"
++	"github.com/containerd/containerd/pkg/testutil"
++	"github.com/opencontainers/runtime-spec/specs-go"
++)
++
++func TestNewBundle(t *testing.T) {
++	testutil.RequiresRoot(t)
++	tests := []struct {
++		userns bool
++	}{{
++		userns: false,
++	}, {
++		userns: true,
++	}}
++	const usernsGID = 4200
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			dir, err := ioutil.TempDir("", "test-new-bundle")
++			if err != nil {
++				t.Fatal("failed to create test directory", err)
++			}
++			defer os.RemoveAll(dir)
++			work := filepath.Join(dir, "work")
++			state := filepath.Join(dir, "state")
++			id := fmt.Sprintf("new-bundle-%d", i)
++			spec := oci.Spec{}
++			if tc.userns {
++				spec.Linux = &specs.Linux{
++					GIDMappings: []specs.LinuxIDMapping{{ContainerID: 0, HostID: usernsGID}},
++				}
++			}
++			specBytes, err := json.Marshal(&spec)
++			if err != nil {
++				t.Fatal("failed to marshal spec", err)
++			}
++
++			ctx := namespaces.WithNamespace(context.TODO(), namespaces.Default)
++			b, err := NewBundle(ctx, work, state, id, specBytes)
++			if err != nil {
++				t.Fatal("NewBundle should succeed", err)
++			}
++			if b == nil {
++				t.Fatal("bundle should not be nil")
++			}
++
++			fi, err := os.Stat(b.Path)
++			if err != nil {
++				t.Error("should be able to stat bundle path", err)
++			}
++			if tc.userns {
++				if fi.Mode() != os.ModeDir|0710 {
++					t.Error("bundle path should be a directory with perm 0710")
++				}
++			} else {
++				if fi.Mode() != os.ModeDir|0700 {
++					t.Error("bundle path should be a directory with perm 0700")
++				}
++			}
++			stat, ok := fi.Sys().(*syscall.Stat_t)
++			if !ok {
++				t.Fatal("should assert to *syscall.Stat_t")
++			}
++			expectedGID := uint32(0)
++			if tc.userns {
++				expectedGID = usernsGID
++			}
++			if expectedGID != stat.Gid {
++				t.Error("gid should match", expectedGID, stat.Gid)
++			}
++		})
++	}
++}
++
++func TestRemappedGID(t *testing.T) {
++	tests := []struct {
++		spec oci.Spec
++		gid  uint32
++	}{{
++		// empty spec
++		spec: oci.Spec{},
++		gid:  0,
++	}, {
++		// empty Linux section
++		spec: oci.Spec{
++			Linux: &specs.Linux{},
++		},
++		gid: 0,
++	}, {
++		// empty ID mappings
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: make([]specs.LinuxIDMapping, 0),
++			},
++		},
++		gid: 0,
++	}, {
++		// valid ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 0,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 1000,
++	}, {
++		// missing ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 100,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 0,
++	}}
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			s, err := json.Marshal(tc.spec)
++			if err != nil {
++				t.Fatal("failed to marshal spec", err)
++			}
++			gid, err := remappedGID(s)
++			if err != nil {
++				t.Error("should unmarshal successfully", err)
++			}
++			if tc.gid != gid {
++				t.Error("expected GID to match", tc.gid, gid)
++			}
++		})
++	}
++}
+diff --git a/runtime/v2/bundle_test.go b/runtime/v2/bundle_test.go
+new file mode 100644
+index 000000000..54e5f24cc
+--- /dev/null
++++ b/runtime/v2/bundle_test.go
+@@ -0,0 +1,23 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++import (
++	// When testutil is imported for one platform (bundle_linux_test.go) it
++	// should be imported for all platforms.
++	_ "github.com/containerd/containerd/pkg/testutil"
++)
+-- 
+2.33.0
+

--- a/packages/containerd/0002-v1-runtime-reduce-permissions-for-bundle-dir.patch
+++ b/packages/containerd/0002-v1-runtime-reduce-permissions-for-bundle-dir.patch
@@ -1,0 +1,289 @@
+From 78204966b8ef86da7f62dbb4be20bd5d282fd2cc Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Tue, 21 Sep 2021 13:46:40 -0700
+Subject: [PATCH 2/3] v1 runtime: reduce permissions for bundle dir
+
+Bundle directory permissions should be 0700 by default.  On Linux with
+user namespaces enabled, the remapped root also needs access to the
+bundle directory.  In this case, the bundle directory is modified to
+0710 and group ownership is changed to the remapped root group.
+
+Port of the same change for the v2 runtime
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ runtime/v1/linux/bundle.go      |  56 ++++++++++-
+ runtime/v1/linux/bundle_test.go | 166 ++++++++++++++++++++++++++++++++
+ 2 files changed, 221 insertions(+), 1 deletion(-)
+ create mode 100644 runtime/v1/linux/bundle_test.go
+
+diff --git a/runtime/v1/linux/bundle.go b/runtime/v1/linux/bundle.go
+index 9d0a6c447..48d81e8e0 100644
+--- a/runtime/v1/linux/bundle.go
++++ b/runtime/v1/linux/bundle.go
+@@ -21,6 +21,7 @@ package linux
+ import (
+ 	"context"
+ 	"crypto/sha256"
++	"encoding/json"
+ 	"fmt"
+ 	"io/ioutil"
+ 	"os"
+@@ -30,6 +31,7 @@ import (
+ 	"github.com/containerd/containerd/runtime/linux/runctypes"
+ 	"github.com/containerd/containerd/runtime/v1/shim"
+ 	"github.com/containerd/containerd/runtime/v1/shim/client"
++	"github.com/opencontainers/runtime-spec/specs-go"
+ 	"github.com/pkg/errors"
+ )
+ 
+@@ -48,7 +50,7 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
+ 		return nil, err
+ 	}
+ 	path = filepath.Join(path, id)
+-	if err := os.Mkdir(path, 0711); err != nil {
++	if err := os.Mkdir(path, 0700); err != nil {
+ 		return nil, err
+ 	}
+ 	defer func() {
+@@ -56,6 +58,9 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
+ 			os.RemoveAll(path)
+ 		}
+ 	}()
++	if err := prepareBundleDirectoryPermissions(path, spec); err != nil {
++		return nil, err
++	}
+ 	workDir = filepath.Join(workDir, id)
+ 	if err := os.MkdirAll(workDir, 0711); err != nil {
+ 		return nil, err
+@@ -77,6 +82,55 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
+ 	}, err
+ }
+ 
++// prepareBundleDirectoryPermissions prepares the permissions of the bundle
++// directory. When user namespaces are enabled, the permissions are modified
++// to allow the remapped root GID to access the bundle.
++func prepareBundleDirectoryPermissions(path string, spec []byte) error {
++	gid, err := remappedGID(spec)
++	if err != nil {
++		return err
++	}
++	if gid == 0 {
++		return nil
++	}
++	if err := os.Chown(path, -1, int(gid)); err != nil {
++		return err
++	}
++	return os.Chmod(path, 0710)
++}
++
++// ociSpecUserNS is a subset of specs.Spec used to reduce garbage during
++// unmarshal.
++type ociSpecUserNS struct {
++	Linux *linuxSpecUserNS
++}
++
++// linuxSpecUserNS is a subset of specs.Linux used to reduce garbage during
++// unmarshal.
++type linuxSpecUserNS struct {
++	GIDMappings []specs.LinuxIDMapping
++}
++
++// remappedGID reads the remapped GID 0 from the OCI spec, if it exists. If
++// there is no remapping, remappedGID returns 0. If the spec cannot be parsed,
++// remappedGID returns an error.
++func remappedGID(spec []byte) (uint32, error) {
++	var ociSpec ociSpecUserNS
++	err := json.Unmarshal(spec, &ociSpec)
++	if err != nil {
++		return 0, err
++	}
++	if ociSpec.Linux == nil || len(ociSpec.Linux.GIDMappings) == 0 {
++		return 0, nil
++	}
++	for _, mapping := range ociSpec.Linux.GIDMappings {
++		if mapping.ContainerID == 0 {
++			return mapping.HostID, nil
++		}
++	}
++	return 0, nil
++}
++
+ type bundle struct {
+ 	id      string
+ 	path    string
+diff --git a/runtime/v1/linux/bundle_test.go b/runtime/v1/linux/bundle_test.go
+new file mode 100644
+index 000000000..adf39b4ec
+--- /dev/null
++++ b/runtime/v1/linux/bundle_test.go
+@@ -0,0 +1,166 @@
++//go:build linux
++// +build linux
++
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package linux
++
++import (
++	"encoding/json"
++	"fmt"
++	"io/ioutil"
++	"os"
++	"path/filepath"
++	"strconv"
++	"syscall"
++	"testing"
++
++	"github.com/containerd/containerd/oci"
++	"github.com/containerd/continuity/testutil"
++	"github.com/opencontainers/runtime-spec/specs-go"
++)
++
++func TestNewBundle(t *testing.T) {
++	testutil.RequiresRoot(t)
++	tests := []struct {
++		userns bool
++	}{{
++		userns: false,
++	}, {
++		userns: true,
++	}}
++	const usernsGID = 4200
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			dir, err := ioutil.TempDir("", "test-new-bundle")
++			if err != nil {
++				t.Fatal("failed to create test directory", err)
++			}
++			defer os.RemoveAll(dir)
++			work := filepath.Join(dir, "work")
++			state := filepath.Join(dir, "state")
++			id := fmt.Sprintf("new-bundle-%d", i)
++			spec := oci.Spec{}
++			if tc.userns {
++				spec.Linux = &specs.Linux{
++					GIDMappings: []specs.LinuxIDMapping{{ContainerID: 0, HostID: usernsGID}},
++				}
++			}
++			specBytes, err := json.Marshal(&spec)
++			if err != nil {
++				t.Fatal("failed to marshal spec", err)
++			}
++
++			b, err := newBundle(id, work, state, specBytes)
++			if err != nil {
++				t.Fatal("newBundle should succeed", err)
++			}
++			if b == nil {
++				t.Fatal("bundle should not be nil")
++			}
++
++			fi, err := os.Stat(b.path)
++			if err != nil {
++				t.Error("should be able to stat bundle path", err)
++			}
++			if tc.userns {
++				if fi.Mode() != os.ModeDir|0710 {
++					t.Error("bundle path should be a directory with perm 0710")
++				}
++			} else {
++				if fi.Mode() != os.ModeDir|0700 {
++					t.Error("bundle path should be a directory with perm 0700")
++				}
++			}
++			stat, ok := fi.Sys().(*syscall.Stat_t)
++			if !ok {
++				t.Fatal("should assert to *syscall.Stat_t")
++			}
++			expectedGID := uint32(0)
++			if tc.userns {
++				expectedGID = usernsGID
++			}
++			if stat.Gid != expectedGID {
++				t.Error("gid should match", expectedGID, stat.Gid)
++			}
++		})
++	}
++}
++
++func TestRemappedGID(t *testing.T) {
++	tests := []struct {
++		spec oci.Spec
++		gid  uint32
++	}{{
++		// empty spec
++		spec: oci.Spec{},
++		gid:  0,
++	}, {
++		// empty Linux section
++		spec: oci.Spec{
++			Linux: &specs.Linux{},
++		},
++		gid: 0,
++	}, {
++		// empty ID mappings
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: make([]specs.LinuxIDMapping, 0),
++			},
++		},
++		gid: 0,
++	}, {
++		// valid ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 0,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 1000,
++	}, {
++		// missing ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 100,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 0,
++	}}
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			s, err := json.Marshal(tc.spec)
++			if err != nil {
++				t.Fatal("failed to marshal spec", err)
++			}
++			gid, err := remappedGID(s)
++			if err != nil {
++				t.Error("should unmarshal successfully", err)
++			}
++			if gid != tc.gid {
++				t.Error("expected GID to match", tc.gid, gid)
++			}
++		})
++	}
++}
+-- 
+2.33.0
+

--- a/packages/containerd/0003-btrfs-reduce-permissions-on-plugin-directories.patch
+++ b/packages/containerd/0003-btrfs-reduce-permissions-on-plugin-directories.patch
@@ -1,0 +1,40 @@
+From c186ae1e6dc0084b6499ca0e760f1daa5f0ea72e Mon Sep 17 00:00:00 2001
+From: Derek McGowan <derek@mcg.dev>
+Date: Wed, 15 Sep 2021 17:57:13 -0700
+Subject: [PATCH 3/3] btrfs: reduce permissions on plugin directories
+
+Disallow traversal into directories that may contain
+unpacked or mounted image filesystems.
+
+Signed-off-by: Derek McGowan <derek@mcg.dev>
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+(cherry picked from commit 7c621e1fcc08bcf5a1a48b837342cc22eada1685)
+---
+ snapshots/btrfs/btrfs.go | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/snapshots/btrfs/btrfs.go b/snapshots/btrfs/btrfs.go
+index ea90853da..78f825ce3 100644
+--- a/snapshots/btrfs/btrfs.go
++++ b/snapshots/btrfs/btrfs.go
+@@ -63,11 +63,15 @@ type snapshotter struct {
+ // root needs to be a mount point of btrfs.
+ func NewSnapshotter(root string) (snapshots.Snapshotter, error) {
+ 	// If directory does not exist, create it
+-	if _, err := os.Stat(root); err != nil {
++	if st, err := os.Stat(root); err != nil {
+ 		if !os.IsNotExist(err) {
+ 			return nil, err
+ 		}
+-		if err := os.Mkdir(root, 0755); err != nil {
++		if err := os.Mkdir(root, 0700); err != nil {
++			return nil, err
++		}
++	} else if st.Mode()&os.ModePerm != 0700 {
++		if err := os.Chmod(root, 0700); err != nil {
+ 			return nil, err
+ 		}
+ 	}
+-- 
+2.33.0
+

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -27,6 +27,11 @@ Patch1001: 1001-cri-set-default-RLIMIT_NOFILE.patch
 # TODO: drop this when https://github.com/containerd/containerd/pull/5104/ is merged
 Patch1002: 1002-cri-filter-selinux-xattr-for-image-volumes.patch
 
+# CVE-2021-41103
+Patch2001: 0001-v2-runtime-reduce-permissions-for-bundle-dir.patch
+Patch2002: 0002-v1-runtime-reduce-permissions-for-bundle-dir.patch
+Patch2003: 0003-btrfs-reduce-permissions-on-plugin-directories.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}runc

--- a/packages/docker-cli/0001-registry-ensure-default-auth-config-has-address.patch
+++ b/packages/docker-cli/0001-registry-ensure-default-auth-config-has-address.patch
@@ -1,0 +1,133 @@
+From 42d1c02750b3631402da3973e5f36b76c8c934f4 Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Wed, 21 Jul 2021 17:59:42 -0700
+Subject: [PATCH] registry: ensure default auth config has address
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ cli/command/registry.go       | 15 +++++++--------
+ cli/command/registry/login.go | 13 +++++--------
+ cli/command/registry_test.go  | 16 +++++++++++++++-
+ 3 files changed, 27 insertions(+), 17 deletions(-)
+
+diff --git a/cli/command/registry.go b/cli/command/registry.go
+index e6311c8bf..68e3dd36e 100644
+--- a/cli/command/registry.go
++++ b/cli/command/registry.go
+@@ -63,17 +63,14 @@ func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInf
+ 		indexServer := registry.GetAuthConfigKey(index)
+ 		isDefaultRegistry := indexServer == ElectAuthServer(context.Background(), cli)
+ 		authConfig, err := GetDefaultAuthConfig(cli, true, indexServer, isDefaultRegistry)
+-		if authConfig == nil {
+-			authConfig = &types.AuthConfig{}
+-		}
+ 		if err != nil {
+ 			fmt.Fprintf(cli.Err(), "Unable to retrieve stored credentials for %s, error: %s.\n", indexServer, err)
+ 		}
+-		err = ConfigureAuth(cli, "", "", authConfig, isDefaultRegistry)
++		err = ConfigureAuth(cli, "", "", &authConfig, isDefaultRegistry)
+ 		if err != nil {
+ 			return "", err
+ 		}
+-		return EncodeAuthToBase64(*authConfig)
++		return EncodeAuthToBase64(authConfig)
+ 	}
+ }
+ 
+@@ -92,7 +89,7 @@ func ResolveAuthConfig(ctx context.Context, cli Cli, index *registrytypes.IndexI
+ 
+ // GetDefaultAuthConfig gets the default auth config given a serverAddress
+ // If credentials for given serverAddress exists in the credential store, the configuration will be populated with values in it
+-func GetDefaultAuthConfig(cli Cli, checkCredStore bool, serverAddress string, isDefaultRegistry bool) (*types.AuthConfig, error) {
++func GetDefaultAuthConfig(cli Cli, checkCredStore bool, serverAddress string, isDefaultRegistry bool) (types.AuthConfig, error) {
+ 	if !isDefaultRegistry {
+ 		serverAddress = registry.ConvertToHostname(serverAddress)
+ 	}
+@@ -101,13 +98,15 @@ func GetDefaultAuthConfig(cli Cli, checkCredStore bool, serverAddress string, is
+ 	if checkCredStore {
+ 		authconfig, err = cli.ConfigFile().GetAuthConfig(serverAddress)
+ 		if err != nil {
+-			return nil, err
++			return types.AuthConfig{
++				ServerAddress: serverAddress,
++			}, err
+ 		}
+ 	}
+ 	authconfig.ServerAddress = serverAddress
+ 	authconfig.IdentityToken = ""
+ 	res := types.AuthConfig(authconfig)
+-	return &res, nil
++	return res, nil
+ }
+ 
+ // ConfigureAuth handles prompting of user's username and password if needed
+diff --git a/cli/command/registry/login.go b/cli/command/registry/login.go
+index 61dd90c33..3820c414b 100644
+--- a/cli/command/registry/login.go
++++ b/cli/command/registry/login.go
+@@ -114,22 +114,19 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error { //nolint: gocycl
+ 	var response registrytypes.AuthenticateOKBody
+ 	isDefaultRegistry := serverAddress == authServer
+ 	authConfig, err := command.GetDefaultAuthConfig(dockerCli, opts.user == "" && opts.password == "", serverAddress, isDefaultRegistry)
+-	if authConfig == nil {
+-		authConfig = &types.AuthConfig{}
+-	}
+ 	if err == nil && authConfig.Username != "" && authConfig.Password != "" {
+-		response, err = loginWithCredStoreCreds(ctx, dockerCli, authConfig)
++		response, err = loginWithCredStoreCreds(ctx, dockerCli, &authConfig)
+ 	}
+ 	if err != nil || authConfig.Username == "" || authConfig.Password == "" {
+-		err = command.ConfigureAuth(dockerCli, opts.user, opts.password, authConfig, isDefaultRegistry)
++		err = command.ConfigureAuth(dockerCli, opts.user, opts.password, &authConfig, isDefaultRegistry)
+ 		if err != nil {
+ 			return err
+ 		}
+ 
+-		response, err = clnt.RegistryLogin(ctx, *authConfig)
++		response, err = clnt.RegistryLogin(ctx, authConfig)
+ 		if err != nil && client.IsErrConnectionFailed(err) {
+ 			// If the server isn't responding (yet) attempt to login purely client side
+-			response, err = loginClientSide(ctx, *authConfig)
++			response, err = loginClientSide(ctx, authConfig)
+ 		}
+ 		// If we (still) have an error, give up
+ 		if err != nil {
+@@ -152,7 +149,7 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error { //nolint: gocycl
+ 		}
+ 	}
+ 
+-	if err := creds.Store(configtypes.AuthConfig(*authConfig)); err != nil {
++	if err := creds.Store(configtypes.AuthConfig(authConfig)); err != nil {
+ 		return errors.Errorf("Error saving credentials: %v", err)
+ 	}
+ 
+diff --git a/cli/command/registry_test.go b/cli/command/registry_test.go
+index ae7c3ac05..f98589fed 100644
+--- a/cli/command/registry_test.go
++++ b/cli/command/registry_test.go
+@@ -145,7 +145,21 @@ func TestGetDefaultAuthConfig(t *testing.T) {
+ 			assert.Check(t, is.Equal(tc.expectedErr, err.Error()))
+ 		} else {
+ 			assert.NilError(t, err)
+-			assert.Check(t, is.DeepEqual(tc.expectedAuthConfig, *authconfig))
++			assert.Check(t, is.DeepEqual(tc.expectedAuthConfig, authconfig))
+ 		}
+ 	}
+ }
++
++func TestGetDefaultAuthConfig_HelperError(t *testing.T) {
++	cli := test.NewFakeCli(&fakeClient{})
++	errBuf := new(bytes.Buffer)
++	cli.SetErr(errBuf)
++	cli.ConfigFile().CredentialsStore = "fake-does-not-exist"
++	serverAddress := "test-server-address"
++	expectedAuthConfig := types.AuthConfig{
++		ServerAddress: serverAddress,
++	}
++	authconfig, err := GetDefaultAuthConfig(cli, true, serverAddress, serverAddress == "https://index.docker.io/v1/")
++	assert.Check(t, is.DeepEqual(expectedAuthConfig, authconfig))
++	assert.Check(t, is.ErrorContains(err, "docker-credential-fake-does-not-exist"))
++}
+-- 
+2.33.0
+

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -18,6 +18,10 @@ License: Apache-2.0
 URL: https://%{goimport}
 Source0: https://%{goimport}/archive/v%{gover}/cli-%{gover}.tar.gz
 Source1000: clarify.toml
+
+# CVE-2021-41092
+Patch0001: 0001-registry-ensure-default-auth-config-has-address.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 

--- a/packages/docker-engine/0001-Lock-down-docker-root-dir-perms.patch
+++ b/packages/docker-engine/0001-Lock-down-docker-root-dir-perms.patch
@@ -1,0 +1,382 @@
+From 93ac040bf0c0b51d9a7fedaf994bf5bf1d68ee0e Mon Sep 17 00:00:00 2001
+From: Brian Goff <cpuguy83@gmail.com>
+Date: Fri, 2 Jul 2021 17:27:45 +0000
+Subject: [PATCH 1/2] Lock down docker root dir perms.
+
+Do not use 0701 perms.
+0701 dir perms allows anyone to traverse the docker dir.
+It happens to allow any user to execute, as an example, suid binaries
+from image rootfs dirs because it allows traversal AND critically
+container users need to be able to do execute things.
+
+0701 on lower directories also happens to allow any user to modify
+     things in, for instance, the overlay upper dir which neccessarily
+     has 0755 permissions.
+
+This changes to use 0710 which allows users in the group to traverse.
+In userns mode the UID owner is (real) root and the GID is the remapped
+root's GID.
+
+This prevents anyone but the remapped root to traverse our directories
+(which is required for userns with runc).
+
+Signed-off-by: Brian Goff <cpuguy83@gmail.com>
+(cherry picked from commit ef7237442147441a7cadcda0600be1186d81ac73)
+Signed-off-by: Brian Goff <cpuguy83@gmail.com>
+---
+ daemon/container_operations_unix.go           |  2 +-
+ daemon/create.go                              |  5 ++--
+ daemon/daemon.go                              |  5 +++-
+ daemon/daemon_unix.go                         | 14 +++++------
+ daemon/graphdriver/aufs/aufs.go               | 13 ++++++++--
+ daemon/graphdriver/btrfs/btrfs.go             | 18 ++++++++++++--
+ .../fuse-overlayfs/fuseoverlayfs.go           | 24 +++++++++++++++----
+ daemon/graphdriver/overlay/overlay.go         | 20 ++++++++++++----
+ daemon/graphdriver/overlay2/overlay.go        | 24 +++++++++++++++----
+ daemon/graphdriver/vfs/driver.go              | 17 +++++++++++--
+ daemon/graphdriver/zfs/zfs.go                 | 11 ++++++++-
+ 11 files changed, 121 insertions(+), 32 deletions(-)
+
+diff --git a/daemon/container_operations_unix.go b/daemon/container_operations_unix.go
+index 5521adbd27..1647df0ce7 100644
+--- a/daemon/container_operations_unix.go
++++ b/daemon/container_operations_unix.go
+@@ -466,5 +466,5 @@ func (daemon *Daemon) setupContainerMountsRoot(c *container.Container) error {
+ 	if err != nil {
+ 		return err
+ 	}
+-	return idtools.MkdirAllAndChown(p, 0701, idtools.CurrentIdentity())
++	return idtools.MkdirAllAndChown(p, 0710, idtools.Identity{UID: idtools.CurrentIdentity().UID, GID: daemon.IdentityMapping().RootPair().GID})
+ }
+diff --git a/daemon/create.go b/daemon/create.go
+index 57f1eff665..b07851aec9 100644
+--- a/daemon/create.go
++++ b/daemon/create.go
+@@ -212,10 +212,11 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
+ 	}
+ 	ctr.RWLayer = rwLayer
+ 
+-	if err := idtools.MkdirAndChown(ctr.Root, 0701, idtools.CurrentIdentity()); err != nil {
++	current := idtools.CurrentIdentity()
++	if err := idtools.MkdirAndChown(ctr.Root, 0710, idtools.Identity{UID: current.UID, GID: daemon.IdentityMapping().RootPair().GID}); err != nil {
+ 		return nil, err
+ 	}
+-	if err := idtools.MkdirAndChown(ctr.CheckpointDir(), 0700, idtools.CurrentIdentity()); err != nil {
++	if err := idtools.MkdirAndChown(ctr.CheckpointDir(), 0700, current); err != nil {
+ 		return nil, err
+ 	}
+ 
+diff --git a/daemon/daemon.go b/daemon/daemon.go
+index 3d8cca2880..2a2fbbd52e 100644
+--- a/daemon/daemon.go
++++ b/daemon/daemon.go
+@@ -861,7 +861,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
+ 	}
+ 
+ 	daemonRepo := filepath.Join(config.Root, "containers")
+-	if err := idtools.MkdirAllAndChown(daemonRepo, 0701, idtools.CurrentIdentity()); err != nil {
++	if err := idtools.MkdirAllAndChown(daemonRepo, 0710, idtools.Identity{
++		UID: idtools.CurrentIdentity().UID,
++		GID: rootIDs.GID,
++	}); err != nil {
+ 		return nil, err
+ 	}
+ 
+diff --git a/daemon/daemon_unix.go b/daemon/daemon_unix.go
+index 8754d4f972..d982018c34 100644
+--- a/daemon/daemon_unix.go
++++ b/daemon/daemon_unix.go
+@@ -1216,21 +1216,21 @@ func setupDaemonRoot(config *config.Config, rootDir string, remappedRoot idtools
+ 		}
+ 	}
+ 
++	id := idtools.Identity{UID: idtools.CurrentIdentity().UID, GID: remappedRoot.GID}
++	// First make sure the current root dir has the correct perms.
++	if err := idtools.MkdirAllAndChown(config.Root, 0710, id); err != nil {
++		return errors.Wrapf(err, "could not create or set daemon root permissions: %s", config.Root)
++	}
++
+ 	// if user namespaces are enabled we will create a subtree underneath the specified root
+ 	// with any/all specified remapped root uid/gid options on the daemon creating
+ 	// a new subdirectory with ownership set to the remapped uid/gid (so as to allow
+ 	// `chdir()` to work for containers namespaced to that uid/gid)
+ 	if config.RemappedRoot != "" {
+-		id := idtools.CurrentIdentity()
+-		// First make sure the current root dir has the correct perms.
+-		if err := idtools.MkdirAllAndChown(config.Root, 0701, id); err != nil {
+-			return errors.Wrapf(err, "could not create or set daemon root permissions: %s", config.Root)
+-		}
+-
+ 		config.Root = filepath.Join(rootDir, fmt.Sprintf("%d.%d", remappedRoot.UID, remappedRoot.GID))
+ 		logrus.Debugf("Creating user namespaced daemon root: %s", config.Root)
+ 		// Create the root directory if it doesn't exist
+-		if err := idtools.MkdirAllAndChown(config.Root, 0701, id); err != nil {
++		if err := idtools.MkdirAllAndChown(config.Root, 0710, id); err != nil {
+ 			return fmt.Errorf("Cannot create daemon root: %s: %v", config.Root, err)
+ 		}
+ 		// we also need to verify that any pre-existing directories in the path to
+diff --git a/daemon/graphdriver/aufs/aufs.go b/daemon/graphdriver/aufs/aufs.go
+index b007274e13..cfa18666d9 100644
+--- a/daemon/graphdriver/aufs/aufs.go
++++ b/daemon/graphdriver/aufs/aufs.go
+@@ -130,14 +130,23 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
+ 	}
+ 
+ 	currentID := idtools.CurrentIdentity()
++	_, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
++	if err != nil {
++		return nil, err
++	}
++	dirID := idtools.Identity{
++		UID: currentID.UID,
++		GID: rootGID,
++	}
++
+ 	// Create the root aufs driver dir
+-	if err := idtools.MkdirAllAndChown(root, 0701, currentID); err != nil {
++	if err := idtools.MkdirAllAndChown(root, 0710, dirID); err != nil {
+ 		return nil, err
+ 	}
+ 
+ 	// Populate the dir structure
+ 	for _, p := range paths {
+-		if err := idtools.MkdirAllAndChown(path.Join(root, p), 0701, currentID); err != nil {
++		if err := idtools.MkdirAllAndChown(path.Join(root, p), 0710, dirID); err != nil {
+ 			return nil, err
+ 		}
+ 	}
+diff --git a/daemon/graphdriver/btrfs/btrfs.go b/daemon/graphdriver/btrfs/btrfs.go
+index 0499489d16..8fd2854a26 100644
+--- a/daemon/graphdriver/btrfs/btrfs.go
++++ b/daemon/graphdriver/btrfs/btrfs.go
+@@ -70,7 +70,14 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
+ 		return nil, graphdriver.ErrPrerequisites
+ 	}
+ 
+-	if err := idtools.MkdirAllAndChown(home, 0701, idtools.CurrentIdentity()); err != nil {
++	remappedRoot := idtools.NewIDMappingsFromMaps(uidMaps, gidMaps)
++	currentID := idtools.CurrentIdentity()
++	dirID := idtools.Identity{
++		UID: currentID.UID,
++		GID: remappedRoot.RootPair().GID,
++	}
++
++	if err := idtools.MkdirAllAndChown(home, 0710, dirID); err != nil {
+ 		return nil, err
+ 	}
+ 
+@@ -521,7 +528,14 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
+ 	if err != nil {
+ 		return err
+ 	}
+-	if err := idtools.MkdirAllAndChown(subvolumes, 0701, idtools.CurrentIdentity()); err != nil {
++
++	currentID := idtools.CurrentIdentity()
++	dirID := idtools.Identity{
++		UID: currentID.UID,
++		GID: rootGID,
++	}
++
++	if err := idtools.MkdirAllAndChown(subvolumes, 0710, dirID); err != nil {
+ 		return err
+ 	}
+ 	if parent == "" {
+diff --git a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+index 782e8be984..1bf30f4298 100644
+--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
++++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+@@ -88,7 +88,17 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
+ 		return nil, graphdriver.ErrNotSupported
+ 	}
+ 
+-	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 0701, idtools.CurrentIdentity()); err != nil {
++	remappedRoot := idtools.NewIDMappingsFromMaps(uidMaps, gidMaps)
++	currentID := idtools.CurrentIdentity()
++	dirID := idtools.Identity{
++		UID: currentID.UID,
++		GID: remappedRoot.RootPair().GID,
++	}
++
++	if err := idtools.MkdirAllAndChown(home, 0710, dirID); err != nil {
++		return nil, err
++	}
++	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 700, currentID); err != nil {
+ 		return nil, err
+ 	}
+ 
+@@ -173,11 +183,15 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
+ 	}
+ 	root := idtools.Identity{UID: rootUID, GID: rootGID}
+ 
+-	currentID := idtools.CurrentIdentity()
+-	if err := idtools.MkdirAllAndChown(path.Dir(dir), 0701, currentID); err != nil {
++	dirID := idtools.Identity{
++		UID: rootUID,
++		GID: rootGID,
++	}
++
++	if err := idtools.MkdirAllAndChown(path.Dir(dir), 0710, dirID); err != nil {
+ 		return err
+ 	}
+-	if err := idtools.MkdirAndChown(dir, 0701, currentID); err != nil {
++	if err := idtools.MkdirAndChown(dir, 0710, dirID); err != nil {
+ 		return err
+ 	}
+ 
+@@ -211,7 +225,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
+ 		return nil
+ 	}
+ 
+-	if err := idtools.MkdirAndChown(path.Join(dir, workDirName), 0701, currentID); err != nil {
++	if err := idtools.MkdirAndChown(path.Join(dir, workDirName), 0710, dirID); err != nil {
+ 		return err
+ 	}
+ 
+diff --git a/daemon/graphdriver/overlay/overlay.go b/daemon/graphdriver/overlay/overlay.go
+index 90be0e3d64..6e9897da05 100644
+--- a/daemon/graphdriver/overlay/overlay.go
++++ b/daemon/graphdriver/overlay/overlay.go
+@@ -156,11 +156,20 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
+ 		logrus.WithField("storage-driver", "overlay").Warn(overlayutils.ErrDTypeNotSupported("overlay", backingFs))
+ 	}
+ 
+-	// Create the driver home dir
+-	if err := idtools.MkdirAllAndChown(home, 0701, idtools.CurrentIdentity()); err != nil {
++	currentID := idtools.CurrentIdentity()
++	_, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
++	if err != nil {
+ 		return nil, err
+ 	}
++	dirID := idtools.Identity{
++		UID: currentID.UID,
++		GID: rootGID,
++	}
+ 
++	// Create the driver home dir
++	if err := idtools.MkdirAllAndChown(home, 0710, dirID); err != nil {
++		return nil, err
++	}
+ 	d := &Driver{
+ 		home:          home,
+ 		uidMaps:       uidMaps,
+@@ -262,10 +271,11 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr
+ 	root := idtools.Identity{UID: rootUID, GID: rootGID}
+ 
+ 	currentID := idtools.CurrentIdentity()
+-	if err := idtools.MkdirAllAndChown(path.Dir(dir), 0701, currentID); err != nil {
+-		return err
++	dirID := idtools.Identity{
++		UID: currentID.UID,
++		GID: rootGID,
+ 	}
+-	if err := idtools.MkdirAndChown(dir, 0701, currentID); err != nil {
++	if err := idtools.MkdirAndChown(dir, 0710, dirID); err != nil {
+ 		return err
+ 	}
+ 
+diff --git a/daemon/graphdriver/overlay2/overlay.go b/daemon/graphdriver/overlay2/overlay.go
+index 36a921a018..562d1e58fd 100644
+--- a/daemon/graphdriver/overlay2/overlay.go
++++ b/daemon/graphdriver/overlay2/overlay.go
+@@ -165,7 +165,20 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
+ 		logger.Warn(overlayutils.ErrDTypeNotSupported("overlay2", backingFs))
+ 	}
+ 
+-	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 0701, idtools.CurrentIdentity()); err != nil {
++	_, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
++	if err != nil {
++		return nil, err
++	}
++
++	cur := idtools.CurrentIdentity()
++	dirID := idtools.Identity{
++		UID: cur.UID,
++		GID: rootGID,
++	}
++	if err := idtools.MkdirAllAndChown(home, 0710, dirID); err != nil {
++		return nil, err
++	}
++	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 0700, cur); err != nil {
+ 		return nil, err
+ 	}
+ 
+@@ -344,12 +357,15 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
+ 		return err
+ 	}
+ 	root := idtools.Identity{UID: rootUID, GID: rootGID}
+-	current := idtools.CurrentIdentity()
++	dirID := idtools.Identity{
++		UID: idtools.CurrentIdentity().UID,
++		GID: rootGID,
++	}
+ 
+-	if err := idtools.MkdirAllAndChown(path.Dir(dir), 0701, current); err != nil {
++	if err := idtools.MkdirAllAndChown(path.Dir(dir), 0710, dirID); err != nil {
+ 		return err
+ 	}
+-	if err := idtools.MkdirAndChown(dir, 0701, current); err != nil {
++	if err := idtools.MkdirAndChown(dir, 0710, dirID); err != nil {
+ 		return err
+ 	}
+ 
+diff --git a/daemon/graphdriver/vfs/driver.go b/daemon/graphdriver/vfs/driver.go
+index af9b107609..f903393da2 100644
+--- a/daemon/graphdriver/vfs/driver.go
++++ b/daemon/graphdriver/vfs/driver.go
+@@ -37,8 +37,16 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
+ 	if err := d.parseOptions(options); err != nil {
+ 		return nil, err
+ 	}
++	_, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
++	if err != nil {
++		return nil, err
++	}
+ 
+-	if err := idtools.MkdirAllAndChown(home, 0701, idtools.CurrentIdentity()); err != nil {
++	dirID := idtools.Identity{
++		UID: idtools.CurrentIdentity().UID,
++		GID: rootGID,
++	}
++	if err := idtools.MkdirAllAndChown(home, 0710, dirID); err != nil {
+ 		return nil, err
+ 	}
+ 
+@@ -140,7 +148,12 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
+ func (d *Driver) create(id, parent string, size uint64) error {
+ 	dir := d.dir(id)
+ 	rootIDs := d.idMapping.RootPair()
+-	if err := idtools.MkdirAllAndChown(filepath.Dir(dir), 0701, idtools.CurrentIdentity()); err != nil {
++
++	dirID := idtools.Identity{
++		UID: idtools.CurrentIdentity().UID,
++		GID: rootIDs.GID,
++	}
++	if err := idtools.MkdirAllAndChown(filepath.Dir(dir), 0710, dirID); err != nil {
+ 		return err
+ 	}
+ 	if err := idtools.MkdirAndChown(dir, 0755, rootIDs); err != nil {
+diff --git a/daemon/graphdriver/zfs/zfs.go b/daemon/graphdriver/zfs/zfs.go
+index f9099a2094..2fbbe9498f 100644
+--- a/daemon/graphdriver/zfs/zfs.go
++++ b/daemon/graphdriver/zfs/zfs.go
+@@ -104,7 +104,16 @@ func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdri
+ 		return nil, fmt.Errorf("BUG: zfs get all -t filesystem -rHp '%s' should contain '%s'", options.fsName, options.fsName)
+ 	}
+ 
+-	if err := idtools.MkdirAllAndChown(base, 0701, idtools.CurrentIdentity()); err != nil {
++	_, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
++	if err != nil {
++		return nil, err
++	}
++
++	dirID := idtools.Identity{
++		UID: idtools.CurrentIdentity().UID,
++		GID: rootGID,
++	}
++	if err := idtools.MkdirAllAndChown(base, 0710, dirID); err != nil {
+ 		return nil, fmt.Errorf("Failed to create '%s': %v", base, err)
+ 	}
+ 
+-- 
+2.33.0
+

--- a/packages/docker-engine/0002-chrootarchive-don-t-create-parent-dirs-outside-of-ch.patch
+++ b/packages/docker-engine/0002-chrootarchive-don-t-create-parent-dirs-outside-of-ch.patch
@@ -1,0 +1,49 @@
+From 80f1169eca587305759829e626cebd2a434664f6 Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Wed, 19 May 2021 16:51:35 -0700
+Subject: [PATCH 2/2] chrootarchive: don't create parent dirs outside of chroot
+
+If chroot is used with a special root directory then create
+destination directory within chroot. This works automatically
+already due to extractor creating parent paths and is only
+used currently with cp where parent paths are actually required
+and error will be shown to user before reaching this point.
+
+Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
+(cherry picked from commit 52d285184068998c22632bfb869f6294b5613a58)
+Signed-off-by: Brian Goff <cpuguy83@gmail.com>
+---
+ pkg/chrootarchive/archive.go | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/pkg/chrootarchive/archive.go b/pkg/chrootarchive/archive.go
+index 83ed0c6b2f..d11cbdf277 100644
+--- a/pkg/chrootarchive/archive.go
++++ b/pkg/chrootarchive/archive.go
+@@ -74,13 +74,17 @@ func untarHandler(tarArchive io.Reader, dest string, options *archive.TarOptions
+ 		options.ExcludePatterns = []string{}
+ 	}
+ 
+-	idMapping := idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps)
+-	rootIDs := idMapping.RootPair()
++	// If dest is inside a root then directory is created within chroot by extractor.
++	// This case is only currently used by cp.
++	if dest == root {
++		idMapping := idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps)
++		rootIDs := idMapping.RootPair()
+ 
+-	dest = filepath.Clean(dest)
+-	if _, err := os.Stat(dest); os.IsNotExist(err) {
+-		if err := idtools.MkdirAllAndChownNew(dest, 0755, rootIDs); err != nil {
+-			return err
++		dest = filepath.Clean(dest)
++		if _, err := os.Stat(dest); os.IsNotExist(err) {
++			if err := idtools.MkdirAllAndChownNew(dest, 0755, rootIDs); err != nil {
++				return err
++			}
+ 		}
+ 	}
+ 
+-- 
+2.33.0
+

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -24,6 +24,9 @@ Source3: docker-sysusers.conf
 Source4: daemon-json
 Source1000: clarify.toml
 
+# CVE-2021-41091
+Patch0001: 0001-Lock-down-docker-root-dir-perms.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libseccomp-devel

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -27,6 +27,9 @@ Source1000: clarify.toml
 # CVE-2021-41091
 Patch0001: 0001-Lock-down-docker-root-dir-perms.patch
 
+# CVE-2021-41089
+Patch0002: 0002-chrootarchive-don-t-create-parent-dirs-outside-of-ch.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libseccomp-devel


### PR DESCRIPTION
**Description of changes:**
Apply patches for the following CVEs:
- Docker CLI - https://github.com/docker/cli/security/advisories/GHSA-99pg-grm5-qq3v (CVE-2021-41092)
- Docker engine - https://github.com/moby/moby/security/advisories/GHSA-3fwx-pjgw-3558 (CVE-2021-41091)
- Docker engine - https://github.com/moby/moby/security/advisories/GHSA-v994-f8vw-g7j4 (CVE-2021-41089)
- containerd - https://github.com/containerd/containerd/security/advisories/GHSA-c2h3-6mxw-7mvq (CVE-2021-41103)


**Testing done:**
Tested `aws-k8s-1.17`, `aws-k8s-1.18`, `aws-k8s-1.19`, `aws-k8s-1.20`, `aws-k8s-1.21`, and `aws-ecs-1`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
