### PR TITLE
netdog: add attribute to ignore compiler dead-code warning

### DIFF
--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -48,6 +48,7 @@ lazy_static! {
 
 /// Stores fields extracted from a DHCP lease.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct LeaseInfo {
     #[serde(rename = "ipaddr")]
     ip_address: IpNet,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Compiling netdog with rust v1.58.1 gives a compiler warning about dead_code in netdog.

```
Author: Erikson Tung <etung@amazon.com>
Date:   Wed Feb 9 15:11:25 2022 -0800

    netdog: add attribute to ignore compiler dead-code warning
    
    We want to store fields from a DHCP lease, even if we don't necessary
    need to use all the fields right now.

```


**Testing done:**
Before the change, when we compile:
```
warning: field is never read: `dns_domain`
  --> api/netdog/src/main.rs:57:5
   |
57 |     dns_domain: Option<String>,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `netdog` (bin "netdog") generated 1 warning
```
After the change:
No more compiler warnings in netdog.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
