### PR TITLE
Restart container runtimes when certificates store changes

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -123,4 +123,5 @@ version = "1.7.2"
     "migrate_v1.8.0_etc-hosts.lz4",
     "migrate_v1.8.0_etc-hosts-metadata.lz4",
     "migrate_v1.8.0_cluster-dns-ip-list.lz4",
+    "migrate_v1.8.0_pki-affected-services.lz4"
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2537,6 +2537,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pki-affected-services"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
 name = "pluto"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "api/migration/migrations/v1.8.0/etc-hosts",
     "api/migration/migrations/v1.8.0/etc-hosts-metadata",
     "api/migration/migrations/v1.8.0/cluster-dns-ip-list",
+    "api/migration/migrations/v1.8.0/pki-affected-services",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.8.0/pki-affected-services/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/pki-affected-services/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pki-affected-services"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.8.0/pki-affected-services/build.rs
+++ b/sources/api/migration/migrations/v1.8.0/pki-affected-services/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.8.0/pki-affected-services/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/pki-affected-services/src/main.rs
@@ -1,0 +1,35 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{
+    MetadataListReplacement, ReplaceMetadataListsMigration,
+};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the 'affected-services' list metadata for 'settings.pki' to include
+/// containerd or docker on upgrade, and to remove them on downgrade depending on the
+/// running variant.
+fn run() -> Result<()> {
+    migrate(ReplaceMetadataListsMigration(vec![
+        MetadataListReplacement {
+            setting: "settings.pki",
+            metadata: "affected-services",
+            old_vals: &["pki"],
+            new_vals: if cfg!(variant_runtime = "k8s") {
+                &["pki", "containerd"]
+            } else {
+                &["pki", "docker"]
+            },
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/containerd-cri-pki.toml
+++ b/sources/models/shared-defaults/containerd-cri-pki.toml
@@ -1,0 +1,2 @@
+[metadata.settings.pki]
+affected-services = ["pki", "containerd"]

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -149,6 +149,3 @@ affected-services = ["bootstrap-containers"]
 [services.pki]
 configuration-files = []
 restart-commands = ["/usr/bin/certdog"]
-
-[metadata.settings.pki]
-affected-services = ["pki"]

--- a/sources/models/shared-defaults/docker-pki.toml
+++ b/sources/models/shared-defaults/docker-pki.toml
@@ -1,0 +1,2 @@
+[metadata.settings.pki]
+affected-services = ["pki", "docker"]

--- a/sources/models/src/aws-dev/defaults.d/53-docker-pki.toml
+++ b/sources/models/src/aws-dev/defaults.d/53-docker-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-pki.toml

--- a/sources/models/src/aws-ecs-1-nvidia/defaults.d/54-docker-pki.toml
+++ b/sources/models/src/aws-ecs-1-nvidia/defaults.d/54-docker-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-pki.toml

--- a/sources/models/src/aws-ecs-1/defaults.d/53-docker-pki.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/53-docker-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-pki.toml

--- a/sources/models/src/aws-k8s-1.19/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/models/src/aws-k8s-1.19/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/models/src/aws-k8s-1.22/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/models/src/aws-k8s-1.22/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/models/src/metal-dev/defaults.d/52-docker-pki.toml
+++ b/sources/models/src/metal-dev/defaults.d/52-docker-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-pki.toml

--- a/sources/models/src/metal-k8s-1.22/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/models/src/metal-k8s-1.22/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/models/src/vmware-dev/defaults.d/52-docker-pki.toml
+++ b/sources/models/src/vmware-dev/defaults.d/52-docker-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-pki.toml

--- a/sources/models/src/vmware-k8s-1.22/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/models/src/vmware-k8s-1.22/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml


### PR DESCRIPTION
**Issue number:**
Fixes #2021 


**Description of changes:**

```
ca-certificates: restart container runtimes when certificates store changes

The containerd and docker daemons cache the certificates store, so any
updates to the store will be ignored by the daemons. With this, the
daemons will be restarted whenever the certificates store is updated.
```


**Testing done:**
In aws-ecs-1, aws-k8s-1.21:
- I tried to pull down an image from a local registry, which uses custom CA certificates
- I validated the pull failed before the CA certificates store was updated
- I validated the pull succeeded after the CA certificates store was updated

ECS:

```bash
# Pull image from local registry, with pki.local-registry.trusted=false, which failed as expected
bash-5.0# docker pull <ip>.us-west-2.compute.amazonaws.com:5000/alpine
Using default tag: latest
Error response from daemon: Get "https://<ip>.us-west-2.compute.amazonaws.com:5000/v2/": x509: certificate signed by unknown authority

# Update certificates store to trust custom CA certificate
bash-5.0# apiclient set pki.local-registry.trusted=true
# Successfully pull down image
bash-5.0# docker pull <ip>.us-west-2.compute.amazonaws.com:5000/alpine
Using default tag: latest
latest: Pulling from alpine
df9b9388f04a: Pull complete
Digest: sha256:a777c9c66ba177ccfea23f2a216ff6721e78a662cd17019488c417135299cd89
Status: Downloaded newer image for <ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest
<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest
```

k8s:
I deployed a pod that used an image in my local registry, since k8s variants don't have docker. After I updated the certificates store (like in the ECS test), the image was successfully pulled:


```
  Normal   Pulling    43s (x3 over 79s)  kubelet            Pulling image "<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest"
  Warning  Failed     43s (x3 over 79s)  kubelet            Failed to pull image "<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest": rpc error: code = Unknown desc = failed to pull and unpack image "<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest": failed to resolve reference "<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest": failed to do request: Head "https://<ip>.us-west-2.compute.amazonaws.com:5000/v2/alpine/manifests/latest": x509: certificate signed by unknown authority
  Warning  Failed     43s (x3 over 79s)  kubelet            Error: ErrImagePull
  Normal   BackOff    30s (x3 over 78s)  kubelet            Back-off pulling image "<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest"
  Warning  Failed     30s (x3 over 78s)  kubelet            Error: ImagePullBackOff
  Normal   Pulling    20s                kubelet            Pulling image "<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest"
  Normal   Pulled     20s                kubelet            Successfully pulled image "<ip>.us-west-2.compute.amazonaws.com:5000/alpine:latest" in 73.145474ms
  Normal   Created    20s                kubelet            Created container image
  Normal   Started    20s                kubelet            Started container image

```

- [x] aws-k8s-1.22 upgrade/downgrade
- [x] aws-k8s-1.19 upgrade/downgrade
- [x] aws-k8s-1.22-nvidia upgrade/downgrade
- [x] aws-ecs-1 upgrade/downgrade
- [x] aws-ecs-1-nvidia upgrade/downgrade
- [x] vmware-k8s-1.22 upgrade/downgrade

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
