### PR TITLE
buildsys: variant and readme standardization

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -298,11 +298,11 @@ checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 name = "apiclient"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
  "constants",
  "datastore",
  "futures",
  "futures-channel",
+ "generate-readme",
  "http",
  "httparse",
  "hyper",
@@ -336,10 +336,10 @@ dependencies = [
  "actix-web-actors",
  "bottlerocket-release",
  "bytes",
- "cargo-readme",
  "datastore",
  "fs2",
  "futures",
+ "generate-readme",
  "http",
  "libc",
  "log",
@@ -612,9 +612,9 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "base64",
- "cargo-readme",
  "constants",
  "datastore",
+ "generate-readme",
  "http",
  "log",
  "models",
@@ -637,8 +637,8 @@ dependencies = [
 name = "bottlerocket-release"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
  "envy",
+ "generate-readme",
  "log",
  "semver",
  "serde",
@@ -717,8 +717,8 @@ dependencies = [
  "apiclient",
  "argh",
  "base64",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "http",
  "log",
  "models",
@@ -741,7 +741,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "cfsignal"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
+ "generate-readme",
  "hyper",
  "imdsclient",
  "log",
@@ -787,7 +787,7 @@ dependencies = [
 name = "constants"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
+ "generate-readme",
 ]
 
 [[package]]
@@ -852,8 +852,8 @@ name = "corndog"
 version = "0.1.0"
 dependencies = [
  "apiclient",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "http",
  "log",
  "models",
@@ -981,7 +981,7 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 name = "datastore"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
+ "generate-readme",
  "libc",
  "log",
  "maplit",
@@ -1104,7 +1104,7 @@ name = "driverdog"
 version = "0.1.0"
 dependencies = [
  "argh",
- "cargo-readme",
+ "generate-readme",
  "log",
  "serde",
  "simplelog",
@@ -1126,9 +1126,9 @@ dependencies = [
  "apiclient",
  "async-trait",
  "base64",
- "cargo-readme",
  "constants",
  "flate2",
+ "generate-readme",
  "hex-literal",
  "http",
  "imdsclient",
@@ -1150,8 +1150,8 @@ dependencies = [
 name = "ecs-settings-applier"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
  "constants",
+ "generate-readme",
  "log",
  "models",
  "schnauzer",
@@ -1375,6 +1375,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "generate-readme"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme",
+ "snafu",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,7 +1417,7 @@ name = "ghostdog"
 version = "0.1.0"
 dependencies = [
  "argh",
- "cargo-readme",
+ "generate-readme",
  "gptman",
  "hex-literal",
  "lazy_static",
@@ -1460,7 +1468,7 @@ name = "growpart"
 version = "0.1.0"
 dependencies = [
  "block-party",
- "cargo-readme",
+ "generate-readme",
  "gptman",
  "inotify",
  "libc",
@@ -1552,8 +1560,8 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "base64",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "http",
  "log",
  "models",
@@ -1700,7 +1708,7 @@ dependencies = [
 name = "imdsclient"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
+ "generate-readme",
  "http",
  "httptest",
  "log",
@@ -1854,10 +1862,10 @@ name = "logdog"
 version = "0.1.0"
 dependencies = [
  "apiclient",
- "cargo-readme",
  "constants",
  "datastore",
  "flate2",
+ "generate-readme",
  "glob",
  "models",
  "reqwest",
@@ -1942,7 +1950,7 @@ name = "metricdog"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-release",
- "cargo-readme",
+ "generate-readme",
  "httptest",
  "log",
  "reqwest",
@@ -1975,8 +1983,8 @@ name = "migrator"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-release",
- "cargo-readme",
  "chrono",
+ "generate-readme",
  "log",
  "lz4",
  "nix 0.23.1",
@@ -2054,8 +2062,8 @@ dependencies = [
 name = "model-derive"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
  "darling",
+ "generate-readme",
  "proc-macro2",
  "quote",
  "syn",
@@ -2067,8 +2075,8 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bottlerocket-release",
- "cargo-readme",
  "filetime",
+ "generate-readme",
  "lazy_static",
  "libc",
  "model-derive",
@@ -2088,9 +2096,9 @@ name = "netdog"
 version = "0.1.0"
 dependencies = [
  "argh",
- "cargo-readme",
  "dns-lookup",
  "envy",
+ "generate-readme",
  "indexmap",
  "ipnet",
  "lazy_static",
@@ -2362,8 +2370,8 @@ dependencies = [
 name = "parse-datetime"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
  "chrono",
+ "generate-readme",
  "snafu",
 ]
 
@@ -2496,8 +2504,8 @@ name = "pluto"
 version = "0.1.0"
 dependencies = [
  "apiclient",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "imdsclient",
  "models",
  "rusoto_core",
@@ -2519,8 +2527,8 @@ version = "0.1.0"
 dependencies = [
  "argh",
  "bytes",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "log",
  "maplit",
  "models",
@@ -2740,7 +2748,7 @@ dependencies = [
 name = "retry-read"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
+ "generate-readme",
 ]
 
 [[package]]
@@ -2954,9 +2962,9 @@ dependencies = [
  "apiclient",
  "base64",
  "bottlerocket-release",
- "cargo-readme",
  "constants",
  "dns-lookup",
+ "generate-readme",
  "handlebars",
  "http",
  "lazy_static",
@@ -3088,9 +3096,9 @@ name = "servicedog"
 version = "0.1.0"
 dependencies = [
  "apiclient",
- "cargo-readme",
  "constants",
  "datastore",
+ "generate-readme",
  "http",
  "log",
  "models",
@@ -3106,8 +3114,8 @@ name = "settings-committer"
 version = "0.1.0"
 dependencies = [
  "apiclient",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "http",
  "log",
  "serde",
@@ -3177,7 +3185,7 @@ name = "shibaken"
 version = "0.1.0"
 dependencies = [
  "base64",
- "cargo-readme",
+ "generate-readme",
  "imdsclient",
  "log",
  "serde",
@@ -3191,7 +3199,7 @@ dependencies = [
 name = "shimpei"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
+ "generate-readme",
  "log",
  "nix 0.23.1",
  "simplelog",
@@ -3305,8 +3313,8 @@ name = "static-pods"
 version = "0.1.0"
 dependencies = [
  "base64",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "log",
  "models",
  "schnauzer",
@@ -3323,9 +3331,9 @@ name = "storewolf"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-release",
- "cargo-readme",
  "constants",
  "datastore",
+ "generate-readme",
  "log",
  "merge-toml",
  "models",
@@ -3384,9 +3392,9 @@ name = "sundog"
 version = "0.1.0"
 dependencies = [
  "apiclient",
- "cargo-readme",
  "constants",
  "datastore",
+ "generate-readme",
  "http",
  "log",
  "models",
@@ -3467,8 +3475,8 @@ name = "thar-be-settings"
 version = "0.1.0"
 dependencies = [
  "apiclient",
- "cargo-readme",
  "constants",
+ "generate-readme",
  "handlebars",
  "http",
  "itertools",
@@ -3489,10 +3497,10 @@ version = "0.1.0"
 dependencies = [
  "apiclient",
  "bottlerocket-release",
- "cargo-readme",
  "chrono",
  "constants",
  "fs2",
+ "generate-readme",
  "http",
  "log",
  "models",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -646,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bottlerocket-variant"
+version = "0.1.0"
+dependencies = [
+ "generate-readme",
+ "serde",
+ "snafu",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1135,7 @@ dependencies = [
  "apiclient",
  "async-trait",
  "base64",
+ "bottlerocket-variant",
  "constants",
  "flate2",
  "generate-readme",
@@ -1150,6 +1160,7 @@ dependencies = [
 name = "ecs-settings-applier"
 version = "0.1.0"
 dependencies = [
+ "bottlerocket-variant",
  "constants",
  "generate-readme",
  "log",
@@ -1862,6 +1873,7 @@ name = "logdog"
 version = "0.1.0"
 dependencies = [
  "apiclient",
+ "bottlerocket-variant",
  "constants",
  "datastore",
  "flate2",
@@ -2075,6 +2087,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bottlerocket-release",
+ "bottlerocket-variant",
  "filetime",
  "generate-readme",
  "lazy_static",
@@ -2504,6 +2517,7 @@ name = "pluto"
 version = "0.1.0"
 dependencies = [
  "apiclient",
+ "bottlerocket-variant",
  "constants",
  "generate-readme",
  "imdsclient",
@@ -3313,6 +3327,7 @@ name = "static-pods"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "bottlerocket-variant",
  "constants",
  "generate-readme",
  "log",
@@ -3331,6 +3346,7 @@ name = "storewolf"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-release",
+ "bottlerocket-variant",
  "constants",
  "datastore",
  "generate-readme",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -56,6 +56,8 @@ members = [
 
     "bottlerocket-release",
 
+    "bottlerocket-variant",
+
     "imdsclient",
 
     "driverdog",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -60,6 +60,8 @@ members = [
 
     "driverdog",
 
+    "generate-readme",
+
     "ghostdog",
 
     "growpart",

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -37,4 +37,4 @@ unindent = "0.1"
 url = "2.2.1"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/apiclient/build.rs
+++ b/sources/api/apiclient/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -36,7 +36,7 @@ thar-be-updates = { path = "../thar-be-updates", version = "0.1.0" }
 walkdir = "2.2"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }
 
 [dev-dependencies]
 maplit = "1.0"

--- a/sources/api/apiserver/build.rs
+++ b/sources/api/apiserver/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut lib = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut lib,            // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/api/bootstrap-containers/Cargo.toml
+++ b/sources/api/bootstrap-containers/Cargo.toml
@@ -24,4 +24,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/bootstrap-containers/build.rs
+++ b/sources/api/bootstrap-containers/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -28,4 +28,4 @@ x509-parser = "0.13"
 tempfile = "3.2.0"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/certdog/build.rs
+++ b/sources/api/certdog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -22,4 +22,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/corndog/build.rs
+++ b/sources/api/corndog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/datastore/Cargo.toml
+++ b/sources/api/datastore/Cargo.toml
@@ -19,7 +19,7 @@ snafu = "0.7"
 walkdir = "2.2"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }
 
 [dev-dependencies]
 maplit = "1.0"

--- a/sources/api/datastore/build.rs
+++ b/sources/api/datastore/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut lib = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut lib,            // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -33,7 +33,7 @@ toml = "0.5"
 vmw_backdoor = "0.2"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -33,6 +33,7 @@ toml = "0.5"
 vmw_backdoor = "0.2"
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../../generate-readme" }
 
 [dev-dependencies]

--- a/sources/api/early-boot-config/build.rs
+++ b/sources/api/early-boot-config/build.rs
@@ -1,10 +1,4 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use std::process;
+use std::{env, process};
 
 fn main() {
     // The code below emits `cfg` operators to conditionally compile this program based on the
@@ -29,27 +23,5 @@ fn main() {
         }
     }
 
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/early-boot-config/build.rs
+++ b/sources/api/early-boot-config/build.rs
@@ -1,27 +1,19 @@
-use std::{env, process};
+use bottlerocket_variant::{Variant, VARIANT_ENV};
 
 fn main() {
-    // The code below emits `cfg` operators to conditionally compile this program based on the
-    // current variant.
-    // TODO: Replace this approach when the build system supports ideas like "variant
-    // tags": https://github.com/bottlerocket-os/bottlerocket/issues/1260
-    println!("cargo:rerun-if-env-changed=VARIANT");
-    if let Ok(variant) = env::var("VARIANT") {
-        if variant.starts_with("aws") {
-            println!("cargo:rustc-cfg=bottlerocket_platform=\"aws\"");
-        } else if variant.starts_with("vmware") {
-            println!("cargo:rustc-cfg=bottlerocket_platform=\"vmware\"");
-        } else if variant.starts_with("metal") {
-            println!("cargo:rustc-cfg=bottlerocket_platform=\"metal\"");
-        } else {
+    let variant = match Variant::from_env() {
+        Ok(variant) => variant,
+        Err(e) => {
             eprintln!(
-            "For local builds, you must set the 'VARIANT' environment variable so we know which data \
-            provider to build. Valid values are the directories in models/src/variants/, for \
-            example 'aws-ecs-1'."
+                "For local builds, you must set the '{}' environment variable so we know \
+                which data provider to build. Valid values are the directories in \
+                models/src/variants/, for example 'aws-ecs-1': {}",
+                VARIANT_ENV, e,
             );
-            process::exit(1);
+            std::process::exit(1);
         }
-    }
+    };
+    variant.emit_cfgs();
 
     generate_readme::from_main().unwrap();
 }

--- a/sources/api/early-boot-config/src/provider.rs
+++ b/sources/api/early-boot-config/src/provider.rs
@@ -5,19 +5,19 @@ use async_trait::async_trait;
 
 mod local_file;
 
-#[cfg(bottlerocket_platform = "aws")]
+#[cfg(variant_platform = "aws")]
 mod aws;
-#[cfg(bottlerocket_platform = "aws")]
+#[cfg(variant_platform = "aws")]
 pub(crate) use aws::AwsDataProvider as Platform;
 
-#[cfg(bottlerocket_platform = "vmware")]
+#[cfg(variant_platform = "vmware")]
 mod vmware;
-#[cfg(bottlerocket_platform = "vmware")]
+#[cfg(variant_platform = "vmware")]
 pub(crate) use vmware::VmwareDataProvider as Platform;
 
-#[cfg(bottlerocket_platform = "metal")]
+#[cfg(variant_platform = "metal")]
 mod metal;
-#[cfg(bottlerocket_platform = "metal")]
+#[cfg(variant_platform = "metal")]
 pub(crate) use metal::MetalDataProvider as Platform;
 
 /// Support for new platforms can be added by implementing this trait.

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -21,4 +21,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -21,4 +21,5 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/ecs-settings-applier/build.rs
+++ b/sources/api/ecs-settings-applier/build.rs
@@ -1,9 +1,6 @@
 // Automatically generate README.md from rustdoc.
 
 use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=VARIANT");
@@ -22,27 +19,5 @@ fn main() {
         println!("cargo:rustc-cfg=variant_type=\"{}\"", variant_type);
     }
 
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/ecs.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_file("src/ecs.rs").unwrap();
 }

--- a/sources/api/ecs-settings-applier/build.rs
+++ b/sources/api/ecs-settings-applier/build.rs
@@ -1,23 +1,7 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
+use bottlerocket_variant::Variant;
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=VARIANT");
-    if let Ok(variant) = env::var("VARIANT") {
-        println!("cargo:rustc-cfg=variant=\"{}\"", variant);
-        let parts = variant.split('-').collect::<Vec<&str>>();
-        println!(
-            "cargo:rustc-cfg=variant_family=\"{}\"",
-            parts[0..2].join("-")
-        );
-        let variant_type = if parts.len() > 3 {
-            parts[3]
-        } else {
-            "general_purpose"
-        };
-        println!("cargo:rustc-cfg=variant_type=\"{}\"", variant_type);
-    }
-
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
     generate_readme::from_file("src/ecs.rs").unwrap();
 }

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -128,7 +128,7 @@ async fn run() -> Result<()> {
         // awsvpc mode is always available
         task_eni_enabled: true,
 
-        gpu_support_enabled: cfg!(variant_type = "nvidia"),
+        gpu_support_enabled: cfg!(variant_flavor = "nvidia"),
         ..Default::default()
     };
     if let Some(os) = settings.os {

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -23,4 +23,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/host-containers/build.rs
+++ b/sources/api/host-containers/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -25,7 +25,7 @@ update_metadata = { path = "../../../updater/update_metadata", version = "0.1.0"
 url = "2.1.1"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../../generate-readme" }
 
 [dev-dependencies]
 chrono = "0.4.11"

--- a/sources/api/migration/migrator/build.rs
+++ b/sources/api/migration/migrator/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -28,4 +28,4 @@ toml = { version = "0.5", features = ["preserve_order"] }
 tempfile = "3.2.0"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/netdog/build.rs
+++ b/sources/api/netdog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -21,4 +21,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -21,4 +21,5 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/pluto/build.rs
+++ b/sources/api/pluto/build.rs
@@ -1,9 +1,4 @@
-// Automatically generate README.md from rustdoc.
-
 use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
 
 fn main() {
     // TODO: Replace this approach when the build system supports ideas like "variant
@@ -15,27 +10,5 @@ fn main() {
         }
     }
 
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/pluto/build.rs
+++ b/sources/api/pluto/build.rs
@@ -1,14 +1,7 @@
-use std::env;
+use bottlerocket_variant::Variant;
 
 fn main() {
-    // TODO: Replace this approach when the build system supports ideas like "variant
-    // tags": https://github.com/bottlerocket-os/bottlerocket/issues/1260
-    println!("cargo:rerun-if-env-changed=VARIANT");
-    if let Ok(variant) = env::var("VARIANT") {
-        if variant.starts_with("aws-k8s") {
-            println!("cargo:rustc-cfg=aws_k8s_variant");
-        }
-    }
-
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
     generate_readme::from_main().unwrap();
 }

--- a/sources/api/pluto/src/api.rs
+++ b/sources/api/pluto/src/api.rs
@@ -12,8 +12,7 @@ pub(crate) struct AwsK8sInfo {
 
 /// This code is the 'actual' implementation compiled when the `sources` workspace is being compiled
 /// for `aws-k8s-*` variants.
-// TODO - find a better way https://github.com/bottlerocket-os/bottlerocket/issues/1260
-#[cfg(aws_k8s_variant)]
+#[cfg(variant_family = "aws-k8s")]
 mod inner {
     use super::*;
     use constants;
@@ -62,8 +61,7 @@ mod inner {
 
 /// This dummy code is compiled when the `sources` workspace is being compiled for non `aws-k8s-*`
 /// variants.
-// TODO - find a better way https://github.com/bottlerocket-os/bottlerocket/issues/1260
-#[cfg(not(aws_k8s_variant))]
+#[cfg(not(variant_family = "aws-k8s"))]
 mod inner {
     use super::*;
     use snafu::Snafu;

--- a/sources/api/prairiedog/Cargo.toml
+++ b/sources/api/prairiedog/Cargo.toml
@@ -26,4 +26,4 @@ tokio = { version = "~1.14", default-features = false, features = ["macros", "rt
 maplit = "1.0"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/prairiedog/build.rs
+++ b/sources/api/prairiedog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -29,4 +29,4 @@ url = "2.1"
 num_cpus = "1.0"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/schnauzer/build.rs
+++ b/sources/api/schnauzer/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/servicedog/Cargo.toml
+++ b/sources/api/servicedog/Cargo.toml
@@ -23,4 +23,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/servicedog/build.rs
+++ b/sources/api/servicedog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -21,4 +21,4 @@ simplelog = "0.11"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/settings-committer/build.rs
+++ b/sources/api/settings-committer/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -20,4 +20,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/shibaken/build.rs
+++ b/sources/api/shibaken/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -23,4 +23,4 @@ tokio = { version = "~1.14", default-features = false, features = ["macros", "rt
 tempfile = "3.2.0"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -23,4 +23,5 @@ tokio = { version = "~1.14", default-features = false, features = ["macros", "rt
 tempfile = "3.2.0"
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/static-pods/build.rs
+++ b/sources/api/static-pods/build.rs
@@ -1,14 +1,7 @@
-use std::env;
+use bottlerocket_variant::Variant;
 
 fn main() {
-    // TODO: Replace this approach when the build system supports ideas like "variant
-    // tags": https://github.com/bottlerocket-os/bottlerocket/issues/1260
-    println!("cargo:rerun-if-env-changed=VARIANT");
-    if let Ok(variant) = env::var("VARIANT") {
-        if variant.contains("k8s") {
-            println!("cargo:rustc-cfg=k8s_variant");
-        }
-    }
-
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
     generate_readme::from_file("src/static_pods.rs").unwrap();
 }

--- a/sources/api/static-pods/build.rs
+++ b/sources/api/static-pods/build.rs
@@ -1,9 +1,4 @@
-// Automatically generate README.md from rustdoc.
-
 use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
 
 fn main() {
     // TODO: Replace this approach when the build system supports ideas like "variant
@@ -15,27 +10,5 @@ fn main() {
         }
     }
 
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/static_pods.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_file("src/static_pods.rs").unwrap();
 }

--- a/sources/api/static-pods/src/main.rs
+++ b/sources/api/static-pods/src/main.rs
@@ -1,16 +1,16 @@
 #![deny(rust_2018_idioms)]
 
-#[cfg(k8s_variant)]
+#[cfg(variant_runtime = "k8s")]
 mod static_pods;
-#[cfg(k8s_variant)]
+#[cfg(variant_runtime = "k8s")]
 #[macro_use]
 extern crate log;
 
-#[cfg(k8s_variant)]
+#[cfg(variant_runtime = "k8s")]
 #[tokio::main]
 async fn main() {
     static_pods::main().await
 }
 
-#[cfg(not(k8s_variant))]
+#[cfg(not(variant_runtime = "k8s"))]
 fn main() {}

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -22,6 +22,7 @@ snafu = "0.7"
 toml = "0.5"
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../../generate-readme" }
 merge-toml = { path = "merge-toml", version = "0.1.0" }
 # We have a models build-dep because we read default settings from the models

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -22,7 +22,7 @@ snafu = "0.7"
 toml = "0.5"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }
 merge-toml = { path = "merge-toml", version = "0.1.0" }
 # We have a models build-dep because we read default settings from the models
 # directory and need its build.rs to run first; we also reflect the dependency

--- a/sources/api/storewolf/build.rs
+++ b/sources/api/storewolf/build.rs
@@ -6,6 +6,7 @@
 /// groups of default settings, without having to ship those files in the OS image.  Specifically,
 /// we read any number of files from a defaults.d directory in the variant's model directory and
 /// merge later entries into earlier entries, so later files take precedence.
+use bottlerocket_variant::Variant;
 use merge_toml::merge_values;
 use snafu::ResultExt;
 use std::fs;
@@ -22,7 +23,7 @@ fn main() -> Result<()> {
     generate_defaults_toml()?;
 
     // Reflect that we need to rerun if variant has changed to pick up the new default settings.
-    println!("cargo:rerun-if-env-changed=VARIANT");
+    Variant::rerun_if_changed();
 
     Ok(())
 }

--- a/sources/api/storewolf/build.rs
+++ b/sources/api/storewolf/build.rs
@@ -8,10 +8,8 @@
 /// merge later entries into earlier entries, so later files take precedence.
 use merge_toml::merge_values;
 use snafu::ResultExt;
-use std::env;
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::fs;
+use std::path::Path;
 use toml::{map::Map, Value};
 use walkdir::WalkDir;
 
@@ -30,29 +28,7 @@ fn main() -> Result<()> {
 }
 
 fn generate_readme() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }
 
 /// Merge the variant's default settings files into a single TOML value.  The result is serialized

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -23,4 +23,4 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/sundog/build.rs
+++ b/sources/api/sundog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -25,7 +25,7 @@ snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }
 
 [dev-dependencies]
 maplit = "1.0"

--- a/sources/api/thar-be-settings/build.rs
+++ b/sources/api/thar-be-settings/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -33,4 +33,4 @@ tokio = { version = "~1.14", default-features = false, features = ["macros", "rt
 update_metadata = { path = "../../updater/update_metadata", version = "0.1.0" }
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/thar-be-updates/build.rs
+++ b/sources/api/thar-be-updates/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/bottlerocket-release/Cargo.toml
+++ b/sources/bottlerocket-release/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 snafu = "0.7"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/bottlerocket-release/build.rs
+++ b/sources/bottlerocket-release/build.rs
@@ -1,34 +1,8 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::{env, fs};
 
 fn generate_readme() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }
 
 fn generate_constants() {

--- a/sources/bottlerocket-variant/Cargo.toml
+++ b/sources/bottlerocket-variant/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bottlerocket-variant"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+serde = "1"
+snafu = "0.7"
+
+[build-dependencies]
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/bottlerocket-variant/README.md
+++ b/sources/bottlerocket-variant/README.md
@@ -1,0 +1,10 @@
+# bottlerocket-variant
+
+Current version: 0.1.0
+
+This library provides a structure for representing a Bottlerocket variant as well as functionality
+useful in build scripts and other tooling that is variant-aware.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/bottlerocket-variant/README.tpl
+++ b/sources/bottlerocket-variant/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/bottlerocket-variant/build.rs
+++ b/sources/bottlerocket-variant/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_lib().unwrap();
+}

--- a/sources/bottlerocket-variant/src/lib.rs
+++ b/sources/bottlerocket-variant/src/lib.rs
@@ -1,0 +1,442 @@
+/*!
+This library provides a structure for representing a Bottlerocket variant as well as functionality
+useful in build scripts and other tooling that is variant-aware.
+*/
+
+use error::Error;
+use serde::de::Error as SerdeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::borrow::Borrow;
+use std::convert::TryFrom;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use std::str::FromStr;
+
+/// The name of the environment variable that tells us the current variant. Variant-sensitive crates
+/// will need to be rebuilt if this changes. `Makefile.toml` emits the variant string in the
+/// `BUILDSYS_VARIANT` environment variable. This is then passed to crate builds by the `Dockerfile`
+/// as `VARIANT`.
+pub const VARIANT_ENV: &str = "VARIANT";
+
+/// The default `variant_version`. If the third position of a variant string tuple does not exist,
+/// then the `variant_version` is `"undefined"`.
+pub const DEFAULT_VARIANT_VERSION: &str = "0";
+
+/// The default `variant_flavor`. If the fourth position of a variant string tuple does not exist,
+/// then the variant_flavor cfg will be `"none"`.
+pub const DEFAULT_VARIANT_FLAVOR: &str = "none";
+
+pub type Result<T> = std::result::Result<T, error::Error>;
+
+pub mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub enum Error {
+        #[snafu(display(
+            "The 'VARIANT' environment variable is missing or unable to be read: {}",
+            source
+        ))]
+        VariantEnv { source: std::env::VarError },
+
+        #[snafu(display("The '{}' segment of the variant '{}' is missing", part_name, variant))]
+        VariantPart { part_name: String, variant: String },
+
+        #[snafu(display("The '{}' segment of the variant '{}' is empty", part_name, variant))]
+        VariantPartEmpty { part_name: String, variant: String },
+    }
+}
+
+/// # Variant
+///
+/// Represents a Bottlerocket variant string. These are in the form
+/// `platform-runtime-[variant_version]-[variant_flavor]`.
+///
+/// For example, here are some valid variant strings:
+/// - aws-ecs-1
+/// - vmware-k8s-1.18
+/// - metal-dev
+/// - aws-k8s-1.21-nvidia
+///
+/// The `platform` and `runtime` values are required. `variant_version` and `variant_flavor` values
+/// are optional and will default to `"undefined"` and `"general_purpose"` respectively.
+///
+/// In a `build.rs` file, you may use the function `emit_cfgs()` if you need to conditionally
+/// compile code based on variant characteristics.
+///
+/// # Example
+///
+/// ```rust
+/// use bottlerocket_variant::{Variant, VARIANT_ENV};
+/// std::env::set_var(VARIANT_ENV, "metal-k8s-1.21");
+/// let variant = Variant::from_env().unwrap();
+///
+/// assert_eq!(variant.version().unwrap(), "1.21");
+///
+/// // In a `build.rs` file, you may want to emit cfgs that you can use for conditional compilation.
+/// variant.emit_cfgs();
+/// ```
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Variant {
+    variant: String,
+    platform: String,
+    runtime: String,
+    family: String,
+    version: Option<String>,
+    variant_flavor: Option<String>,
+}
+
+impl Variant {
+    /// Create a new `Variant` from a dash-delimited string. The first two tuple positions,
+    /// `platform` and `runtime` are required. The next two, representing `variant_version` and
+    /// `variant_flavor`, are optional.
+    ///
+    /// # Valid Values
+    ///
+    /// - `aws-dev`
+    /// - `vmware-k8s-1.21`
+    /// - `aws-k8s-1.21-nvidia`
+    /// - `aws-k8s-1.21-nvidia-some-additional-ignored-tuple-positions`
+    ///
+    /// # Invalid Values
+    ///
+    /// - `aws`
+    /// - `aws-dev-`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bottlerocket_variant::Variant;
+    /// let variant = Variant::new("aws-k8s").unwrap();
+    /// assert_eq!(variant.family(), "aws-k8s");
+    /// ```
+    pub fn new<S: Into<String>>(value: S) -> Result<Self> {
+        Self::parse(value)
+    }
+
+    /// Create a new `Variant` from the `VARIANT` environment variable's value. The environment
+    /// variable must exist and its value must be a valid variant string tuple.
+    pub fn from_env() -> Result<Self> {
+        let value = std::env::var(VARIANT_ENV).context(error::VariantEnvSnafu)?;
+        Variant::new(value)
+    }
+
+    /// The variant's platform. This is the first member of the tuple. For example, in `vmware-dev`,
+    /// `vmware` is the platform.
+    pub fn platform(&self) -> &str {
+        &self.platform
+    }
+
+    /// The variant's runtime. This is the second member of the tuple. For example, in
+    /// `metal-k8s-1.21`, `k8s` is the `runtime`.
+    pub fn runtime(&self) -> &str {
+        &self.runtime
+    }
+
+    /// The variant's family. This is the `platform` and `runtime` together. For example, in
+    /// `aws-k8s-1.21`, `aws-k8s` is the `family`.
+    pub fn family(&self) -> &str {
+        &self.family
+    }
+
+    /// The variant's version. This is the optional third value in the variant string tuple. For
+    /// example for `aws-ecs-1` the `version` is `1`. If the `version` does not exist,
+    /// [`DEFAULT_VARIANT_VERSION`] is returned.
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
+    }
+
+    /// The variant's flavor. This is the optional fourth value in the variant string tuple. For
+    /// example for `aws-k8s-1.21-nvidia` the `variant_flavor` is `nvidia`.
+    pub fn variant_flavor(&self) -> Option<&str> {
+        self.variant_flavor.as_deref()
+    }
+
+    /// This can be used in a `build.rs` file to tell cargo that the crate needs to be rebuilt if
+    /// the variant changes.
+    pub fn rerun_if_changed() {
+        println!("cargo:rerun-if-env-changed={}", VARIANT_ENV);
+    }
+
+    /// This can be used in a `build.rs` file to emit `cfg` values that can be used for conditional
+    /// compilation based on variant characteristics. This function also emits rerun-if-changed so
+    /// that variant-sensitive builds will rebuild if the variant changes.
+    ///
+    /// # Example
+    ///
+    /// Given a variant `aws-k8s-1.21`, if this function has been called in `build.rs`, then
+    /// all of the following conditional complition checks would evaluate to `true`.
+    ///
+    /// `#[cfg(variant = "aws-k8s-1.21")]`
+    /// `#[cfg(variant_platform = "aws")]`
+    /// `#[cfg(variant_runtime = "k8s")]`
+    /// `#[cfg(variant_family = "aws-k8s")]`
+    /// `#[cfg(variant_version = "1.21")]`
+    /// `#[cfg(variant_flavor = "none")]`
+    pub fn emit_cfgs(&self) {
+        Self::rerun_if_changed();
+        println!("cargo:rustc-cfg=variant=\"{}\"", self);
+        println!("cargo:rustc-cfg=variant_platform=\"{}\"", self.platform());
+        println!("cargo:rustc-cfg=variant_runtime=\"{}\"", self.runtime());
+        println!("cargo:rustc-cfg=variant_family=\"{}\"", self.family());
+        println!(
+            "cargo:rustc-cfg=variant_version=\"{}\"",
+            self.version().unwrap_or(DEFAULT_VARIANT_VERSION)
+        );
+        println!(
+            "cargo:rustc-cfg=variant_flavor=\"{}\"",
+            self.variant_flavor().unwrap_or(DEFAULT_VARIANT_FLAVOR)
+        );
+    }
+
+    fn parse<S: Into<String>>(value: S) -> Result<Self> {
+        let variant = value.into();
+        let mut parts = variant.split('-');
+        let platform = parts
+            .next()
+            .with_context(|| error::VariantPartSnafu {
+                part_name: "platform",
+                variant: variant.clone(),
+            })?
+            .to_string();
+        ensure!(
+            !platform.is_empty(),
+            error::VariantPartEmptySnafu {
+                part_name: "platform",
+                variant: variant.clone()
+            }
+        );
+        let runtime = parts
+            .next()
+            .with_context(|| error::VariantPartSnafu {
+                part_name: "runtime",
+                variant: variant.clone(),
+            })?
+            .to_string();
+        ensure!(
+            !runtime.is_empty(),
+            error::VariantPartEmptySnafu {
+                part_name: "runtime",
+                variant: variant.clone()
+            }
+        );
+        let variant_family = format!("{}-{}", platform, runtime);
+        let variant_version = parts.next().map(|s| s.to_string());
+        if let Some(value) = variant_version.as_ref() {
+            ensure!(
+                !value.is_empty(),
+                error::VariantPartEmptySnafu {
+                    part_name: "variant_version",
+                    variant: variant.clone()
+                }
+            );
+        }
+        let variant_flavor = parts.next().map(|s| s.to_string());
+        if let Some(value) = variant_flavor.as_ref() {
+            ensure!(
+                !value.is_empty(),
+                error::VariantPartEmptySnafu {
+                    part_name: "variant_flavor",
+                    variant: variant.clone()
+                }
+            );
+        }
+        Ok(Self {
+            variant,
+            platform,
+            runtime,
+            family: variant_family,
+            version: variant_version,
+            variant_flavor,
+        })
+    }
+}
+
+impl FromStr for Variant {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Variant::new(s)
+    }
+}
+
+impl TryFrom<String> for Variant {
+    type Error = Error;
+
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        Variant::new(value)
+    }
+}
+
+impl TryFrom<&str> for Variant {
+    type Error = Error;
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        Variant::new(value)
+    }
+}
+
+impl Serialize for Variant {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.variant)
+    }
+}
+
+impl<'de> Deserialize<'de> for Variant {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Variant, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Variant::new(value).map_err(|e| D::Error::custom(format!("Error parsing variant: {}", e)))
+    }
+}
+
+impl Deref for Variant {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.variant
+    }
+}
+
+impl Borrow<String> for Variant {
+    fn borrow(&self) -> &String {
+        &self.variant
+    }
+}
+
+impl Borrow<str> for Variant {
+    fn borrow(&self) -> &str {
+        &self.variant
+    }
+}
+
+impl AsRef<str> for Variant {
+    fn as_ref(&self) -> &str {
+        &self.variant
+    }
+}
+
+impl Display for Variant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.variant, f)
+    }
+}
+
+impl From<Variant> for String {
+    fn from(x: Variant) -> Self {
+        x.variant
+    }
+}
+
+impl PartialEq<str> for Variant {
+    fn eq(&self, other: &str) -> bool {
+        self.variant == other
+    }
+}
+
+impl PartialEq<String> for Variant {
+    fn eq(&self, other: &String) -> bool {
+        &self.variant == other
+    }
+}
+
+impl PartialEq<&str> for Variant {
+    fn eq(&self, other: &&str) -> bool {
+        &self.variant == other
+    }
+}
+
+impl PartialEq<Variant> for str {
+    fn eq(&self, other: &Variant) -> bool {
+        self == other.variant
+    }
+}
+
+impl PartialEq<Variant> for String {
+    fn eq(&self, other: &Variant) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<Variant> for &str {
+    fn eq(&self, other: &Variant) -> bool {
+        self == &other.variant
+    }
+}
+
+#[test]
+fn parse_ok() {
+    struct Test {
+        input: &'static str,
+        platform: &'static str,
+        runtime: &'static str,
+        variant_family: &'static str,
+        variant_version: Option<&'static str>,
+        variant_flavor: Option<&'static str>,
+    }
+
+    let tests = vec![
+        Test {
+            input: "aws-k8s-1.21",
+            platform: "aws",
+            runtime: "k8s",
+            variant_family: "aws-k8s",
+            variant_version: Some("1.21"),
+            variant_flavor: None,
+        },
+        Test {
+            input: "metal-dev",
+            platform: "metal",
+            runtime: "dev",
+            variant_family: "metal-dev",
+            variant_version: None,
+            variant_flavor: None,
+        },
+        Test {
+            input: "aws-ecs-1",
+            platform: "aws",
+            runtime: "ecs",
+            variant_family: "aws-ecs",
+            variant_version: Some("1"),
+            variant_flavor: None,
+        },
+        Test {
+            input: "aws-k8s-1.21-nvidia-some-additional-ignored-tuple-positions",
+            platform: "aws",
+            runtime: "k8s",
+            variant_family: "aws-k8s",
+            variant_version: Some("1.21"),
+            variant_flavor: Some("nvidia"),
+        },
+    ];
+
+    for test in tests {
+        let parsed = Variant::new(test.input.clone()).unwrap();
+        assert_eq!(parsed, test.input);
+        assert_eq!(test.input, parsed);
+        assert_eq!(parsed.platform(), test.platform.to_string());
+        assert_eq!(parsed.runtime(), test.runtime);
+        assert_eq!(parsed.family(), test.variant_family);
+        assert_eq!(parsed.version(), test.variant_version);
+        assert_eq!(parsed.variant_flavor(), test.variant_flavor);
+    }
+}
+
+#[test]
+fn parse_err() {
+    let tests = vec!["aws", "aws-", "aws-dev-", "aws-k8s-1.21-"];
+    for test in tests {
+        let result = Variant::new(test);
+        assert!(
+            result.is_err(),
+            "Expected Variant::new(\"{}\") to return an error",
+            test
+        );
+    }
+}

--- a/sources/cfsignal/Cargo.toml
+++ b/sources/cfsignal/Cargo.toml
@@ -20,4 +20,4 @@ imdsclient = { path = "../imdsclient", version = "0.1.0" }
 hyper = "0.14.2"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/cfsignal/build.rs
+++ b/sources/cfsignal/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/constants/Cargo.toml
+++ b/sources/constants/Cargo.toml
@@ -11,4 +11,4 @@ exclude = ["README.md"]
 [dependencies]
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/constants/build.rs
+++ b/sources/constants/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/driverdog/Cargo.toml
+++ b/sources/driverdog/Cargo.toml
@@ -18,4 +18,4 @@ tempfile = "3.2.0"
 toml = "0.5.8"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/driverdog/build.rs
+++ b/sources/driverdog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/generate-readme/Cargo.toml
+++ b/sources/generate-readme/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "generate-readme"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+cargo-readme = "3"
+snafu = "0.7"

--- a/sources/generate-readme/src/lib.rs
+++ b/sources/generate-readme/src/lib.rs
@@ -1,0 +1,92 @@
+/*!
+This small lib is used to generate README files for the crates in the `sources` workspace. These
+functions are called in a crate's build.rs file to generate a README from Rust doc comments.
+!*/
+
+use snafu::ResultExt;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub type Result<T> = std::result::Result<T, error::Error>;
+
+pub mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub enum Error {
+        #[snafu(display("Unable to create the 'README.md' file: {}", source))]
+        ReadmeCreate { source: std::io::Error },
+
+        #[snafu(display("Unable to generate the 'README.md' file contents: {}", error))]
+        ReadmeGenerate { error: String },
+
+        #[snafu(display("Unable to open '{}': {}", file.display(), source))]
+        ReadmeSourceOpen {
+            file: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Unable to open 'README.tpl': {}", source))]
+        ReadmeTemplateOpen { source: std::io::Error },
+
+        #[snafu(display("Unable to write to the 'README.md' file: {}", source))]
+        ReadmeWrite { source: std::io::Error },
+    }
+}
+
+/// When this function is called in a `build.rs` file, it will generate a `README.md` (as a sibling
+/// to `build.rs`). It uses the doc comments found in `src/main.rs` and the `cargo-readme` crate to
+/// do so. The template for `cargo-readme` is expected to be `README.tpl` as a sibling file to
+/// `build.rs`.
+pub fn from_main() -> Result<()> {
+    from_file("src/main.rs")
+}
+
+/// When this function is called in a `build.rs` file, it will generate a `README.md` (as a sibling
+/// to `build.rs`). It uses the doc comments found in `src/lib.rs` and the `cargo-readme` crate to
+/// do so. The template for `cargo-readme` is expected to be `README.tpl` as a sibling file to
+/// `build.rs`.
+pub fn from_lib() -> Result<()> {
+    from_file("src/lib.rs")
+}
+
+/// When this function is called in a `build.rs` file, it will generate a `README.md` (as a sibling
+/// to `build.rs`). It uses the doc comments found in `rust_file` and the `cargo-readme` crate to do
+/// so. The template for `cargo-readme` is expected to be `README.tpl` as a sibling file to
+/// `build.rs`.
+pub fn from_file<P>(rust_file: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    // Check for environment variable "SKIP_README". If it is set,
+    // skip README generation
+    if std::env::var_os("SKIP_README").is_some() {
+        return Ok(());
+    }
+
+    let mut source = File::open(rust_file.as_ref()).context(error::ReadmeSourceOpenSnafu {
+        file: rust_file.as_ref(),
+    })?;
+    let mut template = File::open("README.tpl").context(error::ReadmeTemplateOpenSnafu)?;
+
+    let content = cargo_readme::generate_readme(
+        &PathBuf::from("."), // root
+        &mut source,         // source
+        Some(&mut template), // template
+        // The "add x" arguments don't apply when using a template.
+        true,  // add title
+        false, // add badges
+        false, // add license
+        true,  // indent headings
+    )
+    .map_err(|e| error::ReadmeGenerateSnafu { error: e }.build())?;
+
+    let mut readme = File::create("README.md").context(error::ReadmeCreateSnafu)?;
+    readme
+        .write_all(content.as_bytes())
+        .context(error::ReadmeWriteSnafu)?;
+    Ok(())
+}

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -17,4 +17,4 @@ signpost = { path = "../updater/signpost", version = "0.1.0" }
 snafu = "0.7"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/ghostdog/build.rs
+++ b/sources/ghostdog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/growpart/Cargo.toml
+++ b/sources/growpart/Cargo.toml
@@ -16,4 +16,4 @@ block-party = { path = "../updater/block-party", version = "0.1.0" }
 inotify = "0.10"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/growpart/build.rs
+++ b/sources/growpart/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/imdsclient/Cargo.toml
+++ b/sources/imdsclient/Cargo.toml
@@ -20,7 +20,7 @@ tokio-retry = "0.3"
 url = "2.1.1"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }
 
 [dev-dependencies]
 httptest = "0.15"

--- a/sources/imdsclient/build.rs
+++ b/sources/imdsclient/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -26,4 +26,4 @@ url = "2.1.1"
 walkdir = "2.3"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -26,4 +26,5 @@ url = "2.1.1"
 walkdir = "2.3"
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/logdog/build.rs
+++ b/sources/logdog/build.rs
@@ -1,7 +1,5 @@
 // Automatically generate README.md from rustdoc and generate variant symlink
 
-use std::fs::File;
-use std::io::Write;
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::{env, fs, io, process};
@@ -66,29 +64,7 @@ where
 }
 
 fn generate_readme() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }
 
 fn main() {

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -20,7 +20,7 @@ toml = "0.5.1"
 url = "2.1.1"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }
 
 [dev-dependencies]
 httptest = "0.15"

--- a/sources/metricdog/build.rs
+++ b/sources/metricdog/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -25,6 +25,7 @@ x509-parser = "0.13"
 url = "2.1"
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../generate-readme" }
 filetime = "0.2"
 rand = "0.8"

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -25,7 +25,7 @@ x509-parser = "0.13"
 url = "2.1"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }
 filetime = "0.2"
 rand = "0.8"
 

--- a/sources/models/build.rs
+++ b/sources/models/build.rs
@@ -4,18 +4,14 @@
 //
 // See README.md to understand the symlink setup.
 
+use bottlerocket_variant::{Variant, VARIANT_ENV};
 use filetime::{set_symlink_file_times, FileTime};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use std::env;
 use std::fs;
 use std::io;
 use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::process;
-
-/// The name of the environment variable that tells us the current variant; we need to rebuild if
-/// this changes.
-const VARIANT_ENV: &str = "VARIANT";
 
 /// We create a link from 'current' to the variant selected by the environment variable above.
 const VARIANT_LINK: &str = "src/variant/current";
@@ -30,25 +26,32 @@ const MOD_LINK: &str = "src/variant/mod.rs";
 const MOD_LINK_TARGET: &str = "../variant_mod.rs";
 
 fn main() {
+    // The VARIANT variable is originally BUILDSYS_VARIANT, set in the top-level Makefile.toml,
+    // and is passed through as VARIANT by the top-level Dockerfile. It represents which OS variant
+    // we're building, and therefore which API model to use.
+    let variant = match Variant::from_env() {
+        Ok(variant) => variant,
+        Err(e) => {
+            eprintln!(
+                "For local builds, you must set the '{}' environment variable so we know which API \
+                model to build against. Valid values are the directories in variants/, for example \
+                'aws-ecs-1': {}",
+                VARIANT_ENV, e
+            );
+            std::process::exit(1);
+        }
+    };
     // Tell cargo when we have to rerun; we always want variant links to be correct, especially
     // after changing the variant we're building for.
-    println!("cargo:rerun-if-env-changed={}", VARIANT_ENV);
+    Variant::rerun_if_changed();
     println!("cargo:rerun-if-changed={}", VARIANT_LINK);
     println!("cargo:rerun-if-changed={}", MOD_LINK);
 
-    generate_readme();
-    link_current_variant();
+    generate_readme::from_lib().unwrap();
+    link_current_variant(variant);
 }
 
-fn link_current_variant() {
-    // The VARIANT variable is originally BUILDSYS_VARIANT, set in the top-level Makefile.toml,
-    // and is passed through as VARIANT by the top-level Dockerfile.  It represents which OS
-    // variant we're building, and therefore which API model to use.
-    let variant = env::var(VARIANT_ENV).unwrap_or_else(|_| {
-        eprintln!("For local builds, you must set the {} environment variable so we know which API model to build against.  Valid values are the directories in variants/, for example \"aws-ecs-1\".", VARIANT_ENV);
-        process::exit(1);
-    });
-
+fn link_current_variant(variant: Variant) {
     // Point to the source for the requested variant
     let variant_target = format!("../{}", variant);
 
@@ -94,10 +97,6 @@ fn link_current_variant() {
             );
         }
     }
-}
-
-fn generate_readme() {
-    generate_readme::from_lib().unwrap();
 }
 
 // Creates the requested symlink through an atomic swap, so it doesn't matter if the link path

--- a/sources/models/build.rs
+++ b/sources/models/build.rs
@@ -7,10 +7,10 @@
 use filetime::{set_symlink_file_times, FileTime};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::env;
-use std::fs::{self, File};
-use std::io::{self, Write};
+use std::fs;
+use std::io;
 use std::os::unix::fs::symlink;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process;
 
 /// The name of the environment variable that tells us the current variant; we need to rebuild if
@@ -97,29 +97,7 @@ fn link_current_variant() {
 }
 
 fn generate_readme() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut lib = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut lib,            // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }
 
 // Creates the requested symlink through an atomic swap, so it doesn't matter if the link path

--- a/sources/models/model-derive/Cargo.toml
+++ b/sources/models/model-derive/Cargo.toml
@@ -20,4 +20,4 @@ quote = "1.0"
 syn = { version = "1.0", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/models/model-derive/build.rs
+++ b/sources/models/model-derive/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut lib = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut lib,            // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/parse-datetime/Cargo.toml
+++ b/sources/parse-datetime/Cargo.toml
@@ -13,4 +13,4 @@ chrono = "0.4.11"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/parse-datetime/build.rs
+++ b/sources/parse-datetime/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/retry-read/Cargo.toml
+++ b/sources/retry-read/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 exclude = ["README.md"]
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/retry-read/build.rs
+++ b/sources/retry-read/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/lib.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_lib().unwrap();
 }

--- a/sources/shimpei/Cargo.toml
+++ b/sources/shimpei/Cargo.toml
@@ -15,4 +15,4 @@ snafu = "0.7"
 nix = "0.23"
 
 [build-dependencies]
-cargo-readme = "3.1"
+generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/shimpei/build.rs
+++ b/sources/shimpei/build.rs
@@ -1,32 +1,3 @@
-// Automatically generate README.md from rustdoc.
-
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    // Check for environment variable "SKIP_README". If it is set,
-    // skip README generation
-    if env::var_os("SKIP_README").is_some() {
-        return;
-    }
-
-    let mut source = File::open("src/main.rs").unwrap();
-    let mut template = File::open("README.tpl").unwrap();
-
-    let content = cargo_readme::generate_readme(
-        &PathBuf::from("."), // root
-        &mut source,         // source
-        Some(&mut template), // template
-        // The "add x" arguments don't apply when using a template.
-        true,  // add title
-        false, // add badges
-        false, // add license
-        true,  // indent headings
-    )
-    .unwrap();
-
-    let mut readme = File::create("README.md").unwrap();
-    readme.write_all(content.as_bytes()).unwrap();
+    generate_readme::from_main().unwrap();
 }

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -604,6 +604,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "generate-readme"
+version = "0.1.0"
+dependencies = [
+ "cargo-readme",
+ "snafu",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,8 +1140,8 @@ dependencies = [
 name = "parse-datetime"
 version = "0.1.0"
 dependencies = [
- "cargo-readme",
  "chrono",
+ "generate-readme",
  "snafu",
 ]
 


### PR DESCRIPTION
**Issue number:**

Related to #1260
Also will be used for #1419
Also see https://github.com/bottlerocket-os/bottlerocket/pull/2098#discussion_r859041469

**Description of changes:**

```
generate readme

We had readme generating code pasted into most of our build.rs file.
This has now been moved to a public function in a library so that the
code is not duplicated.
```

```
standardize variant concepts

We had several crates that interpreted the VARIANT env variable in
different ways in build.rs. This standardizes the treatment of the
VARIANT variable by centralizing it in a library.
```

**Ain't nobody got time for that**

- First look at `tools/buildsys/src/public/readme.rs`
- Then look at, e.g. `sources/shimpei/build.rs`: simple, we've just refactored away the duplicative readme generation code.
- Next look at `tools/buildsys/src/public/variant.rs`
- Then look at, e.g. `sources/api/pluto/build.rs`: we have factored out the emitting of `cfg` variables in the build.rs

That's basically it. Most of the crates are copy-paste nothing interesting. But these crates are the ones that actually have `cfg` usage:
- `sources/api/early-boot-config/build.rs`
- `sources/api/ecs-settings-applier/build.rs`
- `sources/api/pluto/build.rs`
- `sources/api/static-pods/build.rs`
- `sources/api/storewolf/build.rs`
- `sources/logdog/build.rs`
- `sources/models/build.rs`

**Testing done:**

- [x] I changed a `README.tpl` file and observed that `README.md` was changed.
- [x] I changed a rust doc comment and observed that `README.md` was changed.
- [x] I verified that SKIP_README skips readme generation.
- [x] run an aws-k8s sonobuoy 'quick'
- [x] run an ecs task
- [x] run a vmware sonobuoy quick

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
