### PR TITLE
host-containers: update admin to v0.7.3, update control to v0.5.3

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -78,3 +78,7 @@ version = "1.4.1"
     "migrate_v1.4.0_registry-mirror-representation.lz4",
 ]
 "(1.4.0, 1.4.1)" = []
+"(1.4.1, 1.4.2)" = [
+    "migrate_v1.4.2_admin-container-v0-7-3.lz4",
+    "migrate_v1.4.2_control-container-v0-5-3.lz4",
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -267,6 +267,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "admin-container-v0-7-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +717,13 @@ dependencies = [
 
 [[package]]
 name = "control-container-v0-5-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "control-container-v0-5-3"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -29,6 +29,8 @@ members = [
     "api/migration/migrations/v1.3.0/hostname-affects-etc-hosts",
     "api/migration/migrations/v1.3.0/control-container-v0-5-2",
     "api/migration/migrations/v1.4.0/registry-mirror-representation",
+    "api/migration/migrations/v1.4.2/admin-container-v0-7-3",
+    "api/migration/migrations/v1.4.2/control-container-v0-5-3",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.4.2/admin-container-v0-7-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.4.2/admin-container-v0-7-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "admin-container-v0-7-3"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.4.2/admin-container-v0-7-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.4.2/admin-container-v0-7-3/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.2";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.3";
+
+/// We bumped the version of the default admin container from v0.7.2 to v0.7.3
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.4.2/control-container-v0-5-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.4.2/control-container-v0-5-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "control-container-v0-5-3"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.4.2/control-container-v0-5-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.4.2/control-container-v0-5-3/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.2";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.3";
+
+/// We bumped the version of the default control container from v0.5.2 to v0.5.3
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.3"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.3"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Dec 1 13:16:24 2021 -0800

    host-containers: migrations for new container image versions
    
    admin container to v0.7.3
    control container to v0.5.3

```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Dec 1 13:14:03 2021 -0800

    host-containers: new templates for new container image versions
    
    admin container to v0.7.3
    control container to v0.5.3
```

**Testing done:**
Tested migrations. The host-containers templates get changed on upgrade and downgrade as expected. Host-containers run without problem.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
