### PR TITLE
imdsclient: better retries with tokio retry and timeout

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "tokio-retry",
  "tokio-test",
  "url",
 ]
@@ -3440,6 +3441,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project 1.0.8",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/sources/api/early-boot-config/src/provider/aws.rs
+++ b/sources/api/early-boot-config/src/provider/aws.rs
@@ -85,7 +85,7 @@ impl PlatformDataProvider for AwsDataProvider {
     ) -> std::result::Result<Vec<SettingsJson>, Box<dyn std::error::Error>> {
         let mut output = Vec::new();
 
-        let mut client = ImdsClient::new().await.context(error::ImdsClient)?;
+        let mut client = ImdsClient::new();
 
         // Attempt to read from local file first on the `aws-dev` variant
         #[cfg(bottlerocket_platform = "aws-dev")]

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -303,7 +303,7 @@ fn parse_args(mut args: env::Args) -> String {
 
 async fn run() -> Result<()> {
     let setting_name = parse_args(env::args());
-    let mut client = ImdsClient::new().await.context(error::ImdsClient)?;
+    let mut client = ImdsClient::new();
 
     let setting = match setting_name.as_ref() {
         "cluster-dns-ip" => get_cluster_dns_ip(&mut client).await,

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -42,7 +42,7 @@ impl UserData {
 /// Returns a list of public keys.
 async fn fetch_public_keys_from_imds() -> Result<Vec<String>> {
     info!("Connecting to IMDS");
-    let mut client = ImdsClient::new().await.context(error::ImdsClient)?;
+    let mut client = ImdsClient::new();
     let public_keys = client
         .fetch_public_ssh_keys()
         .await

--- a/sources/imdsclient/Cargo.toml
+++ b/sources/imdsclient/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.11.1", default-features = false }
 serde_json = "1"
 snafu = "0.6"
 tokio = { version = "~1.8", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
+tokio-retry = "0.3"
 url = "2.1.1"
 
 [build-dependencies]

--- a/sources/imdsclient/README.md
+++ b/sources/imdsclient/README.md
@@ -6,6 +6,9 @@ Current version: 0.1.0
 
 The library uses IMDSv2 (session-oriented) requests over a pinned schema to guarantee compatibility.
 Session tokens are fetched automatically and refreshed if the request receives a `401` response.
+If an IMDS token fetch or query fails, the library will continue to retry with a fibonacci backoff
+strategy until it is successful or times out. The default timeout is 300s to match the ifup timeout
+set in wicked.service, but can configured using `.with_timeout` during client creation.
 
 Each public method is explicitly targeted and return either bytes or a `String`.
 


### PR DESCRIPTION
**Description of changes:**

To mitigate things like closed connections, IMDSv2 token and data
fetches will continue to retry until success or until the timeout has
been reached.

The default timeout is 300s to match the ifup timeout in wicked, but can
be set manually using `.with_timeout` when creating a new ImdsClient.

Also moves the token fetch to just before the IMDS data fetch so
that building a new ImdsClient no longer needs an await.

`refresh_token` has been replaced by `clear_token` and `write_token`.

**Testing done:**
In addition to the unit testing...
- Built `aws-k8s-1.21` ami and launched instance.
- Instance connected to eks cluster.
- Connected to control container via ssm session.
- Verified that `host-containers.admin.user-data` contained a base64-encoded block.
- Connected to admin container via ssh.
- Verified that `/.bottlerocket/host-containers/admin/user-data` contained JSON.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.
- Ran `pluto` with it's sub-commands to verify functionality.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
