### PR TITLE
SDK bump v0.25.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches: [develop]
     # Here we list file types that don't affect the build and don't need to use
     # up our Actions runners.
-    paths-ignore: 
+    paths-ignore:
       # draw.io (diagrams.net) files, the source of png images for docs
       - '**.drawio'
       # Example configuration files
@@ -46,8 +46,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - run: rustup toolchain install 1.56.1 && rustup default 1.56.1
-      - run: cargo install --version 0.30.0 cargo-make
+      - run: rustup toolchain install 1.58.0 && rustup default 1.58.0
+      - run: cargo install --version 0.35.8 cargo-make
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-fmt
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} -e BUILDSYS_ARCH=${{ matrix.arch }} -e BUILDSYS_JOBS=12

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK name used for building
 BUILDSYS_SDK_NAME="bottlerocket"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.24.0"
+BUILDSYS_SDK_VERSION="v0.25.0"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -25,6 +25,8 @@ BUILDSYS_NAME = "bottlerocket"
 # If you're building a Bottlerocket remix, you'd want to set this to something like
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
+# SDK name used for building
+BUILDSYS_SDK_NAME="bottlerocket"
 # SDK version used for building
 BUILDSYS_SDK_VERSION="v0.24.0"
 # Site for fetching the SDK
@@ -114,9 +116,10 @@ AMI_DATA_FILE_SUFFIX = "amis.json"
 # Certain variables are defined here to allow us to override a component value
 # on the command line.
 
-# Depends on ${BUILDSYS_REGISTRY}, ${BUILDSYS_ARCH} and ${BUILDSYS_SDK_VERSION}.
-BUILDSYS_SDK_IMAGE = { script = [ "echo ${BUILDSYS_REGISTRY}/bottlerocket-sdk-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
-BUILDSYS_TOOLCHAIN = { script = [ "echo ${BUILDSYS_REGISTRY}/bottlerocket-toolchain-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
+# Depends on ${BUILDSYS_ARCH}, ${BUILDSYS_REGISTRY}, ${BUILDSYS_SDK_NAME}, and
+# ${BUILDSYS_SDK_VERSION}.
+BUILDSYS_SDK_IMAGE = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME}-sdk-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
+BUILDSYS_TOOLCHAIN = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME}-toolchain-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -63,7 +63,6 @@ BuildRequires: automake
 BuildRequires: bison
 BuildRequires: flex
 BuildRequires: gettext-devel
-BuildRequires: grub2-tools
 BuildRequires: %{_cross_os}glibc-devel
 
 %description

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -220,6 +220,7 @@ struct Metadata {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
+#[allow(dead_code)]
 pub(crate) struct BuildPackage {
     pub(crate) external_files: Option<Vec<ExternalFile>>,
     pub(crate) package_name: Option<String>,


### PR DESCRIPTION
**Description of changes:**

Various fixes, tweaks, and bumps to build with SDK v0.25.0

**Build**

- Update SDK to 0.25.0
- Add `BUILDSYS_SDK_NAME`
_(to make it easier to point to custom names)_

**buildsys**

- Allow 'dead code' in BuildPackage
_(fixes clippy error in manifest.rs)_

**grub**

- Remove `grub2-tools` as a dependency
_(no longer needed after #1893,
nor part of SDK from v0.25.0)_

**Actions**

- Bump rust to 1.58.0
- Bump cargo-make to 0.35.8

**Testing done:**

- [x] Build **aws-k8s-1.21** `x86_64` on `x86_64`
- [x] Build **aws-k8s-1.21** `aarch64` on `x86_64`
- [x] Build **aws-ecs-1** `aarch64` on `aarch64`
- [x] Build **aws-ecs-1** `x86_64` on `aarch64`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
