### PR TITLE
Support for ECS Agent parameters ImagePullBehavior and WarmPoolsSupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,13 +432,17 @@ These settings can be changed at any time.
 * `settings.ecs.loglevel`: The level of verbosity for the ECS agent's logs.
   Supported values are `debug`, `info`, `warn`, `error`, and `crit`, and the default is `info`.
 * `settings.ecs.enable-spot-instance-draining`: If the instance receives a spot termination notice, the agent will set the instance's state to `DRAINING`, so the workload can be moved gracefully before the instance is removed. Defaults to `false`.
-
+* `settings.ecs.image-pull-behavior`: The behavior used to customize the [pull image process](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-agent-availparam) for your container instances.
+  Supported values are `default`, `always`, `once`, `prefer-cached`, and the default is `default`.
 #### CloudFormation signal helper settings
 
 For AWS variants, these settings allow you to set up CloudFormation signaling to indicate whether Bottlerocket hosts running in EC2 have been successfully created or updated:
 * `settings.cloudformation.should-signal`: Whether to check status and send signal. Defaults to `false`. If set to `true`, both `stack-name` and `logical-resource-id` need to be specified.
 * `settings.cloudformation.stack-name`: Name of the CloudFormation Stack to signal.
 * `settings.cloudformation.logical-resource-id`: The logical ID of the AutoScalingGroup resource that you want to signal.
+
+#### Auto Scaling group settings
+* `settings.autoscaling.should-wait`: Whether to wait for the instance to reach the `InService` state before the orchestrator agent joins the cluster. Defaults to `false`. Set this to `true` only if the instance is part of an Auto Scaling group, or will be attached to one later.
 
 #### OCI Hooks settings
 

--- a/Release.toml
+++ b/Release.toml
@@ -118,4 +118,6 @@ version = "1.7.2"
     "migrate_v1.8.0_boot-setting.lz4",
     "migrate_v1.8.0_boot-setting-metadata.lz4",
     "migrate_v1.8.0_kubelet-pod-pids-limit.lz4",
+    "migrate_v1.8.0_add-pull-behavior.lz4",
+    "migrate_v1.8.0_add-autoscaling.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -217,7 +217,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-autoscaling"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "add-cfsignal"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "add-pull-behavior"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",
@@ -1139,6 +1153,7 @@ dependencies = [
  "cargo-readme",
  "constants",
  "log",
+ "models",
  "schnauzer",
  "serde",
  "serde_json",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -51,6 +51,8 @@ members = [
     "api/migration/migrations/v1.8.0/boot-setting",
     "api/migration/migrations/v1.8.0/boot-setting-metadata",
     "api/migration/migrations/v1.8.0/kubelet-pod-pids-limit",
+    "api/migration/migrations/v1.8.0/add-pull-behavior",
+    "api/migration/migrations/v1.8.0/add-autoscaling",
 
     "bottlerocket-release",
 

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -15,6 +15,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1"
 schnauzer = { path = "../schnauzer", version = "0.1.0" }
 log = "0.4"
+models = { path = "../../models", version = "0.1.0" }
 simplelog = "0.11"
 snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS

--- a/sources/api/migration/migrations/v1.8.0/add-autoscaling/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/add-autoscaling/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "add-autoscaling"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.8.0/add-autoscaling/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/add-autoscaling/src/main.rs
@@ -1,0 +1,21 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a setting prefix for configuring autoscaling.
+/// Remove the whole `settings.autoscaling` prefix if we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec!["settings.autoscaling"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.8.0/add-pull-behavior/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/add-pull-behavior/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "add-pull-behavior"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.8.0/add-pull-behavior/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/add-pull-behavior/src/main.rs
@@ -1,0 +1,20 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added one new settings for configuring ecs-agent, `settings.ecs.image-pull-behavior`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&["settings.ecs.image-pull-behavior"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/ecs.toml
+++ b/sources/models/shared-defaults/ecs.toml
@@ -12,6 +12,7 @@ affected-services = ["ecs"]
 
 [settings.ecs]
 allow-privileged-containers = false
+image-pull-behavior = "default"
 logging-drivers = ["json-file", "awslogs", "none"]
 loglevel = "info"
 
@@ -26,3 +27,7 @@ affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-con
 # Image registry credentials
 [metadata.settings.container-registry.credentials]
 affected-services = ["ecs", "host-containers", "bootstrap-containers"]
+
+# AutoScaling
+[settings.autoscaling]
+should-wait = false

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, CloudFormationSettings, ECSSettings, HostContainer,
-    KernelSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, ECSSettings,
+    HostContainer, KernelSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
+    PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -27,4 +27,5 @@ struct Settings {
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, CloudFormationSettings, ECSSettings, HostContainer,
-    KernelSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, ECSSettings,
+    HostContainer, KernelSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
+    PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -27,4 +27,5 @@ struct Settings {
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -141,13 +141,13 @@ use std::net::IpAddr;
 use crate::de::{deserialize_mirrors, deserialize_node_taints};
 use crate::modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, DNSDomain,
-    ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
-    KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesCloudProvider,
-    KubernetesClusterName, KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey,
-    KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
-    KubernetesTaintValue, KubernetesThresholdValue, Lockdown, PemCertificateString,
-    SingleLineString, SysctlKey, TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64,
-    ValidLinuxHostname,
+    ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
+    FriendlyVersion, Identifier, KubernetesAuthenticationMode, KubernetesBootstrapToken,
+    KubernetesCloudProvider, KubernetesClusterName, KubernetesDurationValue,
+    KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue, KubernetesQuantityValue,
+    KubernetesReservedResourceKey, KubernetesTaintValue, KubernetesThresholdValue, Lockdown,
+    PemCertificateString, SingleLineString, SysctlKey, TopologyManagerPolicy, TopologyManagerScope,
+    Url, ValidBase64, ValidLinuxHostname,
 };
 
 // Kubernetes static pod manifest settings
@@ -216,6 +216,7 @@ struct ECSSettings {
     logging_drivers: Vec<SingleLineString>,
     loglevel: ECSAgentLogLevel,
     enable_spot_instance_draining: bool,
+    image_pull_behavior: ECSAgentImagePullBehavior,
 }
 
 #[model]
@@ -329,6 +330,12 @@ struct CloudFormationSettings {
     should_signal: bool,
     stack_name: SingleLineString,
     logical_resource_id: SingleLineString,
+}
+
+// AutoScaling settings
+#[model]
+struct AutoScalingSettings {
+    should_wait: bool,
 }
 
 ///// Internal services

--- a/sources/models/src/modeled_types/ecs.rs
+++ b/sources/models/src/modeled_types/ecs.rs
@@ -228,3 +228,66 @@ mod test_ecs_agent_log_level {
         }
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// ECSAgentImagePullBehavior represents a string that contains a valid ECS Image Pull Behavior for the ECS agent.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ECSAgentImagePullBehavior {
+    inner: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ECSImagePullBehavior {
+    Default = 0,
+    Always,
+    Once,
+    PreferCached,
+}
+
+impl TryFrom<&str> for ECSImagePullBehavior {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        let image_pull_behavior = serde_plain::from_str::<ECSImagePullBehavior>(&input).context(
+            error::InvalidPlainValueSnafu {
+                field: "ecs.image_pull_behavior",
+            },
+        )?;
+        Ok(image_pull_behavior)
+    }
+}
+
+string_impls_for!(ECSAgentImagePullBehavior, "ECSAgentImagePullBehavior");
+
+impl TryFrom<&str> for ECSAgentImagePullBehavior {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        ECSImagePullBehavior::try_from(input)?;
+        Ok(ECSAgentImagePullBehavior {
+            inner: input.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test_ecs_agent_image_pull_behavior {
+    use super::ECSAgentImagePullBehavior;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_vals() {
+        for val in &["default", "always", "once", "prefer-cached"] {
+            ECSAgentImagePullBehavior::try_from(*val).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_vals() {
+        for val in &["", "tomorrow", "never", " "] {
+            ECSAgentImagePullBehavior::try_from(*val).unwrap_err();
+        }
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
None.
I have looked in the backlog and found no task regarding new ecs-agent parameters, so i directly opened the PR.
Maybe WarmPoolsSupport can be used for #1788 (for the ECS part).

**Description of changes:**
Added support for ECS Agent parameters `ImagePullBehavior` and `WarmPoolsSupport`.
(relative to variables ECS_IMAGE_PULL_BEHAVIOR and ECS_WARM_POOLS_CHECK)

Can be configured using the keys:
`settings.ecs.image-pull-behavior`
`settings.ecs.warm-pools-check`

image-pull-behavior can have the values: default, always, once, prefer-cached.

**Testing done:**
executed `cargo make unit-tests`.
Launched Bottlerocket instance using builded ami with user-data:
```
[settings.ecs]
image-pull-behavior = "once"
warm-pools-check = true
```
verified that the content of file `/etc/ecs/ecs.config.json` included the new settings:
```
{
  "InstanceAttributes": {
    "bottlerocket.variant": "aws-ecs-1"
  },
  "PrivilegedDisabled": true,
  "AvailableLoggingDrivers": [
    "json-file",
    "awslogs",
    "none"
  ],
  "WarmPoolsSupport": true,
  "ImagePullBehavior": 2,
  "TaskIAMRoleEnabled": true,
  "TaskIAMRoleEnabledForNetworkHost": true,
  "SELinuxCapable": true,
  "OverrideAWSLogsExecutionRole": true,
  "TaskENIEnabled": true
}
```
Note: `ImagePullBehavior` is a `iota`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
