### PR TITLE
README: update caveat about host-containers source updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ The default `admin` host-container, for example, stores its SSH host keys under 
 There are a few important caveats to understand about host containers:
 * They're not orchestrated.  They only start or stop according to that `enabled` flag.
 * They run in a separate instance of containerd than the one used for orchestrated containers like Kubernetes pods.
-* They're not updated automatically.  You need to update the `source`, disable the container, commit those changes, then re-enable it.
+* They're not updated automatically.  You need to update the `source` and commit those changes.
 * If you set `superpowered` to true, they'll essentially have root access to the host.
 
 Because of these caveats, host containers are only intended for special use cases.


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Jan 14 16:24:39 2022 -0800

    README: update caveat about host-containers source updates
    
    Ever since 3bd666b94d84d5c11290659834eca06c1f55f4d3, host containers
    restart whenever their settings change. Users no longer have to disable
    and re-enable host-containers to apply changes to its `source`

```


**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
