### PR TITLE
fixes for release package

### DIFF
--- a/packages/release/prepare-local.service
+++ b/packages/release/prepare-local.service
@@ -1,7 +1,11 @@
 [Unit]
 Description=Prepare Local Directory (/local)
 DefaultDependencies=no
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
 RequiresMountsFor=/local
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -161,7 +161,7 @@ install -p -m 0644 %{S:203} %{buildroot}%{_cross_templatedir}/hosts
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.rules
 
-ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
+ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
 %files
 %{_cross_factorydir}%{_cross_sysconfdir}/nsswitch.conf

--- a/packages/selinux-policy/selinux-policy-files.service
+++ b/packages/selinux-policy/selinux-policy-files.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Copy SELinux policy files
 DefaultDependencies=no
+RefuseManualStart=true
+RefuseManualStop=true
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Make `prepare-local.service` depend on `selinux-policy-files.service`, since otherwise the `setfiles` command can fail if the file contexts haven't been copied yet. I've only seen this on a system that was failing to boot for other reasons, but in theory it could affect the most recent release.

Simplify the default target symlink, which was flagged by the `symlinks` tool while troubleshooting broken symlinks for the systemd upgrade.


**Testing done:**

Verified that the new dependency was used for `prepare-local.service`.
```
bash-5.0# systemctl list-dependencies prepare-local
prepare-local.service
● ├─local.mount
● ├─selinux-policy-files.service
● └─system.slice
```

Verified that the simplified symlink was correct for `default.target`.
```
bash-5.0# ls -latr /usr/lib/systemd/system/default.target
lrwxrwxrwx. 1 root root 20 Jan  4 01:39 /usr/lib/systemd/system/default.target -> preconfigured.target
```

Verified that the two services can't be manually restarted:
```
bash-5.0# systemctl restart prepare-local selinux-policy-files
Failed to restart prepare-local.service: Operation refused, unit prepare-local.service may be requested by dependency only (it is configured to refuse manual start/stop).
See system logs and 'systemctl status prepare-local.service' for details.
Failed to restart selinux-policy-files.service: Operation refused, unit selinux-policy-files.service may be requested by dependency only (it is configured to refuse manual start/stop).
See system logs and 'systemctl status selinux-policy-files.service' for details.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
