### PR TITLE
add support for blocking kernel modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,17 @@ Here are the metrics settings:
   May be set to "none" (the default in older [variants](variants/), up through aws-k8s-1.19), "integrity" (the default for newer [variants](variants/)), or "confidentiality".
   **Important note:** this setting cannot be lowered (toward 'none') at runtime.
   You must reboot for a change to a lower level to take effect.
+* `settings.kernel.modules.<name>.allowed`: Whether the named kernel module is allowed to be loaded.
+  **Important note:** this setting does not affect kernel modules that are already loaded.
+  You may need to reboot for a change to disallow a kernel module to take effect.
+  * Example user data for blocking kernel modules:
+    ```
+    [settings.kernel.modules.sctp]
+    allowed = false
+
+    [settings.kernel.modules.udf]
+    allowed = false
+    ```
 * `settings.kernel.sysctl`: Key/value pairs representing Linux kernel parameters.
   Remember to quote keys (since they often contain ".") and to quote all values.
   * Example user data for setting up sysctl:

--- a/Release.toml
+++ b/Release.toml
@@ -135,5 +135,7 @@ version = "1.8.0"
     "migrate_v1.9.0_shibaken-admin-userdata-semantics.lz4",
     "migrate_v1.9.0_shibaken-send-metrics.lz4",
     "migrate_v1.9.0_image-gc-thresholds.lz4",
+    "migrate_v1.9.0_kernel-modules-setting.lz4",
+    "migrate_v1.9.0_kernel-modules-setting-metadata.lz4",
     "migrate_v1.9.0_kubelet-no-daemon-reload.lz4",
 ]

--- a/packages/release/modprobe-conf.template
+++ b/packages/release/modprobe-conf.template
@@ -1,0 +1,7 @@
+{{#if settings.kernel.modules}}
+{{#each settings.kernel.modules}}
+{{#unless this.allowed }}
+install {{@key}} /bin/true
+{{/unless}}
+{{/each}}
+{{/if}}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -17,6 +17,7 @@ Source200: motd.template
 Source201: proxy-env
 Source202: hostname-env
 Source203: hosts.template
+Source204: modprobe-conf.template
 
 Source1001: multi-user.target
 Source1002: configured.target
@@ -165,6 +166,7 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_templatedir}/hostname-env
 install -p -m 0644 %{S:203} %{buildroot}%{_cross_templatedir}/hosts
+install -p -m 0644 %{S:204} %{buildroot}%{_cross_templatedir}/modprobe-conf
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.rules
@@ -213,6 +215,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %dir %{_cross_unitdir}/systemd-tmpfiles-setup.service.d
 %{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
 %dir %{_cross_templatedir}
+%{_cross_templatedir}/modprobe-conf
 %{_cross_templatedir}/motd
 %{_cross_templatedir}/proxy-env
 %{_cross_templatedir}/hostname-env

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1821,6 +1821,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel-modules-setting"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kernel-modules-setting-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-no-daemon-reload"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -65,6 +65,8 @@ members = [
     "api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics",
     "api/migration/migrations/v1.9.0/shibaken-send-metrics",
     "api/migration/migrations/v1.9.0/image-gc-thresholds",
+    "api/migration/migrations/v1.9.0/kernel-modules-setting",
+    "api/migration/migrations/v1.9.0/kernel-modules-setting-metadata",
     "api/migration/migrations/v1.9.0/kubelet-no-daemon-reload",
 
     "bottlerocket-release",

--- a/sources/api/migration/migrations/v1.9.0/kernel-modules-setting-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/kernel-modules-setting-metadata/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kernel-modules-setting-metadata"
+version = "0.1.0"
+authors = ["Ben Cressey <bcressey@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.9.0/kernel-modules-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/kernel-modules-setting-metadata/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and `affected-services` metadata for `settings.kernel.modules`
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.kernel.modules",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.9.0/kernel-modules-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/kernel-modules-setting/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kernel-modules-setting"
+version = "0.1.0"
+authors = ["Ben Cressey <bcressey@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.9.0/kernel-modules-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/kernel-modules-setting/src/main.rs
@@ -1,0 +1,25 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings under `settings.kernel.modules` for configuring
+/// /etc/modprobe.d/modprobe.conf.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kernel.modules",
+        "services.kernel-modules",
+        "configuration-files.modprobe-conf",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -128,6 +128,17 @@ restart-commands = ["/usr/bin/corndog sysctl"]
 [metadata.settings.kernel.sysctl]
 affected-services = ["sysctl"]
 
+[services.kernel-modules]
+configuration-files = ["modprobe-conf"]
+restart-commands = []
+
+[configuration-files.modprobe-conf]
+path = "/etc/modprobe.d/modprobe.conf"
+template-path = "/usr/share/templates/modprobe-conf"
+
+[metadata.settings.kernel.modules]
+affected-services = ["kernel-modules"]
+
 [services.lockdown]
 configuration-files = []
 restart-commands = ["/usr/bin/corndog lockdown"]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -163,7 +163,7 @@ use crate::modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, DNSDomain,
     ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
     EtcHostsEntries, FriendlyVersion, Identifier, ImageGCHighThresholdPercent,
-    ImageGCLowThresholdPercent, KubernetesAuthenticationMode, KubernetesBootstrapToken,
+    ImageGCLowThresholdPercent, KmodKey, KubernetesAuthenticationMode, KubernetesBootstrapToken,
     KubernetesCloudProvider, KubernetesClusterDnsIp, KubernetesClusterName,
     KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
     KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
@@ -312,8 +312,15 @@ struct NtpSettings {
 #[model]
 struct KernelSettings {
     lockdown: Lockdown,
+    modules: HashMap<KmodKey, KmodSetting>,
     // Values are almost always a single line and often just an integer... but not always.
     sysctl: HashMap<SysctlKey, String>,
+}
+
+// Kernel module settings
+#[model]
+struct KmodSetting {
+    allowed: bool,
 }
 
 // Kernel boot settings

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -41,6 +41,12 @@ pub mod error {
         ))]
         InvalidBootconfigValue { input: String },
 
+        #[snafu(display(
+            "Kernel module keys may only contain ASCII alphanumerics plus hyphens and underscores, received '{}'",
+            input
+        ))]
+        InvalidKmodKey { input: String },
+
         #[snafu(display("Given invalid URL '{}'", input))]
         InvalidUrl { input: String },
 


### PR DESCRIPTION
**Issue number:**
Fixes #2235
Fixes #2236


**Description of changes:**
Provide a settings API for allowing or blocking specific kernel modules.


**Testing done:**
Confirmed that the new settings are available on upgrade, and cleaned up properly on downgrade.

Blocking a module rewrites `modprobe.conf`:
```
# apiclient set kernel.modules.sctp.allowed=false
# cat /etc/modprobe.d/modprobe.conf
install sctp /bin/true
```

A blocked module isn't loaded:
```
# modprobe -v -n sctp
install /bin/true

# modprobe sctp
modprobe: ERROR: Error running install command '/bin/true' for module sctp: retcode 127
modprobe: ERROR: could not insert 'sctp': Invalid argument
```

Allowing a module rewrites `modprobe.conf`:
```
# apiclient set kernel.modules.sctp.allowed=true
# cat /etc/modprobe.d/modprobe.conf
<no output>
```

An allowed module can be loaded:
```
# modprobe -v -n sctp
insmod /lib/modules/5.10.118/kernel/net/sctp/sctp.ko

# modprobe sctp
# grep sctp /proc/modules
sctp 434176 26 - Live 0xffffffffc0745000
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
