### PR TITLE
`netdog`: Deny unknown fields

### DIFF
--- a/sources/api/netdog/src/net_config.rs
+++ b/sources/api/netdog/src/net_config.rs
@@ -39,6 +39,7 @@ pub(crate) struct NetConfig {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct NetInterface {
     // Use this interface as the primary interface for the system
     pub(crate) primary: Option<bool>,
@@ -54,6 +55,7 @@ pub(crate) enum Dhcp4Config {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct Dhcp4Options {
     pub(crate) enabled: Option<bool>,
     pub(crate) optional: Option<bool>,
@@ -69,6 +71,7 @@ pub(crate) enum Dhcp6Config {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct Dhcp6Options {
     pub(crate) enabled: Option<bool>,
     pub(crate) optional: Option<bool>,
@@ -443,6 +446,24 @@ mod tests {
     fn ok_config() {
         let ok = net_config().join("net_config.toml");
         assert!(NetConfig::from_path(ok).is_ok())
+    }
+
+    #[test]
+    fn invalid_interface_config() {
+        let bad = net_config().join("invalid_interface_config.toml");
+        assert!(NetConfig::from_path(bad).is_err())
+    }
+
+    #[test]
+    fn invalid_dhcp4_config() {
+        let bad = net_config().join("invalid_dhcp4_config.toml");
+        assert!(NetConfig::from_path(bad).is_err())
+    }
+
+    #[test]
+    fn invalid_dhcp6_config() {
+        let bad = net_config().join("invalid_dhcp6_config.toml");
+        assert!(NetConfig::from_path(bad).is_err())
     }
 
     #[test]

--- a/sources/api/netdog/test_data/net_config/invalid_dhcp4_options.toml
+++ b/sources/api/netdog/test_data/net_config/invalid_dhcp4_options.toml
@@ -1,0 +1,10 @@
+version = 1
+
+[eno1]
+dhcp4 = true
+
+[eno2.dhcp4]
+optional = true
+route-metric = 100
+# `foo` is not a valid key
+foo = bar

--- a/sources/api/netdog/test_data/net_config/invalid_dhcp6_options.toml
+++ b/sources/api/netdog/test_data/net_config/invalid_dhcp6_options.toml
@@ -1,0 +1,9 @@
+version = 1
+
+[eno1]
+dhcp4 = true
+
+[eno2.dhcp6]
+optional = true
+# `route-metric` is not a valid `dhcp6` option
+route-metric = 100

--- a/sources/api/netdog/test_data/net_config/invalid_interface_config.toml
+++ b/sources/api/netdog/test_data/net_config/invalid_interface_config.toml
@@ -1,0 +1,9 @@
+version = 1
+
+[eno1]
+dhcp4 = true
+
+[eno2]
+dhcp4 = true
+# `optional` is a dhcp4 option, not an interface option
+optional = true

--- a/sources/api/netdog/test_data/net_config/net_config.toml
+++ b/sources/api/netdog/test_data/net_config/net_config.toml
@@ -25,3 +25,26 @@ route-metric = 100
 
 [eno6]
 dhcp6 = false
+
+[eno7]
+dhcp4 = true
+
+[eno7.dhcp6]
+enabled = true
+optional = true
+
+[eno8.dhcp4]
+enabled = true
+optional = true
+
+[eno8.dhcp6]
+enabled = true
+optional = true
+
+[eno9.dhcp4]
+enabled = true
+optional = true
+
+[eno10.dhcp6]
+enabled = true
+optional = true


### PR DESCRIPTION
**Description of changes:**
```
    netdog: Deny unknown fields in interface/dhcp4/dhcp6
    
    Prior to this change, any unknown fields in the `net.toml` would be
    ignored rather than failing to parse.  Failing fast and printing an
    error means we understand immediately if the problem is a config format
    problem or if other debug is necessary.
```
```
    netdog: Extend `net.toml` unit test to include all supported configs
    
    This change extends the test file to include all the supported
    configurations possible with the added `optional` flag.
```

**Testing done:**
Unit tests all pass.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
