### PR TITLE
Update `BUILDING.md` and `PUBLISHING-AWS.md` to mention need for aws creds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -154,6 +154,10 @@ cargo make \
 
 To use the image in Amazon EC2, we need to register the image as an AMI.
 
+To do this, you'll need to have your AWS account credentials setup on your system.
+There are lots of ways to do this; one method is using [the `aws` CLI](https://aws.amazon.com/cli/) via its `configure` command with your user's access and secret keys.
+If you're using an EC2 instance, the [EC2 instance's IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) will be used automatically if available.
+
 For a simple start, pick an [EC2 region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions), then run:
 
 ```

--- a/PUBLISHING-AWS.md
+++ b/PUBLISHING-AWS.md
@@ -12,6 +12,11 @@ You can also specify this in your `Infra.toml` file:
 regions = ["us-west-2", "us-east-1", "us-east-2"]
 ```
 
+Note: several commands work with AWS services, so there's some shared configuration related to AWS accounts and AWS IAM roles.
+For example, you can specify a role to assume before any API calls are made, and a role to assume before any API calls in a specific region.
+This can be useful if you want to use roles to control access to the accounts that own AMIs, for example.
+See the commented [example Infra.toml](tools/pubsys/Infra.toml.example) for details.
+
 If you specify multiple regions, an AMI will be registered in the first region and then copied to the other regions.
 
 After putting this in `Infra.toml`, you can make an AMI more easily:


### PR DESCRIPTION
**Issue number:**

Closes #2327

**Description of changes:**

```
Update BUILDING.md and PUBLISHING-AWS.md to mention need for aws creds

Several commands referenced in the developer docs interact with AWS
services; AMI, EKS, etc. In order to successfully publish AMIs via the
quickstart, AWS creds must be setup. This patch updates both BUILDING.md
and PUBLISHING-AWS.md to reflect the need to have this setup.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

**Testing done:**

N/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
