### PR TITLE
kernel: Disable drivers for USB-attached network interfaces

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -130,3 +130,6 @@ CONFIG_EXT4_USE_FOR_EXT2=y
 # CONFIG_RDS is not set
 # CONFIG_RFKILL is not set
 # CONFIG_TIPC is not set
+
+# Disable USB-attached network interfaces, unused in the cloud and on server-grade hardware.
+# CONFIG_USB_NET_DRIVERS is not set

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -131,3 +131,6 @@ CONFIG_EXT4_USE_FOR_EXT2=y
 # CONFIG_RDS is not set
 # CONFIG_RFKILL is not set
 # CONFIG_TIPC is not set
+
+# Disable USB-attached network interfaces, unused in the cloud and on server-grade hardware.
+# CONFIG_USB_NET_DRIVERS is not set


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a



**Description of changes:** There is no need to support USB-attached network interfaces in the cloud, and such devices are equally unlikely to be encountered in servers. Make sure not to build any drivers for them as they would just be dead weight.

We had those drivers for the 5.4 kernel variants (last `aws-k8s-1.19`, now gone) already and picked them up for the 5.10 kernel variants (any variants except `*-dev`) with release 1.9.0. This reverses course for the 5.10 kernel and ensures future upstream changes won't bring those drivers into the 5.15 kernel.



**Testing done:**

* [x] Builds and boots
* [x] Config differences in final builds are only those expected

The full list of resulting config changes can be found in [this Gist](https://gist.github.com/markusboehme/ba3478def8a1408dd36104df9112b183).


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
