### PR TITLE
Change kernel module compression from zstd to xz

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -82,9 +82,9 @@ CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
 
-# Enable ZSTD modules compression
+# Enable xz modules compression
 CONFIG_MODULE_COMPRESS=y
-CONFIG_MODULE_COMPRESS_ZSTD=y
+CONFIG_MODULE_COMPRESS_XZ=y
 
 # Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
 # them before mounting the root device.

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -82,9 +82,9 @@ CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
 
-# Enable ZSTD modules compression
+# Enable xz modules compression
 # CONFIG_MODULE_COMPRESS_NONE is not set
-CONFIG_MODULE_COMPRESS_ZSTD=y
+CONFIG_MODULE_COMPRESS_XZ=y
 
 # Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
 # them before mounting the root device.

--- a/packages/kernel-5.4/config-bottlerocket
+++ b/packages/kernel-5.4/config-bottlerocket
@@ -77,9 +77,9 @@ CONFIG_ZSTD_COMPRESS=y
 CONFIG_ZSTD_DECOMPRESS=y
 CONFIG_DECOMPRESS_ZSTD=y
 
-# Enable ZSTD modules compression
+# Enable xz modules compression
 CONFIG_MODULE_COMPRESS=y
-CONFIG_MODULE_COMPRESS_ZSTD=y
+CONFIG_MODULE_COMPRESS_XZ=y
 
 # Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
 # them before mounting the root device.

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -17,4 +17,5 @@ sha512 = "e2cd34e600a72e44710760dfda9364b790b8352a99eafbd43e683e4a06f37e6b5c0b5d
 
 [build-dependencies]
 glibc = { path = "../glibc" }
+liblzma = { path = "../liblzma" }
 libzstd = { path = "../libzstd" }

--- a/packages/kmod/kmod.spec
+++ b/packages/kmod/kmod.spec
@@ -6,7 +6,9 @@ License: GPL-2.0-or-later AND LGPL-2.1-or-later
 URL: http://git.kernel.org/?p=utils/kernel/kmod/kmod.git;a=summary
 Source0: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-%{version}.tar.xz
 BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}liblzma-devel
 BuildRequires: %{_cross_os}libzstd-devel
+Requires: %{_cross_os}liblzma
 Requires: %{_cross_os}libzstd
 
 %description
@@ -26,10 +28,10 @@ cp tools/COPYING COPYING.GPL
 
 %build
 %cross_configure \
+  --with-xz \
   --with-zstd \
   --without-openssl \
-  --without-zlib \
-  --without-xz
+  --without-zlib
 
 %make_build
 

--- a/packages/liblzma/Cargo.toml
+++ b/packages/liblzma/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "liblzma"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://tukaani.org/xz"
+
+[[package.metadata.build-package.external-files]]
+url = "https://tukaani.org/xz/xz-5.2.5.tar.xz"
+sha512 = "59266068a51cb616eb31b67cd8f07ffeb2288d1391c61665ae2ec6814465afac80fec69248f6a2f2db45b44475af001296a99af6a32287226a9c41419173ccbb"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/liblzma/build.rs
+++ b/packages/liblzma/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/liblzma/liblzma.spec
+++ b/packages/liblzma/liblzma.spec
@@ -1,0 +1,49 @@
+Name: %{_cross_os}liblzma
+Version: 5.2.5
+Release: 1%{?dist}
+Summary: Library for XZ and LZMA compressed files
+URL: https://tukaani.org/xz
+License: LicenseRef-scancode-lzma-sdk-pd
+Source: https://tukaani.org/xz/xz-%{version}.tar.xz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for XZ and LZMA compression
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%setup -n xz-%{version}
+
+%build
+%cross_configure \
+  --disable-doc \
+  --disable-lzma-links \
+  --disable-lzmadec \
+  --disable-lzmainfo \
+  --disable-scripts \
+  --disable-xz \
+  --disable-xzdec
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+%exclude %{_cross_localedir}
+
+%files devel
+%{_cross_includedir}/*.h
+%{_cross_includedir}/lzma/*.h
+%{_cross_libdir}/*.a
+%{_cross_libdir}/*.so
+%{_cross_pkgconfigdir}/*.pc
+%exclude %{_cross_libdir}/*.la

--- a/packages/liblzma/pkg.rs
+++ b/packages/liblzma/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -416,6 +416,7 @@ name = "kmod"
 version = "0.1.0"
 dependencies = [
  "glibc",
+ "liblzma",
  "libzstd",
 ]
 
@@ -547,6 +548,13 @@ dependencies = [
 
 [[package]]
 name = "libiw"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "liblzma"
 version = "0.1.0"
 dependencies = [
  "glibc",


### PR DESCRIPTION
**Issue number:** #2317



**Description of changes:** Change the compression method for kernel modules from zstd to xz. Bottlerocket release 1.9.0 enabled kernel module compression and chose zstd as the compression method. While the Bottlerocket host system's kmod can work with zstd-compressed modules, it turns out that kmod support for zstd is not yet as widespread in container images. This change proposes to keep kernel module compression enabled, but switch to xz instead.

To work with xz-compressed modules, the host system's kmod package is reconfigured. Switching to xz also means taking a new dependency on XZ Utils for liblzma.

**Testing done:** I built a metal-dev variant with these changes. It boots successfully and kernel modules can be loaded both from the host system and the admin container. Without the changes in this PR, the latter did not work with zstd-compressed modules unless `sheltie` was used to load the module from within the host system.

Since this touches kernel configuration, I collected before and after configurations for all kernels, architectures and cloud/metal variant combinations. The only configuration changes identified are those that were intended:

```
==> configs/config-aarch64-5.4-aws-k8s-1.19-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-aarch64-5.10-aws-k8s-1.23-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-aarch64-5.15-aws-dev-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-aarch64-5.15-metal-dev-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-x86_64-5.4-aws-k8s-1.19-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-x86_64-5.10-aws-k8s-1.23-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-x86_64-5.10-metal-k8s-1.23-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-x86_64-5.15-aws-dev-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n

==> configs/config-x86_64-5.15-metal-dev-diff <==
 MODULE_COMPRESS_XZ n -> y
 MODULE_COMPRESS_ZSTD y -> n
```

I'll submit the script for collecting these diffs in a separate PR after some polishing.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
