### PR TITLE
defer squashfs mounts

### DIFF
--- a/packages/os/link-kernel-modules.service.in
+++ b/packages/os/link-kernel-modules.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Link additional kernel modules
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
 # Rerunning this service after the system is fully loaded will override
 # the already linked kernel modules. This doesn't affect the running system,
 # since kernel modules are linked early in the boot sequence, but we still

--- a/packages/os/load-kernel-modules.service.in
+++ b/packages/os/load-kernel-modules.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Load additional kernel modules
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
 After=link-kernel-modules.service
 Requires=link-kernel-modules.service
 # Disable manual restarts to prevent loading kernel modules

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -43,8 +43,8 @@ Source111: metricdog.service
 Source112: metricdog.timer
 Source113: send-boot-success.service
 Source114: bootstrap-containers@.service
-Source115: link-kernel-modules.service
-Source116: load-kernel-modules.service
+Source115: link-kernel-modules.service.in
+Source116: load-kernel-modules.service.in
 Source117: cfsignal.service
 Source118: generate-network-config.service
 Source119: prepare-primary-interface.service
@@ -430,10 +430,16 @@ install -p -m 0644 \
   %{S:100} %{S:101} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
   %{S:113} %{S:114} %{S:118} %{S:119} \
-%if %{_is_vendor_variant}
-  %{S:115} %{S:116} \
-%endif
   %{buildroot}%{_cross_unitdir}
+
+%if %{_is_vendor_variant}
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:115} > link-kernel-modules.service
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:116} > load-kernel-modules.service
+install -p -m 0644 \
+  link-kernel-modules.service \
+  load-kernel-modules.service \
+  %{buildroot}%{_cross_unitdir}
+%endif
 
 %if %{_is_aws_variant}
 install -p -m 0644 %{S:9} %{buildroot}%{_cross_templatedir}

--- a/packages/release/usr-share-licenses.mount.in
+++ b/packages/release/usr-share-licenses.mount.in
@@ -2,8 +2,8 @@
 Description=License files
 DefaultDependencies=no
 Conflicts=umount.target
-Before=local-fs.target umount.target
-After=local-fs-pre.target
+Before=umount.target
+After=local-fs.target
 
 [Mount]
 What=PREFIX/share/bottlerocket/licenses.squashfs

--- a/packages/release/usr-src-kernels.mount.in
+++ b/packages/release/usr-src-kernels.mount.in
@@ -3,7 +3,8 @@ Description=Kernel Development Sources (Read-Write)
 DefaultDependencies=no
 Conflicts=umount.target
 RequiresMountsFor=/var/lib/kernel-devel/.overlay/lower
-Before=local-fs.target umount.target
+Before=umount.target
+After=local-fs.target
 
 [Mount]
 What=overlay

--- a/packages/release/var-lib-kernel-devel-lower.mount.in
+++ b/packages/release/var-lib-kernel-devel-lower.mount.in
@@ -2,9 +2,9 @@
 Description=Kernel Development Sources (Read-Only)
 DefaultDependencies=no
 Conflicts=umount.target
-Before=local-fs.target umount.target
+Before=umount.target
 Wants=prepare-var.service
-After=prepare-var.service
+After=prepare-var.service local-fs.target
 RequiresMountsFor=/var
 
 [Mount]


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Mounting `/usr/share/licenses` and `/usr/src/kernels` can add up to one second of delay before reaching `local-fs.target`.

It's not necessary to read software licenses or build out-of-tree kernel modules at this stage in the boot process. Moving the mounts after `local-fs.target` doesn't eliminate the delay, but does allow the system to do other useful work in parallel, like acquiring DHCP leases and applying settings.


**Testing done:**
I verified that `link-kernel-modules.service` and `load-kernel-modules` run correctly on the `aws-k8s-1.22-nvidia` variant.

It's difficult to quantify the actual benefit of this since it can vary widely, and depends on other factors like the amount of console logging and whether the wrong kernel thread gets "stuck" flushing to the console when these messages are printed:
```
[    4.630105] loop: module loaded
[    4.644181] squashfs: version 4.0 (2009/01/31) Phillip Lougher
```

Instead I'll just point to the actual mount unit times:
```
 275ms var-lib-kernel\x2ddevel-.overlay-lower.mount
 274ms x86_64\x2dbottlerocket\x2dlinux\x2dgnu-sys\x2droot-usr-share-licenses.mount
 146ms sys-kernel-tracing.mount
 145ms tmp.mount
 140ms etc-cni.mount
 140ms sys-kernel-debug.mount
 140ms dev-mqueue.mount
 139ms dev-hugepages.mount
  24ms opt-cni-bin.mount
  22ms var-lib-bottlerocket.mount
  21ms etc-containerd.mount
  20ms x86_64\x2dbottlerocket\x2dlinux\x2dgnu-sys\x2droot-usr-lib-modules.mount
  18ms etc-host\x2dcontainers.mount
  17ms sys-kernel-config.mount
  17ms sys-fs-fuse-connections.mount
  14ms local.mount
  11ms mnt.mount
   9ms opt.mount
   8ms var.mount
   5ms x86_64\x2dbottlerocket\x2dlinux\x2dgnu-sys\x2droot-usr-src-kernels.mount
```

These are consistently the two slowest mounts, and intuitively it is preferable to deal with slow mounts later in boot if possible, to avoid unlucky sequences where the system stalls for 300 ms before reaching `local-fs.target`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
