### PR TITLE
Improvements on boot speed and rootfs size

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -82,6 +82,10 @@ CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
 
+# Enable ZSTD modules compression
+CONFIG_MODULE_COMPRESS=y
+CONFIG_MODULE_COMPRESS_ZSTD=y
+
 # Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
 # them before mounting the root device.
 CONFIG_SERIO_I8042=m

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -82,6 +82,10 @@ CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
 
+# Enable ZSTD modules compression
+# CONFIG_MODULE_COMPRESS_NONE is not set
+CONFIG_MODULE_COMPRESS_ZSTD=y
+
 # Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
 # them before mounting the root device.
 CONFIG_SERIO_I8042=m

--- a/packages/kernel-5.4/config-bottlerocket
+++ b/packages/kernel-5.4/config-bottlerocket
@@ -77,6 +77,10 @@ CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
 
+# Enable ZSTD modules compression
+CONFIG_MODULE_COMPRESS=y
+CONFIG_MODULE_COMPRESS_ZSTD=y
+
 # Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
 # them before mounting the root device.
 CONFIG_SERIO_I8042=m

--- a/packages/kubernetes-1.19/kubernetes-1.19.spec
+++ b/packages/kubernetes-1.19/kubernetes-1.19.spec
@@ -29,6 +29,7 @@ Source10: prepare-var-lib-kubelet.service
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
 Source21: make-kubelet-dirs.conf
+Source22: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
@@ -75,7 +76,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -108,6 +109,7 @@ install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
+%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config

--- a/packages/kubernetes-1.19/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.19/load-ipvs-modules.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
+After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.20/kubernetes-1.20.spec
+++ b/packages/kubernetes-1.20/kubernetes-1.20.spec
@@ -29,6 +29,7 @@ Source10: prepare-var-lib-kubelet.service
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
 Source21: make-kubelet-dirs.conf
+Source22: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 Patch1: 0001-always-set-relevant-variables-for-cross-compiling.patch
@@ -75,7 +76,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -108,6 +109,7 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
+%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config

--- a/packages/kubernetes-1.20/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.20/load-ipvs-modules.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
+After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -39,6 +39,7 @@ Source10: prepare-var-lib-kubelet.service
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
 Source21: make-kubelet-dirs.conf
+Source22: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -91,7 +92,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -124,6 +125,7 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
+%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config

--- a/packages/kubernetes-1.21/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.21/load-ipvs-modules.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
+After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -39,6 +39,7 @@ Source10: prepare-var-lib-kubelet.service
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
 Source21: make-kubelet-dirs.conf
+Source22: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -88,7 +89,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -121,6 +122,7 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
+%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env
 %{_cross_templatedir}/kubelet-config

--- a/packages/kubernetes-1.22/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.22/load-ipvs-modules.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
+After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -40,6 +40,7 @@ Source10: prepare-var-lib-kubelet.service
 Source20: prestart-pull-pause-ctr.conf
 Source21: dockershim-symlink.conf
 Source22: make-kubelet-dirs.conf
+Source23: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -89,7 +90,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -122,6 +123,7 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
+%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env

--- a/packages/kubernetes-1.23/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.23/load-ipvs-modules.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
+After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
+++ b/packages/systemd/9001-use-absolute-path-for-var-run-symlink.patch
@@ -1,7 +1,7 @@
 From 4582d854afd5b42fdc952fafd89d762dcb279da9 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Mon, 3 Jan 2022 20:22:17 +0000
-Subject: [PATCH 9001/9010] use absolute path for /var/run symlink
+Subject: [PATCH 9001/9011] use absolute path for /var/run symlink
 
 Otherwise the symlink may be broken if /var is a bind mount from
 somewhere else.

--- a/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
+++ b/packages/systemd/9002-core-add-separate-timeout-for-system-shutdown.patch
@@ -1,7 +1,7 @@
 From 71a774ad3c3dfd5f9ddb96f7b08a957144e93323 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Tue, 10 Mar 2020 20:30:10 +0000
-Subject: [PATCH 9002/9010] core: add separate timeout for system shutdown
+Subject: [PATCH 9002/9011] core: add separate timeout for system shutdown
 
 There is an existing setting for this (DefaultTimeoutStopUSec), but
 changing it has no effect because `reset_arguments()` is called just

--- a/packages/systemd/9003-machine-id-setup-generate-stable-ID-under-Xen-and-VM.patch
+++ b/packages/systemd/9003-machine-id-setup-generate-stable-ID-under-Xen-and-VM.patch
@@ -1,7 +1,7 @@
 From 95824ee80743b604e4b1757818f1ea7bf2971462 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Mon, 3 Jan 2022 21:57:11 +0000
-Subject: [PATCH 9003/9010] machine-id-setup: generate stable ID under Xen and
+Subject: [PATCH 9003/9011] machine-id-setup: generate stable ID under Xen and
  VMware
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>

--- a/packages/systemd/9004-units-mount-tmp-with-noexec.patch
+++ b/packages/systemd/9004-units-mount-tmp-with-noexec.patch
@@ -1,7 +1,7 @@
 From e02f2a077e97a4f73697ef9a6769e41401b1ca97 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 28 May 2022 03:52:28 +0000
-Subject: [PATCH 9004/9010] units: mount /tmp with noexec
+Subject: [PATCH 9004/9011] units: mount /tmp with noexec
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 ---

--- a/packages/systemd/9005-mount-setup-apply-noexec-to-more-mounts.patch
+++ b/packages/systemd/9005-mount-setup-apply-noexec-to-more-mounts.patch
@@ -1,7 +1,7 @@
 From 5a822486905915396d27da85b336f0877e612532 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 28 May 2022 03:49:46 +0000
-Subject: [PATCH 9005/9010] mount-setup: apply noexec to more mounts
+Subject: [PATCH 9005/9011] mount-setup: apply noexec to more mounts
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 ---

--- a/packages/systemd/9006-mount-setup-mount-etc-with-specific-label.patch
+++ b/packages/systemd/9006-mount-setup-mount-etc-with-specific-label.patch
@@ -1,7 +1,7 @@
 From 2e871585a26b1f107db88a0ec0d9951735a6ec49 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 9 Jul 2020 20:00:36 +0000
-Subject: [PATCH 9006/9010] mount-setup: mount /etc with specific label
+Subject: [PATCH 9006/9011] mount-setup: mount /etc with specific label
 
 The filesystem is mounted after we load the SELinux policy, so we can
 apply the label we need to restrict access.

--- a/packages/systemd/9007-journal-disable-keyed-hashes-for-compatibility.patch
+++ b/packages/systemd/9007-journal-disable-keyed-hashes-for-compatibility.patch
@@ -1,7 +1,7 @@
 From 81808b8ed1259d4d05052b6825d9b560f93098e5 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Thu, 12 Nov 2020 16:18:15 +0000
-Subject: [PATCH 9007/9010] journal: disable keyed hashes for compatibility
+Subject: [PATCH 9007/9011] journal: disable keyed hashes for compatibility
 
 Otherwise the journal is not readable by older versions of systemd.
 

--- a/packages/systemd/9008-pkg-config-stop-hardcoding-prefix-to-usr.patch
+++ b/packages/systemd/9008-pkg-config-stop-hardcoding-prefix-to-usr.patch
@@ -1,7 +1,7 @@
 From dc6abce8797a6a2e63c4ae58218588327e73d4cb Mon Sep 17 00:00:00 2001
 From: Erikson Tung <etung@amazon.com>
 Date: Mon, 3 Jan 2022 22:07:25 +0000
-Subject: [PATCH 9008/9010] pkg-config: stop hardcoding prefix to /usr
+Subject: [PATCH 9008/9011] pkg-config: stop hardcoding prefix to /usr
 
 While we ensure /usr points to the sys-root at runtime, for Bottlerocket's
 packaging we need to be careful to avoid dependencies on the host OS so

--- a/packages/systemd/9009-sysctl-do-not-set-rp_filter-via-wildcard.patch
+++ b/packages/systemd/9009-sysctl-do-not-set-rp_filter-via-wildcard.patch
@@ -1,7 +1,7 @@
 From 0aee69ee8b337ff50d4f7723e3c93f222bf239b1 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Mon, 21 Jun 2021 20:53:47 +0000
-Subject: [PATCH 9009/9010] sysctl: do not set rp_filter via wildcard
+Subject: [PATCH 9009/9011] sysctl: do not set rp_filter via wildcard
 
 The wildcard matches existing interfaces when `systemd-sysctl` runs
 at startup, but also applies to new interfaces when it is invoked by

--- a/packages/systemd/9010-sysusers-set-root-shell-to-sbin-nologin.patch
+++ b/packages/systemd/9010-sysusers-set-root-shell-to-sbin-nologin.patch
@@ -1,7 +1,7 @@
 From 6f28750806a6e25e4f83784e7c29aca8e9c3903b Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 28 May 2022 04:12:07 +0000
-Subject: [PATCH 9010/9010] sysusers: set root shell to /sbin/nologin
+Subject: [PATCH 9010/9011] sysusers: set root shell to /sbin/nologin
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 ---

--- a/packages/systemd/9011-units-keep-modprobe-service-units-running.patch
+++ b/packages/systemd/9011-units-keep-modprobe-service-units-running.patch
@@ -1,0 +1,24 @@
+From 13bf60bf11edf407246176262865c8e93f66c1e8 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Sun, 17 Jul 2022 16:21:16 +0000
+Subject: [PATCH 9011/9011] units: keep modprobe service units running
+
+Otherwise, the units are restarted when the default target changes.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ units/modprobe@.service | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/units/modprobe@.service b/units/modprobe@.service
+index cf8baf6..a029ab0 100644
+--- a/units/modprobe@.service
++++ b/units/modprobe@.service
+@@ -17,3 +17,4 @@ ConditionCapability=CAP_SYS_MODULE
+ [Service]
+ Type=oneshot
+ ExecStart=-/sbin/modprobe -abq %I
++RemainAfterExit=true
+-- 
+2.36.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -49,6 +49,9 @@ Patch9009: 9009-sysctl-do-not-set-rp_filter-via-wildcard.patch
 # Local patch to set root's shell to /sbin/nologin rather than /bin/sh.
 Patch9010: 9010-sysusers-set-root-shell-to-sbin-nologin.patch
 
+# Local patch to keep modprobe units running to avoid repeated log entries.
+Patch9011: 9011-units-keep-modprobe-service-units-running.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
In #1689, we reverted the ZSTD compression for kernel modules due to problems with `rpm` and `kube-proxy`. The problem with `rpm` is gone, and the build doesn't hang anymore. As part of this pull request, the `ipvs` kernel modules are loaded early on the boot sequence to prevent `kube-proxy` from loading them.

```
kernel-5.15: enable ZSTD compression for kernel modules
```

```
kernel-5.10: enable ZSTD compression for kernel modules
```

```
kernel-5.4: enable ZSTD compression for kernel modules
```

```
kubelet: load ipvs modules for kube-proxy

The `insmod` binary that kube-proxy uses does not support compressed
modules, and hands the compressed file to the kernel to load. This
leads to warnings that unsigned modules are not allowed, if lockdown
is enabled, or errors about malformed modules otherwise.

kube-proxy does check whether the module is loaded, so we can avoid
these errors by loading the necessary modules before kubelet starts.
```

```
systemd: keep modprobe units running

This avoids repeated log entries and unnecessary modprobe invocations
when the default target changes.
```



**Testing done:**

- I built a variant for each kernel 10 times in a row, and the built didn't hang
- I confirmed that `ipvs` kernel modules won't be loaded when they are blocked by the new `settings.kernel.modules` API
- I confirmed that only a warning is shown by `kube-proxy` for the `ipvs` kernel modules, since [it will try to load](https://github.com/kubernetes/kubernetes/blob/7b9a20b587de81ed7b885e97f2fd1db1deca548b/pkg/proxy/ipvs/proxier.go#L660) them without failing:

```
Failed to load kernel module ip_vs_wrr with modprobe. You can ignore this message when kube-proxy is running inside container without mounting /lib/modules
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
