### PR TITLE
schnauzer: add support for update repositories in China

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -138,4 +138,5 @@ version = "1.8.0"
     "migrate_v1.9.0_kernel-modules-setting.lz4",
     "migrate_v1.9.0_kernel-modules-setting-metadata.lz4",
     "migrate_v1.9.0_kubelet-no-daemon-reload.lz4",
+    "migrate_v1.9.0_updates-targets-base-url.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4071,6 +4071,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "updates-targets-base-url"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "updog"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -68,6 +68,7 @@ members = [
     "api/migration/migrations/v1.9.0/kernel-modules-setting",
     "api/migration/migrations/v1.9.0/kernel-modules-setting-metadata",
     "api/migration/migrations/v1.9.0/kubelet-no-daemon-reload",
+    "api/migration/migrations/v1.9.0/updates-targets-base-url",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.9.0/updates-targets-base-url/Cargo.toml
+++ b/sources/api/migration/migrations/v1.9.0/updates-targets-base-url/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "updates-targets-base-url"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.9.0/updates-targets-base-url/src/main.rs
+++ b/sources/api/migration/migrations/v1.9.0/updates-targets-base-url/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a `setting-generator` for `settings.updates.targets-base-url` on AWS variants.
+/// This migration will do nothing on upgrade, but will remove the metadata if present on downgrade.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        setting: "settings.updates.targets-base-url",
+        metadata: &["setting-generator"],
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -125,6 +125,8 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("default", Box::new(helpers::default));
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
     template_registry.register_helper("pause-prefix", Box::new(helpers::pause_prefix));
+    template_registry.register_helper("tuf-prefix", Box::new(helpers::tuf_prefix));
+    template_registry.register_helper("metadata-prefix", Box::new(helpers::metadata_prefix));
     template_registry.register_helper("host", Box::new(helpers::host));
     template_registry.register_helper("goarch", Box::new(helpers::goarch));
     template_registry.register_helper("join_array", Box::new(helpers::join_array));

--- a/sources/models/shared-defaults/aws-tuf.toml
+++ b/sources/models/shared-defaults/aws-tuf.toml
@@ -1,0 +1,7 @@
+[metadata.settings.updates.targets-base-url]
+setting-generator = "schnauzer settings.updates.targets-base-url"
+template = "{{ tuf-prefix settings.aws.region }}/targets/"
+
+[metadata.settings.updates.metadata-base-url]
+setting-generator = "schnauzer settings.updates.metadata-base-url"
+template = "{{ tuf-prefix settings.aws.region }}{{ metadata-prefix settings.aws.region }}/2020-07-07/{{ os.variant_id }}/{{ os.arch }}/"

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -38,13 +38,8 @@ restart-commands = ["/bin/systemctl try-restart host-containerd.service"]
 # Updates.
 
 [settings.updates]
-targets-base-url = "https://updates.bottlerocket.aws/targets/"
 version-lock = "latest"
 ignore-waves = false
-
-[metadata.settings.updates.metadata-base-url]
-setting-generator = "schnauzer settings.updates.metadata-base-url"
-template = "https://updates.bottlerocket.aws/2020-07-07/{{ os.variant_id }}/{{ os.arch }}/"
 
 [services.updog]
 configuration-files = ["updog-toml"]

--- a/sources/models/shared-defaults/public-tuf.toml
+++ b/sources/models/shared-defaults/public-tuf.toml
@@ -1,0 +1,6 @@
+[settings.updates]
+targets-base-url = "https://updates.bottlerocket.aws/targets/"
+
+[metadata.settings.updates.metadata-base-url]
+setting-generator = "schnauzer settings.updates.metadata-base-url"
+template = "https://updates.bottlerocket.aws/2020-07-07/{{ os.variant_id }}/{{ os.arch }}/"

--- a/sources/models/src/aws-dev/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-dev/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-ecs-1-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-ecs-1-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-ecs-1/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-k8s-1.19/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-k8s-1.19/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-k8s-1.22/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-k8s-1.22/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-k8s-1.23-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-k8s-1.23-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-k8s-1.23/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-k8s-1.23/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/metal-dev/defaults.d/15-public-tuf.toml
+++ b/sources/models/src/metal-dev/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/models/src/metal-k8s-1.22/defaults.d/15-public-tuf.toml
+++ b/sources/models/src/metal-k8s-1.22/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/models/src/metal-k8s-1.23/defaults.d/15-public-tuf.toml
+++ b/sources/models/src/metal-k8s-1.23/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/models/src/vmware-dev/defaults.d/15-public-tuf.toml
+++ b/sources/models/src/vmware-dev/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/models/src/vmware-k8s-1.22/defaults.d/15-public-tuf.toml
+++ b/sources/models/src/vmware-k8s-1.22/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/models/src/vmware-k8s-1.23/defaults.d/15-public-tuf.toml
+++ b/sources/models/src/vmware-k8s-1.23/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml


### PR DESCRIPTION
**Description of changes:**

This adds helpers that settings generators can use to set the `updates.metadata-base-url` and `updates.targets-base-url` values to regionalized repositories. For now, this only includes China regions `cn-north-1` and `cn-northwest-1`, while current regions will continue to use the public updates repository, updates.bottlerocket.aws.

**Testing done:**

Built and launched Bottlerocket and verified the expected `updates` settings in:

- [x] us-west-2
- [x] cn-north-1
- [x] vmware (thanks, @mchaker!)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
