### PR TITLE
netdog: remove outdated TODO

### DIFF
--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -12,13 +12,6 @@ It contains two subcommands meant for use as settings generators:
 The subcommand `set-hostname` sets the hostname for the system.
 */
 
-// TODO:
-// We should rework this to store info in the API and delegate rewriting of
-// files and any required process restarts to the existing machinery.
-// This is blocked on the ability to apply and commit settings in separate
-// transactions; otherwise a lease renewal while settings were being added
-// by other processes could cause them to be applied in an incomplete state.
-
 #![deny(rust_2018_idioms)]
 
 #[macro_use]


### PR DESCRIPTION
```
The blocker wasn't just API transactions, but also the fact that we'd want to
store netdog settings in a private space, which isn't currently supported in
the API.  Also, netdog starts before the API system, so it would require
reworking the startup process.  The benefit would be minimal in any case, so we
can just get rid of this TODO.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
