### PR TITLE
install kernel headers and modules in parallel

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -112,8 +112,8 @@ make -s\\\
 %kmake %{?_smp_mflags} modules
 
 %install
-%kmake headers_install
-%kmake modules_install
+%kmake %{?_smp_mflags} headers_install
+%kmake %{?_smp_mflags} modules_install
 
 install -d %{buildroot}/boot
 install -T -m 0755 arch/%{_cross_karch}/boot/%{_cross_kimage} %{buildroot}/boot/vmlinuz

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -119,8 +119,8 @@ make -s\\\
 %kmake %{?_smp_mflags} modules
 
 %install
-%kmake headers_install
-%kmake modules_install
+%kmake %{?_smp_mflags} headers_install
+%kmake %{?_smp_mflags} modules_install
 
 install -d %{buildroot}/boot
 install -T -m 0755 arch/%{_cross_karch}/boot/%{_cross_kimage} %{buildroot}/boot/vmlinuz


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Install kernel headers and modules in parallel, to speed up kernel builds.


**Testing done:**
Built the 5.4 and 5.10 kernels.

I've been using this patch locally for a few weeks and haven't seen any build failures.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
