### PR TITLE
Add missing shimpei configuration

### DIFF
--- a/sources/models/src/aws-k8s-1.19/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/aws-k8s-1.19/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml


### PR DESCRIPTION
**Description of changes:**
Settings generators for shimpei were missing for Kubernetes 1.18 and 1.19 variants. This adds them.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
