### PR TITLE
API: support prefix query parameter consistently

### DIFF
--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -12,6 +12,27 @@ servers:
   description: The production API server
 
 paths:
+  /:
+    get:
+      summary: "Get current model, including settings, services, configuration files, and os info"
+      operationId: "get_model"
+      parameters:
+        - in: query
+          name: prefix
+          description: "Specific key prefix to query"
+          schema:
+            type: string
+          required: false
+      responses:
+        200:
+          description: "Successful request"
+          content:
+            application/json:
+              schema:
+                $ref: "Model"
+        500:
+          description: "Server error"
+
   /settings:
     get:
       summary: "Get current settings"

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -179,6 +179,13 @@ paths:
     get:
       summary: "Get OS information such as version, variant, and architecture"
       operationId: "get_os_info"
+      parameters:
+        - in: query
+          name: prefix
+          description: "Specific key prefix to query"
+          schema:
+            type: string
+          required: false
       responses:
         200:
           description: "Successful request"
@@ -279,6 +286,12 @@ paths:
           style: form
           explode: false
           required: false
+        - in: query
+          name: prefix
+          description: "Specific key prefix to query. This parameter will be ignored if 'names' is also supplied"
+          schema:
+            type: string
+          required: false
       responses:
         200:
           description: "Successful request"
@@ -304,6 +317,13 @@ paths:
           # `style: form` and `explode: false` format parameters as such:  /configuration-files?names=file1,file2
           style: form
           explode: false
+          required: false
+      parameters:
+        - in: query
+          name: prefix
+          description: "Specific key prefix to query. This parameter will be ignored if 'names' is also supplied"
+          schema:
+            type: string
           required: false
       responses:
         200:


### PR DESCRIPTION
**Description of changes:**

```
40cacee0 API: support prefix query parameter consistently
57074659 API: add missing OpenAPI definition for /
```

`apiclient get` (#1836) supports prefix queries of the API, and this PR is needed to consistently support the `?prefix=` parameter for all of the different data types - settings (which was already supported), services, configuration files, and os.  (`apiclient get` just queries `/` but consistency is good.)

**Testing done:**

Existing and new unit tests pass.

Started a 1.4.1 AMI and a new one with these changes.

The following queries return exactly the same response (after keys are sorted) modulo the build version, IP address, and update seed, as expected:
* `apiclient -u /`
* `apiclient -u /settings`
* `apiclient -u /settings?prefix=m` shows motd, metrics, etc.
* `apiclient -u /settings?prefix=motd` shows motd
* `apiclient -u /settings?prefix=x` shows nothing
* `apiclient -u /services`
* `apiclient -u /configuration-files`
* `apiclient -u /os`

The following queries used to ignore the unknown `prefix` query and return all results, but now properly restrict to the given prefix:
* `apiclient -u /?prefix=x` shows nothing
* `apiclient -u /?prefix=s` shows settings and services
* `apiclient -u /services?prefix=x` shows nothing
* `apiclient -u /services?prefix=m` shows motd and metricdog
* `apiclient -u /configuration-files?prefix=x` shows nothing
* `apiclient -u /configuration-files?prefix=m` shows motd and metricdog-toml
* `apiclient -u /os?prefix=x` shows nothing
* `apiclient -u /os?prefix=a` shows arch

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
