### PR TITLE
host-containers: update admin to v0.8.0, update control to v0.6.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -106,3 +106,7 @@ version = "1.6.2"
     "migrate_v1.6.2_container-registry-credentials.lz4",
     "migrate_v1.6.2_container-registry-credentials-metadata.lz4",
 ]
+"(1.6.2, 1.7.0)" = [
+    "migrate_v1.7.0_aws-admin-container-v0-8-0.lz4",
+    "migrate_v1.7.0_public-admin-container-v0-8-0.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -108,5 +108,7 @@ version = "1.6.2"
 ]
 "(1.6.2, 1.7.0)" = [
     "migrate_v1.7.0_aws-admin-container-v0-8-0.lz4",
+    "migrate_v1.7.0_aws-control-container-v0-6-0.lz4",
     "migrate_v1.7.0_public-admin-container-v0-8-0.lz4",
+    "migrate_v1.7.0_public-control-container-v0-6-0.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -430,6 +430,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-8-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-control-container-v0-5-5"
 version = "0.1.0"
 dependencies = [
@@ -2511,6 +2518,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-7-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-8-0"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -444,6 +444,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-6-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2539,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-5-5"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-6-0"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -44,7 +44,9 @@ members = [
     "api/migration/migrations/v1.6.2/container-registry-credentials",
     "api/migration/migrations/v1.6.2/container-registry-credentials-metadata",
     "api/migration/migrations/v1.7.0/aws-admin-container-v0-8-0",
+    "api/migration/migrations/v1.7.0/aws-control-container-v0-6-0",
     "api/migration/migrations/v1.7.0/public-admin-container-v0-8-0",
+    "api/migration/migrations/v1.7.0/public-control-container-v0-6-0",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -43,6 +43,8 @@ members = [
     "api/migration/migrations/v1.6.2/add-cfsignal",
     "api/migration/migrations/v1.6.2/container-registry-credentials",
     "api/migration/migrations/v1.6.2/container-registry-credentials-metadata",
+    "api/migration/migrations/v1.7.0/aws-admin-container-v0-8-0",
+    "api/migration/migrations/v1.7.0/public-admin-container-v0-8-0",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.7.0/aws-admin-container-v0-8-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.7.0/aws-admin-container-v0-8-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-8-0"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.7.0/aws-admin-container-v0-8-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.7.0/aws-admin-container-v0-8-0/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.4";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.8.0";
+
+/// We bumped the version of the default admin container from v0.7.4 to v0.8.0
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.7.0/aws-control-container-v0-6-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.7.0/aws-control-container-v0-6-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-6-0"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.7.0/aws-control-container-v0-6-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.7.0/aws-control-container-v0-6-0/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.5";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.0";
+
+/// We bumped the version of the default control container from v0.5.5 to v0.6.0
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.7.0/public-admin-container-v0-8-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.7.0/public-admin-container-v0-8-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-8-0"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.7.0/public-admin-container-v0-8-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.7.0/public-admin-container-v0-8-0/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0";
+
+/// We bumped the version of the default admin container from v0.7.4 to v0.8.0
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.7.0/public-control-container-v0-6-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.7.0/public-control-container-v0-6-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-6-0"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.7.0/public-control-container-v0-6-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.7.0/public-control-container-v0-6-0/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.5";
+const NEW_CONTROL_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.0";
+
+/// We bumped the version of the default control container from v0.5.5 to v0.6.0
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_SOURCE_VAL,
+        new_val: NEW_CONTROL_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.7.4"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.8.0"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.5.5"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.0"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0"
 
 [settings.host-containers.control]
 enabled = false

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.5.5"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.0"


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/1967

**Description of changes:**

* admin-container: **0.7.4 → 0.8.0**
* control-container **0.5.5 → 0.6.0**

**Testing done:**
- [x] aws-k8s-1.21 (x86_64)
- [x] vmware-k8s-1.21 (x86_64) (thanks, @etungsten!)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.