### PR TITLE
Support '*' in Bottlerocket setting keys

### DIFF
--- a/sources/api/datastore/src/key.rs
+++ b/sources/api/datastore/src/key.rs
@@ -233,7 +233,7 @@ impl Key {
     /// separate from quoting; if a character isn't valid, it isn't valid quoted, either.
     fn valid_character(c: char) -> bool {
         match c {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '/' => true,
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '/' | '*' => true,
             _ => false,
         }
     }
@@ -455,7 +455,7 @@ mod test {
 
     #[test]
     fn key_with_special_chars_ok() {
-        data_and_meta!(|t| assert!(Key::new(t, "a-b_c").is_ok()));
+        data_and_meta!(|t| assert!(Key::new(t, "a-b_c*").is_ok()));
     }
 
     #[test]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1780


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Oct 18 12:13:19 2021 -0700

    datastore: adds '*' to the list of valid key characters
    
    Adds '*' to the list of valid key characters.
    Adds unit tests to make sure paths components are correctly encoded and
    decoded.

```


**Testing done:**
Adds additional unit tests with `*` in the key segments and path components for the datastore and they all pass.

On a bottlerocket host, I was able to set a setting with a key of `*` and see that it gets encoded correctly in the datastore.
Bottlerocket was also able to configuration for containerd with a settings key containing `*`.

Userdata:
```
[settings.container-registry.mirrors]
"*" = ["https://registry-0.acme.com","https://registry-1.acme.com"]
```

On the host (note that `%2A` is `*` URL encoded):
```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/container-registry/mirrors/%2A 
["https://registry-0.acme.com","https://registry-1.acme.com"]

```

```
bash-5.0# cat /etc/containerd/config.toml 
...
[plugins."io.containerd.grpc.v1.cri".registry.mirrors."*"]
endpoint = ["https://registry-0.acme.com", "https://registry-1.acme.com"]

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
