### PR TITLE
Include driverdog in vendor variants

### DIFF
--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -578,19 +578,19 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %{_cross_unitdir}/cfsignal.service
 %endif
 
+%if %{_is_vendor_variant}
+%files -n %{_cross_os}driverdog
+%{_cross_bindir}/driverdog
+%{_cross_unitdir}/link-kernel-modules.service
+%{_cross_unitdir}/load-kernel-modules.service
+%endif
+
 %if %{_is_k8s_variant}
 %if %{_is_aws_variant}
 %files -n %{_cross_os}pluto
 %{_cross_bindir}/pluto
 %dir %{_cross_datadir}/eks
 %{_cross_datadir}/eks/eni-max-pods
-%endif
-
-%if %{_is_vendor_variant}
-%files -n %{_cross_os}driverdog
-%{_cross_bindir}/driverdog
-%{_cross_unitdir}/link-kernel-modules.service
-%{_cross_unitdir}/load-kernel-modules.service
 %endif
 
 %files -n %{_cross_os}static-pods


### PR DESCRIPTION
**Issue number:**

N / A


**Description of changes:**

In preparation of #1074, we need to compile `driverdog` for `NVIDIA` variants, not just for aws-k8s-*-nvidia variants

```
Now `driverdog` will be included in all vendor variants regardless of
the orchestrator type.
```


**Testing done:**
- In aws-k8s-1.21-nvidia I checked `driverdog ` was included in the image and that `link-kernel-modules.service` and `load-kernel-modules.service` run as expected:

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "ad2484e4",
    "pretty_name": "Bottlerocket OS 1.7.2 (aws-k8s-1.21-nvidia)",
    "variant_id": "aws-k8s-1.21-nvidia",
    "version_id": "1.7.2"
  }
}
bash-5.1# systemctl status load-kernel-modules.service
● load-kernel-modules.service - Load additional kernel modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-kernel-modules.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2022-04-22 20:48:35 UTC; 3min 32s ago
   Main PID: 2699 (code=exited, status=0/SUCCESS)

Apr 22 20:48:33 localhost systemd[1]: Starting Load additional kernel modules...
Apr 22 20:48:35 ip-172-31-29-12.us-west-2.compute.internal driverdog[2699]: 20:48:35 [INFO] Updated modules dependencies
Apr 22 20:48:35 ip-172-31-29-12.us-west-2.compute.internal driverdog[2699]: 20:48:35 [INFO] Loaded kernel modules
Apr 22 20:48:35 ip-172-31-29-12.us-west-2.compute.internal systemd[1]: Finished Load additional kernel modules.
bash-5.1# systemctl status link-kernel-modules.service
● link-kernel-modules.service - Link additional kernel modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/link-kernel-modules.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2022-04-22 20:48:33 UTC; 3min 36s ago
   Main PID: 2605 (code=exited, status=0/SUCCESS)

Apr 22 20:48:31 localhost systemd[1]: Starting Link additional kernel modules...
Apr 22 20:48:32 localhost driverdog[2605]: 20:48:32 [INFO] Linked object 'nvidia.o'
Apr 22 20:48:32 localhost driverdog[2605]: 20:48:32 [INFO] Stripped object 'nvidia.o'
Apr 22 20:48:33 localhost driverdog[2605]: 20:48:33 [INFO] Linked object 'nvidia-modeset.o'
Apr 22 20:48:33 localhost driverdog[2605]: 20:48:33 [INFO] Stripped object 'nvidia-modeset.o'
Apr 22 20:48:33 localhost driverdog[2605]: 20:48:33 [INFO] Linked nvidia-uvm.ko
Apr 22 20:48:33 localhost driverdog[2605]: 20:48:33 [INFO] Linked nvidia-modeset.ko
Apr 22 20:48:33 localhost driverdog[2605]: 20:48:33 [INFO] Linked nvidia.ko
Apr 22 20:48:33 localhost systemd[1]: Finished Link additional kernel modules.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
