### PR TITLE
vmware-variants: migrate host-container versions to latest versions

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -90,3 +90,6 @@ version = "1.5.2"
     "migrate_v1.5.1_control-container-v0-5-4.lz4",
 ]
 "(1.5.1, 1.5.2)" = []
+"(1.5.2, 1.6.0)" = [
+    "migrate_v1.6.0_vmware-host-containers.lz4",
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3800,6 +3800,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "vmware-host-containers"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "api/migration/migrations/v1.5.0/oci-hooks-setting",
     "api/migration/migrations/v1.5.0/oci-hooks-setting-metadata",
     "api/migration/migrations/v1.5.1/control-container-v0-5-4",
+    "api/migration/migrations/v1.6.0/vmware-host-containers",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.6.0/vmware-host-containers/Cargo.toml
+++ b/sources/api/migration/migrations/v1.6.0/vmware-host-containers/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vmware-host-containers"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+serde_json = "1"
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.6.0/vmware-host-containers/src/main.rs
+++ b/sources/api/migration/migrations/v1.6.0/vmware-host-containers/src/main.rs
@@ -1,0 +1,111 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use std::process;
+
+const ADMIN_CONTAINER_SOURCE_SETTING_NAME: &str = "settings.host-containers.admin.source";
+const ADMIN_CONTAINER_IMAGE_REPOSITORY: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin";
+const PREVIOUS_ADMIN_CONTAINER_VERSIONS: &[&str] = &["v0.7.0", "v0.7.1", "v0.7.2"];
+const TARGET_ADMIN_CONTAINER_VERSION: &str = "v0.7.3";
+
+const CONTROL_CONTAINER_SOURCE_SETTING_NAME: &str = "settings.host-containers.control.source";
+const CONTROL_CONTAINER_IMAGE_REPOSITORY: &str = "public.ecr.aws/bottlerocket/bottlerocket-control";
+const PREVIOUS_CONTROL_CONTAINER_VERSIONS: &[&str] = &["v0.5.0", "v0.5.1", "v0.5.2", "v0.5.3"];
+const TARGET_CONTROL_CONTAINER_VERSION: &str = "v0.5.4";
+
+pub struct VmwareHostContainerVersions;
+
+impl Migration for VmwareHostContainerVersions {
+    fn forward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        // For admin container
+        if let Some(data) = input.data.get_mut(ADMIN_CONTAINER_SOURCE_SETTING_NAME) {
+            match data {
+                serde_json::Value::String(source) => {
+                    for ver in PREVIOUS_ADMIN_CONTAINER_VERSIONS {
+                        let prev_source = format!("{}:{}", ADMIN_CONTAINER_IMAGE_REPOSITORY, ver);
+                        if *source == prev_source {
+                            *source = format!(
+                                "{}:{}",
+                                ADMIN_CONTAINER_IMAGE_REPOSITORY, TARGET_ADMIN_CONTAINER_VERSION
+                            );
+                            println!(
+                                "Changed value of '{}' from '{}' to '{}' on upgrade",
+                                ADMIN_CONTAINER_SOURCE_SETTING_NAME, prev_source, source
+                            );
+                            break;
+                        }
+                    }
+                }
+                _ => {
+                    println!(
+                        "'{}' is set to non-string value '{}'",
+                        ADMIN_CONTAINER_SOURCE_SETTING_NAME, data
+                    );
+                }
+            }
+        } else {
+            println!(
+                "Found no '{}' to change on upgrade",
+                ADMIN_CONTAINER_SOURCE_SETTING_NAME
+            );
+        }
+
+        // For control container
+        if let Some(data) = input.data.get_mut(CONTROL_CONTAINER_SOURCE_SETTING_NAME) {
+            match data {
+                serde_json::Value::String(source) => {
+                    for ver in PREVIOUS_CONTROL_CONTAINER_VERSIONS {
+                        let prev_source = format!("{}:{}", CONTROL_CONTAINER_IMAGE_REPOSITORY, ver);
+                        if *source == prev_source {
+                            *source = format!(
+                                "{}:{}",
+                                CONTROL_CONTAINER_IMAGE_REPOSITORY,
+                                TARGET_CONTROL_CONTAINER_VERSION
+                            );
+                            println!(
+                                "Changed value of '{}' from '{}' to '{}' on upgrade",
+                                CONTROL_CONTAINER_SOURCE_SETTING_NAME, prev_source, source
+                            );
+                            break;
+                        }
+                    }
+                }
+                _ => {
+                    println!(
+                        "'{}' is set to non-string value '{}'",
+                        CONTROL_CONTAINER_SOURCE_SETTING_NAME, data
+                    );
+                }
+            }
+        } else {
+            println!(
+                "Found no '{}' to change on upgrade",
+                CONTROL_CONTAINER_SOURCE_SETTING_NAME
+            );
+        }
+
+        Ok(input)
+    }
+
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        // It's unclear what version of the host-containers we should downgrade to since it could
+        // be any of the older host-container versions.
+        // We can just stay on the latest host-container version since there are no breaking changes.
+        println!("Vmware host-container versions migration has no work to do on downgrade");
+        Ok(input)
+    }
+}
+
+fn run() -> Result<()> {
+    migrate(VmwareHostContainerVersions)
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Jan 11 13:32:12 2022 -0800

    vmware-variants: migrate host-container versions to latest versions
    
    We haven't been migrating host-container versions for vmware-variants.
    This migration migrates all previous host-container versions to the
    latest host-container version on upgrade.
    
    It is unclear what version of the host-containers we should downgrade to
    since it could be any of the older host-container versions.
    We can just stay on the latest host-container version since there are no
    breaking changes.

```


**Testing done:**
Built v1.6.0 with migration and uploaded to my own TUF update repository.
Then I built a v1.2.0 vmware-k8s-1.20 OVA and launched a VM with it.
Before updating to v1.6.0:
```
[ec2-user@198 ~]$ apiclient -u /settings?keys=settings.host-containers.admin.source
{"host-containers":{"admin":{"source":"public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.2"}}}
[ec2-user@198 ~]$ apiclient -u /settings?keys=settings.host-containers.control.source
{"host-containers":{"control":{"source":"public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.1"}}}
```
After updating to v1.6.0, the migration ran and the host-container sources got updated as expected:
```
bash-5.0# updog check-update 
vmware-k8s-1.20 1.6.0
bash-5.0# updog update -r -n
Starting update to 1.6.0
...
bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.6.0 (vmware-k8s-1.20)"
PRETTY_NAME="Bottlerocket OS 1.6.0 (vmware-k8s-1.20)"
VARIANT_ID=vmware-k8s-1.20
VERSION_ID=1.6.0
BUILD_ID=082e231c-dirty
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
bash-5.0# apiclient -u /settings?keys=settings.host-containers.admin.source
{"host-containers":{"admin":{"source":"public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.3"}}}
bash-5.0# apiclient -u /settings?keys=settings.host-containers.control.source
{"host-containers":{"control":{"source":"public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.4"}}}
```
After rolling back, the host-containers version stayed on the latest as expected,
```
bash-5.0# signpost rollback-to-inactive
bash-5.0# reboot
....
bash-5.0# apiclient -u /settings?keys=settings.host-containers.admin.source
{"host-containers":{"admin":{"source":"public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.3"}}}
bash-5.0# apiclient -u /settings?keys=settings.host-containers.control.source
{"host-containers":{"control":{"source":"public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.4"}}}
```
I tried the same procedure with a v1.3.0 vmware-k8s-1.21 OVA and produced the same results.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
