### PR TITLE
variants: remove aws-k8s-1.18 reference from Cargo.lock

### DIFF
--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -47,18 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-k8s-1_18"
-version = "0.1.0"
-dependencies = [
- "aws-iam-authenticator",
- "cni",
- "cni-plugins",
- "kernel-5_4",
- "kubernetes-1_18",
- "release",
-]
-
-[[package]]
 name = "aws-k8s-1_19"
 version = "0.1.0"
 dependencies = [
@@ -378,13 +366,6 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "kernel-5_10",
-]
-
-[[package]]
-name = "kubernetes-1_18"
-version = "0.1.0"
-dependencies = [
- "glibc",
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Removes 1.18 variant and k8s-1.18 from `variants/Cargo.lock`


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
