### PR TITLE
reduce log output for DHCP services

### DIFF
--- a/packages/wicked/wickedd-dhcp4.service
+++ b/packages/wicked/wickedd-dhcp4.service
@@ -8,6 +8,6 @@ PartOf=wickedd.service
 [Service]
 Type=notify
 LimitCORE=infinity
-ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp4 --systemd --foreground --log-level debug --debug most
+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp4 --systemd --foreground --log-level notice
 StandardError=null
 Restart=on-abort

--- a/packages/wicked/wickedd-dhcp6.service
+++ b/packages/wicked/wickedd-dhcp6.service
@@ -8,6 +8,6 @@ PartOf=wickedd.service
 [Service]
 Type=notify
 LimitCORE=infinity
-ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp6 --systemd --foreground --log-level debug --debug most
+ExecStart=/usr/libexec/wicked/bin/wickedd-dhcp6 --systemd --foreground --log-level notice
 StandardError=null
 Restart=on-abort


### PR DESCRIPTION
**Issue number:**
Fixes #2254


**Description of changes:**
Changing the log level to "notice" makes it so only new and renewed leases are logged, rather than every step of the lease negotiation process.


**Testing done:**
Verified that the remaining output consists of messages like these:
```
Jul 04 16:22:04.002962 localhost wickedd-dhcp4[1521]: eth0: Request to acquire DHCPv4 lease with UUID ab13c362-fe3f-0f00-0306-000002000000
Jul 04 16:22:04.004096 localhost wickedd-dhcp6[1522]: eth0: Request to acquire DHCPv6 lease with UUID ab13c362-fe3f-0f00-0306-000003000000 in mode auto
Jul 04 16:22:04.644916 localhost wickedd-dhcp4[1521]: eth0: Committed DHCPv4 lease with address 10.0.85.39 (lease time 3600 sec, renew in 1800 sec, rebind in 3150 sec)
Jul 04 16:22:05.967654 localhost wickedd-dhcp6[1522]: eth0: Committing DHCPv6 lease with:
Jul 04 16:22:05.967681 localhost wickedd-dhcp6[1522]: eth0    +ia-na.address 2600:1f14:ae2:f103:baa1:f578:6e8a:6b0e/0, pref-lft 140, valid-lft 450
Jul 04 16:23:16.657088 localhost wickedd-dhcp6[1522]: eth0: Committing DHCPv6 lease with:
Jul 04 16:23:16.657114 localhost wickedd-dhcp6[1522]: eth0    +ia-na.address 2600:1f14:ae2:f103:baa1:f578:6e8a:6b0e/0, pref-lft 140, valid-lft 450
Jul 04 16:24:26.668959 localhost wickedd-dhcp6[1522]: eth0: Committing DHCPv6 lease with:
Jul 04 16:24:26.668975 localhost wickedd-dhcp6[1522]: eth0    +ia-na.address 2600:1f14:ae2:f103:baa1:f578:6e8a:6b0e/0, pref-lft 140, valid-lft 450
```

In steady state in EC2, this results in two log entries every 70 seconds for DHCPv6 leases, and one log entry every 30 minutes for DHCPv4 leases.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
