### PR TITLE
Remove redundant closure

### DIFF
--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -17,7 +17,6 @@ use model::{
     TestSpec,
 };
 use std::collections::BTreeMap;
-use std::convert::identity;
 
 pub(crate) struct AwsK8s {
     pub(crate) arch: String,
@@ -465,10 +464,7 @@ where
         .send()
         .await?
         .images;
-    let images: Vec<&Image> = describe_images
-        .iter()
-        .flat_map(|image| identity(image))
-        .collect();
+    let images: Vec<&Image> = describe_images.iter().flatten().collect();
     if images.len() > 1 {
         return Err(anyhow!("Multiple images were found"));
     };


### PR DESCRIPTION
**Issue number:**

Closes #2345 

**Description of changes:**

Clippy warnings about a redundant closure. The closure just makes a call
to a function that would take the passed argument anyway, so we should
remove the closure and just provide the function directly.

**Testing done:**

Built with changes and verified rust was happy.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
