### PR TITLE
kernel: add fix for cgroup v1 release agent

### DIFF
--- a/packages/kernel-5.10/0001-cgroup-v1-Require-capabilities-to-set-release_agent.patch
+++ b/packages/kernel-5.10/0001-cgroup-v1-Require-capabilities-to-set-release_agent.patch
@@ -1,0 +1,54 @@
+From ea044e9e1c65fe83d2e50580e43c4e9775414af1 Mon Sep 17 00:00:00 2001
+From: "Eric W. Biederman" <ebiederm@xmission.com>
+Date: Thu, 20 Jan 2022 11:04:01 -0600
+Subject: [PATCH] cgroup-v1: Require capabilities to set release_agent
+
+The cgroup release_agent is called with call_usermodehelper.  The function
+call_usermodehelper starts the release_agent with a full set fo capabilities.
+Therefore require capabilities when setting the release_agaent.
+
+Reported-by: Tabitha Sable <tabitha.c.sable@gmail.com>
+Tested-by: Tabitha Sable <tabitha.c.sable@gmail.com>
+Fixes: 81a6a5cdd2c5 ("Task Control Groups: automatic userspace notification of idle cgroups")
+Cc: stable@vger.kernel.org # v2.6.24+
+Signed-off-by: "Eric W. Biederman" <ebiederm@xmission.com>
+Signed-off-by: Tejun Heo <tj@kernel.org>
+---
+ kernel/cgroup/cgroup-v1.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/kernel/cgroup/cgroup-v1.c b/kernel/cgroup/cgroup-v1.c
+index 7f71b54c06c5..69fba563c810 100644
+--- a/kernel/cgroup/cgroup-v1.c
++++ b/kernel/cgroup/cgroup-v1.c
+@@ -545,6 +545,14 @@ static ssize_t cgroup_release_agent_write(struct kernfs_open_file *of,
+ 
+ 	BUILD_BUG_ON(sizeof(cgrp->root->release_agent_path) < PATH_MAX);
+ 
++	/*
++	 * Release agent gets called with all capabilities,
++	 * require capabilities to set release agent.
++	 */
++	if ((of->file->f_cred->user_ns != &init_user_ns) ||
++	    !capable(CAP_SYS_ADMIN))
++		return -EPERM;
++
+ 	cgrp = cgroup_kn_lock_live(of->kn, false);
+ 	if (!cgrp)
+ 		return -ENODEV;
+@@ -958,6 +966,12 @@ int cgroup1_parse_param(struct fs_context *fc, struct fs_parameter *param)
+ 		/* Specifying two release agents is forbidden */
+ 		if (ctx->release_agent)
+ 			return invalfc(fc, "release_agent respecified");
++		/*
++		 * Release agent gets called with all capabilities,
++		 * require capabilities to set release agent.
++		 */
++		if ((fc->user_ns != &init_user_ns) || !capable(CAP_SYS_ADMIN))
++			return invalfc(fc, "Setting release_agent not allowed");
+ 		ctx->release_agent = param->string;
+ 		param->string = NULL;
+ 		break;
+-- 
+2.32.0
+

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -10,8 +10,12 @@ URL: https://www.kernel.org/
 Source0: https://cdn.amazonlinux.com/blobstore/c80d649c51b68fdb2bc126c326f83fed93ed242d675f978a9a0da4012e9789a5/kernel-5.10.93-87.444.amzn2.src.rpm
 Source100: config-bottlerocket
 
+# cgroup v1 release agent fix
+Patch0001: 0001-cgroup-v1-Require-capabilities-to-set-release_agent.patch
+
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
+
 # Add zstd support for compressed kernel modules
 Patch2000: 2000-kbuild-move-module-strip-compression-code-into-scrip.patch
 Patch2001: 2001-kbuild-add-support-for-zstd-compressed-modules.patch

--- a/packages/kernel-5.4/0001-cgroup-v1-Require-capabilities-to-set-release_agent.patch
+++ b/packages/kernel-5.4/0001-cgroup-v1-Require-capabilities-to-set-release_agent.patch
@@ -1,0 +1,55 @@
+From da405f0c70e6daba64d112c9036fedc28906a937 Mon Sep 17 00:00:00 2001
+From: "Eric W. Biederman" <ebiederm@xmission.com>
+Date: Thu, 20 Jan 2022 11:04:01 -0600
+Subject: [PATCH] cgroup-v1: Require capabilities to set release_agent
+
+The cgroup release_agent is called with call_usermodehelper.  The function
+call_usermodehelper starts the release_agent with a full set fo capabilities.
+Therefore require capabilities when setting the release_agaent.
+
+Reported-by: Tabitha Sable <tabitha.c.sable@gmail.com>
+Tested-by: Tabitha Sable <tabitha.c.sable@gmail.com>
+Fixes: 81a6a5cdd2c5 ("Task Control Groups: automatic userspace notification of idle cgroups")
+Cc: stable@vger.kernel.org # v2.6.24+
+Signed-off-by: "Eric W. Biederman" <ebiederm@xmission.com>
+Signed-off-by: Tejun Heo <tj@kernel.org>
+---
+ kernel/cgroup/cgroup-v1.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/kernel/cgroup/cgroup-v1.c b/kernel/cgroup/cgroup-v1.c
+index 2d0ef613ca07..07917ac2c303 100644
+--- a/kernel/cgroup/cgroup-v1.c
++++ b/kernel/cgroup/cgroup-v1.c
+@@ -549,6 +549,15 @@ static ssize_t cgroup_release_agent_write(struct kernfs_open_file *of,
+ 
+ 	BUILD_BUG_ON(sizeof(cgrp->root->release_agent_path) < PATH_MAX);
+ 
++	/*
++	 * Release agent gets called with all capabilities,
++	 * require capabilities to set release agent.
++	 */
++
++	if ((of->file->f_cred->user_ns != &init_user_ns) ||
++	    !capable(CAP_SYS_ADMIN))
++		return -EPERM;
++
+ 	cgrp = cgroup_kn_lock_live(of->kn, false);
+ 	if (!cgrp)
+ 		return -ENODEV;
+@@ -961,6 +970,12 @@ int cgroup1_parse_param(struct fs_context *fc, struct fs_parameter *param)
+ 		/* Specifying two release agents is forbidden */
+ 		if (ctx->release_agent)
+ 			return cg_invalf(fc, "cgroup1: release_agent respecified");
++		/*
++		 * Release agent gets called with all capabilities,
++		 * require capabilities to set release agent.
++		 */
++		if ((fc->user_ns != &init_user_ns) || !capable(CAP_SYS_ADMIN))
++			return cg_invalf(fc, "cgroup1: Setting release_agent not allowed");
+ 		ctx->release_agent = param->string;
+ 		param->string = NULL;
+ 		break;
+-- 
+2.32.0
+

--- a/packages/kernel-5.4/3001-lustrefsx-Disable-Werror-stringop-overflow.patch
+++ b/packages/kernel-5.4/3001-lustrefsx-Disable-Werror-stringop-overflow.patch
@@ -1,7 +1,7 @@
 From a5f6b26082e0022d3c3e70e0718e4787939778d8 Mon Sep 17 00:00:00 2001
 From: iliana destroyer of worlds <iweller@amazon.com>
 Date: Tue, 30 Jul 2019 12:59:09 -0700
-Subject: [PATCH 1/2] lustrefsx: Disable -Werror=stringop-overflow=
+Subject: [PATCH] lustrefsx: Disable -Werror=stringop-overflow=
 
 Signed-off-by: iliana destroyer of worlds <iweller@amazon.com>
 ---

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -10,8 +10,8 @@ URL: https://www.kernel.org/
 Source0: https://cdn.amazonlinux.com/blobstore/9d3d2fc3caf5bc68bcc257a426b1a3177f60f1acd62e27d772b58156c1b76e57/kernel-5.4.172-90.336.amzn2.src.rpm
 Source100: config-bottlerocket
 
-# Make Lustre FSx work with a newer GCC.
-Patch0001: 0001-lustrefsx-Disable-Werror-stringop-overflow.patch
+# cgroup v1 release agent fix
+Patch0001: 0001-cgroup-v1-Require-capabilities-to-set-release_agent.patch
 
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
@@ -26,6 +26,9 @@ Patch2005: 2005-.gitignore-Add-ZSTD-compressed-files.patch
 # Add zstd support for compressed kernel modules
 Patch2006: 2006-kbuild-move-module-strip-compression-code-into-scrip.patch
 Patch2007: 2007-kbuild-add-support-for-zstd-compressed-modules.patch
+
+# Make Lustre FSx work with a newer GCC.
+Patch3001: 3001-lustrefsx-Disable-Werror-stringop-overflow.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Backport [24f6008564](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=24f6008564183aa120d07c03d9289519c2fe02af) from upstream to kernel 5.4 and 5.10.

Did a minor rework of the 5.4 spec to make it more obvious where to add these backported patches in the future.

**Testing done:**

TODO:
- [x] smoke test aws-k8s-1.19 x86_64 
- [x] smoke test aws-k8s-1.21 aarch64


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
