### PR TITLE
kernel: config: clean up '=n' settings

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -39,13 +39,13 @@ CONFIG_FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER=y
 CONFIG_SECURITY_YAMA=y
 
 # Do not allow SELinux to be disabled at boot.
-CONFIG_SECURITY_SELINUX_BOOTPARAM=n
+# CONFIG_SECURITY_SELINUX_BOOTPARAM is not set
 
 # Do not allow SELinux to be disabled at runtime.
-CONFIG_SECURITY_SELINUX_DISABLE=n
+# CONFIG_SECURITY_SELINUX_DISABLE is not set
 
 # Do not allow SELinux to use `enforcing=0` behavior.
-CONFIG_SECURITY_SELINUX_DEVELOP=n
+# CONFIG_SECURITY_SELINUX_DEVELOP is not set
 
 # Check the protection applied by the kernel for mmap and mprotect,
 # rather than the protection requested by userspace.
@@ -73,7 +73,7 @@ CONFIG_DEBUG_INFO_BTF=y
 
 # We don't want to extend the kernel command line with any upstream defaults;
 # Bottlerocket uses a fairly custom setup that needs tight control over it.
-CONFIG_CMDLINE_EXTEND=n
+# CONFIG_CMDLINE_EXTEND is not set
 
 # Enable ZSTD kernel image compression
 CONFIG_HAVE_KERNEL_ZSTD=y
@@ -98,31 +98,31 @@ CONFIG_BOOT_CONFIG=y
 CONFIG_CHECKPOINT_RESTORE=y
 
 # Disable unused filesystems.
-CONFIG_AFS_FS=n
-CONFIG_CRAMFS=n
-CONFIG_ECRYPT_FS=n
-CONFIG_EXT2_FS=n
-CONFIG_EXT3_FS=n
+# CONFIG_AFS_FS is not set
+# CONFIG_CRAMFS is not set
+# CONFIG_ECRYPT_FS is not set
+# CONFIG_EXT2_FS is not set
+# CONFIG_EXT3_FS is not set
 CONFIG_EXT4_USE_FOR_EXT2=y
-CONFIG_GFS2_FS=n
-CONFIG_HFS_FS=n
-CONFIG_HFSPLUS_FS=n
-CONFIG_JFS_FS=n
-CONFIG_JFFS2_FS=n
-CONFIG_NFS_V2=n
-CONFIG_NILFS2_FS=n
-CONFIG_NTFS_FS=n
-CONFIG_ROMFS_FS=n
-CONFIG_UFS_FS=n
-CONFIG_ZONEFS_FS=n
+# CONFIG_GFS2_FS is not set
+# CONFIG_HFS_FS is not set
+# CONFIG_HFSPLUS_FS is not set
+# CONFIG_JFS_FS is not set
+# CONFIG_JFFS2_FS is not set
+# CONFIG_NFS_V2 is not set
+# CONFIG_NILFS2_FS is not set
+# CONFIG_NTFS_FS is not set
+# CONFIG_ROMFS_FS is not set
+# CONFIG_UFS_FS is not set
+# CONFIG_ZONEFS_FS is not set
 
 # Disable unused network protocols.
-CONFIG_AF_RXRPC=n
-CONFIG_ATM=n
-CONFIG_CAN=n
-CONFIG_HSR=n
-CONFIG_IP_DCCP=n
-CONFIG_L2TP=n
-CONFIG_RDS=n
-CONFIG_RFKILL=n
-CONFIG_TIPC=n
+# CONFIG_AF_RXRPC is not set
+# CONFIG_ATM is not set
+# CONFIG_CAN is not set
+# CONFIG_HSR is not set
+# CONFIG_IP_DCCP is not set
+# CONFIG_L2TP is not set
+# CONFIG_RDS is not set
+# CONFIG_RFKILL is not set
+# CONFIG_TIPC is not set

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -39,13 +39,13 @@ CONFIG_FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER=y
 CONFIG_SECURITY_YAMA=y
 
 # Do not allow SELinux to be disabled at boot.
-CONFIG_SECURITY_SELINUX_BOOTPARAM=n
+# CONFIG_SECURITY_SELINUX_BOOTPARAM is not set
 
 # Do not allow SELinux to be disabled at runtime.
-CONFIG_SECURITY_SELINUX_DISABLE=n
+# CONFIG_SECURITY_SELINUX_DISABLE is not set
 
 # Do not allow SELinux to use `enforcing=0` behavior.
-CONFIG_SECURITY_SELINUX_DEVELOP=n
+# CONFIG_SECURITY_SELINUX_DEVELOP is not set
 
 # Check the protection applied by the kernel for mmap and mprotect,
 # rather than the protection requested by userspace.
@@ -73,7 +73,7 @@ CONFIG_DEBUG_INFO_BTF=y
 
 # We don't want to extend the kernel command line with any upstream defaults;
 # Bottlerocket uses a fairly custom setup that needs tight control over it.
-CONFIG_CMDLINE_EXTEND=n
+# CONFIG_CMDLINE_EXTEND is not set
 
 # Enable ZSTD kernel image compression
 CONFIG_HAVE_KERNEL_ZSTD=y
@@ -98,32 +98,32 @@ CONFIG_BOOT_CONFIG=y
 CONFIG_CHECKPOINT_RESTORE=y
 
 # Disable unused filesystems.
-CONFIG_AFS_FS=n
-CONFIG_CRAMFS=n
-CONFIG_ECRYPT_FS=n
-CONFIG_EXT2_FS=n
-CONFIG_EXT3_FS=n
+# CONFIG_AFS_FS is not set
+# CONFIG_CRAMFS is not set
+# CONFIG_ECRYPT_FS is not set
+# CONFIG_EXT2_FS is not set
+# CONFIG_EXT3_FS is not set
 CONFIG_EXT4_USE_FOR_EXT2=y
-CONFIG_GFS2_FS=n
-CONFIG_HFS_FS=n
-CONFIG_HFSPLUS_FS=n
-CONFIG_JFS_FS=n
-CONFIG_JFFS2_FS=n
-CONFIG_NFS_V2=n
-CONFIG_NILFS2_FS=n
-CONFIG_NTFS_FS=n
-CONFIG_ROMFS_FS=n
-CONFIG_UFS_FS=n
-CONFIG_ZONEFS_FS=n
-CONFIG_NTFS3_FS=n
+# CONFIG_GFS2_FS is not set
+# CONFIG_HFS_FS is not set
+# CONFIG_HFSPLUS_FS is not set
+# CONFIG_JFS_FS is not set
+# CONFIG_JFFS2_FS is not set
+# CONFIG_NFS_V2 is not set
+# CONFIG_NILFS2_FS is not set
+# CONFIG_NTFS_FS is not set
+# CONFIG_ROMFS_FS is not set
+# CONFIG_UFS_FS is not set
+# CONFIG_ZONEFS_FS is not set
+# CONFIG_NTFS3_FS is not set
 
 # Disable unused network protocols.
-CONFIG_AF_RXRPC=n
-CONFIG_ATM=n
-CONFIG_CAN=n
-CONFIG_HSR=n
-CONFIG_IP_DCCP=n
-CONFIG_L2TP=n
-CONFIG_RDS=n
-CONFIG_RFKILL=n
-CONFIG_TIPC=n
+# CONFIG_AF_RXRPC is not set
+# CONFIG_ATM is not set
+# CONFIG_CAN is not set
+# CONFIG_HSR is not set
+# CONFIG_IP_DCCP is not set
+# CONFIG_L2TP is not set
+# CONFIG_RDS is not set
+# CONFIG_RFKILL is not set
+# CONFIG_TIPC is not set

--- a/packages/kernel-5.4/config-bottlerocket
+++ b/packages/kernel-5.4/config-bottlerocket
@@ -34,13 +34,13 @@ CONFIG_EFI_MIXED=y
 CONFIG_SECURITY_YAMA=y
 
 # Do not allow SELinux to be disabled at boot.
-CONFIG_SECURITY_SELINUX_BOOTPARAM=n
+# CONFIG_SECURITY_SELINUX_BOOTPARAM is not set
 
 # Do not allow SELinux to be disabled at runtime.
-CONFIG_SECURITY_SELINUX_DISABLE=n
+# CONFIG_SECURITY_SELINUX_DISABLE is not set
 
 # Do not allow SELinux to use `enforcing=0` behavior.
-CONFIG_SECURITY_SELINUX_DEVELOP=n
+# CONFIG_SECURITY_SELINUX_DEVELOP is not set
 
 # Check the protection applied by the kernel for mmap and mprotect,
 # rather than the protection requested by userspace.
@@ -68,7 +68,7 @@ CONFIG_DEBUG_INFO_BTF=y
 
 # We don't want to extend the kernel command line with any upstream defaults;
 # Bottlerocket uses a fairly custom setup that needs tight control over it.
-CONFIG_CMDLINE_EXTEND=n
+# CONFIG_CMDLINE_EXTEND is not set
 
 # Enable ZSTD kernel image compression
 CONFIG_HAVE_KERNEL_ZSTD=y
@@ -87,31 +87,31 @@ CONFIG_MOUSE_PS2=m
 CONFIG_CHECKPOINT_RESTORE=y
 
 # Disable unused filesystems.
-CONFIG_AFS_FS=n
-CONFIG_CRAMFS=n
-CONFIG_ECRYPT_FS=n
-CONFIG_EXT2_FS=n
-CONFIG_EXT3_FS=n
+# CONFIG_AFS_FS is not set
+# CONFIG_CRAMFS is not set
+# CONFIG_ECRYPT_FS is not set
+# CONFIG_EXT2_FS is not set
+# CONFIG_EXT3_FS is not set
 CONFIG_EXT4_USE_FOR_EXT2=y
-CONFIG_GFS2_FS=n
-CONFIG_HFS_FS=n
-CONFIG_HFSPLUS_FS=n
-CONFIG_JFS_FS=n
-CONFIG_JFFS2_FS=n
-CONFIG_NFS_V2=n
-CONFIG_NILFS2_FS=n
-CONFIG_NTFS_FS=n
-CONFIG_ROMFS_FS=n
-CONFIG_UFS_FS=n
-CONFIG_ZONEFS_FS=n
+# CONFIG_GFS2_FS is not set
+# CONFIG_HFS_FS is not set
+# CONFIG_HFSPLUS_FS is not set
+# CONFIG_JFS_FS is not set
+# CONFIG_JFFS2_FS is not set
+# CONFIG_NFS_V2 is not set
+# CONFIG_NILFS2_FS is not set
+# CONFIG_NTFS_FS is not set
+# CONFIG_ROMFS_FS is not set
+# CONFIG_UFS_FS is not set
+# CONFIG_ZONEFS_FS is not set
 
 # Disable unused network protocols.
-CONFIG_AF_RXRPC=n
-CONFIG_ATM=n
-CONFIG_CAN=n
-CONFIG_HSR=n
-CONFIG_IP_DCCP=n
-CONFIG_L2TP=n
-CONFIG_RDS=n
-CONFIG_RFKILL=n
-CONFIG_TIPC=n
+# CONFIG_AF_RXRPC is not set
+# CONFIG_ATM is not set
+# CONFIG_CAN is not set
+# CONFIG_HSR is not set
+# CONFIG_IP_DCCP is not set
+# CONFIG_L2TP is not set
+# CONFIG_RDS is not set
+# CONFIG_RFKILL is not set
+# CONFIG_TIPC is not set


### PR DESCRIPTION
```
Disabling a kernel config setting is usually done in a config file in
the form of

\# CONFIG_<CONFIG_NAME> is not set

instead of

CONFIG_<CONFIG_NAME>=n

While both today should be equivalent historically there was problems
with specifying '=n' still making that setting defined and having the
opposite effect of what is intended by setting '=n'. Nowadays either way
will result in a final config that will only have the `is not set`
variant for all deactivated options, so the diff of the resulting
artifact before and after this patch will be empty.

As the `is not used` form is the commonly used form, lets adhere to it.
As a bonus it reduces the noise when comparing configs that are manually
merged using the merge-config script.

Replaced all the '=n' settings by the common form through command:

for file in packages/kernel*/config*;
do
    sed -E -i "s/^(CONFIG_[A-Z0-9_]*)=n/# \1 is not set/g" $file;
done

Signed-off-by: Leonard Foerster <foersleo@amazon.com>
```

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/72



**Description of changes:**

Clean up an un-common way of disabling kernel config options. See commit message above for more detail.


**Testing done:**

Checked resulting config that will be installed as part of the kernel rpm before and after this patch. The diff is empty.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
