### PR TITLE
netdog: Move to `quick-xml` for XML serialization

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2493,10 +2493,10 @@ dependencies = [
  "indexmap",
  "ipnet",
  "lazy_static",
+ "quick-xml",
  "rand",
  "regex",
  "serde",
- "serde-xml-rs",
  "serde_json",
  "serde_plain",
  "snafu",
@@ -3034,6 +3034,16 @@ name = "public-control-container-v0-6-1"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9279fbdacaad3baf559d8cabe0acc3d06e30ea14931af31af79578ac0946decc"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -15,12 +15,12 @@ ipnet = { version = "2.0", features = ["serde"] }
 indexmap = { version = "1.8", features = ["serde"]}
 envy = "0.4"
 lazy_static = "1.2"
+quick-xml = {version = "0.23", features = ["serialize"]}
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 regex = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1.0"
-serde-xml-rs = "0.5"
 snafu = "0.7"
 toml = { version = "0.5", features = ["preserve_order"] }
 


### PR DESCRIPTION
**Description of changes:**


```
`serde_xml_rs` has a few bugs that we were able to work around, but the
inability to serialize a `Vec` is something we can't work around.  This
change moves the netdog code to `quick-xml` for serialization.
```

This change also allows us to get rid of the `_f: ()` struct member that worked around a `serde_xml_rs` bug.  However, `quick-xml` is slightly more wordy in that you need to supply ` $unflatten` attributes for anything that is a simple type and needs to have it's own tag; otherwise it gets made an attribute of the tag itself.


**Testing done:**
* All unit tests still pass
* Built and ran an aws-k8s-1.21 node successfully.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
