### PR TITLE
Updated to EKS-D v1.23-3 and fix invalid release number in spec

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/2/artifacts/kubernetes/v1.23.7/kubernetes-src.tar.gz"
-sha512 = "f3f03970f9ceb25d5993d7d20bfa5d39b24d52e686fab556b1f9c5aae2c5b2297281460196047c98d843d6694086eee949f0afb291c92952bf320fa43887d6b7"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/3/artifacts/kubernetes/v1.23.7/kubernetes-src.tar.gz"
+sha512 = "aa3862ad4145f42a2f9701acaa0ac25be93ce4a8e316fe7ce182bf1d9feb03a6fc0225228fd3c3fcd97aeb08ce34722dacdb1479ee2be07a79c01ba34e49feea"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://eks-d-postsubmit-artifacts.s3.us-west-2.amazonaws.com/kubernetes-1-23/releases/1/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**
Closes #2258
Closes https://github.com/aws/eks-distro/issues/1091

**Description of changes:**
* **Updates the EKS-D version from 1.23-2 to 1.23-3** 
  * There is a [new patch](https://github.com/aws/eks-distro/blob/main/projects/kubernetes/kubernetes/1-23/patches/0009-EKS-PATCH-Make-kubelet-set-alpha.kubernetes.io-provi.patch) for kubelet.
  * The Kubernetes version (1.23.7) does NOT change in the release.
* **Fixes invalid source value in `kubernetes-1.23.spec`**
  * The current value should not have worked (please let me know if it did!)
  * For a full explanation, see #2261

**Testing done:**
None. Let me know if anythings is needed.

---

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
