### PR TITLE
bash: update to 5.1.16

### DIFF
--- a/packages/bash/Cargo.toml
+++ b/packages/bash/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://ftp.gnu.org/gnu/bash"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz"
-sha512 = "bb4519f06e278f271d08722b531e49d2e842cc3e0b02a6b3eee422e2efcb5b6226111af43f5e5eae56beb85ac8bfebcd6a4aacbabb8f609e529aa4d571890864"
+url = "https://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz"
+sha512 = "a32a343b6dde9a18eb6217602655f72c4098b0d90f04cf4e686fb21b81fc4ef26ade30f7226929fbb7c207cde34617dbad2c44f6103161d1141122bb31dc6c80"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/bash/bash.spec
+++ b/packages/bash/bash.spec
@@ -1,14 +1,10 @@
 Name: %{_cross_os}bash
-Version: 5.0
+Version: 5.1.16
 Release: 1%{?dist}
 Summary: The GNU Bourne Again shell
 License: GPL-3.0-or-later
 URL: https://www.gnu.org/software/bash
 Source0: https://ftp.gnu.org/gnu/bash/bash-%{version}.tar.gz
-
-# Official upstream patches
-Patch1: bash-5.0-patch-1.patch
-Patch2: bash-5.0-patch-2.patch
 
 # Disable loadable builtin examples
 Patch127: bash-4.4-no-loadable-builtins.patch


### PR DESCRIPTION
**Issue number:**

#1613 


**Description of changes:**

This updates the bash of the host, included in the -dev variants only, to version 5.1.16. The bash used now matches the version in the admin container used by `sheltie`.


**Testing done:**

* I built several variants multiple times and for both aarch64 and x86_64 (cross-compiled). I did not encounter the issue in #1613.
* Booted the metal-dev variant in QEMU and verified the bash version being used:

```plain
bash-5.1# echo ${BASH_VERSION}
5.1.16(1)-release
bash-5.1# bash --version
GNU bash, version 5.1.16(1)-release (aarch64-bottlerocket-linux-gnu)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
