### PR TITLE
imdsclient: add fetch_partition function

### DIFF
--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -99,6 +99,12 @@ impl ImdsClient {
         Ok(region)
     }
 
+    /// Returns the partition that the instance is in.
+    pub async fn fetch_partition(&mut self) -> Result<Option<String>> {
+        let partition_target = "meta-data/services/partition";
+        self.fetch_string(&partition_target).await
+    }
+
     /// Returns the list of network interface mac addresses.
     pub async fn fetch_mac_addresses(&mut self) -> Result<Option<Vec<String>>> {
         let macs_target = "meta-data/network/interfaces/macs";


### PR DESCRIPTION
**Description of changes:**

Adds another helper function to fetch the partition that the Bottlerocket instance resides.

**Testing done:**
- Manually `curl`ed from IMDS on an EC2 host.
- Built Bottlerocket with a function fetching the partition and received the expected values.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
