### PR TITLE
modeled_types: Use FromStr instead of TryFrom

### DIFF
--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -563,8 +563,9 @@ mod test {
     use datastore::memory::MemoryDataStore;
     use datastore::{Committed, DataStore, Key, KeyType};
     use maplit::{hashmap, hashset};
+    use model::modeled_types::SingleLineString;
     use model::{ConfigurationFile, Service};
-    use std::convert::TryInto;
+    use std::str::FromStr;
 
     #[test]
     fn get_settings_works() {
@@ -579,7 +580,10 @@ mod test {
 
         // Retrieve with helper
         let settings = get_settings(&ds, &Committed::Live).unwrap();
-        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
+        assert_eq!(
+            settings.motd,
+            Some(("json string").parse::<String>().unwrap())
+        );
     }
 
     #[test]
@@ -597,13 +601,19 @@ mod test {
         let settings = get_settings_prefix(&ds, "settings.", &Committed::Live)
             .unwrap() // Result Ok
             .unwrap(); // got Some result
-        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
+        assert_eq!(
+            settings.motd,
+            Some(("json string").parse::<String>().unwrap())
+        );
 
         // Retrieve with more specific prefix OK
         let settings = get_settings_prefix(&ds, "settings.mot", &Committed::Live)
             .unwrap() // Result Ok
             .unwrap(); // got Some result
-        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
+        assert_eq!(
+            settings.motd,
+            Some(("json string").parse::<String>().unwrap())
+        );
 
         // No match should return None; the "view" layer of the API, in mod.rs, turns this into an
         // empty object if desired.
@@ -636,7 +646,10 @@ mod test {
         // Retrieve with helper
         let settings =
             get_settings_keys(&ds, &hashset!("settings.motd"), &Committed::Live).unwrap();
-        assert_eq!(settings.motd, Some("json string 1".try_into().unwrap()));
+        assert_eq!(
+            settings.motd,
+            Some(("json string 1").parse::<String>().unwrap())
+        );
         assert_eq!(settings.ntp, None);
     }
 
@@ -663,7 +676,7 @@ mod test {
         assert_eq!(
             services,
             hashmap!("foo".to_string() => Service {
-                configuration_files: vec!["file1".try_into().unwrap()],
+                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             })
         );
@@ -694,7 +707,7 @@ mod test {
         assert_eq!(
             services,
             hashmap!("foo".to_string() => Service {
-                configuration_files: vec!["file1".try_into().unwrap()],
+                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             })
         );
@@ -735,8 +748,8 @@ mod test {
         assert_eq!(
             configuration_files,
             hashmap!("foo".to_string() => ConfigurationFile {
-                path: "file".try_into().unwrap(),
-                template_path: "template".try_into().unwrap(),
+                path: ("file").parse::<SingleLineString>().unwrap(),
+                template_path: ("template").parse::<SingleLineString>().unwrap(),
             })
         );
 
@@ -754,7 +767,7 @@ mod test {
     #[test]
     fn set_settings_works() {
         let mut settings = Settings::default();
-        settings.motd = Some("tz".try_into().unwrap());
+        settings.motd = Some(("tz").parse::<String>().unwrap());
 
         // Set with helper
         let mut ds = MemoryDataStore::new();
@@ -832,7 +845,10 @@ mod test {
 
         // Confirm pending
         let settings = get_settings(&ds, &pending).unwrap();
-        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
+        assert_eq!(
+            settings.motd,
+            Some(("json string").parse::<String>().unwrap())
+        );
         // No live settings yet
         get_settings(&ds, &Committed::Live).unwrap_err();
 
@@ -843,6 +859,9 @@ mod test {
         get_settings(&ds, &pending).unwrap_err();
         // Confirm live
         let settings = get_settings(&ds, &Committed::Live).unwrap();
-        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
+        assert_eq!(
+            settings.motd,
+            Some(("json string").parse::<String>().unwrap())
+        );
     }
 }

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -80,7 +80,6 @@ use datastore::{serialize_scalar, Key, KeyType};
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Write;
@@ -243,7 +242,8 @@ fn parse_mark_bootstrap_args(args: Vec<String>) -> Result<Subcommand> {
     Ok(Subcommand::MarkBootstrap(MarkBootstrapArgs {
         container_id: container_id,
         // Fail if 'mode' is invalid
-        mode: BootstrapContainerMode::try_from(mode.to_string())
+        mode: mode
+            .parse::<BootstrapContainerMode>()
             .context(error::BootstrapContainerModeSnafu)?,
     }))
 }

--- a/sources/api/certdog/src/main.rs
+++ b/sources/api/certdog/src/main.rs
@@ -301,8 +301,8 @@ mod test_certdog {
     use model;
     use model::modeled_types::{Identifier, PemCertificateString};
     use std::collections::HashMap;
-    use std::convert::TryFrom;
     use std::fs::File;
+    use std::str::FromStr;
 
     static TEST_PEM: &str = include_str!("../../../models/tests/data/test-pem");
 
@@ -310,23 +310,23 @@ mod test_certdog {
     fn bundles_splitted() {
         let mut bundle = HashMap::new();
         bundle.insert(
-            Identifier::try_from("trusted").unwrap(),
+            ("trusted").parse::<Identifier>().unwrap(),
             model::PemCertificate {
-                data: Some(PemCertificateString::try_from(TEST_PEM).unwrap()),
+                data: Some(PemCertificateString::from_str(TEST_PEM).unwrap()),
                 trusted: Some(true),
             },
         );
         bundle.insert(
-            Identifier::try_from("distrusted").unwrap(),
+            ("distrusted").parse::<Identifier>().unwrap(),
             model::PemCertificate {
-                data: Some(PemCertificateString::try_from(TEST_PEM).unwrap()),
+                data: Some(PemCertificateString::from_str(TEST_PEM).unwrap()),
                 trusted: Some(false),
             },
         );
         bundle.insert(
-            Identifier::try_from("distrusted-without-flag").unwrap(),
+            ("distrusted-without-flag").parse::<Identifier>().unwrap(),
             model::PemCertificate {
-                data: Some(PemCertificateString::try_from(TEST_PEM).unwrap()),
+                data: Some(PemCertificateString::from_str(TEST_PEM).unwrap()),
                 trusted: None,
             },
         );

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -16,6 +16,7 @@ use snafu::{OptionExt, ResultExt};
 use std::convert::TryFrom;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 use std::{env, process};
 
 const DEFAULT_ECS_CONFIG_PATH: &str = "/etc/ecs/ecs.config.json";
@@ -112,7 +113,7 @@ async fn run() -> Result<()> {
         image_pull_behavior: ecs
             .image_pull_behavior
             .as_ref()
-            .map(|b| ECSImagePullBehavior::try_from(b.as_ref()).unwrap() as u8),
+            .map(|b| b.parse::<ECSImagePullBehavior>().unwrap() as u8),
 
         // Task role support is always enabled
         task_iam_role_enabled: true,

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -15,7 +15,6 @@ use semver::Version;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
 use std::io;
 use std::path::Path;
 use std::str::FromStr;
@@ -186,10 +185,12 @@ fn parse_metadata_toml(md_toml_val: toml::Value) -> Result<Vec<model::Metadata>>
                 );
 
                 // Ensure the metadata/data keys don't contain newline chars
-                let md =
-                    SingleLineString::try_from(md_key).context(error::SingleLineStringSnafu)?;
-                let key =
-                    SingleLineString::try_from(data_key).context(error::SingleLineStringSnafu)?;
+                let md = md_key
+                    .parse::<SingleLineString>()
+                    .context(error::SingleLineStringSnafu)?;
+                let key = data_key
+                    .parse::<SingleLineString>()
+                    .context(error::SingleLineStringSnafu)?;
 
                 // Create the Metadata struct
                 def_metadatas.push(model::Metadata { key, md, val })

--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -165,17 +165,17 @@ mod test {
     use super::*;
     use crate::service::Services;
     use maplit::{hashmap, hashset};
-    use std::convert::TryInto;
+    use model::modeled_types::SingleLineString;
 
     #[test]
     fn test_get_config_file_names() {
         let input_map = hashmap!(
             "foo".to_string() => model::Service {
-                configuration_files: vec!["file1".try_into().unwrap()],
+                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             },
             "bar".to_string() => model::Service {
-                configuration_files: vec!["file1".try_into().unwrap(), "file2".try_into().unwrap()],
+                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap(), ("file2").parse::<SingleLineString>().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             },
         );

--- a/sources/models/src/de.rs
+++ b/sources/models/src/de.rs
@@ -3,7 +3,6 @@ use serde::de::value::SeqAccessDeserializer;
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fmt::Formatter;
 use toml::Value;
 
@@ -35,7 +34,8 @@ where
                     Value::String(taint_val) => {
                         node_taints.insert(
                             k,
-                            vec![KubernetesTaintValue::try_from(taint_val)
+                            vec![taint_val
+                                .parse::<KubernetesTaintValue>()
                                 .map_err(M::Error::custom)?],
                         );
                     }
@@ -65,7 +65,6 @@ where
 #[cfg(test)]
 mod node_taint_tests {
     use crate::{KubernetesSettings, KubernetesTaintValue};
-    use std::convert::TryFrom;
     static TEST_NODE_TAINT_LIST: &str = include_str!("../tests/data/node-taint-list-val");
     static TEST_NODE_TAINT_SINGLE: &str = include_str!("../tests/data/node-taint-single-val");
     static TEST_NODE_TAINT_EMPTY_LIST: &str = include_str!("../tests/data/node-taint-empty-list");
@@ -82,8 +81,12 @@ mod node_taint_tests {
                 .unwrap()
                 .to_owned(),
             vec![
-                KubernetesTaintValue::try_from("value1:NoSchedule").unwrap(),
-                KubernetesTaintValue::try_from("value1:NoExecute").unwrap()
+                ("value1:NoSchedule")
+                    .parse::<KubernetesTaintValue>()
+                    .unwrap(),
+                ("value1:NoExecute")
+                    .parse::<KubernetesTaintValue>()
+                    .unwrap()
             ]
         );
         assert_eq!(
@@ -94,7 +97,9 @@ mod node_taint_tests {
                 .get("key2")
                 .unwrap()
                 .to_owned(),
-            vec![KubernetesTaintValue::try_from("value2:NoSchedule").unwrap()]
+            vec![("value2:NoSchedule")
+                .parse::<KubernetesTaintValue>()
+                .unwrap()]
         );
     }
 
@@ -109,7 +114,9 @@ mod node_taint_tests {
                 .get("key1")
                 .unwrap()
                 .to_owned(),
-            vec![KubernetesTaintValue::try_from("value1:NoSchedule").unwrap()]
+            vec![("value1:NoSchedule")
+                .parse::<KubernetesTaintValue>()
+                .unwrap()]
         );
         assert_eq!(
             k8s_settings
@@ -119,7 +126,9 @@ mod node_taint_tests {
                 .get("key2")
                 .unwrap()
                 .to_owned(),
-            vec![KubernetesTaintValue::try_from("value2:NoExecute").unwrap()]
+            vec![("value2:NoExecute")
+                .parse::<KubernetesTaintValue>()
+                .unwrap()]
         );
     }
 

--- a/sources/models/src/modeled_types/ecs.rs
+++ b/sources/models/src/modeled_types/ecs.rs
@@ -9,6 +9,7 @@ use std::borrow::Borrow;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
+use std::str::FromStr;
 
 /// ECSAttributeKey represents a string that contains a valid ECS attribute key.  It stores
 /// the original string and makes it accessible through standard traits.
@@ -30,10 +31,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl TryFrom<&str> for ECSAttributeKey {
-    type Error = error::Error;
+impl FromStr for ECSAttributeKey {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             ECS_ATTRIBUTE_KEY.is_match(input),
             error::BigPatternSnafu {
@@ -52,7 +53,6 @@ string_impls_for!(ECSAttributeKey, "ECSAttributeKey");
 #[cfg(test)]
 mod test_ecs_attribute_key {
     use super::ECSAttributeKey;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_keys() {
@@ -67,7 +67,7 @@ mod test_ecs_attribute_key {
             ".leadingperiod",
             "trailingperiod.",
         ] {
-            ECSAttributeKey::try_from(*key).unwrap();
+            key.parse::<ECSAttributeKey>().unwrap();
         }
     }
 
@@ -82,7 +82,7 @@ mod test_ecs_attribute_key {
             ":",
             "no spaces allowed",
         ] {
-            ECSAttributeKey::try_from(*key).unwrap_err();
+            key.parse::<ECSAttributeKey>().unwrap_err();
         }
     }
 }
@@ -115,10 +115,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl TryFrom<&str> for ECSAttributeValue {
-    type Error = error::Error;
+impl FromStr for ECSAttributeValue {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             ECS_ATTRIBUTE_VALUE.is_match(input),
             error::BigPatternSnafu {
@@ -137,7 +137,6 @@ string_impls_for!(ECSAttributeValue, "ECSAttributeValue");
 #[cfg(test)]
 mod test_ecs_attribute_value {
     use super::ECSAttributeValue;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_vals() {
@@ -157,7 +156,7 @@ mod test_ecs_attribute_value {
             "\\",
             "\\ \\",
         ] {
-            ECSAttributeValue::try_from(*val).unwrap();
+            val.parse::<ECSAttributeValue>().unwrap();
         }
     }
 
@@ -171,7 +170,7 @@ mod test_ecs_attribute_value {
             " leading space",
             "trailing space ",
         ] {
-            ECSAttributeValue::try_from(*val).unwrap_err();
+            val.parse::<ECSAttributeValue>().unwrap_err();
         }
     }
 }
@@ -196,11 +195,11 @@ enum ECSLogLevel {
 
 string_impls_for!(ECSAgentLogLevel, "ECSAgentLogLevel");
 
-impl TryFrom<&str> for ECSAgentLogLevel {
-    type Error = error::Error;
+impl FromStr for ECSAgentLogLevel {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        serde_plain::from_str::<ECSLogLevel>(&input).context(error::InvalidPlainValueSnafu {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str::<ECSLogLevel>(input).context(error::InvalidPlainValueSnafu {
             field: "ecs.loglevel",
         })?;
         Ok(ECSAgentLogLevel {
@@ -212,19 +211,18 @@ impl TryFrom<&str> for ECSAgentLogLevel {
 #[cfg(test)]
 mod test_ecs_agent_log_level {
     use super::ECSAgentLogLevel;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_vals() {
         for val in &["debug", "info", "warn"] {
-            ECSAgentLogLevel::try_from(*val).unwrap();
+            val.parse::<ECSAgentLogLevel>().unwrap();
         }
     }
 
     #[test]
     fn bad_vals() {
         for val in &["", "warning", "errors", " "] {
-            ECSAgentLogLevel::try_from(*val).unwrap_err();
+            val.parse::<ECSAgentLogLevel>().unwrap_err();
         }
     }
 }
@@ -246,11 +244,11 @@ pub enum ECSImagePullBehavior {
     PreferCached,
 }
 
-impl TryFrom<&str> for ECSImagePullBehavior {
-    type Error = error::Error;
+impl FromStr for ECSImagePullBehavior {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        let image_pull_behavior = serde_plain::from_str::<ECSImagePullBehavior>(&input).context(
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let image_pull_behavior = serde_plain::from_str::<ECSImagePullBehavior>(input).context(
             error::InvalidPlainValueSnafu {
                 field: "ecs.image_pull_behavior",
             },
@@ -261,11 +259,11 @@ impl TryFrom<&str> for ECSImagePullBehavior {
 
 string_impls_for!(ECSAgentImagePullBehavior, "ECSAgentImagePullBehavior");
 
-impl TryFrom<&str> for ECSAgentImagePullBehavior {
-    type Error = error::Error;
+impl FromStr for ECSAgentImagePullBehavior {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        ECSImagePullBehavior::try_from(input)?;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        input.parse::<ECSImagePullBehavior>()?;
         Ok(ECSAgentImagePullBehavior {
             inner: input.to_string(),
         })
@@ -275,19 +273,18 @@ impl TryFrom<&str> for ECSAgentImagePullBehavior {
 #[cfg(test)]
 mod test_ecs_agent_image_pull_behavior {
     use super::ECSAgentImagePullBehavior;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_vals() {
         for val in &["default", "always", "once", "prefer-cached"] {
-            ECSAgentImagePullBehavior::try_from(*val).unwrap();
+            val.parse::<ECSAgentImagePullBehavior>().unwrap();
         }
     }
 
     #[test]
     fn bad_vals() {
         for val in &["", "tomorrow", "never", " "] {
-            ECSAgentImagePullBehavior::try_from(*val).unwrap_err();
+            val.parse::<ECSAgentImagePullBehavior>().unwrap_err();
         }
     }
 }

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::net::IpAddr;
 use std::ops::Deref;
+use std::str::FromStr;
 
 // Declare constant values usable by any type
 const IMAGE_GC_THRESHOLD_MAX: i32 = 100;
@@ -27,10 +28,10 @@ lazy_static! {
     pub(crate) static ref KUBERNETES_NAME: Regex = Regex::new(r"^[0-9a-z.-]{1,253}$").unwrap();
 }
 
-impl TryFrom<&str> for KubernetesName {
-    type Error = error::Error;
+impl FromStr for KubernetesName {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             KUBERNETES_NAME.is_match(input),
             error::PatternSnafu {
@@ -50,19 +51,18 @@ string_impls_for!(KubernetesName, "KubernetesName");
 #[cfg(test)]
 mod test_kubernetes_name {
     use super::KubernetesName;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_names() {
         for ok in &["howdy", "42", "18-eighteen."] {
-            KubernetesName::try_from(*ok).unwrap();
+            ok.parse::<KubernetesName>().unwrap();
         }
     }
 
     #[test]
     fn bad_names() {
         for err in &["", "HOWDY", "@", "hi/there", &"a".repeat(254)] {
-            KubernetesName::try_from(*err).unwrap_err();
+            err.parse::<KubernetesName>().unwrap_err();
         }
     }
 }
@@ -93,10 +93,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl TryFrom<&str> for KubernetesLabelKey {
-    type Error = error::Error;
+impl FromStr for KubernetesLabelKey {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             KUBERNETES_LABEL_KEY.is_match(input),
             error::BigPatternSnafu {
@@ -115,7 +115,6 @@ string_impls_for!(KubernetesLabelKey, "KubernetesLabelKey");
 #[cfg(test)]
 mod test_kubernetes_label_key {
     use super::KubernetesLabelKey;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_keys() {
@@ -126,7 +125,7 @@ mod test_kubernetes_label_key {
             &"a".repeat(63),
             &format!("{}/{}", "a".repeat(253), "name"),
         ] {
-            KubernetesLabelKey::try_from(*ok).unwrap();
+            ok.parse::<KubernetesLabelKey>().unwrap();
         }
     }
 
@@ -138,7 +137,7 @@ mod test_kubernetes_label_key {
             &"a".repeat(64),
             &format!("{}/{}", "a".repeat(254), "name"),
         ] {
-            KubernetesLabelKey::try_from(*err).unwrap_err();
+            err.parse::<KubernetesLabelKey>().unwrap_err();
         }
     }
 }
@@ -169,10 +168,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl TryFrom<&str> for KubernetesLabelValue {
-    type Error = error::Error;
+impl FromStr for KubernetesLabelValue {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             KUBERNETES_LABEL_VALUE.is_match(input),
             error::BigPatternSnafu {
@@ -191,19 +190,18 @@ string_impls_for!(KubernetesLabelValue, "KubernetesLabelValue");
 #[cfg(test)]
 mod test_kubernetes_label_value {
     use super::KubernetesLabelValue;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_values() {
         for ok in &["", "more-chars_here.now", &"a".repeat(63)] {
-            KubernetesLabelValue::try_from(*ok).unwrap();
+            ok.parse::<KubernetesLabelValue>().unwrap();
         }
     }
 
     #[test]
     fn bad_values() {
         for err in &[".bad", "bad.", &"a".repeat(64)] {
-            KubernetesLabelValue::try_from(*err).unwrap_err();
+            err.parse::<KubernetesLabelValue>().unwrap_err();
         }
     }
 }
@@ -242,10 +240,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl TryFrom<&str> for KubernetesTaintValue {
-    type Error = error::Error;
+impl FromStr for KubernetesTaintValue {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             KUBERNETES_TAINT_VALUE.is_match(input),
             error::BigPatternSnafu {
@@ -264,7 +262,6 @@ string_impls_for!(KubernetesTaintValue, "KubernetesTaintValue");
 #[cfg(test)]
 mod test_kubernetes_taint_value {
     use super::KubernetesTaintValue;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_values() {
@@ -277,7 +274,7 @@ mod test_kubernetes_taint_value {
             "a:NoSchedule",
             "a-b:NoSchedule",
         ] {
-            KubernetesTaintValue::try_from(*ok).unwrap();
+            ok.parse::<KubernetesTaintValue>().unwrap();
         }
     }
 
@@ -292,7 +289,7 @@ mod test_kubernetes_taint_value {
             "-a:NoSchedule",
             "a-:NoSchedule",
         ] {
-            KubernetesTaintValue::try_from(*err).unwrap_err();
+            err.parse::<KubernetesTaintValue>().unwrap_err();
         }
     }
 }
@@ -309,10 +306,10 @@ pub struct KubernetesClusterName {
     inner: String,
 }
 
-impl TryFrom<&str> for KubernetesClusterName {
-    type Error = error::Error;
+impl FromStr for KubernetesClusterName {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             !input.is_empty(),
             error::InvalidClusterNameSnafu {
@@ -321,7 +318,7 @@ impl TryFrom<&str> for KubernetesClusterName {
             }
         );
         ensure!(
-            KubernetesLabelValue::try_from(input).is_ok(),
+            input.parse::<KubernetesLabelValue>().is_ok(),
             error::InvalidClusterNameSnafu {
                 name: input,
                 msg: "cluster names must be valid Kubernetes label values"
@@ -339,19 +336,18 @@ string_impls_for!(KubernetesClusterName, "KubernetesClusterName");
 #[cfg(test)]
 mod test_kubernetes_cluster_name {
     use super::KubernetesClusterName;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_cluster_names() {
         for ok in &["more-chars_here.now", &"a".repeat(63)] {
-            KubernetesClusterName::try_from(*ok).unwrap();
+            ok.parse::<KubernetesClusterName>().unwrap();
         }
     }
 
     #[test]
     fn bad_values() {
         for err in &["", ".bad", "bad.", &"a".repeat(64)] {
-            KubernetesClusterName::try_from(*err).unwrap_err();
+            err.parse::<KubernetesClusterName>().unwrap_err();
         }
     }
 }
@@ -365,10 +361,10 @@ pub struct KubernetesAuthenticationMode {
     inner: String,
 }
 
-impl TryFrom<&str> for KubernetesAuthenticationMode {
-    type Error = error::Error;
+impl FromStr for KubernetesAuthenticationMode {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, error::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             matches!(input, "aws" | "tls"),
             error::InvalidAuthenticationModeSnafu { input }
@@ -384,19 +380,18 @@ string_impls_for!(KubernetesAuthenticationMode, "KubernetesAuthenticationMode");
 #[cfg(test)]
 mod test_kubernetes_authentication_mode {
     use super::KubernetesAuthenticationMode;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_modes() {
         for ok in &["aws", "tls"] {
-            KubernetesAuthenticationMode::try_from(*ok).unwrap();
+            ok.parse::<KubernetesAuthenticationMode>().unwrap();
         }
     }
 
     #[test]
     fn bad_modes() {
         for err in &["", "anonymous"] {
-            KubernetesAuthenticationMode::try_from(*err).unwrap_err();
+            err.parse::<KubernetesAuthenticationMode>().unwrap_err();
         }
     }
 }
@@ -416,10 +411,10 @@ lazy_static! {
         Regex::new(r"^[a-z0-9]{6}\.[a-z0-9]{16}$").unwrap();
 }
 
-impl TryFrom<&str> for KubernetesBootstrapToken {
-    type Error = error::Error;
+impl FromStr for KubernetesBootstrapToken {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             KUBERNETES_BOOTSTRAP_TOKEN.is_match(input),
             error::PatternSnafu {
@@ -439,19 +434,18 @@ string_impls_for!(KubernetesBootstrapToken, "KubernetesBootstrapToken");
 #[cfg(test)]
 mod test_kubernetes_bootstrap_token {
     use super::KubernetesBootstrapToken;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_tokens() {
         for ok in &["abcdef.0123456789abcdef", "07401b.f395accd246ae52d"] {
-            KubernetesBootstrapToken::try_from(*ok).unwrap();
+            ok.parse::<KubernetesBootstrapToken>().unwrap();
         }
     }
 
     #[test]
     fn bad_names() {
         for err in &["", "ABCDEF.0123456789ABCDEF", "secret", &"a".repeat(23)] {
-            KubernetesBootstrapToken::try_from(*err).unwrap_err();
+            err.parse::<KubernetesBootstrapToken>().unwrap_err();
         }
     }
 }
@@ -483,11 +477,11 @@ enum EvictionSignal {
     PidAvailable,
 }
 
-impl TryFrom<&str> for KubernetesEvictionHardKey {
-    type Error = error::Error;
+impl FromStr for KubernetesEvictionHardKey {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        serde_plain::from_str::<EvictionSignal>(&input).context(error::InvalidPlainValueSnafu {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str::<EvictionSignal>(input).context(error::InvalidPlainValueSnafu {
             field: "Eviction Hard key",
         })?;
         Ok(KubernetesEvictionHardKey {
@@ -500,7 +494,6 @@ string_impls_for!(KubernetesEvictionHardKey, "KubernetesEvictionHardKey");
 #[cfg(test)]
 mod test_kubernetes_eviction_hard_key {
     use super::KubernetesEvictionHardKey;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_eviction_hard_key() {
@@ -512,14 +505,14 @@ mod test_kubernetes_eviction_hard_key {
             "imagefs.inodesFree",
             "pid.available",
         ] {
-            KubernetesEvictionHardKey::try_from(*ok).unwrap();
+            ok.parse::<KubernetesEvictionHardKey>().unwrap();
         }
     }
 
     #[test]
     fn bad_eviction_hard_key() {
         for err in &["", "storage.available", ".bad", "bad.", &"a".repeat(64)] {
-            KubernetesEvictionHardKey::try_from(*err).unwrap_err();
+            err.parse::<KubernetesEvictionHardKey>().unwrap_err();
         }
     }
 }
@@ -549,10 +542,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl TryFrom<&str> for KubernetesThresholdValue {
-    type Error = error::Error;
+impl FromStr for KubernetesThresholdValue {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         if input.ends_with("%") {
             let input_f32 = input[..input.len() - 1]
                 .parse::<f32>()
@@ -582,14 +575,13 @@ string_impls_for!(KubernetesThresholdValue, "KubernetesThresholdValue");
 #[cfg(test)]
 mod test_kubernetes_threshold_value {
     use super::KubernetesThresholdValue;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_kubernetes_threshold_value() {
         for ok in &[
             "10%", "129e6", "10Mi", "1024M", "1Gi", "120Ki", "1Ti", "1000n", "100m",
         ] {
-            KubernetesThresholdValue::try_from(*ok).unwrap();
+            ok.parse::<KubernetesThresholdValue>().unwrap();
         }
     }
 
@@ -605,7 +597,7 @@ mod test_kubernetes_threshold_value {
             "1000i",
             &"a".repeat(64),
         ] {
-            KubernetesThresholdValue::try_from(*err).unwrap_err();
+            err.parse::<KubernetesThresholdValue>().unwrap_err();
         }
     }
 }
@@ -630,11 +622,11 @@ enum ReservedResources {
     EphemeralStorage,
 }
 
-impl TryFrom<&str> for KubernetesReservedResourceKey {
-    type Error = error::Error;
+impl FromStr for KubernetesReservedResourceKey {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        serde_plain::from_str::<ReservedResources>(&input).context(
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str::<ReservedResources>(input).context(
             error::InvalidPlainValueSnafu {
                 field: "Reserved sources key",
             },
@@ -652,19 +644,18 @@ string_impls_for!(
 #[cfg(test)]
 mod test_reserved_resources_key {
     use super::KubernetesReservedResourceKey;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_reserved_resources_key() {
         for ok in &["cpu", "memory", "ephemeral-storage"] {
-            KubernetesReservedResourceKey::try_from(*ok).unwrap();
+            ok.parse::<KubernetesReservedResourceKey>().unwrap();
         }
     }
 
     #[test]
     fn bad_reserved_resources_key() {
         for err in &["", "cpa", ".bad", "bad.", &"a".repeat(64)] {
-            KubernetesReservedResourceKey::try_from(*err).unwrap_err();
+            err.parse::<KubernetesReservedResourceKey>().unwrap_err();
         }
     }
 }
@@ -679,10 +670,10 @@ pub struct KubernetesQuantityValue {
     inner: String,
 }
 
-impl TryFrom<&str> for KubernetesQuantityValue {
-    type Error = error::Error;
+impl FromStr for KubernetesQuantityValue {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             KUBERNETES_QUANTITY.is_match(input),
             error::PatternSnafu {
@@ -702,14 +693,13 @@ string_impls_for!(KubernetesQuantityValue, "KubernetesQuantityValue");
 #[cfg(test)]
 mod test_kubernetes_quantity_value {
     use super::KubernetesQuantityValue;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_kubernetes_quantity_value() {
         for ok in &[
             "129e6", "10Mi", "1024M", "1Gi", "120Ki", "1Ti", "1000n", "100m",
         ] {
-            KubernetesQuantityValue::try_from(*ok).unwrap();
+            ok.parse::<KubernetesQuantityValue>().unwrap();
         }
     }
 
@@ -726,7 +716,7 @@ mod test_kubernetes_quantity_value {
             "1000i",
             &"a".repeat(64),
         ] {
-            KubernetesQuantityValue::try_from(*err).unwrap_err();
+            err.parse::<KubernetesQuantityValue>().unwrap_err();
         }
     }
 }
@@ -740,10 +730,10 @@ pub struct KubernetesCloudProvider {
     inner: String,
 }
 
-impl TryFrom<&str> for KubernetesCloudProvider {
-    type Error = error::Error;
+impl FromStr for KubernetesCloudProvider {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, error::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         // Kubelet expects the empty string to be double-quoted when be passed to `--cloud-provider`
         let cloud_provider = if input.is_empty() { "\"\"" } else { input };
         ensure!(
@@ -763,19 +753,18 @@ string_impls_for!(KubernetesCloudProvider, "KubernetesCloudProvider");
 #[cfg(test)]
 mod test_kubernetes_cloud_provider {
     use super::KubernetesCloudProvider;
-    use std::convert::TryFrom;
 
     #[test]
     fn allowed_providers() {
         for ok in &["aws", "external", "\"\"", ""] {
-            KubernetesCloudProvider::try_from(*ok).unwrap();
+            ok.parse::<KubernetesCloudProvider>().unwrap();
         }
     }
 
     #[test]
     fn disallowed_providers() {
         for err in &["internal"] {
-            KubernetesCloudProvider::try_from(*err).unwrap_err();
+            err.parse::<KubernetesCloudProvider>().unwrap_err();
         }
     }
 }
@@ -796,11 +785,11 @@ enum ValidCpuManagerPolicy {
     None,
 }
 
-impl TryFrom<&str> for CpuManagerPolicy {
-    type Error = error::Error;
+impl FromStr for CpuManagerPolicy {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        serde_plain::from_str::<ValidCpuManagerPolicy>(&input)
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str::<ValidCpuManagerPolicy>(input)
             .context(error::InvalidCpuManagerPolicySnafu { input })?;
         Ok(CpuManagerPolicy {
             inner: input.to_string(),
@@ -812,19 +801,18 @@ string_impls_for!(CpuManagerPolicy, "CpuManagerPolicy");
 #[cfg(test)]
 mod test_cpu_manager_policy {
     use super::CpuManagerPolicy;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_cpu_manager_policy() {
         for ok in &["static", "none"] {
-            CpuManagerPolicy::try_from(*ok).unwrap();
+            ok.parse::<CpuManagerPolicy>().unwrap();
         }
     }
 
     #[test]
     fn bad_cpu_manager_policy() {
         for err in &["", "bad", "100", &"a".repeat(64)] {
-            CpuManagerPolicy::try_from(*err).unwrap_err();
+            err.parse::<CpuManagerPolicy>().unwrap_err();
         }
     }
 }
@@ -844,10 +832,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl TryFrom<&str> for KubernetesDurationValue {
-    type Error = error::Error;
+impl FromStr for KubernetesDurationValue {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         ensure!(
             !input.is_empty(),
             error::InvalidKubernetesDurationValueSnafu { input }
@@ -867,7 +855,6 @@ string_impls_for!(KubernetesDurationValue, "KubernetesDurationValue");
 #[cfg(test)]
 mod test_kubernetes_duration_value {
     use super::KubernetesDurationValue;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_tokens() {
@@ -881,7 +868,7 @@ mod test_kubernetes_duration_value {
             "2h3s10ms",
             "1.5h3.5m",
         ] {
-            KubernetesDurationValue::try_from(*ok).unwrap();
+            ok.parse::<KubernetesDurationValue>().unwrap();
         }
     }
 
@@ -897,7 +884,7 @@ mod test_kubernetes_duration_value {
             "9ns",
             &"a".repeat(23),
         ] {
-            KubernetesDurationValue::try_from(*err).unwrap_err();
+            err.parse::<KubernetesDurationValue>().unwrap_err();
         }
     }
 }
@@ -918,11 +905,11 @@ enum ValidTopologyManagerScope {
     Pod,
 }
 
-impl TryFrom<&str> for TopologyManagerScope {
-    type Error = error::Error;
+impl FromStr for TopologyManagerScope {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        serde_plain::from_str::<ValidTopologyManagerScope>(&input)
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str::<ValidTopologyManagerScope>(input)
             .context(error::InvalidTopologyManagerScopeSnafu { input })?;
         Ok(TopologyManagerScope {
             inner: input.to_string(),
@@ -934,19 +921,18 @@ string_impls_for!(TopologyManagerScope, "TopologyManagerScope");
 #[cfg(test)]
 mod test_topology_manager_scope {
     use super::TopologyManagerScope;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_topology_manager_scope() {
         for ok in &["container", "pod"] {
-            TopologyManagerScope::try_from(*ok).unwrap();
+            ok.parse::<TopologyManagerScope>().unwrap();
         }
     }
 
     #[test]
     fn bad_topology_manager_scope() {
         for err in &["", "bad", "100", &"a".repeat(64)] {
-            TopologyManagerScope::try_from(*err).unwrap_err();
+            err.parse::<TopologyManagerScope>().unwrap_err();
         }
     }
 }
@@ -971,11 +957,11 @@ enum ValidTopologyManagerPolicy {
     SingleNumaNode,
 }
 
-impl TryFrom<&str> for TopologyManagerPolicy {
-    type Error = error::Error;
+impl FromStr for TopologyManagerPolicy {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        serde_plain::from_str::<ValidTopologyManagerPolicy>(&input)
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str::<ValidTopologyManagerPolicy>(input)
             .context(error::InvalidTopologyManagerPolicySnafu { input })?;
         Ok(TopologyManagerPolicy {
             inner: input.to_string(),
@@ -987,19 +973,18 @@ string_impls_for!(TopologyManagerPolicy, "TopologyManagerPolicy");
 #[cfg(test)]
 mod test_topology_manager_policy {
     use super::TopologyManagerPolicy;
-    use std::convert::TryFrom;
 
     #[test]
     fn good_topology_manager_policy() {
         for ok in &["none", "restricted", "best-effort", "single-numa-node"] {
-            TopologyManagerPolicy::try_from(*ok).unwrap();
+            ok.parse::<TopologyManagerPolicy>().unwrap();
         }
     }
 
     #[test]
     fn bad_topology_manager_policy() {
         for err in &["", "bad", "100", &"a".repeat(64)] {
-            TopologyManagerPolicy::try_from(*err).unwrap_err();
+            err.parse::<TopologyManagerPolicy>().unwrap_err();
         }
     }
 }
@@ -1018,10 +1003,10 @@ pub struct ImageGCHighThresholdPercent {
     inner: String,
 }
 
-impl TryFrom<&str> for ImageGCHighThresholdPercent {
-    type Error = error::Error;
+impl FromStr for ImageGCHighThresholdPercent {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         let parsed_input: i32 = input
             .parse::<i32>()
             .context(error::ParseIntSnafu { input })?;
@@ -1050,26 +1035,25 @@ string_impls_for!(ImageGCHighThresholdPercent, "ImageGCHighThresholdPercent");
 #[cfg(test)]
 mod test_image_gc_high_threshold_percent {
     use super::ImageGCHighThresholdPercent;
-    use std::convert::TryFrom;
 
     // test 1: good values should succeed
     #[test]
     fn image_gc_high_threshold_percent_between_0_and_100_inclusive() {
         for ok in &["0", "1", "99", "100"] {
-            ImageGCHighThresholdPercent::try_from(*ok).unwrap();
+            ok.parse::<ImageGCHighThresholdPercent>().unwrap();
         }
     }
 
     // test 2: values too low should return Errors
     #[test]
     fn image_gc_high_threshold_percent_less_than_0_fails() {
-        ImageGCHighThresholdPercent::try_from("-1").unwrap_err();
+        ("-1").parse::<ImageGCHighThresholdPercent>().unwrap_err();
     }
 
     // test 3: values too high should return Errors
     #[test]
     fn image_gc_high_threshold_percent_greater_than_100_fails() {
-        ImageGCHighThresholdPercent::try_from("101").unwrap_err();
+        ("101").parse::<ImageGCHighThresholdPercent>().unwrap_err();
     }
 }
 
@@ -1088,10 +1072,10 @@ pub struct ImageGCLowThresholdPercent {
     inner: String,
 }
 
-impl TryFrom<&str> for ImageGCLowThresholdPercent {
-    type Error = error::Error;
+impl FromStr for ImageGCLowThresholdPercent {
+    type Err = error::Error;
 
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         let parsed_input: i32 = input
             .parse::<i32>()
             .context(error::ParseIntSnafu { input })?;
@@ -1120,26 +1104,25 @@ string_impls_for!(ImageGCLowThresholdPercent, "ImageGCLowThresholdPercent");
 #[cfg(test)]
 mod test_image_gc_low_threshold_percent {
     use super::ImageGCLowThresholdPercent;
-    use std::convert::TryFrom;
 
     // test 1: good values should succeed
     #[test]
     fn image_gc_low_threshold_percent_between_0_and_100_inclusive() {
         for ok in &["0", "1", "99", "100"] {
-            ImageGCLowThresholdPercent::try_from(*ok).unwrap();
+            ok.parse::<ImageGCLowThresholdPercent>().unwrap();
         }
     }
 
     // test 2: values too low should return Errors
     #[test]
     fn image_gc_low_threshold_percent_less_than_0_fails() {
-        ImageGCLowThresholdPercent::try_from("-1").unwrap_err();
+        ("-1").parse::<ImageGCLowThresholdPercent>().unwrap_err();
     }
 
     // test 3: values too high should return Errors
     #[test]
     fn image_gc_low_threshold_percent_greater_than_100_fails() {
-        ImageGCLowThresholdPercent::try_from("101").unwrap_err();
+        ("101").parse::<ImageGCLowThresholdPercent>().unwrap_err();
     }
 }
 

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -158,7 +158,7 @@ macro_rules! string_impls_for {
             type Error = $crate::modeled_types::error::Error;
 
             fn try_from(input: String) -> Result<Self, Self::Error> {
-                Self::try_from(input.as_ref())
+                input.parse::<Self>()
             }
         }
 
@@ -168,7 +168,7 @@ macro_rules! string_impls_for {
                 D: Deserializer<'de>,
             {
                 let original = String::deserialize(deserializer)?;
-                Self::try_from(original).map_err(|e| {
+                original.parse::<Self>().map_err(|e| {
                     D::Error::custom(format!("Unable to deserialize into {}: {}", $for_str, e))
                 })
             }

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -17,7 +17,7 @@ use signal_hook::iterator::Signals;
 use signpost::State;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ErrorCompat, OptionExt, ResultExt};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::Path;
@@ -181,9 +181,11 @@ fn update_required<'a>(
     if version_lock != "latest" {
         // Make sure the version string from the config is a valid version string that might be prefixed with 'v'
         let friendly_version_lock =
-            FriendlyVersion::try_from(version_lock).context(error::BadVersionConfigSnafu {
-                version_str: version_lock,
-            })?;
+            version_lock
+                .parse::<FriendlyVersion>()
+                .context(error::BadVersionConfigSnafu {
+                    version_str: version_lock,
+                })?;
         // Convert back to semver::Version
         let semver_version_lock =
             friendly_version_lock


### PR DESCRIPTION
**Issue number:**

Closes #1061 

**Description of changes:**

In order to clean up the code, this change replaces TryFrom<&str>
with FromStr. This change has been made for all `modeled_types`.

**Testing done:**

- [x] performed a complete build of `aws-dev` with no errors
- [x] performed a complete build of `metal-dev` with no errors
- [x] performed a complete build of `vmware-dev` with no errors

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
