### PR TITLE
metal-k8s: default 'settings.kubernetes.cloud-provider' to empty

### DIFF
--- a/sources/models/shared-defaults/kubernetes-metal.toml
+++ b/sources/models/shared-defaults/kubernetes-metal.toml
@@ -4,7 +4,7 @@ standalone-mode = false
 authentication-mode = "tls"
 pod-infra-container-image = "public.ecr.aws/eks-distro/kubernetes/pause:3.5"
 server-tls-bootstrap = false
-cloud-provider = "external"
+cloud-provider = ""
 
 [metadata.settings.kubernetes]
 node-ip.setting-generator = "netdog node-ip"

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -58,6 +58,9 @@ pub mod error {
         #[snafu(display("{} given invalid input: {}", thing, input))]
         BigPattern { thing: String, input: String },
 
+        #[snafu(display("Invalid Kubernetes cloud provider '{}'", input))]
+        InvalidCloudProvider { input: String },
+
         #[snafu(display("Invalid Kubernetes authentication mode '{}'", input))]
         InvalidAuthenticationMode { input: String },
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
    metal-k8s: default 'settings.kubernetes.cloud-provider' to empty
    
    When cloud-provider is set to 'external', kubelet will add a taint
    'node.cloudprovider.kubernetes.io/uninitialized' with an effect
    'NoSchedule' during initialization. This taint will prevent workloads
    from being scheduled onto the node until it is removed by some external
    cloud controller manager. In baremetal clusters, this cloud controller
    manager is not guaranteed to exist.
    
    For metal variants, we should by default set cloud-provider to an empty
    string so kubelet will not set the taint. If users do use a cloud
    controller manager that needs to do additional initialization to the
    nodes, then they can set the 'settings.kubernetes.cloud-provider'
    setting to 'external'.
```
```
    models: allow empty string for KubernetesCloudProvider
    
    This updates the KubernetesCloudProvider model to allow empty strings
    for setting cloud provider to "none" in kubelet.
    
    This also fixes one of the error messages
```


**Testing done:**
Metal bottlerocket hosts join the cluster fine. The nodes no longer have the `node.cloudprovider.kubernetes.io/uninitialized` taint. I can schedule pods onto the nodes without problem.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
