### PR TITLE
apiserver, apiclient: revise closing frame construction

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3556,13 +3556,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
 dependencies = [
  "futures-util",
  "log",
- "pin-project",
  "tokio",
  "tungstenite",
 ]
@@ -3651,9 +3650,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
 dependencies = [
  "base64",
  "byteorder",

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -33,7 +33,7 @@ signal-hook = "0.3"
 simplelog = "0.11"
 snafu = { version = "0.7", features = ["futures"] }
 tokio = { version = "~1.14", default-features = false, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
-tokio-tungstenite = { version = "0.15", default-features = false, features = ["connect"] }
+tokio-tungstenite = { version = "0.16", default-features = false, features = ["connect"] }
 toml = "0.5"
 unindent = "0.1"
 url = "2.2.1"

--- a/sources/api/apiserver/src/server/exec.rs
+++ b/sources/api/apiserver/src/server/exec.rs
@@ -355,7 +355,8 @@ impl Handler<message::ProcessReturn> for WsExec {
         // they're just a u8.  If that assumption breaks for some reason, we don't have a
         // reasonable code to send to the user, so just give a 0.
         let code = u16::try_from(msg.code).unwrap_or(0);
-        stop(ctx, None::<String>, ws::CloseCode::Other(code));
+        // We send the process return code in the closing frame's reason message.
+        stop(ctx, Some(code.to_string()), ws::CloseCode::Normal);
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket/issues/1947


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Feb 8 13:33:53 2022 -0800

    apiserver, apiclient: revise closing frame construction
    
    apiserver now sends closing code "Normal" when the apiclient-exec'd
    process finishes regardless of its exit code.
    The process's exit code is now stored in the closing frame's reason
    message which then gets extracted out in apiclient to determine the
    proper exit status.

```
```

Author: Erikson Tung <etung@amazon.com>
Date:   Tue Feb 8 13:32:55 2022 -0800

    apiclient: update tokio-tungstenite to v0.16+

```

**Testing done:**
Built aws-k8s-1.21 x86_64 image and created AMI out of it
Launched instance, boots fine, both host containers come up fine.
Got into the control container via SSM start-session and tried the following:
```
[ssm-user@ip-192-168-7-35 /]$ apiclient -u /os
{"arch":"x86_64","build_id":"efda1795","pretty_name":"Bottlerocket OS 1.6.0 (aws-k8s-1.21)","variant_id":"aws-k8s-1.21","version_id":"1.6.0"}

[ssm-user@ip-192-168-7-35 /]$ apiclient exec admin cat /etc/motd
Welcome to Bottlerocket's admin container!

This container provides access to the Bottlerocket host filesystems (see
/.bottlerocket/rootfs) and contains common tools for inspection and
troubleshooting.  It is based on Amazon Linux 2, and most things are in the
same places you would find them on an AL2 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[ssm-user@ip-192-168-7-35 /]$ echo $?
0

[ssm-user@ip-192-168-7-35 /]$ apiclient exec admin cat /path/to/nowhere
cat: /path/to/nowhere: No such file or directory
[ssm-user@ip-192-168-7-35 /]$ echo $?
1

[ssm-user@ip-192-168-7-35 /]$ enter-admin-container
Confirming admin container is enabled...
Waiting for admin container to start...
Entering admin container
bash-4.2# exit                                                                                                                    
exit
[ssm-user@ip-192-168-7-35 /]$ echo $?
0
[ssm-user@ip-192-168-7-35 /]$ 
```
apiclient exec behaves as expected, the exit status reflects the exec'd process's exit status.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
