### PR TITLE
Added missed step in building packages guide

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -228,7 +228,10 @@ $ rpmspec \
 ### Next Steps
 
 The variants workspace's `Cargo.lock` may be affected by adding a package.
-`cd` into the `variants` directory at the root of the repository and run `cargo generate-lockfile` to refresh `Cargo.lock`.
+
+1. `cd` into the `variants` directory at the root of the repository.
+2. Include the new package inside the `Cargo.toml` file of the variant you want to modify. 
+3. Run `cargo generate-lockfile` to refresh `Cargo.lock`.
 
 To build your package, run the following command in the top-level Bottlerocket directory.
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
[#2249](https://github.com/bottlerocket-os/bottlerocket/discussions/2249)


**Description of changes:**
Added a missed step in the package installation guide to avoid "error: package ID specification xxx did not match any packages" issue


**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.