### PR TITLE
ecs: add `iptables` rules for ECS introspection server

### DIFF
--- a/packages/ecs-agent/ecs.service
+++ b/packages/ecs-agent/ecs.service
@@ -13,17 +13,29 @@ RestartSec=1s
 EnvironmentFile=-/etc/ecs/ecs.config
 EnvironmentFile=/etc/network/proxy.env
 Environment=ECS_CHECKPOINT=true
+# Grant ECS tasks access to the ECS task metadata endpoint
 ExecStartPre=/sbin/iptables -t nat -A PREROUTING -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679
 ExecStartPre=/sbin/iptables -t nat -A OUTPUT -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
+# Grant access to the ECS Introspection server
+ExecStartPre=/sbin/iptables -t nat -A PREROUTING -d 172.17.0.1/32 \
+ -p tcp -m tcp --dport 51678 -j DNAT --to-destination 127.0.0.1:51678
+ExecStartPre=/sbin/iptables -t nat -A OUTPUT -d 172.17.0.1/32 \
+ -p tcp -m tcp --dport 51678 -j REDIRECT --to-ports 51678
 ExecStartPre=/sbin/iptables -t filter -I INPUT --dst 127.0.0.0/8 ! \
  --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
 ExecStart=/usr/bin/amazon-ecs-agent
+# Remove access to the ECS task metadata endpoint from ECS tasks
 ExecStopPost=-/sbin/iptables -t nat -D PREROUTING -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679
 ExecStopPost=-/sbin/iptables -t nat -D OUTPUT -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
+# Remove access to the ECS Introspection server
+ExecStopPost=-/sbin/iptables -t nat -D PREROUTING -d 172.17.0.1/32 \
+ -p tcp -m tcp --dport 51678 -j DNAT --to-destination 127.0.0.1:51678
+ExecStopPost=-/sbin/iptables -t nat -D OUTPUT -d 172.17.0.1/32 \
+ -p tcp -m tcp --dport 51678 -j REDIRECT --to-ports 51678
 ExecStopPost=-/sbin/iptables -t filter -D INPUT --dst 127.0.0.0/8 ! \
  --src 127.0.0.0/8  -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
 


### PR DESCRIPTION
**Issue number:**

Closes #2195

**Description of changes:**

Adds `iptables` rules that forward traffic destined for the ECS Introspection port on the Docker Bridge interface address to the ECS Introspection port on the localhost interface (where the ECS Introspection Server is listening).

**Testing done:**

- [x] tested on Bottlerocket `aws-ecs-1` variant in an ECS cluster, which consisted of:
  1. Run an ECS Task on a cluster consisting of Bottlerocket nodes (task was: a fedora image that sat and waited)
  1. Attempt to `curl` the API endpoint (172.17.0.1:51678) over HTTP from within that fedora container (ECS Task)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
