### PR TITLE
Dependabot updates to rust dependencies 

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2374,17 +2374,6 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
-dependencies = [
- "base64",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "pem"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
@@ -3709,7 +3698,7 @@ dependencies = [
  "log",
  "olpc-cjson",
  "path-absolutize",
- "pem 1.0.2",
+ "pem",
  "percent-encoding",
  "reqwest",
  "ring",
@@ -4054,7 +4043,7 @@ version = "0.22.2"
 dependencies = [
  "lazy_static",
  "log",
- "pem 0.8.3",
+ "pem",
  "webpki 0.21.4",
 ]
 

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -23,14 +23,14 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
 name = "actix-codec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36c014a3e811624313b51a227b775ecba55d36ef9462bbaac7d4f13e54c9271"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
  "bitflags",
  "bytes",
@@ -40,14 +40,14 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-rc.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08aac516b88cb8cfbfa834c76b58607ffac75946d947dcb6a9ffc5673e1e875d"
+checksum = "a5885cb81a0d4d0d322864bea1bb6c2a8144626b4fdc625d4c51eba197e7797a"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.0-rc.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6506dbef336634ff35d994d58daa0a412ea23751f15f9b4dcac4d594b1ed1f"
+checksum = "eb60846b52c118f2f04a56cc90880a274271c489b2498623d58176f8ca21fa80"
 dependencies = [
  "bytestring",
  "firestorm",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-rc.2"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73170d019de2d82c0d826c1f315c3106134bd764e9247505ba6f0d78d22dfe9e"
+checksum = "f4e5ebffd51d50df56a3ae0de0e59487340ca456f05dd0b90c0a7a6dd6a74d31"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -166,6 +166,7 @@ dependencies = [
  "actix-utils",
  "ahash",
  "bytes",
+ "bytestring",
  "cfg-if",
  "derive_more",
  "encoding_rs",
@@ -189,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-actors"
-version = "4.0.0-beta.11"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf2ef3eae6001ac2fa6690b2f8b152c00b5b8b2248e3e30f82dd2ec1e941345"
+checksum = "31efe7896f3933ce03dd4710be560254272334bb321a18fd8ff62b1a557d9d19"
 dependencies = [
  "actix",
  "actix-codec",
@@ -1460,7 +1461,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -3677,6 +3678,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,7 +3741,19 @@ checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -10,10 +10,10 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-actix = { version = "0.12", default-features = false, features = ["macros"] }
+actix = { version = "0.12.0", default-features = false, features = ["macros"] }
 actix-rt = "2"
-actix-web = { version = "4.0.0-rc.2", default-features = false }
-actix-web-actors = { version = "4.0.0-beta.11", default-features = false }
+actix-web = { version = "4.0.1", default-features = false }
+actix-web-actors = { version = "4.0.0", default-features = false }
 bytes = "1.1"
 bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
 datastore = { path = "../datastore", version = "0.1.0" }

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -59,9 +59,6 @@ skip = [
     # older version used by clap 2.34.0, via cargo-readme
     { name = "strsim", version = "0.8.0" },
 
-    # older version used by webpki-roots 0.21.1
-    { name = "pem", version = "0.8.3" },
-
     # older version used by chrono 0.4.19
     { name = "time", version = "0.1.43" },
 ]

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -56,7 +56,7 @@ skip = [
     { name = "nix", version = "0.22.0" },
 
     # newer version used by model-derive and darling
-    # older version used by clap 2.33.3, via cargo-readme and structopt
+    # older version used by clap 2.34.0, via cargo-readme
     { name = "strsim", version = "0.8.0" },
 
     # older version used by webpki-roots 0.21.1

--- a/sources/webpki-roots-shim/Cargo.toml
+++ b/sources/webpki-roots-shim/Cargo.toml
@@ -20,5 +20,5 @@ exclude = ["README.md"]
 [dependencies]
 lazy_static = "1.4.0"
 log = "0.4"
-pem = "0.8.1"
+pem = "1.0.2"
 webpki = "0.21.0"

--- a/sources/webpki-roots-shim/src/lib.rs
+++ b/sources/webpki-roots-shim/src/lib.rs
@@ -29,7 +29,13 @@ lazy_static::lazy_static! {
 fn tls_server_roots_pem() -> Vec<Pem> {
     match std::fs::read(&*CERT_PATH) {
         Ok(data) => {
-            let mut v = pem::parse_many(&data);
+            let mut v = match pem::parse_many(&data) {
+                Ok(v) => v,
+                Err(err) => {
+                    error!("failed to parse {}: {}", CERT_PATH.display(), err);
+                    Vec::new()
+                }
+            };
             v.shrink_to_fit();
             v
         }

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -194,7 +194,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66dbfc9307f5b2429656e07533613cd3f26803fd2857fc33be22aa2711181d58"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "percent-encoding",
  "regex",
@@ -238,10 +238,25 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+dependencies = [
+ "atty",
+ "bitflags",
+ "indexmap",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -821,7 +836,7 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "clap",
+ "clap 3.1.8",
  "hex",
  "log",
  "pubsys-config",
@@ -1075,6 +1090,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,7 +1222,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "clap",
+ "clap 3.1.8",
  "coldsnap",
  "duct",
  "futures",
@@ -1954,12 +1978,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -2035,6 +2065,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/tools/infrasys/Cargo.toml
+++ b/tools/infrasys/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-async-trait = "0.1.53"  
-clap = "2.33"  
+async-trait = "0.1.53"
+clap = "3.1"
 hex = "0.4.0"
-log = "0.4.14"  
+log = "0.4.14"
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 rusoto_cloudformation = { version = "0.47", default-features = false, features = ["rustls"] }
 rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }
@@ -18,10 +18,10 @@ rusoto_s3 = { version = "0.47", default-features = false, features = ["rustls"] 
 serde_json = "1.0.66"
 serde_yaml = "0.8.17"
 sha2 = "0.10"
-shell-words = "1.0.0" 
+shell-words = "1.0.0"
 simplelog = "0.11"
 snafu = "0.7"
-structopt = { version = "0.3", default-features = false }  
+structopt = { version = "0.3", default-features = false }
 tokio = { version = "~1.8", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
 toml = "0.5"
 url = "2.2.2"

--- a/tools/infrasys/src/main.rs
+++ b/tools/infrasys/src/main.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::{fs, process};
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use tokio::runtime::Runtime;
 use url::Url;
 

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-trait = "0.1.53"
 chrono = "0.4"
-clap = "2.33"
+clap = "3.1"
 coldsnap = { version = "0.3", default-features = false, features = ["rusoto-rustls"]}
 duct = "0.13.0"
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -24,7 +24,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::PathBuf;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use wait::wait_for_ami;
 
 /// Builds Bottlerocket AMIs using latest build artifacts

--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -12,7 +12,7 @@ use rusoto_ssm::SsmClient;
 use snafu::{ensure, ResultExt};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 
 /// Copies sets of SSM parameters
 #[derive(Debug, StructOpt)]

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::iter::FromIterator;
 use std::path::PathBuf;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 
 /// Grants or revokes permissions to Bottlerocket AMIs
 #[derive(Debug, StructOpt)]

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::iter::FromIterator;
 use std::path::PathBuf;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 
 /// Sets SSM parameters based on current build information
 #[derive(Debug, StructOpt)]

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -32,7 +32,7 @@ use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::ResultExt;
 use std::path::PathBuf;
 use std::process;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use tokio::runtime::Runtime;
 
 fn run() -> Result<()> {

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -21,7 +21,7 @@ use std::fs::{self, File};
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use tempfile::NamedTempFile;
 use tough::{
     editor::signed::PathExists,

--- a/tools/pubsys/src/repo/check_expirations/mod.rs
+++ b/tools/pubsys/src/repo/check_expirations/mod.rs
@@ -11,7 +11,7 @@ use snafu::{OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::PathBuf;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use tough::{ExpirationEnforcement, Repository, RepositoryLoader};
 use url::Url;
 

--- a/tools/pubsys/src/repo/refresh_repo/mod.rs
+++ b/tools/pubsys/src/repo/refresh_repo/mod.rs
@@ -13,7 +13,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use std::fs;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use tough::editor::RepositoryEditor;
 use tough::key_source::{KeySource, LocalKeySource};
 use tough::{ExpirationEnforcement, RepositoryLoader};

--- a/tools/pubsys/src/repo/validate_repo/mod.rs
+++ b/tools/pubsys/src/repo/validate_repo/mod.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 use std::sync::mpsc;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use tough::{Repository, RepositoryLoader};
 use url::Url;
 

--- a/tools/pubsys/src/vmware/upload_ova/mod.rs
+++ b/tools/pubsys/src/vmware/upload_ova/mod.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::fs;
 use std::path::PathBuf;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 use tempfile::NamedTempFile;
 use tinytemplate::TinyTemplate;
 


### PR DESCRIPTION
**Description of changes:**

This is a collection of rust dependency updates brought on by dependabot.

**Testing done:**

- Built and launched aws-k8s-1.21 instance.
- Verified the instance connected to the cluster.
- Enabled and interacted with the admin container via `apiclient exec`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
