### PR TITLE
add support for CPU microcode updates

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -15,3 +15,6 @@ path = "pkg.rs"
 # Use latest-srpm-url.sh to get this.
 url = "https://cdn.amazonlinux.com/blobstore/2463ceff87cbe05e736813f33f5a8b70f9c98effe9eb5167fa613fae1fb9a943/kernel-5.10.68-62.173.amzn2.src.rpm"
 sha512 = "42bca6a73a9d6ddae9553f1d71d4f28d436d813b1068f270fe2ae80701201b88946dc3c094829c90f62fc4894910867d7afeccdfbe2abf3a19848fc4c28d51b9"
+
+[build-dependencies]
+microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -22,6 +22,14 @@ BuildRequires: hostname
 BuildRequires: kmod
 BuildRequires: openssl-devel
 
+# CPU microcode updates are included as "extra firmware" so the files don't
+# need to be installed on the root filesystem. However, we want the license and
+# attribution files to be available in the usual place.
+%if "%{_cross_arch}" == "x86_64"
+BuildRequires: %{_cross_os}microcode
+Requires: %{_cross_os}microcode-licenses
+%endif
+
 # Pull in expected modules and development files.
 Requires: %{name}-modules = %{version}-%{release}
 Requires: %{name}-devel = %{version}-%{release}
@@ -66,10 +74,24 @@ for patch in ../*.patch; do
 done
 # Patches listed in this spec (Patch0001...)
 %autopatch -p1
+
+%if "%{_cross_arch}" == "x86_64"
+microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P ')"
+cat <<EOF > ../config-microcode
+CONFIG_EXTRA_FIRMWARE="${microcode}"
+CONFIG_EXTRA_FIRMWARE_DIR="%{_cross_libdir}/firmware"
+EOF
+%endif
+
 KCONFIG_CONFIG="arch/%{_cross_karch}/configs/%{_cross_vendor}_defconfig" \
-    ARCH="%{_cross_karch}" \
-    scripts/kconfig/merge_config.sh ../config-%{_cross_arch} %{SOURCE100}
-rm -f ../config-%{_cross_arch} ../*.patch
+ARCH="%{_cross_karch}" \
+scripts/kconfig/merge_config.sh \
+  ../config-%{_cross_arch} \
+%if "%{_cross_arch}" == "x86_64"
+  ../config-microcode \
+%endif
+  %{SOURCE100}
+rm -f ../config-* ../*.patch
 
 %global kmake \
 make -s\\\

--- a/packages/kernel-5.4/Cargo.toml
+++ b/packages/kernel-5.4/Cargo.toml
@@ -16,6 +16,5 @@ path = "pkg.rs"
 url = "https://cdn.amazonlinux.com/blobstore/a068a12de784cc571656e680fbd3213773032b6b4d3c940b37b9db664fb7be52/kernel-5.4.149-73.259.amzn2.src.rpm"
 sha512 = "d7b86a37257fe02e8fda360397371662215dd916f4f6e82a9c9174bec385dd7347197baa17ba9666dd31f7b41472cde6fc293f431098a53526de1b86a71bb386"
 
-# RPM BuildRequires
 [build-dependencies]
-# Provided by Bottlerocket SDK
+microcode = { path = "../microcode" }

--- a/packages/microcode/Cargo.toml
+++ b/packages/microcode/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "microcode"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+# Use latest-srpm-urls.sh to get these.
+
+[[package.metadata.build-package.external-files]]
+url = "https://cdn.amazonlinux.com/blobstore/6d7f707779f6aff41c89bad00f7abe69dc70919cee29a8d3e5060f8070efe71d/linux-firmware-20200421-79.git78c0348.amzn2.src.rpm"
+sha512 = "d5a62eca6ddd7ff322574f17359681d03a733acc51c334127f291af5d5e39fcdf821c073ddcd977b2ca088cd95d35dc31db2001ca4c312a62dcbd4ea935434fd"
+
+[[package.metadata.build-package.external-files]]
+url = "https://cdn.amazonlinux.com/blobstore/76e8f9f15ec2b27c70aff3ca15a28df51790b25c73fc8dc1bf1f28a9069b15e8/microcode_ctl-2.1-47.amzn2.0.9.src.rpm"
+sha512 = "e1347139d1edbd52d2619d970ba0f03500ba7367d071bb30ab3d209e44b3ff63000fcaa681f7352c79f7d5d2f0753130161b42b0eab7aab97b5b4fc4bfaa1b3b"

--- a/packages/microcode/build.rs
+++ b/packages/microcode/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/microcode/latest-srpm-urls.sh
+++ b/packages/microcode/latest-srpm-urls.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm amazonlinux:2 sh -c 'yum install -q -y yum-utils && yumdownloader -q --source --urls linux-firmware microcode_ctl | grep ^http'

--- a/packages/microcode/microcode.spec
+++ b/packages/microcode/microcode.spec
@@ -1,0 +1,120 @@
+# This is a wrapper package for binary-only microcode from Intel and AMD.
+%global debug_package %{nil}
+
+# These are specific to the upstream source RPM, and will likely need to be
+# updated for each new version.
+%global amd_ucode_archive linux-firmware-20200421.tar.gz
+%global intel_ucode_archive microcode-20210608-1-amzn.tgz
+
+Name: %{_cross_os}microcode
+Version: 0.0
+Release: 1%{?dist}
+Summary: Microcode for AMD and Intel processors
+License: LicenseRef-scancode-amd-linux-firmware-export AND LicenseRef-scancode-intel-mcu-2018
+
+# Packaging AMD and Intel microcode together is specific to Bottlerocket, and
+# RPM only allows one URL field per package, so this is about as accurate as we
+# can be. The real upstream URLs for AMD and Intel microcode are given below in
+# the subpackage definitions.
+URL: https://github.com/bottlerocket-os/bottlerocket/tree/develop/packages/microcode
+
+# We use Amazon Linux 2 as our upstream for microcode updates.
+Source0: https://cdn.amazonlinux.com/blobstore/6d7f707779f6aff41c89bad00f7abe69dc70919cee29a8d3e5060f8070efe71d/linux-firmware-20200421-79.git78c0348.amzn2.src.rpm
+Source1: https://cdn.amazonlinux.com/blobstore/76e8f9f15ec2b27c70aff3ca15a28df51790b25c73fc8dc1bf1f28a9069b15e8/microcode_ctl-2.1-47.amzn2.0.9.src.rpm
+
+# Lets us install "microcode" to pull in the AMD and Intel updates.
+Requires: %{_cross_os}microcode-amd
+Requires: %{_cross_os}microcode-intel
+
+%description
+%{summary}.
+
+%package amd
+Summary: Microcode for AMD processors
+License: LicenseRef-scancode-amd-linux-firmware-export
+URL: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tree/amd-ucode
+Requires: %{_cross_os}microcode-amd-license
+
+%description amd
+%{summary}.
+
+%package amd-license
+Summary: License files for microcode for AMD processors
+License: LicenseRef-scancode-amd-linux-firmware-export
+URL: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENSE.amd-ucode
+
+%description amd-license
+%{summary}.
+
+%package intel
+Summary: Microcode for Intel processors
+License: LicenseRef-scancode-intel-mcu-2018
+URL: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files
+Requires: %{_cross_os}microcode-intel-license
+
+%description intel
+%{summary}.
+
+%package intel-license
+Summary: License files for microcode for Intel processors
+License: LicenseRef-scancode-intel-mcu-2018
+URL: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/main/license
+
+%description intel-license
+%{summary}.
+
+# Lets us install "microcode-licenses" for just the license files.
+%package licenses
+Summary: License files for microcode for AMD and Intel processors
+License: LicenseRef-scancode-amd-linux-firmware-export AND LicenseRef-scancode-intel-mcu-2018
+URL: https://github.com/bottlerocket-os/bottlerocket/tree/develop/packages/microcode
+Requires: %{_cross_os}microcode-amd-license
+Requires: %{_cross_os}microcode-intel-license
+
+%description licenses
+%{summary}.
+
+%prep
+rpm2cpio %{SOURCE0} | cpio -iu %{amd_ucode_archive}
+rpm2cpio %{SOURCE1} | cpio -iu %{intel_ucode_archive}
+mkdir amd intel
+tar -C amd -xof %{amd_ucode_archive}
+tar -C intel -xof %{intel_ucode_archive}
+cp {amd/,}LICENSE.amd-ucode
+cp intel/intel-ucode-with-caveats/* intel/intel-ucode
+cp intel/license LICENSE.intel-ucode
+
+# Create links to the SPDX identifiers we're using, so they're easier to match
+# up with the license text.
+ln -s LICENSE.intel-ucode LicenseRef-scancode-intel-mcu-2018
+ln -s LICENSE.amd-ucode LicenseRef-scancode-amd-linux-firmware-export
+
+%build
+
+%install
+install -d %{buildroot}%{_cross_libdir}/firmware/{amd,intel}-ucode
+install -p -m 0644 amd/amd-ucode/*.bin %{buildroot}%{_cross_libdir}/firmware/amd-ucode
+install -p -m 0644 intel/intel-ucode/* %{buildroot}%{_cross_libdir}/firmware/intel-ucode
+
+%files
+
+%files amd
+%dir %{_cross_libdir}/firmware
+%dir %{_cross_libdir}/firmware/amd-ucode
+%{_cross_libdir}/firmware/amd-ucode/microcode_amd*.bin
+
+%files amd-license
+%license LICENSE.amd-ucode LicenseRef-scancode-amd-linux-firmware-export
+
+%files intel
+%dir %{_cross_libdir}/firmware
+%dir %{_cross_libdir}/firmware/intel-ucode
+%{_cross_libdir}/firmware/intel-ucode/??-??-??
+
+%files intel-license
+%license LICENSE.intel-ucode LicenseRef-scancode-intel-mcu-2018
+
+%files licenses
+%{_cross_attribution_file}
+
+%changelog

--- a/packages/microcode/pkg.rs
+++ b/packages/microcode/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -288,10 +288,16 @@ dependencies = [
 [[package]]
 name = "kernel-5_10"
 version = "0.1.0"
+dependencies = [
+ "microcode",
+]
 
 [[package]]
 name = "kernel-5_4"
 version = "0.1.0"
+dependencies = [
+ "microcode",
+]
 
 [[package]]
 name = "kexec-tools"
@@ -587,6 +593,10 @@ dependencies = [
  "libelf",
  "libz",
 ]
+
+[[package]]
+name = "microcode"
+version = "0.1.0"
 
 [[package]]
 name = "ncurses"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Adds support for updating AMD and Intel CPU microcode, using the Linux kernel's early loading feature.


**Testing done:**
Verified that microcode is loaded early on an x86_64 variant.
```
# dmesg|head -n1
[    0.000000] microcode: microcode updated early to revision 0x5003102, date = 2021-03-08
```

Verified that the expected license files are included on an x86_64 variant.
```
# ls -l /usr/share/licenses/microcode/
-rw-r--r--. 1 root root 3758 Nov 16 02:02 LICENSE.amd-ucode
-rw-r--r--. 1 root root 1677 Nov 16 02:02 LICENSE.intel-ucode
lrwxrwxrwx. 1 root root   17 Nov 16 02:02 LicenseRef-scancode-amd-linux-firmware-export -> LICENSE.amd-ucode
lrwxrwxrwx. 1 root root   19 Nov 16 02:02 LicenseRef-scancode-intel-mcu-2018 -> LICENSE.intel-ucode
-rw-r--r--. 1 root root  222 Nov 16 02:02 attribution.txt
```

Verified that the attribution file looks reasonable.
```
# cat /usr/share/licenses/microcode/attribution.txt
bottlerocket-x86_64-microcode - https://github.com/bottlerocket-os/bottlerocket/tree/develop/packages/microcode
SPDX-License-Identifier: LicenseRef-scancode-amd-linux-firmware-export AND LicenseRef-scancode-intel-mcu-2018
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
