### PR TITLE
grub: Use `grub-mkimage` from build step rather than SDK version

### DIFF
--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -178,7 +178,7 @@ MODS="configfile echo ext2 gptprio linux normal part_gpt reboot sleep zstd"
 pushd bios-build
 %make_install
 mkdir -p %{buildroot}%{biosdir}
-grub2-mkimage \
+%{buildroot}%{_cross_bindir}/grub-mkimage \
   -c %{S:1} \
   -d ./grub-core/ \
   -O "i386-pc" \
@@ -193,7 +193,7 @@ popd
 pushd efi-build
 %make_install
 mkdir -p %{buildroot}%{efidir}
-grub2-mkimage \
+%{buildroot}%{_cross_bindir}/grub-mkimage \
   -c %{S:2} \
   -d ./grub-core/ \
   -O "%{_cross_grub_efi_format}" \


### PR DESCRIPTION
**Description of changes:**
```
This changes the grub build process to use `grub-mkimage` from the build
step in the spec, rather than use `grub2-mkimage` from the SDK.  The
reason for this is the SDK's version is a Fedora build which may
not match our grub images or modules.
```


**Testing done:**
* Build and boot an x86/aarch AWS variant successfully
* Build and boot an x86 VMware variant successfully


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
