### PR TITLE
Add ap-southeast-3 to supported region list

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -43,6 +43,7 @@ ap-northeast-3
 ap-south-1
 ap-southeast-1
 ap-southeast-2
+ap-southeast-3
 ca-central-1
 eu-central-1
 eu-north-1

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -108,6 +108,7 @@ ap-northeast-3
 ap-south-1
 ap-southeast-1
 ap-southeast-2
+ap-southeast-3
 ca-central-1
 eu-central-1
 eu-north-1


### PR DESCRIPTION
**Description of changes:**

Now that v1.7.2 is live, Bottlerocket is available in the ap-southeast-3 (Jakarta) AWS region.

**Testing done:**

Created EKS and ECS clusters in ap-southeast-3 and successfully used v1.7.2 in each.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
