### PR TITLE
models, kubernetes: add new provider-id setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.topology-manager-policy`: Specifies the topology manager policy. Possible values are `none`, `restricted`, `best-effort`, and `single-numa-node`. Defaults to `none`.
 * `settings.kubernetes.topology-manager-scope`: Specifies the topology manager scope. Possible values are `container` and `pod`. Defaults to `container`. If you want to group all containers in a pod to a common set of NUMA nodes, you can set this setting to `pod`.
 * `settings.kubernetes.pod-pids-limit`: The maximum number of processes per pod.
+* `settings.kubernetes.provider-id`: This sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -123,5 +123,6 @@ version = "1.7.2"
     "migrate_v1.8.0_etc-hosts.lz4",
     "migrate_v1.8.0_etc-hosts-metadata.lz4",
     "migrate_v1.8.0_cluster-dns-ip-list.lz4",
-    "migrate_v1.8.0_pki-affected-services.lz4"
+    "migrate_v1.8.0_pki-affected-services.lz4",
+    "migrate_v1.8.0_kubelet-provider-id.lz4"
 ]

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -93,6 +93,9 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.provider-id}}
+providerID: {{settings.kubernetes.provider-id}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -93,6 +93,9 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.provider-id}}
+providerID: {{settings.kubernetes.provider-id}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -93,6 +93,9 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.provider-id}}
+providerID: {{settings.kubernetes.provider-id}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -93,6 +93,9 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.provider-id}}
+providerID: {{settings.kubernetes.provider-id}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -93,6 +93,9 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.provider-id}}
+providerID: {{settings.kubernetes.provider-id}}
+{{/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1841,6 +1841,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-provider-id"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "api/migration/migrations/v1.8.0/etc-hosts-metadata",
     "api/migration/migrations/v1.8.0/cluster-dns-ip-list",
     "api/migration/migrations/v1.8.0/pki-affected-services",
+    "api/migration/migrations/v1.8.0/kubelet-provider-id",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.8.0/kubelet-provider-id/Cargo.toml
+++ b/sources/api/migration/migrations/v1.8.0/kubelet-provider-id/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-provider-id"
+version = "0.1.0"
+edition = "2018"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.8.0/kubelet-provider-id/src/main.rs
+++ b/sources/api/migration/migrations/v1.8.0/kubelet-provider-id/src/main.rs
@@ -1,0 +1,20 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring kubelet's provider-id option, `settings.kubernetes.provider-id`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&["settings.kubernetes.provider-id"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -218,6 +218,7 @@ struct KubernetesSettings {
     topology_manager_scope: TopologyManagerScope,
     topology_manager_policy: TopologyManagerPolicy,
     pod_pids_limit: i64,
+    provider_id: Url,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```

    migrations: migrate new 'settings.kubernetes.provider-id'
    
    We added a new setting for configuring kubelet's provider-id option.
```
```
    models, kubernetes: add new provider-id setting
    
    This adds a new `settings.kubernetes.provider-id` setting for
    configuring the `providerID` item in kubelet config.

```


**Testing done:**
Built and ran metal-k8s-1.22.
The node joins the cluster without problem. 
When I updated the `settings.kubernetes.provider-id` setting, the config gets rendered correctly:
```
bash-5.1# apiclient set settings.kubernetes.provider-id=tinkerbell://eksa-system/worker1
bash-5.1# cat /etc/kubernetes/kubelet/config        
---
kind: KubeletConfiguration
apiVersion: kubelet.config.k8s.io/v1beta1
....

providerID: tinkerbell://eksa-system/worker1
resolvConf: "/etc/resolv.conf"
...
```
Kubelet also successfully restarts and reregisters the node fine:
```
bash-5.1# systemctl status kubelet
● kubelet.service - Kubelet
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/kubelet.service.d
             └─exec-start.conf
     Active: active (running) since Wed 2022-06-08 02:59:02 UTC; 3min 25s ago
       Docs: https://github.com/kubernetes/kubernetes
    Process: 85750 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT (code=exited, status=0/SUCCESS)
    Process: 85751 ExecStartPre=/usr/bin/host-ctr --containerd-socket=/run/dockershim.sock --namespace=k8s.io pull-image --source=${POD_INFRA_CONTAINER_IMAGE} --registry-config=/etc/host-containers/host-ctr.toml (code=exited, status=0/SUCCESS)
   Main PID: 85763 (kubelet)
      Tasks: 35 (limit: 37730)
     Memory: 61.2M
        CPU: 2.487s
     CGroup: /runtime.slice/kubelet.service
             └─85763 /usr/bin/kubelet --cloud-provider "" --kubeconfig /etc/kubernetes/kubelet/kubeconfig --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig --config /etc/kubernetes/kubelet/config --container-runtime=remote --container-runtime-endpoint=unix:///run/dockershim.sock --containerd=/run/dockershim.sock --network-plugin cni --root-dir /var/lib/kubelet --cert-dir /var/lib/kubelet/pki --node-ip 10.61.248.114 --node-labels "" --register-with-taints "" --pod-infra-container-image public.ecr.aws/eks-distro/kubernetes/pause:3.5
```

If I set the setting in userdata:
```
            [settings.kubernetes]
...
            provider-id = "tinkerbell://eksa-system/worker"
```
kubelet runs fine and registers the node with providerID as expected:
```
$ kubectl  --kubeconfig ./cluster-kubeconfigs/br-test-122-eks-a-cluster.kubeconfig get node eksa-node10 -o yaml                                                                                                    
...                                                          
spec:                                                                                                    
  podCIDR: 192.168.9.0/24                                                                                
  podCIDRs:                                                                                              
  - 192.168.9.0/24                                                                                       
  providerID: tinkerbell://eksa-system/worker   
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
