### PR TITLE
fix ntp service restart when settings change

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -130,3 +130,6 @@ version = "1.8.0"
     "migrate_v1.8.0_public-admin-container-v0-9-0.lz4",
     "migrate_v1.8.0_public-control-container-v0-6-1.lz4",
 ]
+"(1.8.0, 1.9.0)" = [
+    "migrate_v1.9.0_ntp-affected-services.lz4",
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2181,6 +2181,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntp-affected-services"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "api/migration/migrations/v1.8.0/aws-control-container-v0-6-1",
     "api/migration/migrations/v1.8.0/public-admin-container-v0-9-0",
     "api/migration/migrations/v1.8.0/public-control-container-v0-6-1",
+    "api/migration/migrations/v1.9.0/ntp-affected-services",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.9.0/ntp-affected-services/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/ntp-affected-services/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ntp-affected-services"
+version = "0.1.0"
+authors = ["Ben Cressey <bcressey@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.9.0/ntp-affected-services/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/ntp-affected-services/src/main.rs
@@ -1,0 +1,30 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{
+    MetadataListReplacement, ReplaceMetadataListsMigration,
+};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the 'affected-services' list metadata for 'settings.ntp' to refer
+/// to the correct service name ("ntp") instead of the incorrect one ("chronyd").
+fn run() -> Result<()> {
+    migrate(ReplaceMetadataListsMigration(vec![
+        MetadataListReplacement {
+            setting: "settings.ntp",
+            metadata: "affected-services",
+            old_vals: &["chronyd"],
+            new_vals: &["ntp"],
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -117,7 +117,7 @@ path = "/etc/chrony.conf"
 template-path = "/usr/share/templates/chrony-conf"
 
 [metadata.settings.ntp]
-affected-services = ["chronyd"]
+affected-services = ["ntp"]
 
 # Kernel
 


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Since the service is named "ntp" rather than "chronyd", the restart commands were not run when NTP settings changed.

**Testing done:**
Confirmed that both newly launched and upgraded hosts restart the NTP service after settings change.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
