### PR TITLE
Add hotdog OCI hooks

### DIFF
--- a/packages/hotdog/Cargo.toml
+++ b/packages/hotdog/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "hotdog"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/bottlerocket-os/hotdog/archive/f300fb78dd9ffc555af1b284b3627d2f3f5d069e/hotdog-f300fb7.tar.gz"
+sha512 = "7406cbe5b78646613b78c075edf792f42bb16cd2b477dbf1fc219209d1da45762234bbf581856cc3cbe46836e4117431b74b57761eab3393f30ebea1ec889e3f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/opencontainers/runtime-spec/archive/v1.0.2/runtime-spec-1.0.2.tar.gz"
+sha512 = "96676b702d02409d33a5c81886c4db4bf45283c628933c6f0f4c2ed0d7cc44fafe95249151d7dc2d1fc5225944d172cdb45fc2f2f5f9bb87531e93421933b664"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/golang/sys/archive/4abf325e0275e4ef0bdd441dcf497570f1419ab9/sys-4abf325.tar.gz"
+sha512 = "74c51b1eb48a0a31443f9cb7ee4e2d7550f2477cbc89fad3909f973f042c8bc2bfc378582847c498ce157c3c28d14a3b22d69e9220539dc5dd87a77bb7b407e3"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/hotdog/build.rs
+++ b/packages/hotdog/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/hotdog/hotdog.spec
+++ b/packages/hotdog/hotdog.spec
@@ -1,0 +1,79 @@
+# Don't generate debug packages because we are compiling without CGO,
+# and the `gc` compiler doesn't append the  the ".note.gnu.build-id" section
+# https://fedoraproject.org/wiki/PackagingDrafts/Go#Build_ID
+%global debug_package %{nil}
+
+%global goproject github.com/bottlerocket
+%global gorepo hotdog
+%global goimport %{goproject}/%{gorepo}
+
+%global gitrev f300fb78dd9ffc555af1b284b3627d2f3f5d069e
+%global shortrev %(c=%{gitrev}; echo ${c:0:7})
+
+%global gosysrev 4abf325e0275e4ef0bdd441dcf497570f1419ab9
+%global gosysrevshort %(c=%{gosysrev}; echo ${c:0:7})
+
+%global runtimespec 1.0.2
+
+Name: %{_cross_os}hotdog
+Version: 1.0.0
+Release: 1%{?dist}
+Summary: Tool with OCI hooks to run the Log4j Hot Patch in containers
+License: Apache-2.0
+URL: https://github.com/awslabs/oci-add-hooks
+Source0: https://%{goimport}/archive/%{gorev}/%{gorepo}-%{shortrev}.tar.gz
+Source1: https://github.com/opencontainers/runtime-spec/archive/v%{runtimespec}/runtime-spec-%{runtimespec}.tar.gz
+Source2: https://github.com/golang/sys/archive/%{gosysrev}/sys-%{gosysrevshort}.tar.gz
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup -Sgit -n %{gorepo}-%{gitrev} -p1
+%cross_go_setup %{gorepo}-%{gitrev} %{goproject} %{goimport}
+
+# We need to manage these third-party dependencies because the hotdog
+# "release" that we use doesn't include the `vendor` directory, unlike our other
+# go third party dependencies
+mkdir -p GOPATH/src/github.com/opencontainers/runtime-spec
+tar -C GOPATH/src/github.com/opencontainers/runtime-spec -xzf %{SOURCE1} --strip 1
+cp GOPATH/src/github.com/opencontainers/runtime-spec/LICENSE LICENSE.runtime-spec
+
+mkdir -p GOPATH/src/golang.org/x/sys
+tar -C GOPATH/src/golang.org/x/sys -xzf %{SOURCE2} --strip 1
+ls -la GOPATH/src/golang.org/x/sys
+cp GOPATH/src/golang.org/x/sys/LICENSE LICENSE.golang-sys
+
+%build
+# Set CGO_ENABLED=0 to statically link hotdog-hotpath, since it runs inside containers that
+# may not have the glibc version used to compile it
+# Set `GO111MODULE=off` to force golang to look for the dependencies in the GOPATH
+export GOPATH=$PWD/GOPATH
+CGO_ENABLED=0 GO111MODULE=off go build -installsuffix cgo -a -ldflags "-s" -o hotdog-hotpatch ./cmd/hotdog-hotpatch
+
+# The oci hooks commands can be compiled as we usually compile golang packages
+%cross_go_configure %{goimport}
+for cmd in hotdog-cc-hook hotdog-poststart-hook; do
+  GO111MODULE=off go build -buildmode=pie -ldflags "${GOLDFLAGS}" -o $cmd ./cmd/$cmd
+done
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}/hotdog/
+install -d %{buildroot}%{_cross_datadir}/hotdog/
+
+install -p -m 0755 hotdog-hotpatch %{buildroot}%{_cross_datadir}/hotdog/
+
+for cmd in hotdog-cc-hook hotdog-poststart-hook; do
+  install -p -m 0755 $cmd %{buildroot}%{_cross_libexecdir}/hotdog
+done
+
+%files
+%license LICENSE LICENSE.runtime-spec LICENSE.golang-sys
+%{_cross_attribution_file}
+%dir %{_cross_libexecdir}/hotdog
+%dir %{_cross_datadir}/hotdog
+%{_cross_libexecdir}/hotdog/hotdog-cc-hook
+%{_cross_libexecdir}/hotdog/hotdog-poststart-hook
+%{_cross_datadir}/hotdog/hotdog-hotpatch

--- a/packages/hotdog/pkg.rs
+++ b/packages/hotdog/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -28,6 +28,7 @@ glibc = { path = "../glibc" }
 grep = { path = "../grep" }
 grub = { path = "../grub" }
 host-ctr = { path = "../host-ctr" }
+hotdog = { path = "../hotdog" }
 iproute = { path = "../iproute" }
 iptables = { path = "../iptables" }
 kexec-tools = { path = "../../packages/kexec-tools" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -75,6 +75,7 @@ Requires: %{_cross_os}glibc
 Requires: %{_cross_os}grep
 Requires: %{_cross_os}grub
 Requires: %{_cross_os}host-ctr
+Requires: %{_cross_os}hotdog
 Requires: %{_cross_os}iproute
 Requires: %{_cross_os}iptables
 Requires: %{_cross_os}kexec-tools

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -257,6 +257,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hotdog"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "iproute"
 version = "0.1.0"
 dependencies = [
@@ -674,6 +681,7 @@ dependencies = [
  "grep",
  "grub",
  "host-ctr",
+ "hotdog",
  "iproute",
  "iptables",
  "kexec-tools",


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
`hotdog` provides oci hooks to apply the hotpatch for Apache log4j2, to containers running JVM machines

Remaining tasks:

- [x] Change the sources to the public hotdog repo
- [x] Update cache

**Testing done:**
I built it with my local copy of the sources.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
