### PR TITLE
packages: add NVIDIA k8s device plugin

### DIFF
--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -18,6 +18,7 @@ sha512 = "7bc3601ca5cca5b3ad7f30f9c2453d41452b425811d37209c20b7f375d557666a1369d
 [build-dependencies]
 glibc = { path = "../glibc" }
 libnvidia-container = { path = "../libnvidia-container" }
+nvidia-k8s-device-plugin = { path = "../nvidia-k8s-device-plugin" }
 # This package depends on `shimpei`, but it is built in the `os` package
 # which is expected to be pulled in
 # os = { path = "../os" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -20,6 +20,7 @@ Source3: nvidia-oci-hooks-json
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container
 Requires: %{_cross_os}shimpei
+Requires: %{_cross_os}nvidia-k8s-device-plugin
 
 %description
 %{summary}.

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nvidia-k8s-device-plugin"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.10.0/v0.10.0.tar.gz"
+sha512 = "d83107ef511a1fa8b43596726e084feea1bbf9b0e22754444e76cbf0aefd5476421d00bc02173c606509f0dbf7b4e86f9453d59fca976b7f8f15c7667932bebe"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/build.rs
+++ b/packages/nvidia-k8s-device-plugin/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Start NVIDIA kubernetes device plugin
+RefuseManualStart=true
+RefuseManualStop=true
+After=kubelet.service
+BindsTo=kubelet.service
+
+[Service]
+ExecStart=/usr/bin/nvidia-device-plugin
+Type=simple
+TimeoutSec=0
+RestartSec=2
+Restart=always
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -1,0 +1,43 @@
+%global goproject github.com/NVIDIA
+%global gorepo k8s-device-plugin
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 0.10.0
+%global rpmver %{gover}
+
+Name: %{_cross_os}nvidia-k8s-device-plugin
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: Kubernetes device plugin for NVIDIA GPUs
+License: Apache-2.0
+URL: https://github.com/NVIDIA/k8s-device-plugin
+Source0: https://%{goimport}/archive/v%{gover}/v%{gover}.tar.gz
+Source1: nvidia-k8s-device-plugin.service
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{gorepo}-%{gover} -p1
+%cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
+
+%build
+%cross_go_configure %{goimport}
+# We don't set `-Wl,-z,now`, because the binary uses lazy loading
+# to load the NVIDIA libraries in the host
+export CGO_LDFLAGS="-Wl,-z,relro"
+go build -ldflags="${GOLDFLAGS}" -o nvidia-device-plugin ./cmd/nvidia-device-plugin/
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0755 nvidia-device-plugin %{buildroot}%{_cross_bindir}
+install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_unitdir}/nvidia-k8s-device-plugin.service
+%{_cross_bindir}/nvidia-device-plugin

--- a/packages/nvidia-k8s-device-plugin/pkg.rs
+++ b/packages/nvidia-k8s-device-plugin/pkg.rs
@@ -1,0 +1,1 @@
+// not used


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
```
packages: add NVIDIA k8s device plugin

The NVIDIA k8s device plugin exposes to the kubelet the NVIDIA GPUs in
the host. By providing the k8s device plugin in the base image, the
startup time for a GPU workload decreases, since the kubelet doesn't
have to fetch yet another system container.
```

**Testing done:**
I launched a nodegroup without the NVIDIA k8s device plugin daemonset:

```
eksctl create nodegroup --install-nvidia-plugin=false --config-file=../k8s-1.21.yamlh
```

I was able to launch a pod in the new host and run `nvidia-smi` within the host


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
