### PR TITLE
Automated reconciliation of boot settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,16 +716,20 @@ Here are the metrics settings:
 
 *Please note that boot settings currently only exist for the bare metal variants and \*-k8s-1.23 variants. Boot settings will be added to any future variant introduced after Bottlerocket v1.8.0.*
 
-Specifying either of the following settings will generate a kernel boot config file to be loaded on subsequent boots:
+Specifying any of the following settings will generate a kernel boot config file to be loaded on subsequent boots:
 
 * `settings.boot.kernel-parameters`: This allows additional kernel parameters to be specified on the kernel command line during boot.
 * `settings.boot.init-parameters`: This allows additional init parameters to be specified on the kernel command line during boot.
+* `settings.boot.reboot-to-reconcile`: If set to `true`, Bottlerocket will automatically reboot again during boot if either the `settings.boot.kernel-parameters` or `settings.boot.init-parameters` were changed via user data or a bootstrap container so that these changes may take effect.
 
 You can learn more about kernel boot configuration [here](https://www.kernel.org/doc/html/latest/admin-guide/bootconfig.html).
 
 Example user data for specifying boot settings:
 
 ```toml
+[settings.boot]
+reboot-to-reconcile = true
+
 [settings.boot.kernel-parameters]
 "console" = [
   "tty0",

--- a/Release.toml
+++ b/Release.toml
@@ -145,4 +145,5 @@ version = "1.10.0"
 "(1.9.2, 1.10.0)" = [
     "migrate_v1.10.0_dns-settings.lz4",
     "migrate_v1.10.0_dns-settings-metadata.lz4",
+    "migrate_v1.10.0_reboot-to-reconcile-setting.lz4",
 ]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -44,6 +44,7 @@ Source116: load-kernel-modules.service.in
 Source117: cfsignal.service
 Source118: generate-network-config.service
 Source119: prepare-primary-interface.service
+Source120: reboot-if-required.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -402,7 +403,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:100} %{S:101} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
-  %{S:113} %{S:114} %{S:118} %{S:119} \
+  %{S:113} %{S:114} %{S:118} %{S:119} %{S:120} \
   %{buildroot}%{_cross_unitdir}
 
 %if %{with nvidia_flavor}
@@ -563,6 +564,7 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 
 %files -n %{_cross_os}prairiedog
 %{_cross_bindir}/prairiedog
+%{_cross_unitdir}/reboot-if-required.service
 
 %files -n %{_cross_os}certdog
 %{_cross_bindir}/certdog

--- a/packages/os/reboot-if-required.service
+++ b/packages/os/reboot-if-required.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reboot system if needed for configuration changes to take effect
+# Block manual interactions for now to prevent unplanned reboots.
+RefuseManualStart=true
+RefuseManualStop=true
+After=configured.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/prairiedog reboot-if-required
+StandardError=journal+console

--- a/packages/release/activate-multi-user.service
+++ b/packages/release/activate-multi-user.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Isolates multi-user.target
-After=configured.target
-Requires=configured.target
+After=configured.target reboot-if-required.service
+Requires=configured.target reboot-if-required.service
 
 [Service]
 Type=oneshot

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2848,6 +2848,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "reboot-to-reconcile-setting"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     # "api/migration/migrations/vX.Y.Z/..."
     "api/migration/migrations/v1.10.0/dns-settings",
     "api/migration/migrations/v1.10.0/dns-settings-metadata",
+    "api/migration/migrations/v1.10.0/reboot-to-reconcile-setting",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.10.0/reboot-to-reconcile-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.10.0/reboot-to-reconcile-setting/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "reboot-to-reconcile-setting"
+version = "0.1.0"
+edition = "2018"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.10.0/reboot-to-reconcile-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.0/reboot-to-reconcile-setting/src/main.rs
@@ -1,0 +1,21 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for letting the host reboot if boot settings changed,
+/// `settings.boot.reboot-to-reconcile`
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&["settings.boot.reboot-to-reconcile"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/prairiedog/src/bootconfig.rs
+++ b/sources/api/prairiedog/src/bootconfig.rs
@@ -227,6 +227,7 @@ fn parse_boot_config_to_boot_settings(bootconfig: &str) -> Result<BootSettings> 
     }
 
     Ok(BootSettings {
+        reboot_to_reconcile: None,
         kernel_parameters: if kernel_params.is_empty() {
             None
         } else {
@@ -264,6 +265,7 @@ mod boot_settings_tests {
     #[test]
     fn boot_settings_to_string() {
         let boot_settings = BootSettings {
+            reboot_to_reconcile: None,
             kernel_parameters: Some(
                 hashmap! {
                     "console" => vec!["ttyS1,115200n8", "tty0"],
@@ -320,6 +322,7 @@ mod boot_settings_tests {
     #[test]
     fn none_boot_settings_to_string() {
         let boot_settings = BootSettings {
+            reboot_to_reconcile: None,
             kernel_parameters: None,
             init_parameters: None,
         };
@@ -329,6 +332,7 @@ mod boot_settings_tests {
         );
 
         let init_none_boot_settings = BootSettings {
+            reboot_to_reconcile: None,
             kernel_parameters: Some(
                 hashmap! {
                     "console" => vec!["ttyS1,115200n8", "tty0"],
@@ -370,6 +374,7 @@ mod boot_settings_tests {
     #[test]
     fn empty_map_boot_settings_to_string() {
         let boot_settings = BootSettings {
+            reboot_to_reconcile: None,
             kernel_parameters: Some(hashmap! {}),
             init_parameters: None,
         };

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -328,6 +328,7 @@ struct KmodSetting {
 // Kernel boot settings
 #[model]
 struct BootSettings {
+    reboot_to_reconcile: bool,
     #[serde(
         alias = "kernel",
         rename(serialize = "kernel"),


### PR DESCRIPTION
**Issue number:**

Closes #2155 

**Description of changes:**

This PR implements what has been proposed in #2155, the addition of a new `settings.boot.reboot-to-reconcile` setting to automatically reboot Bottlerocket if either the kernel or systemd command line were changed during boot. At a high level, prairiedog now compares any newly written bootconfig initrd against the one already present and flags the need for a reboot. Before entering the `configured` systemd target, a new service unit then triggers the reboot if needed.

To reviewers, I recommend going commit by commit. The commits are fairly detailed and hopefully tell a story if followed in order.

**Testing done:**

* [x] No boot settings specified: No automatic reboot; host can be rebooted
* [x] Boot settings specified with `reboot-to-reconcile` unset: No automatic reboot; host can be rebooted and comes up with specified settings
* [x] Boot settings specified with `reboot-to-reconcile` set to false: No automatic reboot; host can be rebooted and comes up with specified settings
* [x] Boot settings specified with `reboot-to-reconcile` set to true: Automatic reboot; host comes up with specified settings
* [x] Boot settings specified with `reboot-to-reconcile` set to true and bootstrap containers: Automatic reboot after bootstrap containers have exited; host comes up with specified settings
* [x] Tested forward and backward migration from 1.9.2 to a faux 1.10.0 with this PR on builds of the `aws-k8s-1.23` variant, both with and without `reboot-to-reconcile` set

**Notes:**

* ~While this implements a new setting, I don't think a migration is needed as the setting is persisted and restored by prairiedog in the bootconfig initrd. Older versions of prairiedog will just ignore the setting.~ Update: A migration is needed as pointed out by @etungsten: While prairiedog may ignore the unknown setting, it will bite when trying to deserialize the data store. The current version comes with a migration.
* If you're taking this on a test ride yourself, please see #2359: If you configure a boot setting that doesn't require a value, please specify the empty string for now.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
