### PR TITLE
Makefile: Create symlinks to images with friendly names (excluding SHA)

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -137,6 +137,8 @@ BUILDSYS_VERSION_FULL="${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
 BUILDSYS_NAME_VARIANT="${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}"
 BUILDSYS_NAME_VERSION="${BUILDSYS_NAME}-${BUILDSYS_VERSION_FULL}"
 BUILDSYS_NAME_FULL="${BUILDSYS_NAME_VARIANT}-${BUILDSYS_VERSION_FULL}"
+# This name does not include the build short SHA
+BUILDSYS_NAME_FRIENDLY = "${BUILDSYS_NAME_VARIANT}-v${BUILDSYS_VERSION_IMAGE}"
 # Path to repo-specific root role.
 PUBLISH_REPO_ROOT_JSON = "${BUILDSYS_ROOT_DIR}/roles/${PUBLISH_REPO}.root.json"
 # If you don't specify a signing key in Infra.toml, we generate one at this path.
@@ -689,7 +691,8 @@ script = [
 for link in \
     ${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_VARIANT}* \
     ${BUILDSYS_OUTPUT_DIR}/latest/*-kmod-kit-* \
-    ${BUILDSYS_OUTPUT_DIR}/latest/*.ova ; do
+    ${BUILDSYS_OUTPUT_DIR}/latest/*.ova \
+    ${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_FRIENDLY}*; do
   if [ -L "${link}" ]; then
     rm ${link}
   fi
@@ -711,6 +714,15 @@ done
 ln -snf "../${BUILDSYS_NAME_FULL}-kmod-kit.tar.xz" "${BUILDSYS_KMOD_KIT_PATH}"
 if [ -s "${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.ova" ] ; then
   ln -snf "../${BUILDSYS_NAME_FULL}.ova" "${BUILDSYS_OVA_PATH}"
+fi
+
+# Symlink the root and data disk images to a more friendly name.  All variants
+# will have an image, not all builds have a data disk image
+os_disk_img="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.img.lz4"
+data_disk_img="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-data.img.lz4"
+ln -snf "${os_disk_img}" "${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_FRIENDLY}.img.lz4"
+if [ -s "${data_disk_img}" ]; then
+   ln -snf "${data_disk_img}" "${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_FRIENDLY}-data.img.lz4"
 fi
 '''
 ]
@@ -820,15 +832,22 @@ done
 # modules for a given release.
 LINK_REPO_TARGETS=("--link-target ${BUILDSYS_KMOD_KIT_PATH}")
 
-# Include the root and data disk images in the repo if they exist
+# Include the root and data disk images in the repo both with and without a
+# friendly name if they exist.  Check for the existence of the image and not
+# the friendly symlink to guard against the case where the link may not have
+# been created. `pubsys` will also fail if the friendly link does not exist
 os_disk_img="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}.img.lz4"
+os_disk_img_friendly="${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_FRIENDLY}.img.lz4"
 if [ -s "${os_disk_img}" ] ; then
    LINK_REPO_TARGETS+=("--link-target ${os_disk_img}")
+   LINK_REPO_TARGETS+=("--link-target ${os_disk_img_friendly}")
 fi
 
 data_disk_img="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_NAME_FULL}-data.img.lz4"
+data_disk_img_friendly="${BUILDSYS_OUTPUT_DIR}/latest/${BUILDSYS_NAME_FRIENDLY}-data.img.lz4"
 if [ -s "${data_disk_img}" ]; then
    LINK_REPO_TARGETS+=("--link-target ${data_disk_img}")
+   LINK_REPO_TARGETS+=("--link-target ${data_disk_img_friendly}")
 fi
 
 # Ensure we link an OVA if an OVF template exists (in which case we should have


### PR DESCRIPTION
**Description of changes:**
```
    Makefile: Create symlinks to images with friendly names (excluding SHA)
    
    This change includes an additional copy of the root and data disk images
    when including them in the TUF repo.  The additional copy excludes the
    git SHA from the name.  This makes the images easier to directly
    download using the currently released version.
```

It's important to note that this _does not_ change the `{boot,root,hash}` artifact filenames since those are used for updates and we can't change them.

**Testing done:**
* Build a repo with `cargo make repo` and observe the `{.img, -data.img}` files being linked to the proper artifacts in the `images` directory _AND_ and the repository

*In the `images` directory*
```
$ ls -lah build/images/x86_64-aws-k8s-1.21/latest/
...
bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz4 -> /home/fedora/bottlerocket/bottlerocket/build/images/x86_64-aws-k8s-1.21/bottlerocket-aws-k8s-1.21-x86_64-1.8.0-bad04b4c-data.img.lz4
bottlerocket-aws-k8s-1.21-x86_64-v1.8.0.img.lz4 -> /home/fedora/bottlerocket/bottlerocket/build/images/x86_64-aws-k8s-1.21/bottlerocket-aws-k8s-1.21-x86_64-1.8.0-bad04b4c.img.lz
...
```

*In the repository*
```
$  ls -lah build/repos/default/bottlerocket-1.8.0-bad04b4c/targets/
...
b4e7c3915a91b17b843918a31d5ead6b0e0e70f9aa63c3a95c52bb17531d399c.bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz4 -> /home/fedora/bottlerocket/bottlerocket/build/images/x86_64-aws-k8s-1.21/latest/bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz4
f5fbabd2a18e1dfe7e464f38f3b4ddf240ea68e49ed6037a1124dc46ced2451e.bottlerocket-aws-k8s-1.21-x86_64-v1.8.0.img.lz4 -> /home/fedora/bottlerocket/bottlerocket/build/images/x86_64-aws-k8s-1.21/latest/bottlerocket-aws-k8s-1.21-x86_64-v1.8.0.img.lz4
...
```
* Ensure that the symlink chain ends at the right file
```
$  namei build/repos/default/bottlerocket-1.8.0-bad04b4c/targets/b4e7c3915a91b17b843918a31d5ead6b0e0e70f9aa63c3a95c52bb17531d399c.bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz4

f: build/repos/default/bottlerocket-1.8.0-bad04b4c/targets/b4e7c3915a91b17b843918a31d5ead6b0e0e70f9aa63c3a95c52bb17531d399c.bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz
...
 l b4e7c3915a91b17b843918a31d5ead6b0e0e70f9aa63c3a95c52bb17531d399c.bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz4 -> /home/fedora/bottlerocket/bottlerocket/build/images/x86_64-aws-k8s-1.21/latest/bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz4
...
   l bottlerocket-aws-k8s-1.21-x86_64-v1.8.0-data.img.lz4 -> /home/fedora/bottlerocket/bottlerocket/build/images/x86_64-aws-k8s-1.21/bottlerocket-aws-k8s-1.21-x86_64-1.8.0-bad04b4c-data.img.lz4
...
     - bottlerocket-aws-k8s-1.21-x86_64-1.8.0-bad04b4c-data.img.lz4
```

* Observe the sha256sum of the local image as identical to the sha256sum prefixed to the image in the repository
```
$ sha256sum build/images/x86_64-aws-k8s-1.21/bottlerocket-aws-k8s-1.21-x86_64-1.8.0-bad04b4c.img.lz4
 
f5fbabd2a18e1dfe7e464f38f3b4ddf240ea68e49ed6037a1124dc46ced2451e  build/images/x86_64-aws-k8s-1.21/bottlerocket-aws-k8s-1.21-x86_64-1.8.0-bad04b4c.img.lz4
```

Image name in the repository: `f5fbabd2a18e1dfe7e464f38f3b4ddf240ea68e49ed6037a1124dc46ced2451e.bottlerocket-aws-k8s-1.21-x86_64-v1.8.0.img.lz4`

* Ensure the `link-clean` target does indeed clean up the new links in the images dir:


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
