### PR TITLE
Update x509-parser from 0.9.2 to 0.11.0

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -493,9 +493,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.19.5"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
 dependencies = [
  "funty",
  "radium",
@@ -653,7 +653,6 @@ dependencies = [
  "base64",
  "cargo-readme",
  "constants",
- "der-parser",
  "http",
  "log",
  "models",
@@ -903,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "5.1.0"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120842c2385dea19347e2f6e31caa5dced5ba8afdfacaac16c59465fdd1168f2"
+checksum = "2d7ededb7525bb4114bc209685ce7894edc2965f4914312a1ea578a645a237f0"
 dependencies = [
  "der-oid-macro",
  "nom",
@@ -2756,12 +2755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,9 +3898,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x509-parser"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64abca276c58f8341ddc13fd4bd6ae75993cc669043f5b34813c90f7dff04771"
+checksum = "d2ce30cd4a10592affdced3f5c95e03e8f23599d282e727fc44035c21250d552"
 dependencies = [
  "base64",
  "chrono",
@@ -3917,7 +3910,6 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "rustversion",
  "thiserror",
 ]
 

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -14,10 +14,6 @@ apiclient = { path = "../apiclient", version = "0.1.0" }
 argh = "0.1.3"
 base64 = "0.13"
 constants = { path = "../../constants", version = "0.1.0" }
-# x509-parser depends on der-parser ^5.0.  5.1.1 contains breaking changes.
-# The 5.1.1 release isn't in the master branch; those changes are instead in a
-# 6.0.0 release, more clearly implying breaking changes.  Lock to 5.1.0.
-der-parser = "=5.1.0"
 http = "0.2"
 log = "0.4"
 models = { path = "../../models", version = "0.1.0" }
@@ -26,7 +22,7 @@ serde_json = "1"
 simplelog = "0.10"
 snafu = "0.6"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
-x509-parser = "0.9.2"
+x509-parser = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_plain = "1.0"
 snafu = "0.6"
 toml = "0.5"
-x509-parser = "0.9.2"
+x509-parser = "0.11.0"
 url = "2.1"
 
 [build-dependencies]


### PR DESCRIPTION
**Issue number:**
#1743


**Description of changes:**

```
5edde283  sources: update x509-parser
```

I tried to update to the latest version (0.12.0), however, there is a problem in a license of one of the dependencies, apparently, the license text doesn't match with the identifier used for the License. I'll dig into that problem later, since I might have to contribute to the library to fix the problem.


**Testing done:**
In AWS ECS, launched a bootstrap-container with the following definition:

```Dockerfile
FROM alpine

RUN apk add openssl

ADD ./generate-certificate ./csr.conf ./config.yml ./

ENTRYPOINT ["sh", "generate-certificate"]
```

And `generate-certificate` as:

```bash
#!/bin/sh

set -xe

PERSISTENT_DIR=/.bottlerocket/rootfs/mnt/certificates

mkdir -p $PERSISTENT_DIR

# Mount certificates as a tmpfs filesystem
mount -t tmpfs none $PERSISTENT_DIR
cp config.yml $PERSISTENT_DIR

# Generate 3 certificates
for i in $(seq 3); do
  # Generate CA Certificate and Key
  openssl genrsa -out $PERSISTENT_DIR/ca-$i.key 2048
  openssl req -x509 -new -nodes -key $PERSISTENT_DIR/ca-$i.key \
    -subj "/CN=bottlerocket/C=US/L=WASHINGTON" -days 1825 -out $PERSISTENT_DIR/ca-$i.crt
done

# Randomly select the CA certificate
TARGET=ca-$(( $RANDOM % 3 + 1 ))
ln -s $PERSISTENT_DIR/$TARGET.crt $PERSISTENT_DIR/ca.crt
ln -s $PERSISTENT_DIR/$TARGET.key $PERSISTENT_DIR/ca.key

# Generate SSL/TLS Certificates
openssl genrsa -out $PERSISTENT_DIR/server.key 2048
openssl req -new -key $PERSISTENT_DIR/server.key -out $PERSISTENT_DIR/server.csr -config csr.conf
openssl x509 -req -in $PERSISTENT_DIR/server.csr -CA $PERSISTENT_DIR/ca.crt -CAkey $PERSISTENT_DIR/ca.key \
  -CAcreateserial -out $PERSISTENT_DIR/server.crt -days 10000 -extensions req_ext \
  -extfile csr.conf

# Save all certificates as a bundle
BUNDLE=$(cat $PERSISTENT_DIR/ca-1.crt $PERSISTENT_DIR/ca-2.crt $PERSISTENT_DIR/ca-3.crt | base64 -w0)
apiclient set pki.local-registry.data=$BUNDLE \
  pki.local-registry.trusted=true
```

From `sheltie`, validated that the certificates store has the 3 new certificates:

```shell
bash-5.0# grep bottlerocket /etc/pki/tls/certs/ca-bundle.crt
# bottlerocket
# bottlerocket
# bottlerocket
```
Validated that the certificates store is updated when the bundle is marked as 'distrusted':

```
bash-5.0# apiclient set pki.local-registry.trusted=false
bash-5.0# grep bottlerocket /etc/pki/tls/certs/ca-bundle.crt
# ^ didn't return any matches
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
