### PR TITLE
grub: Add "console" to `terminal_output` command for BIOS systems

### DIFF
--- a/packages/grub/bios.cfg
+++ b/packages/grub/bios.cfg
@@ -1,6 +1,6 @@
 set no_modules=y
 serial
-terminal_output serial
+terminal_output serial console
 gptprio.next -d boot_dev -u boot_uuid
 set root=$boot_dev
 set prefix=($root)/grub


### PR DESCRIPTION
**Description of changes:**
This change adds the local console to the list of terminals to which grub will send output for systems using BIOS.

Before this change, on real hardware I wasn't able to see grub via serial console or local console.  This change fixes that!


**Testing done:**
For the testing below, I bumped up the grub timeout to 10 seconds and verified grub's output:

* EC2 virtualized x86_64 (BIOS)
* EC2 metal x86_64 (BIOS)
* VMware x86_64 (BIOS)
* Supermicro SYS-E200-8D (BIOS) :)



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
