### PR TITLE
docker: fix daemon-json template

### DIFF
--- a/packages/docker-engine/daemon-json
+++ b/packages/docker-engine/daemon-json
@@ -7,9 +7,11 @@
   "data-root": "/var/lib/docker",
   "selinux-enabled": true,
   "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 1024, "Hard": 4096 } }
+  {{#if settings.container-registry.mirrors}}
   {{#each settings.container-registry.mirrors}}
   {{#if (eq registry "docker.io" )}},
   "registry-mirrors": [{{join_array ", " endpoint}}]
   {{/if}}
   {{/each}}
+  {{/if}}
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Nov 11 15:52:17 2021 -0800

    docker: fix daemon-json template
    
    This fixes rendering of docker/daemon.json when
    container-registry.mirrors is not specified.

```


**Testing done:**
Launch instance with the following userdata, no container-registry.mirrors setting:
```
[settings.host-containers.admin]
enabled = true

[settings.host-containers.control]
enabled=true
```
Docker daemon.json renders correctly
```
bash-5.0# cat /etc/docker/daemon.json 
{
  "log-driver": "journald",
  "live-restore": true,
  "max-concurrent-downloads": 10,
  "storage-driver": "overlay2",
  "exec-opts": ["native.cgroupdriver=cgroupfs"],
  "data-root": "/var/lib/docker",
  "selinux-enabled": true,
  "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 1024, "Hard": 4096 } }
}
```

Launch instance with the following userdata, with container-registry.mirrors setting:
```
[settings.host-containers.admin]
enabled = true

[settings.host-containers.control]
enabled=true

[[settings.container-registry.mirrors]]
registry = "docker.io"
endpoint = ["https://registry-0.acme.com","https://registry-1.acme.com"]

[[settings.container-registry.mirrors]]
registry = "example"
endpoint = [ "hello", "hellohello"]
```
Docker daemon.json renders correctly:
```
bash-5.0# cat /etc/docker/daemon.json 
{
  "log-driver": "journald",
  "live-restore": true,
  "max-concurrent-downloads": 10,
  "storage-driver": "overlay2",
  "exec-opts": ["native.cgroupdriver=cgroupfs"],
  "data-root": "/var/lib/docker",
  "selinux-enabled": true,
  "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 1024, "Hard": 4096 } }
  ,
  "registry-mirrors": ["https://registry-0.acme.com", "https://registry-1.acme.com"]
  }
bash-5.0# 
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
