### PR TITLE
add support for custom image sizes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,8 +164,12 @@ ARG VARIANT
 ARG PRETTY_NAME
 ARG IMAGE_NAME
 ARG IMAGE_FORMAT
+ARG OS_IMAGE_SIZE_GIB
+ARG DATA_IMAGE_SIZE_GIB
 ARG KERNEL_PARAMETERS
-ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} IMAGE_FORMAT=${IMAGE_FORMAT} KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
+ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
+    PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
+    KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
 WORKDIR /root
 
 USER root
@@ -174,6 +178,8 @@ RUN --mount=target=/host \
       --package-dir=/local/rpms \
       --output-dir=/local/output \
       --output-fmt=${IMAGE_FORMAT} \
+      --os-image-size-gib=${OS_IMAGE_SIZE_GIB} \
+      --data-image-size-gib=${DATA_IMAGE_SIZE_GIB} \
     && echo ${NOCACHE}
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -192,8 +192,9 @@ fn build_variant() -> Result<()> {
 
     if let Some(packages) = manifest.included_packages() {
         let image_format = manifest.image_format();
+        let image_layout = manifest.image_layout();
         let kernel_parameters = manifest.kernel_parameters();
-        VariantBuilder::build(&packages, image_format, kernel_parameters)
+        VariantBuilder::build(&packages, image_format, image_layout, kernel_parameters)
             .context(error::BuildAttempt)?;
     } else {
         println!("cargo:warning=No included packages in manifest. Skipping variant build.");

--- a/tools/partyplanner
+++ b/tools/partyplanner
@@ -110,9 +110,9 @@ PRIVATE_SCALE_FACTOR="24"
 
 # Populate the caller's tables with sizes and offsets for known partitions.
 set_partition_sizes() {
-  local disk_image_gib data_image_gib
+  local os_image_gib data_image_gib
   local -n pp_size pp_offset
-  disk_image_gib="${1:?}"
+  os_image_gib="${1:?}"
   data_image_gib="${2:?}"
 
   # Table for partition sizes, in MiB.
@@ -123,16 +123,16 @@ set_partition_sizes() {
 
   # Most of the partitions on the main image scale with the overall size.
   local boot_mib root_mib hash_mib reserved_mib private_mib
-  boot_mib="$((disk_image_gib * BOOT_SCALE_FACTOR))"
-  root_mib="$((disk_image_gib * ROOT_SCALE_FACTOR))"
-  hash_mib="$((disk_image_gib * HASH_SCALE_FACTOR))"
+  boot_mib="$((os_image_gib * BOOT_SCALE_FACTOR))"
+  root_mib="$((os_image_gib * ROOT_SCALE_FACTOR))"
+  hash_mib="$((os_image_gib * HASH_SCALE_FACTOR))"
 
   # Reserved space is everything left in the bank after the other partitions
   # are scaled, minus the fixed 5 MiB EFI partition in that bank.
-  reserved_mib=$((disk_image_gib * RESERVE_SCALE_FACTOR - EFI_MIB))
+  reserved_mib=$((os_image_gib * RESERVE_SCALE_FACTOR - EFI_MIB))
 
   # Private space scales per GiB, minus the BIOS and GPT partition overhead.
-  private_mib=$((disk_image_gib * PRIVATE_SCALE_FACTOR - OVERHEAD_MIB))
+  private_mib=$((os_image_gib * PRIVATE_SCALE_FACTOR - OVERHEAD_MIB))
 
   # Skip the GPT label at start of disk.
   local offset

--- a/tools/partyplanner
+++ b/tools/partyplanner
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+###############################################################################
+# Section 1: partition type GUIDs
+
+# Define partition type GUIDs for all OS-managed partitions. This is required
+# for the boot partition, where we set gptprio bits in the GUID-specific use
+# field, but we might as well do it for all of them.
+BOTTLEROCKET_BOOT_TYPECODE="6b636168-7420-6568-2070-6c616e657421"
+BOTTLEROCKET_ROOT_TYPECODE="5526016a-1a97-4ea4-b39a-b7c8c6ca4502"
+BOTTLEROCKET_HASH_TYPECODE="598f10af-c955-4456-6a99-7720068a6cea"
+BOTTLEROCKET_RESERVED_TYPECODE="0c5d99a5-d331-4147-baef-08e2b855bdc9"
+BOTTLEROCKET_PRIVATE_TYPECODE="440408bb-eb0b-4328-a6e5-a29038fad706"
+BOTTLEROCKET_DATA_TYPECODE="626f7474-6c65-6474-6861-726d61726b73"
+
+# Under BIOS, the firmware will transfer control to the MBR on the boot device,
+# which will pass control to the GRUB stage 2 binary written to the BIOS boot
+# partition. The BIOS does not attach any significance to this partition type,
+# but GRUB knows to install itself there when we run `grub-bios-setup`.
+BIOS_BOOT_TYPECODE="ef02"
+
+# Under EFI, the firmware will find the EFI system partition and execute the
+# program at a platform-defined path like `bootx64.efi`. The partition type
+# must match what the firmware expects.
+EFI_SYSTEM_TYPECODE="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+
+# Whichever entry point is used for booting the system, it's important to note
+# that only one build of GRUB is involved - the one that's installed during the
+# image build.
+
+# GRUB understands the GPT priorities scheme we use to find the active boot
+# partition; EFI and BIOS firmware does not. This is why we do not update GRUB
+# during our system updates; we would have no way to revert to an earlier copy
+# of the bootloader if it failed to boot.
+#
+# We may eventually want to have an active/passive scheme for EFI partitions,
+# to allow for potential GRUB and shim updates on EFI platforms in cases where
+# we need to deliver security fixes. For now, add a placeholder partition type
+# for an alternate bank.
+EFI_BACKUP_TYPECODE="B39CE39C-0A00-B4AB-2D11-F18F8237A21C"
+
+###############################################################################
+# Section 2: fixed size partitions and reservations
+
+# The GPT header and footer each take up 32 sectors, but we reserve a full MiB
+# so that partitions can all be aligned on MiB boundaries.
+GPT_MIB="1" # two per disk
+
+# The BIOS partition is only used on x86 platforms, and only needs to be large
+# enough for the GRUB stage 2. Increasing its size will reduce the size of the
+# "private" and "reserved" partitions. This should be relatively safe since we
+# don't apply image updates to those partitions.
+BIOS_MIB="4" # one per disk
+
+# The GPT and BIOS reservations are fixed overhead that will be deducted from
+# the space nominally given to the private partition used to persist settings.
+OVERHEAD_MIB="$((GPT_MIB * 2 + BIOS_MIB))"
+
+# The 'recommended' size for the EFI partition is 100MB but our EFI images are
+# under 1MB, so this will suffice for now. It would be possible to increase the
+# EFI partition size by taking space from the "reserved" area below.
+EFI_MIB="5" # one per bank
+
+###############################################################################
+# Section 3: variable sized partitions
+
+# These partitions scale based on image size. The scaling factors are chosen so
+# that we end up with the same partition sizes for the banks on a 2 GiB image,
+# which was the only image size we historically supported.
+#
+# !!! WARNING !!!
+#
+# Increasing any of these constants is very likely break systems on update,
+# since the corresponding partitions are adjacent on disk and have no room to
+# grow.
+BOOT_SCALE_FACTOR="20"
+ROOT_SCALE_FACTOR="460"
+HASH_SCALE_FACTOR="5"
+RESERVE_SCALE_FACTOR="15"
+PRIVATE_SCALE_FACTOR="24"
+
+###############################################################################
+# Section 4: ASCII art gallery
+
+# Layout for a 1 GiB OS image. Sizes marked with (*) scale with overall image
+# size, based on the constant factors above.
+
+#          +---------------------------------+
+#  Prelude | GPT header               1 MiB  | 5 MiB
+#          | BIOS boot partition      4 MiB  | Fixed size.
+#          +---------------------------------+
+#          | EFI system partition     5 MiB  |
+#          | Boot partition A        20 MiB* | (image size - prelude - postlude) / 2
+#   Bank A | Root partition A       460 MiB* | Example: (1 GiB - 5 MiB - 19 MiB) / 2
+#          | Hash partition A         5 MiB* |          500 MiB
+#          | Reserved partition A    10 MiB* |
+#          +---------------------------------+
+#          | EFI backup partition     5 MiB  |
+#          | Boot partition B        20 MiB* | (image size - prelude - postlude) / 2
+#   Bank B | Root partition B       460 MiB* | Example: (1 GiB - 5 MiB - 19 MiB) / 2
+#          | Hash partition B         5 MiB* |          500 MiB
+#          | Reserved partition B    10 MiB* |
+#          +---------------------------------+
+#          | Private partition       18 MiB* | (image size * 24 as MiB) - prelude
+# Postlude | GPT footer               1 MiB  | GPT is fixed, private partition grows.
+#          +---------------------------------+
+
+##############################################################################
+# Section 5: library functions
+
+# Populate the caller's tables with sizes and offsets for known partitions.
+set_partition_sizes() {
+  local disk_image_gib data_image_gib
+  local -n pp_size pp_offset
+  disk_image_gib="${1:?}"
+  data_image_gib="${2:?}"
+
+  # Table for partition sizes, in MiB.
+  pp_size="${3:?}"
+
+  # Table for partition offsets from start of disk, in MiB.
+  pp_offset="${4:?}"
+
+  # Most of the partitions on the main image scale with the overall size.
+  local boot_mib root_mib hash_mib reserved_mib private_mib
+  boot_mib="$((disk_image_gib * BOOT_SCALE_FACTOR))"
+  root_mib="$((disk_image_gib * ROOT_SCALE_FACTOR))"
+  hash_mib="$((disk_image_gib * HASH_SCALE_FACTOR))"
+
+  # Reserved space is everything left in the bank after the other partitions
+  # are scaled, minus the fixed 5 MiB EFI partition in that bank.
+  reserved_mib=$((disk_image_gib * RESERVE_SCALE_FACTOR - EFI_MIB))
+
+  # Private space scales per GiB, minus the BIOS and GPT partition overhead.
+  private_mib=$((disk_image_gib * PRIVATE_SCALE_FACTOR - OVERHEAD_MIB))
+
+  # Skip the GPT label at start of disk.
+  local offset
+  ((offset = 1))
+
+  pp_offset["BIOS"]="${offset}"
+  pp_size["BIOS"]="${BIOS_MIB}"
+  ((offset += BIOS_MIB))
+
+  for bank in A B ; do
+    pp_offset["EFI-${bank}"]="${offset}"
+    pp_size["EFI-${bank}"]="${EFI_MIB}"
+    ((offset += EFI_MIB))
+
+    pp_offset["BOOT-${bank}"]="${offset}"
+    pp_size["BOOT-${bank}"]="${boot_mib}"
+    ((offset += boot_mib))
+
+    pp_offset["ROOT-${bank}"]="${offset}"
+    pp_size["ROOT-${bank}"]="${root_mib}"
+    ((offset += root_mib))
+
+    pp_offset["HASH-${bank}"]="${offset}"
+    pp_size["HASH-${bank}"]="${hash_mib}"
+    ((offset += hash_mib))
+
+    pp_offset["RESERVED-${bank}"]="${offset}"
+    pp_size["RESERVED-${bank}"]="${reserved_mib}"
+    ((offset += reserved_mib))
+  done
+
+  pp_offset["PRIVATE"]="${offset}"
+  pp_size["PRIVATE"]="${private_mib}"
+  ((offset += private_mib))
+
+  # The data image is relatively easy to plan, at least until we add support
+  # for unified images. The first and last MiB are reserved for the GPT labels,
+  # and the remainder is for the lone "data" partition.
+  pp_size["DATA"]="$((data_image_gib * 1024 - GPT_MIB * 2))"
+  pp_offset["DATA"]="1"
+}
+
+# Populate the caller's table with labels for known partitions.
+set_partition_labels() {
+  local -n pp_label
+  pp_label="${1:?}"
+  pp_label["BIOS"]="BIOS-BOOT"
+  pp_label["DATA"]="BOTTLEROCKET-DATA"
+  pp_label["EFI-A"]="EFI-SYSTEM"
+  pp_label["EFI-B"]="EFI-BACKUP"
+  pp_label["PRIVATE"]="BOTTLEROCKET-PRIVATE"
+  for part in BOOT ROOT HASH RESERVED ; do
+    for bank in A B ; do
+      pp_label["${part}-${bank}"]="BOTTLEROCKET-${part}-${bank}"
+    done
+  done
+}
+
+# Populate the caller's table with GPT type codes for known partitions.
+set_partition_types() {
+  local -n pp_type
+  pp_type="${1:?}"
+  pp_type["BIOS"]="${BIOS_BOOT_TYPECODE}"
+  pp_type["DATA"]="${BOTTLEROCKET_DATA_TYPECODE}"
+  pp_type["EFI-A"]="${EFI_SYSTEM_TYPECODE}"
+  pp_type["EFI-B"]="${EFI_BACKUP_TYPECODE}"
+  pp_type["PRIVATE"]="${BOTTLEROCKET_PRIVATE_TYPECODE}"
+  local typecode
+  for part in BOOT ROOT HASH RESERVED ; do
+    for bank in A B ; do
+        typecode="BOTTLEROCKET_${part}_TYPECODE"
+        typecode="${!typecode}"
+        pp_type["${part}-${bank}"]="${typecode}"
+    done
+  done
+}

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -15,6 +15,8 @@ for opt in "$@"; do
       --package-dir=*) PACKAGE_DIR="${optarg}" ;;
       --output-dir=*) OUTPUT_DIR="${optarg}" ;;
       --output-fmt=*) OUTPUT_FMT="${optarg}" ;;
+      --os-image-size-gib=*) OS_IMAGE_SIZE_GIB="${optarg}" ;;
+      --data-image-size-gib=*) DATA_IMAGE_SIZE_GIB="${optarg}" ;;
    esac
 done
 
@@ -30,17 +32,14 @@ mkdir -p "${OUTPUT_DIR}"
 
 FILENAME_PREFIX="${IMAGE_NAME}-${VARIANT}-${ARCH}-${VERSION_ID}-${BUILD_ID}"
 
-DISK_IMAGE_BASENAME="${FILENAME_PREFIX}"
+OS_IMAGE_BASENAME="${FILENAME_PREFIX}"
 DATA_IMAGE_BASENAME="${FILENAME_PREFIX}-data"
 
 BOOT_IMAGE_NAME="${FILENAME_PREFIX}-boot.ext4.lz4"
 VERITY_IMAGE_NAME="${FILENAME_PREFIX}-root.verity.lz4"
 ROOT_IMAGE_NAME="${FILENAME_PREFIX}-root.ext4.lz4"
 
-DISK_IMAGE_SIZE_GIB="2"
-DATA_IMAGE_SIZE_GIB="1"
-
-DISK_IMAGE="$(mktemp)"
+OS_IMAGE="$(mktemp)"
 BOOT_IMAGE="$(mktemp)"
 VERITY_IMAGE="$(mktemp)"
 ROOT_IMAGE="$(mktemp)"
@@ -63,11 +62,11 @@ VERITY_HASH_ALGORITHM=sha256
 VERITY_DATA_BLOCK_SIZE=4096
 VERITY_HASH_BLOCK_SIZE=4096
 
-truncate -s "${DISK_IMAGE_SIZE_GIB}"G "${DISK_IMAGE}"
+truncate -s "${OS_IMAGE_SIZE_GIB}"G "${OS_IMAGE}"
 
 declare -A partlabel parttype partsize partoff
 set_partition_sizes \
-  "${DISK_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
+  "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   partsize partoff
 set_partition_labels partlabel
 set_partition_types parttype
@@ -100,7 +99,7 @@ do
   esac
 done
 
-sgdisk --clear "${partargs[@]}" --sort --print "${DISK_IMAGE}"
+sgdisk --clear "${partargs[@]}" --sort --print "${OS_IMAGE}"
 
 rpm -iv --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
 install -p -m 0644 /host/{COPYRIGHT,LICENSE-APACHE,LICENSE-MIT} "${ROOT_MOUNT}"/usr/share/licenses/
@@ -112,13 +111,13 @@ rm -rf "${ROOT_MOUNT}"/var/lib "${ROOT_MOUNT}"/usr/share/licenses/*
 
 if [[ "${ARCH}" == "x86_64" ]]; then
   # MBR and BIOS-BOOT
-  echo "(hd0) ${DISK_IMAGE}" > "${ROOT_MOUNT}/boot/grub/device.map"
+  echo "(hd0) ${OS_IMAGE}" > "${ROOT_MOUNT}/boot/grub/device.map"
   "${ROOT_MOUNT}/sbin/grub-bios-setup" \
      --directory="${ROOT_MOUNT}/boot/grub" \
      --device-map="${ROOT_MOUNT}/boot/grub/device.map" \
      --root="hd0" \
      --skip-fs-probe \
-     "${DISK_IMAGE}"
+     "${OS_IMAGE}"
 
   rm -vf "${ROOT_MOUNT}"/boot/grub/* "${ROOT_MOUNT}"/sbin/grub*
 fi
@@ -133,7 +132,7 @@ mkfs.vfat -I -S 512 "${EFI_IMAGE}" $((partsize[EFI-A] * 2048))
 mmd -i "${EFI_IMAGE}" ::/EFI
 mmd -i "${EFI_IMAGE}" ::/EFI/BOOT
 mcopy -i "${EFI_IMAGE}" "${EFI_MOUNT}/EFI/BOOT"/*.efi ::/EFI/BOOT
-dd if="${EFI_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[EFI-A]}"
+dd if="${EFI_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[EFI-A]}"
 
 # Ensure that the grub directory exists.
 mkdir -p "${ROOT_MOUNT}/boot/grub"
@@ -163,7 +162,7 @@ ROOT_LABELS=$(setfiles -n -d -F -m -r "${ROOT_MOUNT}" \
 mkfs.ext4 -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" "${partsize[ROOT-A]}M"
 echo "${ROOT_LABELS}" | debugfs -w -f - "${ROOT_IMAGE}"
 resize2fs -M "${ROOT_IMAGE}"
-dd if="${ROOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[ROOT-A]}"
+dd if="${ROOT_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[ROOT-A]}"
 
 # BOTTLEROCKET-VERITY-A
 veritypart_mib="${partsize[HASH-A]}"
@@ -186,7 +185,7 @@ VERITY_DATA_512B_BLOCKS="$((VERITY_DATA_4K_BLOCKS * 8))"
 VERITY_ROOT_HASH="$(grep '^Root hash:' <<<"${veritysetup_output}" | awk '{ print $NF }')"
 VERITY_SALT="$(grep '^Salt:' <<<"${veritysetup_output}" | awk '{ print $NF }')"
 veritysetup verify "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${VERITY_ROOT_HASH}"
-dd if="${VERITY_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[HASH-A]}"
+dd if="${VERITY_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[HASH-A]}"
 
 # write GRUB config
 cat <<EOF > "${BOOT_MOUNT}/grub/grub.cfg"
@@ -214,7 +213,7 @@ BOOT_LABELS=$(setfiles -n -d -F -m -r "${BOOT_MOUNT}" \
 mkfs.ext4 -O ^has_journal -d "${BOOT_MOUNT}" "${BOOT_IMAGE}" "${partsize[BOOT-A]}M"
 echo "${BOOT_LABELS}" | debugfs -w -f - "${BOOT_IMAGE}"
 resize2fs -M "${BOOT_IMAGE}"
-dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[BOOT-A]}"
+dd if="${BOOT_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[BOOT-A]}"
 
 # BOTTLEROCKET-PRIVATE
 
@@ -224,7 +223,7 @@ dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[BOOT
 # - retain the inode size to allow most settings to be stored inline
 # - retain the block size to handle worse-case alignment for hardware
 mkfs.ext4 -b 4096 -i 4096 -I 256 "${PRIVATE_IMAGE}" "${partsize[PRIVATE]}M"
-dd if="${PRIVATE_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
+dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
 
 # BOTTLEROCKET-DATA
 truncate -s "${DATA_IMAGE_SIZE_GIB}"G "${DATA_IMAGE}"
@@ -246,18 +245,18 @@ mkfs.ext4 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" "${partsize[DATA]}M"
 echo "${UNLABELED}" | debugfs -w -f - "${BOTTLEROCKET_DATA}"
 dd if="${BOTTLEROCKET_DATA}" of="${DATA_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA]}"
 
-sgdisk -v "${DISK_IMAGE}"
+sgdisk -v "${OS_IMAGE}"
 sgdisk -v "${DATA_IMAGE}"
 
 if [[ ${OUTPUT_FMT} == "raw" ]]; then
-  lz4 -vc "${DISK_IMAGE}" >"${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.img.lz4"
+  lz4 -vc "${OS_IMAGE}" >"${OUTPUT_DIR}/${OS_IMAGE_BASENAME}.img.lz4"
   lz4 -vc "${DATA_IMAGE}" >"${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.img.lz4"
 elif [[ ${OUTPUT_FMT} == "qcow2" ]]; then
-  qemu-img convert -f raw -O qcow2 "${DISK_IMAGE}" "${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.qcow2"
+  qemu-img convert -f raw -O qcow2 "${OS_IMAGE}" "${OUTPUT_DIR}/${OS_IMAGE_BASENAME}.qcow2"
   qemu-img convert -f raw -O qcow2 "${DATA_IMAGE}" "${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.qcow2"
 elif [[ ${OUTPUT_FMT} == "vmdk" ]]; then
   # Stream optimization is required for creating an Open Virtual Appliance (OVA)
-  qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "${DISK_IMAGE}" "${OUTPUT_DIR}/${DISK_IMAGE_BASENAME}.vmdk"
+  qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "${OS_IMAGE}" "${OUTPUT_DIR}/${OS_IMAGE_BASENAME}.vmdk"
   qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "${DATA_IMAGE}" "${OUTPUT_DIR}/${DATA_IMAGE_BASENAME}.vmdk"
 fi
 

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -3,6 +3,10 @@
 set -eu -o pipefail
 shopt -qs failglob
 
+# import the partition helper functions
+# shellcheck source=partyplanner
+. "${0%/*}/partyplanner"
+
 OUTPUT_FMT="raw"
 
 for opt in "$@"; do
@@ -33,6 +37,9 @@ BOOT_IMAGE_NAME="${FILENAME_PREFIX}-boot.ext4.lz4"
 VERITY_IMAGE_NAME="${FILENAME_PREFIX}-root.verity.lz4"
 ROOT_IMAGE_NAME="${FILENAME_PREFIX}-root.ext4.lz4"
 
+DISK_IMAGE_SIZE_GIB="2"
+DATA_IMAGE_SIZE_GIB="1"
+
 DISK_IMAGE="$(mktemp)"
 BOOT_IMAGE="$(mktemp)"
 VERITY_IMAGE="$(mktemp)"
@@ -56,58 +63,44 @@ VERITY_HASH_ALGORITHM=sha256
 VERITY_DATA_BLOCK_SIZE=4096
 VERITY_HASH_BLOCK_SIZE=4096
 
-# Define partition type GUIDs for all OS-managed partitions. This is required
-# for the boot partition, where we set gptprio bits in the GUID-specific use
-# field, but we might as well do it for all of them.
-BOTTLEROCKET_BOOT_TYPECODE="6b636168-7420-6568-2070-6c616e657421"
-BOTTLEROCKET_ROOT_TYPECODE="5526016a-1a97-4ea4-b39a-b7c8c6ca4502"
-BOTTLEROCKET_HASH_TYPECODE="598f10af-c955-4456-6a99-7720068a6cea"
-BOTTLEROCKET_RESERVED_TYPECODE="0c5d99a5-d331-4147-baef-08e2b855bdc9"
-BOTTLEROCKET_PRIVATE_TYPECODE="440408bb-eb0b-4328-a6e5-a29038fad706"
-BOTTLEROCKET_DATA_TYPECODE="626f7474-6c65-6474-6861-726d61726b73"
+truncate -s "${DISK_IMAGE_SIZE_GIB}"G "${DISK_IMAGE}"
 
-# Under BIOS, the firmware will transfer control to the MBR on the boot device,
-# which will pass control to the GRUB stage 2 binary written to the BIOS boot
-# partition. The BIOS does not attach any significance to this partition type,
-# but GRUB knows to install itself there when we run `grub-bios-setup`.
-BIOS_BOOT_TYPECODE="ef02"
+declare -A partlabel parttype partsize partoff
+set_partition_sizes \
+  "${DISK_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
+  partsize partoff
+set_partition_labels partlabel
+set_partition_types parttype
 
-# Under EFI, the firmware will find the EFI system partition and execute the
-# program at a platform-defined path like `bootx64.efi`. The partition type
-# must match what the firmware expects.
-EFI_SYSTEM_TYPECODE="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+declare -a partargs
+for part in \
+  BIOS \
+  EFI-A BOOT-A ROOT-A HASH-A RESERVED-A \
+  EFI-B BOOT-B ROOT-B HASH-B RESERVED-B \
+  PRIVATE ;
+do
+  # Each partition is aligned to a 1 MiB boundary, and extends to the sector
+  # before the next partition starts. Specify the end point in sectors so we
+  # can subtract a sector to fix the off-by-one error that comes from adding
+  # start and size together. (1 MiB contains 2048 512-byte sectors.)
+  part_start="${partoff[${part}]}"
+  part_end="$((part_start + partsize[${part}]))"
+  part_end="$((part_end * 2048 - 1))"
 
-# Whichever entry point is used for booting the system, it's important to note
-# that only one build of GRUB is involved - the one that's installed below when
-# we run this script. GRUB understands the GPT priorities scheme we use to find
-# the active boot partition; EFI and BIOS firmware does not. This is why we do
-# not update GRUB during our system updates; we would have no way to revert to
-# an earlier copy of the bootloader if it failed to boot.
-#
-# We may eventually want to have an active/passive scheme for EFI partitions,
-# to allow for potential GRUB and shim updates on EFI platforms in cases where
-# we need to deliver security fixes. For now, add a placeholder partition type
-# and reserve space for an alternate bank.
-EFI_BACKUP_TYPECODE="B39CE39C-0A00-B4AB-2D11-F18F8237A21C"
+  partargs+=(-n "0:${part_start}M:${part_end}")
+  partargs+=(-c "0:${partlabel[${part}]}")
+  partargs+=(-t "0:${parttype[${part}]}")
 
-truncate -s 2G "${DISK_IMAGE}"
-# efi: 5M + boot: 40M + root: 920M + hash: 10M + reserved: 25M = 1000M
-# boot partition attributes (-A): 48 = gptprio priority bit; 56 = gptprio successful bit
-# partitions are backwards so that we don't make things inconsistent when specifying a wrong end sector :)
-sgdisk --clear \
-   -n 0:2005M:2047M -c 0:"BOTTLEROCKET-PRIVATE"    -t 0:"${BOTTLEROCKET_PRIVATE_TYPECODE}" \
-   -n 0:1980M:0     -c 0:"BOTTLEROCKET-RESERVED-B" -t 0:"${BOTTLEROCKET_RESERVED_TYPECODE}" \
-   -n 0:1970M:0     -c 0:"BOTTLEROCKET-HASH-B"     -t 0:"${BOTTLEROCKET_HASH_TYPECODE}" \
-   -n 0:1050M:0     -c 0:"BOTTLEROCKET-ROOT-B"     -t 0:"${BOTTLEROCKET_ROOT_TYPECODE}" \
-   -n 0:1010M:0     -c 0:"BOTTLEROCKET-BOOT-B"     -t 0:"${BOTTLEROCKET_BOOT_TYPECODE}" -A 0:"clear":48 -A 0:"clear":56 \
-   -n 0:1005M:0     -c 0:"EFI-BACKUP"              -t 0:"${EFI_BACKUP_TYPECODE}" \
-   -n 0:980M:0      -c 0:"BOTTLEROCKET-RESERVED-A" -t 0:"${BOTTLEROCKET_RESERVED_TYPECODE}" \
-   -n 0:970M:0      -c 0:"BOTTLEROCKET-HASH-A"     -t 0:"${BOTTLEROCKET_HASH_TYPECODE}" \
-   -n 0:50M:0       -c 0:"BOTTLEROCKET-ROOT-A"     -t 0:"${BOTTLEROCKET_ROOT_TYPECODE}" \
-   -n 0:10M:0       -c 0:"BOTTLEROCKET-BOOT-A"     -t 0:"${BOTTLEROCKET_BOOT_TYPECODE}" -A 0:"set":48 -A 0:"set":56 \
-   -n 0:5M:0        -c 0:"EFI-SYSTEM"              -t 0:"${EFI_SYSTEM_TYPECODE}" \
-   -n 0:1M:0        -c 0:"BIOS-BOOT"               -t 0:"${BIOS_BOOT_TYPECODE}" \
-   --sort --print "${DISK_IMAGE}"
+  # Boot partition attributes:
+  #  48 = gptprio priority bit
+  #  56 = gptprio successful bit
+  case "${part}" in
+    BOOT-A) partargs+=(-A 0:"set":48 -A 0:"set":56) ;;
+    BOOT-B) partargs+=(-A 0:"clear":48 -A 0:"clear":56) ;;
+  esac
+done
+
+sgdisk --clear "${partargs[@]}" --sort --print "${DISK_IMAGE}"
 
 rpm -iv --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
 install -p -m 0644 /host/{COPYRIGHT,LICENSE-APACHE,LICENSE-MIT} "${ROOT_MOUNT}"/usr/share/licenses/
@@ -135,14 +128,12 @@ fi
 # package has placed the image in /boot/efi/EFI/BOOT.
 mv "${ROOT_MOUNT}/boot/efi"/* "${EFI_MOUNT}"
 
-# The 'recommended' size for the EFI partition is 100MB but our EFI
-# images are under 1MB, so this will suffice for now.
-dd if=/dev/zero of="${EFI_IMAGE}" bs=1M count=5
-mkfs.vfat -I -S 512 "${EFI_IMAGE}" $((5*2048))
+dd if=/dev/zero of="${EFI_IMAGE}" bs=1M count="${partsize[EFI-A]}"
+mkfs.vfat -I -S 512 "${EFI_IMAGE}" $((partsize[EFI-A] * 2048))
 mmd -i "${EFI_IMAGE}" ::/EFI
 mmd -i "${EFI_IMAGE}" ::/EFI/BOOT
 mcopy -i "${EFI_IMAGE}" "${EFI_MOUNT}/EFI/BOOT"/*.efi ::/EFI/BOOT
-dd if="${EFI_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=5
+dd if="${EFI_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[EFI-A]}"
 
 # Ensure that the grub directory exists.
 mkdir -p "${ROOT_MOUNT}/boot/grub"
@@ -169,13 +160,14 @@ mkdir -p "${ROOT_MOUNT}/lost+found"
 ROOT_LABELS=$(setfiles -n -d -F -m -r "${ROOT_MOUNT}" \
     "${SELINUX_FILE_CONTEXTS}" "${ROOT_MOUNT}" \
     | awk -v root="${ROOT_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_set", $1, "security.selinux", $4}')
-mkfs.ext4 -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" 920M
+mkfs.ext4 -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" "${partsize[ROOT-A]}M"
 echo "${ROOT_LABELS}" | debugfs -w -f - "${ROOT_IMAGE}"
 resize2fs -M "${ROOT_IMAGE}"
-dd if="${ROOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=50
+dd if="${ROOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[ROOT-A]}"
 
 # BOTTLEROCKET-VERITY-A
-truncate -s 8M "${VERITY_IMAGE}"
+veritypart_mib="${partsize[HASH-A]}"
+truncate -s "${veritypart_mib}M" "${VERITY_IMAGE}"
 veritysetup_output="$(veritysetup format \
     --format "$VERITY_VERSION" \
     --hash "$VERITY_HASH_ALGORITHM" \
@@ -183,16 +175,18 @@ veritysetup_output="$(veritysetup format \
     --hash-block-size "$VERITY_HASH_BLOCK_SIZE" \
     "${ROOT_IMAGE}" "${VERITY_IMAGE}" \
     | tee /dev/stderr)"
-if ! stat -c %s "${VERITY_IMAGE}" | grep -q '^8388608$'; then
-    echo "verity partition is larger than expected (8M)"
+verityimage_size="$(stat -c %s "${VERITY_IMAGE}")"
+veritypart_bytes="$((veritypart_mib * 1024 * 1024))"
+if [ "${verityimage_size}" -gt "${veritypart_bytes}" ] ; then
+    echo "verity content is larger than partition (${veritypart_mib}M)"
     exit 1
 fi
-VERITY_DATA_4K_BLOCKS="$(grep '^Data blocks:' <<<$veritysetup_output | awk '{ print $NF }')"
-VERITY_DATA_512B_BLOCKS="$(($VERITY_DATA_4K_BLOCKS * 8))"
-VERITY_ROOT_HASH="$(grep '^Root hash:' <<<$veritysetup_output | awk '{ print $NF }')"
-VERITY_SALT="$(grep '^Salt:' <<<$veritysetup_output | awk '{ print $NF }')"
+VERITY_DATA_4K_BLOCKS="$(grep '^Data blocks:' <<<"${veritysetup_output}" | awk '{ print $NF }')"
+VERITY_DATA_512B_BLOCKS="$((VERITY_DATA_4K_BLOCKS * 8))"
+VERITY_ROOT_HASH="$(grep '^Root hash:' <<<"${veritysetup_output}" | awk '{ print $NF }')"
+VERITY_SALT="$(grep '^Salt:' <<<"${veritysetup_output}" | awk '{ print $NF }')"
 veritysetup verify "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${VERITY_ROOT_HASH}"
-dd if="${VERITY_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=970
+dd if="${VERITY_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[HASH-A]}"
 
 # write GRUB config
 cat <<EOF > "${BOOT_MOUNT}/grub/grub.cfg"
@@ -217,10 +211,10 @@ mkdir -p "${BOOT_MOUNT}/lost+found"
 BOOT_LABELS=$(setfiles -n -d -F -m -r "${BOOT_MOUNT}" \
     "${SELINUX_FILE_CONTEXTS}" "${BOOT_MOUNT}" \
   | awk -v root="${BOOT_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_set", $1, "security.selinux", $4}')
-mkfs.ext4 -O ^has_journal -d "${BOOT_MOUNT}" "${BOOT_IMAGE}" 40M
+mkfs.ext4 -O ^has_journal -d "${BOOT_MOUNT}" "${BOOT_IMAGE}" "${partsize[BOOT-A]}M"
 echo "${BOOT_LABELS}" | debugfs -w -f - "${BOOT_IMAGE}"
 resize2fs -M "${BOOT_IMAGE}"
-dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=10
+dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[BOOT-A]}"
 
 # BOTTLEROCKET-PRIVATE
 
@@ -229,23 +223,28 @@ dd if="${BOOT_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=10
 # - adjust the inode ratio since we expect lots of small files
 # - retain the inode size to allow most settings to be stored inline
 # - retain the block size to handle worse-case alignment for hardware
-mkfs.ext4 -b 4096 -i 4096 -I 256 "${PRIVATE_IMAGE}" 42M
-dd if="${PRIVATE_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek=2005
+mkfs.ext4 -b 4096 -i 4096 -I 256 "${PRIVATE_IMAGE}" "${partsize[PRIVATE]}M"
+dd if="${PRIVATE_IMAGE}" of="${DISK_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
 
 # BOTTLEROCKET-DATA
-truncate -s 1G "${DATA_IMAGE}"
+truncate -s "${DATA_IMAGE_SIZE_GIB}"G "${DATA_IMAGE}"
+data_start="${partoff[DATA]}"
+data_end=$((data_start + partsize[DATA]))
+data_end=$((data_end * 2048 - 1))
 sgdisk --clear \
-   -n 0:1M:1023M -c 0:"BOTTLEROCKET-DATA" -t 0:"${BOTTLEROCKET_DATA_TYPECODE}" \
-   --sort --print "${DATA_IMAGE}"
+  -n "0:${data_start}M:${data_end}" \
+  -c "0:${partlabel[DATA]}" \
+  -t "0:${parttype[DATA]}" \
+  --sort --print "${DATA_IMAGE}"
 # If we build on a host with SELinux enabled, we could end up with labels that
 # do not match our policy. Since we allow replacing the data volume at runtime,
 # we can't count on these labels being correct in any case, and it's better to
 # remove them all.
 UNLABELED=$(find "${DATA_MOUNT}" \
     | awk -v root="${DATA_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_rm", $1, "security.selinux"}')
-mkfs.ext4 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" 1022M
+mkfs.ext4 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" "${partsize[DATA]}M"
 echo "${UNLABELED}" | debugfs -w -f - "${BOTTLEROCKET_DATA}"
-dd if="${BOTTLEROCKET_DATA}" of="${DATA_IMAGE}" conv=notrunc bs=1M seek=1
+dd if="${BOTTLEROCKET_DATA}" of="${DATA_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA]}"
 
 sgdisk -v "${DISK_IMAGE}"
 sgdisk -v "${DATA_IMAGE}"


### PR DESCRIPTION
**Issue number:**
Fixes #1821


**Description of changes:**
Refactor partition layout code into a helper library, and add support for custom OS and data image sizes in the variant specification.

Fix a bug that affected the last partition on each disk, where it was one sector larger than intended. (The corresponding filesystems were already the correct size.)


**Testing done:**
- [x] verify that the partition offsets are the same (modulo fix) for the default layout
- [x] verify that an undersized hash partition is rejected by the new check
- [x] verify that in-place upgrade works for the default layout, since this touches the GPT priority bits
- [x] verify that in-place upgrade works for custom layouts with a larger OS image

Confirmed that the "old" and "new" layouts only differ by one sector in the last partition.

**Old layout**
```
Sector size (logical): 512 bytes
Disk identifier (GUID): 309D0119-AA57-4863-B5DE-37833FEE0E97
Partition table holds up to 128 entries
Main partition table begins at sector 2 and ends at sector 33
First usable sector is 34, last usable sector is 4194270
Partitions will be aligned on 2048-sector boundaries
Total free space is 4028 sectors (2.0 MiB)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     EF02  BIOS-BOOT
   2           10240           20479   5.0 MiB     EF00  EFI-SYSTEM
   3           20480          102399   40.0 MiB    FFFF  BOTTLEROCKET-BOOT-A
   4          102400         1986559   920.0 MiB   FFFF  BOTTLEROCKET-ROOT-A
   5         1986560         2007039   10.0 MiB    FFFF  BOTTLEROCKET-HASH-A
   6         2007040         2058239   25.0 MiB    FFFF  BOTTLEROCKET-RESERV...
   7         2058240         2068479   5.0 MiB     FFFF  EFI-BACKUP
   8         2068480         2150399   40.0 MiB    FFFF  BOTTLEROCKET-BOOT-B
   9         2150400         4034559   920.0 MiB   FFFF  BOTTLEROCKET-ROOT-B
  10         4034560         4055039   10.0 MiB    FFFF  BOTTLEROCKET-HASH-B
  11         4055040         4106239   25.0 MiB    FFFF  BOTTLEROCKET-RESERV...
  12         4106240         4192256   42.0 MiB    FFFF  BOTTLEROCKET-PRIVATE
```

**New layout**
```
Sector size (logical): 512 bytes
Disk identifier (GUID): 1754185D-33D2-4008-A1DA-FC84B274EFFB
Partition table holds up to 128 entries
Main partition table begins at sector 2 and ends at sector 33
First usable sector is 34, last usable sector is 4194270
Partitions will be aligned on 2048-sector boundaries
Total free space is 4029 sectors (2.0 MiB)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     EF02  BIOS-BOOT
   2           10240           20479   5.0 MiB     EF00  EFI-SYSTEM
   3           20480          102399   40.0 MiB    FFFF  BOTTLEROCKET-BOOT-A
   4          102400         1986559   920.0 MiB   FFFF  BOTTLEROCKET-ROOT-A
   5         1986560         2007039   10.0 MiB    FFFF  BOTTLEROCKET-HASH-A
   6         2007040         2058239   25.0 MiB    FFFF  BOTTLEROCKET-RESERV...
   7         2058240         2068479   5.0 MiB     FFFF  EFI-BACKUP
   8         2068480         2150399   40.0 MiB    FFFF  BOTTLEROCKET-BOOT-B
   9         2150400         4034559   920.0 MiB   FFFF  BOTTLEROCKET-ROOT-B
  10         4034560         4055039   10.0 MiB    FFFF  BOTTLEROCKET-HASH-B
  11         4055040         4106239   25.0 MiB    FFFF  BOTTLEROCKET-RESERV...
  12         4106240         4192255   42.0 MiB    FFFF  BOTTLEROCKET-PRIVATE
```

Confirmed that an undersized hash partition is rejected if I reduce `HASH_SCALE_FACTOR` to `2`.
```
  #12 18.32 verity content is larger than partition (4M)
  #12 ERROR: executor failed running [/bin/sh -c /host/tools/rpm2img ...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
