### PR TITLE
sundog, pluto: run settings generators with network proxy environment vars

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -969,6 +969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct 0.6.1",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1569,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1 0.10.0",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,6 +1745,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-rustls 0.22.1",
+ "rustls-native-certs 0.5.0",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "tower-service",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,10 +1789,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.20.6",
+ "rustls-native-certs 0.6.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2584,6 +2654,9 @@ dependencies = [
  "bottlerocket-variant",
  "constants",
  "generate-readme",
+ "hyper",
+ "hyper-proxy",
+ "hyper-rustls 0.23.0",
  "imdsclient",
  "models",
  "rusoto_core",
@@ -2808,7 +2881,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.0",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -2816,13 +2889,13 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.6",
  "rustls-pemfile 0.3.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2880,7 +2953,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.0",
  "lazy_static",
  "log",
  "rusoto_credential",
@@ -2977,14 +3050,39 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
  "log",
  "ring",
- "sct",
+ "sct 0.7.0",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3071,6 +3169,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -3715,11 +3823,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.6",
  "tokio",
  "webpki 0.22.0",
 ]

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -12,6 +12,9 @@ exclude = ["README.md"]
 [dependencies]
 apiclient = { path = "../apiclient", version = "0.1.0" }
 constants = { path = "../../constants", version = "0.1.0" }
+hyper = "0.14.2"
+hyper-proxy = {  version = "0.9", default-features = false, features = ["rustls"] }
+hyper-rustls = "0.23"
 imdsclient = { path = "../../imdsclient", version = "0.1.0" }
 models = { path = "../../models", version = "0.1.0" }
 rusoto_core = { version = "0.48.0", default-features = false, features = ["rustls"] }

--- a/sources/api/pluto/src/eks.rs
+++ b/sources/api/pluto/src/eks.rs
@@ -1,7 +1,13 @@
+use hyper::http::uri::InvalidUri;
+use hyper::Uri;
+use hyper_proxy::{Proxy, ProxyConnector};
+use hyper_rustls::HttpsConnectorBuilder;
+use rusoto_core::credential::ChainProvider;
 use rusoto_core::region::ParseRegionError;
 use rusoto_core::{Region, RusotoError};
 use rusoto_eks::{DescribeClusterError, Eks, EksClient, KubernetesNetworkConfigResponse};
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::env;
 use std::str::FromStr;
 
 pub(crate) type ClusterNetworkConfig = KubernetesNetworkConfigResponse;
@@ -21,6 +27,12 @@ pub(super) enum Error {
         region: String,
         source: ParseRegionError,
     },
+
+    #[snafu(display("Unable to parse '{}' as URI: {}", input, source))]
+    UriParse { input: String, source: InvalidUri },
+
+    #[snafu(display("Failed to create proxy creator: {}", source))]
+    ProxyConnector { source: std::io::Error },
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -32,7 +44,71 @@ pub(super) async fn get_cluster_network_config(
     cluster: &str,
 ) -> Result<ClusterNetworkConfig> {
     let parsed_region = Region::from_str(region).context(RegionParseSnafu { region })?;
-    let client = EksClient::new(parsed_region);
+
+    // Respect proxy environment variables when making AWS EKS API requests
+    let https_proxy = ["https_proxy", "HTTPS_PROXY"]
+        .iter()
+        .map(env::var)
+        .find(|env_var| *env_var != Err(env::VarError::NotPresent))
+        .and_then(|s| s.ok());
+    let no_proxy = ["no_proxy", "NO_PROXY"]
+        .iter()
+        .map(env::var)
+        .find(|env_var| *env_var != Err(env::VarError::NotPresent))
+        .and_then(|s| s.ok());
+
+    let client = if let Some(https_proxy) = https_proxy {
+        // Determines whether a request of a given scheme, host and port should be proxied
+        // according to `https_proxy` and `no_proxy`.
+        let intercept = move |scheme: Option<&str>, host: Option<&str>, _port| {
+            if let Some(host) = host {
+                if let Some(no_proxy) = &no_proxy {
+                    if scheme != Some("https") {
+                        return false;
+                    }
+                    let no_proxy_hosts: Vec<&str> = no_proxy.split(',').map(|s| s.trim()).collect();
+                    if no_proxy_hosts.iter().any(|s| *s == "*") {
+                        // Don't proxy anything
+                        return false;
+                    }
+                    // If the host matches one of the no proxy list entries, return false (don't proxy)
+                    // Note that we're not doing anything fancy here for checking `no_proxy` since
+                    // we only expect requests here to be going out to some AWS API endpoint.
+                    return !no_proxy_hosts.iter().any(|no_proxy_host| {
+                        !no_proxy_host.is_empty() && host.ends_with(no_proxy_host)
+                    });
+                }
+                true
+            } else {
+                false
+            }
+        };
+        let mut proxy_uri = https_proxy.parse::<Uri>().context(UriParseSnafu {
+            input: &https_proxy,
+        })?;
+        // If the proxy's URI doesn't have a scheme, assume HTTP for the scheme and let the proxy
+        // server forward HTTPS connections and start a tunnel.
+        if proxy_uri.scheme().is_none() {
+            proxy_uri =
+                format!("http://{}", https_proxy)
+                    .parse::<Uri>()
+                    .context(UriParseSnafu {
+                        input: &https_proxy,
+                    })?;
+        }
+        let proxy = Proxy::new(intercept, proxy_uri);
+        let https_connector = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_or_http()
+            .enable_http2()
+            .build();
+        let proxy_connector =
+            ProxyConnector::from_proxy(https_connector, proxy).context(ProxyConnectorSnafu)?;
+        let http_client = rusoto_core::request::HttpClient::from_connector(proxy_connector);
+        EksClient::new_with(http_client, ChainProvider::new(), parsed_region)
+    } else {
+        EksClient::new(parsed_region)
+    };
     let describe_cluster = rusoto_eks::DescribeClusterRequest {
         name: cluster.to_owned(),
     };
@@ -40,7 +116,7 @@ pub(super) async fn get_cluster_network_config(
     client
         .describe_cluster(describe_cluster)
         .await
-        .context(DescribeClusterSnafu {})?
+        .context(DescribeClusterSnafu)?
         .cluster
         .context(MissingSnafu { field: "cluster" })?
         .kubernetes_network_config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/2197


**Description of changes:**
```
    sundog: run settings generators with network proxy environment vars
    
    We make sure settings generators are kicked-off with user-specified
    network proxy environment variables.
```
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Jun 21 18:16:38 2022 -0700

    pluto: respect `https_proxy` and `no_proxy` when making EKS API reqs
    
    Both `rusoto` and `aws-sdk-rust` do not respect `https_proxy` and
    `no_proxy` env vars. We have to handle it ourselves by creating a custom
    hyper http 'connector' that's configured with the right proxying
    configuration.

```

**Testing done:**
Builds and runs fine. 
Launched instance with aws-k8s-1.23 AMI with user-data that includes the following:
```
[settings.network]
https-proxy = "my-proxy:9898"
```
Checked proxy server logs and found all traffic being tunneled including the EKS API calls for `DescribeCluster`
```
CONNECT   Jun 22 08:00:00 [3794]: Connect (file descriptor 7): ec2-35-88-231-112.us-west-2.compute.amazonaws.com [35.88.231.112]   
CONNECT   Jun 22 08:00:00 [3794]: Request (file descriptor 7): CONNECT eks.us-west-2.amazonaws.com:443 HTTP/1.1                    
INFO      Jun 22 08:00:00 [3794]: No upstream proxy for eks.us-west-2.amazonaws.com                                                
INFO      Jun 22 08:00:00 [3794]: opensock: opening connection to eks.us-west-2.amazonaws.com:443                                  
INFO      Jun 22 08:00:00 [3794]: opensock: getaddrinfo returned for eks.us-west-2.amazonaws.com:443                               
CONNECT   Jun 22 08:00:00 [3794]: Established connection to host "eks.us-west-2.amazonaws.com" using file descriptor 8.            
INFO      Jun 22 08:00:00 [3794]: Not sending client headers to remote machine                                                     
INFO      Jun 22 08:00:00 [3794]: Closed connection between local client (fd:7) and remote client (fd:8) 
```

Checking CloudTrail, I can see that the DescribeCluster API call source IP is my proxy server
```
...
    "eventTime": "2022-06-22T08:00:00Z",
    "eventSource": "eks.amazonaws.com",
    "eventName": "DescribeCluster",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "my-proxy-IP",
    "userAgent": "rusoto/0.48.0 rust/1.61.0 linux",
...
```


If I set `no-proxy` for the EKS API endpoint for a new instance launch like so:
```
[settings.network]
https-proxy = "my-proxy:9898"
no-proxy = ["eks.us-west-2.amazonaws.com"]
```

Then I can see that EKS API calls do not get proxied and the source IP is my actual instance:
```
...
    "eventTime": "2022-06-22T08:10:04Z",
    "eventSource": "eks.amazonaws.com",
    "eventName": "DescribeCluster",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "34.211.227.47",
    "userAgent": "rusoto/0.48.0 rust/1.61.0 linux",
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
