### PR TITLE
Fetch packages' licenses at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /*.pem
 /keys
 /roles
+/Licenses.toml
+/licenses

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -92,6 +92,35 @@ cargo make -e BUILDSYS_ARCH=my-arch-here
 
 (You can use variant and arch arguments together, too.)
 
+#### Package licenses
+
+Most packages will include license files extracted from upstream source archives.
+However, in some rare cases there are multiple licenses that could apply to a package.
+Bottlerocket's build system uses the `Licenses.toml` file in conjuction with the `licenses` directory to configure the licenses used for such special packages.
+Here is an example of a simple `Licenses.toml` configuration file:
+
+```toml
+[package]
+spdx-id = "SPDX-ID"
+licenses = [
+  { path = "the-license.txt" }
+]
+```
+
+In the previous example, it is expected that the file `the-license.txt` is present in `licenses`.
+You can retrieve the licenses from a remote endpoint, or the local filesystem if you specify the `license-url` field:
+
+```toml
+[package]
+spdx-id = "SPDX-ID AND SPDX-ID-2" # Package with multiple licenses
+licenses = [
+  # This file is copied from a file system, and will be saved as `path`
+  { license-url = "file:///path/to/spdx-id-license.txt", path = "spdx-id-license.txt" },
+  # This file is fetched from an https endpoint, and will be saved as `path`
+  { license-url = "https://localhost/spdx-id-license-v2.txt", path = "spdx-id-license-2.txt" }
+]
+```
+
 ### Register an AMI
 
 To use the image in Amazon EC2, we need to register the image as an AMI.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -57,6 +57,10 @@ PUBLISH_UNIFIED_VOLUME_SIZE = "22"
 # tools/pubsys/policies/ssm/README.md for more information.
 PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm/defaults.toml"
 
+# This can be overriden with -e to change the source path
+# for the Licenses.toml file
+BUILDSYS_LICENSES_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Licenses.toml"
+
 # Specifies whether to validate all targets when validating TUF repositories
 REPO_VALIDATE_TARGETS = "true"
 # Specifies the timeframe to look for upcoming repository metadata expirations
@@ -88,6 +92,10 @@ BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"
 # BUILDSYS_ALLOW_FAILED_LICENSE_CHECK=true` to allow the build to continue even
 # if the license check fails.
 BUILDSYS_ALLOW_FAILED_LICENSE_CHECK = "false"
+
+# Disallow pulling licenses from Upstream URLs. To fetch licenses from the upstream source,
+# override this on the command line and set it to 'true'
+BUILDSYS_UPSTREAM_LICENSE_FETCH= "false"
 
 # This controls how many `docker build` commands we'll invoke at once.
 BUILDSYS_JOBS = "8"
@@ -391,7 +399,7 @@ fi
 
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["check-cargo-version", "build-tools", "publish-setup"]
+dependencies = ["check-cargo-version", "build-tools", "publish-setup", "fetch-licenses"]
 script_runner = "bash"
 script = [
 '''
@@ -605,6 +613,44 @@ docker run --rm \
 '''
 ]
 
+[tasks.fetch-licenses]
+dependencies = ["fetch"]
+script = [
+'''
+if [ "${BUILDSYS_UPSTREAM_LICENSE_FETCH}" = "false" ]; then
+  echo "Skipping fetching licenses"
+  exit 0
+fi
+
+# Attempt copy Licenses.toml
+cp "${BUILDSYS_LICENSES_CONFIG_PATH}" "${BUILDSYS_ROOT_DIR}/Licenses.toml" 2>/dev/null \
+  || echo "Skipping copying file from ${BUILDSYS_LICENSES_CONFIG_PATH}"
+
+if [ ! -s "${BUILDSYS_ROOT_DIR}"/Licenses.toml ] ; then
+  echo "Not fetching licenses since 'Licenses.toml' doesn't exist"
+  exit 0
+fi
+
+mkdir -p "${BUILDSYS_ROOT_DIR}"/licenses
+
+run_fetch_licenses="
+bottlerocket-license-tool -l /tmp/Licenses.toml fetch /tmp/licenses
+"
+set +e
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
+  -e CARGO_HOME="/tmp/.cargo" \
+  -v "${CARGO_HOME}":/tmp/.cargo \
+  -v "${BUILDSYS_ROOT_DIR}/licenses:/tmp/licenses" \
+  -v "${BUILDSYS_ROOT_DIR}/Licenses.toml:/tmp/Licenses.toml" \
+  "${BUILDSYS_SDK_IMAGE}" \
+  bash -c "${run_fetch_licenses}"
+'''
+]
+
+
 [tasks.link-clean]
 dependencies = ["fetch"]
 script = [
@@ -642,6 +688,7 @@ fi
 dependencies = [
     "link-clean",
     "check-licenses",
+    "fetch-licenses",
     "build-variant",
     "build-ova",
     "link-variant",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N / A

**Description of changes:**

There are packages to which multiple licenses apply, depending on who distributes the software. For said packages, the licenses are fetched at build time when the `Licenses.toml` configuration file is present. The fetched licenses are stored in the `licenses` folder, used to retrieve the license of the special packages while they are built.

When the `Licenses.toml` file and the `licenses` folder are provided, they are copied to the build directory of the package. If either path is missing, empty configurations are provided. Packages that use the `Licenses.toml` file to retrieve their licensing information, will fail the build, since it is expected that the user will provide said configurations.

TODO:
- [x] Update `BUILDING.md` to document `Licenses.toml`

**Testing done:**
- With `Licenses.toml`:

```toml
[package]
spdx-id = "LicenseRef-<PACKAGE-LICENSE>"
licenses = [
  { path = "LicensesRef-<PACKAGE-LICENSE>.pdf", license-url = "<url-to-remote-license>" }
]
```
And with a spec file as follows:
```spec
%global spdx_id %(bottlerocket-license-tool -l $PWD/rpmbuild/BUILD/Licenses.toml spdx-id <package>)
%global license_file %(bottlerocket-license-tool -l $PWD/rpmbuild/BUILD/Licenses.toml path <package> -p ./licenses)

# ...

License: %{spdx_id}

# ...
%files <package>
%license %{license_file}
```

Verified the built rpm used the correct configurations

- Verified licenses files from `Licenses.toml` are retrieved and stored in `licenses`
- Verified the build doesn't fail for packages that don't use `Licenses.toml`
- Verified the build fails for packages that use `Licenses.toml`, and this is missing

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
