### PR TITLE
Fix invalid EKS-D 1.22 release number in spec

### DIFF
--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/7/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/8/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**
Closes #2261

**Description of changes:**
* **Fixes invalid source value in `kubernetes-1.22.spec`**
  * The current value should not have worked (please let me know if it did!)
  * For a full explanation, see above-mentioned issue

**Testing done:**
 None. Let me know if anythings is needed.

---

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
