### PR TITLE
Increase vm.max_map_count to match AL2 setting

### DIFF
--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -62,3 +62,6 @@ net.core.bpf_jit_harden = 2
 # Increase inotify limits to allow for a greater number of containers
 fs.inotify.max_user_instances = 8192
 fs.inotify.max_user_watches = 524288
+
+# Increase virtual memory to allow for larger workloads
+vm.max_map_count = 524288


### PR DESCRIPTION
**Issue number:**

Related #1525 

**Description of changes:**

This increases the vm.max_map_count to match the value configured in
Amazon Linux so we have a consistent value and user experience across AL
and Bottlerocket.

Related AL change: https://github.com/awslabs/amazon-eks-ami/pull/589

**Testing done:**

Verified value changed in deployed image.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
