### PR TITLE
kubernetes: unset `configMapAndSecretChangeDetectionStrategy`

### DIFF
--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -101,7 +101,6 @@ featureGates:
 protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
-configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -101,7 +101,6 @@ featureGates:
 protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
-configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -101,7 +101,6 @@ featureGates:
 protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
-configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -101,7 +101,6 @@ featureGates:
 protectKernelDefaults: true
 serializeImagePulls: false
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
-configMapAndSecretChangeDetectionStrategy: Cache
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
    kubernetes: unset `configMapAndSecretChangeDetectionStrategy`
    
    We've carried this kubelet config setting since the beginning and it has
    become apparent that this causes significant pod start up delays.
    
    The default value for `configMapAndSecretChangeDetectionStrategy` is
    "watch" which seems appropriate for most use cases.
```


**Testing done:**
Applying a deployment of 300 nginx pods takes 1 min 30~ on two `m5.8xlarge` nodes. Where as before this change, it would have taken at least 3 mins:
```
$ time kubectl wait --for=condition=available --timeout=600s deployment/nginx-deployment
deployment.apps/nginx-deployment condition met

real    1m30.614s
```


Run some workloads with the following variants and their corresponding clusters
- [x] aws-k8s-1.19
- [x] aws-k8s-1.20
- [x] aws-k8s-1.21
- [x] aws-k8s-1.22
- [x] vmware-k8s-1.20
- [x] vmware-k8s-1.21
- [x] vmware-k8s-1.22

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
