### PR TITLE
docs: Update cargo-make commands so that tasks come after arguments

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -98,15 +98,17 @@ To use the image in Amazon EC2, we need to register the image as an AMI.
 For a simple start, pick an [EC2 region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions), then run:
 
 ```
-cargo make ami -e PUBLISH_REGIONS=your-region-here
+cargo make -e PUBLISH_REGIONS=your-region-here ami
 ```
+
+Note that the task ("ami") must come **after** the arguments to `cargo make` that are specified with `-e`.
 
 Your new AMI ID will be printed after it's registered.
 
 If you built your image for a different architecture or variant, just use the same arguments here:
 
 ```
-cargo make ami -e PUBLISH_REGIONS=your-region-here -e BUILDSYS_VARIANT=my-variant-here
+cargo make -e PUBLISH_REGIONS=your-region-here -e BUILDSYS_VARIANT=my-variant-here ami
 ```
 
 (There's a lot more detail on building and managing AMIs in the [PUBLISHING](PUBLISHING.md) guide.)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -392,7 +392,7 @@ script = [
 set -e
 if [ -z "${PACKAGE}" ]; then
     echo "The PACKAGE environment variable must be set. For example:"
-    echo "cargo make build-package -e PACKAGE=kernel"
+    echo "cargo make -e PACKAGE=kernel build-package"
     exit 1
 fi
 
@@ -1031,7 +1031,7 @@ pubsys \
 [tasks._upload-ova-base]
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the image files below to save time.
-# This does mean that `cargo make` must be run before 
+# This does mean that `cargo make` must be run before
 # `cargo make _upload-ova-base`.
 dependencies = ["setup-build", "publish-tools"]
 script_runner = "bash"

--- a/PUBLISHING-AWS.md
+++ b/PUBLISHING-AWS.md
@@ -30,13 +30,13 @@ If you want to change the name or description of your AMI, you can add on `-e PU
 If you use different accounts to make and test your AMIs, you can grant access to specific accounts like this:
 
 ```shell
-cargo make grant-ami -e GRANT_TO_USERS=0123456789,9876543210
+cargo make -e GRANT_TO_USERS=0123456789,9876543210 grant-ami
 ```
 
 (Later, if you need to revoke access, you can do this:)
 
 ```shell
-cargo make revoke-ami -e REVOKE_FROM_USERS=0123456789,9876543210
+cargo make -e REVOKE_FROM_USERS=0123456789,9876543210 revoke-ami
 ```
 
 > Note: similar to `cargo make ami`, you can specify `PUBLISH_REGIONS` on the command line if you don't want to make an `Infra.toml` config.
@@ -94,7 +94,7 @@ Once you're satisfied with your image and parameters, you can promote the parame
 Note: if you want to customize the SSM parameters that get set, you can copy and modify the existing template file, then point to your file like this:
 
 ```shell
-cargo make ssm -e PUBLISH_SSM_TEMPLATES_PATH=/my/template/path
+cargo make -e PUBLISH_SSM_TEMPLATES_PATH=/my/template/path ssm
 ```
 
 ### Making your AMIs public
@@ -122,7 +122,7 @@ The SSM parameter names include version numbers, which is handy for testing, but
 Once we're satisfied, we can promote the SSM parameters to simpler names.
 
 ```shell
-cargo make promote-ssm -e SSM_TARGET=latest
+cargo make -e SSM_TARGET=latest promote-ssm
 ```
 
 This will copy the fully versioned parameter from earlier, something like:

--- a/PUBLISHING-VMWARE.md
+++ b/PUBLISHING-VMWARE.md
@@ -46,13 +46,13 @@ datacenters = ["foo", "bar"]
 Then you can easily upload your OVA, specifying the variant you wish to upload (currently only VMware variants).
 
 ```shell
-cargo make upload-ova -e BUILDSYS_VARIANT=vmware-k8s-1.20
+cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.20 upload-ova
 ```
 
 If you would like to upload your OVA as a VM template, you can do this in a single step:
 
 ```shell
-cargo make vmware-template -e BUILDSYS_VARIANT=vmware-k8s-1.20
+cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.20 vmware-template
 ```
 
 You can override the list of datacenters to upload to by specifying `VMWARE_DATACENTERS`:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -35,7 +35,7 @@ cargo make -e BUILDSYS_VARIANT=my-variant -e BUILDSYS_ARCH=my-arch
 ...then you can then build a repo for it like this:
 
 ```shell
-cargo make repo -e BUILDSYS_VARIANT=my-variant -e BUILDSYS_ARCH=my-arch
+cargo make -e BUILDSYS_VARIANT=my-variant -e BUILDSYS_ARCH=my-arch repo
 ```
 
 ## Publishing your image
@@ -75,7 +75,7 @@ RELEASE_START_TIME="$(date '+%Y-%m-%dT%H:%M:%S%:z' -d 'Monday 10am')"
 Now we can create the repo using that time:
 
 ```shell
-cargo make repo -e "RELEASE_START_TIME=${RELEASE_START_TIME}"
+cargo make -e "RELEASE_START_TIME=${RELEASE_START_TIME}" repo
 ```
 
 ### Roles and keys
@@ -249,7 +249,7 @@ If you want to use a different policy, pass `-e PUBLISH_WAVE_POLICY_PATH=sources
 For example, to use the accelerated schedule:
 
 ```shell
-cargo make repo -e PUBLISH_WAVE_POLICY_PATH=sources/updater/waves/accelerated-waves.toml
+cargo make -e PUBLISH_WAVE_POLICY_PATH=sources/updater/waves/accelerated-waves.toml repo
 ```
 
 To learn more about waves, check out the [README](sources/updater/waves).
@@ -263,7 +263,7 @@ The [default policy](tools/pubsys/policies/repo-expiration/2w-2w-1w.toml) sets t
 If you want to use different expiration policy, you can copy and modify the existing policy, then point to your file like this:
 
 ```shell
-cargo make repo -e PUBLISH_EXPIRATION_POLICY_PATH=/my/policy/path
+cargo make -e PUBLISH_EXPIRATION_POLICY_PATH=/my/policy/path repo
 ```
 
 **Note:** remember to update your repo before the expiration date.

--- a/packages/README.md
+++ b/packages/README.md
@@ -233,7 +233,7 @@ The variants workspace's `Cargo.lock` may be affected by adding a package.
 To build your package, run the following command in the top-level Bottlerocket directory.
 
 ```sh
-cargo make build-package -e PACKAGE=libwoof
+cargo make -e PACKAGE=libwoof build-package
 ```
 
 This will build your package and its dependencies.

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -3,7 +3,7 @@
 # at the root of the repo, then edit the settings below to match your use case.
 
 # You can have any number of repos defined and build a specific one by running like this:
-#     cargo make repo -e PUBLISH_REPO=myrepo
+#     cargo make -e PUBLISH_REPO=myrepo repo
 [repo.default]
 # URL to your root role JSON file; can be a file:// URL for local files.  If
 # you don't specify one here, a file will be generated for you under /roles.
@@ -65,7 +65,7 @@ datacenters = ["north", "south"]
 # ***
 
 # Optional common configuration
-# This configuration allow values to be set in a single place if they are common in 
+# This configuration allow values to be set in a single place if they are common in
 # multiple datacenters.  They can be overridden in the datacenter's block below.
 [vmware.common]
 network = "a_network"


### PR DESCRIPTION
**Issue number:**

#1796

**Description of changes:**

Due to a change in `cargo-make` **v0.35.3**, arguments like `-e PUBLISH_REGION` must be passed before the task name (instead of after).

**Testing done:**

Built, published, and ran `aws-k8s-1.20` AMI without an `Infra.toml` file.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
