### PR TITLE
Package updates

### DIFF
--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.4/containerd-1.6.4.tar.gz"
-sha512 = "a913dbfdcf29faebd5617f64e7c5e62b366cb9c80d0dbf55337121601f3c5b7d19c1670f71e9454513b681a1568c7cd1fc28c5daf3ea1c820279f2a2356ff8c6"
+url = "https://github.com/containerd/containerd/archive/v1.6.6/containerd-1.6.6.tar.gz"
+sha512 = "f16f23384dbaa67075f2d35b7fc752938dd15601bbe3a919bc8eaa53fa1b2dea2e2d7f613a0f2f492910213dc2f7e96f0a1d38dde35bfb6d15f18167313f9817"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.4
+%global gover 1.6.6
 %global rpmver %{gover}
-%global gitrev 212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
+%global gitrev 96df0994faabc1944fc614e52b0b3c6feb609a57
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -4,7 +4,7 @@
 
 %global gover 1.6.6
 %global rpmver %{gover}
-%global gitrev 96df0994faabc1944fc614e52b0b3c6feb609a57
+%global gitrev 10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/70822ee2bc85888532dc1238257e5dd10ba67243f849a6a8d17cac89ae1663b6/kernel-5.10.112-108.499.amzn2.src.rpm"
-sha512 = "0ec959cdc92684bbc4a1dc758f84ebd12e085a951c7425d9783daf5932eb27a026e2cbb6c1f7bacd9ac5f47b6c9ecaad020d07e7641294f1cad072163e71385e"
+url = "https://cdn.amazonlinux.com/blobstore/fd3a270843eca4874b201fd3554b484a79b18edc0d3b845ff3288dd9dd0d69a8/kernel-5.10.118-111.515.amzn2.src.rpm"
+sha512 = "f9d8d4f43757a84072e585b20f4bbec188d4d28d12c7183dae65348ff487508eab999048f1796f2f4bb1a8de71412156eae62248343f3a7e579d0babfce9fd64"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.112
+Version: 5.10.118
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/70822ee2bc85888532dc1238257e5dd10ba67243f849a6a8d17cac89ae1663b6/kernel-5.10.112-108.499.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/fd3a270843eca4874b201fd3554b484a79b18edc0d3b845ff3288dd9dd0d69a8/kernel-5.10.118-111.515.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.4/Cargo.toml
+++ b/packages/kernel-5.4/Cargo.toml
@@ -13,8 +13,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/ef7cb8ef41ebe7e5edc8bbf23eebc16600d6a8e21f8b468723b31fb32ef3e583/kernel-5.4.190-107.353.amzn2.src.rpm"
-sha512 = "8682ee3ec20558b4e82d688fe83134ee01b6379b7da8cb7a367f1534000891384b5364b8ef991d8bd88ab53ad83d8984014f284f43ea13952b0e36bf3b6f2cd7"
+url = "https://cdn.amazonlinux.com/blobstore/9959b4af12a63755e451619398b6471f3c6a496b854ce73740c786907f67560a/kernel-5.4.196-108.356.amzn2.src.rpm"
+sha512 = "4b063d857d05a2796fc607ba425d5f75964e1123b24cb0f0ab8e1cb8334944b9fc5d734c83f1d5ef186b2ac38fb7ece5be62a49579f3b4187ee380cd28bdfaaf"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.4
-Version: 5.4.190
+Version: 5.4.196
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/ef7cb8ef41ebe7e5edc8bbf23eebc16600d6a8e21f8b468723b31fb32ef3e583/kernel-5.4.190-107.353.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/9959b4af12a63755e451619398b6471f3c6a496b854ce73740c786907f67560a/kernel-5.4.196-108.356.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**

```
packages: update kernel-5.4
packages: update kernel-5.10
containerd: fix CVE-2022-31030
```


**Testing done:**
In aws-k8s-1.21,aws-k8s-1.19, x86_64, verified that pods can be scheduled:

```bash
# k8s-1.19
eksctl-configs ❯ kubectl exec fedora-ln6j4 -- uname -a
Linux fedora-ln6j4 5.4.196 #1 SMP Tue Jun 7 22:42:18 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

eksctl-configs ❯ kubectl exec fedora-qpxwv -- uname -a
Linux fedora-qpxwv 5.4.196 #1 SMP Tue Jun 7 23:50:45 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

# k8s-1.21
eksctl-configs ❯ kubectl exec fedora-qx4pv -- uname -a
Linux fedora-qx4pv 5.10.118 #1 SMP Tue Jun 7 22:57:16 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

eksctl-configs ❯ kubectl exec fedora-vj9fq -- uname -a
Linux fedora-vj9fq 5.10.118 #1 SMP Wed Jun 8 00:08:50 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

```

TODO:

- [x] Update lookaside cache
- [x] Pods in aws-k8s-1.21,aws-k8s-1.19, aarch64


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
