### PR TITLE
build hotdog agent for target arch

### DIFF
--- a/packages/hotdog/hotdog.spec
+++ b/packages/hotdog/hotdog.spec
@@ -48,14 +48,14 @@ ls -la GOPATH/src/golang.org/x/sys
 cp GOPATH/src/golang.org/x/sys/LICENSE LICENSE.golang-sys
 
 %build
+%cross_go_configure %{goimport}
+
 # Set CGO_ENABLED=0 to statically link hotdog-hotpath, since it runs inside containers that
 # may not have the glibc version used to compile it
 # Set `GO111MODULE=off` to force golang to look for the dependencies in the GOPATH
-export GOPATH=$PWD/GOPATH
 CGO_ENABLED=0 GO111MODULE=off go build -installsuffix cgo -a -ldflags "-s" -o hotdog-hotpatch ./cmd/hotdog-hotpatch
 
 # The oci hooks commands can be compiled as we usually compile golang packages
-%cross_go_configure %{goimport}
 for cmd in hotdog-cc-hook hotdog-poststart-hook; do
   GO111MODULE=off go build -buildmode=pie -ldflags "${GOLDFLAGS}" -o $cmd ./cmd/$cmd
 done


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Invoke our Go configure macros before building the static hotdog agent, to ensure it's built for the target arch rather than the build host's arch.


**Testing done:**
Built the package for both architectures and extracted the contents.

```
❯ file x86_64-bottlerocket-linux-gnu/sys-root/usr/share/hotdog/hotdog-hotpatch
x86_64-bottlerocket-linux-gnu/sys-root/usr/share/hotdog/hotdog-hotpatch: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=pPGmtPvQOy2ULivD_xWT/D85pvf0zvsMqHksW55YA/SbZK18T9_60cOacnd-NP/D0ocIFepLcgO-21pJg2-, stripped

❯ file aarch64-bottlerocket-linux-gnu/sys-root/usr/share/hotdog/hotdog-hotpatch
aarch64-bottlerocket-linux-gnu/sys-root/usr/share/hotdog/hotdog-hotpatch: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=7US3YoRoQl9qVnC3gwMR/Bm88ojKcIly_JFuIN_Er/3bak_vRYp-BHCFIHdyPT/N-dGjxYqLmNv1qFwHsLD, stripped
```

Verified that aarch64 AMIs built on an x86_64 host could apply the hotpatch correctly after this fix - thanks @webern !

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
