### PR TITLE
use "quiet" kernel parameter for aws and vmware

### DIFF
--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -1,7 +1,4 @@
 ## AL2 defaults ##
-# Maximize console logging level for kernel printk messages
-kernel.printk = 8 4 1 7
-
 # Wait 10 seconds and then reboot
 kernel.panic = 10
 

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -281,7 +281,7 @@ menuentry "${PRETTY_NAME} ${VERSION_ID}" {
        $VERITY_DATA_BLOCK_SIZE $VERITY_HASH_BLOCK_SIZE $VERITY_DATA_4K_BLOCKS 1 $VERITY_HASH_ALGORITHM $VERITY_ROOT_HASH $VERITY_SALT \\
        2 restart_on_corruption ignore_zero_blocks" \\
        -- \\
-       systemd.log_target=journal-or-kmsg systemd.log_color=0
+       systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true
    ${INITRD}
 }
 EOF

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -15,6 +15,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
 # core

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -13,7 +13,8 @@ kernel-parameters = [
     "console=tty0",
     "console=ttyS0,115200n8",
     "net.ifnames=0",
-    "netdog.default-interface=eth0:dhcp4,dhcp6?"
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
 # core
@@ -29,7 +30,7 @@ included-packages = [
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit",
-    "kmod-5.10-nvidia-tesla-470"
+    "kmod-5.10-nvidia-tesla-470",
 ]
 
 [lib]

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -11,6 +11,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
 # core

--- a/variants/aws-k8s-1.19/Cargo.toml
+++ b/variants/aws-k8s-1.19/Cargo.toml
@@ -15,6 +15,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
     "aws-iam-authenticator",

--- a/variants/aws-k8s-1.20/Cargo.toml
+++ b/variants/aws-k8s-1.20/Cargo.toml
@@ -23,6 +23,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-k8s-1.21-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.21-nvidia/Cargo.toml
@@ -22,13 +22,14 @@ included-packages = [
     "release",
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
-    "kmod-5.10-nvidia-tesla-470"
+    "kmod-5.10-nvidia-tesla-470",
 ]
 kernel-parameters = [
     "console=tty0",
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-k8s-1.21/Cargo.toml
+++ b/variants/aws-k8s-1.21/Cargo.toml
@@ -23,6 +23,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-k8s-1.22-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.22-nvidia/Cargo.toml
@@ -22,13 +22,14 @@ included-packages = [
     "release",
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
-    "kmod-5.10-nvidia-tesla-470"
+    "kmod-5.10-nvidia-tesla-470",
 ]
 kernel-parameters = [
     "console=tty0",
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-k8s-1.22/Cargo.toml
+++ b/variants/aws-k8s-1.22/Cargo.toml
@@ -23,6 +23,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-k8s-1.23-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.23-nvidia/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
     "release",
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
-    "kmod-5.10-nvidia-tesla-470"
+    "kmod-5.10-nvidia-tesla-470",
 ]
 grub-features = [
     "set-private-var"
@@ -32,6 +32,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-k8s-1.23/Cargo.toml
+++ b/variants/aws-k8s-1.23/Cargo.toml
@@ -26,6 +26,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -16,6 +16,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
 # core

--- a/variants/vmware-k8s-1.20/Cargo.toml
+++ b/variants/vmware-k8s-1.20/Cargo.toml
@@ -18,6 +18,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
     "cni",

--- a/variants/vmware-k8s-1.21/Cargo.toml
+++ b/variants/vmware-k8s-1.21/Cargo.toml
@@ -18,6 +18,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
     "cni",

--- a/variants/vmware-k8s-1.22/Cargo.toml
+++ b/variants/vmware-k8s-1.22/Cargo.toml
@@ -21,6 +21,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 included-packages = [
     "cni",

--- a/variants/vmware-k8s-1.23/Cargo.toml
+++ b/variants/vmware-k8s-1.23/Cargo.toml
@@ -21,6 +21,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 grub-features = [
     "set-private-var"


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
Use the "quiet" parameter for platforms where the hardware is known and the kernel output is not generally needed on the console in order to diagnose issues. This includes the "aws" and "vmware" variants.

The "metal" variants continue to use the more verbose default output so that any hardware without matching driver support can be detected.

Force systemd to always print the status of units, since this can be invaluable data when troubleshooting failures caused by dependency ordering problems.

Remove the printk settings from the default sysctls, since these will be applied by `systemd` very early and override the "quiet" behavior. The default values in `/proc/sys/kernel/printk` are controlled by the kernel config, and will be "7 4 1 7" without the "quiet" parameter, and "4 4 1 7" when it is present.

The main motivation for this is to improve boot performance and make it more consistent. printk logging is expensive, and can slow down many code paths in the kernel.

**Testing done:**
Verified that we still get reasonable systemd output in the "success" and "failure" cases:
https://gist.github.com/bcressey/1b8889c772cef9d88ce37b38f6051b0a

Overall this change saves at least two seconds when booting an m5ad.large instance in EC2. I ignored the results from the first boot to rule out the impact of populating the EBS volume with snapshot blocks.

Measurements were done with `systemctl show --all | grep UserspaceTimestampMonotonic`, which is what `systemd-analyze` uses as the zero point for its own measurements.

Before:
```
UserspaceTimestampMonotonic=1815492
UserspaceTimestampMonotonic=1711044
UserspaceTimestampMonotonic=1806789
```

After:
```
UserspaceTimestampMonotonic=598559
UserspaceTimestampMonotonic=594318
UserspaceTimestampMonotonic=599811
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
