### PR TITLE
apiclient: pin tokio-tungstenite to v0.15

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3556,12 +3556,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.16.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
+ "pin-project",
  "tokio",
  "tungstenite",
 ]
@@ -3650,9 +3651,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.16.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
  "base64",
  "byteorder",

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -33,7 +33,7 @@ signal-hook = "0.3"
 simplelog = "0.11"
 snafu = { version = "0.7", features = ["futures"] }
 tokio = { version = "~1.14", default-features = false, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
-tokio-tungstenite = { version = "0.16", default-features = false, features = ["connect"] }
+tokio-tungstenite = { version = "0.15", default-features = false, features = ["connect"] }
 toml = "0.5"
 unindent = "0.1"
 url = "2.2.1"


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Fri Feb 4 18:22:42 2022 -0800

    apiclient: pin tokio-tungstenite to v0.15
    
    This pins the tokio-tungstenite dependency to v0.15
    Upgrading to v0.16 requires some additional thought and work.

```


**Testing done:**
Built aws-k8s-1.21 x86_64 AMI and `apiclient exec admin` works from the control container without problem
```
[ssm-user@ip-192-168-1-197 /]$ apiclient exec admin cat /etc/motd 
Welcome to Bottlerocket's admin container!

This container provides access to the Bottlerocket host filesystems (see
/.bottlerocket/rootfs) and contains common tools for inspection and
troubleshooting.  It is based on Amazon Linux 2, and most things are in the
same places you would find them on an AL2 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[ssm-user@ip-192-168-1-197 /]$ echo $?
0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
