### PR TITLE
Add NVIDIA tools for GPU support in containers

### DIFF
--- a/packages/libnvidia-container/0001-use-shared-libtirpc.patch
+++ b/packages/libnvidia-container/0001-use-shared-libtirpc.patch
@@ -1,0 +1,50 @@
+From e84335c28beaf0d9eab6861f6ae3bc72556f4439 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Mon, 20 Sep 2021 23:41:28 +0000
+Subject: [PATCH 1/4] use shared libtirpc
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index c281b8f..60a27f1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -141,9 +141,8 @@ else
+ LIB_LDLIBS_STATIC  += -l:libelf.a
+ endif
+ ifeq ($(WITH_TIRPC), yes)
+-LIB_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
+-LIB_LDLIBS_STATIC  += -l:libtirpc.a
+-LIB_LDLIBS_SHARED  += -lpthread
++LIB_CPPFLAGS       += -DWITH_TIRPC
++LIB_LDLIBS_SHARED  += -ltirpc
+ endif
+ ifeq ($(WITH_SECCOMP), yes)
+ LIB_CPPFLAGS       += -DWITH_SECCOMP $(shell pkg-config --cflags libseccomp)
+@@ -235,9 +234,6 @@ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
+ ifeq ($(WITH_LIBELF), no)
+ 	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk install
+ endif
+-ifeq ($(WITH_TIRPC), yes)
+-	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk install
+-endif
+ 
+ install: all
+ 	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(includedir) $(bindir) $(libdir) $(docdir) $(libdbgdir) $(pkgconfdir))
+@@ -283,9 +279,6 @@ depsclean:
+ ifeq ($(WITH_LIBELF), no)
+ 	-$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk clean
+ endif
+-ifeq ($(WITH_TIRPC), yes)
+-	-$(MAKE) -f $(MAKE_DIR)/libtirpc.mk clean
+-endif
+ 
+ mostlyclean:
+ 	$(RM) $(LIB_OBJS) $(LIB_STATIC_OBJ) $(BIN_OBJS) $(DEPENDENCIES)
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/0002-use-prefix-from-environment.patch
+++ b/packages/libnvidia-container/0002-use-prefix-from-environment.patch
@@ -1,0 +1,27 @@
+From e5a5f7877832ab255721d2e5971a85e0940043d2 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 21 Sep 2021 00:03:42 +0000
+Subject: [PATCH 2/4] use prefix from environment
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 60a27f1..9d19d11 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,7 +23,7 @@ WITH_SECCOMP ?= yes
+ 
+ ##### Global definitions #####
+ 
+-export prefix      = /usr/local
++export prefix      ?= /usr/local
+ export exec_prefix = $(prefix)
+ export bindir      = $(exec_prefix)/bin
+ export libdir      = $(exec_prefix)/lib
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/0003-keep-debug-symbols.patch
+++ b/packages/libnvidia-container/0003-keep-debug-symbols.patch
@@ -1,0 +1,50 @@
+From db8ae6f5a08db43884b154be07a4b4506a65507d Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 21 Sep 2021 00:22:37 +0000
+Subject: [PATCH 3/4] keep debug symbols
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 9d19d11..ad84d7f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -193,22 +193,14 @@ $(BIN_OBJS): %.o: %.c | shared
+ -include $(DEPENDENCIES)
+ 
+ $(LIB_SHARED): $(LIB_OBJS)
+-	$(MKDIR) -p $(DEBUG_DIR)
+ 	$(CC) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(LIB_LDFLAGS) $(OUTPUT_OPTION) $^ $(LIB_SCRIPT) $(LIB_LDLIBS)
+-	$(OBJCPY) --only-keep-debug $@ $(LIB_SONAME)
+-	$(OBJCPY) --add-gnu-debuglink=$(LIB_SONAME) $@
+-	$(MV) $(LIB_SONAME) $(DEBUG_DIR)
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ $(LIB_STATIC_OBJ): $(LIB_OBJS)
+ 	# FIXME Handle user-defined LDFLAGS and LDLIBS
+ 	$(LD) -d -r --exclude-libs ALL -L$(DEPS_DIR)$(libdir) $(OUTPUT_OPTION) $^ $(LIB_LDLIBS_STATIC)
+-	$(OBJCPY) --localize-hidden $@
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ $(BIN_NAME): $(BIN_OBJS)
+ 	$(CC) $(BIN_CFLAGS) $(BIN_CPPFLAGS) $(BIN_LDFLAGS) $(OUTPUT_OPTION) $^ $(BIN_SCRIPT) $(BIN_LDLIBS)
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ ##### Public rules #####
+ 
+@@ -244,8 +236,6 @@ install: all
+ 	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
+ 	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
+ 	$(LDCONFIG) -n $(DESTDIR)$(libdir)
+-	# Install debugging symbols
+-	$(INSTALL) -m 644 $(DEBUG_DIR)/$(LIB_SONAME) $(DESTDIR)$(libdbgdir)
+ 	# Install configuration files
+ 	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
+ 	# Install binary files
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+++ b/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
@@ -1,0 +1,28 @@
+From 6103d57aebf610ff552e9fb5a36c3bae66f23c0d Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Mon, 1 Nov 2021 16:18:19 +0000
+Subject: [PATCH 4/4] Use NVIDIA_PATH to look up binaries
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ src/nvc_info.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/nvc_info.c b/src/nvc_info.c
+index 3b3d2d5..99ff881 100644
+--- a/src/nvc_info.c
++++ b/src/nvc_info.c
+@@ -249,8 +249,8 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
+         char path[PATH_MAX];
+         int rv = -1;
+ 
+-        if ((env = secure_getenv("PATH")) == NULL) {
+-                error_setx(err, "environment variable PATH not found");
++        if ((env = secure_getenv("NVIDIA_PATH")) == NULL && (env = secure_getenv("PATH")) == NULL) {
++                error_setx(err, "environment variables NVIDIA_PATH/PATH not found");
+                 return (-1);
+         }
+         if ((env = ptr = xstrdup(err, env)) == NULL)
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "libnvidia-container"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.7.0.tar.gz"
+sha512 = "cb2bedc7f3278c56f9da003257ea1c16116ac52cc4a792e4bdfc7e1739a5504436b61db65abb159f4bd4702d961ebd4c455605ce5e9daac00a2ab282a1b1348f"
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/nvidia-modprobe/archive/495.44/nvidia-modprobe-495.44.tar.gz"
+sha512 = "67486ed1b17c8962786e13880910bb2b1938206a0fd76b360ddef7faf80ee0c941a2e3fbc73fa92a92009e2c54130dce17a466c8079537a981a2fed09c07e4c9"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libelf = { path = "../libelf" }
+libcap = { path = "../libcap" }
+libseccomp = { path = "../libseccomp" }
+libtirpc = { path = "../libtirpc" }

--- a/packages/libnvidia-container/build.rs
+++ b/packages/libnvidia-container/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,0 +1,80 @@
+%global nvidia_modprobe_version 495.44
+
+Name: %{_cross_os}libnvidia-container
+Version: 1.7.0
+Release: 1%{?dist}
+Summary: NVIDIA container runtime library
+# The COPYING and COPYING.LESSER files in the sources don't apply to libnvidia-container
+# they are there because they apply to libelf in elfutils
+License: Apache-2.0
+URL: https://github.com/NVIDIA/libnvidia-container
+Source0: https://github.com/NVIDIA/libnvidia-container/archive/v%{version}.tar.gz
+Source1: https://github.com/NVIDIA/nvidia-modprobe/archive/%{nvidia_modprobe_version}/nvidia-modprobe-%{nvidia_modprobe_version}.tar.gz
+
+# First party patches from 1 to 1000
+Patch0001: 0001-use-shared-libtirpc.patch
+Patch0002: 0002-use-prefix-from-environment.patch
+Patch0003: 0003-keep-debug-symbols.patch
+Patch0004: 0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libelf-devel
+BuildRequires: %{_cross_os}libcap-devel
+BuildRequires: %{_cross_os}libseccomp-devel
+BuildRequires: %{_cross_os}libtirpc-devel
+Requires: %{_cross_os}libelf
+Requires: %{_cross_os}libcap
+Requires: %{_cross_os}libseccomp
+Requires: %{_cross_os}libtirpc
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the NVIDIA container runtime library
+Requires: %{_cross_os}libnvidia-container
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -Sgit -n libnvidia-container-%{version} -p1
+mkdir -p deps/src/nvidia-modprobe-%{nvidia_modprobe_version}
+tar -C deps/src/nvidia-modprobe-%{nvidia_modprobe_version} --strip-components=1 \
+  -xzf %{SOURCE1} nvidia-modprobe-%{nvidia_modprobe_version}/{modprobe-utils,COPYING}
+patch -d deps/src/nvidia-modprobe-%{nvidia_modprobe_version} -p1 < mk/nvidia-modprobe.patch
+touch deps/src/nvidia-modprobe-%{nvidia_modprobe_version}/.download_stamp
+
+%global set_env \
+%set_cross_build_flags \\\
+export CC=%{_cross_target}-gcc \\\
+export LD=%{_cross_target}-ld \\\
+export CFLAGS="${CFLAGS} -I%{_cross_includedir}/tirpc" \\\
+export WITH_LIBELF=yes \\\
+export WITH_SECCOMP=yes \\\
+export WITH_TIRPC=yes \\\
+export prefix=%{_cross_prefix} \\\
+export DESTDIR=%{buildroot} \\\
+%{nil}
+
+%build
+%set_env
+%make_build
+
+%install
+%set_env
+%make_install
+
+%files
+%license NOTICE LICENSE
+%{_cross_attribution_file}
+%{_cross_libdir}/libnvidia-container.so.1
+%{_cross_libdir}/libnvidia-container.so.%{version}
+%{_cross_bindir}/nvidia-container-cli
+%exclude %{_cross_docdir}
+
+%files devel
+%{_cross_includedir}/*.h
+%{_cross_libdir}/*.so
+%{_cross_libdir}/*.a
+%{_cross_libdir}/pkgconfig/*.pc

--- a/packages/libnvidia-container/pkg.rs
+++ b/packages/libnvidia-container/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nvidia-container-toolkit"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.7.0/v1.7.0.tar.gz"
+sha512 = "7bc3601ca5cca5b3ad7f30f9c2453d41452b425811d37209c20b7f375d557666a1369d756b52a007406996758b09d47635f2e8628bf363298ec247cb3d3f8845"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libnvidia-container = { path = "../libnvidia-container" }
+# This package depends on `shimpei`, but it is built in the `os` package
+# which is expected to be pulled in
+# os = { path = "../os" }

--- a/packages/nvidia-container-toolkit/build.rs
+++ b/packages/nvidia-container-toolkit/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config.toml
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config.toml
@@ -1,0 +1,5 @@
+[nvidia-container-cli]
+root = "/"
+path = "/usr/bin/nvidia-container-cli"
+environment = []
+ldconfig = "@/sbin/ldconfig"

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles.conf
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/nvidia-container-runtime/config.toml - - - -

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -1,0 +1,54 @@
+%global goproject github.com/NVIDIA
+%global gorepo nvidia-container-toolkit
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 1.7.0
+%global rpmver %{gover}
+
+Name: %{_cross_os}nvidia-container-toolkit
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: Tool to build and run GPU accelerated containers
+License: Apache-2.0
+URL: https://%{goimport}
+
+Source0: https://%{goimport}/archive/v%{gover}/v%{gover}.tar.gz
+Source1: nvidia-container-toolkit-config.toml
+Source2: nvidia-container-toolkit-tmpfiles.conf
+Source3: nvidia-oci-hooks-json
+
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}libnvidia-container
+Requires: %{_cross_os}shimpei
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{gorepo}-%{gover} -p1
+%cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
+
+%build
+%cross_go_configure %{goimport}
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o nvidia-container-toolkit ./cmd/nvidia-container-toolkit
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -d %{buildroot}%{_cross_templatedir}
+install -d %{buildroot}%{_cross_datadir}/nvidia-container-toolkit
+install -d %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime
+install -p -m 0755 nvidia-container-toolkit %{buildroot}%{_cross_bindir}/nvidia-container-runtime-hook
+install -m 0644 %{S:1} %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime/config.toml
+install -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit.conf
+install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-oci-hooks-json
+ln -s shimpei %{buildroot}%{_cross_bindir}/nvidia-oci
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_bindir}/nvidia-container-runtime-hook
+%{_cross_bindir}/nvidia-oci
+%{_cross_templatedir}/nvidia-oci-hooks-json
+%{_cross_factorydir}/etc/nvidia-container-runtime/config.toml
+%{_cross_tmpfilesdir}/nvidia-container-toolkit.conf

--- a/packages/nvidia-container-toolkit/nvidia-oci-hooks-json
+++ b/packages/nvidia-container-toolkit/nvidia-oci-hooks-json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "prestart": [
+      {{#if settings.oci-hooks.log4j-hotpatch-enabled}}
+      { "path": "/usr/libexec/hotdog/hotdog-cc-hook" },
+      {{/if}}
+      {
+        "path": "/usr/bin/nvidia-container-runtime-hook",
+        "args": ["nvidia-container-runtime-hook", "prestart"]
+      }
+    ],
+    "poststart": [
+      {{#if settings.oci-hooks.log4j-hotpatch-enabled}}
+      { "path": "/usr/libexec/hotdog/hotdog-poststart-hook" }
+      {{/if}}
+    ]
+  }
+}

--- a/packages/nvidia-container-toolkit/pkg.rs
+++ b/packages/nvidia-container-toolkit/pkg.rs
@@ -1,0 +1,1 @@
+// not used


### PR DESCRIPTION
**Issue number:**
N / A

**Description of changes:**

Related to #1799 , that PR is quite big. I'm taking some of the commits in that PR as their individual PR. The packages in this PR were build in #1799, but this PR also updates the packages to their latest versions.

```
* bb4a5a30 packages: add nvidia-container-toolkit
* 24b3812a packages: add libnvidia-container
```

**Testing done:**

I included both commits in a local branch based on #1799, and I launched a container with k8s. I was able to execute `nvidia-smi` from the container:

```
~ ❯ kubectl exec cuda-vectoradd -- nvidia-smi
Wed Jan 12 02:42:10 2022
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.2     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   32C    P0    25W / 300W |      0MiB / 16160MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
