### PR TITLE
Fix aws-ecs-1-nvidia configurations

### DIFF
--- a/packages/docker-engine/daemon-nvidia-json
+++ b/packages/docker-engine/daemon-nvidia-json
@@ -5,7 +5,7 @@
   "storage-driver": "overlay2",
   "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "data-root": "/var/lib/docker",
-  "default-runtime": "nvidia",
+  "default-runtime": "shimpei",
   "runtimes": { "shimpei": { "path": "shimpei" }, "nvidia": { "path": "nvidia-oci" } },
   "selinux-enabled": true,
   "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 1024, "Hard": 4096 } }

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -12,6 +12,8 @@ os-image-size-gib = 4
 kernel-parameters = [
     "console=tty0",
     "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?"
 ]
 included-packages = [
 # core


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
aws-ecs-1-nvidia: add netdog configurations to cmdline

This adds new boot configurations for netdog to prepare the primary
network interface
```

```
docker-engine: fix daemon configuration for NVIDIA

The default runtime for all ECS variants should be `shimpie`, since the
ecs-agent knows when to switch runtimes depending on the task's
configurations
```


**Testing done:**
Using the new variant, I scheduled two tasks, one with 1 GPU. I verified the two tasks were scheduled and that only the task with the GPU had access to `nvidia-smi`:

```
bash-5.1# docker ps
CONTAINER ID   IMAGE                                                       COMMAND            CREATED              STATUS              PORTS     NAMES
2be3a1aa4a4d   fedora:35                                                   "sleep infinity"   About a minute ago   Up About a minute             ecs-fedora-2-fedora-b2b8dc9a8ee7fcc9e301
2edadda4084c   <>                                                          "sleep infinity"   2 minutes ago        Up 2 minutes                  ecs-nvidia-3-nvidia-cac8f5e5ea96bdc15f00
bash-5.1# docker exec 2be3a1aa4a4d nvidia-smi
OCI runtime exec failed: exec failed: unable to start container process: exec: "nvidia-smi": executable file not found in $PATH: unknown
bash-5.1# docker exec 2edadda4084c nvidia-smi
Thu Jun  2 01:42:54 2022
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.4     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  Off  | 00000000:00:1C.0 Off |                    0 |
| N/A   35C    P0    50W / 300W |      0MiB / 16160MiB |      2%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
