### PR TITLE
Add shimpei to inject runc prestart hooks

### DIFF
--- a/packages/oci-add-hooks/Cargo.toml
+++ b/packages/oci-add-hooks/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "oci-add-hooks"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/awslabs/oci-add-hooks/archive/ef29fe312d2e1858d5eb28ab0abe0cbee298a165/oci-add-hooks-ef29fe3.tar.gz"
+sha512 = "018b561f838172e768a70acdeb2c27939f931391ced019a23c5193eee6b8970bc02a3e5fa05917010ca2064d1876649ef139d7657700c42a3ddd6e2c174f27dc"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/bitly/go-simplejson/archive/v0.5.0/go-simplejson-0.5.0.tar.gz"
+sha512 = "39c0d85d6ee06a8a795c1e344f0669f5ae8371d1122f09a1b13e5ff7629dd7faf633f9fcb449e19aadab9ad3e42e93143205781a822a29f27758872cf7e09e18"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/joeshaw/json-lossless/archive/e0cd1ca6349bf167e33d44f28c14c728a277205f/json-lossless-e0cd1ca.tar.gz"
+sha512 = "b9eb6170f662a396370ae1e170d89e15efc0a96fee6046fbd749c7a65f09f808e08bc2cf91962db65fd86a2aac4dddf428412b568fe1d03a77a7de22ad0690aa"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/oci-add-hooks/build.rs
+++ b/packages/oci-add-hooks/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/oci-add-hooks/oci-add-hooks.spec
+++ b/packages/oci-add-hooks/oci-add-hooks.spec
@@ -1,0 +1,51 @@
+%global goproject github.com/awslabs
+%global gorepo oci-add-hooks
+%global goimport %{goproject}/%{gorepo}
+
+%global gitrev ef29fe312d2e1858d5eb28ab0abe0cbee298a165
+%global shortrev %(c=%{gitrev}; echo ${c:0:7})
+%global gosimplejson 0.5.0
+%global jsonlosslessrev e0cd1ca6349bf167e33d44f28c14c728a277205f
+%global jsonlosslessshort %(c=%{jsonlosslessrev}; echo ${c:0:7})
+
+Name: %{_cross_os}oci-add-hooks
+Version: 1.0.0
+Release: 1%{?dist}
+Summary: OCI runtime wrapper that injects OCI hooks
+License: Apache-2.0 and MIT
+URL: https://github.com/awslabs/oci-add-hooks
+Source0: https://%{goimport}/archive/%{gorev}/%{gorepo}-%{shortrev}.tar.gz
+Source1: https://github.com/bitly/go-simplejson/archive/v%{gosimplejson}/go-simplejson-%{gosimplejson}.tar.gz
+Source2: https://github.com/joeshaw/json-lossless/archive/%{jsonlosslessrev}/json-lossless-%{jsonlosslessshort}.tar.gz
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{gorepo}-%{gitrev}
+%cross_go_setup %{gorepo}-%{gitrev} %{goproject} %{goimport}
+
+# We need to manage these third-party dependencies because the oci-add-hooks
+# "release" that we use doesn't include the `vendor` directory, unlike our other
+# go third party dependencies
+mkdir -p GOPATH/src/github.com/bitly/go-simplejson GOPATH/src/github.com/joeshaw/json-lossless
+tar -C GOPATH/src/github.com/bitly/go-simplejson -xzf %{SOURCE1} --strip 1
+cp GOPATH/src/github.com/bitly/go-simplejson/LICENSE LICENSE.go-simplejson
+tar -C GOPATH/src/github.com/joeshaw/json-lossless -xzf %{SOURCE2} --strip 1
+cp GOPATH/src/github.com/joeshaw/json-lossless/LICENSE LICENSE.json-lossless
+
+%build
+%cross_go_configure %{goimport}
+# We use `GO111MODULE=off` to force golang to look for the dependencies in the GOPATH
+GO111MODULE=off go build -buildmode=pie -ldflags "-linkmode=external" -o oci-add-hooks
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 oci-add-hooks %{buildroot}%{_cross_bindir}
+
+%files
+%license LICENSE NOTICE LICENSE.go-simplejson LICENSE.json-lossless
+%{_cross_attribution_file}
+%{_cross_bindir}/oci-add-hooks

--- a/packages/oci-add-hooks/pkg.rs
+++ b/packages/oci-add-hooks/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -21,6 +21,7 @@ source-groups = [
     "models",
     "imdsclient",
     "retry-read",
+    "shimpei"
 ]
 
 [lib]
@@ -39,3 +40,5 @@ glibc = { path = "../glibc" }
 # kexec-tools and makedumpfile required for prairiedog functionality
 # kexec-tools = { path = "../kexec-tools" }
 # makedumpfile = { path = "../makedumpfile" }
+# oci-add-hooks required for shimpei functionality
+# oci-add-hooks = { path = "../oci-add-hooks" }

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -36,6 +36,11 @@ libgcc = { path = "../libgcc" }
 libstd-rust = { path = "../libstd-rust" }
 makedumpfile = { path = "../../packages/makedumpfile" }
 os = { path = "../os" }
+# We don't include `oci-add-hooks` in all variants, and its only consumer is
+# `shimpei` in the "os" package. However, we want to start the "os" package
+# build ASAP since it takes the most time. Since `oci-add-hooks` builds quickly,
+# it doesn't affect other variants very much even when it's not used.
+oci-add-hooks = { path = "../oci-add-hooks" }
 policycoreutils = { path = "../policycoreutils" }
 procps = { path = "../procps" }
 selinux-policy = { path = "../selinux-policy" }

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3041,6 +3041,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shimpei"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme",
+ "log",
+ "nix 0.23.0",
+ "simplelog",
+ "snafu",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -59,7 +59,9 @@ members = [
 
     "webpki-roots-shim",
 
-    "constants"
+    "constants",
+
+    "shimpei"
 ]
 
 [profile.release]

--- a/sources/shimpei/Cargo.toml
+++ b/sources/shimpei/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "shimpei"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+log = "0.4"
+simplelog = "0.10"
+snafu = "0.6"
+nix = "0.23"
+
+[build-dependencies]
+cargo-readme = "3.1"

--- a/sources/shimpei/README.md
+++ b/sources/shimpei/README.md
@@ -1,0 +1,11 @@
+# shimpei
+
+Current version: 0.1.0
+
+  shimpei is an OCI compatible shim wrapper around `oci-add-hooks`. Its sole purpose is
+  to call `oci-add-hooks` with the additional `--hook-config-path` and `--runtime-path`
+  parameters that can't be provided by containerd.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/shimpei/README.tpl
+++ b/sources/shimpei/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/shimpei/build.rs
+++ b/sources/shimpei/build.rs
@@ -1,0 +1,32 @@
+// Automatically generate README.md from rustdoc.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if env::var_os("SKIP_README").is_some() {
+        return;
+    }
+
+    let mut source = File::open("src/main.rs").unwrap();
+    let mut template = File::open("README.tpl").unwrap();
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .unwrap();
+
+    let mut readme = File::create("README.md").unwrap();
+    readme.write_all(content.as_bytes()).unwrap();
+}

--- a/sources/shimpei/src/main.rs
+++ b/sources/shimpei/src/main.rs
@@ -1,0 +1,110 @@
+/*!
+  shimpei is an OCI compatible shim wrapper around `oci-add-hooks`. Its sole purpose is
+  to call `oci-add-hooks` with the additional `--hook-config-path` and `--runtime-path`
+  parameters that can't be provided by containerd.
+*/
+
+#![deny(rust_2018_idioms)]
+
+#[macro_use]
+extern crate log;
+
+use nix;
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
+use snafu::{OptionExt, ResultExt};
+use std::env;
+use std::ffi::CString;
+use std::path::Path;
+use std::process;
+
+/// Path to runc binary
+const RUNC_BIN_PATH: &str = "/usr/bin/runc";
+
+/// Path to hooks definitions
+const HOOK_CONFIG_BASE_PATH: &str = "/usr/share/oci-add-hooks";
+
+/// Path to oci-add-hooks
+const OCI_ADD_HOOKS: &str = "/usr/bin/oci-add-hooks";
+
+fn run() -> Result<()> {
+    setup_logger()?;
+    let mut args = env::args();
+    let prefix = args.next().context(error::MissingArg { what: "name" })?;
+    let hook_path = Path::new(HOOK_CONFIG_BASE_PATH).join(format!("{}-hook.json", prefix));
+
+    let mut oci_add_hooks_args: Vec<CString> = vec![
+        CString::new("oci-add-hooks").expect("Coulnd't create CString from 'oci-add-hooks'"),
+        CString::new("--hook-config-path")
+            .expect("Couldn't create CString from '--hook-config-path'"),
+        CString::new(hook_path.display().to_string()).context(error::InvalidString {
+            input: hook_path.display().to_string(),
+        })?,
+        CString::new("--runtime-path").expect("Couldn't create CString from '--runtime-path'"),
+        CString::new(RUNC_BIN_PATH).context(error::InvalidString {
+            input: RUNC_BIN_PATH.to_string(),
+        })?,
+    ];
+    for arg in args {
+        oci_add_hooks_args
+            .push(CString::new(arg.as_bytes()).context(error::InvalidString { input: arg })?);
+    }
+
+    // Use the `execv` syscall instead of `std::process::Command`, since
+    // it will call `posix_spawn` under the hood, which forks instead of
+    // replacing the current process
+
+    nix::unistd::execv(
+        &CString::new(OCI_ADD_HOOKS).context(error::InvalidString {
+            input: OCI_ADD_HOOKS.to_string(),
+        })?,
+        &oci_add_hooks_args,
+    )
+    .context(error::Execv {
+        program: OCI_ADD_HOOKS.to_string(),
+    })?;
+
+    Ok(())
+}
+
+fn setup_logger() -> Result<()> {
+    SimpleLogger::init(LevelFilter::Info, LogConfig::default()).context(error::Logger)
+}
+
+fn main() {
+    if let Err(e) = run() {
+        error!("{}", e);
+        process::exit(1);
+    }
+}
+
+/// ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡 ＜コ：ミ くコ:彡
+mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("Failed to setup logger: {}", source))]
+        Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Invalid log level '{}'", log_level))]
+        LogLevel {
+            log_level: String,
+            source: log::ParseLevelError,
+        },
+
+        #[snafu(display("Couldn't create CString from '{}': {}", input, source))]
+        InvalidString {
+            input: String,
+            source: std::ffi::NulError,
+        },
+
+        #[snafu(display("Failed to exec '{}' : {}", program, source))]
+        Execv { program: String, source: nix::Error },
+
+        #[snafu(display("Missing argument '{}'", what))]
+        MissingArg { what: String },
+    }
+}
+
+type Result<T> = std::result::Result<T, error::Error>;

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -606,6 +606,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-add-hooks"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "open-vm-tools"
 version = "0.1.0"
 dependencies = [
@@ -674,6 +681,7 @@ dependencies = [
  "libgcc",
  "libstd-rust",
  "makedumpfile",
+ "oci-add-hooks",
  "os",
  "policycoreutils",
  "procps",


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
Related to #1799 , that PR is quite big. I'm taking some of the commits in that PR as their individual PR.

```
 sources: add shimpei

 shimpei is an OCI shim wrapper around `oci-add-hooks`, whose sole
 porpuse is to call `oci-add-hooks` with additional parameters that can't
 be provided by containerd.
```

```
packages: add oci-add-hooks
```

`oci-add-hooks` is built as part of the release package, but it isn't included in any variant. Instead, packages that depend on it will include it in their spec file, as follows:

Requires: %{_cross_os}oci-add-hooks


**Testing done:**
In the new variant created in #1799:

I created a new containerd configuration that calls `shimpei` instead of runc:

```toml
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
SystemdCgroup = true
BinaryName = "nvidia-oci" # this is a symlink to `shimpei`, used to figure out the `hooks.json` file 
```

The prestart hook in #1799, sets up GPUs and mounts helper binaries like `nvidia-smi`. In my test, I called `nvidia-smi` in a GPU-enabled orchestrated container:

```
kubectl exec -it nvidia-device-plugin-daemonset-4q2zf -n kube-system -- /bin/bash
root@nvidia-device-plugin-daemonset-4q2zf:/# nvidia-smi
Mon Dec 13 20:33:53 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.57.02    Driver Version: 470.57.02    CUDA Version: N/A      |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   29C    P0    24W / 300W |      0MiB / 16160MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
