### PR TITLE
kernel: add support for MegaRAID SAS

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -123,3 +123,6 @@ CONFIG_BOOT_CONFIG=y
 
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
+
+# Enables support for LSI Logic's SAS based RAID controllers
+CONFIG_MEGARAID_SAS=y

--- a/packages/kernel-5.4/config-bottlerocket
+++ b/packages/kernel-5.4/config-bottlerocket
@@ -85,3 +85,6 @@ CONFIG_MOUSE_PS2=m
 
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
+
+# Enables support for LSI Logic's SAS based RAID controllers
+CONFIG_MEGARAID_SAS=y


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
    kernel-5.10: add kernel config to enable support for RAID
    
    This adds kernel configs to enable support for MegaRAID SAS RAID
    controllers.

```


**Testing done:**
I was able to boot Bottlerocket from RAID0 on a baremetal server.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
