### PR TITLE
SDK bump v0.25.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - run: rustup toolchain install 1.58.0 && rustup default 1.58.0
+      - run: rustup toolchain install 1.58.1 && rustup default 1.58.1
       - run: cargo install --version 0.35.8 cargo-make
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-fmt

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK name used for building
 BUILDSYS_SDK_NAME="bottlerocket"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.25.0"
+BUILDSYS_SDK_VERSION="v0.25.1"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 


### PR DESCRIPTION
**Description of changes:**

Update to a newer SDK that contains a security fix.

* Rust: **1.58.0 → 1.58.1**

**Testing done:**

_See https://github.com/bottlerocket-os/bottlerocket-sdk/pull/71_.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
