### PR TITLE
hotdog: correct release version

### DIFF
--- a/packages/hotdog/hotdog.spec
+++ b/packages/hotdog/hotdog.spec
@@ -20,7 +20,7 @@
 %global libcap 1.2.62
 
 Name: %{_cross_os}hotdog
-Version: 1.0.0
+Version: 1.0.1
 Release: 1%{?dist}
 Summary: Tool with OCI hooks to run the Log4j Hot Patch in containers
 License: Apache-2.0


### PR DESCRIPTION
I forgot to bump the release of hotdog's version string in the previous update.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
