### PR TITLE
model, schnauzer: change `kubernetes.node-taints` model type to map of taint keys to list of taint value/effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,15 +319,15 @@ For Kubernetes variants in VMware, you must specify:
 
 The following settings can be optionally set to customize the node labels and taints. Remember to quote keys (since they often contain ".") and to quote all values.
 * `settings.kubernetes.node-labels`: [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) in the form of key, value pairs added when registering the node in the cluster.
-* `settings.kubernetes.node-taints`: [Taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) in the form of key, value and effect entries added when registering the node in the cluster.
+* `settings.kubernetes.node-taints`: [Taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) in the form of key, values and effects entries added when registering the node in the cluster.
   * Example user data for setting up labels and taints:
     ```
     [settings.kubernetes.node-labels]
     "label1" = "foo"
     "label2" = "bar"
     [settings.kubernetes.node-taints]
-    "dedicated" = "experimental:PreferNoSchedule"
-    "special" = "true:NoSchedule"
+    "dedicated" = ["experimental:PreferNoSchedule", "experimental:NoExecute"]
+    "special" = ["true:NoSchedule"]
     ```
 
 The following settings are optional and allow you to further configure your cluster.

--- a/Release.toml
+++ b/Release.toml
@@ -92,4 +92,5 @@ version = "1.5.2"
 "(1.5.1, 1.5.2)" = []
 "(1.5.2, 1.6.0)" = [
     "migrate_v1.6.0_vmware-host-containers.lz4",
+    "migrate_v1.6.0_node-taints-representation.lz4",
 ]

--- a/packages/kubernetes-1.18/kubelet-env
+++ b/packages/kubernetes-1.18/kubelet-env
@@ -1,4 +1,4 @@
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
-NODE_TAINTS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-taints}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}
 POD_INFRA_CONTAINER_IMAGE={{settings.kubernetes.pod-infra-container-image}}

--- a/packages/kubernetes-1.19/kubelet-env
+++ b/packages/kubernetes-1.19/kubelet-env
@@ -1,4 +1,4 @@
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
-NODE_TAINTS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-taints}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}
 POD_INFRA_CONTAINER_IMAGE={{settings.kubernetes.pod-infra-container-image}}

--- a/packages/kubernetes-1.20/kubelet-env
+++ b/packages/kubernetes-1.20/kubelet-env
@@ -1,4 +1,4 @@
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
-NODE_TAINTS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-taints}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}
 POD_INFRA_CONTAINER_IMAGE={{settings.kubernetes.pod-infra-container-image}}

--- a/packages/kubernetes-1.21/kubelet-env
+++ b/packages/kubernetes-1.21/kubelet-env
@@ -1,4 +1,4 @@
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
-NODE_TAINTS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-taints}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}
 POD_INFRA_CONTAINER_IMAGE={{settings.kubernetes.pod-infra-container-image}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2028,6 +2028,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "node-taints-representation"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "nom"
 version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "api/migration/migrations/v1.5.0/oci-hooks-setting-metadata",
     "api/migration/migrations/v1.5.1/control-container-v0-5-4",
     "api/migration/migrations/v1.6.0/vmware-host-containers",
+    "api/migration/migrations/v1.6.0/node-taints-representation",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -73,7 +73,7 @@ pub enum Error {
     },
 
     #[snafu(display("'{}' is set to non-string value", setting))]
-    NonStringSettingDataType { setting: &'static str },
+    NonStringSettingDataType { setting: String },
 
     #[snafu(display("Unable to deserialize datastore data: {}", source))]
     DeserializeDatastore {

--- a/sources/api/migration/migrations/v1.6.0/node-taints-representation/Cargo.toml
+++ b/sources/api/migration/migrations/v1.6.0/node-taints-representation/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "node-taints-representation"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+serde_json = "1"
+snafu = "0.6"

--- a/sources/api/migration/migrations/v1.6.0/node-taints-representation/src/main.rs
+++ b/sources/api/migration/migrations/v1.6.0/node-taints-representation/src/main.rs
@@ -1,0 +1,96 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{error, migrate, Migration, MigrationData, Result};
+use serde_json::Value;
+use snafu::OptionExt;
+use std::process;
+
+const NODE_TAINTS_SETTING_NAME: &str = "settings.kubernetes.node-taints";
+
+/// This migration changes the model type of `settings.kubernetes.node-taints` from `HashMap<KubernetesLabelKey, KubernetesTaintValue>`
+/// to `HashMap<KubernetesLabelKey, Vec<KubernetesTaintValue>>` on upgrade and vice-versa on downgrades.
+pub struct ChangeNodeTaintsType;
+
+impl Migration for ChangeNodeTaintsType {
+    /// Newer versions store `settings.kubernetes.node-taints` as `HashMap<KubernetesLabelKey, Vec<KubernetesTaintValue>>`.
+    /// Need to convert from `HashMap<KubernetesLabelKey, KubernetesTaintValue>`.
+    fn forward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        for (taint_key, taint_val) in input
+            .data
+            .iter_mut()
+            .filter(|&(k, _)| k.starts_with(format!("{}.", NODE_TAINTS_SETTING_NAME).as_str()))
+        {
+            match taint_val {
+                Value::String(taint_val_string) => {
+                    let taint_val_array =
+                        Value::Array(vec![Value::String(taint_val_string.to_owned())]);
+                    println!(
+                        "Changing '{}', from '{}' to '{}' on upgrade",
+                        taint_key, &taint_val, taint_val_array
+                    );
+                    *taint_val = taint_val_array;
+                }
+                _ => {
+                    println!(
+                        "'{}' is not a JSON string value: '{}'",
+                        taint_key, taint_val
+                    );
+                }
+            }
+        }
+        Ok(input)
+    }
+
+    /// Older versions store `settings.kubernetes.node-taints` as `HashMap<KubernetesLabelKey, KubernetesTaintValue>`.
+    /// Need to convert from `HashMap<KubernetesLabelKey, Vec<KubernetesTaintValue>>`.
+    ///
+    /// Note that this potentially causes data loss if there are more than one taint value/effect assigned to a taint key.
+    /// Older versions can only map one taint value/effect to a taint key, so we default to choosing the first in the list if there are multiple.
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        for (taint_key, taint_val) in input
+            .data
+            .iter_mut()
+            .filter(|&(k, _)| k.starts_with(format!("{}.", NODE_TAINTS_SETTING_NAME).as_str()))
+        {
+            match taint_val {
+                Value::Array(taint_val_array) => {
+                    // There should always at least be one value in the sequence
+                    let first_taint_val = Value::String(
+                        taint_val_array
+                            .first()
+                            .cloned()
+                            .unwrap_or_default()
+                            .as_str()
+                            .context(error::NonStringSettingDataType {
+                                setting: taint_key.to_string(),
+                            })?
+                            .to_string(),
+                    );
+                    println!(
+                        "Changing '{}', from '{}' to '{}' on downgrade",
+                        taint_key, &taint_val, first_taint_val
+                    );
+                    *taint_val = first_taint_val;
+                }
+                _ => {
+                    println!("'{}' is not a JSON Array value: '{}'", taint_key, taint_val);
+                }
+            }
+        }
+        Ok(input)
+    }
+}
+
+fn run() -> Result<()> {
+    migrate(ChangeNodeTaintsType)
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -121,6 +121,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     // Prefer snake case for helper names (we accidentally created a few with kabob case)
     template_registry.register_helper("base64_decode", Box::new(helpers::base64_decode));
     template_registry.register_helper("join_map", Box::new(helpers::join_map));
+    template_registry.register_helper("join_node_taints", Box::new(helpers::join_node_taints));
     template_registry.register_helper("default", Box::new(helpers::default));
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
     template_registry.register_helper("pause-prefix", Box::new(helpers::pause_prefix));

--- a/sources/models/src/de.rs
+++ b/sources/models/src/de.rs
@@ -1,8 +1,139 @@
-use crate::RegistryMirror;
+use crate::{KubernetesLabelKey, KubernetesTaintValue, RegistryMirror};
 use serde::de::value::SeqAccessDeserializer;
-use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::fmt::Formatter;
+use toml::Value;
+
+// Our standard representation of node-taints is a `HashMap` of label keys to a list of taint values and effects;
+// for backward compatibility, we also allow a `HashMap` of label keys to a singular taint value/effect.
+pub(crate) fn deserialize_node_taints<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<KubernetesLabelKey, Vec<KubernetesTaintValue>>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct NodeTaints;
+
+    impl<'de> Visitor<'de> for NodeTaints {
+        type Value = Option<HashMap<KubernetesLabelKey, Vec<KubernetesTaintValue>>>;
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("TOML table")
+        }
+
+        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut node_taints: HashMap<KubernetesLabelKey, Vec<KubernetesTaintValue>> =
+                HashMap::new();
+            while let Some((k, v)) = map.next_entry()? {
+                match v {
+                    // If we encounter a singular mapped value, convert it into a list of one
+                    Value::String(taint_val) => {
+                        node_taints.insert(
+                            k,
+                            vec![KubernetesTaintValue::try_from(taint_val)
+                                .map_err(M::Error::custom)?],
+                        );
+                    }
+                    // If we encounter a list of values, just insert it as is
+                    Value::Array(taint_values) => {
+                        let taint_values = taint_values
+                            .iter()
+                            .map(|v| v.to_owned().try_into().map_err(M::Error::custom))
+                            .collect::<Result<Vec<KubernetesTaintValue>, _>>()?;
+                        if taint_values.is_empty() {
+                            return Err(M::Error::custom("empty taint value"));
+                        }
+                        node_taints.insert(k, taint_values);
+                    }
+                    _ => {
+                        return Err(M::Error::custom("unsupported taint value type"));
+                    }
+                }
+            }
+            Ok(Some(node_taints))
+        }
+    }
+
+    deserializer.deserialize_map(NodeTaints)
+}
+
+#[cfg(test)]
+mod node_taint_tests {
+    use crate::{KubernetesSettings, KubernetesTaintValue};
+    use std::convert::TryFrom;
+    static TEST_NODE_TAINT_LIST: &str = include_str!("../tests/data/node-taint-list-val");
+    static TEST_NODE_TAINT_SINGLE: &str = include_str!("../tests/data/node-taint-single-val");
+    static TEST_NODE_TAINT_EMPTY_LIST: &str = include_str!("../tests/data/node-taint-empty-list");
+
+    #[test]
+    fn node_taints_list_representation() {
+        let k8s_settings = toml::from_str::<KubernetesSettings>(TEST_NODE_TAINT_LIST).unwrap();
+        assert_eq!(
+            k8s_settings
+                .node_taints
+                .as_ref()
+                .unwrap()
+                .get("key1")
+                .unwrap()
+                .to_owned(),
+            vec![
+                KubernetesTaintValue::try_from("value1:NoSchedule").unwrap(),
+                KubernetesTaintValue::try_from("value1:NoExecute").unwrap()
+            ]
+        );
+        assert_eq!(
+            k8s_settings
+                .node_taints
+                .as_ref()
+                .unwrap()
+                .get("key2")
+                .unwrap()
+                .to_owned(),
+            vec![KubernetesTaintValue::try_from("value2:NoSchedule").unwrap()]
+        );
+    }
+
+    #[test]
+    fn node_taint_single_representation() {
+        let k8s_settings = toml::from_str::<KubernetesSettings>(TEST_NODE_TAINT_SINGLE).unwrap();
+        assert_eq!(
+            k8s_settings
+                .node_taints
+                .as_ref()
+                .unwrap()
+                .get("key1")
+                .unwrap()
+                .to_owned(),
+            vec![KubernetesTaintValue::try_from("value1:NoSchedule").unwrap()]
+        );
+        assert_eq!(
+            k8s_settings
+                .node_taints
+                .as_ref()
+                .unwrap()
+                .get("key2")
+                .unwrap()
+                .to_owned(),
+            vec![KubernetesTaintValue::try_from("value2:NoExecute").unwrap()]
+        );
+    }
+
+    #[test]
+    fn node_taint_none_representation() {
+        let k8s_settings = toml::from_str::<KubernetesSettings>("").unwrap();
+        assert!(k8s_settings.node_taints.is_none());
+    }
+
+    #[test]
+    fn node_taint_empty_list() {
+        assert!(toml::from_str::<KubernetesSettings>(TEST_NODE_TAINT_EMPTY_LIST).is_err());
+    }
+}
 
 // Our standard representation of registry mirrors is a `Vec` of `RegistryMirror`; for backward compatibility, we also allow a `HashMap` of registry to endpoints.
 pub(crate) fn deserialize_mirrors<'de, D>(

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -113,7 +113,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::IpAddr;
 
-use crate::de::deserialize_mirrors;
+use crate::de::{deserialize_mirrors, deserialize_node_taints};
 use crate::modeled_types::{
     BootstrapContainerMode, CpuManagerPolicy, DNSDomain, ECSAgentLogLevel, ECSAttributeKey,
     ECSAttributeValue, FriendlyVersion, Identifier, KubernetesAuthenticationMode,
@@ -142,7 +142,12 @@ struct KubernetesSettings {
     cluster_certificate: ValidBase64,
     api_server: Url,
     node_labels: HashMap<KubernetesLabelKey, KubernetesLabelValue>,
-    node_taints: HashMap<KubernetesLabelKey, KubernetesTaintValue>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_node_taints"
+    )]
+    node_taints: HashMap<KubernetesLabelKey, Vec<KubernetesTaintValue>>,
     static_pods: HashMap<Identifier, StaticPod>,
     authentication_mode: KubernetesAuthenticationMode,
     bootstrap_token: KubernetesBootstrapToken,

--- a/sources/models/tests/data/node-taint-empty-list
+++ b/sources/models/tests/data/node-taint-empty-list
@@ -1,0 +1,2 @@
+[node-taints]
+"key1" = []

--- a/sources/models/tests/data/node-taint-list-val
+++ b/sources/models/tests/data/node-taint-list-val
@@ -1,0 +1,3 @@
+[node-taints]
+"key1" = ["value1:NoSchedule","value1:NoExecute"]
+"key2" = "value2:NoSchedule"

--- a/sources/models/tests/data/node-taint-single-val
+++ b/sources/models/tests/data/node-taint-single-val
@@ -1,0 +1,3 @@
+[node-taints]
+"key1" = "value1:NoSchedule"
+"key2" = "value2:NoExecute"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1897


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Jan 13 22:46:26 2022 -0800

    model, schnauzer: change `kubernetes.node-taints` type
    
    Changes the model for `kubernetes.node-taints` from a map of keys to
    single values/effect to a map of keys to list of values/effects.
    Adds a custom deserializer to deserialize from both ways of representing
    node-taints in Bottlerocket user-data.
```

```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Jan 14 11:02:35 2022 -0800

    migrations: 'kubernetes.node-taints' model representation migration
```


**Testing done:**
Launched new instance with the following in userdata, note how the two key value pairs accept different value types, either a single taint value or a list of taint value/effects:
```
[settings.kubernetes.node-taints]
"key1" = ["value1:NoSchedule", "value1:NoExecute"]
"key2" = "value2:NoExecute"
```
And the node comes up successfully in the cluster with the correct node taints:
```
$ kubectl describe node ip-192-168-7-94.us-west-2.compute.internal
Name:               ip-192-168-7-94.us-west-2.compute.internal
....
CreationTimestamp:  Fri, 14 Jan 2022 14:59:45 -0800
Taints:             key1=value1:NoExecute
                    key2=value2:NoExecute
                    key1=value1:NoSchedule
```
Checking kubelet service:
```
bash-5.0# systemctl status kubelet
● kubelet.service - Kubelet
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/kubelet.service.d
             └─exec-start.conf
     Active: active (running) since Fri 2022-01-14 22:59:44 UTC; 10min ago
       Docs: https://github.com/kubernetes/kubernetes
    Process: 510 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT (code=exited, status=0/SUCCESS)
    Process: 522 ExecStartPre=/usr/bin/host-ctr --containerd-socket=/run/dockershim.sock --namespace=k8s.io pull-image --source=${POD_INFRA_CONTAINER_IMAGE} --registry-config=/etc/host-containers/host-ctr.toml (code=exited, status=0/SUCCESS)
   Main PID: 536 (kubelet)
      Tasks: 15 (limit: 9217)
     Memory: 209.6M
        CPU: 5.460s
     CGroup: /runtime.slice/kubelet.service
             └─536 /usr/bin/kubelet --cloud-provider aws --kubeconfig /etc/kubernetes/kubelet/kubeconfig --config /etc/kubernetes/kubelet/config --container-runtime=remote --container-runtime-endpoint=unix:///run/dockershim.sock --containerd=/run/dockershim.sock --network-plugin cni --root-dir /var/lib/kubelet --cert-dir /var/lib/kubelet/pki --node-ip 192.168.7.94 --node-labels  --register-with-taints key1=value1:NoSchedule,key1=value1:NoExecute,key2=value2:NoExecute --pod-infra-container-image 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-arm64:3.1
```


Testing migrations:
Launched new v1.5.2 instance with the following userdata:
```
[settings.kubernetes.node-taints]
"key1" = "value1:NoSchedule"
"key2" = "value2:NoExecute"
```

The node registers successfully with specified taints.
```
$ kubectl describe node ip-192-168-28-121.us-west-2.compute.internal
Name:               ip-192-168-28-121.us-west-2.compute.internal
....
CreationTimestamp:  Fri, 14 Jan 2022 15:40:32 -0800
Taints:             key2=value2:NoExecute
                    key1=value1:NoSchedule
```
Checking the datastore representation of the node-taint setting
```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/node-taints/key1 
"value1:NoSchedule"
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/node-taints/key2 
"value2:NoExecute"
```

After upgrading to v1.6.0, the node comes up fine, the taints are still there:
```
bash-5.0# systemctl status kubelet
● kubelet.service - Kubelet
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/kubelet.service.d
             └─exec-start.conf
     Active: active (running) since Fri 2022-01-14 23:44:06 UTC; 1min 27s ago
....
     CGroup: /runtime.slice/kubelet.service
             └─505 /usr/bin/kubelet --cloud-provider aws --kubeconfig /etc/kubernetes/kubelet/kubeconfig --config /etc/kubernetes/kubelet/config --container-runtime=remote --container-runtime-endpoint=unix:///run/dockershim.sock --containerd=/run/dockershim.sock --network-plugin cni --root-dir /var/lib/kubelet --cert-dir /var/lib/kubelet/pki --node-ip 192.168.28.121 --node-labels  --register-with-taints key1=value1:NoSchedule,key2=value2:NoExecute --pod-infra-container-image 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-arm64:3.1
```
The datastore representation of node-taints got updated to maps of key to list of taint values by the migration as expected
```
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/node-taints/key1 
["value1:NoSchedule"]
bash-5.0# cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/node-taints/key2 
["value2:NoExecute"]
```
After downgrading back to v1.5.2, the node still comes up fine with the right taints:
```
bash-5.0# systemctl status kubelet
● kubelet.service - Kubelet
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/kubelet.service.d
             └─exec-start.conf
     Active: active (running) since Fri 2022-01-14 23:47:35 UTC; 33s ago
....
             └─498 /usr/bin/kubelet --cloud-provider aws --kubeconfig /etc/kubernetes/kubelet/kubeconfig --config /etc/kubernetes/kubelet/config --container-runtime=remote --container-runtime-endpoint=unix:///run/dockershim.sock --containerd=/run/dockershim.sock --network-plugin cni --root-dir /var/lib/kubelet --cert-dir /var/lib/kubelet/pki --node-ip 192.168.28.121 --node-labels  --register-with-taints key1=value1:NoSchedule,key2=value2:NoExecute --pod-infra-container-image 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause-arm64:3.1
```
Checking the datastore, node-taint gets rollbacked to the previous representation (map of keys to single taint values):
```
bash-5.0#  cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/node-taints/key1  
"value1:NoSchedule"
bash-5.0#  cat /var/lib/bottlerocket/datastore/current/live/settings/kubernetes/node-taints/key2 
"value2:NoExecute"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
