### PR TITLE
Mount /lib/modules as overlay filesystem

### DIFF
--- a/packages/release/lib-modules.mount.in
+++ b/packages/release/lib-modules.mount.in
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kernel Modules (Read-Write)
+Conflicts=umount.target
+Before=local-fs.target umount.target
+Wants=prepare-local.service
+After=prepare-local.service
+RequiresMountsFor=/var
+
+[Mount]
+What=overlay
+Where=PREFIX/lib/modules
+Type=overlay
+Options=noatime,nosuid,nodev,lowerdir=/lib/modules,upperdir=/var/lib/kernel-modules/.overlay/upper,workdir=/var/lib/kernel-modules/.overlay/work,context=system_u:object_r:state_t:s0
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -36,12 +36,15 @@ ExecStart=/usr/lib/systemd/systemd-growfs ${LOCAL_DIR}
 ExecStart=/usr/bin/mkdir -p ${LOCAL_DIR}/var ${LOCAL_DIR}/opt ${LOCAL_DIR}/mnt
 
 # Create the directories we need to set up a read-write overlayfs for the kernel
-# development sources.
-ExecStart=/usr/bin/rm -rf ${LOCAL_DIR}/var/lib/kernel-devel
+# development sources and the kernel modules
+ExecStart=/usr/bin/rm -rf ${LOCAL_DIR}/var/lib/kernel-devel \
+    %{LOCAL_DIR}/var/lib/kernel-modules
 ExecStart=/usr/bin/mkdir -p \
     ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/lower \
     ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/upper \
-    ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/work
+    ${LOCAL_DIR}/var/lib/kernel-devel/.overlay/work \
+    ${LOCAL_DIR}/var/lib/kernel-modules/.overlay/upper \
+    ${LOCAL_DIR}/var/lib/kernel-modules/.overlay/work
 
 # Create the directories we need to set up a read-write overlayfs for any CNI
 # plugin binaries.

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -40,6 +40,7 @@ Source1016: mount-cdrom.rules
 Source1020: var-lib-kernel-devel-lower.mount.in
 Source1021: usr-src-kernels.mount.in
 Source1022: usr-share-licenses.mount.in
+Source1023: lib-modules.mount.in
 
 # Mounts that require helper programs
 Source1040: prepare-boot.service
@@ -139,6 +140,11 @@ LICENSEPATH=$(systemd-escape --path %{_cross_licensedir})
 sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1022} > ${LICENSEPATH}.mount
 install -p -m 0644 ${LICENSEPATH}.mount %{buildroot}%{_cross_unitdir}
 
+# Mounting on lib/modules requires using the real path: %{_cross_libdir}/modules
+LIBDIRPATH=$(systemd-escape --path %{_cross_libdir})
+sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1023} > ${LIBDIRPATH}-modules.mount
+install -p -m 0644 ${LIBDIRPATH}-modules.mount %{buildroot}%{_cross_unitdir}
+
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
@@ -178,6 +184,7 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %{_cross_unitdir}/*-kernels.mount
 %{_cross_unitdir}/*-licenses.mount
 %{_cross_unitdir}/var-lib-bottlerocket.mount
+%{_cross_unitdir}/*-modules.mount
 %{_cross_unitdir}/runtime.slice
 %{_cross_unitdir}/set-hostname.service
 %dir %{_cross_unitdir}/systemd-tmpfiles-setup.service.d


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**
Related to #1799 , that PR is quite big. I'm taking some of the commits in that PR as their individual PR. The commit in this PR is variant independent, since it changes a package used among all variants.

```
Mount /lib/modules as overlay filesystem
```

The /lib/modules directory must have write access in order for us to add kernel modules at runtime. With this commit, an overlay filesystem will be mounted in /lib/modules/ so that kernel modules can be added at runtime.

**Testing done:**
- Build an aws-dev Bottlerocket image
- Confirmed that there is a writable `overlay` filesystem in `/lib/modules` 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
