### PR TITLE
makefile: add top level "check" target

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -330,6 +330,10 @@ done
 '''
 ]
 
+# A top level target for devs to ensure review and patch readiness
+[tasks.check]
+dependencies = ["check-cargo-version", "unit-tests", "check-fmt", "check-lints"]
+
 [tasks.check-fmt]
 script = [
 '''


### PR DESCRIPTION
### Issue number:

Closes #2381

### Description of changes:

```
"cargo make check" will check the cargo version, invoke the unit tests
(which in turn calls rustc thereby creating necessary build file links for
the default variant), checks formatting, and checks the linters.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

Provides a unified, top level "check" target to the makefile that can be used in a `.git/hooks/pre-commit` script to ensure review and patch readiness.

Incorporates only the `check-*` targets that are relevant for development work (unit tests, formatting, linting, etc.)

### Testing done:

Ran `cargo make check` and 👍🏼
Ran `cargo make check` in a new git clone of the repo and 👍🏼 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
