### PR TITLE
update to SDK 0.23.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - run: rustup toolchain install 1.53.0 && rustup default 1.53.0
+      - run: rustup toolchain install 1.56.0 && rustup default 1.56.0
       - run: cargo install --version 0.30.0 cargo-make
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-fmt

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,7 +26,7 @@ BUILDSYS_NAME = "bottlerocket"
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.22.0"
+BUILDSYS_SDK_VERSION="v0.23.0"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -498,8 +498,8 @@ dependencies = ["fetch"]
 script = [
 '''
 run_cargo_deny="
-(cd /tmp/sources && cargo deny check --disable-fetch licenses)
-(cd /tmp/tools && cargo deny check --disable-fetch licenses)
+(cd /tmp/sources && cargo deny --all-features check --disable-fetch licenses bans sources) &&
+(cd /tmp/tools && cargo deny --all-features check --disable-fetch licenses bans sources)
 "
 set +e
 docker run --rm \

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -10,8 +10,8 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-constants = { path = "../../constants" }
-datastore = { path = "../datastore" }
+constants = { path = "../../constants", version = "0.1.0" }
+datastore = { path = "../datastore", version = "0.1.0" }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 # Ensure we use exactly hyper 0.14.2 which is the last version that does not emit a cdylib
@@ -19,7 +19,7 @@ http = "0.2"
 hyper = { version = "=0.14.2", default-features = false, features = [ "client", "http1", "http2" ] }
 hyper-unix-connector = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 rand = "0.8"
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -11,14 +11,14 @@ exclude = ["README.md"]
 
 [dependencies]
 actix-web = { version = "4.0.0-beta.5", default-features = false }
-bottlerocket-release = { path = "../../bottlerocket-release" }
-datastore = { path = "../datastore" }
+bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
+datastore = { path = "../datastore", version = "0.1.0" }
 fs2 = "0.4.3"
 futures = { version = "0.3", default-features = false }
 http = "0.2.1"
 libc = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 nix = "0.22"
 num = "0.4"
 percent-encoding = "2.1"
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.10"
 snafu = "0.6"
-thar-be-updates = { path = "../thar-be-updates" }
+thar-be-updates = { path = "../thar-be-updates", version = "0.1.0" }
 walkdir = "2.2"
 
 [build-dependencies]

--- a/sources/api/bootstrap-containers/Cargo.toml
+++ b/sources/api/bootstrap-containers/Cargo.toml
@@ -10,13 +10,13 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
-datastore = { path = "../datastore" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
+datastore = { path = "../datastore", version = "0.1.0" }
 base64 = "0.13"
 http = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -10,17 +10,17 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
 argh = "0.1.3"
 base64 = "0.13"
-constants = { path = "../../constants" }
+constants = { path = "../../constants", version = "0.1.0" }
 # x509-parser depends on der-parser ^5.0.  5.1.1 contains breaking changes.
 # The 5.1.1 release isn't in the master branch; those changes are instead in a
 # 6.0.0 release, more clearly implying breaking changes.  Lock to 5.1.0.
 der-parser = "=5.1.0"
 http = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -10,11 +10,11 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
 http = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -10,13 +10,13 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
 async-trait = "0.1.36"
 base64 = "0.13"
-constants = { path = "../../constants" }
+constants = { path = "../../constants", version = "0.1.0" }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 http = "0.2"
-imdsclient = { path = "../../imdsclient" }
+imdsclient = { path = "../../imdsclient", version = "0.1.0" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -10,10 +10,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-constants = { path = "../../constants" }
+constants = { path = "../../constants", version = "0.1.0" }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1"
-schnauzer = { path = "../schnauzer" }
+schnauzer = { path = "../schnauzer", version = "0.1.0" }
 log = "0.4"
 snafu = "0.6"
 tokio = { version = "~1.8", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -10,12 +10,12 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
 base64 = "0.13"
-constants = { path = "../../constants" }
+constants = { path = "../../constants", version = "0.1.0" }
 http = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../../../bottlerocket-release" }
-datastore = { path = "../../datastore" }
+bottlerocket-release = { path = "../../../bottlerocket-release", version = "0.1.0" }
+datastore = { path = "../../datastore", version = "0.1.0" }
 handlebars = "4.1"
-schnauzer = { path = "../../schnauzer" }
+schnauzer = { path = "../../schnauzer", version = "0.1.0" }
 serde = "1.0.104"
 serde_json = "1.0"
 snafu = "0.6"

--- a/sources/api/migration/migrations/v1.3.0/control-container-v0-5-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.3.0/control-container-v0-5-2/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-migration-helpers = { path = "../../../migration-helpers" }
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.3.0/etc-hosts-service/Cargo.toml
+++ b/sources/api/migration/migrations/v1.3.0/etc-hosts-service/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-migration-helpers = { path = "../../../migration-helpers" }
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.3.0/hostname-affects-etc-hosts/Cargo.toml
+++ b/sources/api/migration/migrations/v1.3.0/hostname-affects-etc-hosts/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-migration-helpers = { path = "../../../migration-helpers" }
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../../../bottlerocket-release" }
+bottlerocket-release = { path = "../../../bottlerocket-release", version = "0.1.0" }
 log = "0.4"
 lz4 = "1.23.1"
 nix = "0.22"
@@ -21,7 +21,7 @@ semver = "1.0"
 simplelog = "0.10"
 snafu = "0.6"
 tough = "0.11"
-update_metadata = { path = "../../../updater/update_metadata" }
+update_metadata = { path = "../../../updater/update_metadata", version = "0.1.0" }
 url = "2.1.1"
 
 [build-dependencies]
@@ -29,7 +29,7 @@ cargo-readme = "3.1"
 
 [dev-dependencies]
 chrono = "0.4.11"
-storewolf = { path = "../../storewolf" }
+storewolf = { path = "../../storewolf", version = "0.1.0" }
 tempfile = "3.1.0"
 
 [[bin]]

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -10,10 +10,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
-imdsclient = { path = "../../imdsclient" }
-models = { path = "../../models" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
+imdsclient = { path = "../../imdsclient", version = "0.1.0" }
+models = { path = "../../models", version = "0.1.0" }
 rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }
 rusoto_eks = { version = "0.47", default-features = false, features = ["rustls"] }
 serde_json = "1"

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -10,16 +10,16 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
 base64 = "0.13"
-constants = { path = "../../constants" }
-bottlerocket-release = { path = "../../bottlerocket-release" }
+constants = { path = "../../constants", version = "0.1.0" }
+bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
 dns-lookup = "1.0"
 handlebars = "4.1"
 http = "0.2"
 lazy_static = "1.4"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/sources/api/servicedog/Cargo.toml
+++ b/sources/api/servicedog/Cargo.toml
@@ -10,12 +10,12 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
-datastore = { path = "../datastore" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
+datastore = { path = "../datastore", version = "0.1.0" }
 http = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -10,8 +10,8 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
 snafu = "0.6"
 http = "0.2"
 log = "0.4"

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 base64 = "0.13"
-imdsclient = { path = "../../imdsclient" }
+imdsclient = { path = "../../imdsclient", version = "0.1.0" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -10,11 +10,11 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-constants = { path = "../../constants" }
+constants = { path = "../../constants", version = "0.1.0" }
 base64 = "0.13"
 log = "0.4"
-models = { path = "../../models" }
-schnauzer = { path = "../schnauzer" }
+models = { path = "../../models", version = "0.1.0" }
+schnauzer = { path = "../schnauzer", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -10,11 +10,11 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-constants = { path = "../../constants" }
-bottlerocket-release = { path = "../../bottlerocket-release" }
-datastore = { path = "../datastore" }
+constants = { path = "../../constants", version = "0.1.0" }
+bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
+datastore = { path = "../datastore", version = "0.1.0" }
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 semver = "1.0"
 simplelog = "0.10"
@@ -23,13 +23,13 @@ toml = "0.5"
 
 [build-dependencies]
 cargo-readme = "3.1"
-merge-toml = { path = "merge-toml" }
+merge-toml = { path = "merge-toml", version = "0.1.0" }
 # We have a models build-dep because we read default settings from the models
 # directory and need its build.rs to run first; we also reflect the dependency
 # with cargo:rerun-if-changed statements in our build.rs.  The models build.rs
 # runs twice, once for the above dependency and once for this build-dependency,
 # so it's important that it remains reentrant.
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 snafu = "0.6"
 toml = "0.5"
 walkdir = "2"

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -10,12 +10,12 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
-datastore = { path = "../datastore" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
+datastore = { path = "../datastore", version = "0.1.0" }
 http = "0.2"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.10"

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -10,15 +10,15 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
 handlebars = "4.1"
 http = "0.2"
 itertools = "0.10"
 log = "0.4"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 nix = "0.22"
-schnauzer = { path = "../schnauzer" }
+schnauzer = { path = "../schnauzer", version = "0.1.0" }
 serde_json = "1"
 simplelog = "0.10"
 snafu = "0.6"

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -10,14 +10,14 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient" }
-constants = { path = "../../constants" }
-bottlerocket-release = { path = "../../bottlerocket-release" }
+apiclient = { path = "../apiclient", version = "0.1.0" }
+constants = { path = "../../constants", version = "0.1.0" }
+bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
 chrono = { version = "0.4.11", features = [ "serde" ] }
 fs2 = "0.4.3"
 http = "0.2.1"
 log = "0.4.8"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 nix = "0.22"
 num-derive = "0.3.0"
 num-traits = "0.2.12"
@@ -25,12 +25,12 @@ semver = { version = "1.0", features = [ "serde" ] }
 serde = { version = "1.0.111", features = [ "derive" ] }
 serde_json = "1.0.53"
 serde_plain = "1.0"
-signpost = { path = "../../updater/signpost" }
+signpost = { path = "../../updater/signpost", version = "0.1.0" }
 simplelog = "0.10"
 snafu = "0.6.8"
 tempfile = "3.1.0"
 tokio = { version = "~1.8", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
-update_metadata = { path = "../../updater/update_metadata" }
+update_metadata = { path = "../../updater/update_metadata", version = "0.1.0" }
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -35,3 +35,37 @@ expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
+
+[bans]
+# Deny multiple versions or wildcard dependencies.
+multiple-versions = "deny"
+wildcards = "deny"
+
+skip = [
+    # older version used by gptman 0.6.5
+    { name = "nix", version = "0.17.0" },
+
+    # newer version used by model-derive and darling
+    # older version used by clap 2.33.3, via cargo-readme and structopt
+    { name = "strsim", version = "0.8.0" },
+
+    # older version used by hyper 0.14.2
+    { name = "socket2", version = "0.3.19" },
+
+    # older version used by tough 0.11.2
+    { name = "serde_plain", version = "0.3.0" },
+]
+
+skip-tree = [
+    # handlebars dependency, uses older versions of SHA-1 and its dependencies
+    { name = "pest_meta", version = "2.1.3" },
+
+    # actix-http uses older and newer versions of crates like rustc_version and
+    # semver, for build vs. runtime dependencies.
+    { name = "actix-http", version = "3.0.0-beta.10" },
+]
+
+[sources]
+# Deny crates from unknown registries or git repositories.
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -13,7 +13,7 @@ argh = "0.1.3"
 gptman = { version = "0.6.1", default-features = false }
 hex-literal = "0.3.0"
 lazy_static = "1.2"
-signpost = { path = "../updater/signpost" }
+signpost = { path = "../updater/signpost", version = "0.1.0" }
 snafu = "0.6"
 
 [build-dependencies]

--- a/sources/growpart/Cargo.toml
+++ b/sources/growpart/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["README.md"]
 gptman = { version = "0.6.1", default-features = false }
 snafu = "0.6"
 libc = "0.2"
-block-party = { path = "../updater/block-party" }
+block-party = { path = "../updater/block-party", version = "0.1.0" }
 inotify = "0.9"
 
 [build-dependencies]

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../api/apiclient" }
-constants = { path = "../constants" }
-datastore = { path = "../api/datastore" }
+apiclient = { path = "../api/apiclient", version = "0.1.0" }
+constants = { path = "../constants", version = "0.1.0" }
+datastore = { path = "../api/datastore", version = "0.1.0" }
 flate2 = "1.0"
 glob = "0.3"
-models = { path = "../models" }
+models = { path = "../models", version = "0.1.0" }
 reqwest = { version = "0.11.1", default-features = false, features = ["blocking", "rustls-tls"] }
 serde_json = "1"
 shell-words = "1.0.0"

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../bottlerocket-release"}
+bottlerocket-release = { path = "../bottlerocket-release", version = "0.1.0" }
 log = "0.4"
 reqwest = { version = "0.11.1", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0.100", features = ["derive"] }

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -11,9 +11,9 @@ exclude = ["README.md"]
 
 [dependencies]
 base64 = "0.13"
-bottlerocket-release = { path = "../bottlerocket-release" }
+bottlerocket-release = { path = "../bottlerocket-release", version = "0.1.0" }
 lazy_static = "1.2"
-model-derive = { path = "model-derive" }
+model-derive = { path = "model-derive", version = "0.1.0" }
 regex = "1.1"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/sources/prairiedog/Cargo.toml
+++ b/sources/prairiedog/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["README.md"]
 argh = "0.1.3"
 log = "0.4"
 nix = "0.22"
-signpost = { path = "../updater/signpost" }
+signpost = { path = "../updater/signpost", version = "0.1.0" }
 simplelog = "0.10"
 snafu = "0.6"
 

--- a/sources/updater/signpost/Cargo.toml
+++ b/sources/updater/signpost/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["README.md"]
 
 [dependencies]
 bit_field = "0.10.0"
-block-party = { path = "../block-party" }
+block-party = { path = "../block-party", version = "0.1.0" }
 gptman = { version = "0.6.1", default-features = false }
 hex-literal = "0.3.0"
 serde = { version = "1.0.91", features = ["derive"] }

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["README.md"]
 
 [dependencies]
 chrono = { version = "0.4.9", features = ["serde"] }
-parse-datetime = { path = "../../parse-datetime" }
+parse-datetime = { path = "../../parse-datetime", version = "0.1.0" }
 regex = "1.1"
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0.100", features = ["derive"] }

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../../bottlerocket-release" }
+bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
 chrono = "0.4.9"
 log = "0.4"
 lz4 = "1.23.1"
@@ -19,16 +19,16 @@ semver = "1.0"
 serde = { version = "1.0.100", features = ["derive"] }
 serde_json = "1.0.40"
 serde_plain = "1.0"
-signpost = { path = "../signpost" }
+signpost = { path = "../signpost", version = "0.1.0" }
 simplelog = "0.10"
 snafu = "0.6.0"
 toml = "0.5.1"
 tough = { version = "0.11", features = ["http"] }
-update_metadata = { path = "../update_metadata" }
+update_metadata = { path = "../update_metadata", version = "0.1.0" }
 structopt = "0.3"
 url = "2.1.0"
 signal-hook = "0.3"
-models = { path = "../../models" }
+models = { path = "../../models", version = "0.1.0" }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -40,3 +40,18 @@ expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
+
+[bans]
+# Deny multiple versions or wildcard dependencies.
+multiple-versions = "deny"
+wildcards = "deny"
+
+skip = [
+    # older version required by tough 0.11.2
+    { name = "serde_plain", version = "0.3.0" },
+]
+
+[sources]
+# Deny crates from unknown registries or git repositories.
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/tools/infrasys/Cargo.toml
+++ b/tools/infrasys/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1.51"
 clap = "2.33"  
 hex = "0.4.0"
 log = "0.4.14"  
-pubsys-config = { path = "../pubsys-config/" }  
+pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 rusoto_cloudformation = { version = "0.47", default-features = false, features = ["rustls"] }
 rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }
 rusoto_s3 = { version = "0.47", default-features = false, features = ["rustls"] }

--- a/tools/pubsys-config/Cargo.toml
+++ b/tools/pubsys-config/Cargo.toml
@@ -11,7 +11,7 @@ chrono = "0.4"
 home = "0.5"
 lazy_static = "1.4"
 log = "0.4"
-parse-datetime = { path = "../../sources/parse-datetime" }
+parse-datetime = { path = "../../sources/parse-datetime", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"]  }
 serde_yaml = "0.8.17"
 snafu = "0.6"

--- a/tools/pubsys-setup/Cargo.toml
+++ b/tools/pubsys-setup/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 hex = "0.4.0"
 log = "0.4"
-pubsys-config = { path = "../pubsys-config/" }
+pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "blocking"] }
 sha2 = "0.9"
 shell-words = "1.0"

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -12,13 +12,13 @@ chrono = "0.4"
 clap = "2.33"
 coldsnap = { version = "0.3", default-features = false, features = ["rusoto-rustls"]}
 duct = "0.13.0"
-pubsys-config = { path = "../pubsys-config/" }
+pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 futures = "0.3.5"
 indicatif = "0.16.0"
 lazy_static = "1.4"
 log = "0.4"
 num_cpus = "1"
-parse-datetime = { path = "../../sources/parse-datetime" }
+parse-datetime = { path = "../../sources/parse-datetime", version = "0.1.0" }
 rayon = "1"
 # Need to bring in reqwest with a TLS feature so tough can support TLS repos.
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "blocking"] }
@@ -43,6 +43,6 @@ toml = "0.5"
 tough = { version = "0.11", features = ["http"] }
 tough-kms = "0.3"
 tough-ssm = "0.6"
-update_metadata = { path = "../../sources/updater/update_metadata/" }
+update_metadata = { path = "../../sources/updater/update_metadata/", version = "0.1.0" }
 url = { version = "2.1.0", features = ["serde"] }
 tempfile = "3.1"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Uses the SDK with changes from https://github.com/bottlerocket-os/bottlerocket-sdk/pull/60. Notably, this includes newer versions of Rust, Go, and `cargo-deny`.


**Testing done:**
Confirmed that new `cargo deny` checks pass with no warnings.

Built `aws-k8s-1.21` variants for x86_64 and aarch64; confirmed that a `sonobuoy` run passes with no issues.

Built `aws-ecs-1` variant for x86_64 and verified that tasks ran OK.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
