### PR TITLE
docs: recommend Docker 20.10.10+ in BUILDING guide

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -53,8 +53,9 @@ cargo install cargo-make
 
 Bottlerocket uses [Docker](https://docs.docker.com/install/#supported-platforms) to orchestrate package and image builds.
 
-We recommend Docker 19.03 or later.
+We recommend Docker 20.10.10 or later.
 Builds rely on Docker's integrated BuildKit support, which has received many fixes and improvements in newer versions.
+The default seccomp policy of older versions of Docker do not support the `clone3` syscall in recent versions of Fedora or Ubuntu, on which the Bottlerocket SDK is based.
 
 You'll need to have Docker installed and running, with your user account added to the `docker` group.
 Docker's [post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/) will walk you through that.


### PR DESCRIPTION
**Description of changes:**

Since v0.24.0 of the Bottlerocket SDK (https://github.com/bottlerocket-os/bottlerocket/pull/1869) has been re-based to Fedora 35, it is recommended that we build with Docker 20.10.10 or later. This version of docker updates the default SECCOMP profile to allow for the new clone() syscall wrapper for glibc 2.34.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
