### PR TITLE
kubernetes: create node-feature-discovery directory

### DIFF
--- a/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.18/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
+d /var/lib/kubelet/node-feature-discovery/features.d - - - -
+L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d

--- a/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.19/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
+d /var/lib/kubelet/node-feature-discovery/features.d - - - -
+L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d

--- a/packages/kubernetes-1.20/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.20/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
+d /var/lib/kubelet/node-feature-discovery/features.d - - - -
+L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d

--- a/packages/kubernetes-1.21/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.21/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 d /var/lib/kubelet/providers/secrets-store - - - -
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
+d /var/lib/kubelet/node-feature-discovery/features.d - - - -
+L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**
Related to #1799 , that PR is quite big. I'm taking some of the commits in that PR as their individual PR.

```
19ec743c  kubernetes: create node-feature-discovery directory
```

For plugins to properly work with the Node Feature Discovery implementation, the plugin has to have read/write access to `/etc/node-feature-discovery/features.d`. With this commit, the directory is created as a symlink to
`/var/lib/kubelet/node-feature-discovery/features.d`.

**Testing done:**
In aws-k8s-1.18,1.19,1.20,1.21:
- Deployed the `node-feature-discovery` daemonset with helm
- Verified the daemonset's pods were running and had access to `/etc/node-feature-discovery/features.d`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
