### PR TITLE
ignore zero blocks on dm-verity root

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -278,7 +278,8 @@ menuentry "${PRETTY_NAME} ${VERSION_ID}" {
        random.trust_cpu=on selinux=1 enforcing=1 \\
        dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\
        dm-mod.create="root,,,ro,0 $VERITY_DATA_512B_BLOCKS verity $VERITY_VERSION PARTUUID=\$boot_uuid/PARTNROFF=1 PARTUUID=\$boot_uuid/PARTNROFF=2 \\
-       $VERITY_DATA_BLOCK_SIZE $VERITY_HASH_BLOCK_SIZE $VERITY_DATA_4K_BLOCKS 1 $VERITY_HASH_ALGORITHM $VERITY_ROOT_HASH $VERITY_SALT 1 restart_on_corruption" \\
+       $VERITY_DATA_BLOCK_SIZE $VERITY_HASH_BLOCK_SIZE $VERITY_DATA_4K_BLOCKS 1 $VERITY_HASH_ALGORITHM $VERITY_ROOT_HASH $VERITY_SALT \\
+       2 restart_on_corruption ignore_zero_blocks" \\
        -- \\
        systemd.log_target=journal-or-kmsg systemd.log_color=0
    ${INITRD}


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
We omit 512 KiB blocks of all zeroes when registering EBS snapshots.

If an encrypted EBS volume is subsequently created from the snapshot, reads from these uninitialized regions will return the decryption of zero with the volume key. This is essentially random garbage and the hash will not match what dm-verity expects.

These large zero blocks are mostly found in the space between the end of the filesystem and the partition boundary, but there are some at the start of the filesystem as well. The regions are not accessed under normal circumstances. However, tools such as `blkid` will scan them to fingerprint the device, at which point dm-verity detects the "corruption" and reboots the instance.

To avoid this, pass the dm-verity option to ignore zero blocks so that they are never actually read from the backing storage.

**Testing done:**
Built an AMI after applying this patch and verified that the zero blocks around the partition boundaries could be accessed without triggering the dm-verity corruption restart.

I also confirmed that corrupting the block device by writing random data to it still triggered a restart - meaning that both options are honored, as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
