### PR TITLE
Enable oci hooks through API settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ These settings can be changed at any time.
   Supported values are `debug`, `info`, `warn`, `error`, and `crit`, and the default is `info`.
 * `settings.ecs.enable-spot-instance-draining`: If the instance receives a spot termination notice, the agent will set the instance's state to `DRAINING`, so the workload can be moved gracefully before the instance is removed. Defaults to `false`.
 
+#### OCI Hooks settings
+
+Bottlerocket allows you to opt-in to use additional [OCI hooks](https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#lifecycle) for your orchestrated containers.
+Once you opt-in to use additional OCI hooks, any new orchestrated containers will be configured with them, but existing containers won't be changed.
+
+* `settings.oci-hooks.log4j-hotpatch-enabled`: Enables the [hotdog OCI hooks](https://github.com/bottlerocket-os/hotdog), which are used to inject the [Log4j Hot Patch](https://github.com/corretto/hotpatch-for-apache-log4j2) into containers. Defaults to `false`.
+
 #### Container image registry settings
 
 The following setting is optional and allows you to configure image registry mirrors and pull-through caches for your containers.

--- a/Release.toml
+++ b/Release.toml
@@ -82,3 +82,7 @@ version = "1.4.2"
     "migrate_v1.4.2_admin-container-v0-7-3.lz4",
     "migrate_v1.4.2_control-container-v0-5-3.lz4",
 ]
+"(1.4.2, 1.5.0)" = [
+    "migrate_v1.5.0_oci-hooks-setting.lz4",
+    "migrate_v1.5.0_oci-hooks-setting-metadata.lz4",
+]

--- a/packages/containerd/containerd-config-toml_k8s
+++ b/packages/containerd/containerd-config-toml_k8s
@@ -18,13 +18,14 @@ enable_selinux = true
 sandbox_image = "{{settings.kubernetes.pod-infra-container-image}}"
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
-default_runtime_name = "runc"
+default_runtime_name = "shimpei"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.shimpei]
 runtime_type = "io.containerd.runc.v2"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.shimpei.options]
 SystemdCgroup = true
+BinaryName = "shimpei"
 
 [plugins."io.containerd.grpc.v1.cri".cni]
 bin_dir = "/opt/cni/bin"

--- a/packages/docker-engine/daemon-json
+++ b/packages/docker-engine/daemon-json
@@ -5,6 +5,8 @@
   "storage-driver": "overlay2",
   "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "data-root": "/var/lib/docker",
+  "default-runtime": "shimpei",
+  "runtimes": { "shimpei": { "path": "shimpei" } },
   "selinux-enabled": true,
   "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 1024, "Hard": 4096 } }
   {{#if settings.container-registry.mirrors}}

--- a/packages/hotdog/Cargo.toml
+++ b/packages/hotdog/Cargo.toml
@@ -22,3 +22,6 @@ sha512 = "74c51b1eb48a0a31443f9cb7ee4e2d7550f2477cbc89fad3909f973f042c8bc2bfc378
 
 [build-dependencies]
 glibc = { path = "../glibc" }
+
+[dependencies]
+log4j2-hotpatch= { path = "../log4j2-hotpatch" }

--- a/packages/hotdog/hotdog.spec
+++ b/packages/hotdog/hotdog.spec
@@ -26,6 +26,7 @@ Source1: https://github.com/opencontainers/runtime-spec/archive/v%{runtimespec}/
 Source2: https://github.com/golang/sys/archive/%{gosysrev}/sys-%{gosysrevshort}.tar.gz
 
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}log4j2-hotpatch
 
 %description
 %{summary}.

--- a/packages/os/oci-default-hooks-json
+++ b/packages/os/oci-default-hooks-json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "prestart": [
+      {{#if settings.oci-hooks.log4j-hotpatch-enabled}}
+      { "path": "/usr/libexec/hotdog/hotdog-cc-hook" }
+      {{/if}}
+    ],
+    "poststart": [
+      {{#if settings.oci-hooks.log4j-hotpatch-enabled}}
+      { "path": "/usr/libexec/hotdog/hotdog-poststart-hook" }
+      {{/if}}
+    ]
+  }
+}

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -37,10 +37,6 @@ libgcc = { path = "../libgcc" }
 libstd-rust = { path = "../libstd-rust" }
 makedumpfile = { path = "../../packages/makedumpfile" }
 os = { path = "../os" }
-# We don't include `oci-add-hooks` in all variants, and its only consumer is
-# `shimpei` in the "os" package. However, we want to start the "os" package
-# build ASAP since it takes the most time. Since `oci-add-hooks` builds quickly,
-# it doesn't affect other variants very much even when it's not used.
 oci-add-hooks = { path = "../oci-add-hooks" }
 policycoreutils = { path = "../policycoreutils" }
 procps = { path = "../procps" }

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2135,6 +2135,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-hooks-setting"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "oci-hooks-setting-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -31,6 +31,8 @@ members = [
     "api/migration/migrations/v1.4.0/registry-mirror-representation",
     "api/migration/migrations/v1.4.2/admin-container-v0-7-3",
     "api/migration/migrations/v1.4.2/control-container-v0-5-3",
+    "api/migration/migrations/v1.5.0/oci-hooks-setting",
+    "api/migration/migrations/v1.5.0/oci-hooks-setting-metadata",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.5.0/oci-hooks-setting-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.5.0/oci-hooks-setting-metadata/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "oci-hooks-setting-metadata"
+version = "0.1.0"
+authors = ["Arnaldo Garcia <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.5.0/oci-hooks-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.5.0/oci-hooks-setting-metadata/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and generator for configuring oci hooks
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.oci-hooks",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.5.0/oci-hooks-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.5.0/oci-hooks-setting/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "oci-hooks-setting"
+version = "0.1.0"
+authors = ["Arnaldo Garcia <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.5.0/oci-hooks-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.5.0/oci-hooks-setting/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and generator for configuring oci hooks
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.oci-hooks",
+        "services.oci-hooks",
+        "configuration-files.oci-hooks",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/oci-hooks.toml
+++ b/sources/models/shared-defaults/oci-hooks.toml
@@ -1,0 +1,13 @@
+[settings.oci-hooks]
+log4j-hotpatch-enabled = false
+
+[metadata.settings.oci-hooks]
+affected-services = ["oci-hooks"]
+
+[services.oci-hooks]
+configuration-files = ["oci-hooks"]
+restart-commands = []
+
+[configuration-files.oci-hooks]
+path = "/etc/shimpei/shimpei-hooks.json"
+template-path = "/usr/share/templates/oci-default-hooks-json"

--- a/sources/models/src/aws-dev/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/aws-dev/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::modeled_types::Identifier;
 use crate::{
     AwsSettings, BootstrapContainer, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -23,4 +23,5 @@ struct Settings {
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
+    oci_hooks: OciHooks,
 }

--- a/sources/models/src/aws-ecs-1/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::modeled_types::Identifier;
 use crate::{
     AwsSettings, BootstrapContainer, ECSSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -24,4 +24,5 @@ struct Settings {
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
+    oci_hooks: OciHooks,
 }

--- a/sources/models/src/aws-k8s-1.21/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/aws-k8s-1.21/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/models/src/aws-k8s-1.21/mod.rs
+++ b/sources/models/src/aws-k8s-1.21/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::modeled_types::Identifier;
 use crate::{
     AwsSettings, BootstrapContainer, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, PemCertificate, RegistrySettings,
+    MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
     UpdatesSettings,
 };
 
@@ -25,4 +25,5 @@ struct Settings {
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
+    oci_hooks: OciHooks,
 }

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -301,3 +301,9 @@ struct PemCertificate {
     data: PemCertificateString,
     trusted: bool,
 }
+
+///// OCI hooks
+#[model]
+struct OciHooks {
+    log4j_hotpatch_enabled: bool,
+}

--- a/sources/models/src/vmware-dev/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/vmware-dev/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::modeled_types::Identifier;
 use crate::{
     BootstrapContainer, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, PemCertificate, RegistrySettings, UpdatesSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -22,4 +22,5 @@ struct Settings {
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
+    oci_hooks: OciHooks,
 }

--- a/sources/models/src/vmware-k8s-1.21/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/vmware-k8s-1.21/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/models/src/vmware-k8s-1.21/mod.rs
+++ b/sources/models/src/vmware-k8s-1.21/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::modeled_types::Identifier;
 use crate::{
     BootstrapContainer, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -23,4 +23,5 @@ struct Settings {
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,
+    oci_hooks: OciHooks,
 }

--- a/sources/shimpei/src/main.rs
+++ b/sources/shimpei/src/main.rs
@@ -21,7 +21,7 @@ use std::process;
 const RUNC_BIN_PATH: &str = "/usr/bin/runc";
 
 /// Path to hooks definitions
-const HOOK_CONFIG_BASE_PATH: &str = "/usr/share/oci-add-hooks";
+const HOOKS_CONFIG_BASE_PATH: &str = "/etc/shimpei";
 
 /// Path to oci-add-hooks
 const OCI_ADD_HOOKS: &str = "/usr/bin/oci-add-hooks";
@@ -30,7 +30,7 @@ fn run() -> Result<()> {
     setup_logger()?;
     let mut args = env::args();
     let prefix = args.next().context(error::MissingArg { what: "name" })?;
-    let hook_path = Path::new(HOOK_CONFIG_BASE_PATH).join(format!("{}-hook.json", prefix));
+    let hook_path = Path::new(HOOKS_CONFIG_BASE_PATH).join(format!("{}-hooks.json", prefix));
 
     let mut oci_add_hooks_args: Vec<CString> = vec![
         CString::new("oci-add-hooks").expect("Coulnd't create CString from 'oci-add-hooks'"),

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -261,6 +261,7 @@ name = "hotdog"
 version = "0.1.0"
 dependencies = [
  "glibc",
+ "log4j2-hotpatch",
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**

```
api: add oci-hooks setting to enable OCI hooks
```

The oci-hooks setting allows a user to enable OCI hooks provided by the OS. For the time being, the only OCI hook provided is the `log4j2-hotpatch`, which applies the hotpatch for Apache Log4j2 to containers running JVMs.

Remaining work:
- [x] Documentation for the new setting
- [x] Add API setting to vmware variants
- [x] Add migrations
- [x] Upgrade/Downgrade migration test

**Testing done:**
In aws-ecs/aws-k8s-1.21:

Run workloads with java services, with and without enabling the `log4j-hotpatch` hook. I saw the containers being patched, and the logs generated in `/dev/shm/hotdog.log`.

- [x] Run testing pods in aws k8s variants
- [ ] Run testing pods in vmware k8s variants

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
