### PR TITLE
libnvidia-container: fix arm64 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /*.pem
 /keys
 /roles
+/Licenses.toml
+/licenses

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -92,6 +92,35 @@ cargo make -e BUILDSYS_ARCH=my-arch-here
 
 (You can use variant and arch arguments together, too.)
 
+#### Package licenses
+
+Most packages will include license files extracted from upstream source archives.
+However, in some rare cases there are multiple licenses that could apply to a package.
+Bottlerocket's build system uses the `Licenses.toml` file in conjuction with the `licenses` directory to configure the licenses used for such special packages.
+Here is an example of a simple `Licenses.toml` configuration file:
+
+```toml
+[package]
+spdx-id = "SPDX-ID"
+licenses = [
+  { path = "the-license.txt" }
+]
+```
+
+In the previous example, it is expected that the file `the-license.txt` is present in `licenses`.
+You can retrieve the licenses from a remote endpoint, or the local filesystem if you specify the `license-url` field:
+
+```toml
+[package]
+spdx-id = "SPDX-ID AND SPDX-ID-2" # Package with multiple licenses
+licenses = [
+  # This file is copied from a file system, and will be saved as `path`
+  { license-url = "file:///path/to/spdx-id-license.txt", path = "spdx-id-license.txt" },
+  # This file is fetched from an https endpoint, and will be saved as `path`
+  { license-url = "https://localhost/spdx-id-license-v2.txt", path = "spdx-id-license-2.txt" }
+]
+```
+
 ### Register an AMI
 
 To use the image in Amazon EC2, we need to register the image as an AMI.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -57,6 +57,10 @@ PUBLISH_UNIFIED_VOLUME_SIZE = "22"
 # tools/pubsys/policies/ssm/README.md for more information.
 PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm/defaults.toml"
 
+# This can be overriden with -e to change the source path
+# for the Licenses.toml file
+BUILDSYS_LICENSES_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Licenses.toml"
+
 # Specifies whether to validate all targets when validating TUF repositories
 REPO_VALIDATE_TARGETS = "true"
 # Specifies the timeframe to look for upcoming repository metadata expirations
@@ -88,6 +92,10 @@ BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"
 # BUILDSYS_ALLOW_FAILED_LICENSE_CHECK=true` to allow the build to continue even
 # if the license check fails.
 BUILDSYS_ALLOW_FAILED_LICENSE_CHECK = "false"
+
+# Disallow pulling licenses from Upstream URLs. To fetch licenses from the upstream source,
+# override this on the command line and set it to 'true'
+BUILDSYS_UPSTREAM_LICENSE_FETCH= "false"
 
 # This controls how many `docker build` commands we'll invoke at once.
 BUILDSYS_JOBS = "8"
@@ -391,7 +399,7 @@ fi
 
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["check-cargo-version", "build-tools", "publish-setup"]
+dependencies = ["check-cargo-version", "build-tools", "publish-setup", "fetch-licenses"]
 script_runner = "bash"
 script = [
 '''
@@ -605,6 +613,44 @@ docker run --rm \
 '''
 ]
 
+[tasks.fetch-licenses]
+dependencies = ["fetch"]
+script = [
+'''
+if [ "${BUILDSYS_UPSTREAM_LICENSE_FETCH}" = "false" ]; then
+  echo "Skipping fetching licenses"
+  exit 0
+fi
+
+# Attempt copy Licenses.toml
+cp "${BUILDSYS_LICENSES_CONFIG_PATH}" "${BUILDSYS_ROOT_DIR}/Licenses.toml" 2>/dev/null \
+  || echo "Skipping copying file from ${BUILDSYS_LICENSES_CONFIG_PATH}"
+
+if [ ! -s "${BUILDSYS_ROOT_DIR}"/Licenses.toml ] ; then
+  echo "Not fetching licenses since 'Licenses.toml' doesn't exist"
+  exit 0
+fi
+
+mkdir -p "${BUILDSYS_ROOT_DIR}"/licenses
+
+run_fetch_licenses="
+bottlerocket-license-tool -l /tmp/Licenses.toml fetch /tmp/licenses
+"
+set +e
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
+  -e CARGO_HOME="/tmp/.cargo" \
+  -v "${CARGO_HOME}":/tmp/.cargo \
+  -v "${BUILDSYS_ROOT_DIR}/licenses:/tmp/licenses" \
+  -v "${BUILDSYS_ROOT_DIR}/Licenses.toml:/tmp/Licenses.toml" \
+  "${BUILDSYS_SDK_IMAGE}" \
+  bash -c "${run_fetch_licenses}"
+'''
+]
+
+
 [tasks.link-clean]
 dependencies = ["fetch"]
 script = [
@@ -642,6 +688,7 @@ fi
 dependencies = [
     "link-clean",
     "check-licenses",
+    "fetch-licenses",
     "build-variant",
     "build-ova",
     "link-variant",

--- a/packages/libnvidia-container/0001-use-shared-libtirpc.patch
+++ b/packages/libnvidia-container/0001-use-shared-libtirpc.patch
@@ -1,0 +1,50 @@
+From e84335c28beaf0d9eab6861f6ae3bc72556f4439 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Mon, 20 Sep 2021 23:41:28 +0000
+Subject: [PATCH 1/4] use shared libtirpc
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index c281b8f..60a27f1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -141,9 +141,8 @@ else
+ LIB_LDLIBS_STATIC  += -l:libelf.a
+ endif
+ ifeq ($(WITH_TIRPC), yes)
+-LIB_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
+-LIB_LDLIBS_STATIC  += -l:libtirpc.a
+-LIB_LDLIBS_SHARED  += -lpthread
++LIB_CPPFLAGS       += -DWITH_TIRPC
++LIB_LDLIBS_SHARED  += -ltirpc
+ endif
+ ifeq ($(WITH_SECCOMP), yes)
+ LIB_CPPFLAGS       += -DWITH_SECCOMP $(shell pkg-config --cflags libseccomp)
+@@ -235,9 +234,6 @@ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
+ ifeq ($(WITH_LIBELF), no)
+ 	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk install
+ endif
+-ifeq ($(WITH_TIRPC), yes)
+-	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk install
+-endif
+ 
+ install: all
+ 	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(includedir) $(bindir) $(libdir) $(docdir) $(libdbgdir) $(pkgconfdir))
+@@ -283,9 +279,6 @@ depsclean:
+ ifeq ($(WITH_LIBELF), no)
+ 	-$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk clean
+ endif
+-ifeq ($(WITH_TIRPC), yes)
+-	-$(MAKE) -f $(MAKE_DIR)/libtirpc.mk clean
+-endif
+ 
+ mostlyclean:
+ 	$(RM) $(LIB_OBJS) $(LIB_STATIC_OBJ) $(BIN_OBJS) $(DEPENDENCIES)
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/0001-use-shared-libtirpc.patch
+++ b/packages/libnvidia-container/0001-use-shared-libtirpc.patch
@@ -1,7 +1,7 @@
-From e84335c28beaf0d9eab6861f6ae3bc72556f4439 Mon Sep 17 00:00:00 2001
+From 57c5b0010797280351d547e0f7c4cd6475868a0d Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Mon, 20 Sep 2021 23:41:28 +0000
-Subject: [PATCH 1/4] use shared libtirpc
+Subject: [PATCH 1/5] use shared libtirpc
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
@@ -10,10 +10,10 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 2 insertions(+), 9 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index c281b8f..60a27f1 100644
+index 92d6f6e..bb0a610 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -141,9 +141,8 @@ else
+@@ -148,9 +148,8 @@ else
  LIB_LDLIBS_STATIC  += -l:libelf.a
  endif
  ifeq ($(WITH_TIRPC), yes)
@@ -25,7 +25,7 @@ index c281b8f..60a27f1 100644
  endif
  ifeq ($(WITH_SECCOMP), yes)
  LIB_CPPFLAGS       += -DWITH_SECCOMP $(shell pkg-config --cflags libseccomp)
-@@ -235,9 +234,6 @@ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
+@@ -242,9 +241,6 @@ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
  ifeq ($(WITH_LIBELF), no)
  	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk install
  endif
@@ -35,7 +35,7 @@ index c281b8f..60a27f1 100644
  
  install: all
  	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(includedir) $(bindir) $(libdir) $(docdir) $(libdbgdir) $(pkgconfdir))
-@@ -283,9 +279,6 @@ depsclean:
+@@ -290,9 +286,6 @@ depsclean:
  ifeq ($(WITH_LIBELF), no)
  	-$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk clean
  endif
@@ -46,5 +46,5 @@ index c281b8f..60a27f1 100644
  mostlyclean:
  	$(RM) $(LIB_OBJS) $(LIB_STATIC_OBJ) $(BIN_OBJS) $(DEPENDENCIES)
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0002-use-prefix-from-environment.patch
+++ b/packages/libnvidia-container/0002-use-prefix-from-environment.patch
@@ -1,7 +1,7 @@
-From e5a5f7877832ab255721d2e5971a85e0940043d2 Mon Sep 17 00:00:00 2001
+From cddc27a808db79b0cd6cbce3eaacd62327978733 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 21 Sep 2021 00:03:42 +0000
-Subject: [PATCH 2/4] use prefix from environment
+Subject: [PATCH 2/5] use prefix from environment
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
@@ -10,7 +10,7 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 60a27f1..9d19d11 100644
+index bb0a610..9552ddd 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -23,7 +23,7 @@ WITH_SECCOMP ?= yes
@@ -23,5 +23,5 @@ index 60a27f1..9d19d11 100644
  export bindir      = $(exec_prefix)/bin
  export libdir      = $(exec_prefix)/lib
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0002-use-prefix-from-environment.patch
+++ b/packages/libnvidia-container/0002-use-prefix-from-environment.patch
@@ -1,0 +1,27 @@
+From e5a5f7877832ab255721d2e5971a85e0940043d2 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 21 Sep 2021 00:03:42 +0000
+Subject: [PATCH 2/4] use prefix from environment
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 60a27f1..9d19d11 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,7 +23,7 @@ WITH_SECCOMP ?= yes
+ 
+ ##### Global definitions #####
+ 
+-export prefix      = /usr/local
++export prefix      ?= /usr/local
+ export exec_prefix = $(prefix)
+ export bindir      = $(exec_prefix)/bin
+ export libdir      = $(exec_prefix)/lib
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/0003-keep-debug-symbols.patch
+++ b/packages/libnvidia-container/0003-keep-debug-symbols.patch
@@ -1,0 +1,50 @@
+From db8ae6f5a08db43884b154be07a4b4506a65507d Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 21 Sep 2021 00:22:37 +0000
+Subject: [PATCH 3/4] keep debug symbols
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 9d19d11..ad84d7f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -193,22 +193,14 @@ $(BIN_OBJS): %.o: %.c | shared
+ -include $(DEPENDENCIES)
+ 
+ $(LIB_SHARED): $(LIB_OBJS)
+-	$(MKDIR) -p $(DEBUG_DIR)
+ 	$(CC) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(LIB_LDFLAGS) $(OUTPUT_OPTION) $^ $(LIB_SCRIPT) $(LIB_LDLIBS)
+-	$(OBJCPY) --only-keep-debug $@ $(LIB_SONAME)
+-	$(OBJCPY) --add-gnu-debuglink=$(LIB_SONAME) $@
+-	$(MV) $(LIB_SONAME) $(DEBUG_DIR)
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ $(LIB_STATIC_OBJ): $(LIB_OBJS)
+ 	# FIXME Handle user-defined LDFLAGS and LDLIBS
+ 	$(LD) -d -r --exclude-libs ALL -L$(DEPS_DIR)$(libdir) $(OUTPUT_OPTION) $^ $(LIB_LDLIBS_STATIC)
+-	$(OBJCPY) --localize-hidden $@
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ $(BIN_NAME): $(BIN_OBJS)
+ 	$(CC) $(BIN_CFLAGS) $(BIN_CPPFLAGS) $(BIN_LDFLAGS) $(OUTPUT_OPTION) $^ $(BIN_SCRIPT) $(BIN_LDLIBS)
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ ##### Public rules #####
+ 
+@@ -244,8 +236,6 @@ install: all
+ 	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
+ 	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
+ 	$(LDCONFIG) -n $(DESTDIR)$(libdir)
+-	# Install debugging symbols
+-	$(INSTALL) -m 644 $(DEBUG_DIR)/$(LIB_SONAME) $(DESTDIR)$(libdbgdir)
+ 	# Install configuration files
+ 	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
+ 	# Install binary files
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/0003-keep-debug-symbols.patch
+++ b/packages/libnvidia-container/0003-keep-debug-symbols.patch
@@ -1,7 +1,7 @@
-From db8ae6f5a08db43884b154be07a4b4506a65507d Mon Sep 17 00:00:00 2001
+From b994aa569b2b84ed892e86b9610fb051286e0ab9 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 21 Sep 2021 00:22:37 +0000
-Subject: [PATCH 3/4] keep debug symbols
+Subject: [PATCH 3/5] keep debug symbols
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
@@ -10,10 +10,10 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 10 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 9d19d11..ad84d7f 100644
+index 9552ddd..34fb136 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -193,22 +193,14 @@ $(BIN_OBJS): %.o: %.c | shared
+@@ -200,22 +200,14 @@ $(BIN_OBJS): %.o: %.c | shared
  -include $(DEPENDENCIES)
  
  $(LIB_SHARED): $(LIB_OBJS)
@@ -36,7 +36,7 @@ index 9d19d11..ad84d7f 100644
  
  ##### Public rules #####
  
-@@ -244,8 +236,6 @@ install: all
+@@ -251,8 +243,6 @@ install: all
  	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
  	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
  	$(LDCONFIG) -n $(DESTDIR)$(libdir)
@@ -46,5 +46,5 @@ index 9d19d11..ad84d7f 100644
  	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
  	# Install binary files
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+++ b/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
@@ -1,7 +1,7 @@
-From 6103d57aebf610ff552e9fb5a36c3bae66f23c0d Mon Sep 17 00:00:00 2001
+From 334cf602d9ea6247d7b0baec1785d9ab4c0fe5d9 Mon Sep 17 00:00:00 2001
 From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 Date: Mon, 1 Nov 2021 16:18:19 +0000
-Subject: [PATCH 4/4] Use NVIDIA_PATH to look up binaries
+Subject: [PATCH 4/5] Use NVIDIA_PATH to look up binaries
 
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/nvc_info.c b/src/nvc_info.c
-index 3b3d2d5..99ff881 100644
+index 252dd5c..0697fba 100644
 --- a/src/nvc_info.c
 +++ b/src/nvc_info.c
 @@ -249,8 +249,8 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
@@ -24,5 +24,5 @@ index 3b3d2d5..99ff881 100644
          }
          if ((env = ptr = xstrdup(err, env)) == NULL)
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+++ b/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
@@ -1,0 +1,28 @@
+From 6103d57aebf610ff552e9fb5a36c3bae66f23c0d Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Mon, 1 Nov 2021 16:18:19 +0000
+Subject: [PATCH 4/4] Use NVIDIA_PATH to look up binaries
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ src/nvc_info.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/nvc_info.c b/src/nvc_info.c
+index 3b3d2d5..99ff881 100644
+--- a/src/nvc_info.c
++++ b/src/nvc_info.c
+@@ -249,8 +249,8 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
+         char path[PATH_MAX];
+         int rv = -1;
+ 
+-        if ((env = secure_getenv("PATH")) == NULL) {
+-                error_setx(err, "environment variable PATH not found");
++        if ((env = secure_getenv("NVIDIA_PATH")) == NULL && (env = secure_getenv("PATH")) == NULL) {
++                error_setx(err, "environment variables NVIDIA_PATH/PATH not found");
+                 return (-1);
+         }
+         if ((env = ptr = xstrdup(err, env)) == NULL)
+-- 
+2.31.1
+

--- a/packages/libnvidia-container/0005-makefile-fix-symlinks-to-shared-library.patch
+++ b/packages/libnvidia-container/0005-makefile-fix-symlinks-to-shared-library.patch
@@ -1,0 +1,26 @@
+From 27170027de5fdfbfd752fa30d6f9b98cc4f9e4cd Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Tue, 18 Jan 2022 23:57:24 +0000
+Subject: [PATCH 5/5] makefile: fix symlinks to shared library
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 34fb136..1c3d9d2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -242,7 +242,7 @@ install: all
+ 	$(INSTALL) -m 644 $(LIB_STATIC) $(DESTDIR)$(libdir)
+ 	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
+ 	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
+-	$(LDCONFIG) -n $(DESTDIR)$(libdir)
++	$(LN) -sf $(LIB_SHARED) $(DESTDIR)$(libdir)/$(LIB_SONAME)
+ 	# Install configuration files
+ 	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
+ 	# Install binary files
+-- 
+2.33.1
+

--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "libnvidia-container"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.7.0.tar.gz"
+sha512 = "cb2bedc7f3278c56f9da003257ea1c16116ac52cc4a792e4bdfc7e1739a5504436b61db65abb159f4bd4702d961ebd4c455605ce5e9daac00a2ab282a1b1348f"
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/nvidia-modprobe/archive/495.44/nvidia-modprobe-495.44.tar.gz"
+sha512 = "67486ed1b17c8962786e13880910bb2b1938206a0fd76b360ddef7faf80ee0c941a2e3fbc73fa92a92009e2c54130dce17a466c8079537a981a2fed09c07e4c9"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libelf = { path = "../libelf" }
+libcap = { path = "../libcap" }
+libseccomp = { path = "../libseccomp" }
+libtirpc = { path = "../libtirpc" }

--- a/packages/libnvidia-container/build.rs
+++ b/packages/libnvidia-container/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -16,6 +16,7 @@ Patch0001: 0001-use-shared-libtirpc.patch
 Patch0002: 0002-use-prefix-from-environment.patch
 Patch0003: 0003-keep-debug-symbols.patch
 Patch0004: 0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+Patch0005: 0005-makefile-fix-symlinks-to-shared-library.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libelf-devel
@@ -68,6 +69,7 @@ export DESTDIR=%{buildroot} \\\
 %files
 %license NOTICE LICENSE
 %{_cross_attribution_file}
+%{_cross_libdir}/libnvidia-container.so
 %{_cross_libdir}/libnvidia-container.so.1
 %{_cross_libdir}/libnvidia-container.so.%{version}
 %{_cross_bindir}/nvidia-container-cli

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,0 +1,80 @@
+%global nvidia_modprobe_version 495.44
+
+Name: %{_cross_os}libnvidia-container
+Version: 1.7.0
+Release: 1%{?dist}
+Summary: NVIDIA container runtime library
+# The COPYING and COPYING.LESSER files in the sources don't apply to libnvidia-container
+# they are there because they apply to libelf in elfutils
+License: Apache-2.0
+URL: https://github.com/NVIDIA/libnvidia-container
+Source0: https://github.com/NVIDIA/libnvidia-container/archive/v%{version}.tar.gz
+Source1: https://github.com/NVIDIA/nvidia-modprobe/archive/%{nvidia_modprobe_version}/nvidia-modprobe-%{nvidia_modprobe_version}.tar.gz
+
+# First party patches from 1 to 1000
+Patch0001: 0001-use-shared-libtirpc.patch
+Patch0002: 0002-use-prefix-from-environment.patch
+Patch0003: 0003-keep-debug-symbols.patch
+Patch0004: 0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libelf-devel
+BuildRequires: %{_cross_os}libcap-devel
+BuildRequires: %{_cross_os}libseccomp-devel
+BuildRequires: %{_cross_os}libtirpc-devel
+Requires: %{_cross_os}libelf
+Requires: %{_cross_os}libcap
+Requires: %{_cross_os}libseccomp
+Requires: %{_cross_os}libtirpc
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the NVIDIA container runtime library
+Requires: %{_cross_os}libnvidia-container
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -Sgit -n libnvidia-container-%{version} -p1
+mkdir -p deps/src/nvidia-modprobe-%{nvidia_modprobe_version}
+tar -C deps/src/nvidia-modprobe-%{nvidia_modprobe_version} --strip-components=1 \
+  -xzf %{SOURCE1} nvidia-modprobe-%{nvidia_modprobe_version}/{modprobe-utils,COPYING}
+patch -d deps/src/nvidia-modprobe-%{nvidia_modprobe_version} -p1 < mk/nvidia-modprobe.patch
+touch deps/src/nvidia-modprobe-%{nvidia_modprobe_version}/.download_stamp
+
+%global set_env \
+%set_cross_build_flags \\\
+export CC=%{_cross_target}-gcc \\\
+export LD=%{_cross_target}-ld \\\
+export CFLAGS="${CFLAGS} -I%{_cross_includedir}/tirpc" \\\
+export WITH_LIBELF=yes \\\
+export WITH_SECCOMP=yes \\\
+export WITH_TIRPC=yes \\\
+export prefix=%{_cross_prefix} \\\
+export DESTDIR=%{buildroot} \\\
+%{nil}
+
+%build
+%set_env
+%make_build
+
+%install
+%set_env
+%make_install
+
+%files
+%license NOTICE LICENSE
+%{_cross_attribution_file}
+%{_cross_libdir}/libnvidia-container.so.1
+%{_cross_libdir}/libnvidia-container.so.%{version}
+%{_cross_bindir}/nvidia-container-cli
+%exclude %{_cross_docdir}
+
+%files devel
+%{_cross_includedir}/*.h
+%{_cross_libdir}/*.so
+%{_cross_libdir}/*.a
+%{_cross_libdir}/pkgconfig/*.pc

--- a/packages/libnvidia-container/pkg.rs
+++ b/packages/libnvidia-container/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nvidia-container-toolkit"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.7.0/v1.7.0.tar.gz"
+sha512 = "7bc3601ca5cca5b3ad7f30f9c2453d41452b425811d37209c20b7f375d557666a1369d756b52a007406996758b09d47635f2e8628bf363298ec247cb3d3f8845"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libnvidia-container = { path = "../libnvidia-container" }
+# This package depends on `shimpei`, but it is built in the `os` package
+# which is expected to be pulled in
+# os = { path = "../os" }

--- a/packages/nvidia-container-toolkit/build.rs
+++ b/packages/nvidia-container-toolkit/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config.toml
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config.toml
@@ -1,0 +1,5 @@
+[nvidia-container-cli]
+root = "/"
+path = "/usr/bin/nvidia-container-cli"
+environment = []
+ldconfig = "@/sbin/ldconfig"

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles.conf
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/nvidia-container-runtime/config.toml - - - -

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -1,0 +1,54 @@
+%global goproject github.com/NVIDIA
+%global gorepo nvidia-container-toolkit
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 1.7.0
+%global rpmver %{gover}
+
+Name: %{_cross_os}nvidia-container-toolkit
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: Tool to build and run GPU accelerated containers
+License: Apache-2.0
+URL: https://%{goimport}
+
+Source0: https://%{goimport}/archive/v%{gover}/v%{gover}.tar.gz
+Source1: nvidia-container-toolkit-config.toml
+Source2: nvidia-container-toolkit-tmpfiles.conf
+Source3: nvidia-oci-hooks-json
+
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}libnvidia-container
+Requires: %{_cross_os}shimpei
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{gorepo}-%{gover} -p1
+%cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
+
+%build
+%cross_go_configure %{goimport}
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o nvidia-container-toolkit ./cmd/nvidia-container-toolkit
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -d %{buildroot}%{_cross_templatedir}
+install -d %{buildroot}%{_cross_datadir}/nvidia-container-toolkit
+install -d %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime
+install -p -m 0755 nvidia-container-toolkit %{buildroot}%{_cross_bindir}/nvidia-container-runtime-hook
+install -m 0644 %{S:1} %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime/config.toml
+install -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit.conf
+install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-oci-hooks-json
+ln -s shimpei %{buildroot}%{_cross_bindir}/nvidia-oci
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_bindir}/nvidia-container-runtime-hook
+%{_cross_bindir}/nvidia-oci
+%{_cross_templatedir}/nvidia-oci-hooks-json
+%{_cross_factorydir}/etc/nvidia-container-runtime/config.toml
+%{_cross_tmpfilesdir}/nvidia-container-toolkit.conf

--- a/packages/nvidia-container-toolkit/nvidia-oci-hooks-json
+++ b/packages/nvidia-container-toolkit/nvidia-oci-hooks-json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "prestart": [
+      {{#if settings.oci-hooks.log4j-hotpatch-enabled}}
+      { "path": "/usr/libexec/hotdog/hotdog-cc-hook" },
+      {{/if}}
+      {
+        "path": "/usr/bin/nvidia-container-runtime-hook",
+        "args": ["nvidia-container-runtime-hook", "prestart"]
+      }
+    ],
+    "poststart": [
+      {{#if settings.oci-hooks.log4j-hotpatch-enabled}}
+      { "path": "/usr/libexec/hotdog/hotdog-poststart-hook" }
+      {{/if}}
+    ]
+  }
+}

--- a/packages/nvidia-container-toolkit/pkg.rs
+++ b/packages/nvidia-container-toolkit/pkg.rs
@@ -1,0 +1,1 @@
+// not used


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
libnvidia-container: fix arm64 build

The arm64 build doesn't provide a symlink to
libnvidia-container.so.<version>, which causes runtime errors when the
NVIDIA prestart hooks run.
```

**Testing done:**
Launched a aws-k8s-1.21 g5g instance, with NVIDIA tools. The orchestrated containers were set up correctly, and I was able to call `nvidia-smi`:

```
❯ kubectl exec nvidia-device-plugin-1642187599-jb8tc -n kube-system -it -- sh -c "uname -a && nvidia-smi"
Linux nvidia-device-plugin-1642187599-jb8tc 5.10.75 #1 SMP Fri Jan 14 18:15:25 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

Tue Jan 18 17:37:52 2022
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: N/A      |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA T4G          Off  | 00000000:00:1F.0 Off |                    0 |
| N/A   39C    P8     9W /  70W |      0MiB / 15109MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
