### PR TITLE
avoid unnecessary systemd reloads

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -135,4 +135,5 @@ version = "1.8.0"
     "migrate_v1.9.0_shibaken-admin-userdata-semantics.lz4",
     "migrate_v1.9.0_shibaken-send-metrics.lz4",
     "migrate_v1.9.0_image-gc-thresholds.lz4",
+    "migrate_v1.9.0_kubelet-no-daemon-reload.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1821,6 +1821,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-no-daemon-reload"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-pod-pids-limit"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "api/migration/migrations/v1.9.0/shibaken-admin-userdata-semantics",
     "api/migration/migrations/v1.9.0/shibaken-send-metrics",
     "api/migration/migrations/v1.9.0/image-gc-thresholds",
+    "api/migration/migrations/v1.9.0/kubelet-no-daemon-reload",
 
     "bottlerocket-release",
 

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -457,14 +457,21 @@ impl<'a> SystemdUnit<'a> {
 
     fn enable(&self) -> Result<()> {
         // Only enable the unit, since it will be started once systemd reaches the `preconfigured`
-        // target
-        command(constants::SYSTEMCTL_BIN, &["enable", &self.unit])
+        // target. There's an implied daemon-reload when the target changes, so defer the reload
+        // until then.
+        command(
+            constants::SYSTEMCTL_BIN,
+            &["enable", &self.unit, "--no-reload"],
+        )
     }
 
     fn disable(&self) -> Result<()> {
         // Bootstrap containers won't be up by the time the user sends configurations through
-        // `apiclient`, so there is no need to add `--now` to stop them
-        command(constants::SYSTEMCTL_BIN, &["disable", &self.unit])
+        // `apiclient`, so there is no need to add `--now` to stop them, and no need to reload.
+        command(
+            constants::SYSTEMCTL_BIN,
+            &["disable", &self.unit, "--no-reload"],
+        )
     }
 }
 

--- a/sources/api/migration/migrations/v1.9.0/kubelet-no-daemon-reload/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/kubelet-no-daemon-reload/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-no-daemon-reload"
+version = "0.1.0"
+authors = ["Ben Cressey <bcressey@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.9.0/kubelet-no-daemon-reload/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/kubelet-no-daemon-reload/src/main.rs
@@ -1,0 +1,28 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the restart commands for kubelet to avoid an unnecessary reload
+/// of systemd. They need to be restored to the prior values on downgrade.
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "services.kubernetes.restart-commands",
+        old_vals: &[
+            "/usr/bin/systemctl daemon-reload",
+            "/usr/bin/systemctl try-restart kubelet.service",
+        ],
+        new_vals: &["/usr/bin/systemctl try-restart kubelet.service"],
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/thar-be-settings/src/error.rs
+++ b/sources/api/thar-be-settings/src/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     #[snafu(display("Failed to run restart command - '{}': {}", command, source))]
     CommandExecutionFailure { command: String, source: io::Error },
 
+    #[snafu(display("Reload command failed - '{}': {}", command, stderr))]
+    FailedReloadCommand { command: String, stderr: String },
+
     #[snafu(display("Restart command failed - '{}': {}", command, stderr))]
     FailedRestartCommand { command: String, stderr: String },
 

--- a/sources/models/shared-defaults/kubernetes-services.toml
+++ b/sources/models/shared-defaults/kubernetes-services.toml
@@ -9,7 +9,6 @@ configuration-files = [
   "proxy-env",
 ]
 restart-commands = [
-  "/usr/bin/systemctl daemon-reload",
   "/usr/bin/systemctl try-restart kubelet.service"
 ]
 


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
`systemctl daemon-reload` can be expensive, ranging from 200-500 ms.

On an `aws-k8s` variant, we issue five reloads during the boot:
1. when enabling or disabling the "admin" host container
2. when enabling or disabling the "control" host container
3. when running restart commands for `kubelet`
4. when switching to `configured.target`
5. when switching to `multi-user.target`

These changes eliminate the first three reloads, for a savings of roughly 600ms.


**Testing done:**
Verified that the "admin" and "control" containers are correctly enabled or disabled during boot, and that no `systemctl daemon-reload` runs.

Verified that host containers are correctly enabled or disabled after boot, and that `systemctl daemon-reload` runs, and that `systemctl show host-containers@foo` reflects the expected state.

Verified that `systemctl daemon-reload` is not run when configuring `kubelet` during boot, and that it does run afterwards, and that changes to command-line parameters are picked up.

Verified that the restart command for `kubelet` is updated on upgrade, and restored on downgrade.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
