### PR TITLE
Add missing ECS variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ The following variants support EKS, as described above:
 - `aws-k8s-1.22-nvidia`
 - `aws-k8s-1.23-nvidia`
 
-The following variant supports ECS:
+The following variants support ECS:
 
 - `aws-ecs-1`
+- `aws-ecs-1-nvidia`
 
 We also have variants that are designed to be Kubernetes worker nodes in VMware:
 


### PR DESCRIPTION
**Description of changes:**

```
README: add missing ECS variant
```

The `aws-ecs-1-nvidia` variant was missing in the list of supported ECS variants


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
