### PR TITLE
kmod-5.10-nvidia: fix tmpfilesd configurations

### DIFF
--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -84,7 +84,9 @@ install -d %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/{drivers,ld.so.conf.d}
 
 KERNEL_VERSION=$(cat %{kernel_sources}/include/config/kernel.release)
-sed -e "s|__KERNEL_VERSION__|${KERNEL_VERSION}|" %{S:200} > nvidia.conf
+sed \
+  -e "s|__KERNEL_VERSION__|${KERNEL_VERSION}|" \
+  -e "s|__PREFIX__|%{_cross_prefix}|" %{S:200} > nvidia.conf
 install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
 
 # Install modules-load.d drop-in to autoload required kernel modules

--- a/packages/kmod-5.10-nvidia/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-5.10-nvidia/nvidia-tmpfiles.conf.in
@@ -1,1 +1,2 @@
-D /lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla 0755 root root -
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla 0755 root root - -


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
Now the directory to store the NVIDIA kernel module is created using the
full path with `PREFIX`, instead of the symliked directory `/lib/modules`
```


**Testing done:**
Launched a host with GPUs and `aws-k8s-1.21-nvidia`, I verified the kernel modules were linked and loaded:

```
bash-5.0# systemctl status link-kernel-modules.service
● link-kernel-modules.service - Link additional kernel modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/link-kernel-modules.service; enabled; vendor preset: enabled)
     Active: active (exited) since Thu 2022-03-24 03:57:37 UTC; 56min ago
   Main PID: 2612 (code=exited, status=0/SUCCESS)

Mar 24 03:57:36 localhost systemd[1]: Starting Link additional kernel modules...
Mar 24 03:57:36 localhost driverdog[2612]: 03:57:36 [INFO] Linked object 'nvidia-modeset.o'
Mar 24 03:57:36 localhost driverdog[2612]: 03:57:36 [INFO] Stripped object 'nvidia-modeset.o'
Mar 24 03:57:37 localhost driverdog[2612]: 03:57:37 [INFO] Linked object 'nvidia.o'
Mar 24 03:57:37 localhost driverdog[2612]: 03:57:37 [INFO] Stripped object 'nvidia.o'
Mar 24 03:57:37 localhost driverdog[2612]: 03:57:37 [INFO] Linked nvidia-modeset.ko
Mar 24 03:57:37 localhost driverdog[2612]: 03:57:37 [INFO] Linked nvidia-uvm.ko
Mar 24 03:57:37 localhost driverdog[2612]: 03:57:37 [INFO] Linked nvidia.ko
Mar 24 03:57:37 localhost systemd[1]: Finished Link additional kernel modules.

bash-5.0# lsmod | grep nvidia
nvidia_modeset       1159168  0
nvidia_uvm           1138688  0
nvidia              34799616  2 nvidia_uvm,nvidia_modeset
drm                   606208  1 nvidia
i2c_core               98304  2 nvidia,drm

bash-5.0# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "9672f002",
    "pretty_name": "Bottlerocket OS 1.6.2 (aws-k8s-1.21-nvidia)",
    "variant_id": "aws-k8s-1.21-nvidia",
    "version_id": "1.6.2"
  }
}

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
