### PR TITLE
build smartpqi driver into 5.10 kernel

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -51,6 +51,9 @@ CONFIG_VIRTIO_PCI=y
 # LSI Logic's SAS based RAID controllers
 CONFIG_MEGARAID_SAS=y
 
+# Microsemi PQI controllers
+CONFIG_SCSI_SMARTPQI=y
+
 # dm-verity and enabling it on the kernel command line
 CONFIG_BLK_DEV_DM=y
 CONFIG_DAX=y

--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -48,6 +48,9 @@ CONFIG_VIRTIO=y
 CONFIG_VIRTIO_BLK=y
 CONFIG_VIRTIO_PCI=y
 
+# LSI Logic's SAS based RAID controllers
+CONFIG_MEGARAID_SAS=y
+
 # dm-verity and enabling it on the kernel command line
 CONFIG_BLK_DEV_DM=y
 CONFIG_DAX=y
@@ -128,6 +131,3 @@ CONFIG_BOOT_CONFIG=y
 
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
-
-# Enables support for LSI Logic's SAS based RAID controllers
-CONFIG_MEGARAID_SAS=y

--- a/packages/kernel-5.4/config-bottlerocket
+++ b/packages/kernel-5.4/config-bottlerocket
@@ -85,6 +85,3 @@ CONFIG_MOUSE_PS2=m
 
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
-
-# Enables support for LSI Logic's SAS based RAID controllers
-CONFIG_MEGARAID_SAS=y


### PR DESCRIPTION
**Issue number:**
Fixes #2160


**Description of changes:**
This partially reverts 31d506283f56c0af1432aae7783f173a411dc6e5 since we haven't consistently added new drivers for bare metal to the 5.4 kernel config.

Move `CONFIG_MEGARAID_SAS=y` to the same area of the config as the other storage drivers, and add `CONFIG_SCSI_SMARTPQI=y`.


**Testing done:**
Booted x86_64 and aarch64 VMs with the 5.10 kernel.

Delta between old and new configs was as expected for both architectures.
```
-CONFIG_RAID_ATTRS=m
+CONFIG_RAID_ATTRS=y
...
-CONFIG_SCSI_SAS_ATTRS=m
+CONFIG_SCSI_SAS_ATTRS=y
...
-CONFIG_SCSI_SMARTPQI=m
+CONFIG_SCSI_SMARTPQI=y
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
