### PR TITLE
testsys: Update testsys commit to `07b9ae8`

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -459,8 +459,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-types"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?rev=021e8d6#021e8d69b13b7d05e79963a0ff3f1c5c1af10753"
+version = "0.0.1"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?rev=07b9ae8#07b9ae8e902623842c334889517973d0c9d82691"
 dependencies = [
  "model",
  "serde",
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
+checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
+checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
 dependencies = [
  "base64",
  "bytes",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
+checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb405f0d39181acbfdc7c79e3fc095330c9b6465ab50aeb662d762e53b662f1"
+checksum = "66d74121eb41af4480052901f31142d8d9bbdf1b7c6b856da43bcb02f5b1b177"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1617,8 +1617,8 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?rev=021e8d6#021e8d69b13b7d05e79963a0ff3f1c5c1af10753"
+version = "0.0.1"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?rev=07b9ae8#07b9ae8e902623842c334889517973d0c9d82691"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2883,6 +2883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,7 +2931,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "terminal_size",
+ "term_size",
  "tokio",
  "unescape",
 ]
@@ -3137,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "topological-sort"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7c7f42dea4b1b99439786f5633aeb9c14c1b53f75e282803c2ec2ad545873c"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tough"

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0"
 aws-config = "0.46"
 aws-sdk-ec2 = "0.16"
-bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", rev = "021e8d6", version = "0.1"}
+bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", rev = "07b9ae8", version = "0.0.1"}
 bottlerocket-variant = { version = "0.1", path = "../../sources/bottlerocket-variant" }
 clap = { version = "3", features = ["derive", "env"] }
 env_logger = "0.9"
@@ -18,11 +18,11 @@ futures = "0.3.8"
 k8s-openapi = { version = "0.15", features = ["v1_20", "api"], default-features = false }
 log = "0.4"
 maplit = "1.0.2"
-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", rev = "021e8d6", version = "0.1"}
+model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", rev = "07b9ae8", version = "0.0.1"}
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
-terminal_size = "0.1"
+term_size = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 unescape = "0.1.0"

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -170,6 +170,7 @@ impl AwsK8s {
             },
             spec: ResourceSpec {
                 depends_on: None,
+                conflicts_with: None,
                 agent: Agent {
                     name: "eks-provider".to_string(),
                     image: testsys_images.eks_resource.clone(),
@@ -233,6 +234,7 @@ impl AwsK8s {
             },
             spec: ResourceSpec {
                 depends_on: Some(vec![cluster_name]),
+                conflicts_with: None,
                 agent: Agent {
                     name: "ec2-provider".to_string(),
                     image: testsys_images.ec2_resource.clone(),
@@ -284,6 +286,7 @@ impl AwsK8s {
                             mode: sonobuoy_mode,
                             kubernetes_version: None,
                             kube_conformance_image: self.kube_conformance_image.clone(),
+                            e2e_repo_config_base64: None,
                             assume_role: self.assume_role.clone(),
                         }
                         .into_map()
@@ -493,6 +496,7 @@ impl AwsEcs {
             },
             spec: ResourceSpec {
                 depends_on: None,
+                conflicts_with: None,
                 agent: Agent {
                     name: "ecs-provider".to_string(),
                     image: testsys_images.ecs_resource.clone(),
@@ -548,6 +552,7 @@ impl AwsEcs {
             },
             spec: ResourceSpec {
                 depends_on: Some(vec![cluster_name]),
+                conflicts_with: None,
                 agent: Agent {
                     name: "ec2-provider".to_string(),
                     image: testsys_images.ec2_resource.clone(),

--- a/tools/testsys/src/status.rs
+++ b/tools/testsys/src/status.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use log::{debug, info};
 use model::test_manager::{SelectionParams, TestManager};
-use terminal_size::{Height, Width};
 
 /// Check the status of testsys objects.
 #[derive(Debug, Parser)]
@@ -45,10 +44,9 @@ impl Status {
                     .context("Could not create string from status.")?
             );
         } else {
-            let (terminal_size::Width(width), _) =
-                terminal_size::terminal_size().unwrap_or((Width(80), Height(0)));
+            let (width, _) = term_size::dimensions().unwrap_or((80, 0));
             debug!("Window width '{}'", width);
-            println!("{}", status.to_string(width as usize));
+            println!("{:width$}", status.to_string());
         }
         Ok(())
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #N/A

**Description of changes:**

This PR updates the checkout of testsys to the later version of testsys.
Updating testsys includes:
* Improved status checking with `testsys status`
* Enable the use of conflicting resources
* Sonobuoy test in China partition

This pr will precede a declarative testing pr that introduces `Test.toml`

**Testing done:**

`cargo make test` and other targets work as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
