### PR TITLE
Add GPUSupportEnabled to ECS configurations

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1137,6 +1137,7 @@ dependencies = [
  "schnauzer",
  "serde",
  "serde_json",
+ "simplelog",
  "snafu",
  "tokio",
 ]

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -15,6 +15,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1"
 schnauzer = { path = "../schnauzer", version = "0.1.0" }
 log = "0.4"
+simplelog = "0.11"
 snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 

--- a/sources/api/ecs-settings-applier/build.rs
+++ b/sources/api/ecs-settings-applier/build.rs
@@ -9,6 +9,17 @@ fn main() {
     println!("cargo:rerun-if-env-changed=VARIANT");
     if let Ok(variant) = env::var("VARIANT") {
         println!("cargo:rustc-cfg=variant=\"{}\"", variant);
+        let parts = variant.split('-').collect::<Vec<&str>>();
+        println!(
+            "cargo:rustc-cfg=variant_family=\"{}\"",
+            parts[0..2].join("-")
+        );
+        let variant_type = if parts.len() > 3 {
+            parts[3]
+        } else {
+            "general_purpose"
+        };
+        println!("cargo:rustc-cfg=variant_type=\"{}\"", variant_type);
     }
 
     // Check for environment variable "SKIP_README". If it is set,

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -10,6 +10,7 @@ embedded lists.  The structure and names of fields in the document can be found
 use constants;
 use log::debug;
 use serde::Serialize;
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{OptionExt, ResultExt};
 use std::fs;
 use std::path::Path;
@@ -64,6 +65,7 @@ pub(crate) async fn main() -> () {
 
 async fn run() -> Result<()> {
     let args = parse_args(env::args());
+    SimpleLogger::init(LevelFilter::Info, LogConfig::default()).context(error::LoggerSnafu)?;
 
     // Get all settings values for config file templates
     debug!("Requesting settings values");
@@ -188,6 +190,11 @@ mod error {
         #[snafu(display("Failed to read settings: {}", source))]
         Settings {
             source: schnauzer::Error,
+        },
+
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger {
+            source: log::SetLoggerError,
         },
 
         Model,

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -51,6 +51,9 @@ struct ECSConfig {
 
     #[serde(rename = "TaskENIEnabled")]
     task_eni_enabled: bool,
+
+    #[serde(rename = "GPUSupportEnabled")]
+    gpu_support_enabled: bool,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -103,6 +106,8 @@ async fn run() -> Result<()> {
 
         // awsvpc mode is always available
         task_eni_enabled: true,
+
+        gpu_support_enabled: cfg!(variant_type = "nvidia"),
         ..Default::default()
     };
     if let Some(os) = settings.os {

--- a/sources/api/ecs-settings-applier/src/main.rs
+++ b/sources/api/ecs-settings-applier/src/main.rs
@@ -1,11 +1,11 @@
-#[cfg(variant = "aws-ecs-1")]
+#[cfg(variant_family = "aws-ecs")]
 mod ecs;
 
-#[cfg(variant = "aws-ecs-1")]
+#[cfg(variant_family = "aws-ecs")]
 #[tokio::main]
 async fn main() {
     ecs::main().await
 }
 
-#[cfg(not(variant = "aws-ecs-1"))]
+#[cfg(not(variant_family = "aws-ecs"))]
 fn main() {}


### PR DESCRIPTION
**Issue number:**
Closes #2086 


**Description of changes:**

In preparation for #1074, this adds the `GPUSupportEnabled` flag as `false` for the existing ECS variant.

```
Now the value of the `GPUSupportEnabled` flag will be set at
compile-time depending on the variant being built.
```


**Testing done:**

I checked that the `ecs.config.json` file was created with the expected flag set as `false` for the general purpose variant ECS variant:

```
[root@admin]# cat /.bottlerocket/rootfs/etc/ecs/ecs.config.json  | jq
{
  "Cluster": "bottlerocket",
  "InstanceAttributes": {
    "bottlerocket.variant": "aws-ecs-1"
  },
  "PrivilegedDisabled": true,
  "AvailableLoggingDrivers": [
    "json-file",
    "awslogs",
    "none"
  ],
  "TaskIAMRoleEnabled": true,
  "TaskIAMRoleEnabledForNetworkHost": true,
  "SELinuxCapable": true,
  "OverrideAWSLogsExecutionRole": true,
  "TaskENIEnabled": true,
  "GPUSupportEnabled": false
}

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
