### PR TITLE
suppress SELinux audit for tmpfs relabels

### DIFF
--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -204,6 +204,13 @@
 (neverallow untrusted_s all_s (files (relabel)))
 (neverallow untrusted_s unconstrained_o (files (relabel)))
 
+; Containers may copy or move files from constrained directories
+; into unconstrained ones, such as tmpfs mounts. If they attempt to
+; also copy the "security.selinux" xattr then this is treated as a
+; relabel operation and blocked. Since the operation is otherwise
+; successful, suppress this particular audit message.
+(dontaudit container_t any_t (file (relabelfrom)))
+
 ; No components are allowed to block access to files by using
 ; fanotify permission events. Fanotify only sends events for
 ; accesses from within the mount namespace, so it's unlikely to


### PR DESCRIPTION
**Issue number:**
Fixes #1924

**Description of changes:**
Containers are not permitted to relabel files. However, they may use standard tools such as `mv` that attempt to set xattrs on the target, and this generates an audit message.

Since the operation is otherwise successful, this can be confusing and suggest a problem that doesn't really exist. Turn off the audit message to avoid this.

**Testing done:**
Confirmed on an `aws-k8s-1.22` AMI that the AVC denial for the VPC CNI plugin is no longer logged.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
