### PR TITLE
Add kernel 5.15 sources

### DIFF
--- a/packages/kernel-5.15/1001-Makefile-add-prepare-target-for-external-modules.patch
+++ b/packages/kernel-5.15/1001-Makefile-add-prepare-target-for-external-modules.patch
@@ -1,0 +1,51 @@
+From 0f672709ce4e4dcce5e4f08e47169b9a18c0df08 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Mon, 19 Apr 2021 18:46:04 +0000
+Subject: [PATCH 1001/1002] Makefile: add prepare target for external modules
+
+We need to ensure that native versions of programs like `objtool` are
+built before trying to build out-of-tree modules, or else the build
+will fail.
+
+Unlike other distributions, we cannot include these programs in our
+kernel-devel archive, because we rely on cross-compilation: these are
+"host" programs and may not match the architecture of the target.
+
+Ideally, out-of-tree builds would run `make prepare` first, so that
+these programs could be compiled in the normal fashion. We ship all
+the files needed for this to work. However, this requirement is
+specific to our use case, and DKMS does not support it.
+
+Adding a minimal prepare target to the dependency graph causes the
+programs to be built automatically and improves compatibility with
+existing solutions.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 6192e6be4..473594c61 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1736,6 +1736,15 @@ else # KBUILD_EXTMOD
+ KBUILD_BUILTIN :=
+ KBUILD_MODULES := 1
+ 
++PHONY += modules_prepare
++modules_prepare: tools/objtool
++	$(Q)$(MAKE) $(build)=scripts/basic
++	$(Q)$(MAKE) $(build)=scripts/dtc
++	$(Q)$(MAKE) $(build)=scripts/mod
++	$(Q)$(MAKE) $(build)=scripts
++
++prepare: modules_prepare
++
+ build-dirs := $(KBUILD_EXTMOD)
+ $(MODORDER): descend
+ 	@:
+-- 
+2.33.1
+

--- a/packages/kernel-5.15/1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
+++ b/packages/kernel-5.15/1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
@@ -1,0 +1,64 @@
+From 3d31def7545ae4e6fc33a5b648610fa9c1e06e68 Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Wed, 22 Jun 2022 19:26:43 +0000
+Subject: [PATCH 1002/1002] Revert "kbuild: hide tools/ build targets from
+ external module builds"
+
+This reverts commit 1bb0b18a06dceee1fdc32161a72e28eab6f011c4 in which
+the targets to build "tools/*" were hidden for external modules, but
+they are required by the kmod kit since the 'tools/*' binaries are not
+distributed as part of the archive.
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ Makefile | 27 ++++++++++++++-------------
+ 1 file changed, 14 insertions(+), 13 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 473594c61..da4f000ef 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1357,19 +1357,6 @@ ifneq ($(wildcard $(resolve_btfids_O)),)
+ 	$(Q)$(MAKE) -sC $(srctree)/tools/bpf/resolve_btfids O=$(resolve_btfids_O) clean
+ endif
+ 
+-# Clear a bunch of variables before executing the submake
+-ifeq ($(quiet),silent_)
+-tools_silent=s
+-endif
+-
+-tools/: FORCE
+-	$(Q)mkdir -p $(objtree)/tools
+-	$(Q)$(MAKE) LDFLAGS= MAKEFLAGS="$(tools_silent) $(filter --j% -j,$(MAKEFLAGS))" O=$(abspath $(objtree)) subdir=tools -C $(srctree)/tools/
+-
+-tools/%: FORCE
+-	$(Q)mkdir -p $(objtree)/tools
+-	$(Q)$(MAKE) LDFLAGS= MAKEFLAGS="$(tools_silent) $(filter --j% -j,$(MAKEFLAGS))" O=$(abspath $(objtree)) subdir=tools -C $(srctree)/tools/ $*
+-
+ # ---------------------------------------------------------------------------
+ # Kernel selftest
+ 
+@@ -1989,6 +1976,20 @@ kernelversion:
+ image_name:
+ 	@echo $(KBUILD_IMAGE)
+ 
++# Clear a bunch of variables before executing the submake
++
++ifeq ($(quiet),silent_)
++tools_silent=s
++endif
++
++tools/: FORCE
++	$(Q)mkdir -p $(objtree)/tools
++	$(Q)$(MAKE) LDFLAGS= MAKEFLAGS="$(tools_silent) $(filter --j% -j,$(MAKEFLAGS))" O=$(abspath $(objtree)) subdir=tools -C $(srctree)/tools/
++
++tools/%: FORCE
++	$(Q)mkdir -p $(objtree)/tools
++	$(Q)$(MAKE) LDFLAGS= MAKEFLAGS="$(tools_silent) $(filter --j% -j,$(MAKEFLAGS))" O=$(abspath $(objtree)) subdir=tools -C $(srctree)/tools/ $*
++
+ quiet_cmd_rmfiles = $(if $(wildcard $(rm-files)),CLEAN   $(wildcard $(rm-files)))
+       cmd_rmfiles = rm -rf $(rm-files)
+ 
+-- 
+2.33.1
+

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kernel-5_15"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[package.metadata.build-package]
+package-name = "kernel-5.15"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+# Use latest-srpm-url.sh to get this.
+url = "https://cdn.amazonlinux.com/blobstore/14fac2ab958b3193693bea1691e23f27600ba44cb63009bdc6cc9368271227a5/kernel-5.15.43-20.123.amzn2.src.rpm"
+sha512 = "0d54742e3d4cf03dcfc398f0ebcd2c3294119683ec830efb79a0470e71f039a58d1669d1f84d21827be7d5a785225ffc15e4c0613c154ff7c54de2a208d77c5b"
+
+[build-dependencies]
+microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/build.rs
+++ b/packages/kernel-5.15/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -1,0 +1,129 @@
+# Because Bottlerocket does not have an initramfs, modules required to mount
+# the root filesystem must be set to y.
+
+# The root filesystem is ext4
+CONFIG_EXT4_FS=y
+
+# NVMe support
+CONFIG_BLK_DEV_NVME=y
+CONFIG_NVME_CORE=y
+
+# Xen blkfront for Xen-based EC2 platforms
+CONFIG_XEN_BLKDEV_FRONTEND=y
+
+# virtio for local testing with QEMU
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_BLK=y
+CONFIG_VIRTIO_PCI=y
+
+# dm-verity and enabling it on the kernel command line
+CONFIG_BLK_DEV_DM=y
+CONFIG_DAX=y
+CONFIG_DM_INIT=y
+CONFIG_DM_VERITY=y
+
+# TCMU/LIO
+CONFIG_TCM_USER2=m
+
+# EFI
+CONFIG_EFI=y
+CONFIG_EFI_STUB=y
+CONFIG_EFI_MIXED=y
+
+# EFI video
+CONFIG_FB=y
+CONFIG_FB_EFI=y
+CONFIG_FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER=y
+
+# yama LSM for ptrace restrictions
+CONFIG_SECURITY_YAMA=y
+
+# Do not allow SELinux to be disabled at boot.
+CONFIG_SECURITY_SELINUX_BOOTPARAM=n
+
+# Do not allow SELinux to be disabled at runtime.
+CONFIG_SECURITY_SELINUX_DISABLE=n
+
+# Do not allow SELinux to use `enforcing=0` behavior.
+CONFIG_SECURITY_SELINUX_DEVELOP=n
+
+# Check the protection applied by the kernel for mmap and mprotect,
+# rather than the protection requested by userspace.
+CONFIG_SECURITY_SELINUX_CHECKREQPROT_VALUE=0
+
+# Enable support for the kernel lockdown security module.
+CONFIG_SECURITY_LOCKDOWN_LSM=y
+
+# Enable lockdown early so that if the option is present on the
+# kernel command line, it can be enforced.
+CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=y
+
+# Enable zstd compression for squashfs.
+CONFIG_SQUASHFS_ZSTD=y
+
+# enable /proc/config.gz
+CONFIG_IKCONFIG=y
+CONFIG_IKCONFIG_PROC=y
+
+# kernel headers at /sys/kernel/kheaders.tar.xz
+CONFIG_IKHEADERS=y
+
+# BTF debug info at /sys/kernel/btf/vmlinux
+CONFIG_DEBUG_INFO_BTF=y
+
+# We don't want to extend the kernel command line with any upstream defaults;
+# Bottlerocket uses a fairly custom setup that needs tight control over it.
+CONFIG_CMDLINE_EXTEND=n
+
+# Enable ZSTD kernel image compression
+CONFIG_HAVE_KERNEL_ZSTD=y
+CONFIG_KERNEL_ZSTD=y
+CONFIG_ZSTD_COMPRESS=y
+CONFIG_ZSTD_DECOMPRESS=y
+CONFIG_DECOMPRESS_ZSTD=y
+
+# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
+# them before mounting the root device.
+CONFIG_SERIO_I8042=m
+CONFIG_KEYBOARD_ATKBD=m
+CONFIG_MOUSE_PS2=m
+
+# Add support for IPMI drivers
+CONFIG_IPMI_HANDLER=m
+
+# Add support for bootconfig
+CONFIG_BOOT_CONFIG=y
+
+# Enables support for checkpoint/restore
+CONFIG_CHECKPOINT_RESTORE=y
+
+# Disable unused filesystems.
+CONFIG_AFS_FS=n
+CONFIG_CRAMFS=n
+CONFIG_ECRYPT_FS=n
+CONFIG_EXT2_FS=n
+CONFIG_EXT3_FS=n
+CONFIG_EXT4_USE_FOR_EXT2=y
+CONFIG_GFS2_FS=n
+CONFIG_HFS_FS=n
+CONFIG_HFSPLUS_FS=n
+CONFIG_JFS_FS=n
+CONFIG_JFFS2_FS=n
+CONFIG_NFS_V2=n
+CONFIG_NILFS2_FS=n
+CONFIG_NTFS_FS=n
+CONFIG_ROMFS_FS=n
+CONFIG_UFS_FS=n
+CONFIG_ZONEFS_FS=n
+CONFIG_NTFS3_FS=n
+
+# Disable unused network protocols.
+CONFIG_AF_RXRPC=n
+CONFIG_ATM=n
+CONFIG_CAN=n
+CONFIG_HSR=n
+CONFIG_IP_DCCP=n
+CONFIG_L2TP=n
+CONFIG_RDS=n
+CONFIG_RFKILL=n
+CONFIG_TIPC=n

--- a/packages/kernel-5.15/config-bottlerocket-metal
+++ b/packages/kernel-5.15/config-bottlerocket-metal
@@ -1,0 +1,44 @@
+# This file holds all the settings that are specific to hardware enablement
+# we do for the metal variants.
+
+# SATA support
+CONFIG_BLK_DEV_SD=y
+CONFIG_SATA_AHCI=y
+CONFIG_ATA=y
+CONFIG_ATA_PIIX=y
+
+# Intel network support
+CONFIG_IGB=m
+CONFIG_IGBVF=m
+CONFIG_NET_VENDOR_INTEL=y
+CONFIG_IGB_HWMON=y
+CONFIG_E1000=m
+CONFIG_E1000E=m
+CONFIG_E1000E_HWTS=y
+
+# Broadcom network support
+CONFIG_NET_VENDOR_BROADCOM=y
+CONFIG_TIGON3_HWMON=y
+CONFIG_TIGON3=m
+CONFIG_BNXT=m
+
+# Intel 10G network support
+CONFIG_IXGB=m
+CONFIG_IXGBE=m
+CONFIG_IXGBE_DCB=y
+CONFIG_IXGBE_HWMON=y
+CONFIG_IXGBEVF=m
+
+# Mellanox network support
+CONFIG_MLXFW=m
+CONFIG_MLX5_CORE=m
+CONFIG_MLX5_INFINIBAND=m
+CONFIG_NET_VENDOR_MELLANOX=y
+CONFIG_MLX5_CORE_EN=y
+CONFIG_NET_SWITCHDEV=y
+
+# LSI Logic's SAS based RAID controllers
+CONFIG_MEGARAID_SAS=y
+
+# Microsemi PQI controllers
+CONFIG_SCSI_SMARTPQI=y

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,0 +1,267 @@
+%global debug_package %{nil}
+
+Name: %{_cross_os}kernel-5.15
+Version: 5.15.43
+Release: 1%{?dist}
+Summary: The Linux kernel
+License: GPL-2.0 WITH Linux-syscall-note
+URL: https://www.kernel.org/
+# Use latest-srpm-url.sh to get this.
+Source0: https://cdn.amazonlinux.com/blobstore/14fac2ab958b3193693bea1691e23f27600ba44cb63009bdc6cc9368271227a5/kernel-5.15.43-20.123.amzn2.src.rpm
+Source100: config-bottlerocket
+Source101: config-bottlerocket-metal
+
+# Help out-of-tree module builds run `make prepare` automatically.
+Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
+# Expose tools/* targets for out-of-tree module builds
+Patch1002: 1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
+
+BuildRequires: bc
+BuildRequires: elfutils-devel
+BuildRequires: hostname
+BuildRequires: kmod
+BuildRequires: openssl-devel
+
+# CPU microcode updates are included as "extra firmware" so the files don't
+# need to be installed on the root filesystem. However, we want the license and
+# attribution files to be available in the usual place.
+%if "%{_cross_arch}" == "x86_64"
+BuildRequires: %{_cross_os}microcode
+Requires: %{_cross_os}microcode-licenses
+%endif
+
+# Pull in expected modules and development files.
+Requires: %{name}-modules = %{version}-%{release}
+Requires: %{name}-devel = %{version}-%{release}
+
+%global kernel_sourcedir %{_cross_usrsrc}/kernels
+%global kernel_libdir %{_cross_libdir}/modules/%{version}
+
+%description
+%{summary}.
+
+%package devel
+Summary: Configured Linux kernel source for module building
+
+%description devel
+%{summary}.
+
+%package archive
+Summary: Archived Linux kernel source for module building
+
+%description archive
+%{summary}.
+
+%package modules
+Summary: Modules for the Linux kernel
+
+%description modules
+%{summary}.
+
+%package headers
+Summary: Header files for the Linux kernel for use by glibc
+
+%description headers
+%{summary}.
+
+%prep
+rpm2cpio %{SOURCE0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch"
+tar -xof linux-%{version}.tar; rm linux-%{version}.tar
+%setup -TDn linux-%{version}
+# Patches from the Source0 SRPM
+for patch in ../*.patch; do
+    patch -p1 <"$patch"
+done
+# Patches listed in this spec (Patch0001...)
+%autopatch -p1
+
+%if "%{_cross_arch}" == "x86_64"
+microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P ')"
+cat <<EOF > ../config-microcode
+CONFIG_EXTRA_FIRMWARE="${microcode}"
+CONFIG_EXTRA_FIRMWARE_DIR="%{_cross_libdir}/firmware"
+EOF
+%endif
+
+export ARCH="%{_cross_karch}"
+export CROSS_COMPILE="%{_cross_target}-"
+
+KCONFIG_CONFIG="arch/%{_cross_karch}/configs/%{_cross_vendor}_defconfig" \
+scripts/kconfig/merge_config.sh \
+  ../config-%{_cross_arch} \
+%if "%{_cross_arch}" == "x86_64"
+  ../config-microcode \
+%endif
+  %{SOURCE100} \
+  %{SOURCE101}
+rm -f ../config-* ../*.patch
+
+%global kmake \
+make -s\\\
+  ARCH="%{_cross_karch}"\\\
+  CROSS_COMPILE="%{_cross_target}-"\\\
+  INSTALL_HDR_PATH="%{buildroot}%{_cross_prefix}"\\\
+  INSTALL_MOD_PATH="%{buildroot}%{_cross_prefix}"\\\
+  INSTALL_MOD_STRIP=1\\\
+%{nil}
+
+%build
+%kmake mrproper
+%kmake %{_cross_vendor}_defconfig
+%kmake %{?_smp_mflags} %{_cross_kimage}
+%kmake %{?_smp_mflags} modules
+
+%install
+%kmake %{?_smp_mflags} headers_install
+%kmake %{?_smp_mflags} modules_install
+
+install -d %{buildroot}/boot
+install -T -m 0755 arch/%{_cross_karch}/boot/%{_cross_kimage} %{buildroot}/boot/vmlinuz
+install -m 0644 .config %{buildroot}/boot/config
+
+find %{buildroot}%{_cross_prefix} \
+   \( -name .install -o -name .check -o \
+      -name ..install.cmd -o -name ..check.cmd \) -delete
+
+# For out-of-tree kmod builds, we need to support the following targets:
+#   make scripts -> make prepare -> make modules
+#
+# This requires enough of the kernel tree to build host programs under the
+# "scripts" and "tools" directories.
+
+# Any existing ELF objects will not work properly if we're cross-compiling for
+# a different architecture, so get rid of them to avoid confusing errors.
+find arch scripts tools -type f -executable \
+  -exec sh -c "head -c4 {} | grep -q ELF && rm {}" \;
+
+# We don't need to include these files.
+find -type f \( -name \*.cmd -o -name \*.gitignore \) -delete
+
+# Avoid an OpenSSL dependency by stubbing out options for module signing and
+# trusted keyrings, so `sign-file` and `extract-cert` won't be built. External
+# kernel modules do not have access to the keys they would need to make use of
+# these tools.
+sed -i \
+  -e 's,$(CONFIG_MODULE_SIG_FORMAT),n,g' \
+  -e 's,$(CONFIG_SYSTEM_TRUSTED_KEYRING),n,g' \
+  scripts/Makefile
+
+# Restrict permissions on System.map.
+chmod 600 System.map
+
+(
+  find * \
+    -type f \
+    \( -name Build\* -o -name Kbuild\* -o -name Kconfig\* -o -name Makefile\* \) \
+    -print
+
+  find arch/%{_cross_karch}/ \
+    -type f \
+    \( -name module.lds -o -name vmlinux.lds.S -o -name Platform -o -name \*.tbl \) \
+    -print
+
+  find arch/%{_cross_karch}/{include,lib}/ -type f ! -name \*.o ! -name \*.o.d -print
+  echo arch/%{_cross_karch}/kernel/asm-offsets.s
+  echo lib/vdso/gettimeofday.c
+
+  for d in \
+    arch/%{_cross_karch}/tools \
+    arch/%{_cross_karch}/kernel/vdso ; do
+    [ -d "${d}" ] && find "${d}/" -type f -print
+  done
+
+  find include -type f -print
+  find scripts -type f ! -name \*.l ! -name \*.y ! -name \*.o -print
+
+  find tools/{arch/%{_cross_karch},include,objtool,scripts}/ -type f ! -name \*.o -print
+  echo tools/build/fixdep.c
+  find tools/lib/subcmd -type f -print
+  find tools/lib/{ctype,hweight,rbtree,string,str_error_r}.c
+
+  echo kernel/bounds.c
+  echo kernel/time/timeconst.bc
+  echo security/selinux/include/classmap.h
+  echo security/selinux/include/initial_sid_to_string.h
+  echo security/selinux/include/policycap.h
+  echo security/selinux/include/policycap_names.h
+
+  echo .config
+  echo Module.symvers
+  echo System.map
+) | sort -u > kernel_devel_files
+
+# Create squashfs of kernel-devel files (ie. /usr/src/kernels/<version>).
+#
+# -no-exports:
+# The filesystem does not need to be exported via NFS.
+#
+# -all-root:
+# Make all files owned by root rather than the build user.
+#
+# -comp zstd:
+# zstd offers compression ratios like xz and decompression speeds like lz4.
+SQUASHFS_OPTS="-no-exports -all-root -comp zstd"
+mkdir -p src_squashfs/%{version}
+tar c -T kernel_devel_files | tar x -C src_squashfs/%{version}
+mksquashfs src_squashfs kernel-devel.squashfs ${SQUASHFS_OPTS}
+
+# Create a tarball of the same files, for use outside the running system.
+# In theory we could extract these files with `unsquashfs`, but we do not want
+# to require it to be installed on the build host, and it errors out when run
+# inside Docker unless the limit for open files is lowered.
+tar cf kernel-devel.tar src_squashfs/%{version} --transform='s|src_squashfs/%{version}|kernel-devel|'
+xz -T0 kernel-devel.tar
+
+install -D kernel-devel.squashfs %{buildroot}%{_cross_datadir}/bottlerocket/kernel-devel.squashfs
+install -D kernel-devel.tar.xz %{buildroot}%{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
+install -d %{buildroot}%{kernel_sourcedir}
+
+# Replace the incorrect links from modules_install. These will be bound
+# into a host container (and unused in the host) so they must not point
+# to %{_cross_usrsrc} (eg. /x86_64-bottlerocket-linux-gnu/sys-root/...)
+rm -f %{buildroot}%{kernel_libdir}/build %{buildroot}%{kernel_libdir}/source
+ln -sf %{_usrsrc}/kernels/%{version} %{buildroot}%{kernel_libdir}/build
+ln -sf %{_usrsrc}/kernels/%{version} %{buildroot}%{kernel_libdir}/source
+
+%files
+%license COPYING LICENSES/preferred/GPL-2.0 LICENSES/exceptions/Linux-syscall-note
+%{_cross_attribution_file}
+/boot/vmlinuz
+/boot/config
+
+%files modules
+%dir %{_cross_libdir}/modules
+%{_cross_libdir}/modules/*
+
+%files headers
+%dir %{_cross_includedir}/asm
+%dir %{_cross_includedir}/asm-generic
+%dir %{_cross_includedir}/drm
+%dir %{_cross_includedir}/linux
+%dir %{_cross_includedir}/misc
+%dir %{_cross_includedir}/mtd
+%dir %{_cross_includedir}/rdma
+%dir %{_cross_includedir}/scsi
+%dir %{_cross_includedir}/sound
+%dir %{_cross_includedir}/video
+%dir %{_cross_includedir}/xen
+%{_cross_includedir}/asm/*
+%{_cross_includedir}/asm-generic/*
+%{_cross_includedir}/drm/*
+%{_cross_includedir}/linux/*
+%{_cross_includedir}/misc/*
+%{_cross_includedir}/mtd/*
+%{_cross_includedir}/rdma/*
+%{_cross_includedir}/scsi/*
+%{_cross_includedir}/sound/*
+%{_cross_includedir}/video/*
+%{_cross_includedir}/xen/*
+
+%files devel
+%dir %{kernel_sourcedir}
+%{_cross_datadir}/bottlerocket/kernel-devel.squashfs
+
+%files archive
+%{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
+
+%changelog

--- a/packages/kernel-5.15/latest-srpm-url.sh
+++ b/packages/kernel-5.15/latest-srpm-url.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm amazonlinux:2 sh -c 'amazon-linux-extras enable kernel-5.15 >/dev/null && yum install -q -y yum-utils && yumdownloader -q --source --urls kernel | grep ^http'

--- a/packages/kernel-5.15/pkg.rs
+++ b/packages/kernel-5.15/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/selinux-policy/class.cil
+++ b/packages/selinux-policy/class.cil
@@ -124,6 +124,7 @@
 (classcommon qipcrtr_socket socket)
 (classcommon smc_socket socket)
 (classcommon xdp_socket socket)
+(classcommon mctp_socket socket)
 
 ; Add permissions specific to some socket classes.
 (class socket ())
@@ -186,6 +187,7 @@
 (class qipcrtr_socket ())
 (class smc_socket ())
 (class xdp_socket ())
+(class mctp_socket ())
 
 ; Add permissions for various network classes.
 (class node (recvfrom sendto))
@@ -259,7 +261,7 @@
   phonet_socket ieee802154_socket caif_socket alg_socket
   nfc_socket vsock_socket kcm_socket qipcrtr_socket smc_socket
   infiniband_pkey infiniband_endport bpf xdp_socket
-  perf_event lockdown))
+  mctp_socket perf_event lockdown))
 
 ; Add permissions for SELinux-aware applications.
 ; This includes systemd and dbus-broker.

--- a/packages/selinux-policy/class.cil
+++ b/packages/selinux-policy/class.cil
@@ -50,6 +50,7 @@
 (classcommon blk_file file)
 (classcommon sock_file file)
 (classcommon fifo_file file)
+(classcommon anon_inode file)
 
 ; Add permissions specific to some file classes.
 (class file (execute_no_trans entrypoint))
@@ -60,6 +61,7 @@
 (class blk_file ())
 (class sock_file ())
 (class fifo_file ())
+(class anon_inode ())
 
 ; Add permissions shared by all socket classes.
 (common socket (
@@ -261,7 +263,7 @@
   phonet_socket ieee802154_socket caif_socket alg_socket
   nfc_socket vsock_socket kcm_socket qipcrtr_socket smc_socket
   infiniband_pkey infiniband_endport bpf xdp_socket
-  mctp_socket perf_event lockdown))
+  mctp_socket perf_event lockdown anon_inode))
 
 ; Add permissions for SELinux-aware applications.
 ; This includes systemd and dbus-broker.

--- a/packages/selinux-policy/files.cil
+++ b/packages/selinux-policy/files.cil
@@ -9,6 +9,7 @@
 (classmapping files relabel relabel_blk_file)
 (classmapping files relabel relabel_sock_file)
 (classmapping files relabel relabel_fifo_file)
+(classmapping files relabel relabel_anon_inode)
 
 ; Permission group for mounts.
 (classmapping files mount mount_file)
@@ -19,6 +20,7 @@
 (classmapping files mount mount_sock_file)
 (classmapping files mount mount_fifo_file)
 (classmapping files mount mount_filesystem)
+(classmapping files mount mount_anon_inode)
 
 ; Permission group for relaxing security constraints on files.
 (classmapping files relax relax_file)
@@ -28,6 +30,7 @@
 (classmapping files relax relax_blk_file)
 (classmapping files relax relax_sock_file)
 (classmapping files relax relax_fifo_file)
+(classmapping files relax relax_anon_inode)
 
 ; Permission group for using files as entry points.
 (classmapping files enter enter_file)
@@ -41,6 +44,7 @@
 (classmapping files describe describe_sock_file)
 (classmapping files describe describe_fifo_file)
 (classmapping files describe describe_filesystem)
+(classmapping files describe describe_anon_inode)
 
 ; Permission group for reading and executing files.
 (classmapping files load load_file)
@@ -52,6 +56,7 @@
 (classmapping files load load_fifo_file)
 (classmapping files load load_filesystem)
 (classmapping files load load_fd)
+(classmapping files load load_anon_inode)
 
 ; Permission group for blocking access to files.
 (classmapping files block block_file)
@@ -61,6 +66,7 @@
 (classmapping files block block_blk_file)
 (classmapping files block block_sock_file)
 (classmapping files block block_fifo_file)
+(classmapping files block block_anon_inode)
 
 ; Permission group for mutating files.
 (classmapping files mutate mutate_file)
@@ -70,6 +76,7 @@
 (classmapping files mutate mutate_blk_file)
 (classmapping files mutate mutate_sock_file)
 (classmapping files mutate mutate_fifo_file)
+(classmapping files mutate mutate_anon_inode)
 
 ; Sets of permissions for relabeling file objects.
 (classpermission relabel_file)
@@ -79,6 +86,7 @@
 (classpermission relabel_blk_file)
 (classpermission relabel_sock_file)
 (classpermission relabel_fifo_file)
+(classpermission relabel_anon_inode)
 (classpermissionset relabel_file (
   file (relabelfrom relabelto)))
 (classpermissionset relabel_dir (
@@ -93,6 +101,8 @@
   sock_file (relabelfrom relabelto)))
 (classpermissionset relabel_fifo_file (
   fifo_file (relabelfrom relabelto)))
+(classpermissionset relabel_anon_inode(
+  anon_inode (relabelfrom relabelto)))
 
 ; Sets of permissions for mounts.
 (classpermission mount_file)
@@ -103,6 +113,7 @@
 (classpermission mount_sock_file)
 (classpermission mount_fifo_file)
 (classpermission mount_filesystem)
+(classpermission mount_anon_inode)
 (classpermissionset mount_file (
   file (mounton quotaon)))
 (classpermissionset mount_dir (
@@ -119,6 +130,8 @@
   fifo_file (mounton quotaon)))
 (classpermissionset mount_filesystem (
   filesystem (mount quotamod remount unmount)))
+(classpermissionset mount_anon_inode (
+  anon_inode (mounton quotaon)))
 
 ; Sets of permissions that relax security constraints for file objects.
 (classpermission relax_file)
@@ -128,6 +141,7 @@
 (classpermission relax_blk_file)
 (classpermission relax_sock_file)
 (classpermission relax_fifo_file)
+(classpermission relax_anon_inode)
 (classpermissionset relax_file (
   file (execmod)))
 (classpermissionset relax_dir (
@@ -142,6 +156,8 @@
   sock_file (execmod)))
 (classpermissionset relax_fifo_file (
   fifo_file (execmod)))
+(classpermissionset relax_anon_inode (
+  anon_inode (execmod)))
 
 ; Sets of permissions for using file objects as entry points.
 (classpermission enter_file)
@@ -157,6 +173,7 @@
 (classpermission describe_sock_file)
 (classpermission describe_fifo_file)
 (classpermission describe_filesystem)
+(classpermission describe_anon_inode)
 (classpermissionset describe_file (
   file (getattr)))
 (classpermissionset describe_dir (
@@ -173,6 +190,8 @@
   fifo_file (getattr)))
 (classpermissionset describe_filesystem (
   filesystem (getattr quotaget)))
+(classpermissionset describe_anon_inode (
+  anon_inode (getattr)))
 
 ; Sets of permissions for read-only actions that do not affect the
 ; integrity of file objects.
@@ -185,6 +204,7 @@
 (classpermission load_fifo_file)
 (classpermission load_filesystem)
 (classpermission load_fd)
+(classpermission load_anon_inode)
 (classpermissionset load_file (
   file (
     execute ioctl map open read execute_no_trans
@@ -217,6 +237,10 @@
   filesystem (watch)))
 (classpermissionset load_fd (
   fd (use)))
+(classpermissionset load_anon_inode (
+  anon_inode (
+    execute ioctl map open read
+    watch watch_mount watch_reads watch_sb)))
 
 ; Sets of permissions for blocking access to file objects.
 (classpermission block_file)
@@ -226,6 +250,7 @@
 (classpermission block_blk_file)
 (classpermission block_sock_file)
 (classpermission block_fifo_file)
+(classpermission block_anon_inode)
 (classpermissionset block_file (
   file (watch_with_perm)))
 (classpermissionset block_dir (
@@ -240,6 +265,8 @@
   sock_file (watch_with_perm)))
 (classpermissionset block_fifo_file (
   fifo_file (watch_with_perm)))
+(classpermissionset block_anon_inode (
+  anon_inode (watch_with_perm)))
 
 ; Sets of permissions for mutating file objects, which includes all
 ; actions that are not covered by other policy restrictions.
@@ -250,6 +277,7 @@
 (classpermission mutate_blk_file)
 (classpermission mutate_sock_file)
 (classpermission mutate_fifo_file)
+(classpermission mutate_anon_inode)
 (classpermissionset mutate_file (
   file (not (
     entrypoint execute_no_trans
@@ -284,6 +312,11 @@
     watch watch_mount watch_reads watch_sb watch_with_perm))))
 (classpermissionset mutate_fifo_file (
   fifo_file (not (
+    execute ioctl getattr map open read execmod
+    relabelfrom relabelto mounton quotaon
+    watch watch_mount watch_reads watch_sb watch_with_perm))))
+(classpermissionset mutate_anon_inode (
+  anon_inode (not (
     execute ioctl getattr map open read execmod
     relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))

--- a/packages/selinux-policy/sockets.cil
+++ b/packages/selinux-policy/sockets.cil
@@ -118,6 +118,8 @@
   smc_socket (relabelfrom relabelto)))
 (classmapping sockets relabel (
   xdp_socket (relabelfrom relabelto)))
+(classmapping sockets relabel (
+  mctp_socket (relabelfrom relabelto)))
 
 ; Permission group for other socket actions.
 (classmapping sockets use (
@@ -236,3 +238,5 @@
   smc_socket (not (relabelfrom relabelto))))
 (classmapping sockets use (
   xdp_socket (not (relabelfrom relabelto))))
+(classmapping sockets use (
+  mctp_socket (not (relabelfrom relabelto))))

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "docker-init",
  "docker-proxy",
  "iputils",
- "kernel-5_10",
+ "kernel-5_15",
  "login",
  "release",
  "strace",
@@ -391,6 +391,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel-5_15"
+version = "0.1.0"
+dependencies = [
+ "microcode",
+]
+
+[[package]]
 name = "kernel-5_4"
 version = "0.1.0"
 dependencies = [
@@ -732,7 +739,7 @@ dependencies = [
  "docker-init",
  "docker-proxy",
  "iputils",
- "kernel-5_10",
+ "kernel-5_15",
  "login",
  "release",
  "strace",
@@ -949,7 +956,7 @@ dependencies = [
  "docker-init",
  "docker-proxy",
  "iputils",
- "kernel-5_10",
+ "kernel-5_15",
  "login",
  "open-vm-tools",
  "release",

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -19,7 +19,7 @@ kernel-parameters = [
 included-packages = [
 # core
     "release",
-    "kernel-5.10",
+    "kernel-5.15",
 # docker
     "docker-cli",
     "docker-engine",
@@ -39,7 +39,7 @@ path = "lib.rs"
 [build-dependencies]
 # core
 release = { path = "../../packages/release" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -24,7 +24,7 @@ grub-features = [
 included-packages = [
 # core
     "release",
-    "kernel-5.10",
+    "kernel-5.15",
 # docker
     "docker-cli",
     "docker-engine",
@@ -44,7 +44,7 @@ path = "lib.rs"
 [build-dependencies]
 # core
 release = { path = "../../packages/release" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -21,7 +21,7 @@ kernel-parameters = [
 included-packages = [
 # core
     "release",
-    "kernel-5.10",
+    "kernel-5.15",
     "open-vm-tools",
 # docker
     "docker-cli",
@@ -42,7 +42,7 @@ path = "lib.rs"
 [build-dependencies]
 # core
 release = { path = "../../packages/release" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }


### PR DESCRIPTION
**Issue number:**
Closes #2008


**Description of changes:**

```
variants: update kernel for dev variants
packages: add kernel-5.15 sources
```

TODO:

- [x] Update lookaside cache

**Testing done:**

- Launched `aws-dev` VM, and it booted successfully:

```
bash-5.1# uname -a
Linux ip-172-31-61-1.us-west-2.compute.internal 5.15.43 #1 SMP Tue Jun 21 22:24:09 UTC 2022 x86_64 GNU/Linux
```

- Tested the `kmod-kit` to compile an out-of-tree kernel module:

```bash
> make driver -j
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2021.02.3) 10.3.0
  You are using:           x86_64-bottlerocket-linux-musl-gcc (Buildroot 2021.02.3) 10.3.0
Skipping BTF generation for /tmp/falco/build/driver/src/falco.ko due to unavailability of vmlinux
Built target driver
> [ -f driver/falco.ko ] && echo "Exists!"
Exists!
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
