### PR TITLE
Add GovCloud ECR account IDs

### DIFF
--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -39,6 +39,8 @@ lazy_static! {
         m.insert("us-east-2", "328549459982");
         m.insert("us-west-1", "328549459982");
         m.insert("us-west-2", "328549459982");
+        m.insert("us-gov-west-1", "347163068887");
+        m.insert("us-gov-east-1", "388230364387");
         m
     };
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Adds GovCloud accounts to `schnauzer`


**Testing done:**
* Created EKS Test cluster in GovCloud
    * Launched AMI with changes and confirmed the following: 
        * Could Join the cluster
        * Control-container functions as expected
        * Admin-container functions as expected
 * Created ECS Test cluster in GovCloud
    * Launched AMI with changes and confirmed the following: 
        * Could Join the cluster
        * Control-container functions as expected
        * Admin-container functions as expected
* Created EKS Test cluster in standard partition
    * Launched AMI with changes and confirmed the following: 
        * Could Join the cluster
        * Control-container functions as expected
        * Admin-container functions as expected
* Created ECS Test cluster in standard partition
    * Launched AMI with changes and confirmed the following: 
        * Could Join the cluster
        * Control-container functions as expected
        * Admin-container functions as expected

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
