### PR TITLE
Updated Kubernetes version to 1.23.7

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/1/artifacts/kubernetes/v1.23.6/kubernetes-src.tar.gz"
-sha512 = "944d59dd8938da2422d695478e34e765e4b69d7061f15cb31e0524e79e12b2a7aa5d6063513386924733c4fc390c9e4ac7eb58f7ea5c1d3d1acb17760de11641"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/2/artifacts/kubernetes/v1.23.7/kubernetes-src.tar.gz"
+sha512 = "f3f03970f9ceb25d5993d7d20bfa5d39b24d52e686fab556b1f9c5aae2c5b2297281460196047c98d843d6694086eee949f0afb291c92952bf320fa43887d6b7"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.23.6
+%global gover 1.23.7
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Issue number:**
Closes #2229

**Description of changes:**
Updates Kubernetes from 1.23.6 to 1.23.7


**Testing done:**

etung: Built aws-k8s-1.23 AMI and launched an instance with it and verified that it can join clusters fine, run pods fine.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
