### PR TITLE
Add support for ap-southeast-3: Jakarta

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2736,8 +2736,7 @@ dependencies = [
 [[package]]
 name = "rusoto_cloudformation"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00db4cfcfc14725c720d881443f2c17607bd80aa20fecd1382a5936cc2db05d"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2750,8 +2749,7 @@ dependencies = [
 [[package]]
 name = "rusoto_core"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "base64",
@@ -2775,8 +2773,7 @@ dependencies = [
 [[package]]
 name = "rusoto_credential"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2793,8 +2790,7 @@ dependencies = [
 [[package]]
 name = "rusoto_eks"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bada849ce4a4836ae23920613144339b23dc0ebfc4d19fbc20f6b7b9d3cb6d9"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2808,8 +2804,7 @@ dependencies = [
 [[package]]
 name = "rusoto_signature"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "base64",
  "bytes",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -91,3 +91,11 @@ debug = true
 # webpki-roots-shim/Cargo.toml for more information about using the right version number.
 [patch.crates-io.webpki-roots]
 path = "webpki-roots-shim"
+
+# This patches rusoto with an upstream commit to support ap-southeast-3
+[patch.crates-io]
+rusoto_cloudformation = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_core = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_credential = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_eks = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_signature = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }

--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -26,6 +26,7 @@ lazy_static! {
         m.insert("ap-south-1", "328549459982");
         m.insert("ap-southeast-1", "328549459982");
         m.insert("ap-southeast-2", "328549459982");
+        m.insert("ap-southeast-3", "386774335080");
         m.insert("ca-central-1", "328549459982");
         m.insert("eu-central-1", "328549459982");
         m.insert("eu-north-1", "328549459982");
@@ -63,6 +64,7 @@ lazy_static! {
         m.insert("ap-south-1", "602401143452");
         m.insert("ap-southeast-1", "602401143452");
         m.insert("ap-southeast-2", "602401143452");
+        m.insert("ap-southeast-3", "296578399912");
         m.insert("ca-central-1", "602401143452");
         m.insert("cn-north-1", "918309763551");
         m.insert("cn-northwest-1", "961992271922");

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -79,3 +79,8 @@ skip-tree = [
 # Deny crates from unknown registries or git repositories.
 unknown-registry = "deny"
 unknown-git = "deny"
+
+allow-git = [
+    # rusoto is patched with an upstream commit to support ap-southeast-3
+    "https://github.com/rusoto/rusoto.git",
+]

--- a/sources/models/shared-defaults/kubernetes-aws.toml
+++ b/sources/models/shared-defaults/kubernetes-aws.toml
@@ -13,7 +13,7 @@ affected-services = ["kubernetes"]
 
 [metadata.settings.kubernetes.pod-infra-container-image]
 setting-generator = "schnauzer settings.kubernetes.pod-infra-container-image"
-template = "{{ pause-prefix settings.aws.region }}/eks/pause-{{ goarch os.arch }}:3.1"
+template = "{{ pause-prefix settings.aws.region }}/eks/pause:3.1-eksbuild.1"
 affected-services = ["kubernetes", "containerd"]
 
 [settings.metrics]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1466,8 +1466,7 @@ dependencies = [
 [[package]]
 name = "rusoto_cloudformation"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00db4cfcfc14725c720d881443f2c17607bd80aa20fecd1382a5936cc2db05d"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1480,8 +1479,7 @@ dependencies = [
 [[package]]
 name = "rusoto_core"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "base64",
@@ -1505,8 +1503,7 @@ dependencies = [
 [[package]]
 name = "rusoto_credential"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1523,8 +1520,7 @@ dependencies = [
 [[package]]
 name = "rusoto_ebs"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618ce34e8ec52dfd0f597608ec21049e4d7379d737b5f2cc339c92b61d096e0d"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1538,8 +1534,7 @@ dependencies = [
 [[package]]
 name = "rusoto_ec2"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92315363c2f2acda29029ce0ce0e58e1c32caf10c9719068a1ec102add3d4878"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1552,8 +1547,7 @@ dependencies = [
 [[package]]
 name = "rusoto_kms"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7892cd2cca7644d33bd6fafdb2236efd3659162fd7b73ca68d3877f0528399c"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1566,8 +1560,7 @@ dependencies = [
 [[package]]
 name = "rusoto_s3"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048c2fe811a823ad5a9acc976e8bf4f1d910df719dcf44b15c3e96c5b7a51027"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1579,8 +1572,7 @@ dependencies = [
 [[package]]
 name = "rusoto_signature"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "base64",
  "bytes",
@@ -1605,8 +1597,7 @@ dependencies = [
 [[package]]
 name = "rusoto_ssm"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050304a18997ab01994d4a452472199088dc0376e61d1f50e2d9675227a0fe0c"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1619,8 +1610,7 @@ dependencies = [
 [[package]]
 name = "rusoto_sts"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7edd42473ac006fd54105f619e480b0a94136e7f53cf3fb73541363678fd92"
+source = "git+https://github.com/rusoto/rusoto?rev=37bac105a0c16d2259f8390c1aeef068db713911#37bac105a0c16d2259f8390c1aeef068db713911"
 dependencies = [
  "async-trait",
  "bytes",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -6,3 +6,16 @@ members = [
     "pubsys-config",
     "pubsys-setup",
 ]
+
+# This patches rusoto with an upstream commit to support ap-southeast-3
+[patch.crates-io]
+rusoto_cloudformation = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_core = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_credential = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_ebs = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_ec2 = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_kms = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_s3 = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_signature = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_ssm = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }
+rusoto_sts = { git = "https://github.com/rusoto/rusoto", rev = "37bac105a0c16d2259f8390c1aeef068db713911" }

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -68,3 +68,8 @@ skip-tree = [
 # Deny crates from unknown registries or git repositories.
 unknown-registry = "deny"
 unknown-git = "deny"
+
+allow-git = [
+    # rusoto is patched with an upstream commit to support ap-southeast-3
+    "https://github.com/rusoto/rusoto.git",
+]


### PR DESCRIPTION
**Issue number:**

#1899 (won't be done until we perform a release and update the docs accordingly)

**Description of changes:**

This commit adds support for **ap-southeast-3** by adding the ECR account IDs to `schnauzer`, while also patching `rusoto` crates with https://github.com/rusoto/rusoto/commit/37bac105a0c16d2259f8390c1aeef068db713911.

This also switches the repository of the pause container, while staying more or less on the same version.

**Testing done:**

Build, publish, and launch...
- [x]  aws-ecs-1
- [x]  aws-k8s-1.21

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
