### PR TITLE
host-ctr: add a mount for system logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Here are the metrics settings:
   **Important note:** this setting does not affect kernel modules that are already loaded.
   You may need to reboot for a change to disallow a kernel module to take effect.
   * Example user data for blocking kernel modules:
+
     ```
     [settings.kernel.modules.sctp]
     allowed = false
@@ -681,6 +682,7 @@ Here are the metrics settings:
     [settings.kernel.modules.udf]
     allowed = false
     ```
+
 * `settings.kernel.sysctl`: Key/value pairs representing Linux kernel parameters.
   Remember to quote keys (since they often contain ".") and to quote all values.
   * Example user data for setting up sysctl:
@@ -896,13 +898,14 @@ logdog
 ```
 
 This will write an archive of the logs to `/var/log/support/bottlerocket-logs.tar.gz`.
+This archive is accessible from host containers at `/.bottlerocket/support`.
 You can use SSH to retrieve the file.
 Once you have exited from the Bottlerocket host, run a command like:
 
 ```bash
 ssh -i YOUR_KEY_FILE \
     ec2-user@YOUR_HOST \
-    "cat /.bottlerocket/rootfs/var/log/support/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
+    "cat /.bottlerocket/support/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
 ```
 
 (If your instance isn't accessible through SSH, you can use [SSH over SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html).)

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -708,6 +708,13 @@ func withDefaultMounts(containerID string, persistentDir string) oci.SpecOpts {
 			Destination: fmt.Sprintf("/var/lib/bottlerocket/inventory/application.json"),
 			Source:      fmt.Sprintf("/usr/share/bottlerocket/application-inventory.json"),
 		},
+		// Bottlerocket logs
+		{
+			Options:     []string{"bind", "ro"},
+			Destination: "/.bottlerocket/support",
+			Source:      "/var/log/support",
+			Type:        "bind",
+		},
 	}
 
 	// The `current` dir was added for easier referencing in Dockerfiles and scripts.


### PR DESCRIPTION
**Issue number:**

Closes #2196 

**Description of changes:**

Add a container-visible mount for /var/log/support,
which contains system logs.

**Testing done:**

- [x] booted an `aws-dev` host and checked that both the control and admin containers could see `/.bottlerocket/support/`
- [x] in the `aws-dev` host, ran `logdog` under `sheltie` and checked that I could see the generated file in the control container.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
