### PR TITLE
Update to latest containerd, runc, docker

### DIFF
--- a/packages/containerd/1001-cri-set-default-RLIMIT_NOFILE.patch
+++ b/packages/containerd/1001-cri-set-default-RLIMIT_NOFILE.patch
@@ -1,15 +1,16 @@
-From 072eb5f273434e577025caa9b076b3eec01931bb Mon Sep 17 00:00:00 2001
+From 140991051a106d66170eee7847ad7ee0f36cc106 Mon Sep 17 00:00:00 2001
 From: Zac Mrowicki <mrowicki@amazon.com>
 Date: Thu, 12 Aug 2021 22:48:44 +0000
-Subject: [PATCH 1001/1002] cri: set default RLIMIT_NOFILE
+Subject: [PATCH] cri: set default RLIMIT_NOFILE
 
 The `cri` plugin currently inherits the limit from the default OCI spec
 or the containerd process.  This change sets the default hard
 RLIMIT_NOFILE to 1048576 and the soft limit to 65536 in the OCI spec for
 any container spawned using `cri`.
 
-[ported to containerd 1.5]
+[ported to containerd 1.6]
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Sean P. Kelly <seankell@amazon.com>
 ---
  pkg/cri/config/config.go                 |  6 ++++++
  pkg/cri/config/config_unix.go            |  2 ++
@@ -18,13 +19,13 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  4 files changed, 30 insertions(+)
 
 diff --git a/pkg/cri/config/config.go b/pkg/cri/config/config.go
-index e6f13f9..b10fe06 100644
+index 9a986ef..d58cefe 100644
 --- a/pkg/cri/config/config.go
 +++ b/pkg/cri/config/config.go
-@@ -266,6 +266,12 @@ type PluginConfig struct {
- 	// of being placed under the hardcoded directory /var/run/netns. Changing this setting requires
- 	// that all containers are deleted.
- 	NetNSMountsUnderStateDir bool `toml:"netns_mounts_under_state_dir" json:"netnsMountsUnderStateDir"`
+@@ -302,6 +302,12 @@ type PluginConfig struct {
+ 	// and if it is not overwritten by PodSandboxConfig
+ 	// Note that currently default is set to disabled but target change it in future together with EnableUnprivilegedPorts
+ 	EnableUnprivilegedICMP bool `toml:"enable_unprivileged_icmp" json:"enableUnprivilegedICMP"`
 +	// ProcessRLimitNoFileSoft sets the soft limit of maximum file
 +	// descriptors each container process can use.
 +	ProcessRLimitNoFileSoft int `toml:"process_rlimit_no_file_soft" json:"process_rlimit_no_file_soft"`
@@ -35,10 +36,10 @@ index e6f13f9..b10fe06 100644
  
  // X509KeyPairStreaming contains the x509 configuration for streaming
 diff --git a/pkg/cri/config/config_unix.go b/pkg/cri/config/config_unix.go
-index 3ca1232..b0e0395 100644
+index ed75bb4..8cc7e8d 100644
 --- a/pkg/cri/config/config_unix.go
 +++ b/pkg/cri/config/config_unix.go
-@@ -103,5 +103,7 @@ func DefaultConfig() PluginConfig {
+@@ -104,5 +104,7 @@ func DefaultConfig() PluginConfig {
  		ImageDecryption: ImageDecryption{
  			KeyModel: KeyModelNode,
  		},
@@ -47,10 +48,10 @@ index 3ca1232..b0e0395 100644
  	}
  }
 diff --git a/pkg/cri/opts/spec_linux.go b/pkg/cri/opts/spec_linux.go
-index c5ec3df..282307a 100644
+index 9306d42..48ce258 100644
 --- a/pkg/cri/opts/spec_linux.go
 +++ b/pkg/cri/opts/spec_linux.go
-@@ -43,6 +43,17 @@ import (
+@@ -42,6 +42,17 @@ import (
  	osinterface "github.com/containerd/containerd/pkg/os"
  )
  
@@ -69,16 +70,16 @@ index c5ec3df..282307a 100644
  // /etc/groups file of the image's root filesystem to the OCI spec's additionalGids array.
  func WithAdditionalGIDs(userstr string) oci.SpecOpts {
 diff --git a/pkg/cri/server/container_create_linux.go b/pkg/cri/server/container_create_linux.go
-index 26386e9..a05f16d 100644
+index 8fb41e2..06d5702 100644
 --- a/pkg/cri/server/container_create_linux.go
 +++ b/pkg/cri/server/container_create_linux.go
-@@ -137,6 +137,17 @@ func (c *criService) containerSpec(
+@@ -141,6 +141,17 @@ func (c *criService) containerSpec(
  		// this will be set based on the security context below
  		oci.WithNewPrivileges,
  	)
 +
 +	// Override the default oci.Spec RLIMIT_NOFILE
-+	var rlimits = []runtimespec.POSIXRlimit {
++	var rlimits = []runtimespec.POSIXRlimit{
 +		{
 +			Type: "RLIMIT_NOFILE",
 +			Hard: uint64(c.config.PluginConfig.ProcessRLimitNoFileHard),
@@ -91,5 +92,5 @@ index 26386e9..a05f16d 100644
  		specOpts = append(specOpts, oci.WithProcessCwd(config.GetWorkingDir()))
  	} else if imageConfig.WorkingDir != "" {
 -- 
-2.21.3
+2.32.0
 

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.5.11/containerd-1.5.11.tar.gz"
-sha512 = "6348f4ae7f9b473aac7d5e7325ca4539345d09f01b95383cec28f09d5e5b0b831e25fe305c3a15050f1e1959948ee8dcad788a1d6dd4780cf3077132d5617ef8"
+url = "https://github.com/containerd/containerd/archive/v1.6.4/containerd-1.6.4.tar.gz"
+sha512 = "a913dbfdcf29faebd5617f64e7c5e62b366cb9c80d0dbf55337121601f3c5b7d19c1670f71e9454513b681a1568c7cd1fc28c5daf3ea1c820279f2a2356ff8c6"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.5.11
+%global gover 1.6.4
 %global rpmver %{gover}
-%global gitrev 3df54a852345ae127d1fa3092b95168e4a88e2f8
+%global gitrev 212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v20.10.14/cli-20.10.14.tar.gz"
-sha512 = "f8b7f1040eccd404e39ec33bcef8bb8423636b0695af65f84c0612e77223844892d219f82cfbb99ccd5326e228f8af27be1870d90ebace77810ea5fce9f86e4a"
+url = "https://github.com/docker/cli/archive/v20.10.16/cli-20.10.16.tar.gz"
+sha512 = "90451f71f16f3bd1410b13c5df256ef1f422dd5b9b75d63cf318ee91a07bcb3ddb2876d2fee81e835d8daaee48c4e010c2daf4373de1095e2075fed8ee5fe75e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 20.10.14
+%global gover 20.10.16
 %global rpmver %{gover}
-%global gitrev a224086349269551becacce16e5842ceeb2a98d6
+%global gitrev aa7e414fdcb23a66e8fabbef0a560ef1769eace5
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v20.10.14/moby-20.10.14.tar.gz"
-sha512 = "94ee555337aaf96bb95ce8cbe8fe1d9c8b87fcd4f256d2af5082fc47915f7576882929c1211ef7fba0c754097bdef5e6df59abbdf77456d3babe139f4353ed21"
+url = "https://github.com/moby/moby/archive/v20.10.16/moby-20.10.16.tar.gz"
+sha512 = "5fdf87f98a951af87a334a5a403e36b975ff6c4647d0656dde2bd763d27562c620346f3746adafa1439c205869c721a3bef750f8302734499423ca789218f85d"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 20.10.14
+%global gover 20.10.16
 %global rpmver %{gover}
-%global gitrev 87a90dc786bda134c9eb02adbae2c6a7342fb7f6
+%global gitrev f756502055d2e36a84f2068e6620bea5ecf09058
 
 %global source_date_epoch 1363394400
 

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,9 +12,9 @@ path = "pkg.rs"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.tar.xz"
-path = "runc-v1.1.0.tar.xz"
-sha512 = "fddd9d7f874e21a718c734c85cafc0c917ba90a38a478df42c4cd4a4bc57cdce2de6462ab8f71fe39f3e926777d0e43793db841579f884076d3178e3313c4774"
+url = "https://github.com/opencontainers/runc/releases/download/v1.1.2/runc.tar.xz"
+path = "runc-v1.1.2.tar.xz"
+sha512 = "eaf77e5766cd34c2b8cd6076215a12f0b86bf3ded031e0c573ddfaeea240abde358f47ec033289d148db547211a2b7dc034548530a76da91662a33c2791f2aa1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -1,8 +1,8 @@
 %global goproject github.com/opencontainers
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
-%global commit 067aaf8548d78269dcb2c13b856775e27c410f9c
-%global gover 1.1.0
+%global commit a916309fff0f838eb94e928713dbc3c0d0ac7aa4
+%global gover 1.1.2
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION
**Issue number:** #1971 



**Description of changes:** This moves Bottlerocket to the latest versions of containerd, runc, and docker.


**Testing done:**
Our own changes are pretty small here, but testing for feature compatibility, performance, and regressions is critical. All testing has been done with a local build of the [latest changes to the bottlerocket-sdk](https://github.com/bottlerocket-os/bottlerocket-sdk/commit/907998cf3f8a4093868042ba15fea8cf7c0db278).

* [x] Basic testing of aws-ecs-1 variant
* [x] Basic testing of aws-k8s-1.21 variant
* [x] Sonobuoy conformance testing on several variants
* [x] Test containerd Pod pull improvements from [this containerd improvement](https://github.com/containerd/containerd/pull/6816).
* [x] Test containerd-related settings for compatbility. In particular, #1963 
* [x] Test rlimit patch rebase



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
