### PR TITLE
aws-iam-authenticator: update gitignore to include patch from lookaside cache

### DIFF
--- a/packages/aws-iam-authenticator/.gitignore
+++ b/packages/aws-iam-authenticator/.gitignore
@@ -1,1 +1,1 @@
-0001-Update-vendored-go-dependencies.patch
+aws-iam-authenticator-0.5.3-Update-vendored-go-dependencies.patch


### PR DESCRIPTION
**Description of changes:**
During iteration on #1936, this patch changed names, but I forgot to update `.gitignore`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
