### PR TITLE
fix merge_config.sh invocation in kernel packages

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -84,8 +84,10 @@ CONFIG_EXTRA_FIRMWARE_DIR="%{_cross_libdir}/firmware"
 EOF
 %endif
 
+export ARCH="%{_cross_karch}"
+export CROSS_COMPILE="%{_cross_target}-"
+
 KCONFIG_CONFIG="arch/%{_cross_karch}/configs/%{_cross_vendor}_defconfig" \
-ARCH="%{_cross_karch}" \
 scripts/kconfig/merge_config.sh \
   ../config-%{_cross_arch} \
 %if "%{_cross_arch}" == "x86_64"

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -94,8 +94,10 @@ CONFIG_EXTRA_FIRMWARE_DIR="%{_cross_libdir}/firmware"
 EOF
 %endif
 
+export ARCH="%{_cross_karch}"
+export CROSS_COMPILE="%{_cross_target}-"
+
 KCONFIG_CONFIG="arch/%{_cross_karch}/configs/%{_cross_vendor}_defconfig" \
-ARCH="%{_cross_karch}" \
 scripts/kconfig/merge_config.sh \
   ../config-%{_cross_arch} \
 %if "%{_cross_arch}" == "x86_64"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Run `merge_config.sh` with the correct `ARCH` and `CROSS_COMPILE` values so that the build host architecture doesn't influence the generated config.


**Testing done:**
Compared the following configs for 5.4 and 5.10, before and after this change:
* kernel config, built on x86_64 for x86_64
* kernel config, built on x86_64 for aarch64
* kernel config, built on aarch64 for x86_64
* kernel config, built on aarch64 for aarch64

The only difference was 5.10 built on aarch64 for x86_64, where we now get the EFI related settings we expect.
```
diff --git a/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm b/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm
index 0137555..48a7b26 100644
--- a/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm
+++ b/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm
@@ -442,7 +442,8 @@ CONFIG_X86_INTEL_TSX_MODE_OFF=y
 # CONFIG_X86_INTEL_TSX_MODE_ON is not set
 # CONFIG_X86_INTEL_TSX_MODE_AUTO is not set
 CONFIG_EFI=y
-# CONFIG_EFI_STUB is not set
+CONFIG_EFI_STUB=y
+CONFIG_EFI_MIXED=y
 # CONFIG_HZ_100 is not set
 CONFIG_HZ_250=y
 # CONFIG_HZ_300 is not set
@@ -655,9 +656,12 @@ CONFIG_EFI_VARS_PSTORE=y
 CONFIG_EFI_RUNTIME_MAP=y
 # CONFIG_EFI_FAKE_MEMMAP is not set
 CONFIG_EFI_RUNTIME_WRAPPERS=y
+CONFIG_EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER=y
 # CONFIG_EFI_BOOTLOADER_CONTROL is not set
 # CONFIG_EFI_CAPSULE_LOADER is not set
 # CONFIG_EFI_TEST is not set
+# CONFIG_APPLE_PROPERTIES is not set
+# CONFIG_RESET_ATTACK_MITIGATION is not set
 # CONFIG_EFI_RCI2_TABLE is not set
 # CONFIG_EFI_DISABLE_PCI_DMA is not set
 # end of EFI (Extensible Firmware Interface) Support
```

I also compared the four "good" configs from an x86_64 build host with the ones from an aarch64 build host, and the only difference was how the microcode firmware files were sorted in the two x86_64 configs.
```
diff --git a/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm b/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm
index 48a7b26..8caf62f 100644
--- a/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm
+++ b/config-bottlerocket-x86_64-kernel-5.10-5.10.96-1.aarch64.rpm
@@ -1871,7 +1871,7 @@ CONFIG_PREVENT_FIRMWARE_BUILD=y
 #
 CONFIG_FW_LOADER=y
 CONFIG_FW_LOADER_PAGED_BUF=y
-CONFIG_EXTRA_FIRMWARE="amd-ucode/microcode_amd.bin amd-ucode/microcode_amd_fam16h.bin amd-ucode/microcode_amd_fam17h.bin amd-ucode/microcode_amd_fam15h.bin intel-ucode/06-55-07 intel-ucode/06-3f-02 intel-ucode/06-2c-02 intel-ucode/06-1a-05 intel-ucode/06-2d-06 intel-ucode/06-4f-01 intel-ucode/06-55-04 intel-ucode/06-2d-07 intel-ucode/06-3e-04 intel-ucode/06-3f-04 "
+CONFIG_EXTRA_FIRMWARE="intel-ucode/06-2d-07 intel-ucode/06-3f-02 intel-ucode/06-3e-04 intel-ucode/06-2c-02 intel-ucode/06-3f-04 intel-ucode/06-1a-05 intel-ucode/06-55-04 intel-ucode/06-55-07 intel-ucode/06-2d-06 intel-ucode/06-4f-01 amd-ucode/microcode_amd.bin amd-ucode/microcode_amd_fam15h.bin amd-ucode/microcode_amd_fam17h.bin amd-ucode/microcode_amd_fam16h.bin "
 CONFIG_EXTRA_FIRMWARE_DIR="/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/firmware"
 CONFIG_FW_LOADER_USER_HELPER=y
 # CONFIG_FW_LOADER_USER_HELPER_FALLBACK is not set
diff --git a/config-bottlerocket-x86_64-kernel-5.4-5.4.176-1.aarch64.rpm b/config-bottlerocket-x86_64-kernel-5.4-5.4.176-1.aarch64.rpm
index ca4c033..24ad1a6 100644
--- a/config-bottlerocket-x86_64-kernel-5.4-5.4.176-1.aarch64.rpm
+++ b/config-bottlerocket-x86_64-kernel-5.4-5.4.176-1.aarch64.rpm
@@ -1803,7 +1803,7 @@ CONFIG_PREVENT_FIRMWARE_BUILD=y
 #
 CONFIG_FW_LOADER=y
 CONFIG_FW_LOADER_PAGED_BUF=y
-CONFIG_EXTRA_FIRMWARE="amd-ucode/microcode_amd.bin amd-ucode/microcode_amd_fam16h.bin amd-ucode/microcode_amd_fam17h.bin amd-ucode/microcode_amd_fam15h.bin intel-ucode/06-55-07 intel-ucode/06-3f-02 intel-ucode/06-2c-02 intel-ucode/06-1a-05 intel-ucode/06-2d-06 intel-ucode/06-4f-01 intel-ucode/06-55-04 intel-ucode/06-2d-07 intel-ucode/06-3e-04 intel-ucode/06-3f-04 "
+CONFIG_EXTRA_FIRMWARE="intel-ucode/06-2d-07 intel-ucode/06-3f-02 intel-ucode/06-3e-04 intel-ucode/06-2c-02 intel-ucode/06-3f-04 intel-ucode/06-1a-05 intel-ucode/06-55-04 intel-ucode/06-55-07 intel-ucode/06-2d-06 intel-ucode/06-4f-01 amd-ucode/microcode_amd.bin amd-ucode/microcode_amd_fam15h.bin amd-ucode/microcode_amd_fam17h.bin amd-ucode/microcode_amd_fam16h.bin "
 CONFIG_EXTRA_FIRMWARE_DIR="/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/firmware"
 CONFIG_FW_LOADER_USER_HELPER=y
 # CONFIG_FW_LOADER_USER_HELPER_FALLBACK is not set
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
