### PR TITLE
kmod-5.10-nvidia: add remaining libraries

### DIFF
--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -10,6 +10,7 @@ path = "pkg.rs"
 
 [package.metadata.build-package]
 package-name = "kmod-5.10-nvidia"
+releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 
 [[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/470.82.01/NVIDIA-Linux-x86_64-470.82.01.run"

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -1,4 +1,6 @@
-%global nvidia_tesla_470_version 470.82.01
+%global tesla_470 470.82.01
+%global tesla_470_libdir %{_cross_libdir}/nvidia/tesla/%{tesla_470}
+%global tesla_470_bindir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)
 %global license_file %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml path nvidia -p ./licenses)
 
@@ -12,8 +14,8 @@ License: Apache-2.0 OR MIT
 URL: http://www.nvidia.com/
 
 # NVIDIA .run scripts from 0 to 199
-Source0: https://us.download.nvidia.com/tesla/%{nvidia_tesla_470_version}/NVIDIA-Linux-x86_64-%{nvidia_tesla_470_version}.run
-Source1: https://us.download.nvidia.com/tesla/%{nvidia_tesla_470_version}/NVIDIA-Linux-aarch64-%{nvidia_tesla_470_version}.run
+Source0: https://us.download.nvidia.com/tesla/%{tesla_470}/NVIDIA-Linux-x86_64-%{tesla_470}.run
+Source1: https://us.download.nvidia.com/tesla/%{tesla_470}/NVIDIA-Linux-aarch64-%{tesla_470}.run
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
@@ -33,7 +35,7 @@ BuildRequires: %{_cross_os}kernel-5.10-archive
 
 %package tesla-470
 Summary: NVIDIA 470 Tesla driver
-Version: %{nvidia_tesla_470_version}
+Version: %{tesla_470}
 License: %{spdx_id}
 Requires: %{name}
 
@@ -43,13 +45,13 @@ Requires: %{name}
 %prep
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
-sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{nvidia_tesla_470_version}.run -x
+sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_470}.run -x
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
 
 %build
-pushd NVIDIA-Linux-%{_cross_arch}-%{nvidia_tesla_470_version}/kernel
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_470}/kernel
 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
@@ -90,66 +92,76 @@ install -d %{buildroot}%{_cross_libdir}/modules-load.d
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
 # Begin NVIDIA tesla 470
-pushd NVIDIA-Linux-%{_cross_arch}-%{nvidia_tesla_470_version}
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_470}
 # We install bins and libs in a versioned directory to prevent collisions with future drivers versions
-install -d %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}
-install -d %{buildroot}%{_cross_libdir}/nvidia/tesla/%{nvidia_tesla_470_version}/
-install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install -d %{buildroot}%{_cross_factorydir}/nvidia/tesla/%{nvidia_tesla_470_version}
+install -d %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
+install -d %{buildroot}%{tesla_470_libdir}
+install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install -d %{buildroot}%{_cross_factorydir}/nvidia/tesla/%{tesla_470}
 
-sed -e 's|__NVIDIA_VERSION__|%{nvidia_tesla_470_version}|' %{S:300} > nvidia-tesla-%{nvidia_tesla_470_version}.conf
-install -m 0644 nvidia-tesla-%{nvidia_tesla_470_version}.conf %{buildroot}%{_cross_tmpfilesdir}/
-sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/|' %{S:301} > \
-  nvidia-tesla-%{nvidia_tesla_470_version}.toml
-install -m 0644 nvidia-tesla-%{nvidia_tesla_470_version}.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+sed -e 's|__NVIDIA_VERSION__|%{tesla_470}|' %{S:300} > nvidia-tesla-%{tesla_470}.conf
+install -m 0644 nvidia-tesla-%{tesla_470}.conf %{buildroot}%{_cross_tmpfilesdir}/
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/|' %{S:301} > \
+  nvidia-tesla-%{tesla_470}.toml
+install -m 0644 nvidia-tesla-%{tesla_470}.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
 # Install nvidia-path environment file, will be used as a drop-in for containerd.service since
 # libnvidia-container locates and mounts helper binaries into the containers from either
 # `PATH` or `NVIDIA_PATH`
-sed -e 's|__NVIDIA_BINDIR__|%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}|' %{S:302} > nvidia-path.env
-install -m 0644 nvidia-path.env %{buildroot}%{_cross_factorydir}/nvidia/tesla/%{nvidia_tesla_470_version}
-# We need to add `_cross_libdir/nvidia_tesla_470_version` to the paths loaded by the ldconfig service
+sed -e 's|__NVIDIA_BINDIR__|%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}|' %{S:302} > nvidia-path.env
+install -m 0644 nvidia-path.env %{buildroot}%{_cross_factorydir}/nvidia/tesla/%{tesla_470}
+# We need to add `_cross_libdir/tesla_470` to the paths loaded by the ldconfig service
 # because libnvidia-container uses the `ldcache` file created by the service, to locate and mount the
 # libraries into the containers
-sed -e 's|__LIBDIR__|%{_cross_libdir}|' %{S:303} | sed -e 's|__NVIDIA_VERSION__|%{nvidia_tesla_470_version}|' \
-  > nvidia-tesla-%{nvidia_tesla_470_version}.conf
-install -m 0644 nvidia-tesla-%{nvidia_tesla_470_version}.conf %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/
+sed -e 's|__LIBDIR__|%{_cross_libdir}|' %{S:303} | sed -e 's|__NVIDIA_VERSION__|%{tesla_470}|' \
+  > nvidia-tesla-%{tesla_470}.conf
+install -m 0644 nvidia-tesla-%{tesla_470}.conf %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/
 
 # driver
-install kernel/nvidia.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install kernel/nvidia/nv-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install kernel/nvidia/nv-kernel.o_binary %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nv-kernel.o
+install kernel/nvidia.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install kernel/nvidia/nv-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install kernel/nvidia/nv-kernel.o_binary %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nv-kernel.o
 
 # uvm
-install kernel/nvidia-uvm.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install kernel/nvidia-uvm.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
+install kernel/nvidia-uvm.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install kernel/nvidia-uvm.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
 
 # modeset
-install kernel/nvidia-modeset.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install kernel/nvidia-modeset/nv-modeset-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install kernel/nvidia-modeset/nv-modeset-kernel.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
+install kernel/nvidia-modeset.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install kernel/nvidia-modeset/nv-modeset-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install kernel/nvidia-modeset/nv-modeset-kernel.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
 
 # peermem
-install kernel/nvidia-peermem.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install kernel/nvidia-peermem/nvidia-peermem.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
+install kernel/nvidia-peermem.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install kernel/nvidia-peermem/nvidia-peermem.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
 
 # drm
-install kernel/nvidia-drm.mod.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-install kernel/nvidia-drm.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
+install kernel/nvidia-drm.mod.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+install kernel/nvidia-drm.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
 
-install -m 755 nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}
-install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}
-install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}
-install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}
+# Binaries
+install -m 755 nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
+install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
+install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
+install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %if "%{_cross_arch}" == "x86_64"
-install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}
+install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %endif
 
-# TODO: add remaining libraries
-# misc
-# Add libnvidia-ml.so for testing purposes
-install -m755 libnvidia-ml.so.%{nvidia_tesla_470_version} %{buildroot}%{_cross_libdir}/nvidia/tesla/%{nvidia_tesla_470_version}
+# We install all the libraries, and filter them out in the 'files' section, so we can catch
+# when new libraries are added
+install -m 755 *.so* %{buildroot}/%{tesla_470_libdir}/
 
-ln -s libnvidia-ml.so.%{nvidia_tesla_470_version} %{buildroot}%{_cross_libdir}/nvidia/tesla/%{nvidia_tesla_470_version}/libnvidia-ml.so.1
+# This library has the same SONAME as libEGL.so.1.1.0, this will cause collisions while
+# the symlinks are created. For now, we only symlink libEGL.so.1.1.0.
+EXCLUDED_LIBS="libEGL.so.%{tesla_470}"
+
+for lib in $(find . -maxdepth 1 -type f -name 'lib*.so.*' -printf '%%P\n'); do
+  [[ "${EXCLUDED_LIBS}" =~ "${lib}" ]] && continue
+  soname="$(%{_cross_target}-readelf -d "${lib}" | awk '/SONAME/{print $5}' | tr -d '[]')"
+  [ -n "${soname}" ] || continue
+  [ "${lib}" == "${soname}" ] && continue
+  ln -s "${lib}" %{buildroot}/%{tesla_470_libdir}/"${soname}"
+done
 
 popd
 
@@ -166,50 +178,139 @@ popd
 
 %files tesla-470
 %license %{license_file}
-%dir %{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}
-%dir %{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}
-%dir %{_cross_libdir}/nvidia/tesla/%{nvidia_tesla_470_version}
-%dir %{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d
-%dir %{_cross_factorydir}/nvidia/tesla/%{nvidia_tesla_470_version}
+%dir %{_cross_datadir}/nvidia/tesla/%{tesla_470}
+%dir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
+%dir %{tesla_470_libdir}
+%dir %{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
+%dir %{_cross_factorydir}/nvidia/tesla/%{tesla_470}
 
 # Binaries
-%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}/nvidia-debugdump
-%{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}/nvidia-smi
-
-# Libraries
-%{_cross_libdir}/nvidia/tesla/%{nvidia_tesla_470_version}/libnvidia-ml.so.1
-%{_cross_libdir}/nvidia/tesla/%{nvidia_tesla_470_version}/libnvidia-ml.so.%{nvidia_tesla_470_version}
+%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-debugdump
+%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-smi
 
 # Configuration files
-%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla-%{nvidia_tesla_470_version}.toml
-%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/nvidia-tesla-%{nvidia_tesla_470_version}.conf
-%{_cross_factorydir}/nvidia/tesla/%{nvidia_tesla_470_version}/nvidia-path.env
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla-%{tesla_470}.toml
+%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/nvidia-tesla-%{tesla_470}.conf
+%{_cross_factorydir}/nvidia/tesla/%{tesla_470}/nvidia-path.env
 
 # driver
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia.mod.o
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nv-interface.o
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nv-kernel.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia.mod.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nv-interface.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nv-kernel.o
 
 # uvm
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia-uvm.mod.o
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia-uvm.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia-uvm.mod.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia-uvm.o
 
 # modeset
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nv-modeset-interface.o
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nv-modeset-kernel.o
-%{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia-modeset.mod.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nv-modeset-interface.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nv-modeset-kernel.o
+%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia-modeset.mod.o
 
 # tmpfiles
-%{_cross_tmpfilesdir}/nvidia-tesla-%{nvidia_tesla_470_version}.conf
+%{_cross_tmpfilesdir}/nvidia-tesla-%{tesla_470}.conf
+
+# We only install the libraries required by all the DRIVER_CAPABILITIES, described here:
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
+
+# Utility libs
+%{tesla_470_libdir}/libnvidia-ml.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-ml.so.1
+%{tesla_470_libdir}/libnvidia-cfg.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-cfg.so.1
+%{tesla_470_libdir}/libnvidia-nvvm.so.4.0.0
+%{tesla_470_libdir}/libnvidia-nvvm.so.4
+
+# Compute libs
+%{tesla_470_libdir}/libcuda.so.%{tesla_470}
+%{tesla_470_libdir}/libcuda.so.1
+%{tesla_470_libdir}/libnvidia-opencl.so.470.82.01
+%{tesla_470_libdir}/libnvidia-opencl.so.1
+%{tesla_470_libdir}/libnvidia-ptxjitcompiler.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-ptxjitcompiler.so.1
+%{tesla_470_libdir}/libnvidia-allocator.so.470.82.01
+%{tesla_470_libdir}/libnvidia-allocator.so.1
+%{tesla_470_libdir}/libOpenCL.so.1.0.0
+%{tesla_470_libdir}/libOpenCL.so.1
+%if "%{_cross_arch}" == "x86_64"
+%{tesla_470_libdir}/libnvidia-compiler.so.%{tesla_470}
+%endif
+
+# Video libs
+%{tesla_470_libdir}/libvdpau_nvidia.so.%{tesla_470}
+%{tesla_470_libdir}/libvdpau_nvidia.so.1
+%{tesla_470_libdir}/libnvidia-encode.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-encode.so.1
+%{tesla_470_libdir}/libnvidia-opticalflow.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-opticalflow.so.1
+%{tesla_470_libdir}/libnvcuvid.so.%{tesla_470}
+%{tesla_470_libdir}/libnvcuvid.so.1
+
+# Graphics libs
+%{tesla_470_libdir}/libnvidia-eglcore.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-glcore.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-tls.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-glsi.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-rtcore.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-fbc.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-fbc.so.1
+%{tesla_470_libdir}/libnvoptix.so.%{tesla_470}
+%{tesla_470_libdir}/libnvoptix.so.1
+%{tesla_470_libdir}/libnvidia-vulkan-producer.so.%{tesla_470}
+%if "%{_cross_arch}" == "x86_64"
+%{tesla_470_libdir}/libnvidia-ifr.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-ifr.so.1
+%endif
+
+# Graphics GLVND libs
+%{tesla_470_libdir}/libnvidia-glvkspirv.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-cbl.so.%{tesla_470}
+%{tesla_470_libdir}/libGLX_nvidia.so.%{tesla_470}
+%{tesla_470_libdir}/libGLX_nvidia.so.0
+%{tesla_470_libdir}/libEGL_nvidia.so.%{tesla_470}
+%{tesla_470_libdir}/libEGL_nvidia.so.0
+%{tesla_470_libdir}/libGLESv2_nvidia.so.%{tesla_470}
+%{tesla_470_libdir}/libGLESv2_nvidia.so.2
+%{tesla_470_libdir}/libGLESv1_CM_nvidia.so.%{tesla_470}
+%{tesla_470_libdir}/libGLESv1_CM_nvidia.so.1
+
+# Graphics compat
+%{tesla_470_libdir}/libEGL.so.1.1.0
+%{tesla_470_libdir}/libEGL.so.1
+%{tesla_470_libdir}/libEGL.so.%{tesla_470}
+%{tesla_470_libdir}/libGL.so.1.7.0
+%{tesla_470_libdir}/libGL.so.1
+%{tesla_470_libdir}/libGLESv1_CM.so.1.2.0
+%{tesla_470_libdir}/libGLESv1_CM.so.1
+%{tesla_470_libdir}/libGLESv2.so.2.1.0
+%{tesla_470_libdir}/libGLESv2.so.2
+
+# NGX
+%if "%{_cross_arch}" == "x86_64"
+%{tesla_470_libdir}/libnvidia-ngx.so.%{tesla_470}
+%{tesla_470_libdir}/libnvidia-ngx.so.1
+%endif
 
 # Neither nvidia-peermem nor nvidia-drm are included in driver container images, we exclude them
 # for now, and we will add them if requested
-%exclude %{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia-peermem.mod.o
-%exclude %{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia-peermem.o
-%exclude %{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia-drm.mod.o
-%exclude %{_cross_datadir}/nvidia/tesla/%{nvidia_tesla_470_version}/module-objects.d/nvidia-drm.o
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}/nvidia-cuda-mps-control
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}/nvidia-cuda-mps-server
+%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia-peermem.mod.o
+%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia-peermem.o
+%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia-drm.mod.o
+%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d/nvidia-drm.o
+%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-cuda-mps-control
+%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-cuda-mps-server
 %if "%{_cross_arch}" == "x86_64"
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{nvidia_tesla_470_version}/nvidia-ngx-updater
+%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-ngx-updater
 %endif
+
+# None of these libraries are required by libnvidia-container, so they
+# won't be used by a containerized workload
+%exclude %{tesla_470_libdir}/libGLX.so.0
+%exclude %{tesla_470_libdir}/libGLdispatch.so.0
+%exclude %{tesla_470_libdir}/libOpenGL.so.0
+%exclude %{tesla_470_libdir}/libglxserver_nvidia.so.470.82.01
+%exclude %{tesla_470_libdir}/libnvidia-egl-wayland.so.1.1.7
+%exclude %{tesla_470_libdir}/libnvidia-gtk2.so.470.82.01
+%exclude %{tesla_470_libdir}/libnvidia-gtk3.so.470.82.01
+%exclude %{tesla_470_libdir}/nvidia_drv.so
+%exclude %{tesla_470_libdir}/libnvidia-egl-wayland.so.1

--- a/variants/aws-k8s-1.21-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.21-nvidia/Cargo.toml
@@ -9,6 +9,9 @@ build = "build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
 [package.metadata.build-variant]
 included-packages = [
     "aws-iam-authenticator",


### PR DESCRIPTION
**Issue number:**
Closes #1822

**Description of changes:**
```
kmod-5.10-nvidia: add remaining libraries
kmod-5.10-nvidia: add releases url
```

The NVIDIA sources provide user-space libraries that will be mounted into the containers, depending on the set of driver capabilities configured for the workload.

**Testing done:**

I ran a daemonset in a `p3.2xlarge` instance with the following image definition:

```Dockerfile
FROM nvidia/cuda:11.4.3-devel-ubuntu20.04 as cuda-samples

RUN apt update
RUN apt install git build-essential -y
RUN git clone https://github.com/NVIDIA/cuda-samples.git

# Compute samples
RUN mkdir -p /samples
RUN cd /cuda-samples/Samples/0_Introduction/vectorAdd && make -j && [ -f vectorAdd ] && cp vectorAdd /samples/
RUN cd /cuda-samples/Samples/1_Utilities/bandwidthTest && make -j && [ -f bandwidthTest ] && cp bandwidthTest /samples/
RUN cd /cuda-samples/Samples/1_Utilities/deviceQuery && make -j && [ -f deviceQuery ] && cp deviceQuery /samples/
RUN cd /cuda-samples/Samples/1_Utilities/topologyQuery && make -j && [ -f topologyQuery ] && cp topologyQuery /samples/

FROM alpine as builder
RUN apk update \
  && apk add --update git

FROM builder as benchmarks
RUN git clone https://github.com/tensorflow/benchmarks.git \
  && cd benchmarks \
  && git checkout cnn_tf_v1.15_compatible

FROM tensorflow/tensorflow:1.15.2-gpu
ENV SAMPLES="vectorAdd bandwidthTest deviceQuery topologyQuery"
COPY ./entrypoint.sh /
COPY --from=benchmarks /benchmarks /opt/benchmarks
COPY --from=cuda-samples /samples/* /usr/bin/
RUN chmod +x ./entrypoint.sh && mkdir -p /opt
ENTRYPOINT ["sh", "-c", "/entrypoint.sh"]
```

Entrypoint:

```sh
#! /usr/bin/env bash

# Cuda samples:

for sample in $SAMPLES; do
  $sample
done

# GPU benchmark:
python3 /opt/benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
  --data_name=imagenet                                                 \
  --model=resnet50                                                     \
  --num_batches=100                                                    \
  --batch_size=4                                                       \
  --num_gpus=1                                                         \
  --gpu_memory_frac_for_testing=0.2
```

The containers ran successfully.

TODO:

- [x] Same test for aarch64

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
