### PR TITLE
host-ctr: add '/etc/bottlerocket-release' to host containers

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -695,6 +695,12 @@ func withDefaultMounts(containerID string, persistentDir string) oci.SpecOpts {
 			Source:      "cgroup",
 			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
 		},
+		// Bottlerocket release information for the container
+		{
+			Options:     []string{"bind", "ro"},
+			Destination: fmt.Sprintf("/etc/bottlerocket-release"),
+			Source:      fmt.Sprintf("/etc/os-release"),
+		},
 	}
 
 	// The `current` dir was added for easier referencing in Dockerfiles and scripts.


### PR DESCRIPTION
**Description of changes:**

This grants host containers context to the underlying OS by mounting
Bottlerocket's `/etc/os-release` as `/etc/bottlerocket-release`.

**Testing done:**
- Built `aws-k8s-1.21` instance.
- Ran `cat /etc/bottlerocket-release` in both the control and admin host containers.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
