### PR TITLE
Add a new Kubelet setting podPidsLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.cpu-manager-reconcile-period`: Specifies the CPU manager reconcile period, which controls how often updated CPU assignments are written to cgroupfs. The value is a duration like `30s` for 30 seconds or `1h5m` for 1 hour and 5 minutes.
 * `settings.kubernetes.topology-manager-policy`: Specifies the topology manager policy. Possible values are `none`, `restricted`, `best-effort`, and `single-numa-node`. Defaults to `none`.
 * `settings.kubernetes.topology-manager-scope`: Specifies the topology manager scope. Possible values are `container` and `pod`. Defaults to `container`. If you want to group all containers in a pod to a common set of NUMA nodes, you can set this setting to `pod`.
+* `settings.kubernetes.pod-pids-limit`: The maximum number of processes per pod.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -117,4 +117,5 @@ version = "1.7.2"
 "(1.7.2, 1.8.0)" = [
     "migrate_v1.8.0_boot-setting.lz4",
     "migrate_v1.8.0_boot-setting-metadata.lz4",
+    "migrate_v1.8.0_kubelet-pod-pids-limit.lz4",
 ]

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -86,6 +86,9 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
+podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -86,6 +86,9 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
+podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -86,6 +86,9 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
+podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -86,6 +86,9 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
+podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1773,6 +1773,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-pod-pids-limit"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "api/migration/migrations/v1.7.0/public-control-container-v0-6-0",
     "api/migration/migrations/v1.8.0/boot-setting",
     "api/migration/migrations/v1.8.0/boot-setting-metadata",
+    "api/migration/migrations/v1.8.0/kubelet-pod-pids-limit",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.8.0/kubelet-pod-pids-limit/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/kubelet-pod-pids-limit/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-pod-pids-limit"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.8.0/kubelet-pod-pids-limit/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/kubelet-pod-pids-limit/src/main.rs
@@ -1,0 +1,22 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring pod-pids-limit, `settings.kubernetes.pod-pids-limit`
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.pod-pids-limit",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -196,6 +196,7 @@ struct KubernetesSettings {
     cpu_manager_reconcile_period: KubernetesDurationValue,
     topology_manager_scope: TopologyManagerScope,
     topology_manager_policy: TopologyManagerPolicy,
+    pod_pids_limit: i64,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#2130 

**Description of changes:**
Adds a new settings kubernetes.podPidsLimit


**Testing done:**
#### Effected side test
Setting `podPidsLimit` to a small number which would fail to create pod because it doesn't have room for system process and daemon process alive.
setting.kubernetes.pod-pids-limit = 1
```
...
May 17 03:06:17 ip-192-168-86-168.us-west-2.compute.internal kubelet[4151]: E0517 03:06:17.103675    4151 pod_workers.go:918] "Error syncing pod, skipping" err="failed to \"CreatePodSandbox\" for \"aws-node-xhdtk_kube-system(c711d7d6-6de3-48ed-984a-4afafe1ae6b1)\" with 

CreatePodSandboxError: \"Failed to create sandbox for pod \\\"aws-node-xhdtk_kube-system(c711d7d6-6de3-48ed-984a-4afafe1ae6b1)\\\": rpc error: code = Unknown desc = failed to create containerd task: failed to create shim: OCI runtime create failed: runc create failed: 

unable to start container process: can't get final child's PID from pipe: EOF: unknown\"" pod="kube-system/aws-node-xhdtk" podUID=c711d7d6-6de3-48ed-984a-4afafe1ae6b1
...
```

#### Migration test
Update to latest version
```
bash-5.1# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.22",
    "arch": "x86_64",
    "version": "1.8.0",
    "max_version": "1.8.0",
    }
  }
]
bash-5.1# updog update -i 1.8.0 -r -n
Starting update to 1.8.0
```

set podPidslimit
```
apiclient set -j '{"kubernetes": {"pod-pids-limit": 100}}'

cat var/lib/bottlerocket/datastore/current/live/settings/kubernetes/pod-pids-limit
100
```
signpost rollback-to-inactive
```
cat: var/lib/bottlerocket/datastore/current/live/settings/kubernetes/pod-pids-limit: No such file or directory
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
