### PR TITLE
adjust permissions for /boot and System.map

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -118,7 +118,6 @@ make -s\\\
 install -d %{buildroot}/boot
 install -T -m 0755 arch/%{_cross_karch}/boot/%{_cross_kimage} %{buildroot}/boot/vmlinuz
 install -m 0644 .config %{buildroot}/boot/config
-install -m 0644 System.map %{buildroot}/boot/System.map
 
 find %{buildroot}%{_cross_prefix} \
    \( -name .install -o -name .check -o \
@@ -226,7 +225,6 @@ ln -sf %{_usrsrc}/kernels/%{version} %{buildroot}%{kernel_libdir}/source
 %{_cross_attribution_file}
 /boot/vmlinuz
 /boot/config
-/boot/System.map
 
 %files modules
 %dir %{_cross_libdir}/modules

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -146,6 +146,9 @@ sed -i \
   -e 's,$(CONFIG_SYSTEM_TRUSTED_KEYRING),n,g' \
   scripts/Makefile
 
+# Restrict permissions on System.map.
+chmod 600 System.map
+
 (
   find * \
     -type f \

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -125,7 +125,6 @@ make -s\\\
 install -d %{buildroot}/boot
 install -T -m 0755 arch/%{_cross_karch}/boot/%{_cross_kimage} %{buildroot}/boot/vmlinuz
 install -m 0644 .config %{buildroot}/boot/config
-install -m 0644 System.map %{buildroot}/boot/System.map
 
 find %{buildroot}%{_cross_prefix} \
    \( -name .install -o -name .check -o \
@@ -231,7 +230,6 @@ ln -sf %{_usrsrc}/kernels/%{version} %{buildroot}%{kernel_libdir}/source
 %{_cross_attribution_file}
 /boot/vmlinuz
 /boot/config
-/boot/System.map
 
 %files modules
 %dir %{_cross_libdir}/modules

--- a/packages/kernel-5.4/kernel-5.4.spec
+++ b/packages/kernel-5.4/kernel-5.4.spec
@@ -153,6 +153,9 @@ sed -i \
   -e 's,$(CONFIG_SYSTEM_TRUSTED_KEYRING),n,g' \
   scripts/Makefile
 
+# Restrict permissions on System.map.
+chmod 600 System.map
+
 (
   find * \
     -type f \

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -288,6 +288,7 @@ EOF
 
 # BOTTLEROCKET-BOOT-A
 mkdir -p "${BOOT_MOUNT}/lost+found"
+chmod -R go-rwx "${BOOT_MOUNT}"
 BOOT_LABELS=$(setfiles -n -d -F -m -r "${BOOT_MOUNT}" \
     "${SELINUX_FILE_CONTEXTS}" "${BOOT_MOUNT}" \
   | awk -v root="${BOOT_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_set", $1, "security.selinux", $4}')


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
`System.map` likely isn't used by anything on modern systems, and the copy in `/boot` is even less likely to be used since for most of Bottlerocket's history (until 9e4c2cc055c7eea16550af5ec38cf29f0949050c) we didn't even mount that filesystem. Since `/boot` is space-constrained, especially on aarch64, we should just get rid of it.

Make `/boot` and the remaining copy of `System.map` readable only by UID 0, per convention.

**Testing done:**
Confirmed the new permissions on a running system.

```
bash-5.0# ls -latr /boot
total 32997
-rwx------.  1 root root 39059968 Jun 17 20:41 vmlinuz
-rw-------.  1 root root   165786 Jun 17 20:41 config
drwx------.  2 root root     1024 Jun 17 20:44 efi
drwxr-xr-x. 19 root root     4096 Jun 17 20:44 ..
drwx------.  2 root root    12288 Jun 17 20:44 lost+found
drwx------.  2 root root     1024 Jun 17 20:44 grub
drwxr-xr-x.  5 root root     1024 Jun 17 20:44 .

bash-5.0# ls -latr /lib/modules/5.10.118/build/System.map 
-rw-------. 1 root root 5303557 Jun 17 20:39 /lib/modules/5.10.118/build/System.map
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
