### PR TITLE
Make local file a valid source for all platforms

### DIFF
--- a/sources/api/early-boot-config/build.rs
+++ b/sources/api/early-boot-config/build.rs
@@ -13,9 +13,7 @@ fn main() {
     // tags": https://github.com/bottlerocket-os/bottlerocket/issues/1260
     println!("cargo:rerun-if-env-changed=VARIANT");
     if let Ok(variant) = env::var("VARIANT") {
-        if variant == "aws-dev" {
-            println!("cargo:rustc-cfg=bottlerocket_platform=\"aws-dev\"");
-        } else if variant.starts_with("aws") {
+        if variant.starts_with("aws") {
             println!("cargo:rustc-cfg=bottlerocket_platform=\"aws\"");
         } else if variant.starts_with("vmware") {
             println!("cargo:rustc-cfg=bottlerocket_platform=\"vmware\"");

--- a/sources/api/early-boot-config/src/provider.rs
+++ b/sources/api/early-boot-config/src/provider.rs
@@ -3,12 +3,11 @@
 use crate::settings::SettingsJson;
 use async_trait::async_trait;
 
-#[cfg(any(bottlerocket_platform = "aws-dev", bottlerocket_platform = "metal"))]
 mod local_file;
 
-#[cfg(any(bottlerocket_platform = "aws", bottlerocket_platform = "aws-dev"))]
+#[cfg(bottlerocket_platform = "aws")]
 mod aws;
-#[cfg(any(bottlerocket_platform = "aws", bottlerocket_platform = "aws-dev"))]
+#[cfg(bottlerocket_platform = "aws")]
 pub(crate) use aws::AwsDataProvider as Platform;
 
 #[cfg(bottlerocket_platform = "vmware")]

--- a/sources/api/early-boot-config/src/provider/metal.rs
+++ b/sources/api/early-boot-config/src/provider/metal.rs
@@ -16,8 +16,8 @@ impl PlatformDataProvider for MetalDataProvider {
         let mut output = Vec::new();
 
         match local_file_user_data()? {
-            None => warn!("No user data found via local file: {}", USER_DATA_FILE),
             Some(s) => output.push(s),
+            None => warn!("No user data found via local file: {}", USER_DATA_FILE),
         }
 
         Ok(output)

--- a/variants/README.md
+++ b/variants/README.md
@@ -22,6 +22,15 @@ A variant is essentially a list of packages to install, plus a model that define
 The documentation for [packages](../packages/) covers how to create a package.
 Information about API settings for variants can be found in the [models](../sources/models/) documentation.
 
+### User data
+Bottlerocket variants ingest TOML-formatted [user data](../README.md#using-user-data) from various sources in a predefined order.
+All variants first attempt to read user data from `/var/lib/bottlerocket/user-data.toml`.
+AWS variants then retrieve user data from IMDS.
+VMware variants will attempt to read user data from a mounted CD-ROM (from a file named "user-data" or from an OVF file), and then from VMware's guestinfo interface.
+
+If a setting is defined in more than one source, the value in later sources will override earlier values.
+For example, in a VMware variant, settings read from the guestinfo interface will override settings from CD-ROM, and settings from CD-ROM will override settings from the file.
+
 ## Variants
 
 ### aws-k8s-1.18: Kubernetes 1.18 node
@@ -67,15 +76,11 @@ User data will be read from IMDS.
 
 The [vmware-dev](vmware-dev/Cargo.toml) variant has useful packages for local development of the OS, and is intended to run as a VMware guest.
 It includes tools for troubleshooting as well as Docker for running containers.
-User data will be read from a mounted CD-ROM (from a file named "user-data" or from an OVF file), and from VMware's guestinfo interface.
-If user data exists at both places, settings read from guestinfo will override identical settings from CD-ROM.
 
 ### vmware-k8s-1.20: VMware Kubernetes 1.20 node
 
 The [vmware-k8s-1.20](vmware-k8s-1.20/Cargo.toml) variant includes the packages needed to run a Kubernetes worker node as a VMware guest.
 It supports self-hosted clusters.
-User data will be read from a mounted CD-ROM (from a file named "user-data" or from an OVF file), and from VMware's guestinfo interface.
-If user data exists at both places, settings read from guestinfo will override identical settings from CD-ROM.
 
 This variant is compatible with Kubernetes 1.20, 1.21, and 1.22 clusters.
 
@@ -83,8 +88,6 @@ This variant is compatible with Kubernetes 1.20, 1.21, and 1.22 clusters.
 
 The [vmware-k8s-1.21](vmware-k8s-1.21/Cargo.toml) variant includes the packages needed to run a Kubernetes worker node as a VMware guest.
 It supports self-hosted clusters.
-User data will be read from a mounted CD-ROM (from a file named "user-data" or from an OVF file), and from VMware's guestinfo interface.
-If user data exists at both places, settings read from guestinfo will override identical settings from CD-ROM.
 
 This variant is compatible with Kubernetes 1.21, 1.22, and 1.23 clusters.
 
@@ -92,7 +95,6 @@ This variant is compatible with Kubernetes 1.21, 1.22, and 1.23 clusters.
 
 The [metal-dev](metal-dev/Cargo.toml) variant has useful packages for local development of the OS and is intended to run bare metal.
 It includes tools for troubleshooting as well as Docker for running containers.
-User data will be read from `/var/lib/bottlerocket/user-data.toml`.
 
 ### Deprecated variants
 


### PR DESCRIPTION
**Issue number:**
Fixes #1902 


**Description of changes:**
```
early-boot-config: Make local file a valid source for all platforms

This change adds local file as a valid user data source for all
platforms we support.  Previously local file was only supported on
`aws-dev` and `metal-dev` variants.  A nice side affect of this change
is that it simplifies the platforms we support and streamlines the
conditional compilation a bit more.
```
```
variants: Document user data sources

This commit centralizes information regarding the various sources from
which variants read user data.  It also explains the order in which
sources are read, and how identical settings are handled.
```


**Testing done:**
*metal-dev*
Built an image with a user data file and observed the image boot and ingest user data.  Built another image without the file and the system booted successfully, logging that no user data was present at the desired location.

*aws-k8s-1.21*
*vmware-k8s-1.21*
Build an image with a local file user data containing:
```
settings.motd = "HELLO FROM FILE"
settings.host-containers.admin.enabled = false
```
At runtime I supplied user data to effectively "override" and enable the admin container: `settings.host-containers.admin.enabled = true`.  For both variants I observed via `early-boot-config` logs and the `apiclient` commands below, that the user data was correctly ingested via local file.  The settings ingested from user data via IMDS/guestinfo at runtime correctly overwrote the settings provided via the file.
```
bash-5.0# apiclient -u /settings?keys=settings.motd
{"motd":"HELLO FROM FILE"}

bash-5.0# apiclient -u /settings?keys=settings.host-containers.admin.enabled
{"host-containers":{"admin":{"enabled":true}}}
```
I conducted the same experiment except supplied user data at runtime that _would not_ overwrite the settings supplied via file and observed the correct behavior.
```
bash-5.0# apiclient -u /settings?keys=settings.motd
{"motd":"HELLO FROM FILE"}

$ apiclient -u /settings?keys=settings.host-containers.admin.enabled
{"host-containers":{"admin":{"enabled":false}}}
```

For both variants, I also built images without a local user data file and observed both correctly check for user data at the file location, find nothing, and move on to the other sources.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
