### PR TITLE
Metricdog: use compile time architecture for unit tests

### DIFF
--- a/sources/metricdog/src/metricdog_test.rs
+++ b/sources/metricdog/src/metricdog_test.rs
@@ -53,7 +53,7 @@ fn send_healthy_ping() {
         request::query(url_decoded(contains(("event", "health_ping")))),
         request::query(url_decoded(contains(("version", "0.4.0")))),
         request::query(url_decoded(contains(("variant", "aws-k8s-1.16")))),
-        request::query(url_decoded(contains(("arch", "x86_64")))),
+        request::query(url_decoded(contains(("arch", std::env::consts::ARCH)))),
         request::query(url_decoded(contains(("region", "us-east-1")))),
         request::query(url_decoded(contains(("seed", "2041")))),
         request::query(url_decoded(contains(("failed_services", "")))),
@@ -91,7 +91,7 @@ fn send_unhealthy_ping() {
         request::query(url_decoded(contains(("event", "health_ping")))),
         request::query(url_decoded(contains(("version", "0.4.0")))),
         request::query(url_decoded(contains(("variant", "aws-k8s-1.16")))),
-        request::query(url_decoded(contains(("arch", "x86_64")))),
+        request::query(url_decoded(contains(("arch", std::env::consts::ARCH)))),
         request::query(url_decoded(contains(("region", "us-east-1")))),
         request::query(url_decoded(contains(("seed", "2041")))),
         request::query(url_decoded(contains((
@@ -134,7 +134,7 @@ fn send_boot_success() {
         request::query(url_decoded(contains(("event", "boot_success")))),
         request::query(url_decoded(contains(("version", "0.4.0")))),
         request::query(url_decoded(contains(("variant", "aws-k8s-1.16")))),
-        request::query(url_decoded(contains(("arch", "x86_64")))),
+        request::query(url_decoded(contains(("arch", std::env::consts::ARCH)))),
         request::query(url_decoded(contains(("region", "us-east-1")))),
         request::query(url_decoded(contains(("seed", "2041")))),
     ];


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2360

**Description of changes:**

```
Removes hard coded "x86_64" architecture matcher in metricdog tests
which fail on "aarch" based systems.

Instead, uses the std::env::consts::ARCH constant which is populated
with the "uname" string (i.e. x86_64, aarch) at compile time.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

**Testing done:**

Within `sources/metricdog/`, able to successfully run `cargo test`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
