### PR TITLE
gitignore: add VScode workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /Licenses.toml
 /licenses
 *.run
+*.code-workspace


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

VScode user workspaces should not be tracked.

I work from multiple client machines and want my workspace to persist/sync between them.

**Testing done:**

visual confirmation

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
