### PR TITLE
Add China to supported regions list

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -45,6 +45,8 @@ ap-southeast-1
 ap-southeast-2
 ap-southeast-3
 ca-central-1
+cn-north-1
+cn-northwest-1
 eu-central-1
 eu-north-1
 eu-south-1

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -110,6 +110,8 @@ ap-southeast-1
 ap-southeast-2
 ap-southeast-3
 ca-central-1
+cn-north-1
+cn-northwest-1
 eu-central-1
 eu-north-1
 eu-south-1


### PR DESCRIPTION
**Issue number:**

#1255

**Description of changes:**

Now that v1.9.0 is live, Bottlerocket is available in both AWS China regions, cn-north-1 (Beijing) and cn-northwest-1 (Ningxia).

**Testing done:**

- Launched `aws-ecs-1/aarch64` in `cn-north-1` which connected to an ECS cluster.
- Launched `aws-k8s-1.22/x86_64` in `cn-northwest-1` which connected to an EKS cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
