### PR TITLE
Kernels updates

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/abd0b3e08ff7d32abb916b2664e8de68bd7d16dbbfdcfe8e574d832aa19a3b1e/kernel-5.10.102-99.473.amzn2.src.rpm"
-sha512 = "ed17395fed0480d87e59f80899953641169fae7ef2f34eb74bad66ff92b2eec5c72dbff4a08af49de516cde8fe96218a102857e048073dd6d48fb73be4ef19e0"
+url = "https://cdn.amazonlinux.com/blobstore/3479900579a0dbe61cbe7e6d76620774513369246def8bae42ec791865d68df9/kernel-5.10.109-104.500.amzn2.src.rpm"
+sha512 = "66c840eee5333bb77f8661b14ec07b33ea7b6d9db82c89370c8109c0a315c6ad532364d0c879efd45fff0bfe3855876bbf53b11b5107b0dc55f9d2ac1a59cc6d"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.102
+Version: 5.10.109
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/abd0b3e08ff7d32abb916b2664e8de68bd7d16dbbfdcfe8e574d832aa19a3b1e/kernel-5.10.102-99.473.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/3479900579a0dbe61cbe7e6d76620774513369246def8bae42ec791865d68df9/kernel-5.10.109-104.500.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.4/Cargo.toml
+++ b/packages/kernel-5.4/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/d8a7e800750161a038954b2685ca8c5fb0a0dac22057530c4c0233d60f06c2d3/kernel-5.4.181-99.354.amzn2.src.rpm"
-sha512 = "39903e5164ea966b62ddfa70ffd9a73ba50af363cf87d20011ad8d2f1e471857b79503da75770a1e812058c9cd2a17a88000e6e9a4c44580d3c4210144aa3993"
+url = "https://cdn.amazonlinux.com/blobstore/a120999c2cd538adae1c97c87e6d60f3bcf6f761064204638a5647e06aea1aad/kernel-5.4.188-104.359.amzn2.src.rpm"
+sha512 = "ebb6f8460ddfccc50e89b499563dfa64f1c3228e9fe3cabd20ec1561ca8bf3764a50853b35085742dde3a219ad9314033d8c12cbc2d615f463aab0e062d9a229"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.4
-Version: 5.4.181
+Version: 5.4.188
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/d8a7e800750161a038954b2685ca8c5fb0a0dac22057530c4c0233d60f06c2d3/kernel-5.4.181-99.354.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/a120999c2cd538adae1c97c87e6d60f3bcf6f761064204638a5647e06aea1aad/kernel-5.4.188-104.359.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
kernel-5.10: update to 5.10.109
kernel-5.4: update to 5.4.188
```


**Testing done:**
I ran a pod for each kernel, they work as expected:

```fish
~ ❯ for pod in (kubectl get pods | awk '{ print $1 }' | tail -n +2)
        echo -e "Pod: $pod"
        set --local UNAME (kubectl exec $pod -- uname -a); echo -e "$UNAME \n"
    end

Pod: fedora-59jrw
Linux fedora-59jrw 5.10.109 #1 SMP Wed Apr 20 21:56:38 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

Pod: fedora-ncvpn
Linux fedora-ncvpn 5.10.109 #1 SMP Wed Apr 20 21:57:26 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

Pod: fedora-rwlmq
Linux fedora-rwlmq 5.4.188 #1 SMP Wed Apr 20 22:06:24 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

Pod: fedora-vvpnk
Linux fedora-vvpnk 5.4.188 #1 SMP Wed Apr 20 22:08:32 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
