### PR TITLE
vendor wicked service units

### DIFF
--- a/packages/wicked/0001-avoid-gcrypt-dependency.patch
+++ b/packages/wicked/0001-avoid-gcrypt-dependency.patch
@@ -1,4 +1,4 @@
-From e7c79e21ea1110155660587b084fdae1e1ca7df1 Mon Sep 17 00:00:00 2001
+From d7c3d65bf98d3695bfb2a831b1a6b3c65aa2a9fd Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Fri, 9 Aug 2019 16:39:28 +0000
 Subject: [PATCH 1/3] avoid gcrypt dependency
@@ -20,10 +20,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  3 files changed, 15 insertions(+), 83 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 8ed0e2a..9721991 100644
+index 08df65c..b94dcf4 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -249,14 +249,6 @@ AC_CHECK_LIB([anl], [getaddrinfo_a], [LIBANL_LIBS="-lanl"],[
+@@ -242,14 +242,6 @@ AC_CHECK_LIB([anl], [getaddrinfo_a], [LIBANL_LIBS="-lanl"],[
  ])
  AC_SUBST(LIBANL_LIBS)
  
@@ -160,7 +160,7 @@ index 4fc0dfc..eeb41ee 100644
  }
  
 diff --git a/src/netinfo.c b/src/netinfo.c
-index 6a1348c..dcf0ec7 100644
+index 9598155..63bb6a9 100644
 --- a/src/netinfo.c
 +++ b/src/netinfo.c
 @@ -33,7 +33,6 @@
@@ -227,5 +227,5 @@ index 6a1348c..dcf0ec7 100644
  		if (appname == NULL) {
  			/* Backward compatible - for now.
 -- 
-2.21.0
+2.21.3
 

--- a/packages/wicked/0002-exclude-unused-components.patch
+++ b/packages/wicked/0002-exclude-unused-components.patch
@@ -1,4 +1,4 @@
-From 07708281e6caae63d207e3640a1a92f4b8c9474f Mon Sep 17 00:00:00 2001
+From 73a6d2a91625771f2b3c87651fe234ac4dae4e75 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 10 Aug 2019 04:53:31 +0000
 Subject: [PATCH 2/3] exclude unused components
@@ -14,7 +14,7 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile.am b/Makefile.am
-index 8f6bffc..fcac7be 100644
+index 8f6bffc..2fa645a 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -6,7 +6,7 @@ MAINTAINERCLEANFILES		= Makefile.in aclocal.m4 config.guess config.*   \
@@ -22,10 +22,10 @@ index 8f6bffc..fcac7be 100644
  
  SUBDIRS				= include src util schema client server nanny \
 -				  autoip4 dhcp4 dhcp6 etc extensions man doc testing
-+				  autoip4 dhcp4 dhcp6 etc
++				  dhcp4 dhcp6 etc
  
  
  pkgconfig_DATA			= wicked.pc
 -- 
-2.21.0
+2.21.3
 

--- a/packages/wicked/0003-ship-mkconst-and-schema-sources-for-runtime-use.patch
+++ b/packages/wicked/0003-ship-mkconst-and-schema-sources-for-runtime-use.patch
@@ -1,4 +1,4 @@
-From 859c79f5df14d9cff3383b6ee2709080f38b88c4 Mon Sep 17 00:00:00 2001
+From d108d9eee746b0d9a03f8fd124cbf651da9ba254 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 10 Aug 2019 18:31:42 +0000
 Subject: [PATCH 3/3] ship mkconst and schema sources for runtime use
@@ -44,5 +44,5 @@ index 2af1435..bb9697e 100644
  AM_CPPFLAGS			= -I$(top_srcdir)/src	\
  				  -I$(top_srcdir)/include
 -- 
-2.21.0
+2.21.3
 

--- a/packages/wicked/wicked.service
+++ b/packages/wicked/wicked.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=wicked managed network interfaces
+Wants=network.target wickedd.service wickedd-nanny.service
+After=network-pre.target wickedd.service wickedd-nanny.service
+Before=network-online.target network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+LimitCORE=infinity
+ExecStart=/usr/sbin/wicked --systemd ifup all
+ExecStop=/usr/sbin/wicked --systemd ifdown all
+ExecReload=/usr/sbin/wicked --systemd ifreload all
+
+[Install]
+WantedBy=multi-user.target network-online.target
+Alias=network.service
+Also=wickedd.service

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -26,6 +26,13 @@ Source12: common.xml
 Source13: nanny.xml
 Source14: server.xml
 
+# Override service units to make it easier to pass new options.
+Source20: wicked.service
+Source21: wickedd.service
+Source22: wickedd-dhcp4.service
+Source23: wickedd-dhcp6.service
+Source24: wickedd-nanny.service
+
 %if %{without bootstrap}
 Source99: constants.xml
 %endif
@@ -89,6 +96,10 @@ install -p -m 0644 %{S:11} %{S:12} %{S:13} %{S:14} \
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:10} %{buildroot}%{_cross_tmpfilesdir}/wicked.conf
 
+rm -f %{buildroot}%{_cross_unitdir}/*.service
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{S:24} \
+  %{buildroot}%{_cross_unitdir}
+
 %if %{without bootstrap}
 # install our pre-generated constants
 install -p -m 0644 %{S:99} %{buildroot}%{_cross_datadir}/wicked/schema/constants.xml
@@ -106,10 +117,20 @@ install -p -m 0644 %{S:99} %{buildroot}%{_cross_datadir}/wicked/schema/constants
 %exclude %{_cross_sbindir}/mkconst
 %endif
 %dir %{_cross_libexecdir}/wicked
-%{_cross_libexecdir}/wicked/*
+%dir %{_cross_libexecdir}/wicked/bin
+%{_cross_libexecdir}/wicked/bin/wickedd-dhcp4
+%{_cross_libexecdir}/wicked/bin/wickedd-dhcp6
 %{_cross_libdir}/libwicked-%{version}.so
-%{_cross_unitdir}/wicked*.service
-%{_cross_datadir}/dbus-1/system.d/*.conf
+%{_cross_unitdir}/wicked.service
+%{_cross_unitdir}/wickedd.service
+%{_cross_unitdir}/wickedd-dhcp4.service
+%{_cross_unitdir}/wickedd-dhcp6.service
+%{_cross_unitdir}/wickedd-nanny.service
+%{_cross_datadir}/dbus-1/system.d/org.opensuse.Network.DHCP4.conf
+%{_cross_datadir}/dbus-1/system.d/org.opensuse.Network.DHCP6.conf
+%{_cross_datadir}/dbus-1/system.d/org.opensuse.Network.Nanny.conf
+%{_cross_datadir}/dbus-1/system.d/org.opensuse.Network.conf
+%exclude %{_cross_datadir}/dbus-1/system.d/org.opensuse.Network.AUTO4.conf
 %dir %{_cross_datadir}/wicked
 %{_cross_datadir}/wicked/*
 %if %{without bootstrap}

--- a/packages/wicked/wickedd-dhcp4.service
+++ b/packages/wicked/wickedd-dhcp4.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=wicked DHCPv4 supplicant service
+Requisite=dbus.service
+After=local-fs.target dbus.service network-pre.target
+Before=wickedd.service wicked.service network.target
+PartOf=wickedd.service
+
+[Service]
+Type=notify
+LimitCORE=infinity
+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp4 --systemd --foreground
+StandardError=null
+Restart=on-abort

--- a/packages/wicked/wickedd-dhcp6.service
+++ b/packages/wicked/wickedd-dhcp6.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=wicked DHCPv6 supplicant service
+Requisite=dbus.service
+After=local-fs.target dbus.service network-pre.target
+Before=wickedd.service wicked.service network.target
+PartOf=wickedd.service
+
+[Service]
+Type=notify
+LimitCORE=infinity
+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp6 --systemd --foreground
+StandardError=null
+Restart=on-abort

--- a/packages/wicked/wickedd-nanny.service
+++ b/packages/wicked/wickedd-nanny.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=wicked network nanny service
+Requisite=dbus.service
+After=local-fs.target dbus.service network-pre.target wickedd.service
+Before=wicked.service network.target
+PartOf=wickedd.service
+
+[Service]
+Type=notify
+LimitCORE=infinity
+ExecStart=/usr/sbin/wickedd-nanny --systemd --foreground
+StandardError=null
+Restart=on-abort

--- a/packages/wicked/wickedd.service
+++ b/packages/wicked/wickedd.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=wicked network management service daemon
+Requisite=dbus.service
+Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service systemd-udev-settle.service
+After=local-fs.target dbus.service network-pre.target systemd-udev-settle.service
+Before=wickedd-nanny.service wicked.service network.target
+
+[Service]
+Type=notify
+LimitCORE=infinity
+ExecStart=/usr/sbin/wickedd --systemd --foreground
+StandardError=null
+Restart=on-abort
+
+[Install]
+Also=wickedd-nanny.service
+Also=wickedd-dhcp4.service
+Also=wickedd-dhcp6.service


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This makes it easier to pass new options, for example to change the log output level for debugging purposes. Drop the auto4 service and helper binary, since we don't use auto4.

I also cleaned up references to services and environment files that we don't use.


**Testing done:**
Built an AMI, verified that networking still works.

Diff of upstream units for reference:
```
❯ for i in *.service ; do git diff --word-diff --no-index wicked-version-0.6.66/etc/systemd/$i.in $i ; done
diff --git a/wicked-version-0.6.66/etc/systemd/wickedd-dhcp4.service.in b/wickedd-dhcp4.service
index 5d9af3d9..2a5868fe 100644
--- a/wicked-version-0.6.66/etc/systemd/wickedd-dhcp4.service.in
+++ b/wickedd-dhcp4.service
@@ -1,18 +1,13 @@
[Unit]
Description=wicked DHCPv4 supplicant service
Requisite=dbus.service
After=local-fs.target dbus.service network-pre.target[-SuSEfirewall2_init.service-]
Before=wickedd.service wicked.service network.target
PartOf=wickedd.service

[Service]
Type=notify
LimitCORE=infinity
[-EnvironmentFile=-/etc/sysconfig/network/config-]
[-ExecStart=@wicked_supplicantdir@/wickedd-dhcp4-]{+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp4+} --systemd --foreground
StandardError=null
Restart=on-abort

[-[Install]-]
[-Alias=dbus-org.opensuse.Network.DHCP4.service-]

diff --git a/wicked-version-0.6.66/etc/systemd/wickedd-dhcp6.service.in b/wickedd-dhcp6.service
index 61e3fc93..a15c9488 100644
--- a/wicked-version-0.6.66/etc/systemd/wickedd-dhcp6.service.in
+++ b/wickedd-dhcp6.service
@@ -1,18 +1,13 @@
[Unit]
Description=wicked DHCPv6 supplicant service
Requisite=dbus.service
After=local-fs.target dbus.service network-pre.target[-SuSEfirewall2_init.service-]
Before=wickedd.service wicked.service network.target
PartOf=wickedd.service

[Service]
Type=notify
LimitCORE=infinity
[-EnvironmentFile=-/etc/sysconfig/network/config-]
[-ExecStart=@wicked_supplicantdir@/wickedd-dhcp6-]{+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp6+} --systemd --foreground
StandardError=null
Restart=on-abort

[-[Install]-]
[-Alias=dbus-org.opensuse.Network.DHCP6.service-]

diff --git a/wicked-version-0.6.66/etc/systemd/wickedd-nanny.service.in b/wickedd-nanny.service
index d039ff37..b8640a7b 100644
--- a/wicked-version-0.6.66/etc/systemd/wickedd-nanny.service.in
+++ b/wickedd-nanny.service
@@ -1,18 +1,13 @@
[Unit]
Description=wicked network nanny service
Requisite=dbus.service
After=local-fs.target dbus.service network-pre.target[-SuSEfirewall2_init.service-] wickedd.service
Before=wicked.service network.target
PartOf=wickedd.service

[Service]
Type=notify
LimitCORE=infinity
[-EnvironmentFile=-/etc/sysconfig/network/config-]
[-ExecStart=@wicked_sbindir@/wickedd-nanny-]{+ExecStart=/usr/sbin/wickedd-nanny+} --systemd --foreground
StandardError=null
Restart=on-abort

[-[Install]-]
[-Alias=dbus-org.opensuse.Network.Nanny.service-]

diff --git a/wicked-version-0.6.66/etc/systemd/wickedd.service.in b/wickedd.service
index 4988716d..058dc28c 100644
--- a/wicked-version-0.6.66/etc/systemd/wickedd.service.in
+++ b/wickedd.service
@@ -1,20 +1,18 @@
[Unit]
Description=wicked network management service daemon
Requisite=dbus.service
Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service[-wickedd-auto4.service-] systemd-udev-settle.service
After=local-fs.target dbus.service[-isdn.service rdma.service-] network-pre.target[-SuSEfirewall2_init.service-] systemd-udev-settle.service[-openvswitch.service-]
Before=wickedd-nanny.service wicked.service network.target

[Service]
Type=notify
LimitCORE=infinity
[-EnvironmentFile=-/etc/sysconfig/network/config-]
[-ExecStart=@wicked_sbindir@/wickedd-]{+ExecStart=/usr/sbin/wickedd+} --systemd --foreground
StandardError=null
Restart=on-abort

[Install]
Also=wickedd-nanny.service
[-Also=wickedd-auto4.service-]
Also=wickedd-dhcp4.service
Also=wickedd-dhcp6.service

diff --git a/wicked-version-0.6.66/etc/systemd/wicked.service.in b/wicked.service
index 0503b2cf..ab72e20d 100644
--- a/wicked-version-0.6.66/etc/systemd/wicked.service.in
+++ b/wicked.service
@@ -8,13 +8,11 @@ Before=network-online.target network.target
Type=oneshot
RemainAfterExit=yes
LimitCORE=infinity
[-EnvironmentFile=-/etc/sysconfig/network/config-]
[-ExecStart=@wicked_sbindir@/wicked-]{+ExecStart=/usr/sbin/wicked+} --systemd ifup all
[-ExecStop=@wicked_sbindir@/wicked-]{+ExecStop=/usr/sbin/wicked+} --systemd ifdown all
[-ExecReload=@wicked_sbindir@/wicked-]{+ExecReload=/usr/sbin/wicked+} --systemd ifreload all

[Install]
WantedBy=multi-user.target network-online.target
Alias=network.service
Also=wickedd.service
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
