### PR TITLE
Update CHANGELOG.md and Release.toml for 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v1.4.1 (2021-11-18)
+
+## Security Fixes
+
+* Apply patches to docker and containerd for CVE-2021-41190 ([#1832], [#1833])
+
+## Build Changes
+
+* Update Bottlerocket SDK to 0.23.1 ([#1831])
+
+[#1831]: https://github.com/bottlerocket-os/bottlerocket/pull/1831
+[#1832]: https://github.com/bottlerocket-os/bottlerocket/pull/1832
+[#1833]: https://github.com/bottlerocket-os/bottlerocket/pull/1833
+
+
 # v1.4.0 (2021-11-12)
 
 ## OS Changes

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.4.0"
+version = "1.4.1"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -77,3 +77,4 @@ version = "1.4.0"
 "(1.3.0, 1.4.0)" = [
     "migrate_v1.4.0_registry-mirror-representation.lz4",
 ]
+"(1.4.0, 1.4.1)" = []


### PR DESCRIPTION
**Description of changes:**
Cherry picks commits from the 1.4.x branch for the 1.4.1 point release, which were mistakenly not included in `develop`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
