### PR TITLE
kernel5.10: include missing file for kernel-devel archive

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -171,7 +171,7 @@ sed -i \
   find tools/{arch/%{_cross_karch},include,objtool,scripts}/ -type f ! -name \*.o -print
   echo tools/build/fixdep.c
   find tools/lib/subcmd -type f -print
-  find tools/lib/{ctype,rbtree,string,str_error_r}.c
+  find tools/lib/{ctype,hweight,rbtree,string,str_error_r}.c
 
   echo kernel/bounds.c
   echo kernel/time/timeconst.bc


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
kernel5.10: include missing file for kernel-devel archive

The kernel-devel archive in the 5.10 kernel is missing the sources for
the 'hweight' tool for 'arm64', which causes compilation failures in
out-of-tree kernel modules.
```

**Testing done:**
Before the patch, I was getting this error:

```
#19 16.45 make[5]: *** No rule to make target '../lib/hweight.c', needed by '/home/builder/rpmbuild/BUILD/kernel-devel/tools/objtool/arch/arm64/libhweight.o'.  Stop.
```

With the patch, the compilation succeeds

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
