### PR TITLE
PROVISIONING-METAL: Remove commit from image name

### DIFF
--- a/PROVISIONING-METAL.md
+++ b/PROVISIONING-METAL.md
@@ -36,10 +36,9 @@ Next, set your desired version and variant, and use `tuftool` to download the im
 To install `tuftool` you'll need to install Rust (via [rustup](https://rustup.rs/) or the official site), and then you can run `cargo install tuftool`.
 ```
 ARCH="x86_64"
-VERSION="1.8.0"
+VERSION="v1.9.0"
 VARIANT="metal-k8s-1.23"
-COMMIT="a6233c22"
-IMAGE="bottlerocket-${VARIANT}-${ARCH}-${VERSION}-${COMMIT}.img.lz4"
+IMAGE="bottlerocket-${VARIANT}-${ARCH}-${VERSION}.img.lz4"
 OUTDIR="${VARIANT}-${VERSION}"
 
 tuftool download "${OUTDIR}" --target-name "${IMAGE}" \


### PR DESCRIPTION
**Description of changes:**
```
This change removes the commit from the image name in the `tuftool
download` instructions since we are now uploading versioned images that
don't include the commit SHA.
```


**Testing done:**
Copied and pasted the new instructions and verified I could download the image.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
