### PR TITLE
release: ensure /opt is mounted before /opt/cni/bin

### DIFF
--- a/packages/release/opt-cni-bin.mount
+++ b/packages/release/opt-cni-bin.mount
@@ -1,7 +1,7 @@
 [Unit]
 Description=CNI Plugin Directory (/opt/cni/bin)
 Conflicts=umount.target
-RequiresMountsFor=/var
+RequiresMountsFor=/var /opt
 Before=local-fs.target umount.target
 
 [Mount]


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Otherwise `/opt` might be bound over the mounted overlayfs, or `/opt/cni/bin` could fail to mount.


**Testing done:**
Confirmed that both `/var` and `/opt` are marked as dependencies, and that the overlay is still mounted and writable.

```
# systemctl list-dependencies opt-cni-bin.mount
opt-cni-bin.mount
● ├─opt.mount
● ├─system.slice
● └─var.mount
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
