### PR TITLE
update SDK and build log4j2 hotpatch

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,7 +26,7 @@ BUILDSYS_NAME = "bottlerocket"
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.23.1"
+BUILDSYS_SDK_VERSION="v0.24.0"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 

--- a/macros/shared
+++ b/macros/shared
@@ -234,6 +234,5 @@ CROSS_COMPILATION_CONF_EOF\
 %_binary_payload w1.zstdio
 
 %__arch_install_post \
-  %{?!_cross_allow_rpath:/usr/lib/rpm/check-rpaths} \
   /usr/lib/rpm/check-buildroot \
   %cross_generate_attribution

--- a/macros/shared
+++ b/macros/shared
@@ -179,6 +179,7 @@ CROSS_COMPILATION_CONF_EOF\
   PKG_CONFIG_PATH="%{_cross_pkgconfigdir}" ; export PKG_CONFIG_PATH ; \
   PKG_CONFIG_ALLOW_CROSS=1 ; export PKG_CONFIG_ALLOW_CROSS ; \
   GOFLAGS="-mod=vendor"; export GOFLAGS ; \
+  GOLDFLAGS="-compressdwarf=false -linkmode=external" ; export GOLDFLAGS ; \
   GOPROXY="off"; export GOPROXY ; \
   GOSUMDB="off"; export GOSUMDB ; \
   GO111MODULE="auto"; export GO111MODULE ; \

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -26,7 +26,7 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %build
 %set_cross_go_flags
-go build -buildmode=pie -ldflags=-linkmode=external -o aws-iam-authenticator ./cmd/aws-iam-authenticator
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -28,7 +28,7 @@ Requires: %{_cross_os}iptables
 %build
 %cross_go_configure %{goimport}
 for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
-  go build -buildmode=pie -ldflags=-linkmode=external -o "bin/${d##*/}" %{goimport}/${d}
+  go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o "bin/${d##*/}" %{goimport}/${d}
 done
 
 %install

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -27,7 +27,7 @@ Requires: %{_cross_os}iptables
 
 %build
 %cross_go_configure %{goimport}
-go build -buildmode=pie -ldflags=-linkmode=external -o "bin/cnitool" %{goimport}/cnitool
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o "bin/cnitool" %{goimport}/cnitool
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -49,7 +49,7 @@ for bin in \
 do
   go build \
      -buildmode=pie \
-     -ldflags="-linkmode=external ${LD_VERSION} ${LD_REVISION}" \
+     -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" \
      -tags="${BUILDTAGS}" \
      -o ${bin} \
      %{goimport}/cmd/${bin}

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -41,7 +41,7 @@ BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null | sed 
 LD_BUILDTIME="-X github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}"
 go build \
   -buildmode=pie \
-  -ldflags "-linkmode=external ${LD_VERSION} ${LD_GIT_REV} ${LD_PLATFORM} ${LD_BUILDTIME}" \
+  -ldflags "${GOLDFLAGS} ${LD_VERSION} ${LD_GIT_REV} ${LD_PLATFORM} ${LD_BUILDTIME}" \
   -o docker \
   %{goimport}/cmd/docker
 

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -54,7 +54,7 @@ export GITCOMMIT=%{gitrev}
 export BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 export PLATFORM="Docker Engine - Community"
 source ./hack/make/.go-autogen
-go build -buildmode=pie -ldflags="-linkmode=external ${LDFLAGS}" -tags="${BUILDTAGS}" -o dockerd %{goimport}/cmd/dockerd
+go build -buildmode=pie -ldflags="${GOLDFLAGS} ${LDFLAGS}" -tags="${BUILDTAGS}" -o dockerd %{goimport}/cmd/dockerd
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -31,7 +31,7 @@ cp client/mflag/LICENSE LICENSE.mflag
 
 %build
 %cross_go_configure %{goimport}
-go build -buildmode=pie -ldflags=-linkmode=external -o docker-proxy %{goimport}/cmd/proxy
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o docker-proxy %{goimport}/cmd/proxy
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -168,7 +168,7 @@ LD_VERSION="-X github.com/aws/amazon-ecs-agent/agent/version.Version=%{agent_gov
 LD_GIT_REV="-X github.com/aws/amazon-ecs-agent/agent/version.GitShortHash=%{agent_gitrev}"
 go build -a \
   -buildmode=pie \
-  -ldflags "-linkmode=external ${LD_PAUSE_CONTAINER_NAME} ${LD_PAUSE_CONTAINER_TAG} ${LD_VERSION} ${LD_GIT_REV}" \
+  -ldflags "${GOLDFLAGS} ${LD_PAUSE_CONTAINER_NAME} ${LD_PAUSE_CONTAINER_TAG} ${LD_VERSION} ${LD_GIT_REV}" \
   -o amazon-ecs-agent \
   ./agent
 
@@ -204,17 +204,17 @@ LD_ECS_CNI_SHORT_HASH="-X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitS
 LD_ECS_CNI_PORCELAIN="-X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitPorcelain=0"
 go build -a \
   -buildmode=pie \
-  -ldflags "-linkmode=external ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
+  -ldflags "${GOLDFLAGS} ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
   -o ecs-eni \
   ./plugins/eni
 go build -a \
   -buildmode=pie \
-  -ldflags "-linkmode=external ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
+  -ldflags "${GOLDFLAGS} ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
   -o ecs-ipam \
   ./plugins/ipam
 go build -a \
   -buildmode=pie \
-  -ldflags "-linkmode=external ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
+  -ldflags "${GOLDFLAGS} ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
   -o ecs-bridge \
   ./plugins/ecs-bridge
 
@@ -228,7 +228,7 @@ VPC_CNI_HASH="%{vpccni_gitrev}"
 LD_VPC_CNI_SHORT_HASH="-X github.com/aws/amazon-vpc-cni-plugins/version.GitShortHash=${VPC_CNI_HASH::8}"
 go build -a \
   -buildmode=pie \
-  -ldflags "-linkmode=external ${LD_VPC_CNI_VERSION} ${LD_VPC_CNI_SHORT_HASH} ${LD_VPC_CNI_PORCELAIN}" \
+  -ldflags "${GOLDFLAGS} ${LD_VPC_CNI_VERSION} ${LD_VPC_CNI_SHORT_HASH} ${LD_VPC_CNI_PORCELAIN}" \
   -mod=vendor \
   -o vpc-branch-eni \
   ./plugins/vpc-branch-eni

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -22,7 +22,7 @@ cp -r %{_builddir}/sources/%{workspace_name}/* .
 
 %build
 %set_cross_go_flags
-go build -buildmode=pie -ldflags=-linkmode=external -o host-ctr ./cmd/host-ctr
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o host-ctr ./cmd/host-ctr
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/kubernetes-1.18/kubernetes-1.18.spec
+++ b/packages/kubernetes-1.18/kubernetes-1.18.spec
@@ -60,7 +60,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 %build
 %cross_go_configure %{goimport}
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
-export GOLDFLAGS="-buildmode=pie -linkmode=external"
+export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -57,7 +57,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 %build
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external"
+export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/kubernetes-1.20/kubernetes-1.20.spec
+++ b/packages/kubernetes-1.20/kubernetes-1.20.spec
@@ -57,7 +57,7 @@ cp third_party/intemp/LICENSE LICENSE.intemp
 %build
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external"
+export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -72,7 +72,7 @@ make generated_files
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external"
+export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
 make WHAT="cmd/kubelet"
 
 %install

--- a/packages/log4j2-hotpatch/Cargo.toml
+++ b/packages/log4j2-hotpatch/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "log4j2-hotpatch"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/corretto/hotpatch-for-apache-log4j2/archive/1.3.0/1.3.0.tar.gz"
+path = "hotpatch-for-apache-log4j2-1.3.0.tar.gz"
+sha512 = "70b3e555ae728b1c8e87b80c9b180e1aba0dd01d0ec9632914cc8ecce9270b6dac78f9a91e9e48e05e7a718d6a7abcc02b8edc42d9a7d8d6893162de730b5a89"

--- a/packages/log4j2-hotpatch/build.rs
+++ b/packages/log4j2-hotpatch/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/log4j2-hotpatch/log4j2-hotpatch.spec
+++ b/packages/log4j2-hotpatch/log4j2-hotpatch.spec
@@ -1,0 +1,32 @@
+%global debug_package %{nil}
+
+%global project hotpatch-for-apache-log4j2
+
+Name: %{_cross_os}log4j2-hotpatch
+Version: 1.3.0
+Release: 1%{?dist}
+Summary: Tool for hot patching log4j2 vulnerabilities
+License: Apache-2.0
+URL: https://github.com/corretto/%{project}
+Source0: https://github.com/corretto/%{project}/archive/%{version}/%{version}.tar.gz#/%{project}-%{version}.tar.gz
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{project}-%{version}
+
+%build
+xmvn --offline clean package
+
+%install
+install -d %{buildroot}%{_cross_datadir}/hotdog
+install -p -m 0644 target/Log4jHotPatch.jar %{buildroot}%{_cross_datadir}/hotdog
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%dir %{_cross_datadir}/hotdog
+%{_cross_datadir}/hotdog/Log4jHotPatch.jar
+
+%changelog

--- a/packages/log4j2-hotpatch/pkg.rs
+++ b/packages/log4j2-hotpatch/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/oci-add-hooks/oci-add-hooks.spec
+++ b/packages/oci-add-hooks/oci-add-hooks.spec
@@ -39,7 +39,7 @@ cp GOPATH/src/github.com/joeshaw/json-lossless/LICENSE LICENSE.json-lossless
 %build
 %cross_go_configure %{goimport}
 # We use `GO111MODULE=off` to force golang to look for the dependencies in the GOPATH
-GO111MODULE=off go build -buildmode=pie -ldflags "-linkmode=external" -o oci-add-hooks
+GO111MODULE=off go build -v -x -buildmode=pie -ldflags="${GOLDFLAGS}" -o oci-add-hooks
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -33,7 +33,7 @@ export LD_COMMIT="-X main.gitCommit=%{commit}"
 export BUILDTAGS="ambient seccomp selinux"
 go build \
   -buildmode=pie \
-  -ldflags="-linkmode=external ${LD_VERSION} ${LD_COMMIT}" \
+  -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_COMMIT}" \
   -tags="${BUILDTAGS}" \
   -o bin/runc .
 

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -1,5 +1,5 @@
 # Skip check-rpaths since we expect them for systemd.
-%global _cross_allow_rpath 1
+%global __brp_check_rpaths %{nil}
 
 Name: %{_cross_os}systemd
 Version: 247.10

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -576,6 +576,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "log4j2-hotpatch"
+version = "0.1.0"
+
+[[package]]
 name = "login"
 version = "0.0.1"
 dependencies = [


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Update SDK to the new release, which includes maven, and use it to build the [log4j2 hotpatch](https://github.com/corretto/hotpatch-for-apache-log4j2/).


**Testing done:**
Built some variants on both architectures, for both architectures.

Additional tests:
- [x] smoke tested a task for `aws-ecs-1`
- [x] sonobuoy passed for `aws-k8s-1.21`
- [x] @cbgbt verified that the hotpatch jar works


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
