### PR TITLE
Autoscaling Warm Pool Support for K8S Variants

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -146,3 +146,6 @@ version = "1.10.0"
     "migrate_v1.10.0_dns-settings.lz4",
     "migrate_v1.10.0_dns-settings-metadata.lz4",
 ]
+"(1.9.1, 1.10.0)" = [
+    "migrate_v1.10.0_add-eks-autoscaling.lz4",
+]

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -22,6 +22,7 @@ source-groups = [
     "shimpei",
     "driverdog",
     "cfsignal",
+    "hachiko",
 ]
 
 [lib]

--- a/packages/os/hachiko-toml
+++ b/packages/os/hachiko-toml
@@ -1,0 +1,2 @@
+should_wait = {{settings.autoscaling.should-wait}}
+marker_path = "/var/lib/bottlerocket/hachiko.ran"

--- a/packages/os/hachiko.service
+++ b/packages/os/hachiko.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Autoscaling warm pools support
+After=network-online.target settings-applier.service
+Before=kubelet.service
+Requires=settings-applier.service network-online.target
+# We only want to run once, at first boot. This file is created by hachiko
+# after a successful run.
+ConditionPathExists=!/var/lib/bottlerocket/hachiko.ran
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/hachiko
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -25,6 +25,7 @@ Source6: metricdog-toml
 Source7: host-ctr-toml
 Source8: oci-default-hooks-json
 Source9: cfsignal-toml
+Source10: hachiko-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -44,6 +45,7 @@ Source116: load-kernel-modules.service.in
 Source117: cfsignal.service
 Source118: generate-network-config.service
 Source119: prepare-primary-interface.service
+Source120: hachiko.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -91,6 +93,7 @@ Requires: %{_cross_os}static-pods
 %if %{with aws_platform}
 Requires: %{_cross_os}shibaken
 Requires: %{_cross_os}cfsignal
+Requires: %{_cross_os}hachiko
 %endif
 
 %if %{with ecs_runtime}
@@ -247,6 +250,11 @@ Summary: Setting generator for populating admin container user-data from IMDS.
 Summary: Bottlerocket CloudFormation Stack signaler
 %description -n %{_cross_os}cfsignal
 %{summary}.
+
+%package -n %{_cross_os}hachiko
+Summary: Autoscaling warmpool support
+%description -n %{_cross_os}hachiko
+%{summary}.
 %endif
 
 %package -n %{_cross_os}shimpei
@@ -328,7 +336,7 @@ echo "** Output from non-static builds:"
     -p certdog \
     -p shimpei \
     %{?with_ecs_runtime: -p ecs-settings-applier} \
-    %{?with_aws_platform: -p shibaken -p cfsignal} \
+    %{?with_aws_platform: -p shibaken -p cfsignal -p hachiko} \
     %{?with_aws_k8s_family: -p pluto} \
     %{?with_k8s_runtime: -p static-pods} \
     %{?with_nvidia_flavor: -p driverdog} \
@@ -354,7 +362,7 @@ for p in \
   ghostdog bootstrap-containers \
   shimpei \
   %{?with_ecs_runtime: ecs-settings-applier} \
-  %{?with_aws_platform: shibaken cfsignal} \
+  %{?with_aws_platform: shibaken cfsignal hachiko} \
   %{?with_aws_k8s_family: pluto} \
   %{?with_k8s_runtime: static-pods} \
   %{?with_nvidia_flavor: driverdog} \
@@ -416,7 +424,9 @@ install -p -m 0644 \
 
 %if %{with aws_platform}
 install -p -m 0644 %{S:9} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:10} %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:117} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:120} %{buildroot}%{_cross_unitdir}
 %endif
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
@@ -536,6 +546,12 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/cfsignal-toml
 %{_cross_unitdir}/cfsignal.service
+
+%files -n %{_cross_os}hachiko
+%{_cross_bindir}/hachiko
+%dir %{_cross_templatedir}
+%{_cross_templatedir}/hachiko-toml
+%{_cross_unitdir}/hachiko.service
 %endif
 
 %if %{with nvidia_flavor}

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -47,6 +47,7 @@
 (filecon "/.*/usr/bin/storewolf" file api_exec)
 (filecon "/.*/usr/bin/cfsignal" file api_exec)
 (filecon "/.*/usr/bin/thar-be-settings" file api_exec)
+(filecon "/.*/usr/bin/hachiko" file api_exec)
 (filecon "/.*/usr/bin/dbus-broker.*" file bus_exec)
 (filecon "/.*/usr/sbin/chronyd" file clock_exec)
 (filecon "/.*/usr/sbin/wicked.*" file network_exec)

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1701,6 +1701,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hachiko"
+version = "0.1.0"
+dependencies = [
+ "imdsclient",
+ "log",
+ "serde",
+ "simplelog",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "handlebars"
 version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -217,6 +217,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-eks-autoscaling"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     # "api/migration/migrations/vX.Y.Z/..."
     "api/migration/migrations/v1.10.0/dns-settings",
     "api/migration/migrations/v1.10.0/dns-settings-metadata",
+    "api/migration/migrations/v1.10.0/add-eks-autoscaling",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -61,7 +61,9 @@ members = [
 
     "constants",
 
-    "shimpei"
+    "shimpei",
+
+    "hachiko"
 ]
 
 [profile.release]

--- a/sources/api/migration/migrations/v1.10.0/add-eks-autoscaling/Cargo.toml
+++ b/sources/api/migration/migrations/v1.10.0/add-eks-autoscaling/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "add-eks-autoscaling"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.10.0/add-eks-autoscaling/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.0/add-eks-autoscaling/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting prefix for configuring autoscaling in k8s variants.
+/// Remove the whole `settings.autoscaling` prefix if we downgrade.
+fn run() -> Result<()> {
+    if cfg!(variant_runtime = "k8s") {
+        migrate(AddPrefixesMigration(vec!["settings.autoscaling"]));
+    }
+    Ok(())
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/hachiko/Cargo.toml
+++ b/sources/hachiko/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "hachiko"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+simplelog = "0.12"
+snafu = { version = "0.7" }
+toml = "0.5.1"
+tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }
+imdsclient = { path = "../imdsclient", version = "0.1.0" }
+
+[dev-dependencies]
+tempfile = { version = "3.1.0", default-features = false }

--- a/sources/hachiko/src/config.rs
+++ b/sources/hachiko/src/config.rs
@@ -1,0 +1,58 @@
+use crate::error::{self, Result};
+use serde::Deserialize;
+use snafu::ResultExt;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Config {
+    pub(crate) should_wait: bool,
+    pub(crate) marker_path: String,
+}
+
+impl Config {
+    /// Parses configuration file at passed in path and returns struct containing settings value.
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let string_parse = fs::read_to_string(path).context(error::ConfigReadSnafu { path })?;
+        let config: Config =
+            toml::from_str(&string_parse).context(error::ConfigParseSnafu { path })?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod config_test {
+    use crate::config::Config;
+    use tempfile::TempDir;
+
+    // Example config file where user sets autoscaling.should-wait to false.
+    const FALSE_SHOULD_WAIT: &str = r#"
+    should_wait = false
+    marker_path = "/var/lib/bottlerocket/hachiko.ran"
+    "#;
+
+    // Example config file where user sets autoscaling.should-wait to true.
+    const TRUE_SHOULD_WAIT: &str = r#"
+    should_wait = true
+    marker_path = "/var/lib/bottlerocket/hachiko.ran"
+    "#;
+
+    #[test]
+    fn false_should_wait_test() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, FALSE_SHOULD_WAIT).unwrap();
+        let config = Config::from_file(&path).unwrap();
+        assert!(!config.should_wait);
+    }
+
+    #[test]
+    fn true_should_wait_test() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, TRUE_SHOULD_WAIT).unwrap();
+        let config = Config::from_file(&path).unwrap();
+        assert!(config.should_wait);
+    }
+}

--- a/sources/hachiko/src/error.rs
+++ b/sources/hachiko/src/error.rs
@@ -1,0 +1,36 @@
+use snafu::Snafu;
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+pub enum Error {
+    #[snafu(display("Command '{}' with args '{:?}' failed: {}", command, args, source))]
+    Command {
+        command: String,
+        args: Vec<String>,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]
+    ConfigParse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[snafu(display("Failed to read config file {}: {}", path.display(), source))]
+    ConfigRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("IMDS request failed: {}", source))]
+    ImdsRequest { source: imdsclient::Error },
+
+    #[snafu(display("IMDS request failed: No '{}' found", what))]
+    ImdsNone { what: String },
+
+    #[snafu(display("Logger setup error: {}", source))]
+    Logger { source: log::SetLoggerError },
+}

--- a/sources/hachiko/src/main.rs
+++ b/sources/hachiko/src/main.rs
@@ -1,0 +1,78 @@
+mod config;
+mod error;
+use crate::config::Config;
+use crate::error::Result;
+use imdsclient::ImdsClient;
+use log::LevelFilter;
+use log::{info, warn};
+use simplelog::{Config as LogConfig, SimpleLogger};
+use snafu::{OptionExt, ResultExt};
+use std::fs;
+use std::process;
+use tokio::time::{sleep, Duration};
+
+// Path to config file containing host's autoscaling.should-wait setting
+const CONFIG_PATH: &str = "/etc/hachiko.toml";
+
+/// Uses an imdsclient function to fetch the lifecyclestate of the host
+async fn get_lifecycle_state(client: &mut ImdsClient) -> Result<String> {
+    client
+        .fetch_lifecycle_state()
+        .await
+        .context(error::ImdsRequestSnafu)?
+        .context(error::ImdsNoneSnafu {
+            what: "instance-id",
+        })
+}
+
+/// Continuously fetches lifecycle state of the host.
+/// Returns from function when host is "InService"
+async fn wait_until_inservice() -> Result<()> {
+    let mut client = ImdsClient::new();
+    let mut lifecycle_state = get_lifecycle_state(&mut client).await?;
+    info!("Lifecycle state is {}", lifecycle_state);
+    while lifecycle_state.ne("InService") {
+        lifecycle_state = get_lifecycle_state(&mut client).await?;
+        info!("Lifecycle state is {} ... waiting.", lifecycle_state);
+        sleep(Duration::from_secs(5)).await;
+    }
+    info!("Lifecycle state is {} ... exiting.", lifecycle_state);
+    Ok(())
+}
+
+/// Parses config file for autoscaling.should-wait setting.
+async fn get_config() -> Result<Config> {
+    Config::from_file(CONFIG_PATH)
+}
+
+async fn run() -> Result<()> {
+    SimpleLogger::init(LevelFilter::Info, LogConfig::default()).context(error::LoggerSnafu)?;
+
+    let config_parse = get_config().await?;
+
+    let should_wait_value = config_parse.should_wait;
+    let marker_file_path = config_parse.marker_path;
+    info!("autoscaling.should-wait value is {}", should_wait_value);
+    if should_wait_value {
+        wait_until_inservice().await?;
+    }
+    info!("Marker file path is {}", marker_file_path);
+    fs::write(&marker_file_path, "").unwrap_or_else(|e| {
+        warn!(
+            "Failed to create marker file '{}', Hachiko service may unexpectedly run again: '{}'",
+            &marker_file_path, e
+        )
+    });
+
+    Ok(())
+}
+
+/// If autoscaling.should-wait is true, calls waiting function.
+/// Writes marker file to prevent service from unexpectedly re-running.
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/hachiko/src/testConfig.toml
+++ b/sources/hachiko/src/testConfig.toml
@@ -1,0 +1,2 @@
+should_wait = true
+marker_path = "/var/lib/bottlerocket/hachiko.ran"

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -168,6 +168,12 @@ impl ImdsClient {
         self.fetch_string(&instance_type_target).await
     }
 
+    /// Get lifecycle state from instance metadata.
+    pub async fn fetch_lifecycle_state(&mut self) -> Result<Option<String>> {
+        let instance_type_target = "meta-data/autoscaling/target-lifecycle-state";
+        self.fetch_string(&instance_type_target).await
+    }
+
     /// Returns a list of public ssh keys skipping any keys that do not start with 'ssh'.
     pub async fn fetch_public_ssh_keys(&mut self) -> Result<Option<Vec<String>>> {
         info!("Fetching list of available public keys from IMDS");

--- a/sources/models/shared-defaults/kubernetes-aws.toml
+++ b/sources/models/shared-defaults/kubernetes-aws.toml
@@ -21,3 +21,11 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kube
 
 [metadata.settings.network]
 affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers"]
+
+# AutoScaling
+[settings.autoscaling]
+should-wait = false
+
+[configuration-files.hachiko-toml]
+path = "/etc/hachiko.toml"
+template-path = "/usr/share/templates/hachiko-toml"

--- a/sources/models/src/aws-k8s-1.22-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.22-nvidia/mod.rs
@@ -1,13 +1,12 @@
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::modeled_types::Identifier;
-use crate::{
-    AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
-};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -28,4 +27,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.22/mod.rs
+++ b/sources/models/src/aws-k8s-1.22/mod.rs
@@ -1,13 +1,12 @@
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::modeled_types::Identifier;
-use crate::{
-    AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
-};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -28,4 +27,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.23-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.23-nvidia/mod.rs
@@ -1,13 +1,12 @@
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
+    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::modeled_types::Identifier;
-use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
-};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -29,4 +28,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.23/mod.rs
+++ b/sources/models/src/aws-k8s-1.23/mod.rs
@@ -1,13 +1,12 @@
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
+    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::modeled_types::Identifier;
-use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
-};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -29,4 +28,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    autoscaling: AutoScalingSettings,
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#1788 


**Description of changes:**
**Goal: To support EC2 Autoscaling “warm pools” in K8S Bottlerocket variants.**

- Add autoscaling.should-wait setting to K8S variants. Handle migrations for setting in case of downgrade.
- Create "hachiko", a helper program that retrieves the autoscaling.should-wait setting and autoscaling lifecycle state of host. If this setting is true, program waits until lifecycle state is "InService".
- autoscaling.should-wait setting is written to a config file (according to hachiko-toml template) during instance boot and is later parsed by the helper program.
- Create hachiko.service to execute helper program prior to the running of Kubelet in order to prevent warm pool instances from running Kubelet and falling into the "NotReady" state.

**Testing done:**

- Program is installed properly.
- Service runs as expected and at the right point during host configuration.
- Waiting program tested locally and on a launched bottlerocket instance for ability to correctly parse config file and retrieve lifecycle state of the host.
- Config file with autoscaling.should-wait setting value is correctly generated and parsed. 

**Testing required:**
- Confirm autoscaling.should-wait is migrated properly by confirming it is added to k8s variants upon upgrade to version 10.0.0 and removed upon downgrade.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
