### PR TITLE
Allow `cluster-dns-ip` to be set to a list of IP Addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,19 @@ For Kubernetes variants in AWS, you must also specify:
 
 For Kubernetes variants in VMware, you must specify:
 * `settings.kubernetes.cluster-dns-ip`: The IP of the DNS service running in the cluster.
+
+  This value can be set as a string containing a single IP address, or as a list containing multiple IP addresses.
+  Examples:
+  ```
+  # Valid, single IP
+  [settings.kubernetes]
+  "cluster-dns-ip" = "10.0.0.1"
+
+  # Also valid, multiple nameserver IPs
+  [settings.kubernetes]
+  "cluster-dns-ip" = ["10.0.0.1", "10.0.0.2"]
+  ```
+
 * `settings.kubernetes.bootstrap-token`: The token used for [TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).
 
 The following settings can be optionally set to customize the node labels and taints. Remember to quote keys (since they often contain ".") and to quote all values.

--- a/Release.toml
+++ b/Release.toml
@@ -122,4 +122,5 @@ version = "1.7.2"
     "migrate_v1.8.0_add-autoscaling.lz4",
     "migrate_v1.8.0_etc-hosts.lz4",
     "migrate_v1.8.0_etc-hosts-metadata.lz4",
+    "migrate_v1.8.0_cluster-dns-ip-list.lz4",
 ]

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -29,7 +29,11 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 {{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
+{{#each settings.kubernetes.cluster-dns-ip}}
+- {{this}}
+{{else}}
 - {{settings.kubernetes.cluster-dns-ip}}
+{{/each}}
 {{/if}}
 {{#if settings.kubernetes.eviction-hard}}
 evictionHard:

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -29,7 +29,11 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 {{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
+{{#each settings.kubernetes.cluster-dns-ip}}
+- {{this}}
+{{else}}
 - {{settings.kubernetes.cluster-dns-ip}}
+{{/each}}
 {{/if}}
 {{#if settings.kubernetes.eviction-hard}}
 evictionHard:

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -29,7 +29,11 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 {{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
+{{#each settings.kubernetes.cluster-dns-ip}}
+- {{this}}
+{{else}}
 - {{settings.kubernetes.cluster-dns-ip}}
+{{/each}}
 {{/if}}
 {{#if settings.kubernetes.eviction-hard}}
 evictionHard:

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -29,7 +29,11 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 {{#if settings.kubernetes.cluster-dns-ip}}
 clusterDNS:
+{{#each settings.kubernetes.cluster-dns-ip}}
+- {{this}}
+{{else}}
 - {{settings.kubernetes.cluster-dns-ip}}
+{{/each}}
 {{/if}}
 {{#if settings.kubernetes.eviction-hard}}
 evictionHard:

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -793,6 +793,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cluster-dns-ip-list"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
 name = "constants"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "api/migration/migrations/v1.8.0/add-autoscaling",
     "api/migration/migrations/v1.8.0/etc-hosts",
     "api/migration/migrations/v1.8.0/etc-hosts-metadata",
+    "api/migration/migrations/v1.8.0/cluster-dns-ip-list",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migration-helpers/src/lib.rs
+++ b/sources/api/migration/migration-helpers/src/lib.rs
@@ -60,7 +60,7 @@ pub type Metadata = HashMap<String, Value>;
 /// MigrationData holds all data that can be migrated in a migration, and serves as the input and
 /// output format of migrations.  A serde Value type is used to hold the arbitrary data of each
 /// key because we can't represent types when they could change in the migration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MigrationData {
     /// Mapping of data key names to their arbitrary values.
     pub data: HashMap<String, Value>,

--- a/sources/api/migration/migrations/v1.8.0/cluster-dns-ip-list/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/cluster-dns-ip-list/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cluster-dns-ip-list"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[dev-dependencies]
+serde_json = "1"

--- a/sources/api/migration/migrations/v1.8.0/cluster-dns-ip-list/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/cluster-dns-ip-list/src/main.rs
@@ -1,0 +1,204 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use std::process;
+
+const CLUSTER_DNS_IP_KEY: &str = "settings.kubernetes.cluster-dns-ip";
+
+/// We changed `settings.kubernetes.cluster-dns-ip` to support being either a string or a list of strings.
+fn run() -> Result<()> {
+    migrate(ClusterDNSIPListMigration)
+}
+
+struct ClusterDNSIPListMigration;
+
+impl Migration for ClusterDNSIPListMigration {
+    /// New versions allow the older string values to be present, so we don't need to do anything.
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("ClusterDNSIPListMigration has no work to do on upgrade.");
+        Ok(input)
+    }
+
+    /// Older versions don't know about list-style settings, so we need to create a scalar setting using the first value.
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        let maybe_prior_value = input.data.get(CLUSTER_DNS_IP_KEY);
+
+        // If the current value is a string, don't touch it.
+        if let Some(prior_value) = maybe_prior_value {
+            if prior_value.is_string() {
+                println!(
+                    "{} is already a string value ('{}'), and does not require migration.",
+                    CLUSTER_DNS_IP_KEY, prior_value
+                );
+                return Ok(input);
+            }
+        }
+
+        // If the current value is an array and the first element is a string, that element becomes the new value.
+        // Any other cases result in clearing the value.
+        let new_value = maybe_prior_value
+            .and_then(|dns_ip_value| {
+                println!(
+                    "Found existing value for '{}': '{}'",
+                    CLUSTER_DNS_IP_KEY, dns_ip_value
+                );
+                dns_ip_value.as_array()
+            })
+            .and_then(|ip_array| ip_array.iter().next())
+            .map(|ip_value| ip_value.clone());
+
+        match new_value {
+            Some(ip_value) if ip_value.is_string() => {
+                input
+                    .data
+                    .insert(CLUSTER_DNS_IP_KEY.to_string(), ip_value.clone());
+                println!(
+                    "Replaced prior value for '{}' with '{}'",
+                    CLUSTER_DNS_IP_KEY, ip_value
+                );
+            }
+            _ => {
+                println!(
+                    "Prior value for '{}' was not recognized. Removing it.",
+                    CLUSTER_DNS_IP_KEY
+                );
+                input.data.remove(CLUSTER_DNS_IP_KEY);
+            }
+        };
+
+        Ok(input)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_downgrade_string() {
+        let input = MigrationData {
+            data: serde_json::from_str(r#"{"settings.kubernetes.cluster-dns-ip": "10.0.0.1"}"#)
+                .unwrap(),
+            metadata: HashMap::new(),
+        };
+        let expected = MigrationData {
+            data: serde_json::from_str(r#"{"settings.kubernetes.cluster-dns-ip": "10.0.0.1"}"#)
+                .unwrap(),
+            metadata: HashMap::new(),
+        };
+        assert_eq!(ClusterDNSIPListMigration.backward(input).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_downgrade_list() {
+        let test_cases = [
+            (
+                MigrationData {
+                    data: serde_json::from_str(
+                        r#"{"settings.kubernetes.cluster-dns-ip": ["10.0.0.1"]}"#,
+                    )
+                    .unwrap(),
+                    metadata: HashMap::new(),
+                },
+                MigrationData {
+                    data: serde_json::from_str(
+                        r#"{"settings.kubernetes.cluster-dns-ip": "10.0.0.1"}"#,
+                    )
+                    .unwrap(),
+                    metadata: HashMap::new(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: serde_json::from_str(r#"{"settings.kubernetes.cluster-dns-ip": []}"#)
+                        .unwrap(),
+                    metadata: HashMap::new(),
+                },
+                MigrationData {
+                    data: HashMap::new(),
+                    metadata: HashMap::new(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: serde_json::from_str(
+                        r#"{"settings.kubernetes.cluster-dns-ip": ["10.0.0.2", "10.0.0.1"]}"#,
+                    )
+                    .unwrap(),
+                    metadata: HashMap::new(),
+                },
+                MigrationData {
+                    data: serde_json::from_str(
+                        r#"{"settings.kubernetes.cluster-dns-ip": "10.0.0.2"}"#,
+                    )
+                    .unwrap(),
+                    metadata: HashMap::new(),
+                },
+            ),
+        ];
+        for (input, expected) in test_cases.iter() {
+            assert_eq!(
+                ClusterDNSIPListMigration.backward(input.clone()).unwrap(),
+                *expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_downgrade_other() {
+        let test_cases = [
+            (
+                MigrationData {
+                    data: serde_json::from_str(
+                        r#"{"settings.kubernetes.cluster-dns-ip": {"1": 2}}"#,
+                    )
+                    .unwrap(),
+                    metadata: HashMap::new(),
+                },
+                MigrationData {
+                    data: HashMap::new(),
+                    metadata: HashMap::new(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: serde_json::from_str(r#"{"settings.kubernetes.cluster-dns-ip": 56}"#)
+                        .unwrap(),
+                    metadata: HashMap::new(),
+                },
+                MigrationData {
+                    data: HashMap::new(),
+                    metadata: HashMap::new(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: serde_json::from_str(r#"{"settings.kubernetes.cluster-dns-ip": false}"#)
+                        .unwrap(),
+                    metadata: HashMap::new(),
+                },
+                MigrationData {
+                    data: HashMap::new(),
+                    metadata: HashMap::new(),
+                },
+            ),
+        ];
+        for (input, expected) in test_cases.iter() {
+            assert_eq!(
+                ClusterDNSIPListMigration.backward(input.clone()).unwrap(),
+                *expected
+            );
+        }
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/pluto/src/api.rs
+++ b/sources/api/pluto/src/api.rs
@@ -1,5 +1,4 @@
 pub(super) use inner::{get_aws_k8s_info, Error};
-use std::net::IpAddr;
 
 /// The result type for the [`api`] module.
 pub(super) type Result<T> = std::result::Result<T, Error>;
@@ -7,7 +6,7 @@ pub(super) type Result<T> = std::result::Result<T, Error>;
 pub(crate) struct AwsK8sInfo {
     pub(crate) region: Option<String>,
     pub(crate) cluster_name: Option<String>,
-    pub(crate) cluster_dns_ip: Option<IpAddr>,
+    pub(crate) cluster_dns_ip: Option<model::modeled_types::KubernetesClusterDnsIp>,
 }
 
 /// This code is the 'actual' implementation compiled when the `sources` workspace is being compiled
@@ -15,7 +14,6 @@ pub(crate) struct AwsK8sInfo {
 #[cfg(variant_family = "aws-k8s")]
 mod inner {
     use super::*;
-    use constants;
     use snafu::{ResultExt, Snafu};
 
     #[derive(Debug, Snafu)]
@@ -51,10 +49,7 @@ mod inner {
                 .as_ref()
                 .and_then(|k| k.cluster_name.clone())
                 .map(|s| s.into()),
-            cluster_dns_ip: settings
-                .kubernetes
-                .and_then(|k| k.cluster_dns_ip)
-                .map(|s| s.into()),
+            cluster_dns_ip: settings.kubernetes.and_then(|k| k.cluster_dns_ip),
         })
     }
 }

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -257,7 +257,11 @@ async fn get_node_ip(client: &mut ImdsClient) -> Result<String> {
     // Retrieve the user specified cluster DNS IP if it's specified, otherwise use the pluto-generated
     // cluster DNS IP
     let aws_k8s_info = api::get_aws_k8s_info().await.context(error::AwsInfoSnafu)?;
-    let cluster_dns_ip = if let Some(ip) = aws_k8s_info.cluster_dns_ip {
+    let configured_cluster_dns_ip = aws_k8s_info
+        .cluster_dns_ip
+        .and_then(|cluster_ip| cluster_ip.iter().next().cloned());
+
+    let cluster_dns_ip = if let Some(ip) = configured_cluster_dns_ip {
         ip.to_owned()
     } else {
         let ip = get_cluster_dns_ip(client).await?;

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -143,11 +143,12 @@ use crate::modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, DNSDomain,
     ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
     EtcHostsEntries, FriendlyVersion, Identifier, KubernetesAuthenticationMode,
-    KubernetesBootstrapToken, KubernetesCloudProvider, KubernetesClusterName,
-    KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
-    KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
-    KubernetesThresholdValue, Lockdown, PemCertificateString, SingleLineString, SysctlKey,
-    TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
+    KubernetesBootstrapToken, KubernetesCloudProvider, KubernetesClusterDnsIp,
+    KubernetesClusterName, KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey,
+    KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
+    KubernetesTaintValue, KubernetesThresholdValue, Lockdown, PemCertificateString,
+    SingleLineString, SysctlKey, TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64,
+    ValidLinuxHostname,
 };
 
 // Kubernetes static pod manifest settings
@@ -201,7 +202,7 @@ struct KubernetesSettings {
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.
     max_pods: u32,
-    cluster_dns_ip: IpAddr,
+    cluster_dns_ip: KubernetesClusterDnsIp,
     cluster_domain: DNSDomain,
     node_ip: IpAddr,
     pod_infra_container_image: SingleLineString,


### PR DESCRIPTION
**Issue number:** #2132 


**Description of changes:**
This allows `settings.kubernetes.cluster-dns-ip` to be set to a list. The value may also remain as a string, for backwards compatibility. The model will store the data using the type submitted, so existing code expecting string types will continue to work.

If a list is present, downwards migrations will truncate the list, using the first element as the configured value.



**Testing done:**
* [x] Ensure that `/etc/kubernetes/kubelet/config` contains `clusterDNS` settings, regardless of if the setting is a string or a list
* [x] Push the new migrations to a TUF repo and ensure they work as expected
* [x] Unit tests
* [x] Test on all modified k8s versions (1.19, 1.20, 1.21, 1.22)
* [x] Launch a pod with multiple DNS IPs configured and assert that `/etc/resolv.conf` contains them



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
