### PR TITLE
kubelet: add image GC threshold settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.topology-manager-policy`: Specifies the topology manager policy. Possible values are `none`, `restricted`, `best-effort`, and `single-numa-node`. Defaults to `none`.
 * `settings.kubernetes.topology-manager-scope`: Specifies the topology manager scope. Possible values are `container` and `pod`. Defaults to `container`. If you want to group all containers in a pod to a common set of NUMA nodes, you can set this setting to `pod`.
 * `settings.kubernetes.pod-pids-limit`: The maximum number of processes per pod.
+* `settings.kubernetes.image-gc-high-threshold-percent`: The percent of disk usage after which image garbage collection is always run.
+* `settings.kubernetes.image-gc-low-threshold-percent`: The percent of disk usage before which image garbage collection is never run.
 * `settings.kubernetes.provider-id`: This sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node.
 
 You can also optionally specify static pods for your node with the following settings.

--- a/Release.toml
+++ b/Release.toml
@@ -134,4 +134,5 @@ version = "1.8.0"
     "migrate_v1.9.0_ntp-affected-services.lz4",
     "migrate_v1.9.0_shibaken-admin-userdata-semantics.lz4",
     "migrate_v1.9.0_shibaken-send-metrics.lz4",
+    "migrate_v1.9.0_image-gc-thresholds.lz4",
 ]

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -93,6 +93,12 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
+imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.image-gc-low-threshold-percent includeZero=true}}
+imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent}}
+{{/if}}
 {{#if settings.kubernetes.provider-id}}
 providerID: {{settings.kubernetes.provider-id}}
 {{/if}}

--- a/packages/kubernetes-1.20/kubelet-config
+++ b/packages/kubernetes-1.20/kubelet-config
@@ -93,6 +93,12 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
+imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.image-gc-low-threshold-percent includeZero=true}}
+imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent}}
+{{/if}}
 {{#if settings.kubernetes.provider-id}}
 providerID: {{settings.kubernetes.provider-id}}
 {{/if}}

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -93,6 +93,12 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
+imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.image-gc-low-threshold-percent includeZero=true}}
+imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent}}
+{{/if}}
 {{#if settings.kubernetes.provider-id}}
 providerID: {{settings.kubernetes.provider-id}}
 {{/if}}

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -93,6 +93,12 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
+imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.image-gc-low-threshold-percent includeZero=true}}
+imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent}}
+{{/if}}
 {{#if settings.kubernetes.provider-id}}
 providerID: {{settings.kubernetes.provider-id}}
 {{/if}}

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -93,6 +93,12 @@ topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{#if settings.kubernetes.pod-pids-limit includeZero=true}}
 podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
 {{/if}}
+{{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
+imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.image-gc-low-threshold-percent includeZero=true}}
+imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent}}
+{{/if}}
 {{#if settings.kubernetes.provider-id}}
 providerID: {{settings.kubernetes.provider-id}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1744,6 +1744,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-gc-thresholds"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "imdsclient"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "api/migration/migrations/v1.9.0/ntp-affected-services",
     "api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics",
     "api/migration/migrations/v1.9.0/shibaken-send-metrics",
+    "api/migration/migrations/v1.9.0/image-gc-thresholds",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.9.0/image-gc-thresholds/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/image-gc-thresholds/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "image-gc-thresholds"
+version = "0.1.0"
+edition = "2018"
+authors = ["Mahdi Chaker <mmchaker@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.9.0/image-gc-thresholds/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/image-gc-thresholds/src/main.rs
@@ -1,0 +1,26 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring kubelet's image-gc-high-threshold-percent
+/// and image-gc-low-threshold-percent options,
+/// `settings.kubernetes.image-gc-high-threshold-percent` and
+/// `settings.kubernetes.image-gc-low-threshold-percent`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.image-gc-high-threshold-percent",
+        "settings.kubernetes.image-gc-low-threshold-percent",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -162,13 +162,13 @@ use crate::de::{deserialize_mirrors, deserialize_node_taints};
 use crate::modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, DNSDomain,
     ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
-    EtcHostsEntries, FriendlyVersion, Identifier, KubernetesAuthenticationMode,
-    KubernetesBootstrapToken, KubernetesCloudProvider, KubernetesClusterDnsIp,
-    KubernetesClusterName, KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey,
-    KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
-    KubernetesTaintValue, KubernetesThresholdValue, Lockdown, PemCertificateString,
-    SingleLineString, SysctlKey, TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64,
-    ValidLinuxHostname,
+    EtcHostsEntries, FriendlyVersion, Identifier, ImageGCHighThresholdPercent,
+    ImageGCLowThresholdPercent, KubernetesAuthenticationMode, KubernetesBootstrapToken,
+    KubernetesCloudProvider, KubernetesClusterDnsIp, KubernetesClusterName,
+    KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
+    KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
+    KubernetesThresholdValue, Lockdown, PemCertificateString, SingleLineString, SysctlKey,
+    TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
 };
 
 // Kubernetes static pod manifest settings
@@ -218,6 +218,8 @@ struct KubernetesSettings {
     topology_manager_scope: TopologyManagerScope,
     topology_manager_policy: TopologyManagerPolicy,
     pod_pids_limit: i64,
+    image_gc_high_threshold_percent: ImageGCHighThresholdPercent,
+    image_gc_low_threshold_percent: ImageGCLowThresholdPercent,
     provider_id: Url,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -128,6 +128,18 @@ pub mod error {
             input: String,
             source: serde_plain::Error,
         },
+
+        #[snafu(display("Invalid imageGCHighThresholdPercent '{}': {}", input, msg))]
+        InvalidImageGCHighThresholdPercent { input: String, msg: String },
+
+        #[snafu(display("Invalid imageGCLowThresholdPercent '{}': {}", input, msg))]
+        InvalidImageGCLowThresholdPercent { input: String, msg: String },
+
+        #[snafu(display("Could not parse '{}' as an integer", input))]
+        ParseInt {
+            input: String,
+            source: std::num::ParseIntError,
+        },
     }
 }
 


### PR DESCRIPTION
**Issue number:**
Closes #2216 
Closes #2217 
Closes #2065


**Description of changes:**
Adds two kubelet settings: `imageGCHighThresholdPercent` and `imageGCLowThresholdPercent`.
Also adds validation for those two settings.

From the kubernetes repo (https://pkg.go.dev/k8s.io/kubernetes/pkg/kubelet/apis/config#KubeletConfiguration):

```go
// imageGCHighThresholdPercent is the percent of disk usage after which
// image garbage collection is always run. The percent is calculated as
// this field value out of 100.

// imageGCLowThresholdPercent is the percent of disk usage before which
// image garbage collection is never run. Lowest disk usage to garbage
// collect to. The percent is calculated as this field value out of 100.
```

~~**Some Q&A:**~~

~~1. _Why validate twice: at the apiserver level, and the template rendering level?_~~
    ~~1. There are two kinds of invalidity for the settings this PR adds: independent invalidity and _interdependent invalidity_. Independent invalidity would be a value outside of the defined 0-100 threshold. _Interdependent invalidity_ is when the `High` threshold percent is lower than the `Low` threshold percent, and is only calculable by comparing (or knowing) both settings at the same time.~~
    ~~1. The independent invalidity can and should be checked as soon as possible and stop the user from entering invalid values. That kind of validation can and is done at the apiserver level.~~
    ~~1. The _interdependent_ invalidity is only able to be checked when the template is about to be rendered -- when _both_ setting values are known (since the user can provide only one of the two new settings in an apiserver request, and these settings also have default kubelet values to initially compare against).~~
~~1. _Why does your template code contain `~` characters at each end of the helper function call?_~~
    ~~1. That is a [handlebars](https://docs.rs/handlebars/latest/handlebars/index.html) feature that removes whitespace (including newlines) before or after that `~` character.~~
    ~~1. In the case of this PR, the helper function `image_gc_threshold_percent` actually handles the rendering of necessary whitespace after writing out the setting values (specifically: the newlines after each setting), so the template rendering engine/handlebars should remove the existing newline it sees at the end of the helper function call (after the `}}` at the end of the line). Therefore, the `~` feature of handlebars was used.~~

**Testing done:**
- [x] Upgrade/downgrade for variant: aws-k8s-1.22
- ~[ ] Upgrade/downgrade for variant: metal 1.22~
- [x] Rendering and setting updates for variant: vmware 1.22
- [x] Manual testing of valid and invalid values, in varying order, on a bottlerocket aws-k8s-1.22 node in a k8s 1.22 cluster


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
