### PR TITLE
Migrations: migrations for new admin and control versions

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -124,5 +124,9 @@ version = "1.7.2"
     "migrate_v1.8.0_etc-hosts-metadata.lz4",
     "migrate_v1.8.0_cluster-dns-ip-list.lz4",
     "migrate_v1.8.0_pki-affected-services.lz4",
-    "migrate_v1.8.0_kubelet-provider-id.lz4"
+    "migrate_v1.8.0_kubelet-provider-id.lz4",
+    "migrate_v1.8.0_aws-admin-container-v0-9-0.lz4",
+    "migrate_v1.8.0_aws-control-container-v0-6-1.lz4",
+    "migrate_v1.8.0_public-admin-container-v0-9-0.lz4",
+    "migrate_v1.8.0_public-control-container-v0-6-1.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -491,6 +491,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-9-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-control-container-v0-5-5"
 version = "0.1.0"
 dependencies = [
@@ -499,6 +506,13 @@ dependencies = [
 
 [[package]]
 name = "aws-control-container-v0-6-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "aws-control-container-v0-6-1"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",
@@ -2653,6 +2667,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "public-admin-container-v0-9-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "public-control-container-v0-5-5"
 version = "0.1.0"
 dependencies = [
@@ -2661,6 +2682,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-6-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-6-1"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -58,6 +58,10 @@ members = [
     "api/migration/migrations/v1.8.0/cluster-dns-ip-list",
     "api/migration/migrations/v1.8.0/pki-affected-services",
     "api/migration/migrations/v1.8.0/kubelet-provider-id",
+    "api/migration/migrations/v1.8.0/aws-admin-container-v0-9-0",
+    "api/migration/migrations/v1.8.0/aws-control-container-v0-6-1",
+    "api/migration/migrations/v1.8.0/public-admin-container-v0-9-0",
+    "api/migration/migrations/v1.8.0/public-control-container-v0-6-1",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.8.0/aws-admin-container-v0-9-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/aws-admin-container-v0-9-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-9-0"
+version = "0.1.0"
+authors = ["Richard Kelly <rpkelly@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.8.0/aws-admin-container-v0-9-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/aws-admin-container-v0-9-0/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.8.0";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.0";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.8.0/aws-control-container-v0-6-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/aws-control-container-v0-6-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-6-1"
+version = "0.1.0"
+authors = ["Richard Kelly <rpkelly@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.8.0/aws-control-container-v0-6-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/aws-control-container-v0-6-1/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.0";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.1";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.8.0/public-admin-container-v0-9-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/public-admin-container-v0-9-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-9-0"
+version = "0.1.0"
+authors = ["Richard Kelly <rpkelly@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.8.0/public-admin-container-v0-9-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/public-admin-container-v0-9-0/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.0";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.8.0/public-control-container-v0-6-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/public-control-container-v0-6-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-6-1"
+version = "0.1.0"
+authors = ["Richard Kelly <rpkelly@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.8.0/public-control-container-v0-6-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/public-control-container-v0-6-1/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.0";
+const NEW_CONTROL_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.1";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_SOURCE_VAL,
+        new_val: NEW_CONTROL_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.8.0"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.0"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken"
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.0"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.1"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,9 +6,9 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.0"
 
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.1"


### PR DESCRIPTION
**Description of changes:**
* admin-container: 0.8.0 → 0.9.0
*  control-container 0.6.0 → 0.6.1



**Testing done:**
 aws-k8s-1.21 (x86_64) upgrade/downgrade


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
