### PR TITLE
documentation: explain data partition extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,10 @@ For more details, see the [API system documentation](sources/api/).
 ### Default Volumes
 
 Bottlerocket operates with two default storage volumes.
-* The root device, `/dev/xvda`, holds the active and passive [partition sets](#updates-1).
+* The root device, holds the active and passive [partition sets](#updates-1).
   It also contains the bootloader, the dm-verity hash tree for verifying the [immutable root filesystem](SECURITY_FEATURES.md#immutable-rootfs-backed-by-dm-verity), and the data store for the Bottlerocket API.
-* The data device, `/dev/xvdb`, is used as persistent storage for container images, container orchestration, [host-containers](#Custom-host-containers), and [bootstrap containers](#Bootstrap-containers-settings).
+* The data device is used as persistent storage for container images, container orchestration, [host-containers](#Custom-host-containers), and [bootstrap containers](#Bootstrap-containers-settings).
+
+On boot Bottlerocket will increase the data partition size to use all of the data device.
+If you increase the size of the device, you can reboot Bottlerocket to extend the data partition.
+If you need to extend the data partition without rebooting, have a look at this [discussion](https://github.com/bottlerocket-os/bottlerocket/discussions/2011).


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2012

**Description of changes:**

Adds a note in the documentation about how you can extend the data partition by rebooting and points to existing discussion about doing so without rebooting.

**Testing done:**

Testing was done during discussion #2011

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
