### PR TITLE
containerd: fix CVE-2022-31030

### DIFF
--- a/packages/containerd/0001-release-1.6-Limit-the-response-size-of-ExecSync-16mib.patch
+++ b/packages/containerd/0001-release-1.6-Limit-the-response-size-of-ExecSync-16mib.patch
@@ -1,0 +1,135 @@
+From 4cf5fc62cd8eea092f8c449bf8ef2150d94c89ba Mon Sep 17 00:00:00 2001
+From: Kazuyoshi Kato <katokazu@amazon.com>
+Date: Mon, 16 May 2022 17:33:33 +0000
+Subject: [PATCH] [release/1.6] Limit the response size of ExecSync
+
+Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>
+(cherry picked from commit 49ca87d7270091b8193301dc2f6759e9aa7c97b1)
+Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>
+---
+ pkg/cri/server/container_execsync.go      | 39 +++++++++++++++++-
+ pkg/cri/server/container_execsync_test.go | 49 +++++++++++++++++++++++
+ 2 files changed, 86 insertions(+), 2 deletions(-)
+ create mode 100644 pkg/cri/server/container_execsync_test.go
+
+diff --git a/pkg/cri/server/container_execsync.go b/pkg/cri/server/container_execsync.go
+index 9be392f9c..f2d2a8e6c 100644
+--- a/pkg/cri/server/container_execsync.go
++++ b/pkg/cri/server/container_execsync.go
+@@ -18,6 +18,7 @@ package server
+ 
+ import (
+ 	"bytes"
++	"errors"
+ 	"fmt"
+ 	"io"
+ 	"syscall"
+@@ -38,14 +39,48 @@ import (
+ 	cioutil "github.com/containerd/containerd/pkg/ioutil"
+ )
+ 
++type cappedWriter struct {
++	w      io.WriteCloser
++	remain int
++}
++
++var errNoRemain = errors.New("no more space to write")
++
++func (cw *cappedWriter) Write(p []byte) (int, error) {
++	if cw.remain <= 0 {
++		return 0, errNoRemain
++	}
++
++	end := cw.remain
++	if end > len(p) {
++		end = len(p)
++	}
++	written, err := cw.w.Write(p[0:end])
++	cw.remain -= written
++
++	if err != nil {
++		return written, err
++	}
++	if written < len(p) {
++		return written, errNoRemain
++	}
++	return written, nil
++}
++
++func (cw *cappedWriter) Close() error {
++	return cw.w.Close()
++}
++
+ // ExecSync executes a command in the container, and returns the stdout output.
+ // If command exits with a non-zero exit code, an error is returned.
+ func (c *criService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (*runtime.ExecSyncResponse, error) {
++	const maxStreamSize = 1024 * 1024 * 16
++
+ 	var stdout, stderr bytes.Buffer
+ 	exitCode, err := c.execInContainer(ctx, r.GetContainerId(), execOptions{
+ 		cmd:     r.GetCmd(),
+-		stdout:  cioutil.NewNopWriteCloser(&stdout),
+-		stderr:  cioutil.NewNopWriteCloser(&stderr),
++		stdout:  &cappedWriter{w: cioutil.NewNopWriteCloser(&stdout), remain: maxStreamSize},
++		stderr:  &cappedWriter{w: cioutil.NewNopWriteCloser(&stderr), remain: maxStreamSize},
+ 		timeout: time.Duration(r.GetTimeout()) * time.Second,
+ 	})
+ 	if err != nil {
+diff --git a/pkg/cri/server/container_execsync_test.go b/pkg/cri/server/container_execsync_test.go
+new file mode 100644
+index 000000000..18856b8fc
+--- /dev/null
++++ b/pkg/cri/server/container_execsync_test.go
+@@ -0,0 +1,49 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package server
++
++import (
++	"bytes"
++	"testing"
++
++	cioutil "github.com/containerd/containerd/pkg/ioutil"
++	"github.com/stretchr/testify/assert"
++)
++
++func TestCWWrite(t *testing.T) {
++	var buf bytes.Buffer
++	cw := &cappedWriter{w: cioutil.NewNopWriteCloser(&buf), remain: 10}
++
++	n, err := cw.Write([]byte("hello"))
++	assert.NoError(t, err)
++	assert.Equal(t, 5, n)
++
++	n, err = cw.Write([]byte("helloworld"))
++	assert.Equal(t, []byte("hellohello"), buf.Bytes(), "partial write")
++	assert.Equal(t, 5, n)
++	assert.ErrorIs(t, err, errNoRemain)
++
++	_, err = cw.Write([]byte("world"))
++	assert.ErrorIs(t, err, errNoRemain)
++}
++
++func TestCWClose(t *testing.T) {
++	var buf bytes.Buffer
++	cw := &cappedWriter{w: cioutil.NewNopWriteCloser(&buf), remain: 5}
++	err := cw.Close()
++	assert.NoError(t, err)
++}
+-- 
+2.32.0
+

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -26,6 +26,8 @@ Source100: etc-containerd.mount
 
 Source1000: clarify.toml
 
+Patch0001: 0001-release-1.6-Limit-the-response-size-of-ExecSync-16mib.patch
+
 # TODO: submit this upstream, including a unit test.
 Patch1001: 1001-cri-set-default-RLIMIT_NOFILE.patch
 


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
containerd: fix CVE-2022-31030
```


**Testing done:**
In aws-k8s-1.21, I ran an daemonset and checked the pods were created successfully.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
