### PR TITLE
Format issue field in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Tips:
 
 **Issue number:**
 
-
+Closes #
 
 **Description of changes:**
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

We have had several instances where the issue associated with a PR has
not been automatically closed. Engineers then need to know to track down
the issue after the merge to manually close out the issue.

Part of this appears to be due to the PR not having the format expected
to properly [link the PR to the Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
This updates our pull request template to format this placeholder string to
help guide the user towards using the necessary format to link and close
the issue.

**Testing done:**

Visual review.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
