### PR TITLE
Updated Kubernetes version to 1.22.10

### DIFF
--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.22"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/7/artifacts/kubernetes/v1.22.9/kubernetes-src.tar.gz"
-sha512 = "39175e19fe96c704e0c6c31c844c517288d6655d10cc609e6cc11cdd5e6fb0665b7c2d6e4cc161945b7f8bd34e6c7236674c19705cc72f449080c27bd434def5"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/8/artifacts/kubernetes/v1.22.10/kubernetes-src.tar.gz"
+sha512 = "c3791c28898358ffe656aeeb9bf3a0d00806f76f37cc7c835e9b36f50646b55f2e0fa5b52349e064594e0e84f6ffdd90f1718db4d67428db1561d1d5f2f42974"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.22.9
+%global gover 1.22.10
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Issue number:**
Closes #2231

**Description of changes:**
Updates Kubernetes from 1.22.9 to 1.22.10

**Testing done:**

etung: Built aws-k8s-1.22 AMI and launched an instance with it and verified that it can join clusters fine, run pods fine.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
