### PR TITLE
vmware-variants: remove console=ttyS0 from kernel param

### DIFF
--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["README.md"]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M",

--- a/variants/vmware-k8s-1.20/Cargo.toml
+++ b/variants/vmware-k8s-1.20/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["README.md"]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M",

--- a/variants/vmware-k8s-1.21/Cargo.toml
+++ b/variants/vmware-k8s-1.21/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["README.md"]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M",

--- a/variants/vmware-k8s-1.22/Cargo.toml
+++ b/variants/vmware-k8s-1.22/Cargo.toml
@@ -16,7 +16,6 @@ partition-plan = "unified"
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M",

--- a/variants/vmware-k8s-1.23/Cargo.toml
+++ b/variants/vmware-k8s-1.23/Cargo.toml
@@ -16,7 +16,6 @@ partition-plan = "unified"
 image-format = "vmdk"
 supported-arches = ["x86_64"]
 kernel-parameters = [
-    "console=ttyS0,115200n8",
     "console=tty1",
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
    vmware-variants: remove console=ttyS0 from kernel param
    
    vSphere VMs do not automatically have serial port devices attached. They
    are only guaranteed tty1 (for web remoteconsole). This removes ttyS0 from
    default kernel params for all vmware-variants. If users want to add a
    serial port, they can specify it via 'settings.boot.kernel-parameters'.

```


**Testing done:**
Built and launched vmware-k8s-1.23 VM and the host comes up fine.
There are no errors in host-containers@admin logs:
```
bash-5.1# cat /proc/cmdline 
BOOT_IMAGE=(hd0,gpt3)/vmlinuz console=tty1 crashkernel=2G-:256M net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing=1 dm_verity.max_bios=-1 dm_verity.dev_wait=1 "dm-mod.create=root,,,ro,0 1884160 verity 1 PARTUUID=be6ce1ce-ca5a-4b61-b079-86ee82e253cc/PARTNROFF=1 PARTUUID=be6ce1ce-ca5a-4b61-b079-86ee82e253cc/PARTNROFF=2        4096 4096 235520 1 sha256 cfab6041ef09395e60bbd20d5564d0e50941fd24eb38cb1fd11c9c92b425af97 7357f7358dc329f3e985f31b4a46ca67c23cd2d7a20a6caaa93fe7eaec20b45d        2 restart_on_corruption ignore_zero_blocks" -- systemd.log_target=journal-or-kmsg systemd.log_color=0
bash-5.1# journalctl -u host-containers@admin
Jun 28 00:12:30 198.19.129.182 systemd[1]: Started Host container: admin.
Jun 28 00:12:36 198.19.129.182 host-ctr[2888]: time="2022-06-28T00:12:36Z" level=warning msg="ecr-public: failed to get authorization token, falling back to default resolver (unauthenticated pull)"
Jun 28 00:12:41 198.19.129.182 host-ctr[2888]: time="2022-06-28T00:12:41Z" level=info msg="pulled image successfully" img="public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.0"
Jun 28 00:12:41 198.19.129.182 host-ctr[2888]: time="2022-06-28T00:12:41Z" level=info msg="unpacking image..." img="public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.0"
Jun 28 00:12:48 198.19.129.182 host-ctr[2888]: time="2022-06-28T00:12:48Z" level=info msg="Container does not exist, proceeding to create it" ctr-id=admin
Jun 28 00:12:48 198.19.129.182 host-ctr[2888]: time="2022-06-28T00:12:48Z" level=info msg="container task does not exist, proceeding to create it" container-id=admin
Jun 28 00:12:48 198.19.129.182 host-ctr[2888]: time="2022-06-28T00:12:48Z" level=info msg="successfully started container task"
Jun 28 00:12:49 198.19.129.182 host-ctr[2888]: Created symlink /root/.config/systemd/user/admin.target.wants/getty@tty1.service, pointing to /etc/systemd/user/getty@.service.
Jun 28 00:12:49 198.19.129.182 host-ctr[2888]: Created symlink /root/.config/systemd/user/admin.target.wants/sshd.service, pointing to /etc/systemd/user/sshd.service.
Jun 28 00:12:49 198.19.129.182 host-ctr[2888]: Startup finished in 31ms.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
