### PR TITLE
Add *.zip to packages/.gitignore

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,2 +1,3 @@
 *.patch.bz2
 *.src.rpm
+*.zip

--- a/packages/ncurses/.gitignore
+++ b/packages/ncurses/.gitignore
@@ -1,1 +1,0 @@
-ncurses-*.tgz


### PR DESCRIPTION
**Description of changes:**

This ignores files like `packages/libglib/pcre_8.37-2_patch.zip`.

Also removes an individual `.gitignore` for `ncurses-*.tgz` as the **ncurses** package is now `packages/ncurses/ncurses-6.2.tar.gz`, which is caught by the `*.tar.*` in the repo-level `.gitignore`.

**Testing done:**

Confirmed that there were no untracked ZIPs or TGZs after build.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
