### PR TITLE
schnauzer: add support for non-string JSON data types

### DIFF
--- a/sources/api/schnauzer/README.md
+++ b/sources/api/schnauzer/README.md
@@ -13,6 +13,10 @@ The setting we're generating is expected to have a metadata key already set: "te
 For example, if we're generating "settings.x" and we have template "foo-{{ settings.bar }}", we look up the value of "settings.bar" in the API.
 If the returned value is "baz", our generated value will be "foo-baz".
 
+When dealing with settings that should return a non-string value (ex. booleans), just specify the JSON data type by adding `--type <json-data-type>` to the setting-generator line.
+The resulting setting values will still be returned as stdout to sundog, but will not be wrapped in quotes.
+For example, "schnauzer settings.foo.bar --type bool" could return false and the value in the API would be a proper boolean.
+
 (The name "schnauzer" comes from the fact that Schnauzers are search and rescue dogs (similar to this search and replace task) and because they have mustaches.)
 
 ## Colophon


### PR DESCRIPTION
**Description of changes:**

This adds support for using schnauzer for settings other than strings, like conditionally toggling a setting that expects a boolean. Since this isn't particularly common and we want to ensure backwards compatibility, if a type isn't specified it will default to string.

**Example use case:**

If you wanted to enable/disable metricdog barking conditionally by region, rather than a hard-coded value, you could configure your model as such:
```
[metadata.settings.metrics.should-bark]
setting-generator = "schnauzer settings.metrics.should-bark --type bool"
template = "{{ should-bark settings.aws.region }}"
```
Assuming you write a helper in schnauzer for barking to return `"true"` or `"false"`, Bottlerocket would previously fail to apply this to the API as the model is expecting a bool instead of a string. With the proposed changes, schnauzer would instead return a `true` or `false`. The difference is in the quotes!

**Testing done:**

- Unit testing passed.
- Built `aws-k8s-1.21` and checked ec2 console for errors.
- Built `aws-k8s-1.21` with a bool setting and verified it rendered correctly in API.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
