### PR TITLE
docs: Update note about presence of boot settings to k8s-1.23 and beyond

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ Here are the metrics settings:
 
 #### Boot-related settings
 
-*Please note that boot settings only exist for bare-metal variants at the moment*
+*Please note that boot settings currently only exist for the bare metal variants and \*-k8s-1.23 variants. Boot settings will be added to any future variant introduced after Bottlerocket v1.8.0.*
 
 Specifying either of the following settings will generate a kernel boot config file to be loaded on subsequent boots:
 


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:**

Update the readme to add a note about the presence of boot settings. The settings model includes the boot settings on all k8s-1.23 variants now. Of the non-devel variants, metal-k8s-1.22 was first and deserves a special mention.


**Testing done:**

```
$ git grep 'boot: BootSettings'
sources/models/src/aws-k8s-1.23-nvidia/mod.rs:    boot: BootSettings,
sources/models/src/aws-k8s-1.23/mod.rs:    boot: BootSettings,
sources/models/src/metal-dev/mod.rs:    boot: BootSettings,
sources/models/src/metal-k8s-1.22/mod.rs:    boot: BootSettings,
sources/models/src/metal-k8s-1.23/mod.rs:    boot: BootSettings,
sources/models/src/vmware-k8s-1.23/mod.rs:    boot: BootSettings,
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
