### PR TITLE
Generate `settings.metrics.send-metrics` based on AWS partition for AWS variants

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -133,4 +133,5 @@ version = "1.8.0"
 "(1.8.0, 1.9.0)" = [
     "migrate_v1.9.0_ntp-affected-services.lz4",
     "migrate_v1.9.0_shibaken-admin-userdata-semantics.lz4",
+    "migrate_v1.9.0_shibaken-send-metrics.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -132,4 +132,5 @@ version = "1.8.0"
 ]
 "(1.8.0, 1.9.0)" = [
     "migrate_v1.9.0_ntp-affected-services.lz4",
+    "migrate_v1.9.0_shibaken-admin-userdata-semantics.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "argh"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb41d85d92dfab96cb95ab023c265c5e4261bb956c0fb49ca06d90c570f1958"
+checksum = "a7e7e4aa7e40747e023c0761dafcb42333a9517575bbf1241747f68dd3177a62"
 dependencies = [
  "argh_derive",
  "argh_shared",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "argh_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be69f70ef5497dd6ab331a50bd95c6ac6b8f7f17a7967838332743fbd58dc3b5"
+checksum = "69f2bd7ff6ed6414f4e5521bd509bae46454bbd513801767ced3f21a751ab4bc"
 dependencies = [
  "argh_shared",
  "heck 0.3.3",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "argh_shared"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f8c380fa28aa1b36107cd97f0196474bb7241bb95a453c5c01a15ac74b2eac"
+checksum = "47253b98986dafc7a3e1cf3259194f1f47ac61abb57a57f46ec09e48d004ecda"
 
 [[package]]
 name = "asn1-rs"
@@ -3226,6 +3226,7 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 name = "shibaken"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "base64",
  "generate-readme",
  "imdsclient",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3239,6 +3239,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shibaken-admin-userdata-semantics"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "shimpei"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3246,6 +3246,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shibaken-send-metrics"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "shimpei"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "api/migration/migrations/v1.8.0/public-admin-container-v0-9-0",
     "api/migration/migrations/v1.8.0/public-control-container-v0-6-1",
     "api/migration/migrations/v1.9.0/ntp-affected-services",
+    "api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "api/migration/migrations/v1.8.0/public-control-container-v0-6-1",
     "api/migration/migrations/v1.9.0/ntp-affected-services",
     "api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics",
+    "api/migration/migrations/v1.9.0/shibaken-send-metrics",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shibaken-admin-userdata-semantics"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics/src/main.rs
@@ -1,0 +1,26 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{MetadataReplacement, ReplaceMetadataMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We modified the setting generator for `settings.host-containers.admin.user-data` to use the
+/// new interface to shibaken.
+fn run() -> Result<()> {
+    migrate(ReplaceMetadataMigration(vec![MetadataReplacement {
+        setting: "settings.host-containers.admin.user-data",
+        metadata: "setting-generator",
+        old_val: "shibaken",
+        new_val: "shibaken generate-admin-userdata",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.9.0/shibaken-send-metrics/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/shibaken-send-metrics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shibaken-send-metrics"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.9.0/shibaken-send-metrics/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/shibaken-send-metrics/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a `setting-generator` for `settings.metrics.send-metrics` on AWS variants.
+/// This migration will do nothing on upgrade, but will remove the metadata if present on downgrade.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        setting: "settings.metrics.send-metrics",
+        metadata: &["setting-generator"],
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+argh = "0.1.8"
 base64 = "0.13"
 imdsclient = { path = "../../imdsclient", version = "0.1.0" }
 log = "0.4"

--- a/sources/api/shibaken/README.md
+++ b/sources/api/shibaken/README.md
@@ -6,8 +6,11 @@ Current version: 0.1.0
 
 shibaken is called by sundog as a setting generator.
 
-shibaken will fetch and populate the admin container's user-data with authorized ssh keys from the
-AWS instance metadata service (IMDS).
+shibaken is used to fetch data from the instance metadata service (IMDS) in AWS.
+
+shibaken can:
+* Fetch and populate the admin container's user-data with authorized ssh keys from the IMDS.
+* Perform boolean queries about the AWS partition in which the host is located.
 
 (The name "shibaken" comes from the fact that Shiba are small, but agile, hunting dogs.)
 

--- a/sources/api/shibaken/src/admin_userdata.rs
+++ b/sources/api/shibaken/src/admin_userdata.rs
@@ -1,0 +1,73 @@
+/// This module contains utilities for populating userdata for the admin-container with user SSH keys from IMDS.
+use argh::FromArgs;
+use imdsclient::ImdsClient;
+use serde::Serialize;
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "generate-admin-userdata")]
+/// Fetch and populate the admin container's user-data with authorized ssh keys.
+pub(crate) struct GenerateAdminUserdata {}
+
+impl GenerateAdminUserdata {
+    pub(crate) async fn run(self) -> Result<()> {
+        let public_keys = fetch_public_keys_from_imds().await?;
+
+        let user_data = UserData::new(public_keys);
+
+        log::info!("Generating user-data");
+        // Serialize user_data to a JSON string that can be read by the admin container.
+        let user_data_json =
+            serde_json::to_string(&user_data).context(error::SerializeJsonSnafu)?;
+        log::debug!("{}", &user_data_json);
+
+        log::info!("Encoding user-data");
+        // admin container user-data must be base64-encoded to be passed through to the admin container
+        // using a setting, rather than another arbitrary storage mechanism. This approach allows the
+        // user to bypass shibaken and use their own user-data if desired.
+        let user_data_base64 = base64::encode(&user_data_json);
+
+        log::info!("Outputting base64-encoded user-data");
+        // sundog expects JSON-serialized output so that many types can be represented, allowing the
+        // API model to use more accurate types.
+        let output = serde_json::to_string(&user_data_base64).context(error::SerializeJsonSnafu)?;
+
+        println!("{}", output);
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct UserData {
+    ssh: Ssh,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct Ssh {
+    authorized_keys: Vec<String>,
+}
+impl UserData {
+    fn new(public_keys: Vec<String>) -> Self {
+        UserData {
+            ssh: Ssh {
+                authorized_keys: public_keys,
+            },
+        }
+    }
+}
+
+/// Returns a list of public keys.
+async fn fetch_public_keys_from_imds() -> Result<Vec<String>> {
+    log::info!("Connecting to IMDS");
+    let mut client = ImdsClient::new();
+    let public_keys = client
+        .fetch_public_ssh_keys()
+        .await
+        .context(error::ImdsClientSnafu)?
+        .unwrap_or_default();
+    Ok(public_keys)
+}

--- a/sources/api/shibaken/src/error.rs
+++ b/sources/api/shibaken/src/error.rs
@@ -1,0 +1,32 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+pub(crate) enum Error {
+    #[snafu(display("IMDS request failed: {}", source))]
+    ImdsRequest { source: imdsclient::Error },
+
+    #[snafu(display("IMDS client failed: {}", source))]
+    ImdsClient { source: imdsclient::Error },
+
+    #[snafu(display(
+        "IMDS client failed: Response '404' while fetching '{}' from '{}'",
+        target,
+        target_type,
+    ))]
+    ImdsData { target: String, target_type: String },
+
+    #[snafu(display("Logger setup error: {}", source))]
+    Logger { source: log::SetLoggerError },
+
+    #[snafu(display("Invalid log level '{}'", log_level_str))]
+    LogLevel {
+        log_level_str: String,
+        source: log::ParseLevelError,
+    },
+
+    #[snafu(display("Error serializing to JSON: {}", source))]
+    SerializeJson { source: serde_json::error::Error },
+}
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -3,102 +3,52 @@
 
 shibaken is called by sundog as a setting generator.
 
-shibaken will fetch and populate the admin container's user-data with authorized ssh keys from the
-AWS instance metadata service (IMDS).
+shibaken is used to fetch data from the instance metadata service (IMDS) in AWS.
+
+shibaken can:
+* Fetch and populate the admin container's user-data with authorized ssh keys from the IMDS.
+* Perform boolean queries about the AWS partition in which the host is located.
 
 (The name "shibaken" comes from the fact that Shiba are small, but agile, hunting dogs.)
 */
 
 #![deny(rust_2018_idioms)]
 
-use imdsclient::ImdsClient;
-use log::{debug, info};
-use serde::Serialize;
+use argh::FromArgs;
 use simplelog::{ColorChoice, Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
-use snafu::{OptionExt, ResultExt};
-use std::str::FromStr;
-use std::{env, process};
+use snafu::ResultExt;
+use std::process;
 
-#[derive(Serialize)]
-struct UserData {
-    ssh: Ssh,
-}
+use crate::error::Result;
 
-#[derive(Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct Ssh {
-    authorized_keys: Vec<String>,
-}
-impl UserData {
-    fn new(public_keys: Vec<String>) -> Self {
-        UserData {
-            ssh: Ssh {
-                authorized_keys: public_keys,
-            },
-        }
-    }
-}
+mod admin_userdata;
+pub(crate) mod error;
+mod partition;
 
-/// Returns a list of public keys.
-async fn fetch_public_keys_from_imds() -> Result<Vec<String>> {
-    info!("Connecting to IMDS");
-    let mut client = ImdsClient::new();
-    let public_keys = client
-        .fetch_public_ssh_keys()
-        .await
-        .context(error::ImdsClientSnafu)?
-        .unwrap_or_else(Vec::new);
-    Ok(public_keys)
-}
-
-/// Store the args we receive on the command line.
+/// Returns information gathered from the AWS instance metadata service (IMDS).
+#[derive(FromArgs, Debug)]
 struct Args {
+    #[argh(option, default = "LevelFilter::Info")]
+    /// filter level for log messages
     log_level: LevelFilter,
+
+    #[argh(subcommand)]
+    command: Commands,
 }
 
-/// Print a usage message in the event a bad arg is passed
-fn usage() {
-    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
-    eprintln!(
-        r"Usage: {}
-            [ --log-level trace|debug|info|warn|error ]",
-        program_name
-    );
-}
+#[derive(FromArgs, Debug)]
+#[argh(subcommand)]
+enum Commands {
+    /// Fetch and populate the admin container's user-data with authorized ssh keys.
+    GenerateAdminUserdata(admin_userdata::GenerateAdminUserdata),
 
-/// Parse the args to the program and return an Args struct
-fn parse_args(args: env::Args) -> Result<Args> {
-    let mut log_level = None;
-
-    let mut iter = args.skip(1);
-    while let Some(arg) = iter.next() {
-        match arg.as_ref() {
-            "--log-level" => {
-                let log_level_str = iter.next().context(error::UsageSnafu {
-                    message: "Did not give argument to --log-level",
-                })?;
-                log_level = Some(
-                    LevelFilter::from_str(&log_level_str)
-                        .context(error::LogLevelSnafu { log_level_str })?,
-                );
-            }
-
-            x => {
-                return error::UsageSnafu {
-                    message: format!("unexpected argument '{}'", x),
-                }
-                .fail()
-            }
-        }
-    }
-
-    Ok(Args {
-        log_level: log_level.unwrap_or(LevelFilter::Info),
-    })
+    /// Fetch and return whether or not this host is in the given partition.
+    /// Accepts multiple partitions, returning `true` if the host is in any of the given partitions.
+    IsPartition(partition::IsPartition),
 }
 
 async fn run() -> Result<()> {
-    let args = parse_args(env::args())?;
+    let args: Args = argh::from_env();
 
     // TerminalMode::Stderr will send all logs to stderr, as sundog only expects the json output of
     // the setting on stdout.
@@ -110,31 +60,14 @@ async fn run() -> Result<()> {
     )
     .context(error::LoggerSnafu)?;
 
-    info!("shibaken started");
+    log::info!("shibaken started");
 
-    let public_keys = fetch_public_keys_from_imds().await?;
-
-    let user_data = UserData::new(public_keys);
-
-    info!("Generating user-data");
-    // Serialize user_data to a JSON string that can be read by the admin container.
-    let user_data_json = serde_json::to_string(&user_data).context(error::SerializeJsonSnafu)?;
-    debug!("{}", &user_data_json);
-
-    info!("Encoding user-data");
-    // admin container user-data must be base64-encoded to be passed through to the admin container
-    // using a setting, rather than another arbitrary storage mechanism. This approach allows the
-    // user to bypass shibaken and use their own user-data if desired.
-    let user_data_base64 = base64::encode(&user_data_json);
-
-    info!("Outputting base64-encoded user-data");
-    // sundog expects JSON-serialized output so that many types can be represented, allowing the
-    // API model to use more accurate types.
-    let output = serde_json::to_string(&user_data_base64).context(error::SerializeJsonSnafu)?;
-
-    println!("{}", output);
-
-    Ok(())
+    match args.command {
+        Commands::GenerateAdminUserdata(generate_admin_userdata) => {
+            generate_admin_userdata.run().await
+        }
+        Commands::IsPartition(is_partition) => is_partition.run().await,
+    }
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -143,56 +76,7 @@ async fn run() -> Result<()> {
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
-        match e {
-            error::Error::Usage { .. } => {
-                eprintln!("{}", e);
-                usage();
-                // sundog matches on the exit codes of the setting generators, so we should return 1
-                // to make sure that this is treated as a failure.
-                process::exit(1);
-            }
-            _ => {
-                eprintln!("{}", e);
-                process::exit(1);
-            }
-        }
+        eprintln!("{}", e);
+        process::exit(1);
     }
 }
-
-mod error {
-    use snafu::Snafu;
-
-    #[derive(Debug, Snafu)]
-    #[snafu(visibility(pub(super)))]
-    pub(super) enum Error {
-        #[snafu(display("IMDS request failed: {}", source))]
-        ImdsRequest { source: imdsclient::Error },
-
-        #[snafu(display("IMDS client failed: {}", source))]
-        ImdsClient { source: imdsclient::Error },
-
-        #[snafu(display(
-            "IMDS client failed: Response '404' while fetching '{}' from '{}'",
-            target,
-            target_type,
-        ))]
-        ImdsData { target: String, target_type: String },
-
-        #[snafu(display("Logger setup error: {}", source))]
-        Logger { source: log::SetLoggerError },
-
-        #[snafu(display("Invalid log level '{}'", log_level_str))]
-        LogLevel {
-            log_level_str: String,
-            source: log::ParseLevelError,
-        },
-
-        #[snafu(display("Error serializing to JSON: {}", source))]
-        SerializeJson { source: serde_json::error::Error },
-
-        #[snafu(display("{}", message))]
-        Usage { message: String },
-    }
-}
-use error::Error;
-type Result<T> = std::result::Result<T, Error>;

--- a/sources/api/shibaken/src/partition.rs
+++ b/sources/api/shibaken/src/partition.rs
@@ -1,0 +1,36 @@
+/// This module contains utilities for querying IMDS about the AWS region in which this host is located.
+use argh::FromArgs;
+use imdsclient::ImdsClient;
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "is-partition")]
+/// Fetch and return whether or not this host is in the given partition.
+/// Accepts multiple partitions, returning `true` if the host is in any of the given partitions.
+pub(crate) struct IsPartition {
+    #[argh(option)]
+    /// partition(s) to check current instance against
+    partition: Vec<String>,
+}
+
+impl IsPartition {
+    pub(crate) async fn run(self) -> Result<()> {
+        let mut client = ImdsClient::new();
+
+        let query_partitions = &self.partition;
+
+        let instance_partition = client
+            .fetch_partition()
+            .await
+            .context(error::ImdsClientSnafu)?;
+
+        let query_result = query_partitions
+            .iter()
+            .any(|query_partition| Some(query_partition) == instance_partition.as_ref());
+
+        println!("{}", query_result);
+        Ok(())
+    }
+}

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -60,6 +60,11 @@ skip = [
     # older version used by clap 2.34.0, via cargo-readme
     { name = "strsim", version = "0.8.0" },
 
+    # newer version used by clap 3.x in shibaken
+    # older version used by clap 2.34.0, via cargo-readme
+    { name = "textwrap", version = "0.11.0" },
+    { name = "clap", version = "2.34.0" },
+
     # older version used by chrono 0.4.19
     { name = "time", version = "0.1.43" },
 ]

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -7,7 +7,7 @@ setting-generator = "schnauzer settings.host-containers.admin.source"
 template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.0"
 
 [metadata.settings.host-containers.admin.user-data]
-setting-generator = "shibaken"
+setting-generator = "shibaken generate-admin-userdata"
 
 [settings.host-containers.control]
 enabled = true

--- a/sources/models/shared-defaults/metrics.toml
+++ b/sources/models/shared-defaults/metrics.toml
@@ -1,8 +1,6 @@
 [settings.metrics]
 # the URL to which anonymous health metrics will be sent
 metrics-url = "https://metrics.bottlerocket.aws/v1/metrics"
-# whether or not health metrics will be sent. set to false to opt-out
-send-metrics = true
 # the list of services that are checked to determine if a host is healthy,
 # overridden in each variant to list services critical to that variant
 service-checks = ["apiserver", "chronyd", "containerd", "host-containerd"]

--- a/sources/models/shared-defaults/send-metrics-aws.toml
+++ b/sources/models/shared-defaults/send-metrics-aws.toml
@@ -1,0 +1,3 @@
+[metadata.settings.metrics.send-metrics]
+# only enable metrics in partitions with unhindered access to the metrics endpoint
+setting-generator = "shibaken is-partition --partition aws --partition aws-us-gov"

--- a/sources/models/shared-defaults/send-metrics-global.toml
+++ b/sources/models/shared-defaults/send-metrics-global.toml
@@ -1,0 +1,3 @@
+[settings.metrics]
+# whether or not health metrics will be sent. set to false to opt-out
+send-metrics = true

--- a/sources/models/src/aws-dev/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-dev/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-ecs-1-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-ecs-1-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-ecs-1/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-k8s-1.19/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-k8s-1.19/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-k8s-1.22/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-k8s-1.22/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-k8s-1.23-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-k8s-1.23-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-k8s-1.23/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-k8s-1.23/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/metal-dev/defaults.d/31-send-metrics.toml
+++ b/sources/models/src/metal-dev/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/models/src/metal-k8s-1.22/defaults.d/31-send-metrics.toml
+++ b/sources/models/src/metal-k8s-1.22/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/models/src/metal-k8s-1.23/defaults.d/31-send-metrics.toml
+++ b/sources/models/src/metal-k8s-1.23/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/models/src/vmware-dev/defaults.d/31-send-metrics.toml
+++ b/sources/models/src/vmware-dev/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/models/src/vmware-k8s-1.22/defaults.d/31-send-metrics.toml
+++ b/sources/models/src/vmware-k8s-1.22/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/models/src/vmware-k8s-1.23/defaults.d/31-send-metrics.toml
+++ b/sources/models/src/vmware-k8s-1.23/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml


### PR DESCRIPTION
**Issue number:** Related to #1255

**Description of changes:**
This set of changes modifies `settings.metrics.send-metrics` to use a setting-generator for AWS variants. Specifically, we enable metrics-sending by default on AWS variants if the host is in the `aws` or `aws-us-gov` partitions, according to the IMDS.

This information is retrieved by `shibaken`, which required some changes to the interface, as well as the admin user-data generation which uses that interface.


**Testing done:**
* [x] Checked that admin container user-data is still generated successfully
* [x] Checked that `send-metrics` successfully uses shibaken in the `aws` partition
* [x] Checked that `send-metrics` successfully uses shibaken in the `aws-us-gov` partition
* [x] Tested migrations with a test TUF repo


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
