### PR TITLE
Add driverdog to link and load kernel modules at runtime

### DIFF
--- a/packages/binutils/Cargo.toml
+++ b/packages/binutils/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "binutils"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/binutils/binutils-2.35.2.tar.xz"
+sha512 = "9974ede5978d32e0d68fef23da48fa00bd06b0bff7ec45b00ca075c126d6bbe0cf2defc03ecc3f17bc6cc85b64271a13009c4049d7ba17de26e84e3a6e2c0348"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libz = { path = "../libz" }

--- a/packages/binutils/binutils.spec
+++ b/packages/binutils/binutils.spec
@@ -1,0 +1,67 @@
+Name: %{_cross_os}binutils
+Version: 2.35.2
+Release: 1%{?dist}
+Summary: Tools for working with binaries
+URL: https://sourceware.org/binutils
+License: GPL-2.0-or-later AND LGPL-2.0-or-later AND GPL-3.0-or-later
+Source0: https://ftp.gnu.org/gnu/binutils/binutils-%{version}.tar.xz
+Requires: %{_cross_os}libz
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libz-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using tools for working with binaries
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n binutils-%{version} -p1
+
+%build
+# Fail if the SDK version is different than the one provided in the image
+[ %{version} = $(%{_cross_target}-ld -v | awk '{print $NF}') ] || exit 1
+
+%cross_configure \
+  --disable-gold \
+  --disable-gdb \
+  --with-system-zlib \
+  --without-gnu-as \
+  --disable-plugins \
+  --disable-static
+%make_build MAKEINFO=true tooldir=%{_cross_prefix}
+
+%install
+%make_install MAKEINFO=true tooldir=%{_cross_prefix}
+
+%files
+%license COPYING COPYING3.LIB COPYING3
+%{_cross_attribution_file}
+%{_cross_bindir}/ld
+%{_cross_bindir}/strip
+%exclude %{_cross_infodir}
+%exclude %{_cross_mandir}
+%exclude %{_cross_localedir}
+%exclude %{_cross_libdir}/ldscripts
+%exclude %{_cross_libdir}/lib*.la
+%exclude %{_cross_bindir}/addr2line
+%exclude %{_cross_bindir}/ar
+%exclude %{_cross_bindir}/c++filt
+%exclude %{_cross_bindir}/elfedit
+%exclude %{_cross_bindir}/gprof
+%exclude %{_cross_bindir}/ld.bfd
+%exclude %{_cross_bindir}/nm
+%exclude %{_cross_bindir}/objcopy
+%exclude %{_cross_bindir}/objdump
+%exclude %{_cross_bindir}/ranlib
+%exclude %{_cross_bindir}/readelf
+%exclude %{_cross_bindir}/size
+%exclude %{_cross_bindir}/strings
+
+%files devel
+%{_cross_libdir}/*.a
+%{_cross_includedir}/*.h

--- a/packages/binutils/build.rs
+++ b/packages/binutils/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/binutils/pkg.rs
+++ b/packages/binutils/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -21,7 +21,8 @@ source-groups = [
     "models",
     "imdsclient",
     "retry-read",
-    "shimpei"
+    "shimpei",
+    "driverdog"
 ]
 
 [lib]
@@ -40,5 +41,7 @@ glibc = { path = "../glibc" }
 # kexec-tools and makedumpfile required for prairiedog functionality
 # kexec-tools = { path = "../kexec-tools" }
 # makedumpfile = { path = "../makedumpfile" }
+# binutils required for driverdog functionality
+# binutils = { path = "../binutils" }
 # oci-add-hooks required for shimpei functionality
 # oci-add-hooks = { path = "../oci-add-hooks" }

--- a/packages/os/link-kernel-modules.service
+++ b/packages/os/link-kernel-modules.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Link additional kernel modules
+# Rerunning this service after the system is fully loaded will override
+# the already linked kernel modules. This doesn't affect the running system,
+# since kernel modules are linked early in the boot sequence, but we still
+# disable manual restarts to prevent unnecessary kernel modules rewrites.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/driverdog link-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/os/load-kernel-modules.service
+++ b/packages/os/load-kernel-modules.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Load additional kernel modules
+After=link-kernel-modules.service
+Requires=link-kernel-modules.service
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/driverdog load-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -15,6 +15,7 @@ path = "pkg.rs"
 # RPM Requires
 [dependencies]
 acpid = { path = "../acpid" }
+binutils = { path = "../binutils" }
 ca-certificates = { path = "../ca-certificates" }
 chrony = { path = "../chrony" }
 conntrack-tools = { path = "../conntrack-tools" }

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1005,6 +1005,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "driverdog"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "cargo-readme",
+ "log",
+ "serde",
+ "simplelog",
+ "snafu",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -39,6 +39,8 @@ members = [
 
     "imdsclient",
 
+    "driverdog",
+
     "ghostdog",
 
     "growpart",

--- a/sources/driverdog/Cargo.toml
+++ b/sources/driverdog/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "driverdog"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+argh = "0.1.3"
+log = "0.4"
+simplelog = "0.10"
+snafu = "0.6"
+serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.2.0"
+toml = "0.5.8"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/driverdog/README.md
+++ b/sources/driverdog/README.md
@@ -1,0 +1,14 @@
+# driverdog
+
+Current version: 0.1.0
+
+driverdog is a tool to link kernel modules at runtime. It uses a toml configuration file with the following shape:
+
+`lib-modules-path`: destination path for the .ko linked files
+`objects-source`: path where the objects used to link the kernel module are
+`object-files`: hash with the object files to be linked, each object in the map should include the files used to link it
+`kernel-modules`: hash with the kernel modules to be linked, each kernel module in the map should include the files used to link it
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/driverdog/README.tpl
+++ b/sources/driverdog/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/driverdog/build.rs
+++ b/sources/driverdog/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/driverdog/src/main.rs
+++ b/sources/driverdog/src/main.rs
@@ -1,0 +1,446 @@
+/*!
+driverdog is a tool to link kernel modules at runtime. It uses a toml configuration file with the following shape:
+
+`lib-modules-path`: destination path for the .ko linked files
+`objects-source`: path where the objects used to link the kernel module are
+`object-files`: hash with the object files to be linked, each object in the map should include the files used to link it
+`kernel-modules`: hash with the kernel modules to be linked, each kernel module in the map should include the files used to link it
+*/
+
+#![deny(rust_2018_idioms)]
+
+#[macro_use]
+extern crate log;
+
+use argh::FromArgs;
+use serde::Deserialize;
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
+use std::process::{self, Command};
+
+/// Path to the drivers configuration to use
+const DEFAULT_DRIVER_CONFIG_PATH: &str = "/etc/drivers/";
+
+/// Path where the linked kernel modules will be created
+const LIB_MODULES_PATH: &str = "/lib/modules";
+/// Path to the kernel sources
+const KERNEL_SOURCES: &str = "/usr/src/kernels";
+/// Path to the uname bin
+const UNAME_BIN_PATH: &str = "/usr/bin/uname";
+
+/// Paths to kmod utilities
+const DEPMOD_BIN_PATH: &str = "/usr/bin/depmod";
+const MODPROBE_BIN_PATH: &str = "/usr/bin/modprobe";
+
+/// Paths to binutils tools
+const LD_BIN_PATH: &str = "/usr/bin/ld";
+const STRIP_BIN_PATH: &str = "/usr/bin/strip";
+
+/// Stores arguments
+#[derive(FromArgs, PartialEq, Debug)]
+struct Args {
+    /// log-level trace|debug|info|warn|error
+    #[argh(option)]
+    log_level: Option<LevelFilter>,
+    /// configuration file with the modules to be linked
+    #[argh(
+        option,
+        default = "DEFAULT_DRIVER_CONFIG_PATH.to_string()",
+        short = 'd'
+    )]
+    driver_config_path: String,
+    #[argh(subcommand)]
+    subcommand: Subcommand,
+    /// the modules set used to operate
+    #[argh(option)]
+    modules_set: Option<String>,
+}
+
+/// Stores the subcommand to be executed
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(subcommand)]
+enum Subcommand {
+    LinkModules(LinkModulesArgs),
+    LoadModules(LoadModulesArgs),
+}
+
+/// Links the kernel modules
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(subcommand, name = "link-modules")]
+struct LinkModulesArgs {}
+
+/// Loads the kernel modules
+#[derive(FromArgs, Debug, PartialEq)]
+#[argh(subcommand, name = "load-modules")]
+struct LoadModulesArgs {}
+
+/// Holds the configuration used to link kernel modules
+#[derive(Deserialize, Debug)]
+struct DriverConfig {
+    #[serde(rename(deserialize = "lib-modules-path"))]
+    lib_modules_path: String,
+    #[serde(rename(deserialize = "objects-source"))]
+    objects_source: String,
+    #[serde(rename(deserialize = "kernel-modules"))]
+    kernel_modules: HashMap<String, Linkable>,
+    #[serde(rename(deserialize = "object-files"))]
+    object_files: HashMap<String, Linkable>,
+}
+
+/// Holds the objects to be linked for the object/kernel module
+#[derive(Deserialize, Debug)]
+struct Linkable {
+    #[serde(rename(deserialize = "link-objects"))]
+    link_objects: Vec<String>,
+}
+
+// Links the modules in the modules sets
+fn link_modules_sets(
+    modules_sets: &HashMap<String, DriverConfig>,
+    target: Option<String>,
+) -> Result<()> {
+    // Get current kernel version
+    let kernel_version = get_kernel_version()?;
+
+    // If the target module set was given, link the kernel modules in it
+    if let Some(target) = target {
+        let driver_config = modules_sets
+            .get(&target)
+            .context(error::MissingModuleSet { target })?;
+        link_modules(&driver_config, &kernel_version)?;
+    } else {
+        // Link all the modules sets if no target module was given
+        for driver_config in modules_sets.values() {
+            link_modules(&driver_config, &kernel_version)?;
+        }
+    }
+
+    Ok(())
+}
+
+// Links the kernel modules for the given configuration, and for the given kernel version
+fn link_modules<S>(driver_config: &DriverConfig, kernel_version: S) -> Result<()>
+where
+    S: AsRef<str>,
+{
+    let kernel_version = kernel_version.as_ref();
+    // The directory with the module's objects
+    let driver_path = Path::new(&driver_config.objects_source).to_path_buf();
+    // Destination for the kernel modules
+    let modules_path = Path::new(LIB_MODULES_PATH)
+        .join(&kernel_version)
+        .join(&driver_config.lib_modules_path);
+    // Directory to store temp artifacts
+    let build_dir = tempfile::tempdir().context(error::TmpDir)?;
+    // This script is used to link the kernel module
+    let common_module_script = Path::new(KERNEL_SOURCES)
+        .join(&kernel_version)
+        .join("scripts/module.lds");
+
+    // First, link the object files, and store them in the temp directory
+    for (name, object_file) in driver_config.object_files.iter() {
+        link_object_file(name, &object_file, &build_dir, &driver_path)?;
+    }
+
+    // Next, link the kernel modules
+    for (name, kernel_module) in driver_config.kernel_modules.iter() {
+        link_kernel_module(
+            name,
+            kernel_module,
+            &modules_path,
+            &driver_path,
+            &build_dir,
+            &common_module_script,
+        )?;
+    }
+
+    Ok(())
+}
+
+// Links the given kernel module
+fn link_kernel_module<P, B, S>(
+    name: S,
+    kernel_module: &Linkable,
+    modules_path: P,
+    driver_path: P,
+    build_dir: B,
+    common_module_script_path: P,
+) -> Result<()>
+where
+    S: AsRef<str>,
+    B: AsRef<Path>,
+    P: AsRef<Path>,
+{
+    let name = name.as_ref();
+    let modules_path = modules_path.as_ref();
+    let driver_path = driver_path.as_ref();
+    let build_dir = build_dir.as_ref();
+    let common_module_script_path = common_module_script_path.as_ref();
+    // Destination for this kernel module
+    let kernel_module_path = modules_path.join(name);
+
+    // We make sure the dependencies are present in the build directory, otherwise attempt
+    // to copy them from `driver_path`
+    let mut dependencies_paths: Vec<String> = Vec::new();
+    for object_file in kernel_module.link_objects.iter() {
+        let object_file_path = build_dir.join(object_file);
+        if !object_file_path.exists() {
+            let from = driver_path.join(object_file);
+            fs::copy(&from, &object_file_path).context(error::Copy {
+                from: &from,
+                to: &object_file_path,
+            })?;
+        }
+        dependencies_paths.push(object_file_path.to_string_lossy().into_owned());
+    }
+
+    // Link the kernel module
+    let mut args = vec![
+        "-r".to_string(),
+        "-T".to_string(),
+        common_module_script_path.display().to_string(),
+        "--build-id".to_string(),
+        "-o".to_string(),
+        kernel_module_path
+            .to_str()
+            .context(error::InvalidModulePath {
+                path: &kernel_module_path,
+            })?
+            .to_string(),
+    ];
+    args.append(&mut dependencies_paths);
+
+    command(&LD_BIN_PATH, &args)?;
+    info!("Linked {}", name);
+
+    Ok(())
+}
+
+/// Links the given object file
+fn link_object_file<P, B, S>(
+    name: S,
+    object_file: &Linkable,
+    build_dir: B,
+    driver_path: P,
+) -> Result<()>
+where
+    S: AsRef<str>,
+    B: AsRef<Path>,
+    P: AsRef<Path>,
+{
+    let name = name.as_ref();
+    let build_dir = build_dir.as_ref();
+    let driver_path = driver_path.as_ref();
+
+    // Temporary files are created in build_dir
+    let object_path = Path::new(build_dir)
+        .join(name)
+        .to_string_lossy()
+        .into_owned();
+    // Paths to the dependencies for this object file
+    let mut dependencies = object_file
+        .link_objects
+        .iter()
+        .map(|d| {
+            Path::new(driver_path)
+                .join(d)
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+
+    // Link the object file
+    let mut args = vec!["-r".to_string(), "-o".to_string(), object_path.clone()];
+    args.append(&mut dependencies);
+
+    command(&LD_BIN_PATH, &args)?;
+    info!("Linked object '{}'", name);
+
+    // Strip the object file
+    command(
+        &STRIP_BIN_PATH,
+        &[
+            "-g",
+            "--strip-unneeded",
+            "--keep-symbol",
+            "init_module",
+            "--keep-symbol",
+            "cleanup_module",
+            &object_path,
+        ],
+    )?;
+    info!("Stripped object '{}'", name);
+
+    Ok(())
+}
+
+// Loads the modules in the modules sets
+fn load_modules_sets(
+    modules_sets: &HashMap<String, DriverConfig>,
+    target: Option<String>,
+) -> Result<()> {
+    // Update the modules.dep before we attempt to load kernel modules
+    let args: Vec<String> = Vec::new();
+    command(DEPMOD_BIN_PATH, &args)?;
+    info!("Updated modules dependencies");
+
+    // If the target module set was given, load the kernel modules in it
+    if let Some(target) = target {
+        let driver_config = modules_sets
+            .get(&target)
+            .context(error::MissingModuleSet { target })?;
+        load_modules(&driver_config)?
+    }
+    // Load all the modules sets if no target module was given
+    for driver_config in modules_sets.values() {
+        load_modules(&driver_config)?;
+    }
+
+    Ok(())
+}
+
+fn load_modules(driver_config: &DriverConfig) -> Result<()> {
+    let mut kernel_modules: Vec<String> = driver_config
+        .kernel_modules
+        .keys()
+        .map(|k| k.split('.').collect::<Vec<&str>>()[0].to_string())
+        .collect();
+
+    // Load kernel modules
+    let mut args = vec!["-a".to_string()];
+    args.append(&mut kernel_modules);
+    command(MODPROBE_BIN_PATH, &args)?;
+    info!("Loaded kernel modules");
+
+    Ok(())
+}
+
+/// Returns the kernel version
+fn get_kernel_version() -> Result<String> {
+    Ok(command(&UNAME_BIN_PATH, &["-r"])?.trim().to_string())
+}
+
+/// Wrapper around process::Command that adds error checking.
+fn command<I, S>(bin_path: &str, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new(bin_path);
+    command.args(args);
+    let output = command
+        .output()
+        .context(error::ExecutionFailure { command })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    trace!("stdout: {}", stdout);
+    trace!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    ensure!(
+        output.status.success(),
+        error::CommandFailure { bin_path, output }
+    );
+
+    Ok(stdout)
+}
+
+fn setup_logger(args: &Args) -> Result<()> {
+    let log_level = args.log_level.unwrap_or(LevelFilter::Info);
+    SimpleLogger::init(log_level, LogConfig::default()).context(error::Logger)
+}
+
+fn run() -> Result<()> {
+    let args: Args = argh::from_env();
+    setup_logger(&args)?;
+    let driver_config_path = Path::new(&args.driver_config_path);
+    let mut all_modules_sets: HashMap<String, DriverConfig> = HashMap::new();
+
+    for entry in driver_config_path.read_dir().context(error::ReadPath {
+        path: driver_config_path,
+    })? {
+        if let Ok(entry) = entry {
+            let path = entry.path();
+            let modules_sets: HashMap<String, DriverConfig> =
+                toml::from_slice(&fs::read(&path).context(error::ReadPath { path: &path })?)
+                    .context(error::Deserialize { path: &path })?;
+
+            all_modules_sets.extend(modules_sets);
+        }
+    }
+
+    match args.subcommand {
+        Subcommand::LinkModules(_) => link_modules_sets(&all_modules_sets, args.modules_set),
+        Subcommand::LoadModules(_) => load_modules_sets(&all_modules_sets, args.modules_set),
+    }
+}
+
+fn main() {
+    if let Err(e) = run() {
+        error!("{}", e);
+        process::exit(1);
+    }
+}
+
+/// ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡
+mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+    use std::process::{Command, Output};
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("'{}' failed - stderr: {}",
+                        bin_path, String::from_utf8_lossy(&output.stderr)))]
+        CommandFailure { bin_path: String, output: Output },
+
+        #[snafu(display("Failed to copy '{}' to '{}': {}", from.display(), to.display(), source))]
+        Copy {
+            from: PathBuf,
+            to: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to deserialize '{}': {}", path.display(), source))]
+        Deserialize {
+            path: PathBuf,
+            source: toml::de::Error,
+        },
+
+        #[snafu(display("Failed to execute '{:?}': {}", command, source))]
+        ExecutionFailure {
+            command: Command,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Module path '{}' is not UTF-8", path.display()))]
+        InvalidModulePath { path: PathBuf },
+
+        #[snafu(display("Failed to setup logger: {}", source))]
+        Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Invalid log level '{}'", log_level))]
+        LogLevel {
+            log_level: String,
+            source: log::ParseLevelError,
+        },
+
+        #[snafu(display("Missing module set '{}'", target))]
+        MissingModuleSet { target: String },
+
+        #[snafu(display("Failed to read path '{}': '{}'", path.display(), source))]
+        ReadPath {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to create temporary directory: {}", source))]
+        TmpDir { source: std::io::Error },
+    }
+}
+
+type Result<T> = std::result::Result<T, error::Error>;

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -102,6 +102,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "binutils"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libz",
+]
+
+[[package]]
 name = "ca-certificates"
 version = "0.1.0"
 
@@ -673,6 +681,7 @@ name = "release"
 version = "0.0.0"
 dependencies = [
  "acpid",
+ "binutils",
  "ca-certificates",
  "chrony",
  "conntrack-tools",


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
Related to #1799 , that PR is quite big. I'm taking some of the commits in that PR as their individual PR.

```
3b4cd1da sources: add driver dog

driverdog is a tool to link kernel modules at runtime, given a
configuration. The configuration must be provided per driver vendor, and
it is created at runtime by the tmpfilesd daemon, using a file
from the %{_cross_factorydir} directory.
```
```
e2b2b235 packages: add binutils

Binutils provides the ld linker, required to link proprietary kernel
modules at runtime.
```

We can't ship kernel modules linked against GPL code (i. e. proprietary kernel modules), doing so violates the GPL license under which the kernel is released. Instead, Bottlerocket images with proprietary kernel modules will link and load the kernel modules at runtime using `driverdog`.

`binutils` is built as part of the `release` package, but it isn't included in any variant. Instead, packages that depend on it will include it in their spec file, as follows:

```
Requires: %{_cross_os}binutils
```


**Testing done:**
In the new variant created in #1799:

Shipped a drivers configuration file that looks as follows, along with required objects in the OS image:

```toml
[nvidia-tesla]
lib-modules-path = "kernel/drivers/extra/video/nvidia/tesla"
objects-source = "__NVIDIA_MODULES__" # this is set to the directory where the objects used to like the kernel modules are

[nvidia-tesla.object-files."nvidia.o"]
link-objects = ["nv-interface.o", "nv-kernel.o"]

[nvidia-tesla.kernel-modules."nvidia.ko"]
link-objects = ["nvidia.o", "nvidia.mod.o"]

[nvidia-tesla.object-files."nvidia-modeset.o"]
link-objects = ["nv-modeset-interface.o", "nv-modeset-kernel.o"]

[nvidia-tesla.kernel-modules."nvidia-modeset.ko"]
link-objects = ["nvidia-modeset.o", "nvidia-modeset.mod.o"]

[nvidia-tesla.kernel-modules."nvidia-uvm.ko"]
link-objects = ["nvidia-uvm.o", "nvidia-uvm.mod.o"]
```

Validated the kernel modules were linked and loaded:

```
bash-5.0# systemctl status link-kernel-modules
● link-kernel-modules.service - Link additional kernel modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/link-kernel-modules.service; enabled; vendor preset: enabled)
     Active: active (exited) since Mon 2021-12-13 20:10:53 UTC; 3min 27s ago
   Main PID: 2554 (code=exited, status=0/SUCCESS)

Dec 13 20:10:53 localhost systemd[1]: Starting Link additional kernel modules...
Dec 13 20:10:53 localhost driverdog[2554]: 20:10:53 [INFO] Linked object 'nvidia.o'
Dec 13 20:10:53 localhost driverdog[2554]: 20:10:53 [INFO] Stripped object 'nvidia.o'
Dec 13 20:10:53 localhost driverdog[2554]: 20:10:53 [INFO] Linked object 'nvidia-modeset.o'
Dec 13 20:10:53 localhost driverdog[2554]: 20:10:53 [INFO] Stripped object 'nvidia-modeset.o'
Dec 13 20:10:53 localhost driverdog[2554]: 20:10:53 [INFO] Linked nvidia-modeset.ko
Dec 13 20:10:53 localhost driverdog[2554]: 20:10:53 [INFO] Linked nvidia.ko
Dec 13 20:10:53 localhost driverdog[2554]: 20:10:53 [INFO] Linked nvidia-uvm.ko
Dec 13 20:10:53 localhost systemd[1]: Finished Link additional kernel modules.


bash-5.0# systemctl status load-kernel-modules
● load-kernel-modules.service - Load additional kernel modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-kernel-modules.service; enabled; vendor preset: enabled)
     Active: active (exited) since Mon 2021-12-13 20:10:55 UTC; 3min 31s ago
   Main PID: 2610 (code=exited, status=0/SUCCESS)

Dec 13 20:10:53 localhost systemd[1]: Starting Load additional kernel modules...
Dec 13 20:10:55 localhost driverdog[2610]: 20:10:55 [INFO] Updated modules dependencies
Dec 13 20:10:55 localhost driverdog[2610]: 20:10:55 [INFO] Loaded kernel modules
Dec 13 20:10:55 localhost systemd[1]: Finished Load additional kernel modules.


bash-5.0# lsmod | grep nvidia
nvidia_uvm           1138688  0
nvidia_modeset       1155072  0
nvidia              34754560  18 nvidia_uvm,nvidia_modeset
drm                   606208  1 nvidia
i2c_core               98304  2 nvidia,drm
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
