### PR TITLE
Additional kubernetes GPU docs

### DIFF
--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -383,3 +383,20 @@ You can install them in your cluster by following the `helm install` instruction
 The [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html#install-nvidia-gpu-operator) can also be used to install these tools.
 However, it is cumbersome to select the right subset of features to avoid conflicts with the software included in the variant.
 Therefore we recommend installing the tools individually if they are required.
+
+In hosts with multiple GPUs (ex. EC2 `g4dn` instances) you can assign a GPU per container by specifying the resource in the containers' spec as described in the [official kubernetes documentation](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: test
+      image: amazonlinux:2
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # requesting 1 GPU
+```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following variants support EKS, as described above:
 - `aws-k8s-1.20`
 - `aws-k8s-1.21`
 - `aws-k8s-1.21-nvidia`
+- `aws-k8s-1.22-nvidia`
 
 The following variant supports ECS:
 
@@ -739,6 +740,11 @@ There are a few important caveats about the provided kdump support:
 * Currently, only vmware variants have kdump support enabled
 * The system kernel will reserve 256MB for the crash kernel, only when the host has at least 2GB of memory; the reserved space won't be available for processes running in the host
 * The crash kernel will only be loaded when the `crashkernel` parameter is present in the kernel's cmdline and if there is memory reserved for it
+
+### NVIDIA GPUs Support
+Bottlerocket's `nvidia` variants include the required packages and configurations to leverage NVIDIA GPUs.
+The official AMIs for these variants can be used with EC2 GPU-equipped instance types such as: `p2`, `p3`, `p4`, `g4dn`, `g5` and `g5g`.
+Please see [QUICKSTART-EKS](QUICKSTART-EKS.md#aws-k8s--nvidia-variants) for further details about kubernetes variants.
 
 ## Details
 

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ There are a few important caveats about the provided kdump support:
 ### NVIDIA GPUs Support
 Bottlerocket's `nvidia` variants include the required packages and configurations to leverage NVIDIA GPUs.
 The official AMIs for these variants can be used with EC2 GPU-equipped instance types such as: `p2`, `p3`, `p4`, `g4dn`, `g5` and `g5g`.
-Please see [QUICKSTART-EKS](QUICKSTART-EKS.md#aws-k8s--nvidia-variants) for further details about kubernetes variants.
+Please see [QUICKSTART-EKS](QUICKSTART-EKS.md#aws-k8s--nvidia-variants) for further details about Kubernetes variants.
 
 ## Details
 


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
QUICKSTART-EKS: add NVIDIA GPUs sample configuration

Now the documentation explicitly says that it is possible to use a GPU
per orchestrated container, and references the official kubernetes
documentation to schedule NVIDIA GPUs.
```

```
README: add NVIDIA GPUs section

This adds a new section for NVIDIA GPUs and lists what EC2 instance
types are supported by the official Bottlerocket `nvidia` k8s AMIs.
```



**Testing done:**
- Links work as expected


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
