### PR TITLE
release: Include a default .link file for network interfaces

### DIFF
--- a/packages/release/80-release.link
+++ b/packages/release/80-release.link
@@ -1,0 +1,11 @@
+[Match]
+OriginalName=*
+
+[Link]
+# Bottlerocket disables hwdb so don't include "database" in NamePolicy
+NamePolicy=keep kernel onboard slot path
+AlternativeNamesPolicy=onboard slot path
+
+# Applying a MAC address policy can confuse CNI plugins, which do
+# not expect addresses to change for devices like veth pairs.
+MACAddressPolicy=none

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -60,6 +60,9 @@ Source1080: runtime.slice
 # Drop-in units to override defaults
 Source1100: systemd-tmpfiles-setup-service-debug.conf
 
+# systemd-udevd default link
+Source1200: 80-release.link
+
 BuildArch: noarch
 Requires: %{_cross_os}acpid
 Requires: %{_cross_os}audit
@@ -113,6 +116,9 @@ install -p -m 0644 %{S:97} %{buildroot}%{_cross_sysctldir}/80-release.conf
 
 install -d %{buildroot}%{_cross_libdir}/systemd/system.conf.d
 install -p -m 0644 %{S:98} %{buildroot}%{_cross_libdir}/systemd/system.conf.d/80-release.conf
+
+install -d %{buildroot}%{_cross_libdir}/systemd/network
+install -p -m 0644 %{S:1200} %{buildroot}%{_cross_libdir}/systemd/network/80-release.link
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:99} %{buildroot}%{_cross_tmpfilesdir}/release.conf
@@ -172,6 +178,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %dir %{_cross_libdir}/repart.d
 %{_cross_libdir}/repart.d/80-local.conf
 %{_cross_libdir}/systemd/system.conf.d/80-release.conf
+%{_cross_libdir}/systemd/network/80-release.link
 %{_cross_unitdir}/configured.target
 %{_cross_unitdir}/preconfigured.target
 %{_cross_unitdir}/multi-user.target


### PR DESCRIPTION
**Description of changes:**
This change is the first step towards using `systemd-udevd`'s predictable network interface naming.  

Currently Bottlerocket passes `net.ifnames` on the kernel command line, which explicitly opts-out of the predictable naming scheme and uses the interface names given by the kernel/driver.  As Bottlerocket begins moving into the metal space, using predictable network interface names becomes increasingly important for deterministic configuration both on the host and for CNI.

As it stands, Bottlerocket [does not package](https://github.com/bottlerocket-os/bottlerocket/blob/3bca2493dff700b7844a3c629e4026e98a71d58e/packages/systemd/systemd.spec#L220) any of the default `systemd` network rules, including an important file for device naming: [`99-default.link`](https://github.com/systemd/systemd/blob/main/network/99-default.link).  In order for predictable device naming to work, a `.link` file must exist telling `udev` which interfaces it must rename and the name / MAC address policies to use when new interfaces become available.  

This PR includes a Bottlerocket-specific default `.link` file; additional details on why this is necessary in the commit message below.  This PR _does not_ affect existing device *names* since we continue to pass `net.ifnames=0` on the kernel command line.  However, it does set the stage for us to be able to use predictable names in the future.

```
This change adds a default network configuration .link file that
`systemd-udev` will use when configuring new interfaces.  It contains
the default list of policies that are used when naming interfaces, as
well as the policy by which the MAC address should be set.

Bottlerocket packages its own version of this file rather than the
default from systemd for a few reasons. 1) Bottlerocket does not
create/use a udev hwdb (we disable the option in systemd compile flags),
so we remove this option from the NamePolicy list, 2) CNI plugins can be
confused when MAC addresses change for virtual interfaces, so
Bottlerocket sets the default MACAddress Policy to "none" which
directs systemd not to attempt to manage the MAC.  Hardware usually has
a MAC, and veth devices used by CNI generally get a MAC generated by the
plugin.

Additional information about the MAC address issue:
https://github.com/systemd/systemd/issues/3374#issuecomment-288882355
https://github.com/flatcar-linux/Flatcar/issues/278
https://github.com/flatcar-linux/init/pull/33
```


**Testing done:**
Spun up a few aws-k8s-1.21 nodes with this change in my cluster.
* Able to ping other pods from pods
* Pods can access nginx running on other pods
* Sonobuoy passed
* `ip monitor all` during Sonobuoy run shows links being created and _not_ getting systemd created MACs (as expected) [See related issue](https://github.com/clearlinux/distribution/issues/904#issuecomment-502994415)

I also built an image with `MACAddressPolicy=persistent` and observed:
* coredns pods couldn't reach endpoints on the host, failing to start
* couldn't ping other pods from pods, 
* couldn't ping other pods from the host


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
