### PR TITLE
update gptman to 0.8.2

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "actix-web-codegen",
  "ahash",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derive_more",
  "either",
  "encoding_rs",
@@ -457,7 +457,7 @@ checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -591,12 +591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,12 +665,6 @@ dependencies = [
  "tokio",
  "x509-parser",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -767,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "count-zeroes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c80f87e3dbcccd054a1a06b56548d113a6bce5c1f19b919d0a4dc95e8dd233ca"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,12 +771,18 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "1.8.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
 dependencies = [
- "build_const",
+ "crc-catalog",
 ]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crc32fast"
@@ -790,7 +790,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -809,7 +809,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -951,7 +951,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -972,7 +972,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "socket2 0.4.2",
  "winapi",
@@ -1043,7 +1043,7 @@ version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1053,20 +1053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "err-derive"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -1109,7 +1095,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi",
@@ -1127,7 +1113,7 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -1284,7 +1270,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -1329,16 +1315,16 @@ dependencies = [
 
 [[package]]
 name = "gptman"
-version = "0.6.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a28da0c56b559fbe74ecd953f86fe778ca5ecc9f2a50eee94b86cdf46f9314"
+checksum = "5f1739cf11514f93ee03192cfcdef9c82ae83592c109f4c8cd5c992509adb68c"
 dependencies = [
  "bincode",
+ "count-zeroes",
  "crc",
- "err-derive",
- "nix 0.17.0",
+ "nix 0.22.0",
  "serde",
- "serde_derive",
+ "thiserror",
 ]
 
 [[package]]
@@ -1644,7 +1630,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1700,7 +1686,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
@@ -1744,7 +1730,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1982,15 +1968,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
- "void",
+ "memoffset",
 ]
 
 [[package]]
@@ -2001,7 +1987,7 @@ checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -2195,7 +2181,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -3007,7 +2993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3020,7 +3006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3138,7 +3124,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "winapi",
 ]
@@ -3274,18 +3260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3307,7 +3281,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",
@@ -3578,7 +3552,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -3753,18 +3727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59dadb264325fd034df77ba88c2ddd1650d78ec8e7548af3003ecdc598dfe0b3"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "errno",
  "libc",
  "log",
  "thiserror",
 ]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
@@ -3799,7 +3767,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -3824,7 +3792,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -42,8 +42,8 @@ multiple-versions = "deny"
 wildcards = "deny"
 
 skip = [
-    # older version used by gptman 0.6.5
-    { name = "nix", version = "0.17.0" },
+    # older version used by gptman 0.8.2
+    { name = "nix", version = "0.22.0" },
 
     # newer version used by model-derive and darling
     # older version used by clap 2.33.3, via cargo-readme and structopt

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["README.md"]
 
 [dependencies]
 argh = "0.1.3"
-gptman = { version = "0.6.1", default-features = false }
+gptman = { version = "0.8.2", default-features = false }
 hex-literal = "0.3.0"
 lazy_static = "1.2"
 signpost = { path = "../updater/signpost", version = "0.1.0" }

--- a/sources/ghostdog/src/main.rs
+++ b/sources/ghostdog/src/main.rs
@@ -134,7 +134,7 @@ mod test {
         gpt[1] = GPTPartitionEntry {
             partition_name: partition_name.into(),
             partition_type_guid: partition_type,
-            unique_parition_guid: [0xff; 16],
+            unique_partition_guid: [0xff; 16],
             starting_lba: gpt.header.first_usable_lba,
             ending_lba: gpt.header.last_usable_lba,
             attribute_bits: 0,

--- a/sources/growpart/Cargo.toml
+++ b/sources/growpart/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-gptman = { version = "0.6.1", default-features = false }
+gptman = { version = "0.8.2", default-features = false }
 snafu = "0.6"
 libc = "0.2"
 block-party = { path = "../updater/block-party", version = "0.1.0" }

--- a/sources/growpart/src/diskpart.rs
+++ b/sources/growpart/src/diskpart.rs
@@ -56,7 +56,7 @@ impl DiskPart {
         let current = &gpt[part];
         let partition_name = current.partition_name.clone();
         let partition_type_guid = current.partition_type_guid;
-        let unique_parition_guid = current.unique_parition_guid;
+        let unique_partition_guid = current.unique_partition_guid;
         let path = &self.device;
 
         // Remove all existing partitions so that the space shows up as free.
@@ -82,7 +82,7 @@ impl DiskPart {
             attribute_bits: 0,
             partition_name,
             partition_type_guid,
-            unique_parition_guid,
+            unique_partition_guid,
         };
 
         Ok(())
@@ -96,6 +96,11 @@ impl DiskPart {
             .write(true)
             .open(path)
             .context(error::DeviceOpen { path })?;
+
+        self.gpt
+            .header
+            .update_from(&mut f, self.gpt.sector_size)
+            .context(error::UpdateGeometry { path })?;
 
         self.gpt
             .write_into(&mut f)

--- a/sources/growpart/src/diskpart/error.rs
+++ b/sources/growpart/src/diskpart/error.rs
@@ -42,6 +42,12 @@ pub enum Error {
         count: usize,
     },
 
+    #[snafu(display("Failed to update geometry for '{}': {}", path.display(), source))]
+    UpdateGeometry {
+        path: std::path::PathBuf,
+        source: gptman::Error,
+    },
+
     #[snafu(display("Failed to write partition table to '{}': {}", path.display(), source))]
     WritePartitionTable {
         path: std::path::PathBuf,

--- a/sources/updater/signpost/Cargo.toml
+++ b/sources/updater/signpost/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["README.md"]
 [dependencies]
 bit_field = "0.10.0"
 block-party = { path = "../block-party", version = "0.1.0" }
-gptman = { version = "0.6.1", default-features = false }
+gptman = { version = "0.8.2", default-features = false }
 hex-literal = "0.3.0"
 serde = { version = "1.0.91", features = ["derive"] }
 serde_plain = "1.0"


### PR DESCRIPTION

**Issue number:**
Fixes #1620


**Description of changes:**
Update `gptman` to 0.8.2, with fixes for the two breaking changes in 0.7.0:
* `gptman::GPTPartitionEntry::unique_parition_guid` is now `gptman::GPTPartitionEntry::unique_partition_guid`
* `write_into` does not update the GPT's first/last LBAs according to disk anymore


**Testing done:**
Verified the functionality touched by this update:
* in-place upgrades and downgrades work
* `growpart` resizes the local data partition on each boot
* `ghostdog` creates symlinks in `/dev/disk/ephemeral`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
