### PR TITLE
generate bottlerocket rpm inventory file to share with host containers

### DIFF
--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -5,6 +5,7 @@ Version: 1.0
 Release: 1%{?dist}
 Summary: The basic directory layout
 License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
 BuildArch: noarch
 
 %description

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -6,6 +6,7 @@ Version: 0.0
 Release: 0%{?dist}
 Summary: Bottlerocket host container runner
 License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}containerd
 

--- a/packages/login/login.spec
+++ b/packages/login/login.spec
@@ -5,6 +5,7 @@ Version: 0.0.1
 Release: 1%{?dist}
 Summary: A login helper
 License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
 Source0: login
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}bash

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -9,6 +9,7 @@ Version: 0.0
 Release: 0%{?dist}
 Summary: Bottlerocket's first-party code
 License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
 
 # sources < 100: misc
 Source2: api-sysusers.conf

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -5,6 +5,7 @@ Version: 0.0
 Release: 0%{?dist}
 Summary: Bottlerocket release
 License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
 
 Source11: nsswitch.conf
 Source96: release-repart-local.conf

--- a/packages/selinux-policy/selinux-policy.spec
+++ b/packages/selinux-policy/selinux-policy.spec
@@ -6,6 +6,7 @@ Version: 0.0
 Release: 0%{?dist}
 Summary: SELinux policy
 License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
 
 # CIL policy files
 Source0: base.cil

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -700,6 +700,12 @@ func withDefaultMounts(containerID string, persistentDir string) oci.SpecOpts {
 			Destination: fmt.Sprintf("/etc/bottlerocket-release"),
 			Source:      fmt.Sprintf("/etc/os-release"),
 		},
+		// Bottlerocket RPM inventory available to the container
+		{
+			Options:     []string{"bind", "ro"},
+			Destination: fmt.Sprintf("/var/lib/bottlerocket/inventory/application.json"),
+			Source:      fmt.Sprintf("/usr/share/bottlerocket/application-inventory.json"),
+		},
 	}
 
 	// The `current` dir was added for easier referencing in Dockerfiles and scripts.

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -8,6 +8,7 @@ shopt -qs failglob
 . "${0%/*}/partyplanner"
 
 OUTPUT_FMT="raw"
+BUILDER_ARCH="$(uname -m)"
 
 for opt in "$@"; do
    optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -135,7 +136,38 @@ if [ "${PARTITION_PLAN}" == "split" ] ; then
     --sort --print "${DATA_IMAGE}"
 fi
 
+INSTALL_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 rpm -iv --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
+
+# inventory installed packages
+INVENTORY_QUERY="\{\"Name\":\"%{NAME}\"\
+,\"Publisher\":\"Bottlerocket\"\
+,\"Version\":\"${VERSION_ID}\"\
+,\"Release\":\"${BUILD_ID}\"\
+,\"InstalledTime\":\"${INSTALL_TIME}\"\
+,\"ApplicationType\":\"%{GROUP}\"\
+,\"Architecture\":\"%{ARCH}\"\
+,\"Url\":\"%{URL}\"\
+,\"Summary\":\"%{Summary}\"\}\n"
+
+mapfile -t installed_rpms <<< "$(rpm -qa --root "${ROOT_MOUNT}" \
+  --queryformat "${INVENTORY_QUERY}")"
+
+# wrap installed_rpms mapfile into json
+INVENTORY_DATA="$(jq --raw-output . <<<  "${installed_rpms[@]}")"
+# replace the package architecture with the target architecture (for cross-compiled builds)
+if [[ "${BUILDER_ARCH}" != "${ARCH}" ]]; then
+  INVENTORY_DATA="$(jq --arg BUILDER_ARCH "${BUILDER_ARCH}" --arg TARGET_ARCH "${ARCH}" \
+                  '(.Architecture) |= sub($BUILDER_ARCH; $TARGET_ARCH)' <<< "${INVENTORY_DATA}")"
+fi
+# remove the 'bottlerocket-<arch>-' prefix from package names
+INVENTORY_DATA="$(jq --arg PKG_PREFIX "bottlerocket-${ARCH}-" \
+                '(.Name) |= sub($PKG_PREFIX; "")' <<< "${INVENTORY_DATA}")"
+# sort by package name and add 'Content' as top-level
+INVENTORY_DATA="$(jq --slurp 'sort_by(.Name)' <<< "${INVENTORY_DATA}" | jq '{"Content": .}')"
+printf "%s\n" "${INVENTORY_DATA}" > "${ROOT_MOUNT}/usr/share/bottlerocket/application-inventory.json"
+
+# install licenses
 install -p -m 0644 /host/{COPYRIGHT,LICENSE-APACHE,LICENSE-MIT} "${ROOT_MOUNT}"/usr/share/licenses/
 mksquashfs \
   "${ROOT_MOUNT}"/usr/share/licenses \


### PR DESCRIPTION
**Description of changes:**

This grants host containers context to the underlying Bottlerocket OS packages by generating a JSON-formatted inventory file at the time of RPM install and mounting it as read-only to `/var/lib/bottlerocket/inventory/application.json`.

**Testing done:**

- Built `aws-k8s-1.21` instance.
- `cat` mounted file in both the control and admin host containers.

**Example output:**

https://gist.github.com/jpculp/c1aa3142ce8917eeec47fc170f74873d

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
