### PR TITLE
pubsys: use default AWS region if none are given

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -100,10 +100,13 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     let aws = infra_config.aws.unwrap_or_else(|| Default::default());
 
     // If the user gave an override list of regions, use that, otherwise use what's in the config.
+    // If there is nothing in the config, use the user's default AWS region.
     let mut regions = if !ami_args.regions.is_empty() {
         ami_args.regions.clone()
-    } else {
+    } else if !aws.regions.is_empty() {
         aws.regions.clone().into()
+    } else {
+        vec![Region::default().name().to_string()]
     }
     .into_iter()
     .map(|name| region_from_string(&name, &aws).context(error::ParseRegionSnafu))

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -93,11 +93,15 @@ pub(crate) async fn run(args: &Args, publish_args: &PublishArgs) -> Result<()> {
     let aws = infra_config.aws.unwrap_or_else(Default::default);
 
     // If the user gave an override list of regions, use that, otherwise use what's in the config.
+    // If there is nothing in the config, use the user's default AWS region.
     let regions = if !publish_args.regions.is_empty() {
         publish_args.regions.clone()
-    } else {
+    } else if !aws.regions.is_empty() {
         aws.regions.clone().into()
+    } else {
+        vec![Region::default().name().to_string()]
     };
+
     ensure!(
         !regions.is_empty(),
         error::MissingConfigSnafu {


### PR DESCRIPTION
**Issue number:**

#2135 

**Description of changes:**

Currently, pubsys returns an error (`Failed to build AMI: Infra.toml is missing aws.regions`) if the user does not either specify a target AWS region(s) as a command line parameter, or provide pubsys with an `Infra.toml` configuration file containing AWS region(s).

This change allows pubsys to acquire the user's default AWS region (if no regions are specified otherwise) for publishing AMIs (`cargo make ... ami`).

**Testing done:**

- [x] manual testing
  - specified only a default AWS region via `aws configure set region us-west-2` (no command-line parameters or `Infra.toml` passed to `cargo make ... ami`)
  - confirmed that pubsys picked my default AWS region when I attempted to upload an AMI via `cargo make ... ami`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
