### PR TITLE
update to SDK 0.23.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - run: rustup toolchain install 1.56.0 && rustup default 1.56.0
+      - run: rustup toolchain install 1.56.1 && rustup default 1.56.1
       - run: cargo install --version 0.30.0 cargo-make
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-fmt

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,7 +26,7 @@ BUILDSYS_NAME = "bottlerocket"
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.23.0"
+BUILDSYS_SDK_VERSION="v0.23.1"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 


### PR DESCRIPTION
**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket-sdk/issues/61.

**Description of changes:**

Update to a newer SDK that contains mostly security fixes.

* Rust: **1.56.0 → 1.56.1**
* Go: **1.16.9 → 1.16.10**
* govc: **0.27.0 → 0.27.1**

**Testing done:**

_See https://github.com/bottlerocket-os/bottlerocket-sdk/pull/62_.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
