### PR TITLE
Increase inotify default limits

### DIFF
--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -58,3 +58,7 @@ kernel.unprivileged_bpf_disabled = 1
 
 # Turn on BPF JIT hardening, if the JIT is enabled.
 net.core.bpf_jit_harden = 2
+
+# Increase inotify limits to allow for a greater number of containers
+fs.inotify.max_user_instances = 8192
+fs.inotify.max_user_watches = 524288


### PR DESCRIPTION
**Issue number:**

Closes #1525 

**Description of changes:**

We have had several reports from users that the inotify limits
(fs.inotify.max_user_instances and fs.inotify.max_user_watches) are too
low for their workloads, causing them to get errors when deploying pods.

The user data settings can be used to raise (or lower) these defaults if
an end user needs to fine tune their settings.

Related Amazon Linux changes:
- https://github.com/awslabs/amazon-eks-ami/pull/589
- https://github.com/awslabs/amazon-eks-ami/pull/614

**Testing done:**

Made changes and built image to make sure there were no errors.

Published AMI and spun up EKS cluster. Connected to console, went to admin container, and used
sheltie to verify values returned are what is expected for these settings.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
