### PR TITLE
Enable the metal-dev build for the Arm architecture

### DIFF
--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -12,7 +12,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant]
 image-format = "raw"
-supported-arches = ["x86_64"]
 kernel-parameters = [
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** none



**Description of changes:**

For testing purposes, the metal-dev variant can be built and runs just fine on the Arm architecture (tested with a QEMU/KVM virtual machine on Amazon EC2 Graviton instances). Remove the restriction to x86_64 from the variant definition.

Note that this keeps the restriction for the non-development metal variants for now.


**Testing done:**

* Built the metal-dev variant for aarch64 on a c6g.metal EC2 instance.
* Booted the resulting image in a local QEMU/KVM virtual machine.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
