### PR TITLE
netdog: Require `enabled` key in DHCP configuration

### DIFF
--- a/sources/api/netdog/src/net_config.rs
+++ b/sources/api/netdog/src/net_config.rs
@@ -57,7 +57,7 @@ pub(crate) enum Dhcp4Config {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Dhcp4Options {
-    pub(crate) enabled: Option<bool>,
+    pub(crate) enabled: bool,
     pub(crate) optional: Option<bool>,
     #[serde(rename = "route-metric")]
     pub(crate) route_metric: Option<u32>,
@@ -73,7 +73,7 @@ pub(crate) enum Dhcp6Config {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Dhcp6Options {
-    pub(crate) enabled: Option<bool>,
+    pub(crate) enabled: bool,
     pub(crate) optional: Option<bool>,
 }
 
@@ -255,7 +255,7 @@ impl FromStr for Dhcp4Config {
         }
 
         let dhcp4_options = Dhcp4Options {
-            enabled: Some(true),
+            enabled: true,
             optional,
             route_metric: None,
         };
@@ -293,7 +293,7 @@ impl FromStr for Dhcp6Config {
         }
 
         let dhcp6_options = Dhcp6Options {
-            enabled: Some(true),
+            enabled: true,
             optional,
         };
         Ok(Dhcp6Config::WithOptions(dhcp6_options))
@@ -470,6 +470,18 @@ mod tests {
     fn invalid_dhcp_config() {
         let ok = net_config().join("invalid_dhcp_config.toml");
         assert!(NetConfig::from_path(ok).is_err())
+    }
+
+    #[test]
+    fn dhcp4_missing_enable() {
+        let bad = net_config().join("dhcp4_missing_enabled.toml");
+        assert!(NetConfig::from_path(bad).is_err())
+    }
+
+    #[test]
+    fn dhcp6_missing_enable() {
+        let bad = net_config().join("dhcp6_missing_enabled.toml");
+        assert!(NetConfig::from_path(bad).is_err())
     }
 
     #[test]

--- a/sources/api/netdog/src/wicked.rs
+++ b/sources/api/netdog/src/wicked.rs
@@ -67,8 +67,7 @@ struct LinkDetection {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct WickedDhcp4 {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    enabled: Option<bool>,
+    enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     route_priority: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,7 +81,7 @@ pub(crate) struct WickedDhcp4 {
 impl Default for WickedDhcp4 {
     fn default() -> Self {
         WickedDhcp4 {
-            enabled: Some(true),
+            enabled: true,
             route_priority: None,
             defer_timeout: None,
             flags: None,
@@ -94,8 +93,7 @@ impl Default for WickedDhcp4 {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct WickedDhcp6 {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    enabled: Option<bool>,
+    enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     defer_timeout: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -107,7 +105,7 @@ pub(crate) struct WickedDhcp6 {
 impl Default for WickedDhcp6 {
     fn default() -> Self {
         WickedDhcp6 {
-            enabled: Some(true),
+            enabled: true,
             defer_timeout: None,
             flags: None,
             _f: (),
@@ -128,7 +126,7 @@ impl From<Dhcp4Config> for WickedDhcp4 {
     fn from(dhcp4: Dhcp4Config) -> Self {
         match dhcp4 {
             Dhcp4Config::DhcpEnabled(b) => WickedDhcp4 {
-                enabled: Some(b),
+                enabled: b,
                 _f: (),
                 ..Default::default()
             },
@@ -161,7 +159,7 @@ impl From<Dhcp6Config> for WickedDhcp6 {
     fn from(dhcp6: Dhcp6Config) -> Self {
         match dhcp6 {
             Dhcp6Config::DhcpEnabled(b) => WickedDhcp6 {
-                enabled: Some(b),
+                enabled: b,
                 _f: (),
                 ..Default::default()
             },

--- a/sources/api/netdog/test_data/net_config/dhcp4_missing_enabled.toml
+++ b/sources/api/netdog/test_data/net_config/dhcp4_missing_enabled.toml
@@ -1,0 +1,4 @@
+version = 1
+
+[eno1.dhcp4]
+optional = true

--- a/sources/api/netdog/test_data/net_config/dhcp6_missing_enabled.toml
+++ b/sources/api/netdog/test_data/net_config/dhcp6_missing_enabled.toml
@@ -1,0 +1,4 @@
+version = 1
+
+[eno1.dhcp6]
+optional = true


### PR DESCRIPTION
**Description of changes:**
```
The change makes the `enabled` option required when setting DHCP
options.  Previously the `net.toml` would be parsed and wicked
configuration would be generated just fine, but the interface wouldn't
ever come up because DHCP 4/6 wasn't enabled.  This causes a string of
failures in later services that depend on network being up.  This change
ensures the config requires the `enabled` option be set.

Leaving the `enabled` option out entirely was considered, as one could
assume the user wants DHCP to be enabled if additional options were
being set.  However, we didn't want to assume this for users, as there
could possibly be a use case for setting options, but leaving DHCP
disabled for an interface, perhaps to be used later.
```


**Testing done:**
* Boot a `metal-dev` image with `enabled` missing from the dhcp4/6 options and observed netdog properly fail to parse this
```
version = 1
[eno1]
dhcp4 = true  <-- this is valid syntax for simply turning on dhcp4

[eno2.dhcp4]  <--Missing the `enabled` key
optional = true
```
* Ensure `metal-dev` properly boots with properly formatted config, i.e:
```
version = 1
[eno1]
dhcp4 = true

[eno2.dhcp4]
enabled = true
optional = true
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
