### PR TITLE
Makefile: Add disk image files to TUF repo during `cargo make repo`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -612,6 +612,14 @@ done
 # modules for a given release.
 LINK_REPO_TARGETS=("--link-target ${BUILDSYS_KMOD_KIT_PATH}")
 
+# Include the root and data disk images in the repo if they exist
+os_disk_img="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.img.lz4"
+data_disk_img="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-data.img.lz4"
+if [ -s "${os_disk_img}" ] && [ -s "${data_disk_img}" ]; then
+   LINK_REPO_TARGETS+=("--link-target ${os_disk_img}")
+   LINK_REPO_TARGETS+=("--link-target ${data_disk_img}")
+fi
+
 # Ensure we link an OVA if an OVF template exists (in which case we should have
 # built an OVA)
 if [ -s "${BUILDSYS_OVF_TEMPLATE}" ]; then


### PR DESCRIPTION
**Description of changes:**
```
This change adds the disk image files, if they exist, to the targets that are linked
into the TUF repository during the `cargo make repo` target.  When the
image files are in the repo, we can download them with `tuftool` which
can simplify the process of creating AMIs at a different time or from a
different machine.
```


**Testing done:**
* Ran `cargo make` and `cargo make repo` to build an `aws-k8s-1.21` and a `vmware-k8s-1.20` repo locally and observed the disk image files present in the repo.
```
$ ls build/repos/default/latest/targets/

053689b3deeb42a241afaa31e475b7d654c4f40914c99a401aea63a431823e6f.bottlerocket-aws-k8s-1.21-x86_64-1.3.0-5827e52a-data.img.lz4
06e08aa7765fc2442e6faf9135928ee9f1a976193592ad44f86e7e1312831043.manifest.json
4280b317fa9d37c0534a1547c91dfd5a0cc5c7e5bda5b7f9d88bbb2caa89df98.aws-k8s-1.21-x86_64-kmod-kit-v1.3.0.tar.xz
71136b20803e7bb78157010ac3ef812f5d8ac80809815461302c000460e642a7.bottlerocket-aws-k8s-1.21-x86_64-1.3.0-5827e52a-boot.ext4.lz4
7115fadc493a99afd385f9bbb34f55fb6014abd455699a83c4cf26bd6e10b278.migrate_v1.3.0_control-container-v0-5-2.lz4
80ed4ddbb6af54f2590d6bbda17521889e1f64121680b5525a2fca5d9d63f7c0.migrate_v1.3.0_etc-hosts-service.lz4
8eb06d78727a41919eb54060ee22dbe03d69f6e6523c6f0ac8ffe9fc4ec959ca.bottlerocket-aws-k8s-1.21-x86_64-1.3.0-5827e52a-root.ext4.lz4
b558db24565a3ea639e71340dd69a83469c54d1a1ab94c7c5db87e7e36e96b7f.bottlerocket-aws-k8s-1.21-x86_64-1.3.0-5827e52a-root.verity.lz4
e9fd64b187693e158addc1302544fac319f214e7d3bb7f85a052cb32dde4dd4b.bottlerocket-aws-k8s-1.21-x86_64-1.3.0-5827e52a.img.lz4
ea456c4377bf00ee5f08e0034582bfbdd0b1e080b86b70ccf91d5158254b8157.migrate_v1.3.0_hostname-affects-etc-hosts.lz4
```

* Also ensured that the images ended up in the TUF repo `targets.json`
```
$ cat build/repos/default/latest/aws-k8s-1.21/x86_64/1635186997.targets.json
...
      "bottlerocket-aws-k8s-1.21-x86_64-1.3.0-5827e52a-data.img.lz4": {
        "length": 4220096,
        "hashes": {
          "sha256": "053689b3deeb42a241afaa31e475b7d654c4f40914c99a401aea63a431823e6f"
        }
      },
      "bottlerocket-aws-k8s-1.21-x86_64-1.3.0-5827e52a.img.lz4": {
        "length": 325141152,
        "hashes": {
          "sha256": "e9fd64b187693e158addc1302544fac319f214e7d3bb7f85a052cb32dde4dd4b"
        }
      },
...
```

* Pushed the files to a test TUF repository in S3 and verified I could pull them down with `tuftool`
* Ensure that running `cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.20 repo` doesn't break.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
