### PR TITLE
Add GovCloud regions to Quickstart guides

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -56,6 +56,8 @@ us-east-1
 us-east-2
 us-west-1
 us-west-2
+us-gov-east-1
+us-gov-west-1
 ```
 
 The official AMI IDs are stored in [public SSM parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters.html).

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -121,6 +121,8 @@ us-east-1
 us-east-2
 us-west-1
 us-west-2
+us-gov-east-1
+us-gov-west-1
 ```
 
 The official AMI IDs are stored in [public SSM parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters.html).
@@ -156,7 +158,12 @@ aws ssm get-parameters --region us-west-2 \
 
 ### Cluster setup
 
-*Note:* most commands will have a region argument; make sure to change it if you don't want to set up in us-west-2.
+*Note:* most commands will have a region argument; make sure to change it if you don't want to set up in us-west-2. 
+Also be aware that when operating in GovCloud the IAM ARNs will need to be updated to the following: `arn:aws-us-gov`.   
+For example:  
+ `arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy`   
+ will be updated to:  
+ `arn:aws-us-gov:iam::aws:policy/AmazonEKSWorkerNodePolicy`.
 
 You can set up a new cluster like this:
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Adds information for GovCloud regions to EKS and ECS quick start guides. 


**Testing done:**
Used ECS and EKS QuickStart guides to create clusters in GovCloud regions and verified successful cluster and node creation. Additionally verified that tasks were able to run on GovCloud Bottlerocket ECS clusters and that pods were able to properly deploy to GovCloud Bottlerocket EKS nodes. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
