### PR TITLE
Update third party packages for 1.7.0

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,13 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.5.3/aws-iam-authenticator-0.5.3.tar.gz"
-sha512 = "430af9fd04b9a94205a485281fb668f5bc18cdac569de0232fa98e08ebb0e08a8d233537bd3373a5f1e53cf529bc2050aebc34a4a53c8b29a831070e34213210"
-
-# This blob includes a patch which updates the vendored go dependencies of aws-iam-authenticator, which weren't updated upstream for the 0.5.3 release.
-[[package.metadata.build-package.external-files]]
-url = "https://cache.bottlerocket.aws/aws-iam-authenticator-0.5.3-Update-vendored-go-dependencies.patch/39c9ef0c143b4a6c1374c24cdd7a13a8f5662f206a3200f6d07224359ec0f8350e1456510e9c891fd2e01ac9d261b2d51239a03883b88f1936d8735a01d3bf5f/aws-iam-authenticator-0.5.3-Update-vendored-go-dependencies.patch"
-sha512 = "39c9ef0c143b4a6c1374c24cdd7a13a8f5662f206a3200f6d07224359ec0f8350e1456510e9c891fd2e01ac9d261b2d51239a03883b88f1936d8735a01d3bf5f"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.5.5/aws-iam-authenticator-0.5.5.tar.gz"
+sha512 = "24c2a7fd141f921e18c17f4c7e90bbf5325cc6fad3b35753c0da2d879cf64d8f6af0130f8c45ec7693d6fce043181abbd04a911e6fa778f686bd5c313631ed0f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.5.3
+%global gover 0.5.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -15,9 +15,6 @@ License: Apache-2.0
 URL: https://%{goimport}
 Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
 Source1000: clarify.toml
-
-# 0.5.3 release did not include necessary vendored dependencies.
-Patch0001: aws-iam-authenticator-0.5.3-Update-vendored-go-dependencies.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -12,5 +12,5 @@ path = "pkg.rs"
 releases-url = "https://curl.se/docs/caextract.html"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2021-10-26.pem"
-sha512 = "bcc17f23eb54f943c13c6e8b3b0a7e8b72dc9971720249b3eb7a493a66db21d572ba7eedf4f96d8efd6243c3e89f3e258e59ebc9010bce01556b4112ec7d4a3b"
+url = "https://curl.haxx.se/ca/cacert-2022-03-18.pem"
+sha512 = "ef82868c7d0ea1ff708a4f63cd8f10158384931f39ba2300bbf1ffcc3ff3fea2282f8f78cf74a78d0b93d83297e2cfcabb7427a463d3199087b708b624aabc42"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2021.10.26
+Version: 2022.03.18
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2021-10-26.pem
+Source0: https://curl.haxx.se/ca/cacert-2022-03-18.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.5.9/containerd-1.5.9.tar.gz"
-sha512 = "13d5b8bcfd811b1abf67008d1c664962f315cd45d885adaa88847bcc4f1c5d743dccd62bc34fe77348ca18a4f8841ce7a8a022cccb275b19b59017b3fbf1054b"
+url = "https://github.com/containerd/containerd/archive/v1.5.11/containerd-1.5.11.tar.gz"
+sha512 = "6348f4ae7f9b473aac7d5e7325ca4539345d09f01b95383cec28f09d5e5b0b831e25fe305c3a15050f1e1959948ee8dcad788a1d6dd4780cf3077132d5617ef8"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.5.9
+%global gover 1.5.11
 %global rpmver %{gover}
-%global gitrev 1407cab509ff0d96baa4f0eb6ff9980270e6e620
+%global gitrev 3df54a852345ae127d1fa3092b95168e4a88e2f8
 
 %global _dwz_low_mem_die_limit 0
 
@@ -28,9 +28,6 @@ Source1000: clarify.toml
 
 # TODO: submit this upstream, including a unit test.
 Patch1001: 1001-cri-set-default-RLIMIT_NOFILE.patch
-
-# CVE-2022-23648
-Patch2001: Use-fs.RootPath-when-mounting-volumes-1.5.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v20.10.12/cli-20.10.12.tar.gz"
-sha512 = "ac7c997f5751f2e34b9bcb9f026d3d0c2cd58c32a13e9255536b0eb0d7eabd81c42f2d608c0fe7725322b619f2360818b08379e847d598dd0bec570602ad224f"
+url = "https://github.com/docker/cli/archive/v20.10.14/cli-20.10.14.tar.gz"
+sha512 = "f8b7f1040eccd404e39ec33bcef8bb8423636b0695af65f84c0612e77223844892d219f82cfbb99ccd5326e228f8af27be1870d90ebace77810ea5fce9f86e4a"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 20.10.12
+%global gover 20.10.14
 %global rpmver %{gover}
-%global gitrev e91ed5707e038b02af3b5120fa0835c5bedfd42e
+%global gitrev a224086349269551becacce16e5842ceeb2a98d6
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v20.10.12/moby-20.10.12.tar.gz"
-sha512 = "f4122c8cbc67e6b7703856dc76d6f15d7fab1b2001d4916b89958d5319c16d8b8445881841ef4804e8d47d64694184aec1be93e22d7baceb021c4a99c2c03753"
+url = "https://github.com/moby/moby/archive/v20.10.14/moby-20.10.14.tar.gz"
+sha512 = "94ee555337aaf96bb95ce8cbe8fe1d9c8b87fcd4f256d2af5082fc47915f7576882929c1211ef7fba0c754097bdef5e6df59abbdf77456d3babe139f4353ed21"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 20.10.12
+%global gover 20.10.14
 %global rpmver %{gover}
-%global gitrev 459d0dfbbb51fb2423a43655e6c62368ec0f36c9
+%global gitrev 87a90dc786bda134c9eb02adbae2c6a7342fb7f6
 
 %global source_date_epoch 1363394400
 

--- a/packages/ecs-agent/0008-bottlerocket-Add-missing-go-build-tags.patch
+++ b/packages/ecs-agent/0008-bottlerocket-Add-missing-go-build-tags.patch
@@ -1,0 +1,22 @@
+From c4cc8914418857649958fabd789b6e61453a0ada Mon Sep 17 00:00:00 2001
+From: "Sean P. Kelly" <seankell@amazon.com>
+Date: Wed, 23 Mar 2022 11:39:32 +0000
+Subject: [PATCH 8/8] bottlerocket Add missing go build tags
+
+---
+ agent/async/ttl_cache_test.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/agent/async/ttl_cache_test.go b/agent/async/ttl_cache_test.go
+index 0a319d7..dbf6794 100644
+--- a/agent/async/ttl_cache_test.go
++++ b/agent/async/ttl_cache_test.go
+@@ -1,4 +1,5 @@
+ //go:build unit
++// +build unit
+ 
+ // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ //
+-- 
+2.32.0
+

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.58.0/amazon-ecs-agent-v1.58.0.tar.gz"
-sha512 = "f8636874c81fd99afc219f9bb6153dfc1f5fc2c6e6a025ec734450d6b2a7410646ad629ef23d2f2249f36e90b69a8b69b5e923adb71f07b3c46ecfe87c138b6a"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.60.0/amazon-ecs-agent-v1.60.0.tar.gz"
+sha512 = "0734544463d52d264ef058386766cfdfc9db119e842ddb9a6c0d61f2e089946343693e78e1c5ad966dacfafd42bc6014d359b843f83193f3eb92f763491d6dc6"
 
 # The ECS agent repository includes two CNI plugins as git submodules.  git
 # archive does not include submodules, so the tarball above does not include

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,9 +2,9 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.58.0
+%global agent_gover 1.60.0
 # git rev-parse --short=8
-%global agent_gitrev 80ad4ca4
+%global agent_gitrev f5ac255d
 
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
@@ -70,6 +70,7 @@ Patch0005: 0005-bottlerocket-fix-procfs-path-on-host.patch
 # Bottlerocket-specific - add duplicate +build directives to support Go 1.16
 Patch0006: 0006-bottlerocket-Revert-removing-duplicate-build-tags.patch
 Patch0007: 0007-bottlerocket-Revert-Updating-the-go-build-tags-as-pa.patch
+Patch0008: 0008-bottlerocket-Add-missing-go-build-tags.patch
 
 # Bottlerocket-specific - filesystem location for ECS CNI plugins
 Patch1001: 1001-bottlerocket-default-filesystem-locations.patch

--- a/packages/findutils/Cargo.toml
+++ b/packages/findutils/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://ftp.gnu.org/pub/gnu/findutils"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/pub/gnu/findutils/findutils-4.8.0.tar.xz"
-sha512 = "eaa2da304dbeb2cd659b9210ac37da1bde4cd665c12a818eca98541c5ed5cba1050641fc0c39c0a446a5a7a87a8d654df0e0e6b0cee21752ea485188c9f1071e"
+url = "https://ftp.gnu.org/pub/gnu/findutils/findutils-4.9.0.tar.xz"
+sha512 = "ba4844f4403de0148ad14b46a3dbefd5a721f6257c864bf41a6789b11705408524751c627420b15a52af95564d8e5b52f0978474f640a62ab86a41d20cf14be9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/findutils/findutils.spec
+++ b/packages/findutils/findutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}findutils
-Version: 4.8.0
+Version: 4.9.0
 Release: 1%{?dist}
 Summary: A set of GNU tools for finding
 License: GPL-3.0-or-later

--- a/packages/kubernetes-1.18/kubelet-kubeconfig
+++ b/packages/kubernetes-1.18/kubelet-kubeconfig
@@ -20,7 +20,7 @@ users:
 {{#if settings.kubernetes.cluster-name}}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: "/usr/bin/aws-iam-authenticator"
       args:
       - token

--- a/packages/kubernetes-1.19/kubelet-kubeconfig
+++ b/packages/kubernetes-1.19/kubelet-kubeconfig
@@ -20,7 +20,7 @@ users:
 {{#if settings.kubernetes.cluster-name}}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: "/usr/bin/aws-iam-authenticator"
       args:
       - token

--- a/packages/kubernetes-1.20/kubelet-kubeconfig
+++ b/packages/kubernetes-1.20/kubelet-kubeconfig
@@ -20,7 +20,7 @@ users:
 {{#if settings.kubernetes.cluster-name}}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: "/usr/bin/aws-iam-authenticator"
       args:
       - token

--- a/packages/kubernetes-1.21/Cargo.toml
+++ b/packages/kubernetes-1.21/Cargo.toml
@@ -15,8 +15,8 @@ package-name = "kubernetes-1.21"
 releases-url = "https://github.com/kubernetes/kubernetes/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/kubernetes/archive/v1.21.9/kubernetes-1.21.9.tar.gz"
-sha512 = "d334cab0fa3c173c12eb73c2f6f34a8745447525c6524ebd556cd18587345012e518a2ddb77484f48e01f4bbd795177b0c8b067bdf66715f60a70b0566ac66e8"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.21.11/kubernetes-1.21.11.tar.gz"
+sha512 = "9b8c92f277c2621015fab67832b8d89a9b2c0227a5ca884a58b959de717af9a3c601acaa6522d758673a628943b93ae23b8a95819b5daf4e0419509ec99408a6"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.21/kubelet-kubeconfig
+++ b/packages/kubernetes-1.21/kubelet-kubeconfig
@@ -20,7 +20,7 @@ users:
 {{#if settings.kubernetes.cluster-name}}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: "/usr/bin/aws-iam-authenticator"
       args:
       - token

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.21.9
+%global gover 1.21.11
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.22/kubelet-kubeconfig
+++ b/packages/kubernetes-1.22/kubelet-kubeconfig
@@ -20,7 +20,7 @@ users:
 {{#if settings.kubernetes.cluster-name}}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: "/usr/bin/aws-iam-authenticator"
       args:
       - token

--- a/packages/libdbus/Cargo.toml
+++ b/packages/libdbus/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://dbus.freedesktop.org/releases/dbus"
 
 [[package.metadata.build-package.external-files]]
-url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.12.20.tar.gz"
-sha512 = "0964683bc6859374cc94e42e1ec0cdb542cca67971c205fcba4352500b6c0891665b0718e7d85eb060c81cb82e3346c313892bc02384da300ddd306c7eef0056"
+url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.12.22.tar.gz"
+sha512 = "0a716022f9d693fcaf871b6dfb5f242b49a8dd05d3316ec3e530f5129f1d81a2fa9caec795fa62cfdcba6ed21549fdd2f896f9bf1cc9a96e2a7d04f2c7ec7be6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libdbus
-Version: 1.12.20
+Version: 1.12.22
 Release: 1%{?dist}
 Summary: Library for a message bus
 License: AFL-2.1 OR GPL-2.0-or-later

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/libexpat/libexpat/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libexpat/libexpat/releases/download/R_2_4_4/expat-2.4.4.tar.xz"
-sha512 = "c88a82f4732e27340eb9480c082bcc909b0284e16b368ee9feeb4e2dd058e8f7c42fd48feacd5272cc76cb78bd183df33eb5d0b135fdd1d3c493cb156572ab76"
+url = "https://github.com/libexpat/libexpat/releases/download/R_2_4_7/expat-2.4.7.tar.xz"
+sha512 = "e1a16cd48fcd6c4974dc7058d2e0284e0f91565835ec93f16d3f2c79647124470e5edb9f88f1ab9df5f403883a527750a4d63b941bd26fd43c05cd6f42bdcc48"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -1,4 +1,4 @@
-%global unversion 2_4_4
+%global unversion 2_4_7
 
 Name: %{_cross_os}libexpat
 Version: %(echo %{unversion} | sed 's/_/./g')

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -12,17 +12,17 @@ path = "pkg.rs"
 releases-url = "https://download.gnome.org/sources/glib"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.71/glib-2.71.1.tar.xz"
-sha512 = "eda37d883d27f63eef38a811ce824783d39c6454712d7b7e48507da5d53ff0aebbd05bdf82a6ae5395c0c09d4cdee8ac5ec27ba3d4ff868f146043906876d967"
+url = "https://download.gnome.org/sources/glib/2.72/glib-2.72.0.tar.xz"
+sha512 = "351ff025d26348112584bed2c1052427150a8a2f8642c813dae1583fb105184528ad20e264cdf44bbca658a26c280e36acd0e642add112d29edc1b25dfc94fad"
 
 [[package.metadata.build-package.external-files]]
 url = "https://downloads.sourceforge.net/pcre/pcre-8.37.tar.bz2"
 sha512 = "19344c9add2ebbd26c528505d07d3b028d79bc3e6103d51453a449cebd76bc76f5bc7ddd9ef0de41f98c50be74a2d9a65db539ed60f1add1086d99bde8a81466"
 
 [[package.metadata.build-package.external-files]]
-url = "https://wrapdb.mesonbuild.com/v2/pcre_8.37-2/get_patch"
-path = "pcre_8.37-2_patch.zip"
-sha512 = "601790189ce5553b71931f6eec2bb167f74de53736e84b68fd5e1d8658661b3239782ac9c4cd1eb8c87fbbcdb49f5cd6954d6f48d47c6ef8895ee55bc70f15b8"
+url = "https://wrapdb.mesonbuild.com/v2/pcre_8.37-4/get_patch"
+path = "pcre_8.37-4_patch.zip"
+sha512 = "4cb2164d6a335594f64743cfc75fe16310618cb91ddd4c4fa0015b07a54390620ca379b05f1659e2224a2916b1b976b07d6d6efa4e2a1330d3957fbb9611fbc5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,15 +1,15 @@
 Name: %{_cross_os}libglib
-Version: 2.71.1
+Version: 2.72.0
 Release: 1%{?dist}
 Summary: The GLib libraries
 # glib2 is LGPL-2.1-only
 # pcre is BSD-3-Clause
 License: LGPL-2.1-only AND BSD-3-Clause
 URL: https://www.gtk.org/
-Source0: https://download.gnome.org/sources/glib/2.70/glib-%{version}.tar.xz
+Source0: https://download.gnome.org/sources/glib/2.72/glib-%{version}.tar.xz
 # Note: the pcre version is specified in the glib archive in subprojects/libpcre.wrap
 Source1: https://downloads.sourceforge.net/pcre/pcre-8.37.tar.bz2
-Source2: https://wrapdb.mesonbuild.com/v2/pcre_8.37-2/get_patch#/pcre_8.37-2_patch.zip
+Source2: https://wrapdb.mesonbuild.com/v2/pcre_8.37-4/get_patch#/pcre_8.37-4_patch.zip
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libffi-devel

--- a/packages/libnetfilter_conntrack/Cargo.toml
+++ b/packages/libnetfilter_conntrack/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://netfilter.org/projects/libnetfilter_conntrack/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-1.0.8.tar.bz2"
-sha512 = "ddc70e7e3f2d764ed1e115e4a03fe8848b8c04bd69eea0952e63131dd4dae3c23f33b8be518673e1ec3b5dbf708f5f86eac97be46fe265d95386a5e902bd0b82"
+url = "https://netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-1.0.9.tar.bz2"
+sha512 = "e8b03425aaba3b72e6034c215656c34176d0550c08e0455aaeb1365d9141505d0c4feaa8978c8ccf2b7af9db6c9e874ceb866347e533b41cb03a189884f4004c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
+++ b/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnetfilter_conntrack
-Version: 1.0.8
+Version: 1.0.9
 Release: 1%{?dist}
 Summary: Library for netfilter conntrack
 License: GPL-2.0-or-later

--- a/packages/libpcre/Cargo.toml
+++ b/packages/libpcre/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/PhilipHazel/pcre2/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.37/pcre2-10.37.tar.bz2"
-sha512 = "69f4bf4736b986e0fc855eedb292efe72a0df2e803bc0e61a6cf47775eed433bb1b2f28d7e641591ef4603d47beb543a64ed0eef9538d00f0746bc3435c143ec"
+url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-10.39.tar.bz2"
+sha512 = "b3d898198f4b5ffc3453d2ba56fe2a7298c01c52e5f67d45f1e046fc0dee62e16a4024fcb65839ac9c367beedb531647affd6f8599fbeb102f19423c150d80d4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libpcre/libpcre.spec
+++ b/packages/libpcre/libpcre.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libpcre
-Version: 10.37
+Version: 10.39
 Release: 1%{?dist}
 Summary: Library for regular expressions
 License: BSD-3-Clause

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/besser82/libxcrypt/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/archive/v4.4.27/libxcrypt-4.4.27.tar.gz"
-sha512 = "83b5854ca4b928522b8f4bf865331a50e3ffb3c873727e406a87a96408398c00cb617f68224c3413ed976d8060aa60bdea730e0fc8b0321a163d0b4ec496ce10"
+url = "https://github.com/besser82/libxcrypt/archive/v4.4.28/libxcrypt-4.4.28.tar.gz"
+sha512 = "1ba699345c6437ce32210e07fdce8fdb3ce813133ca4f0ba1950dec0067fa7c2d67ee11d196815b4f9a800796f9273c622f71118ce2e9bbb391f8e0214b6e455"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.27
+Version: 4.4.28
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/readline/Cargo.toml
+++ b/packages/readline/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://ftp.gnu.org/gnu/readline"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz"
-sha512 = "27790d0461da3093a7fee6e89a51dcab5dc61928ec42e9228ab36493b17220641d5e481ea3d8fee5ee0044c70bf960f55c7d3f1a704cf6b9c42e5c269b797e00"
+url = "https://ftp.gnu.org/gnu/readline/readline-8.1.2.tar.gz"
+sha512 = "b512275c8aa8b3b3178366c6d681f867676fc1c881e375134a88e9c860a448535e04ca43df727817fd0048261e48203e88bd1c086e86572022d1d65fb0350e4d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/readline/readline.spec
+++ b/packages/readline/readline.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}readline
-Version: 8.1
+Version: 8.1.2
 Release: 1%{?dist}
 Summary: A library for editing typed command lines
 License: GPL-3.0-or-later


### PR DESCRIPTION
**Issue number:** #1964



**Description of changes:**
This updates our dependencies under `packages/` to the latest upstream versions, minus a few:
* open-vm-tools: This has moved to a new minor update (rather than a patch update) and requires further evaluation
* nvidia-related packages -- excluded for now mostly because I'm still coming up to speed on how they're packaged, and don't want to otherwise block our updates. Here's what's yet to come:
    * libnvidia-container
    * nvidia-container-toolkit
    * nvidia-k8s-device-plugin



**Testing done:**
* [x] sketchy testing of k8s 1.22 x86 against a k8s 1.21 cluster
* [x] k8s 1.22 x86 (with help from @etungsten)
* [x] k8s 1.21 aarch64
* [x] k8s 1.20 x86
* [x] k8s 1.19 aarch64
* [x] k8s 1.18 x86
* [x] ecs-1 aarch64


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
