### PR TITLE
migrations: default host containers container image versions

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -95,4 +95,8 @@ version = "1.5.3"
 ]
 "(1.5.3, 1.6.0)" = [
     "migrate_v1.6.0_node-taints-representation.lz4",
+    "migrate_v1.6.0_aws-admin-container-v0-7-4.lz4",
+    "migrate_v1.6.0_aws-control-container-v0-5-5.lz4",
+    "migrate_v1.6.0_public-admin-container-v0-7-4.lz4",
+    "migrate_v1.6.0_public-control-container-v0-5-5.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -457,6 +457,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "aws-admin-container-v0-7-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "aws-control-container-v0-5-5"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2505,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "public-admin-container-v0-7-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-5-5"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -36,6 +36,10 @@ members = [
     "api/migration/migrations/v1.5.1/control-container-v0-5-4",
     "api/migration/migrations/v1.5.3/vmware-host-containers",
     "api/migration/migrations/v1.6.0/node-taints-representation",
+    "api/migration/migrations/v1.6.0/aws-admin-container-v0-7-4",
+    "api/migration/migrations/v1.6.0/aws-control-container-v0-5-5",
+    "api/migration/migrations/v1.6.0/public-admin-container-v0-7-4",
+    "api/migration/migrations/v1.6.0/public-control-container-v0-5-5",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.6.0/aws-admin-container-v0-7-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.6.0/aws-admin-container-v0-7-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-7-4"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.6.0/aws-admin-container-v0-7-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.6.0/aws-admin-container-v0-7-4/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.3";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.4";
+
+/// We bumped the version of the default admin container from v0.7.3 to v0.7.4
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.6.0/aws-control-container-v0-5-5/Cargo.toml
+++ b/sources/api/migration/migrations/v1.6.0/aws-control-container-v0-5-5/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-5-5"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.6.0/aws-control-container-v0-5-5/src/main.rs
+++ b/sources/api/migration/migrations/v1.6.0/aws-control-container-v0-5-5/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.4";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.5";
+
+/// We bumped the version of the default control container from v0.5.4 to v0.5.5
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.6.0/public-admin-container-v0-7-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.6.0/public-admin-container-v0-7-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-7-4"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.6.0/public-admin-container-v0-7-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.6.0/public-admin-container-v0-7-4/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.3";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4";
+
+/// We bumped the version of the default admin container from v0.7.3 to v0.7.4
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.6.0/public-control-container-v0-5-5/Cargo.toml
+++ b/sources/api/migration/migrations/v1.6.0/public-control-container-v0-5-5/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-5-5"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.6.0/public-control-container-v0-5-5/src/main.rs
+++ b/sources/api/migration/migrations/v1.6.0/public-control-container-v0-5-5/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.4";
+const NEW_CONTROL_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.5";
+
+/// We bumped the version of the default control container from v0.5.4 to v0.5.5
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_SOURCE_VAL,
+        new_val: NEW_CONTROL_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.3"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.4"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.4"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.5"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,9 +6,9 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.3"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4"
 
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.4"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.5"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Feb 2 16:46:34 2022 -0800

    host-containers: migrations for new admin and control versions
    
    Adds migrations for updating default host-container container image
    versions
    admin from v0.7.3 to v0.7.4
    control from v0.5.4 to v0.5.4

```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Feb 2 16:28:07 2022 -0800

    host-containers: update default host container image versions
    
    admin container to v0.7.4
    control container to v0.5.5

```

**Testing done:**
aws-k8s-1.21 migration test:

From v1.5.3:
```
bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.5.3 (aws-k8s-1.21)"
PRETTY_NAME="Bottlerocket OS 1.5.3 (aws-k8s-1.21)"
VARIANT_ID=aws-k8s-1.21
VERSION_ID=1.5.3
BUILD_ID=cd1b8e95
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"

bash-5.0# apiclient -u /settings?keys=settings.host-containers.admin.source
{"host-containers":{"admin":{"source":"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.3"}}}

bash-5.0# apiclient -u /settings?keys=settings.host-containers.control.source
{"host-containers":{"control":{"source":"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.5.4"}}}

```
To v1.6.0 with the migrations:
```
bash-5.0# updog update -r -n
Starting update to 1.6.0
Cannot schedule shutdown without logind support, proceeding with immediate shutdown.
...

bash-5.0# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.6.0 (aws-k8s-1.21)"
PRETTY_NAME="Bottlerocket OS 1.6.0 (aws-k8s-1.21)"
VARIANT_ID=aws-k8s-1.21
VERSION_ID=1.6.0
BUILD_ID=f6aee431-dirty
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
bash-5.0# apiclient -u /settings?keys=settings.host-containers.admin.source
{"host-containers":{"admin":{"source":"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.7.4"}}}
bash-5.0# apiclient -u /settings?keys=settings.host-containers.control.source
{"host-containers":{"control":{"source":"328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.5.5"}}}
```
Both host-container images got migrated successfully.


vmware-k8s-1.21 v1.5.3
```
bash-5.0# apiclient -u /settings?keys=settings.host-containers.admin.source
{"host-containers":{"admin":{"source":"public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.3"}}}
bash-5.0# apiclient -u /settings?keys=settings.host-containers.control.source
{"host-containers":{"control":{"source":"public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.4"}}}
bash-5.0# updog update -r -n
Starting update to 1.6.0
...
```
After update to 1.6.0, the host-containers sources got updated:
```
{"host-containers":{"admin":{"source":"public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4"}}}
bash-5.0# apiclient -u /settings?keys=settings.host-containers.control.source
{"host-containers":{"control":{"source":"public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.5"}}}
```

Rolls back to older values when downgrading as expected

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
