### PR TITLE
Makefile: lock tuftool install

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -705,6 +705,7 @@ script = [
 '''
 cargo install \
   --jobs ${BUILDSYS_JOBS} \
+  --locked \
   --root tools \
   --quiet \
   --version ${PUBLISH_TUFTOOL_VERSION} \


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
When we install tuftool, this locks the dependencies to the versions at
the time of tuftool's publication so random dependency changes won't
break our builds.


**Testing done:**
Can still build tuftool with an older rustc version that doesn't have `edition 2021` features.
```
[ec2-user@ip-172-31-32-162 bottlerocket]$ cargo make tuftool
[cargo-make] INFO - cargo make 0.35.1
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: tuftool
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: tuftool
[cargo-make] INFO - Build Done in 230.38 seconds.
[ec2-user@ip-172-31-32-162 bottlerocket]$ rustc --version
rustc 1.51.0 (2fd73fabe 2021-03-23)

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
