### PR TITLE
CVE-2021-41190

### DIFF
--- a/packages/containerd/0004-images-validate-document-type-before-unmarshal.patch
+++ b/packages/containerd/0004-images-validate-document-type-before-unmarshal.patch
@@ -1,0 +1,251 @@
+From 833407fbff446771e26d6a381897f2c7ae24677e Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Wed, 20 Oct 2021 14:43:16 -0700
+Subject: [PATCH 1/2] images: validate document type before unmarshal
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+(cherry picked from commit eb9ba7ed8d46d48fb22362f9d91fff6fb837e37e)
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ images/image.go      |  55 +++++++++++++++++++
+ images/image_test.go | 127 +++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 182 insertions(+)
+ create mode 100644 images/image_test.go
+
+diff --git a/images/image.go b/images/image.go
+index 27384c16d..2e5cd61c9 100644
+--- a/images/image.go
++++ b/images/image.go
+@@ -19,6 +19,7 @@ package images
+ import (
+ 	"context"
+ 	"encoding/json"
++	"fmt"
+ 	"sort"
+ 	"time"
+ 
+@@ -154,6 +155,10 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
+ 				return nil, err
+ 			}
+ 
++			if err := validateMediaType(p, desc.MediaType); err != nil {
++				return nil, errors.Wrapf(err, "manifest: invalid desc %s", desc.Digest)
++			}
++
+ 			var manifest ocispec.Manifest
+ 			if err := json.Unmarshal(p, &manifest); err != nil {
+ 				return nil, err
+@@ -194,6 +199,10 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
+ 				return nil, err
+ 			}
+ 
++			if err := validateMediaType(p, desc.MediaType); err != nil {
++				return nil, errors.Wrapf(err, "manifest: invalid desc %s", desc.Digest)
++			}
++
+ 			var idx ocispec.Index
+ 			if err := json.Unmarshal(p, &idx); err != nil {
+ 				return nil, err
+@@ -336,6 +345,10 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
+ 			return nil, err
+ 		}
+ 
++		if err := validateMediaType(p, desc.MediaType); err != nil {
++			return nil, errors.Wrapf(err, "children: invalid desc %s", desc.Digest)
++		}
++
+ 		// TODO(stevvooe): We just assume oci manifest, for now. There may be
+ 		// subtle differences from the docker version.
+ 		var manifest ocispec.Manifest
+@@ -351,6 +364,10 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
+ 			return nil, err
+ 		}
+ 
++		if err := validateMediaType(p, desc.MediaType); err != nil {
++			return nil, errors.Wrapf(err, "children: invalid desc %s", desc.Digest)
++		}
++
+ 		var index ocispec.Index
+ 		if err := json.Unmarshal(p, &index); err != nil {
+ 			return nil, err
+@@ -368,6 +385,44 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
+ 	return descs, nil
+ }
+ 
++// unknownDocument represents a manifest, manifest list, or index that has not
++// yet been validated.
++type unknownDocument struct {
++	MediaType string          `json:"mediaType,omitempty"`
++	Config    json.RawMessage `json:"config,omitempty"`
++	Layers    json.RawMessage `json:"layers,omitempty"`
++	Manifests json.RawMessage `json:"manifests,omitempty"`
++	FSLayers  json.RawMessage `json:"fsLayers,omitempty"` // schema 1
++}
++
++// validateMediaType returns an error if the byte slice is invalid JSON or if
++// the media type identifies the blob as one format but it contains elements of
++// another format.
++func validateMediaType(b []byte, mt string) error {
++	var doc unknownDocument
++	if err := json.Unmarshal(b, &doc); err != nil {
++		return err
++	}
++	if len(doc.FSLayers) != 0 {
++		return fmt.Errorf("media-type: schema 1 not supported")
++	}
++	switch mt {
++	case MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
++		if len(doc.Manifests) != 0 ||
++			doc.MediaType == MediaTypeDockerSchema2ManifestList ||
++			doc.MediaType == ocispec.MediaTypeImageIndex {
++			return fmt.Errorf("media-type: expected manifest but found index (%s)", mt)
++		}
++	case MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
++		if len(doc.Config) != 0 || len(doc.Layers) != 0 ||
++			doc.MediaType == MediaTypeDockerSchema2Manifest ||
++			doc.MediaType == ocispec.MediaTypeImageManifest {
++			return fmt.Errorf("media-type: expected index but found manifest (%s)", mt)
++		}
++	}
++	return nil
++}
++
+ // RootFS returns the unpacked diffids that make up and images rootfs.
+ //
+ // These are used to verify that a set of layers unpacked to the expected
+diff --git a/images/image_test.go b/images/image_test.go
+new file mode 100644
+index 000000000..87c84ab05
+--- /dev/null
++++ b/images/image_test.go
+@@ -0,0 +1,127 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package images
++
++import (
++	"encoding/json"
++	"testing"
++
++	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++)
++
++func TestValidateMediaType(t *testing.T) {
++	docTests := []struct {
++		mt    string
++		index bool
++	}{
++		{MediaTypeDockerSchema2Manifest, false},
++		{ocispec.MediaTypeImageManifest, false},
++		{MediaTypeDockerSchema2ManifestList, true},
++		{ocispec.MediaTypeImageIndex, true},
++	}
++	for _, tc := range docTests {
++		t.Run("manifest-"+tc.mt, func(t *testing.T) {
++			manifest := ocispec.Manifest{
++				Config: ocispec.Descriptor{Size: 1},
++				Layers: []ocispec.Descriptor{{Size: 2}},
++			}
++			b, err := json.Marshal(manifest)
++			require.NoError(t, err, "failed to marshal manifest")
++
++			err = validateMediaType(b, tc.mt)
++			if tc.index {
++				assert.Error(t, err, "manifest should not be a valid index")
++			} else {
++				assert.NoError(t, err, "manifest should be valid")
++			}
++		})
++		t.Run("index-"+tc.mt, func(t *testing.T) {
++			index := ocispec.Index{
++				Manifests: []ocispec.Descriptor{{Size: 1}},
++			}
++			b, err := json.Marshal(index)
++			require.NoError(t, err, "failed to marshal index")
++
++			err = validateMediaType(b, tc.mt)
++			if tc.index {
++				assert.NoError(t, err, "index should be valid")
++			} else {
++				assert.Error(t, err, "index should not be a valid manifest")
++			}
++		})
++	}
++
++	mtTests := []struct {
++		mt      string
++		valid   []string
++		invalid []string
++	}{{
++		MediaTypeDockerSchema2Manifest,
++		[]string{MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest},
++		[]string{MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex},
++	}, {
++		ocispec.MediaTypeImageManifest,
++		[]string{MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest},
++		[]string{MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex},
++	}, {
++		MediaTypeDockerSchema2ManifestList,
++		[]string{MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex},
++		[]string{MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest},
++	}, {
++		ocispec.MediaTypeImageIndex,
++		[]string{MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex},
++		[]string{MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest},
++	}}
++	for _, tc := range mtTests {
++		for _, v := range tc.valid {
++			t.Run("valid-"+tc.mt+"-"+v, func(t *testing.T) {
++				doc := struct {
++					MediaType string `json:"mediaType"`
++				}{MediaType: v}
++				b, err := json.Marshal(doc)
++				require.NoError(t, err, "failed to marshal document")
++
++				err = validateMediaType(b, tc.mt)
++				assert.NoError(t, err, "document should be valid")
++			})
++		}
++		for _, iv := range tc.invalid {
++			t.Run("invalid-"+tc.mt+"-"+iv, func(t *testing.T) {
++				doc := struct {
++					MediaType string `json:"mediaType"`
++				}{MediaType: iv}
++				b, err := json.Marshal(doc)
++				require.NoError(t, err, "failed to marshal document")
++
++				err = validateMediaType(b, tc.mt)
++				assert.Error(t, err, "document should not be valid")
++			})
++		}
++	}
++	t.Run("schema1", func(t *testing.T) {
++		doc := struct {
++			FSLayers []string `json:"fsLayers"`
++		}{FSLayers: []string{"1"}}
++		b, err := json.Marshal(doc)
++		require.NoError(t, err, "failed to marshal document")
++
++		err = validateMediaType(b, "")
++		assert.Error(t, err, "document should not be valid")
++	})
++}
+-- 
+2.33.1
+

--- a/packages/containerd/0005-schema1-reject-ambiguous-documents.patch
+++ b/packages/containerd/0005-schema1-reject-ambiguous-documents.patch
@@ -1,0 +1,42 @@
+From 15d8c03e3260953cc560223b42426e8b67dde93c Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Mon, 15 Nov 2021 12:00:01 -0800
+Subject: [PATCH 2/2] schema1: reject ambiguous documents
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+(cherry picked from commit 70c88f507579277ab7af23b06666e3b57d4b4f2d)
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ remotes/docker/schema1/converter.go | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/remotes/docker/schema1/converter.go b/remotes/docker/schema1/converter.go
+index 8314c01d5..f15a9acf3 100644
+--- a/remotes/docker/schema1/converter.go
++++ b/remotes/docker/schema1/converter.go
+@@ -256,6 +256,9 @@ func (c *Converter) fetchManifest(ctx context.Context, desc ocispec.Descriptor)
+ 	if err := json.Unmarshal(b, &m); err != nil {
+ 		return err
+ 	}
++	if len(m.Manifests) != 0 || len(m.Layers) != 0 {
++		return errors.New("converter: expected schema1 document but found extra keys")
++	}
+ 	c.pulledManifest = &m
+ 
+ 	return nil
+@@ -472,8 +475,10 @@ type history struct {
+ }
+ 
+ type manifest struct {
+-	FSLayers []fsLayer `json:"fsLayers"`
+-	History  []history `json:"history"`
++	FSLayers  []fsLayer       `json:"fsLayers"`
++	History   []history       `json:"history"`
++	Layers    json.RawMessage `json:"layers,omitempty"`    // OCI manifest
++	Manifests json.RawMessage `json:"manifests,omitempty"` // OCI index
+ }
+ 
+ type v1History struct {
+-- 
+2.33.1
+

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -32,6 +32,10 @@ Patch2001: 0001-v2-runtime-reduce-permissions-for-bundle-dir.patch
 Patch2002: 0002-v1-runtime-reduce-permissions-for-bundle-dir.patch
 Patch2003: 0003-btrfs-reduce-permissions-on-plugin-directories.patch
 
+# CVE-2021-41190
+Patch2004: 0004-images-validate-document-type-before-unmarshal.patch
+Patch2005: 0005-schema1-reject-ambiguous-documents.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}runc

--- a/packages/docker-engine/1001-vendor-update-github.com-docker-distribution.patch
+++ b/packages/docker-engine/1001-vendor-update-github.com-docker-distribution.patch
@@ -1,0 +1,103 @@
+From b3456925ca8450dedba32752e3417eb6e1ebf336 Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Thu, 4 Nov 2021 14:41:21 -0700
+Subject: [PATCH 1/3] vendor: update github.com/docker/distribution
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ vendor.conf                                   |  2 +-
+ .../manifest/manifestlist/manifestlist.go     | 23 +++++++++++++++++++
+ .../manifest/ocischema/manifest.go            | 22 ++++++++++++++++++
+ 3 files changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/vendor.conf b/vendor.conf
+index a88f05bd71..f16cab8452 100644
+--- a/vendor.conf
++++ b/vendor.conf
+@@ -76,7 +76,7 @@ github.com/ishidawataru/sctp                        f2269e66cdee387bd321445d5d30
+ go.etcd.io/bbolt                                    232d8fc87f50244f9c808f4745759e08a304c029 # v1.3.5
+ 
+ # get graph and distribution packages
+-github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
++github.com/docker/distribution                      58f99e93b767ebacbf8e62a9074844712d31a177 github.com/samuelkarp/docker-distribution
+ github.com/vbatts/tar-split                         620714a4c508c880ac1bdda9c8370a2b19af1a55 # v0.11.1
+ github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
+ 
+diff --git a/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go b/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
+index 54c8f3c94c..09b3609737 100644
+--- a/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
++++ b/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
+@@ -54,6 +54,9 @@ func init() {
+ 	}
+ 
+ 	imageIndexFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
++		if err := validateIndex(b); err != nil {
++			return nil, distribution.Descriptor{}, err
++		}
+ 		m := new(DeserializedManifestList)
+ 		err := m.UnmarshalJSON(b)
+ 		if err != nil {
+@@ -214,3 +217,23 @@ func (m DeserializedManifestList) Payload() (string, []byte, error) {
+ 
+ 	return mediaType, m.canonical, nil
+ }
++
++// unknownDocument represents a manifest, manifest list, or index that has not
++// yet been validated
++type unknownDocument struct {
++	Config interface{} `json:"config,omitempty"`
++	Layers interface{} `json:"layers,omitempty"`
++}
++
++// validateIndex returns an error if the byte slice is invalid JSON or if it
++// contains fields that belong to a manifest
++func validateIndex(b []byte) error {
++	var doc unknownDocument
++	if err := json.Unmarshal(b, &doc); err != nil {
++		return err
++	}
++	if doc.Config != nil || doc.Layers != nil {
++		return errors.New("index: expected index but found manifest")
++	}
++	return nil
++}
+diff --git a/vendor/github.com/docker/distribution/manifest/ocischema/manifest.go b/vendor/github.com/docker/distribution/manifest/ocischema/manifest.go
+index b8c4bab547..910a64afb4 100644
+--- a/vendor/github.com/docker/distribution/manifest/ocischema/manifest.go
++++ b/vendor/github.com/docker/distribution/manifest/ocischema/manifest.go
+@@ -22,6 +22,9 @@ var (
+ 
+ func init() {
+ 	ocischemaFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
++		if err := validateManifest(b); err != nil {
++			return nil, distribution.Descriptor{}, err
++		}
+ 		m := new(DeserializedManifest)
+ 		err := m.UnmarshalJSON(b)
+ 		if err != nil {
+@@ -122,3 +125,22 @@ func (m *DeserializedManifest) MarshalJSON() ([]byte, error) {
+ func (m DeserializedManifest) Payload() (string, []byte, error) {
+ 	return v1.MediaTypeImageManifest, m.canonical, nil
+ }
++
++// unknownDocument represents a manifest, manifest list, or index that has not
++// yet been validated
++type unknownDocument struct {
++	Manifests interface{} `json:"manifests,omitempty"`
++}
++
++// validateManifest returns an error if the byte slice is invalid JSON or if it
++// contains fields that belong to a index
++func validateManifest(b []byte) error {
++	var doc unknownDocument
++	if err := json.Unmarshal(b, &doc); err != nil {
++		return err
++	}
++	if doc.Manifests != nil {
++		return errors.New("ocimanifest: expected manifest but found index")
++	}
++	return nil
++}
+-- 
+2.33.1
+

--- a/packages/docker-engine/1002-vendor-update-github.com-containerd-containerd.patch
+++ b/packages/docker-engine/1002-vendor-update-github.com-containerd-containerd.patch
@@ -1,0 +1,156 @@
+From c96ed28f2f1aa2524564efe6ae02fe76203f1aa7 Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Thu, 4 Nov 2021 14:41:58 -0700
+Subject: [PATCH 2/3] vendor: update github.com/containerd/containerd
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ vendor.conf                                   |  2 +-
+ .../containerd/containerd/images/image.go     | 55 +++++++++++++++++++
+ .../remotes/docker/schema1/converter.go       |  9 ++-
+ 3 files changed, 63 insertions(+), 3 deletions(-)
+
+diff --git a/vendor.conf b/vendor.conf
+index f16cab8452..72d5d5b126 100644
+--- a/vendor.conf
++++ b/vendor.conf
+@@ -130,7 +130,7 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
+ google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
+ 
+ # containerd
+-github.com/containerd/containerd                    0edc412565dcc6e3d6125ff9e4b009ad4b89c638 # master (v1.5.0-dev)
++github.com/containerd/containerd                    e048c115a3a89caf63941d363858e207c28bccd6 github.com/moby/containerd # master (v1.5.0-dev) + patch for CVE-2021-41190
+ github.com/containerd/fifo                          0724c46b320cf96bb172a0550c19a4b1fca4dacb
+ github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
+ github.com/containerd/cgroups                       0b889c03f102012f1d93a97ddd3ef71cd6f4f510
+diff --git a/vendor/github.com/containerd/containerd/images/image.go b/vendor/github.com/containerd/containerd/images/image.go
+index 1868ee88dd..2e42ca09a6 100644
+--- a/vendor/github.com/containerd/containerd/images/image.go
++++ b/vendor/github.com/containerd/containerd/images/image.go
+@@ -19,6 +19,7 @@ package images
+ import (
+ 	"context"
+ 	"encoding/json"
++	"fmt"
+ 	"sort"
+ 	"time"
+ 
+@@ -154,6 +155,10 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
+ 				return nil, err
+ 			}
+ 
++			if err := validateMediaType(p, desc.MediaType); err != nil {
++				return nil, errors.Wrapf(err, "manifest: invalid desc %s", desc.Digest)
++			}
++
+ 			var manifest ocispec.Manifest
+ 			if err := json.Unmarshal(p, &manifest); err != nil {
+ 				return nil, err
+@@ -194,6 +199,10 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
+ 				return nil, err
+ 			}
+ 
++			if err := validateMediaType(p, desc.MediaType); err != nil {
++				return nil, errors.Wrapf(err, "manifest: invalid desc %s", desc.Digest)
++			}
++
+ 			var idx ocispec.Index
+ 			if err := json.Unmarshal(p, &idx); err != nil {
+ 				return nil, err
+@@ -336,6 +345,10 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
+ 			return nil, err
+ 		}
+ 
++		if err := validateMediaType(p, desc.MediaType); err != nil {
++			return nil, errors.Wrapf(err, "children: invalid desc %s", desc.Digest)
++		}
++
+ 		// TODO(stevvooe): We just assume oci manifest, for now. There may be
+ 		// subtle differences from the docker version.
+ 		var manifest ocispec.Manifest
+@@ -351,6 +364,10 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
+ 			return nil, err
+ 		}
+ 
++		if err := validateMediaType(p, desc.MediaType); err != nil {
++			return nil, errors.Wrapf(err, "children: invalid desc %s", desc.Digest)
++		}
++
+ 		var index ocispec.Index
+ 		if err := json.Unmarshal(p, &index); err != nil {
+ 			return nil, err
+@@ -368,6 +385,44 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
+ 	return descs, nil
+ }
+ 
++// unknownDocument represents a manifest, manifest list, or index that has not
++// yet been validated.
++type unknownDocument struct {
++	MediaType string          `json:"mediaType,omitempty"`
++	Config    json.RawMessage `json:"config,omitempty"`
++	Layers    json.RawMessage `json:"layers,omitempty"`
++	Manifests json.RawMessage `json:"manifests,omitempty"`
++	FSLayers  json.RawMessage `json:"fsLayers,omitempty"` // schema 1
++}
++
++// validateMediaType returns an error if the byte slice is invalid JSON or if
++// the media type identifies the blob as one format but it contains elements of
++// another format.
++func validateMediaType(b []byte, mt string) error {
++	var doc unknownDocument
++	if err := json.Unmarshal(b, &doc); err != nil {
++		return err
++	}
++	if len(doc.FSLayers) != 0 {
++		return fmt.Errorf("media-type: schema 1 not supported")
++	}
++	switch mt {
++	case MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
++		if len(doc.Manifests) != 0 ||
++			doc.MediaType == MediaTypeDockerSchema2ManifestList ||
++			doc.MediaType == ocispec.MediaTypeImageIndex {
++			return fmt.Errorf("media-type: expected manifest but found index (%s)", mt)
++		}
++	case MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
++		if len(doc.Config) != 0 || len(doc.Layers) != 0 ||
++			doc.MediaType == MediaTypeDockerSchema2Manifest ||
++			doc.MediaType == ocispec.MediaTypeImageManifest {
++			return fmt.Errorf("media-type: expected index but found manifest (%s)", mt)
++		}
++	}
++	return nil
++}
++
+ // RootFS returns the unpacked diffids that make up and images rootfs.
+ //
+ // These are used to verify that a set of layers unpacked to the expected
+diff --git a/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go b/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go
+index 8314c01d5a..f15a9acf3e 100644
+--- a/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go
++++ b/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go
+@@ -256,6 +256,9 @@ func (c *Converter) fetchManifest(ctx context.Context, desc ocispec.Descriptor)
+ 	if err := json.Unmarshal(b, &m); err != nil {
+ 		return err
+ 	}
++	if len(m.Manifests) != 0 || len(m.Layers) != 0 {
++		return errors.New("converter: expected schema1 document but found extra keys")
++	}
+ 	c.pulledManifest = &m
+ 
+ 	return nil
+@@ -472,8 +475,10 @@ type history struct {
+ }
+ 
+ type manifest struct {
+-	FSLayers []fsLayer `json:"fsLayers"`
+-	History  []history `json:"history"`
++	FSLayers  []fsLayer       `json:"fsLayers"`
++	History   []history       `json:"history"`
++	Layers    json.RawMessage `json:"layers,omitempty"`    // OCI manifest
++	Manifests json.RawMessage `json:"manifests,omitempty"` // OCI index
+ }
+ 
+ type v1History struct {
+-- 
+2.33.1
+

--- a/packages/docker-engine/1003-distribution-validate-blob-type.patch
+++ b/packages/docker-engine/1003-distribution-validate-blob-type.patch
@@ -1,0 +1,186 @@
+From c1f352c4b13a1f562c59908f71a39fa40106ee7c Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Thu, 11 Nov 2021 17:45:40 -0800
+Subject: [PATCH 3/3] distribution: validate blob type
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ distribution/manifest.go      | 45 +++++++++++++++++-----
+ distribution/manifest_test.go | 72 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 108 insertions(+), 9 deletions(-)
+
+diff --git a/distribution/manifest.go b/distribution/manifest.go
+index a97373bd61..3b5a18bad2 100644
+--- a/distribution/manifest.go
++++ b/distribution/manifest.go
+@@ -3,6 +3,7 @@ package distribution
+ import (
+ 	"context"
+ 	"encoding/json"
++	"fmt"
+ 	"io"
+ 	"io/ioutil"
+ 
+@@ -11,7 +12,9 @@ import (
+ 	"github.com/containerd/containerd/log"
+ 	"github.com/containerd/containerd/remotes"
+ 	"github.com/docker/distribution"
++	"github.com/docker/distribution/manifest/manifestlist"
+ 	"github.com/docker/distribution/manifest/schema1"
++	"github.com/docker/distribution/manifest/schema2"
+ 	digest "github.com/opencontainers/go-digest"
+ 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+ 	"github.com/pkg/errors"
+@@ -166,8 +169,10 @@ func detectManifestMediaType(ra content.ReaderAt) (string, error) {
+ func detectManifestBlobMediaType(dt []byte) (string, error) {
+ 	var mfst struct {
+ 		MediaType string          `json:"mediaType"`
+-		Config    json.RawMessage `json:"config"`   // schema2 Manifest
+-		FSLayers  json.RawMessage `json:"fsLayers"` // schema1 Manifest
++		Manifests json.RawMessage `json:"manifests"` // oci index, manifest list
++		Config    json.RawMessage `json:"config"`    // schema2 Manifest
++		Layers    json.RawMessage `json:"layers"`    // schema2 Manifest
++		FSLayers  json.RawMessage `json:"fsLayers"`  // schema1 Manifest
+ 	}
+ 
+ 	if err := json.Unmarshal(dt, &mfst); err != nil {
+@@ -178,18 +183,40 @@ func detectManifestBlobMediaType(dt []byte) (string, error) {
+ 	// Docker types should generally have a media type set.
+ 	// OCI (golang) types do not have a `mediaType` defined, and it is optional in the spec.
+ 	//
+-	// `distrubtion.UnmarshalManifest`, which is used to unmarshal this for real, checks these media type values.
++	// `distribution.UnmarshalManifest`, which is used to unmarshal this for real, checks these media type values.
+ 	// If the specified media type does not match it will error, and in some cases (docker media types) it is required.
+ 	// So pretty much if we don't have a media type we can fall back to OCI.
+ 	// This does have a special fallback for schema1 manifests just because it is easy to detect.
+-	switch {
+-	case mfst.MediaType != "":
++	switch mfst.MediaType {
++	case schema2.MediaTypeManifest, specs.MediaTypeImageManifest:
++		if mfst.Manifests != nil || mfst.FSLayers != nil {
++			return "", fmt.Errorf(`media-type: %q should not have "manifests" or "fsLayers"`, mfst.MediaType)
++		}
++		return mfst.MediaType, nil
++	case manifestlist.MediaTypeManifestList, specs.MediaTypeImageIndex:
++		if mfst.Config != nil || mfst.Layers != nil || mfst.FSLayers != nil {
++			return "", fmt.Errorf(`media-type: %q should not have "config", "layers", or "fsLayers"`, mfst.MediaType)
++		}
++		return mfst.MediaType, nil
++	case schema1.MediaTypeManifest:
++		if mfst.Manifests != nil || mfst.Layers != nil {
++			return "", fmt.Errorf(`media-type: %q should not have "manifests" or "layers"`, mfst.MediaType)
++		}
+ 		return mfst.MediaType, nil
+-	case mfst.FSLayers != nil:
+-		return schema1.MediaTypeManifest, nil
+-	case mfst.Config != nil:
+-		return specs.MediaTypeImageManifest, nil
+ 	default:
++		if mfst.MediaType != "" {
++			return mfst.MediaType, nil
++		}
++	}
++	switch {
++	case mfst.FSLayers != nil && mfst.Manifests == nil && mfst.Layers == nil && mfst.Config == nil:
++		return schema1.MediaTypeManifest, nil
++	case mfst.Config != nil && mfst.Manifests == nil && mfst.FSLayers == nil,
++		mfst.Layers != nil && mfst.Manifests == nil && mfst.FSLayers == nil:
++		return specs.MediaTypeImageManifest, nil
++	case mfst.Config == nil && mfst.Layers == nil && mfst.FSLayers == nil:
++		// fallback to index
+ 		return specs.MediaTypeImageIndex, nil
+ 	}
++	return "", errors.New("media-type: cannot determine")
+ }
+diff --git a/distribution/manifest_test.go b/distribution/manifest_test.go
+index 0976a712ec..578f8ccce8 100644
+--- a/distribution/manifest_test.go
++++ b/distribution/manifest_test.go
+@@ -14,8 +14,10 @@ import (
+ 	"github.com/containerd/containerd/errdefs"
+ 	"github.com/containerd/containerd/remotes"
+ 	"github.com/docker/distribution"
++	"github.com/docker/distribution/manifest/manifestlist"
+ 	"github.com/docker/distribution/manifest/ocischema"
+ 	"github.com/docker/distribution/manifest/schema1"
++	"github.com/docker/distribution/manifest/schema2"
+ 	"github.com/google/go-cmp/cmp/cmpopts"
+ 	digest "github.com/opencontainers/go-digest"
+ 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+@@ -349,3 +351,73 @@ func TestDetectManifestBlobMediaType(t *testing.T) {
+ 	}
+ 
+ }
++
++func TestDetectManifestBlobMediaTypeInvalid(t *testing.T) {
++	type testCase struct {
++		json     []byte
++		expected string
++	}
++	cases := map[string]testCase{
++		"schema 1 mediaType with manifests": {
++			[]byte(`{"mediaType": "` + schema1.MediaTypeManifest + `","manifests":[]}`),
++			`media-type: "application/vnd.docker.distribution.manifest.v1+json" should not have "manifests" or "layers"`,
++		},
++		"schema 1 mediaType with layers": {
++			[]byte(`{"mediaType": "` + schema1.MediaTypeManifest + `","layers":[]}`),
++			`media-type: "application/vnd.docker.distribution.manifest.v1+json" should not have "manifests" or "layers"`,
++		},
++		"schema 2 mediaType with manifests": {
++			[]byte(`{"mediaType": "` + schema2.MediaTypeManifest + `","manifests":[]}`),
++			`media-type: "application/vnd.docker.distribution.manifest.v2+json" should not have "manifests" or "fsLayers"`,
++		},
++		"schema 2 mediaType with fsLayers": {
++			[]byte(`{"mediaType": "` + schema2.MediaTypeManifest + `","fsLayers":[]}`),
++			`media-type: "application/vnd.docker.distribution.manifest.v2+json" should not have "manifests" or "fsLayers"`,
++		},
++		"oci manifest mediaType with manifests": {
++			[]byte(`{"mediaType": "` + specs.MediaTypeImageManifest + `","manifests":[]}`),
++			`media-type: "application/vnd.oci.image.manifest.v1+json" should not have "manifests" or "fsLayers"`,
++		},
++		"manifest list mediaType with fsLayers": {
++			[]byte(`{"mediaType": "` + manifestlist.MediaTypeManifestList + `","fsLayers":[]}`),
++			`media-type: "application/vnd.docker.distribution.manifest.list.v2+json" should not have "config", "layers", or "fsLayers"`,
++		},
++		"index mediaType with layers": {
++			[]byte(`{"mediaType": "` + specs.MediaTypeImageIndex + `","layers":[]}`),
++			`media-type: "application/vnd.oci.image.index.v1+json" should not have "config", "layers", or "fsLayers"`,
++		},
++		"index mediaType with config": {
++			[]byte(`{"mediaType": "` + specs.MediaTypeImageIndex + `","config":{}}`),
++			`media-type: "application/vnd.oci.image.index.v1+json" should not have "config", "layers", or "fsLayers"`,
++		},
++		"config and manifests": {
++			[]byte(`{"config":{}, "manifests":[]}`),
++			`media-type: cannot determine`,
++		},
++		"layers and manifests": {
++			[]byte(`{"layers":[], "manifests":[]}`),
++			`media-type: cannot determine`,
++		},
++		"layers and fsLayers": {
++			[]byte(`{"layers":[], "fsLayers":[]}`),
++			`media-type: cannot determine`,
++		},
++		"fsLayers and manifests": {
++			[]byte(`{"fsLayers":[], "manifests":[]}`),
++			`media-type: cannot determine`,
++		},
++		"config and fsLayers": {
++			[]byte(`{"config":{}, "fsLayers":[]}`),
++			`media-type: cannot determine`,
++		},
++	}
++
++	for name, tc := range cases {
++		t.Run(name, func(t *testing.T) {
++			mt, err := detectManifestBlobMediaType(tc.json)
++			assert.Error(t, err, tc.expected)
++			assert.Equal(t, mt, "")
++		})
++	}
++
++}
+-- 
+2.33.1
+

--- a/packages/docker-engine/1004-vendor-github.com-moby-buildkit-v0.8.3-4-gbc07.patch
+++ b/packages/docker-engine/1004-vendor-github.com-moby-buildkit-v0.8.3-4-gbc07.patch
@@ -1,0 +1,81 @@
+From da9c9837892596fb44a73bcfd3e061bd23d0cff1 Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 17 Nov 2021 20:40:17 +0100
+Subject: [PATCH] [20.10] vendor: github.com/moby/buildkit v0.8.3-4-gbc07b2b8
+
+imageutil: make mediatype detection more stricter to mitigate CVE-2021-41190.
+
+full diff: https://github.com/moby/buildkit/compare/244e8cde639f71a05a1a2e0670bd88e0206ce55c...bc07b2b81b1c6a62d29981ac564b16a15ce2bfa7
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+---
+ vendor.conf                                   |  2 +-
+ .../moby/buildkit/util/imageutil/config.go    | 32 +++++++++++++++----
+ 2 files changed, 27 insertions(+), 7 deletions(-)
+
+diff --git a/vendor.conf b/vendor.conf
+index a88f05bd71..64d4fad331 100644
+--- a/vendor.conf
++++ b/vendor.conf
+@@ -33,7 +33,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
+ golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
+ 
+ # buildkit
+-github.com/moby/buildkit                            244e8cde639f71a05a1a2e0670bd88e0206ce55c # v0.8.3-3-g244e8cde
++github.com/moby/buildkit                            bc07b2b81b1c6a62d29981ac564b16a15ce2bfa7 # v0.8.3-4-gbc07b2b8
+ github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
+ github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
+ github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
+diff --git a/vendor/github.com/moby/buildkit/util/imageutil/config.go b/vendor/github.com/moby/buildkit/util/imageutil/config.go
+index 0be587058a..a93c8ccd6b 100644
+--- a/vendor/github.com/moby/buildkit/util/imageutil/config.go
++++ b/vendor/github.com/moby/buildkit/util/imageutil/config.go
+@@ -183,19 +183,39 @@ func DetectManifestMediaType(ra content.ReaderAt) (string, error) {
+ 
+ func DetectManifestBlobMediaType(dt []byte) (string, error) {
+ 	var mfst struct {
+-		MediaType string          `json:"mediaType"`
++		MediaType *string         `json:"mediaType"`
+ 		Config    json.RawMessage `json:"config"`
++		Manifests json.RawMessage `json:"manifests"`
++		Layers    json.RawMessage `json:"layers"`
+ 	}
+ 
+ 	if err := json.Unmarshal(dt, &mfst); err != nil {
+ 		return "", err
+ 	}
+ 
+-	if mfst.MediaType != "" {
+-		return mfst.MediaType, nil
++	mt := images.MediaTypeDockerSchema2ManifestList
++
++	if mfst.Config != nil || mfst.Layers != nil {
++		mt = images.MediaTypeDockerSchema2Manifest
++
++		if mfst.Manifests != nil {
++			return "", errors.Errorf("invalid ambiguous manifest and manifest list")
++		}
+ 	}
+-	if mfst.Config != nil {
+-		return images.MediaTypeDockerSchema2Manifest, nil
++
++	if mfst.MediaType != nil {
++		switch *mfst.MediaType {
++		case images.MediaTypeDockerSchema2ManifestList, specs.MediaTypeImageIndex:
++			if mt != images.MediaTypeDockerSchema2ManifestList {
++				return "", errors.Errorf("mediaType in manifest does not match manifest contents")
++			}
++			mt = *mfst.MediaType
++		case images.MediaTypeDockerSchema2Manifest, specs.MediaTypeImageManifest:
++			if mt != images.MediaTypeDockerSchema2Manifest {
++				return "", errors.Errorf("mediaType in manifest does not match manifest contents")
++			}
++			mt = *mfst.MediaType
++		}
+ 	}
+-	return images.MediaTypeDockerSchema2ManifestList, nil
++	return mt, nil
+ }
+-- 
+2.34.0
+

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -30,6 +30,12 @@ Patch0001: 0001-Lock-down-docker-root-dir-perms.patch
 # CVE-2021-41089
 Patch0002: 0002-chrootarchive-don-t-create-parent-dirs-outside-of-ch.patch
 
+# CVE-2021-41190
+Patch0003: 1001-vendor-update-github.com-docker-distribution.patch
+Patch0004: 1002-vendor-update-github.com-containerd-containerd.patch
+Patch0005: 1003-distribution-validate-blob-type.patch
+Patch0006: 1004-vendor-github.com-moby-buildkit-v0.8.3-4-gbc07.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libseccomp-devel


### PR DESCRIPTION
**Description of changes:**
 Update docker and containerd with the relevant patches for CVE-2021-41190.


**Testing done:**
Built an aws-ecs-1 image.  Verified that Docker and containerd both worked properly and included the fixes.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
