### PR TITLE
Update default control container to v0.5.4

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -86,3 +86,6 @@ version = "1.5.0"
     "migrate_v1.5.0_oci-hooks-setting.lz4",
     "migrate_v1.5.0_oci-hooks-setting-metadata.lz4",
 ]
+"(1.5.0, 1.5.1)" = [
+    "migrate_v1.5.1_control-container-v0-5-4.lz4",
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -729,6 +729,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "control-container-v0-5-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "api/migration/migrations/v1.4.2/control-container-v0-5-3",
     "api/migration/migrations/v1.5.0/oci-hooks-setting",
     "api/migration/migrations/v1.5.0/oci-hooks-setting-metadata",
+    "api/migration/migrations/v1.5.1/control-container-v0-5-4",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.5.1/control-container-v0-5-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.5.1/control-container-v0-5-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "control-container-v0-5-4"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.5.1/control-container-v0-5-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.5.1/control-container-v0-5-4/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.3";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.4";
+
+/// We bumped the version of the default control container from v0.5.3 to v0.5.4
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.3"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.4"

--- a/sources/models/shared-defaults/vmware-host-containers.toml
+++ b/sources/models/shared-defaults/vmware-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.2"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.2"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.4"


### PR DESCRIPTION
**Description of changes:**

This updates the default control container from v0.5.3 to v0.5.4.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
