### PR TITLE
Makefile: Add targets to create and validate Boot Configuration

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -159,6 +159,11 @@ BUILDSYS_OVF_TEMPLATE = "${BUILDSYS_ROOT_DIR}/variants/${BUILDSYS_VARIANT}/templ
 # The default name of uploaded OVAs; override by setting VMWARE_VM_NAME
 VMWARE_VM_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
 
+# Config file for Boot Configuration initrd generation
+BOOT_CONFIG_INPUT = "${BUILDSYS_ROOT_DIR}/bootconfig-input"
+# Boot Configuration initrd
+BOOT_CONFIG = "${BUILDSYS_ROOT_DIR}/bootconfig.data"
+
 [tasks.setup]
 script = [
 '''
@@ -425,6 +430,61 @@ if [ "${cargo_minor}" -lt "51" ] ; then
   echo "Error: Cargo 1.51.0 or greater is required, your version is ${cargo_version}" >&2
   exit 1
 fi
+'''
+]
+
+[tasks.boot-config]
+dependencies = ["fetch-sdk"]
+script_runner = "bash"
+script = [
+'''
+set -euo pipefail
+
+if [ ! -s "${BOOT_CONFIG_INPUT}" ]; then
+   echo "No boot configuration file exists, please create one at ${BOOT_CONFIG_INPUT}"
+   exit 1
+fi
+
+# If a Boot Config initrd already exists update it, otherwise create a new one
+boot_config_tmp=""
+boot_config=""
+if [ -s "${BOOT_CONFIG}" ]; then
+   echo "Boot config exists at '${BOOT_CONFIG}', updating it with input ${BOOT_CONFIG_INPUT}"
+   boot_config="${BOOT_CONFIG}"
+else
+   echo "Creating a new boot config from input ${BOOT_CONFIG_INPUT}"
+   boot_config_tmp=$(mktemp /tmp/bootconfig.data.XXXXX)
+   boot_config="${boot_config_tmp}"
+fi
+
+docker run --rm \
+   --network=none \
+   --user "$(id -u):$(id -g)" \
+   --security-opt label:disable \
+   -v "${BOOT_CONFIG_INPUT}":/tmp/bootconfig-input \
+   -v "${boot_config}":/tmp/bootconfig.data \
+   "${BUILDSYS_SDK_IMAGE}" \
+   bootconfig -a /tmp/bootconfig-input /tmp/bootconfig.data
+
+if [ -e "${boot_config_tmp}" ] ; then
+   mv "${boot_config_tmp}" "${BOOT_CONFIG}"
+fi
+echo "Boot configuration initrd may be found at ${BOOT_CONFIG}"
+'''
+]
+
+[tasks.validate-boot-config]
+dependencies = ["fetch-sdk"]
+script_runner = "bash"
+script = [
+'''
+docker run --rm \
+   --network=none \
+   --user "$(id -u):$(id -g)" \
+   --security-opt label:disable \
+   -v "${BOOT_CONFIG}":/tmp/bootconfig.data \
+   "${BUILDSYS_SDK_IMAGE}" \
+   bootconfig -l /tmp/bootconfig.data
 '''
 ]
 


### PR DESCRIPTION
**Description of changes:**
```
    This change adds two new targets to the Makefile.  Both make use of the
    `bootconfig` tool in the latest version of the SDK.  The first new
    target, `boot-config`, gives users the ability to create a properly
    formatted Boot Configuration initrd given a valid config file.  The
    second new target `validate-boot-config`, validates the Boot
    Configuration initrd, listing its contents.  If the initrd is somehow in
    a bad format, the tool will fail and print an error.

    The Makefile targets expect a valid configuration file in the root of
    the Bottlerocket repo named "bootconfig-input".  The Boot Configuration
    initrd will be created in the root of the repo with the name
    "bootconfig.data", which is what Bottlerocket expects the file to be
    named when using it.
```


**Testing done:**
Create and validate new Boot Configuration:
```
$ cat bootconfig-input 
kernel {
    console = tty0, "ttyS1,115200n8"
}
init {
    systemd.log_level = debug
}

$ cargo make boot-config
...
[cargo-make] INFO - Running Task: boot-config
Creating a new boot config from input /home/fedora/bottlerocket/bottlerocket/bootconfig-input
Apply /tmp/bootconfig-input to /tmp/bootconfig.data
        Number of nodes: 8
        Size: 88 bytes
        Checksum: 6790
Boot configuration initrd may be found at /home/fedora/bottlerocket/bottlerocket/bootconfig.data
...

$ cargo make validate-boot-config
...
[cargo-make] INFO - Running Task: validate-boot-config
kernel.console = "tty0", "ttyS1,115200n8"
init.systemd.log_level = "debug"
...
```
Update the existing configuration:
```
$ cat bootconfig-input 
kernel {
    console = tty0
}

$ cargo make boot-config
...
Boot config exists at '/home/fedora/bottlerocket/bottlerocket/bootconfig.data', updating it with input /home/fedora/bottlerocket/bottlerocket/bootconfig-input
Apply /tmp/bootconfig-input to /tmp/bootconfig.data
        Number of nodes: 3
        Size: 31 bytes
        Checksum: 2360
Boot configuration initrd may be found at /home/fedora/bottlerocket/bottlerocket/bootconfig.data

$ cat bootconfig.data 
kernel {
    console = tty0
}
...

$ cargo make validate-boot-config
...
[cargo-make] INFO - Running Task: validate-boot-config
kernel.console = "tty0"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
