### PR TITLE
models: add missing serde attributes to `registrysettings.mirrors` field

### DIFF
--- a/sources/models/src/de.rs
+++ b/sources/models/src/de.rs
@@ -63,6 +63,12 @@ mod mirrors_tests {
     }
 
     #[test]
+    fn registry_mirrors_none_representation() {
+        let registry_settings = toml::from_str::<RegistrySettings>("").unwrap();
+        assert!(registry_settings.mirrors.is_none());
+    }
+
+    #[test]
     fn representation_equal() {
         assert_eq!(
             toml::from_str::<RegistrySettings>(TEST_MIRRORS_TABLE).unwrap(),

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -195,7 +195,11 @@ struct RegistryMirror {
 // Image registry settings for the container runtimes.
 #[model]
 struct RegistrySettings {
-    #[serde(deserialize_with = "deserialize_mirrors")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_mirrors"
+    )]
     mirrors: Vec<RegistryMirror>,
 }
 


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1909


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Jan 14 17:01:00 2022 -0800

    models: add missing serde attributes to `registrysettings.mirrors` field
    
    Because we're using a custom deserializer for `mirrors`, we need to also
    add the serde attribute for populating the field with a default value if
    mirrors does not exist in the registry settings table
```


**Testing done:**
Launching an instance with an empty `container-registry` table:
```
[settings.container-registry]
```
And the instance comes up fine. The datastore also doesn't have any thing created for the empty table as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
