### PR TITLE
add CAP_NET_ADMIN to bootstrap containers

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -634,10 +634,12 @@ func withBootstrap() oci.SpecOpts {
 		withPrivilegedMounts(),
 		withRootFsShared(),
 		oci.WithSelinuxLabel("system_u:system_r:control_t:s0-s0:c0.c1023"),
-		// Bootstrap containers don't require all "privileges", we only add the
-		// `CAP_SYS_ADMIN` capability. `WithDefaultProfile` will create the proper
-		// seccomp profile based on the container's capabilities.
-		oci.WithAddedCapabilities([]string{"CAP_SYS_ADMIN"}),
+		// Bootstrap containers don't require all capabilities. We only add
+		// `CAP_SYS_ADMIN` for mounting filesystems, and `CAP_NET_ADMIN` for
+		// managing iptables rules.
+		oci.WithAddedCapabilities([]string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN"}),
+		// `WithDefaultProfile` creates the proper seccomp profile based on the
+		// container's capabilities.
 		seccomp.WithDefaultProfile(),
 		oci.WithAllDevicesAllowed,
 	)


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
`iptables` needs CAP_NET_ADMIN along with the default capabilities granted to containers.

This allows bootstrap containers to use `iptables` to configure the packet filter rules and policies, e.g. to drop incoming connections by default.


**Testing done:**
Ran a bootstrap container with `iptables` commands. Without this change, the commands failed with a "Permission denied (you must be root)" error. With this change, the commands ran successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
