### PR TITLE
Change when ldconfig runs and what files it looks for

### DIFF
--- a/packages/glibc/glibc-tmpfiles.conf
+++ b/packages/glibc/glibc-tmpfiles.conf
@@ -1,4 +1,5 @@
-f /etc/ld.so.conf 0644 root root -
+C /etc/ld.so.conf 0644 root root -
 f /etc/ld.so.cache 0644 root root -
+d /etc/ld.so.conf.d/ 0644 root root -
 d /run/cache/ldconfig 0700 root root -
 f /run/cache/ldconfig/aux-cache 0600 root root -

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -6,6 +6,8 @@ License: LGPL-2.1-or-later AND (LGPL-2.1-or-later WITH GCC-exception-2.0) AND GP
 URL: http://www.gnu.org/software/glibc/
 Source0: https://ftp.gnu.org/gnu/glibc/glibc-%{version}.tar.xz
 Source1: glibc-tmpfiles.conf
+Source2: ld.so.conf
+Source3: ldconfig-service.conf
 
 # Upstream patches from 2.34 release branch:
 # ```
@@ -93,9 +95,13 @@ make %{?_smp_mflags} -O -r
 %install
 make -j1 install_root=%{buildroot} install -C build
 
-mkdir -p %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
+install -d %{buildroot}%{_cross_unitdir}/ldconfig.service.d
+
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/glibc.conf
+install -p -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf
+install -p -m 0644 %{S:3} %{buildroot}%{_cross_unitdir}/ldconfig.service.d/ldconfig.conf
 
 truncate -s 0 %{buildroot}%{_cross_libdir}/gconv/gconv-modules
 chmod 644 %{buildroot}%{_cross_libdir}/gconv/gconv-modules
@@ -176,6 +182,12 @@ chmod 644 %{buildroot}%{_cross_datadir}/locale/locale.alias
 %exclude %{_cross_datadir}/i18n/locales/*
 %exclude %{_cross_datadir}/locale/*
 %exclude %{_cross_localstatedir}/db/Makefile
+
+%dir %{_cross_factorydir}
+%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf
+
+%dir %{_cross_unitdir}/ldconfig.service.d
+%{_cross_libdir}/systemd/system/ldconfig.service.d/ldconfig.conf
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/glibc/ld.so.conf
+++ b/packages/glibc/ld.so.conf
@@ -1,0 +1,1 @@
+include ld.so.conf.d/*.conf

--- a/packages/glibc/ldconfig-service.conf
+++ b/packages/glibc/ldconfig-service.conf
@@ -1,0 +1,4 @@
+[Unit]
+# Run `ldconfig.service` after `tmpfilesd`, since `ldconfig` will attempt to
+# read files from `/etc/ld.so.conf.d`, which are created by `tmpfilesd`
+After=systemd-tmpfiles-setup.service


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**
Related to #1799 , that PR is quite big. I'm taking some of the commits in that PR as their individual PR. The commit in this PR is variant independent, since it changes a package used among all variants.

```
507d5eae systemd: delay ldconfig.service
```

There are packages that create `ldconfig.d/*.conf` files using a tmpfilesd file to cache additional libraries, thus `ldconfig.service` has to run after the tmpfilesd daemon creates the files.

```
8b20ba9b Include ld.so.conf.d/* to build ld cache
```
This commit adds a configuration file for ldconfig to read additional configurations from /etc/ld.so.conf, which will be created at runtime by the tmpfilesd daemon.

**Testing done:**
- Build a Bottlerocket aws-dev image
- Confirmed that `ldconfig.service` waits for `systemd-tmpfiles-setup.service`
- Confirmed that `ldconfig` looks for libraries in directories specified in `/etc/ld.so.conf.d/*.conf` files


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
