### PR TITLE
Documentation: Add and update documentation for metal variants

### DIFF
--- a/PROVISIONING-METAL.md
+++ b/PROVISIONING-METAL.md
@@ -1,0 +1,188 @@
+# Provisioning Bottlerocket on metal
+
+This guide will describe what is needed to properly provision Bottlerocket on bare metal.
+Provisioning Bottlerocket on metal is different than provisioning other general-purpose distros.
+Since Bottlerocket has a `dm-verity`-checked boot and root partition, and is immutable at runtime, a user cannot provision an image and directly write configuration files.
+Bottlerocket requires a few files to be generated and written to disk at provisioning time in order to boot properly; these files are described below.
+
+For more information about the hardware that Bottlerocket for bare metal is currently tested on, see [SUPPORTED-HARDWARE](SUPPORTED-HARDWARE.md).
+
+## High level provisioning steps
+
+The high level steps to provision Bottlerocket images for bare metal to your host are below.
+Most provisioning systems provide methods to achieve the following:
+
+* Decompress (`unlz4`) and write the Bottlerocket image to the desired disk
+* Mount the `BOTTLEROCKET-PRIVATE` partition (partition 12)
+* Write the below files to the mounted partition (these files are further described below):
+  * (Required) [`user-data.toml`](#user-data)
+  * (Required) [`net.toml`](#network-interface-configuration)
+  * (Optional, recommended) [`bootconfig.data`](#boot-configuration)
+* Reboot
+
+### Fetch the Bottlerocket image for bare metal
+
+The Bottlerocket image for bare metal is signed and uploaded alongside the rest of the Bottlerocket release artifacts.
+
+You first need the Bottlerocket root role, which is used by `tuftool` to verify the image.
+The following will download and verify the root role itself:
+
+```
+curl -O "https://cache.bottlerocket.aws/root.json"
+sha512sum -c <<<"e9b1ea5f9b4f95c9b55edada4238bf00b12845aa98bdd2d3edb63ff82a03ada19444546337ec6d6806cbf329027cf49f7fde31f54d551c5e02acbed7efe75785  root.json"
+```
+
+Next, set your desired version and variant, and use `tuftool` to download the image:
+To install `tuftool` you'll need to install Rust (via [rustup](https://rustup.rs/) or the official site), and then you can run `cargo install tuftool`.
+```
+ARCH="x86_64"
+VERSION="1.8.0"
+VARIANT="metal-k8s-1.23"
+COMMIT="a6233c22"
+IMAGE="bottlerocket-${VARIANT}-${ARCH}-${VERSION}-${COMMIT}.img.lz4"
+OUTDIR="${VARIANT}-${VERSION}"
+
+tuftool download "${OUTDIR}" --target-name "${IMAGE}" \
+   --root ./root.json \
+   --metadata-url "https://updates.bottlerocket.aws/2020-07-07/${VARIANT}/x86_64/" \
+   --targets-url "https://updates.bottlerocket.aws/targets/"
+```
+
+### User data
+
+Bottlerocket for bare metal expects a TOML-formatted file named `user-data.toml` that contains user data settings.
+Acceptable settings can be found in the [settings docs](https://github.com/bottlerocket-os/bottlerocket#settings).
+
+If you're just getting started and want to provision a host without connecting to a Kubernetes cluster, you can use the following example user data which will start `kubelet` in standalone mode.
+
+```toml
+[settings.kubernetes]
+standalone-mode = true
+```
+
+For remote access to your running Bottlerocket hosts, you will need to add user data to enable host containers.
+The Bottlerocket images for bare metal don't enable any host containers by default.
+You can use our [admin](https://github.com/bottlerocket-os/bottlerocket-admin-container) and/or [control](https://github.com/bottlerocket-os/bottlerocket-control-container) containers, but they need to be configured first.
+Full configuration details are covered in the [admin container documentation](https://github.com/bottlerocket-os/bottlerocket-admin-container#authenticating-with-the-admin-container) and the [control container documentation](https://github.com/bottlerocket-os/bottlerocket-control-container#connecting-to-aws-systems-manager-ssm).
+
+### Network interface configuration
+
+Bottlerocket for bare metal provides the means to configure the physical network interfaces in the system via TOML-formatted file `net.toml`.
+For now, simple DHCP4 and DHCP6 configuration is supported with plans to support additional configuration in the future.
+
+`net.toml` is read at boot time and generates the proper configuration files in the correct format for each interface described; no default configuration is provided.
+If no network configuration is provided, boot-time services like host containers, `containerd`, and `kubelet` will fail to start.
+When these services fail, your machine will not connect to any cluster and will be unreachable via host containers.
+
+#### `net.toml` structure
+
+The configuration file must be valid TOML and have the filename `net.toml`.
+The first and required top level key in the file is `version`, currently only `1` is supported.
+The rest of the file is a map of interface name to supported settings.
+Interface names are expected to be correct as per `udevd` naming, no interface naming or matching is supported.
+(See the note below regarding `udevd` interface naming.)
+
+#### Supported interface settings
+
+* `primary` (boolean): Use this interface as the primary network interface. `kubelet` will use this interface's IP when joining the cluster.  If none of the interfaces has `primary` set, the first interface in the file is used as the primary interface.
+* `dhcp4` (boolean or map): Turns on DHCP4 for the interface.  If additional DHCP4 configuration is required, the following settings are supported and may be provided as a map with the following keys:
+  * `enabled` (boolean, required): Enables DHCP4.
+  * `route-metric` (integer): Prioritizes routes by setting values for preferred interfaces.
+  * `optional` (boolean): the system will request a lease using this protocol, but will not wait for a valid lease to consider this interface configured.
+* `dhcp6` (boolean or map): Turns on DHCP6 for the interface.  If additional DHCP6 configuration is required, the following settings are supported and may be provided as a map with the following keys:
+  * `enabled` (boolean, required): Enables DHCP6.
+  * `optional` (boolean): the system will request a lease using this protocol, but will not wait for a valid lease to consider this interface configured.
+
+Example `net.toml` with comments:
+```toml
+version = 1
+
+# "eno1" is the interface name
+[eno1]
+# Users may turn on dhcp4 and dhcp6 via boolean
+dhcp4 = true
+dhcp6 = true
+primary = true
+
+# "eno2" is the second interface in this example
+[eno2.dhcp4]
+# `enabled` is a boolean and is a required key when
+# setting up DHCP this way
+enabled = true
+# Route metric may be supplied for ipv4
+route-metric = 200
+
+[eno2.dhcp6]
+enabled = true
+optional = true
+```
+
+**An additional note on network device names**
+
+Interface name policies are [specified in this file](https://github.com/bottlerocket-os/bottlerocket/blob/develop/packages/release/80-release.link#L6); with name precedence in the following order: onboard, slot, path.
+Typically on-board devices are named `eno*`, hot-plug devices are named `ens*`, and if neither of those names are able to be generated, the “path” name is given, i.e `enp*s*f*`.
+
+### Boot Configuration
+
+Bottlerocket for bare metal uses a feature of the Linux kernel called [Boot Configuration](https://www.kernel.org/doc/html/latest/admin-guide/bootconfig.html), which allows a user to pass additional arguments to the kernel command line at runtime.
+An immediate use of this feature for most users is setting `console` settings so boot messages can be seen on the appropriate consoles.
+
+In order to make use of this feature, an initrd is created with the desired settings encoded inside it.
+The initrd is empty save for the encoded boot config data.
+To create the initrd, you must first create a configuration file containing key value pairs for the settings you would like to pass to kernel / init.
+Full syntax is described in the [Boot Config documentation](https://www.kernel.org/doc/html/latest/admin-guide/bootconfig.html#config-file-syntax), but a simple example is provided below that shows the format of console settings as well as an example `systemd` parameter.
+
+The two acceptable prefixes to settings are `kernel` and `init`.
+Settings prefixed with `kernel` are added to the beginning of the kernel command line.
+Settings prefixed with `init` are added to the kernel command line after the `--`, but before any existing init parameters.
+
+In the example below, two console devices are set up, and `systemd`'s log level is set to `debug`.
+
+Example Boot Configuration:
+```
+kernel {
+    console = tty0, "ttyS1,115200n8"
+}
+init {
+    systemd.log_level = debug
+}
+```
+
+The Bottlerocket SDK provides the `bootconfig` CLI tool, which is used to create a Boot Configuration initrd.
+To create the Boot Configuration initrd, create a config file named `bootconfig-input` containing your desired key/value pair kernel and init arguments.
+
+Then run the following (you will need Docker installed):
+```
+ARCH=$(uname -m)
+SDK_VERSION="v0.26.0"
+SDK_IMAGE="public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:${SDK_VERSION}"
+
+touch $(pwd)/bootconfig.data
+
+docker run --rm \
+   --network=none \
+   --user "$(id -u):$(id -g)" \
+   --security-opt label:disable \
+   -v $(pwd)/bootconfig-input:/tmp/bootconfig-input \
+   -v $(pwd)/bootconfig.data:/tmp/bootconfig.data \
+   "${SDK_IMAGE}" \
+   bootconfig -a /tmp/bootconfig-input /tmp/bootconfig.data
+```
+
+The above command will create the properly named initrd `bootconfig.data` in your current directory.
+This is the file you will write to disk during provisioning.
+
+You can list a `bootconfig.data`'s contents, which also validates its format, by running:
+```
+ARCH=$(uname -m)
+SDK_VERSION="v0.26.0"
+SDK_IMAGE="public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:${SDK_VERSION}"
+
+docker run --rm \
+   --network=none \
+   --user "$(id -u):$(id -g)" \
+   --security-opt label:disable \
+   -v $(pwd)/bootconfig.data:/tmp/bootconfig.data \
+   "${SDK_IMAGE}" \
+   bootconfig -l /tmp/bootconfig.data
+```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Welcome to Bottlerocket!
 Bottlerocket is a free and open-source Linux-based operating system meant for hosting containers.
 
 If you’re ready to jump right in, read one of our setup guides for running Bottlerocket in [Amazon EKS](QUICKSTART-EKS.md), [Amazon ECS](QUICKSTART-ECS.md), or [VMware](QUICKSTART-VMWARE.md).
+If you're interested in running Bottlerocket on bare metal servers, please refer to the [provisioning guide](PROVISIONING-METAL.md) to get started.
 
 Bottlerocket focuses on security and maintainability, providing a reliable, consistent, and safe platform for container-based workloads.
 This is a reflection of what we've learned building operating systems and services at Amazon.
@@ -70,7 +71,13 @@ We also have variants that are designed to be Kubernetes worker nodes in VMware:
 - `vmware-k8s-1.22`
 - `vmware-k8s-1.23`
 
-The following variants are no longer supported.:
+The following variants are designed to be Kubernetes worker nodes on bare metal:
+
+- `metal-k8s-1.21`
+- `metal-k8s-1.22`
+- `metal-k8s-1.23`
+
+The following variants are no longer supported:
 
 - `aws-k8s-1.15`
 - `aws-k8s-1.16`
@@ -94,6 +101,8 @@ To get started with Amazon ECS, please see [QUICKSTART-ECS](QUICKSTART-ECS.md).
 These guides describe:
 * how to set up a cluster with the orchestrator, so your Bottlerocket instance can run containers
 * how to launch a Bottlerocket instance in EC2 or VMware
+
+To see how to provision Bottlerocket on bare metal, see [PROVISIONING-METAL](PROVISIONING-METAL.md).
 
 To build your own Bottlerocket images, please see [BUILDING](BUILDING.md).
 It describes:
@@ -410,7 +419,8 @@ Static pods can be particularly useful when running in standalone mode.
 
 For Kubernetes variants in AWS and VMware, the following are set for you automatically, but you can override them if you know what you're doing!
 In AWS, [pluto](sources/api/) sets these based on runtime instance information.
-In VMware, Bottlerocket uses [netdog](sources/api/) (for `node-ip`) or relies on [default values](sources/models/src/vmware-k8s-1.23/defaults.d).
+In VMware and on bare metal, Bottlerocket uses [netdog](sources/api/) (for `node-ip`) or relies on default values.
+(See the [VMware defaults](sources/models/src/vmware-k8s-1.23/defaults.d) or [bare metal defaults](sources/models/src/metal-k8s-1.23/defaults.d)).
 * `settings.kubernetes.node-ip`: The IP address of this node.
 * `settings.kubernetes.pod-infra-container-image`: The URI of the "pause" container.
 * `settings.kubernetes.kube-reserved`: Resources reserved for node components.

--- a/SUPPORTED-HARDWARE.md
+++ b/SUPPORTED-HARDWARE.md
@@ -1,0 +1,25 @@
+# Supported hardware for Bottlerocket on bare metal
+
+This document captures the hardware Bottlerocket for bare metal is tested on and known to work with.
+It also contains hardware that contributors have reported to be functional.
+
+Bottlerocket's kernel configuration isn't as extensive as some other distros, so it's possible that it is missing drivers for your specific hardware.
+If so, please [submit an issue](https://github.com/bottlerocket-os/bottlerocket/issues/new?assignees=&labels=&template=feature.md) and we'll work on integrating the proper kernel modules for your hardware!
+
+## Confirmed support
+
+Bottlerocket is tested on and known to work with the hardware below.
+
+| Server model | CPU | BIOS/UEFI | Network Card | Disk | RAID/Storage controller |
+| --- | --- | --- | --- | --- | --- |
+| Supermicro SYS-E200-8D | Intel Xeon D-1528 | BIOS & UEFI | Intel i350 1G & 10G | SATA SSD, NVME | N/A |
+| Dell R240 | Intel Xeon E2236 | BIOS & UEFI | Broadcom BCM5720 1G | SATA SSD (RAID0) | PERC H730P |
+| Dell R620 | Intel Xeon E5-2660 | BIOS | Intel i350 1G | SATA HDD | PERC H710P |
+| HP DL20 | Intel Xeon E2234 | BIOS | HPE 361i 1G | SATA SSD | HPE Smart Array S100i |
+
+## Reported Support
+
+Bottlerocket has been reported to work on the hardware below.
+
+| Server model | CPU | BIOS/UEFI | Network Card | Disk | RAID/Storage controller |
+| --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION


**Description of changes:**
```
    Add HARDWARE.md
    
    This adds a new file HARDWARE.md meant to document the hardware that
    Bottlerocket is currently tested on, not necessarily all of the hardware
    that can currently boot Bottlerocket.
```
```
    Add PROVISIONING-METAL.md
    
    This adds a new document that describes the files and process needed to
    provision Bottlerocket on a bare metal machine.
```
```
    README.md: Update for metal
    
    Updates README.md to add some additional information for metal variants.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
