### PR TITLE
BUILDING.md: fix typo

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -138,7 +138,7 @@ licenses = [
 2. Fetch the licenses with this command:
 
 ```shell
-cargo make fetch-licenses -e BUILDSYS_UPSTREAM_LICENSES_FETCH=true
+cargo make fetch-licenses -e BUILDSYS_UPSTREAM_LICENSE_FETCH=true
 ```
 
 3. Build your image, setting the `BUILDSYS_UPSTREAM_SOURCE_FALLBACK` flag to `true`, if you haven't cached the driver's sources:


### PR DESCRIPTION
BUILDSYS_UPSTREAM_LICENSES_FETCH should be BUILDSYS_UPSTREAM_LICENSE_FETCH

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Jan 31 15:27:48 2022 -0800

    BUILDING.md: fix typo
    
    BUILDSYS_UPSTREAM_LICENSES_FETCH should be BUILDSYS_UPSTREAM_LICENSE_FETCH
```


**Testing done:**
`cargo make -e BUILDSYS_UPSTREAM_LICENSE_FETCH="true"` works


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
