### PR TITLE
Restart long-running systemd services

### DIFF
--- a/packages/acpid/acpid.service
+++ b/packages/acpid/acpid.service
@@ -4,6 +4,8 @@ Description=ACPI event daemon
 [Service]
 Type=forking
 ExecStart=/usr/sbin/acpid -c /usr/lib/acpid/events
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/open-vm-tools/vmtoolsd.service
+++ b/packages/open-vm-tools/vmtoolsd.service
@@ -5,6 +5,8 @@ ConditionVirtualization=vmware
 
 [Service]
 ExecStart=/usr/bin/vmtoolsd
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/os/apiserver.service
+++ b/packages/os/apiserver.service
@@ -6,6 +6,8 @@ Requires=storewolf.service migrator.service
 [Service]
 Type=notify
 ExecStart=/usr/bin/apiserver --datastore-path /var/lib/bottlerocket/datastore/current --socket-gid 274
+Restart=always
+RestartSec=5
 StandardError=journal+console
 
 [Install]


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
```
packages: restart long-running systemd services

This adds the 'Restart' and 'RestartSec' directives to the following
services since they must be running even if they exit or are killed by
the OS:

- acpid
- vmtoolsd
- apiserver
```


**Testing done:**
I executed this script from the admin container to confirm that the services were restarted after the main process was killed:

```bash
SYSTEMCTL_CMD="chroot /.bottlerocket/rootfs /usr/bin/systemctl"
KILL_CMD="chroot /.bottlerocket/rootfs /usr/bin/kill"
SERVICES="acpid  apiserver"

get_pid() {
    local service
    service="${1}"
    ${SYSTEMCTL_CMD} show "${service}" | grep -E '^ExecMainPID' | awk ' { split($0,a,"="); print a[2] } '
}

for s in ${SERVICES}; do
    OLD_PID=$(get_pid "${s}")
    echo "OLD PID for ${s} is ${OLD_PID}"
    ${KILL_CMD} -9 ${OLD_PID}
    # Sleep a little longer than it takes for the service to restart
    sleep 7
    NEW_PID=$(get_pid "${s}")
    echo "NEW PID for ${s} is ${NEW_PID}"
done
```

Output:

```
OLD PID for acpid is 2291
NEW PID for acpid is 2768
OLD PID for apiserver is 2302
NEW PID for apiserver is 2779
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
