### PR TITLE
Fix NVIDIA tools dependencies

### DIFF
--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -18,7 +18,6 @@ sha512 = "7bc3601ca5cca5b3ad7f30f9c2453d41452b425811d37209c20b7f375d557666a1369d
 [build-dependencies]
 glibc = { path = "../glibc" }
 libnvidia-container = { path = "../libnvidia-container" }
-nvidia-k8s-device-plugin = { path = "../nvidia-k8s-device-plugin" }
 # This package depends on `shimpei`, but it is built in the `os` package
 # which is expected to be pulled in
 # os = { path = "../os" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -20,7 +20,6 @@ Source3: nvidia-oci-hooks-json
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container
 Requires: %{_cross_os}shimpei
-Requires: %{_cross_os}nvidia-k8s-device-plugin
 
 %description
 %{summary}.

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "kmod-5_10-nvidia",
  "kubernetes-1_21",
  "nvidia-container-toolkit",
+ "nvidia-k8s-device-plugin",
  "release",
 ]
 
@@ -131,6 +132,7 @@ dependencies = [
  "kmod-5_10-nvidia",
  "kubernetes-1_22",
  "nvidia-container-toolkit",
+ "nvidia-k8s-device-plugin",
  "release",
 ]
 
@@ -738,7 +740,6 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "libnvidia-container",
- "nvidia-k8s-device-plugin",
 ]
 
 [[package]]

--- a/variants/aws-k8s-1.21-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.21-nvidia/Cargo.toml
@@ -21,6 +21,7 @@ included-packages = [
     "kubelet-1.21",
     "release",
     "nvidia-container-toolkit",
+    "nvidia-k8s-device-plugin",
     "kmod-5.10-nvidia-tesla-470"
 ]
 kernel-parameters = [
@@ -39,4 +40,5 @@ kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_21 = { path = "../../packages/kubernetes-1.21" }
 release = { path = "../../packages/release" }
 nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
 kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }

--- a/variants/aws-k8s-1.22-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.22-nvidia/Cargo.toml
@@ -21,6 +21,7 @@ included-packages = [
     "kubelet-1.22",
     "release",
     "nvidia-container-toolkit",
+    "nvidia-k8s-device-plugin",
     "kmod-5.10-nvidia-tesla-470"
 ]
 kernel-parameters = [
@@ -39,4 +40,5 @@ kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
 release = { path = "../../packages/release" }
 nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
 kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
In preparation for #1074, we need to fix `nvidia-container-toolkit`'s dependencies so that it doesn't pull down `nvidia-k8s-device-plugin`


```
aws-k8s-1.21-nvidia,aws-k8s-1.22-nvidia: fix NVIDIA tools dependencies

`nvidia-container-toolkit` doesn't depend on `nvidia-k8s-device-plugin`,
and vice versa, they are independent of each other. Thus, they should be
included separately in aws-k8s-*-nvidia images.
```


**Testing done:**
- Build `aws-k8s-1.21-nvidia`/`aws-k8s-1.22-nvidia`
- Run a daemonset with the following configuration, and validated I can use `nvidia-smi`:

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: gpu-tests
spec:
  selector:
    matchLabels:
      name: gpu-tests
  template:
    metadata:
      labels:
        name: gpu-tests
    spec:
      containers:
        - name: gpu-tests
          image: amazonlinux:2
          command: ['sh', '-c', 'sleep infinity']
          resources:
            limits:
               nvidia.com/gpu: 1
          env:
            - name: NVIDIA_DRIVER_CAPABILITIES
              value: all
```

Calls to `nvidia-smi`:

```bash
Pod: gpu-tests-m8lzj
Wed Apr 20 23:48:42 2022
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.4     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   26C    P0    22W / 300W |      0MiB / 16160MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```

```bash
Pod: gpu-tests-w5sd5
Wed Apr 20 23:48:43 2022
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.4     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   27C    P0    22W / 300W |      0MiB / 16160MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

```

I validated `nvidia-k8s-device-plugin.service` is running in both versions:

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f3a9afc8",
    "pretty_name": "Bottlerocket OS 1.7.1 (aws-k8s-1.22-nvidia)",
    "variant_id": "aws-k8s-1.22-nvidia",
    "version_id": "1.7.1"
  }
}
bash-5.1# systemctl status nvidia-k8s-device-plugin.service | head -n 10
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2022-04-20 23:24:53 UTC; 34min ago
   Main PID: 3017 (nvidia-device-p)
      Tasks: 10 (limit: 73527)
     Memory: 16.7M
     CGroup: /system.slice/nvidia-k8s-device-plugin.service
             └─3017 /usr/bin/nvidia-device-plugin

Apr 20 23:24:53 ip-192-168-38-175.us-west-2.compute.internal systemd[1]: Started Start NVIDIA kubernetes device plugin.
```

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f3a9afc8",
    "pretty_name": "Bottlerocket OS 1.7.1 (aws-k8s-1.21-nvidia)",
    "variant_id": "aws-k8s-1.21-nvidia",
    "version_id": "1.7.1"
  }
}
bash-5.1# systemctl status nvidia-k8s-device-plugin.service | head -n 10
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2022-04-20 23:25:26 UTC; 34min ago
   Main PID: 3172 (nvidia-device-p)
      Tasks: 9 (limit: 73527)
     Memory: 15.8M
     CGroup: /system.slice/nvidia-k8s-device-plugin.service
             └─3172 /usr/bin/nvidia-device-plugin

Apr 20 23:25:26 ip-192-168-15-27.us-west-2.compute.internal systemd[1]: Started Start NVIDIA kubernetes device plugin.

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
