### PR TITLE
GH Actions: add file types to ignore list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,22 @@ name: Build
 on:
   pull_request:
     branches: [develop]
+    # Here we list file types that don't affect the build and don't need to use
+    # up our Actions runners.
     paths-ignore: 
+      # draw.io (diagrams.net) files, the source of png images for docs
+      - '**.drawio'
+      # Example configuration files
+      - '**.example'
+      # Markdown documentation
       - '**.md'
+      # Images for documentation
+      - '**.png'
+      # Templates for README files
+      - '**.tpl'
+      # Sample config files and OpenAPI docs
+      - '**.yaml'
+
 jobs:
   build:
     runs-on: [self-hosted, linux, x64]


### PR DESCRIPTION
**Description of changes:**

#1823 used up Actions runners, which made me sad!  This adds some file types to the ignore list that have nothing to do with the BR build.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
