### PR TITLE
libnvidia-container: fix arm64 build

### DIFF
--- a/packages/libnvidia-container/0001-use-shared-libtirpc.patch
+++ b/packages/libnvidia-container/0001-use-shared-libtirpc.patch
@@ -1,7 +1,7 @@
-From e84335c28beaf0d9eab6861f6ae3bc72556f4439 Mon Sep 17 00:00:00 2001
+From 57c5b0010797280351d547e0f7c4cd6475868a0d Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Mon, 20 Sep 2021 23:41:28 +0000
-Subject: [PATCH 1/4] use shared libtirpc
+Subject: [PATCH 1/5] use shared libtirpc
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
@@ -10,10 +10,10 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 2 insertions(+), 9 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index c281b8f..60a27f1 100644
+index 92d6f6e..bb0a610 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -141,9 +141,8 @@ else
+@@ -148,9 +148,8 @@ else
  LIB_LDLIBS_STATIC  += -l:libelf.a
  endif
  ifeq ($(WITH_TIRPC), yes)
@@ -25,7 +25,7 @@ index c281b8f..60a27f1 100644
  endif
  ifeq ($(WITH_SECCOMP), yes)
  LIB_CPPFLAGS       += -DWITH_SECCOMP $(shell pkg-config --cflags libseccomp)
-@@ -235,9 +234,6 @@ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
+@@ -242,9 +241,6 @@ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
  ifeq ($(WITH_LIBELF), no)
  	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk install
  endif
@@ -35,7 +35,7 @@ index c281b8f..60a27f1 100644
  
  install: all
  	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(includedir) $(bindir) $(libdir) $(docdir) $(libdbgdir) $(pkgconfdir))
-@@ -283,9 +279,6 @@ depsclean:
+@@ -290,9 +286,6 @@ depsclean:
  ifeq ($(WITH_LIBELF), no)
  	-$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk clean
  endif
@@ -46,5 +46,5 @@ index c281b8f..60a27f1 100644
  mostlyclean:
  	$(RM) $(LIB_OBJS) $(LIB_STATIC_OBJ) $(BIN_OBJS) $(DEPENDENCIES)
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0002-use-prefix-from-environment.patch
+++ b/packages/libnvidia-container/0002-use-prefix-from-environment.patch
@@ -1,7 +1,7 @@
-From e5a5f7877832ab255721d2e5971a85e0940043d2 Mon Sep 17 00:00:00 2001
+From cddc27a808db79b0cd6cbce3eaacd62327978733 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 21 Sep 2021 00:03:42 +0000
-Subject: [PATCH 2/4] use prefix from environment
+Subject: [PATCH 2/5] use prefix from environment
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
@@ -10,7 +10,7 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 60a27f1..9d19d11 100644
+index bb0a610..9552ddd 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -23,7 +23,7 @@ WITH_SECCOMP ?= yes
@@ -23,5 +23,5 @@ index 60a27f1..9d19d11 100644
  export bindir      = $(exec_prefix)/bin
  export libdir      = $(exec_prefix)/lib
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0003-keep-debug-symbols.patch
+++ b/packages/libnvidia-container/0003-keep-debug-symbols.patch
@@ -1,7 +1,7 @@
-From db8ae6f5a08db43884b154be07a4b4506a65507d Mon Sep 17 00:00:00 2001
+From b994aa569b2b84ed892e86b9610fb051286e0ab9 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 21 Sep 2021 00:22:37 +0000
-Subject: [PATCH 3/4] keep debug symbols
+Subject: [PATCH 3/5] keep debug symbols
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
@@ -10,10 +10,10 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 10 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 9d19d11..ad84d7f 100644
+index 9552ddd..34fb136 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -193,22 +193,14 @@ $(BIN_OBJS): %.o: %.c | shared
+@@ -200,22 +200,14 @@ $(BIN_OBJS): %.o: %.c | shared
  -include $(DEPENDENCIES)
  
  $(LIB_SHARED): $(LIB_OBJS)
@@ -36,7 +36,7 @@ index 9d19d11..ad84d7f 100644
  
  ##### Public rules #####
  
-@@ -244,8 +236,6 @@ install: all
+@@ -251,8 +243,6 @@ install: all
  	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
  	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
  	$(LDCONFIG) -n $(DESTDIR)$(libdir)
@@ -46,5 +46,5 @@ index 9d19d11..ad84d7f 100644
  	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
  	# Install binary files
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+++ b/packages/libnvidia-container/0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
@@ -1,7 +1,7 @@
-From 6103d57aebf610ff552e9fb5a36c3bae66f23c0d Mon Sep 17 00:00:00 2001
+From 334cf602d9ea6247d7b0baec1785d9ab4c0fe5d9 Mon Sep 17 00:00:00 2001
 From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 Date: Mon, 1 Nov 2021 16:18:19 +0000
-Subject: [PATCH 4/4] Use NVIDIA_PATH to look up binaries
+Subject: [PATCH 4/5] Use NVIDIA_PATH to look up binaries
 
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/nvc_info.c b/src/nvc_info.c
-index 3b3d2d5..99ff881 100644
+index 252dd5c..0697fba 100644
 --- a/src/nvc_info.c
 +++ b/src/nvc_info.c
 @@ -249,8 +249,8 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
@@ -24,5 +24,5 @@ index 3b3d2d5..99ff881 100644
          }
          if ((env = ptr = xstrdup(err, env)) == NULL)
 -- 
-2.31.1
+2.33.1
 

--- a/packages/libnvidia-container/0005-makefile-avoid-ldconfig-when-cross-compiling.patch
+++ b/packages/libnvidia-container/0005-makefile-avoid-ldconfig-when-cross-compiling.patch
@@ -1,0 +1,26 @@
+From b8d13cfc11a967385f18bfbdd74986a043665832 Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Tue, 18 Jan 2022 23:57:24 +0000
+Subject: [PATCH 5/5] makefile: avoid ldconfig when cross-compiling
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 34fb136..1c3d9d2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -242,7 +242,7 @@ install: all
+ 	$(INSTALL) -m 644 $(LIB_STATIC) $(DESTDIR)$(libdir)
+ 	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
+ 	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
+-	$(LDCONFIG) -n $(DESTDIR)$(libdir)
++	$(LN) -sf $(LIB_SHARED) $(DESTDIR)$(libdir)/$(LIB_SONAME)
+ 	# Install configuration files
+ 	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
+ 	# Install binary files
+-- 
+2.33.1
+

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -16,6 +16,7 @@ Patch0001: 0001-use-shared-libtirpc.patch
 Patch0002: 0002-use-prefix-from-environment.patch
 Patch0003: 0003-keep-debug-symbols.patch
 Patch0004: 0004-Use-NVIDIA_PATH-to-look-up-binaries.patch
+Patch0005: 0005-makefile-avoid-ldconfig-when-cross-compiling.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libelf-devel
@@ -68,8 +69,8 @@ export DESTDIR=%{buildroot} \\\
 %files
 %license NOTICE LICENSE
 %{_cross_attribution_file}
-%{_cross_libdir}/libnvidia-container.so.1
-%{_cross_libdir}/libnvidia-container.so.%{version}
+%{_cross_libdir}/libnvidia-container.so
+%{_cross_libdir}/libnvidia-container.so.*
 %{_cross_bindir}/nvidia-container-cli
 %exclude %{_cross_docdir}
 


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
libnvidia-container: fix arm64 build

The arm64 build doesn't provide a symlink to
libnvidia-container.so.<version>, which causes runtime errors when the
NVIDIA prestart hooks run.
```

**Testing done:**
Launched a aws-k8s-1.21 g5g instance, with NVIDIA tools. The orchestrated containers were set up correctly, and I was able to call `nvidia-smi`:

```
❯ kubectl exec nvidia-device-plugin-1642187599-jb8tc -n kube-system -it -- sh -c "uname -a && nvidia-smi"
Linux nvidia-device-plugin-1642187599-jb8tc 5.10.75 #1 SMP Fri Jan 14 18:15:25 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

Tue Jan 18 17:37:52 2022
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: N/A      |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA T4G          Off  | 00000000:00:1F.0 Off |                    0 |
| N/A   39C    P8     9W /  70W |      0MiB / 15109MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
