### PR TITLE
host-containers: update admin to v0.7.3 for vmware variants

### DIFF
--- a/sources/models/shared-defaults/vmware-host-containers.toml
+++ b/sources/models/shared-defaults/vmware-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.2"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.3"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Description of changes:**

This updates the default admin container for vmware variants from **v0.7.2** to **v0.7.3**.

**Testing done:**
- Launched `vmware-k8s-1.21` instance.
- Connected to admin container via ssh.
- Ran `sudo sheltie` to verify root shell was still available. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
