### PR TITLE
Update pcre URLs now that ftp.pcre.org is deprecated

### DIFF
--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -16,7 +16,7 @@ url = "https://download.gnome.org/sources/glib/2.70/glib-2.70.1.tar.xz"
 sha512 = "639317c98ab72ad853608ab4d395484daff135c0222556c51ca93fd8533c5759db14478beda964e4feb02bb2737a46a4eda25063f98a9c6ba6ae4bc5d74bf5e1"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.pcre.org/pub/pcre/pcre-8.37.tar.bz2"
+url = "https://downloads.sourceforge.net/pcre/pcre-8.37.tar.bz2"
 sha512 = "19344c9add2ebbd26c528505d07d3b028d79bc3e6103d51453a449cebd76bc76f5bc7ddd9ef0de41f98c50be74a2d9a65db539ed60f1add1086d99bde8a81466"
 
 [[package.metadata.build-package.external-files]]

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -8,7 +8,7 @@ License: LGPL-2.1-only AND BSD-3-Clause
 URL: https://www.gtk.org/
 Source0: https://download.gnome.org/sources/glib/2.70/glib-%{version}.tar.xz
 # Note: the pcre version is specified in the glib archive in subprojects/libpcre.wrap
-Source1: https://ftp.pcre.org/pub/pcre/pcre-8.37.tar.bz2
+Source1: https://downloads.sourceforge.net/pcre/pcre-8.37.tar.bz2
 Source2: https://wrapdb.mesonbuild.com/v2/pcre_8.37-2/get_patch#/pcre_8.37-2_patch.zip
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/libpcre/Cargo.toml
+++ b/packages/libpcre/Cargo.toml
@@ -9,10 +9,10 @@ build = "build.rs"
 path = "pkg.rs"
 
 [package.metadata.build-package]
-releases-url = "https://ftp.pcre.org/pub/pcre"
+releases-url = "https://github.com/PhilipHazel/pcre2/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.pcre.org/pub/pcre/pcre2-10.37.tar.bz2"
+url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.37/pcre2-10.37.tar.bz2"
 sha512 = "69f4bf4736b986e0fc855eedb292efe72a0df2e803bc0e61a6cf47775eed433bb1b2f28d7e641591ef4603d47beb543a64ed0eef9538d00f0746bc3435c143ec"
 
 [build-dependencies]

--- a/packages/libpcre/libpcre.spec
+++ b/packages/libpcre/libpcre.spec
@@ -4,7 +4,7 @@ Release: 1%{?dist}
 Summary: Library for regular expressions
 License: BSD-3-Clause
 URL: https://www.pcre.org/
-Source0: https://ftp.pcre.org/pub/pcre/pcre2-%{version}.tar.bz2
+Source0: https://github.com/PhilipHazel/pcre2/releases/download/pcre2-%{version}/pcre2-%{version}.tar.bz2
 BuildRequires: %{_cross_os}glibc-devel
 
 %description


### PR DESCRIPTION
**Issue number:**

Fixes #1837.

**Testing done:**

Downloaded the new URLs, confirmed the sha512sums match the existing ones.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
