### PR TITLE
host-containers: don't forcibly clean-up right after disabling service

### DIFF
--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -439,16 +439,6 @@ where
         };
     } else {
         systemd_unit.disable_and_stop()?;
-
-        // Ensure there's no lingering host-container after it's been disabled.
-        //
-        // We only attempt to do this only if host-containerd is active and running
-        if host_containerd_unit.is_active()? {
-            command(
-                constants::HOST_CTR_BIN,
-                &["clean-up", "--container-id", name],
-            )?;
-        }
     }
 
     Ok(())

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -330,7 +330,9 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 		defer cancel()
 		err := container.Delete(cleanup, containerd.WithSnapshotCleanup)
 		if err != nil {
-			log.G(cleanup).WithError(err).Error("failed to cleanup container")
+			if !errdefs.IsNotFound(err) {
+				log.G(cleanup).WithError(err).Error("failed to cleanup container")
+			}
 		}
 	}()
 
@@ -387,7 +389,9 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 		defer cancel()
 		_, err := task.Delete(cleanup)
 		if err != nil {
-			log.G(cleanup).WithError(err).Error("failed to delete container task")
+			if !errdefs.IsNotFound(err) {
+				log.G(cleanup).WithError(err).Error("failed to delete container task")
+			}
 		}
 	}()
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/2017


**Description of changes:**

See https://github.com/bottlerocket-os/bottlerocket/issues/2017#issuecomment-1163593529 for a more detailed description of the problem that's being fixed here.
```
    host-containers: don't forcibly clean-up right after disabling service
    
    After disabling the host-container's systemd service unit, we need to
    allow it ample time for it to actually gracefully exit. We shouldn't
    just immediately try to kill the container process after stopping the
    host-container service. `host-ctr` should already properly handle the
    termination signal propagation to the container task when stopping the
    systemd unit normally. `host-ctr` also has a kill switch for when the
    container task does not exit in time. Therefore, it's highly unlikely
    that a host-container process will linger long after we disable said
    host-container.

```
```
    host-ctr: ignore 'NotFound' errors when cleaning up
    
    When deleting container tasks and containers, ignore 'NotFound'
    errors.

```


**Testing done:**
Disabled control host-container, and the host-containers@control service unit no longer fails, and the control container exits gracefully:
```
bash-5.1# apiclient set host-containers.control.enabled=false
bash-5.1# systemctl status host-containers@control         
○ host-containers@control.service - Host container: control                                                                                                                                                        
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/host-containers@.service; disabled; vendor preset: enabled)
     Active: inactive (dead)                                                                                                      
                                                                                                                                                                                                                   
Jun 22 21:31:46 ip-192-168-5-9.us-west-2.compute.internal host-ctr[5746]: time="2022-06-22T21:31:46Z" level=info msg="received signal: terminated"
Jun 22 21:31:46 ip-192-168-5-9.us-west-2.compute.internal systemd[1]: Stopping Host container: control...                                                                                                          
Jun 22 21:31:46 ip-192-168-5-9.us-west-2.compute.internal host-ctr[5746]: 2022-06-22 21:31:46 INFO [amazon-ssm-agent] amazon-ssm-agent got signal:terminated value:0x7f6904cd8600
Jun 22 21:31:46 ip-192-168-5-9.us-west-2.compute.internal host-ctr[5746]: 2022-06-22 21:31:46 INFO [amazon-ssm-agent] Stopping Core Agent                                                    
Jun 22 21:31:46 ip-192-168-5-9.us-west-2.compute.internal host-ctr[5746]: 2022-06-22 21:31:46 INFO [amazon-ssm-agent] [LongRunningWorkerContainer] Receiving stop signal, stop worker monitor                      Jun 22 21:31:47 ip-192-168-5-9.us-west-2.compute.internal host-ctr[5746]: 2022-06-22 21:31:47 INFO [amazon-ssm-agent] [LongRunningWorkerContainer] Received worker termination result, &{SchemaVersion:1 Topic:GetWorkerHealthResult Payload:....
Jun 22 21:31:53 ip-192-168-5-9.us-west-2.compute.internal host-ctr[5746]: 2022-06-22 21:31:53 INFO [amazon-ssm-agent] Bye.                                                                                         
Jun 22 21:31:53 ip-192-168-5-9.us-west-2.compute.internal host-ctr[5746]: time="2022-06-22T21:31:53Z" level=info msg="container task exited" code=0
Jun 22 21:31:54 ip-192-168-5-9.us-west-2.compute.internal systemd[1]: host-containers@control.service: Deactivated successfully.                                                                                   Jun 22 21:31:54 ip-192-168-5-9.us-west-2.compute.internal systemd[1]: Stopped Host container: control.                                                                                                             
bash-5.1# ps aux | grep ssm                                                                              
root        6996  0.0  0.0   2512  1328 ?        S+   21:32   0:00 grep ssm                              
```

Flipping the enabled setting on and off again also works as expected and no lingering container process can be found.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
