### PR TITLE
add fixes to improve boot speed

### DIFF
--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -32,8 +32,8 @@ for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
 done
 
 %install
-install -d %{buildroot}%{_cross_factorydir}/opt/cni/bin
-install -p -m 0755 bin/* %{buildroot}%{_cross_factorydir}/opt/cni/bin
+install -d %{buildroot}%{_cross_libexecdir}/cni/bin
+install -p -m 0755 bin/* %{buildroot}%{_cross_libexecdir}/cni/bin
 
 %cross_scan_attribution go-vendor vendor
 
@@ -41,23 +41,22 @@ install -p -m 0755 bin/* %{buildroot}%{_cross_factorydir}/opt/cni/bin
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%dir %{_cross_factorydir}/opt/cni/bin
-%{_cross_factorydir}/opt/cni/bin/loopback
-%{_cross_factorydir}/opt/cni/bin/bandwidth
-%{_cross_factorydir}/opt/cni/bin/bridge
-%{_cross_factorydir}/opt/cni/bin/dhcp
-%{_cross_factorydir}/opt/cni/bin/firewall
-%{_cross_factorydir}/opt/cni/bin/flannel
-%{_cross_factorydir}/opt/cni/bin/host-device
-%{_cross_factorydir}/opt/cni/bin/host-local
-%{_cross_factorydir}/opt/cni/bin/ipvlan
-%{_cross_factorydir}/opt/cni/bin/macvlan
-%{_cross_factorydir}/opt/cni/bin/portmap
-%{_cross_factorydir}/opt/cni/bin/ptp
-%{_cross_factorydir}/opt/cni/bin/sbr
-%{_cross_factorydir}/opt/cni/bin/static
-%{_cross_factorydir}/opt/cni/bin/tuning
-%{_cross_factorydir}/opt/cni/bin/vlan
-%{_cross_factorydir}/opt/cni/bin/vrf
+%{_cross_libexecdir}/cni/bin/loopback
+%{_cross_libexecdir}/cni/bin/bandwidth
+%{_cross_libexecdir}/cni/bin/bridge
+%{_cross_libexecdir}/cni/bin/dhcp
+%{_cross_libexecdir}/cni/bin/firewall
+%{_cross_libexecdir}/cni/bin/flannel
+%{_cross_libexecdir}/cni/bin/host-device
+%{_cross_libexecdir}/cni/bin/host-local
+%{_cross_libexecdir}/cni/bin/ipvlan
+%{_cross_libexecdir}/cni/bin/macvlan
+%{_cross_libexecdir}/cni/bin/portmap
+%{_cross_libexecdir}/cni/bin/ptp
+%{_cross_libexecdir}/cni/bin/sbr
+%{_cross_libexecdir}/cni/bin/static
+%{_cross_libexecdir}/cni/bin/tuning
+%{_cross_libexecdir}/cni/bin/vlan
+%{_cross_libexecdir}/cni/bin/vrf
 
 %changelog

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -30,13 +30,12 @@ Requires: %{_cross_os}iptables
 go build -buildmode=pie -ldflags=-linkmode=external -o "bin/cnitool" %{goimport}/cnitool
 
 %install
-install -d %{buildroot}%{_cross_factorydir}/opt/cni/bin
-install -p -m 0755 bin/cnitool %{buildroot}%{_cross_factorydir}/opt/cni/bin
+install -d %{buildroot}%{_cross_libexecdir}/cni/bin
+install -p -m 0755 bin/cnitool %{buildroot}%{_cross_libexecdir}/cni/bin
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
-%dir %{_cross_factorydir}/opt/cni/bin
-%{_cross_factorydir}/opt/cni/bin/cnitool
+%{_cross_libexecdir}/cni/bin/cnitool
 
 %changelog

--- a/packages/containerd/containerd-tmpfiles.conf
+++ b/packages/containerd/containerd-tmpfiles.conf
@@ -1,3 +1,1 @@
 d /etc/cni/net.d - - - -
-R /opt/cni/bin - - - -
-C /opt/cni/bin - - - -

--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -20,7 +20,7 @@ mkdir -p %{buildroot}%{_cross_prefix}
 mkdir -p %{buildroot}%{_cross_bindir}
 mkdir -p %{buildroot}%{_cross_sbindir}
 mkdir -p %{buildroot}%{_cross_libdir}
-mkdir -p %{buildroot}%{_cross_libexecdir}
+mkdir -p %{buildroot}%{_cross_libexecdir}/cni/bin
 mkdir -p %{buildroot}%{_cross_includedir}
 mkdir -p %{buildroot}%{_cross_sysconfdir}
 mkdir -p %{buildroot}%{_cross_datadir}

--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -73,3 +73,9 @@ CONFIG_KERNEL_ZSTD=y
 CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
+
+# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
+# them before mounting the root device.
+CONFIG_SERIO_I8042=m
+CONFIG_KEYBOARD_ATKBD=m
+CONFIG_MOUSE_PS2=m

--- a/packages/kernel-5.4/config-bottlerocket
+++ b/packages/kernel-5.4/config-bottlerocket
@@ -73,3 +73,9 @@ CONFIG_KERNEL_ZSTD=y
 CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
+
+# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
+# them before mounting the root device.
+CONFIG_SERIO_I8042=m
+CONFIG_KEYBOARD_ATKBD=m
+CONFIG_MOUSE_PS2=m

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -56,6 +56,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 
 %build
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
+export GOFLAGS='-tags=dockerless'
 export GOLDFLAGS="-buildmode=pie -linkmode=external"
 make WHAT="cmd/kubelet"
 

--- a/packages/kubernetes-1.20/kubernetes-1.20.spec
+++ b/packages/kubernetes-1.20/kubernetes-1.20.spec
@@ -56,6 +56,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 
 %build
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
+export GOFLAGS='-tags=dockerless'
 export GOLDFLAGS="-buildmode=pie -linkmode=external"
 make WHAT="cmd/kubelet"
 

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -71,6 +71,7 @@ make generated_files
 # Build kubelet with the target toolchain.
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
+export GOFLAGS='-tags=dockerless'
 export GOLDFLAGS="-buildmode=pie -linkmode=external"
 make WHAT="cmd/kubelet"
 

--- a/packages/release/activate-configured.service
+++ b/packages/release/activate-configured.service
@@ -6,7 +6,7 @@ Requires=preconfigured.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/systemctl set-default configured
-ExecStart=/usr/bin/systemctl isolate default
+ExecStart=/usr/bin/systemctl isolate default --no-block
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/activate-multi-user.service
+++ b/packages/release/activate-multi-user.service
@@ -6,7 +6,7 @@ Requires=configured.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/systemctl set-default multi-user
-ExecStart=/usr/bin/systemctl isolate default
+ExecStart=/usr/bin/systemctl isolate default --no-block
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/opt-cni-bin.mount
+++ b/packages/release/opt-cni-bin.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=CNI Plugin Directory (/opt/cni/bin)
+Conflicts=umount.target
+RequiresMountsFor=/var
+Before=local-fs.target umount.target
+
+[Mount]
+What=overlay
+Where=/opt/cni/bin
+Type=overlay
+Options=noatime,nosuid,nodev,lowerdir=/usr/libexec/cni/bin,upperdir=/var/lib/cni-plugins/.overlay/upper,workdir=/var/lib/cni-plugins/.overlay/work,context=system_u:object_r:local_t:s0
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -39,9 +39,9 @@ ExecStart=/usr/bin/mkdir -p ${LOCAL_DIR}/var ${LOCAL_DIR}/opt ${LOCAL_DIR}/mnt
 # development sources.
 ExecStart=/usr/bin/rm -rf ${LOCAL_DIR}/var/lib/kernel-devel
 ExecStart=/usr/bin/mkdir -p \
-    ${LOCAL_DIR}/var/lib/kernel-devel/lower \
-    ${LOCAL_DIR}/var/lib/kernel-devel/upper \
-    ${LOCAL_DIR}/var/lib/kernel-devel/work
+    ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/lower \
+    ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/upper \
+    ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/work
 
 RemainAfterExit=true
 StandardError=journal+console

--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -43,6 +43,14 @@ ExecStart=/usr/bin/mkdir -p \
     ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/upper \
     ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/work
 
+# Create the directories we need to set up a read-write overlayfs for any CNI
+# plugin binaries.
+ExecStart=/usr/bin/rm -rf ${LOCAL_DIR}/opt/cni ${LOCAL_DIR}/var/lib/cni-plugins
+ExecStart=/usr/bin/mkdir -p \
+    ${LOCAL_DIR}/opt/cni/bin \
+    ${LOCAL_DIR}/var/lib/cni-plugins/.overlay/upper \
+    ${LOCAL_DIR}/var/lib/cni-plugins/.overlay/work \
+
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -30,6 +30,7 @@ Source1007: opt.mount
 Source1008: var-lib-bottlerocket.mount
 Source1009: etc-cni.mount
 Source1010: mnt.mount
+Source1012: opt-cni-bin.mount
 
 # CD-ROM mount & associated udev rules
 Source1015: media-cdrom.mount
@@ -116,7 +117,7 @@ EOF
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} \
-  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} %{S:1011} \
+  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} %{S:1011} %{S:1012} \
   %{S:1015} %{S:1040} %{S:1041} %{S:1060} %{S:1061} %{S:1062} %{S:1080} \
   %{buildroot}%{_cross_unitdir}
 
@@ -171,6 +172,7 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/mnt.mount
 %{_cross_unitdir}/etc-cni.mount
+%{_cross_unitdir}/opt-cni-bin.mount
 %{_cross_unitdir}/media-cdrom.mount
 %{_cross_unitdir}/*-lower.mount
 %{_cross_unitdir}/*-kernels.mount

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -124,7 +124,7 @@ install -d %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d
 install -p -m 0644 %{S:1100} \
   %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
 
-LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/lower)
+LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/.overlay/lower)
 sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1020} > ${LOWERPATH}.mount
 install -p -m 0644 ${LOWERPATH}.mount %{buildroot}%{_cross_unitdir}
 

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -52,6 +52,9 @@ Source1062: load-crash-kernel.service
 # systemd cgroups/slices
 Source1080: runtime.slice
 
+# Drop-in units to override defaults
+Source1100: systemd-tmpfiles-setup-service-debug.conf
+
 BuildArch: noarch
 Requires: %{_cross_os}acpid
 Requires: %{_cross_os}audit
@@ -117,6 +120,10 @@ install -p -m 0644 \
   %{S:1015} %{S:1040} %{S:1041} %{S:1060} %{S:1061} %{S:1062} %{S:1080} \
   %{buildroot}%{_cross_unitdir}
 
+install -d %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d
+install -p -m 0644 %{S:1100} \
+  %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
+
 LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/lower)
 sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1020} > ${LOWERPATH}.mount
 install -p -m 0644 ${LOWERPATH}.mount %{buildroot}%{_cross_unitdir}
@@ -171,6 +178,8 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %{_cross_unitdir}/var-lib-bottlerocket.mount
 %{_cross_unitdir}/runtime.slice
 %{_cross_unitdir}/set-hostname.service
+%dir %{_cross_unitdir}/systemd-tmpfiles-setup.service.d
+%{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/motd
 %{_cross_templatedir}/proxy-env

--- a/packages/release/systemd-tmpfiles-setup-service-debug.conf
+++ b/packages/release/systemd-tmpfiles-setup-service-debug.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=SYSTEMD_LOG_LEVEL=debug

--- a/packages/release/usr-src-kernels.mount.in
+++ b/packages/release/usr-src-kernels.mount.in
@@ -1,14 +1,14 @@
 [Unit]
 Description=Kernel Development Sources (Read-Write)
 Conflicts=umount.target
-RequiresMountsFor=/var/lib/kernel-devel/lower
+RequiresMountsFor=/var/lib/kernel-devel/.overlay/lower
 Before=local-fs.target umount.target
 
 [Mount]
 What=overlay
 Where=PREFIX/src/kernels
 Type=overlay
-Options=noatime,nosuid,nodev,lowerdir=/var/lib/kernel-devel/lower,upperdir=/var/lib/kernel-devel/upper,workdir=/var/lib/kernel-devel/work,context=system_u:object_r:state_t:s0
+Options=noatime,nosuid,nodev,lowerdir=/var/lib/kernel-devel/.overlay/lower,upperdir=/var/lib/kernel-devel/.overlay/upper,workdir=/var/lib/kernel-devel/.overlay/work,context=system_u:object_r:state_t:s0
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/release/var-lib-kernel-devel-lower.mount.in
+++ b/packages/release/var-lib-kernel-devel-lower.mount.in
@@ -7,7 +7,7 @@ Before=local-fs.target umount.target
 
 [Mount]
 What=PREFIX/share/bottlerocket/kernel-devel.squashfs
-Where=/var/lib/kernel-devel/lower
+Where=/var/lib/kernel-devel/.overlay/lower
 Type=squashfs
 Options=defaults,ro,loop,noatime,nosuid,nodev,context=system_u:object_r:os_t:s0
 

--- a/packages/wicked/1001-avoid-gcrypt-dependency.patch
+++ b/packages/wicked/1001-avoid-gcrypt-dependency.patch
@@ -1,7 +1,7 @@
 From d7c3d65bf98d3695bfb2a831b1a6b3c65aa2a9fd Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Fri, 9 Aug 2019 16:39:28 +0000
-Subject: [PATCH 1/3] avoid gcrypt dependency
+Subject: [PATCH 1001/1004] avoid gcrypt dependency
 
 gcrypt is only used for its implementations of SHA-1 and MD5, in order
 to generate UUIDs to fingerprint the XML configuration files. These

--- a/packages/wicked/1002-exclude-unused-components.patch
+++ b/packages/wicked/1002-exclude-unused-components.patch
@@ -1,7 +1,7 @@
 From 73a6d2a91625771f2b3c87651fe234ac4dae4e75 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 10 Aug 2019 04:53:31 +0000
-Subject: [PATCH 2/3] exclude unused components
+Subject: [PATCH 1002/1004] exclude unused components
 
 The extensions are all shell scripts, which we don't support. The docs
 require a native helper program to generate, which doesn't work. While

--- a/packages/wicked/1003-ship-mkconst-and-schema-sources-for-runtime-use.patch
+++ b/packages/wicked/1003-ship-mkconst-and-schema-sources-for-runtime-use.patch
@@ -1,7 +1,7 @@
 From d108d9eee746b0d9a03f8fd124cbf651da9ba254 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 10 Aug 2019 18:31:42 +0000
-Subject: [PATCH 3/3] ship mkconst and schema sources for runtime use
+Subject: [PATCH 1003/1004] ship mkconst and schema sources for runtime use
 
 `mkconst` needs to be compiled for the host architecture, but relies
 on most of the sources in wicked and needs all of the same libraries.

--- a/packages/wicked/1004-adjust-safeguard-for-dhcp6-defer-timeout.patch
+++ b/packages/wicked/1004-adjust-safeguard-for-dhcp6-defer-timeout.patch
@@ -1,0 +1,30 @@
+From a9e6198232b38a778471f986ee416cb78d41e728 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Mon, 8 Nov 2021 05:13:35 +0000
+Subject: [PATCH 1004/1004] adjust safeguard for dhcp6 defer timeout
+
+For low timeout values, such as one second, we could sometimes wait
+twice as long as expected if the timer fired early. If we're within
+one second of the deadline, consider it done.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ src/dhcp6/fsm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/dhcp6/fsm.c b/src/dhcp6/fsm.c
+index b3284f6..690e365 100644
+--- a/src/dhcp6/fsm.c
++++ b/src/dhcp6/fsm.c
+@@ -563,7 +563,7 @@ ni_dhcp6_fsm_timeout(ni_dhcp6_device_t *dev)
+ 			/* Do we still need this safeguard? */
+ 			deadline = ni_dhcp6_remaining_time(&dev->start_time,
+ 						dev->config->defer_timeout);
+-			if (deadline) {
++			if (deadline > 1) {
+ 				deadline *= 1000;
+ 				ni_dhcp6_fsm_set_timeout_msec(dev, deadline);
+ 				dev->fsm.fail_on_timeout = 0;
+-- 
+2.21.3
+

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -40,9 +40,10 @@ Source99: constants.xml
 # upstream fixes
 
 # local hacks
-Patch101: 0001-avoid-gcrypt-dependency.patch
-Patch102: 0002-exclude-unused-components.patch
-Patch103: 0003-ship-mkconst-and-schema-sources-for-runtime-use.patch
+Patch1001: 1001-avoid-gcrypt-dependency.patch
+Patch1002: 1002-exclude-unused-components.patch
+Patch1003: 1003-ship-mkconst-and-schema-sources-for-runtime-use.patch
+Patch1004: 1004-adjust-safeguard-for-dhcp6-defer-timeout.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libdbus-devel

--- a/packages/wicked/wickedd-dhcp4.service
+++ b/packages/wicked/wickedd-dhcp4.service
@@ -8,6 +8,6 @@ PartOf=wickedd.service
 [Service]
 Type=notify
 LimitCORE=infinity
-ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp4 --systemd --foreground
+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp4 --systemd --foreground --log-level debug --debug most
 StandardError=null
 Restart=on-abort

--- a/packages/wicked/wickedd-dhcp6.service
+++ b/packages/wicked/wickedd-dhcp6.service
@@ -8,6 +8,6 @@ PartOf=wickedd.service
 [Service]
 Type=notify
 LimitCORE=infinity
-ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp6 --systemd --foreground
+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp6 --systemd --foreground --log-level debug --debug most
 StandardError=null
 Restart=on-abort

--- a/packages/wicked/wickedd.service
+++ b/packages/wicked/wickedd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=wicked network management service daemon
 Requisite=dbus.service
-Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service systemd-udev-settle.service
-After=local-fs.target dbus.service network-pre.target systemd-udev-settle.service
+Wants=wickedd-nanny.service wickedd-dhcp6.service wickedd-dhcp4.service
+After=local-fs.target dbus.service network-pre.target
 Before=wickedd-nanny.service wicked.service network.target
 
 [Service]

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -203,6 +203,7 @@ menuentry "${PRETTY_NAME} ${VERSION_ID}" {
    linux (\$root)/vmlinuz root=/dev/dm-0 \\
        ${KERNEL_PARAMETERS} \\
        rootwait ro \\
+       raid=noautodetect \\
        random.trust_cpu=on selinux=1 enforcing=1 \\
        systemd.log_target=journal-or-kmsg systemd.log_color=0 net.ifnames=0 \\
        biosdevname=0 dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["README.md"]
 [package.metadata.build-variant]
 kernel-parameters = [
     "console=tty0",
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"
 ]

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 [package.metadata.build-variant]
 kernel-parameters = [
     "console=tty0",
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
 ]
 included-packages = [
 # core

--- a/variants/aws-k8s-1.18/Cargo.toml
+++ b/variants/aws-k8s-1.18/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["README.md"]
 [package.metadata.build-variant]
 kernel-parameters = [
     "console=tty0",
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
 ]
 included-packages = [
     "aws-iam-authenticator",

--- a/variants/aws-k8s-1.19/Cargo.toml
+++ b/variants/aws-k8s-1.19/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["README.md"]
 [package.metadata.build-variant]
 kernel-parameters = [
     "console=tty0",
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
 ]
 included-packages = [
     "aws-iam-authenticator",

--- a/variants/aws-k8s-1.20/Cargo.toml
+++ b/variants/aws-k8s-1.20/Cargo.toml
@@ -20,7 +20,7 @@ included-packages = [
 ]
 kernel-parameters = [
     "console=tty0",
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
 ]
 
 [lib]

--- a/variants/aws-k8s-1.21/Cargo.toml
+++ b/variants/aws-k8s-1.21/Cargo.toml
@@ -20,7 +20,7 @@ included-packages = [
 ]
 kernel-parameters = [
     "console=tty0",
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
 ]
 
 [lib]

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["README.md"]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"

--- a/variants/vmware-k8s-1.20/Cargo.toml
+++ b/variants/vmware-k8s-1.20/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["README.md"]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"

--- a/variants/vmware-k8s-1.21/Cargo.toml
+++ b/variants/vmware-k8s-1.21/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["README.md"]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0",
+    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This is a collection of fixes to improve boot speed and time to a usable node - at least by 5 seconds, at most by 8 seconds.

Building `kubelet` with the "dockerless" tag saves 5 seconds during service startup, as otherwise cadvisor tries for five seconds to connect to the Docker daemon before printing an error.

The fix for the defer timeout in the wicked DHCPv6 client saves 1 second for around half of launches, in cases where the timer fires a little early and would otherwise trigger another 1 second wait.

Using an overlayfs for the CNI plugin directory saves a variable amount of time by avoiding a potentially slow copy to an unwritten EBS volume in the critical path. `systemd-tmpfiles-setup` previously took 900 milliseconds or more in most cases, and now takes 100 milliseconds or less, with most of the remaining time spent populating the SELinux modules in `/var/lib/selinux`.

Building support for the PS/2 controller, keyboard, and mouse as modules saves around 400 milliseconds during boot under KVM, as otherwise device mapper waits for the configuration to finish before mounting the root filesystem. They are still loaded later, after the root filesystem is mounted, but at that point we can do more work in parallel.

Disabling RAID auto-detect avoids another potential device wait and reduces `printk` messages. Writing to the console device at 115200 bits per second speeds up those operations by 12x. Console logging continues to be a drag on overall boot speed. We can turn it off altogether to gain at least 2 seconds, but only at a severe cost to debugging capabilities if anything goes wrong. Using the higher device speed obviously helps, but its impact is spread across all threads that might draw the short straw after triggering a `printk` call, and is difficult to quantify.

Removing the `udevadm settle` dependency doesn't yield a measurable improvement in boot speed, but does stop `systemd` from blaming `wicked` for slowing everything down.

I've kept the two commits that added debug output for `systemd-tmpfiles` and the wicked clients, since these were instrumental in identifying the underlying issues and confirming the fixes. These logs are all sent to the journal rather than the console, so they don't compete with existing output or slow down the boot.


**Testing done:**
For the kernel change: verified that the keyboard and mouse modules were still loaded on x86_64 nodes.

For the changes to kubelet and the CNI plugins directory: verified that sonobuoy runs passed for these versions, and that no Docker related error messages were logged to the journal.

For the "activate" targets: confirmed that these were no longer blamed by `systemd-analyze blame`, and that bootstrap containers still worked as expected.

For the wicked changes: confirmed that the DHCP6 client would defer after the first timeout, whether the timer fired slightly before or slightly after one second elapsed. On instances with DHCP6 enabled, the lease was successfully acquired.

For the udev settle change: used a hacked up local build where wicked was set up to manage "eth1" rather than "eth0", and verified that wicked would still configure the device if I renamed it into existence during the wait.

For the serial console changes: verified that console logs were present for AWS variants across a range of instance types - c1.xlarge, t2.large, m3.2xlarge, c3.large, c4.large, c5.large, c6g.large - and for VMware variants running on ESXi 7.0. Note that we're already using 115200 for GRUB as of #1701, so this setting has previously been validated on a smaller set of instance types.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
