### PR TITLE
testsys: Add declarative testing through `Test.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.gomodcache
 /html
 /Infra.toml
+/Test.toml
 /testsys.kubeconfig
 /*.pem
 /keys

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -133,6 +133,7 @@ TESTSYS_KUBECONFIG_PATH = "${BUILDSYS_ROOT_DIR}/testsys.kubeconfig"
 TESTSYS_STARTING_VERSION = { script = ["git tag --list --sort=version:refname 'v*' | tail -1"] }
 # The commit for the last release of bottlerocket.
 TESTSYS_STARTING_COMMIT = { script = ["git describe --tag ${TESTSYS_STARTING_VERSION} --always --exclude '*' || echo 00000000"] }
+TESTSYS_TEST_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Test.toml"
 
 [env.development]
 # Certain variables are defined here to allow us to override a component value

--- a/TESTING.md
+++ b/TESTING.md
@@ -118,6 +118,25 @@ The Bottlerocket components are found in the `testsys-bottlerocket-aws` Kubernet
 
 Now that you have the testsys cluster set up, it's time to run a Bottlerocket integration test!
 
+### Configuration
+
+There are many arguments that can be configured via environment variables with `cargo make`; however, it is possible to create a configuration file instead.
+Check out the [example config file](tools/testsys/Test.toml.example) for a sample `Test.toml` file.
+
+For example, the instance type can be specified based on variant requirements:
+
+```yaml
+[aws-k8s]
+# Set the default instance type for all `aws-k8s` variants
+instance-type = "m5.xlarge"
+
+[aws-k8s-nvidia]
+# Override the instance type for `nvidia` `aws-k8s` variants
+instance-type = "g5g.2xlarge"
+```
+
+Since `aws-k8s-nvidia` is a `<FAMILY>-<FLAVOR>` level configuration it will take precedence over `aws-k8s` which is `<FAMILY>` level configuration.
+
 ### Variants
 
 Different Bottlerocket variants require different implementations in the test system.

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1243,6 +1243,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b224eaa4987c03c30b251de7ef0c15a6a59f34222905850dbc3026dfb24d5f"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2025,50 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha1",
+]
 
 [[package]]
 name = "pin-project"
@@ -2836,6 +2894,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-ec2",
+ "base64",
  "bottlerocket-types",
  "bottlerocket-variant",
  "clap 3.2.22",
@@ -2850,8 +2909,27 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "term_size",
+ "testsys-config",
  "tokio",
  "unescape",
+]
+
+[[package]]
+name = "testsys-config"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "handlebars",
+ "home",
+ "lazy_static",
+ "log",
+ "maplit",
+ "model",
+ "serde",
+ "serde_yaml",
+ "snafu",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -3246,6 +3324,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unescape"

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -608,8 +608,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-types"
-version = "0.0.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?rev=07b9ae8#07b9ae8e902623842c334889517973d0c9d82691"
+version = "0.0.2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.2#dfd5bc90a481beb05e7a64ac4b20c86fd2491d9d"
 dependencies = [
  "model",
  "serde",
@@ -1734,8 +1734,8 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "0.0.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?rev=07b9ae8#07b9ae8e902623842c334889517973d0c9d82691"
+version = "0.0.2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.2#dfd5bc90a481beb05e7a64ac4b20c86fd2491d9d"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "pubsys-config",
     "pubsys-setup",
     "testsys",
+    "testsys-config",
 ]

--- a/tools/testsys-config/Cargo.toml
+++ b/tools/testsys-config/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "testsys-config"
+version = "0.1.0"
+authors = ["Ethan Pullen <pullenep@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../sources/bottlerocket-variant" }
+handlebars = "4.3"
+home = "0.5"
+lazy_static = "1.4"
+log = "0.4"
+maplit="1.0"
+model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.2", tag = "v0.0.2"}
+serde = { version = "1.0", features = ["derive"]  }
+serde_yaml = "0.8.17"
+snafu = "0.7"
+toml = "0.5"
+url = { version = "2.1.0", features = ["serde"] }

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -1,0 +1,387 @@
+use bottlerocket_variant::Variant;
+pub use error::Error;
+use handlebars::Handlebars;
+use log::warn;
+use maplit::btreemap;
+use model::SecretName;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::Path;
+pub type Result<T> = std::result::Result<T, error::Error>;
+
+/// Configuration needed to run tests
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct TestConfig {
+    /// High level configuration for TestSys
+    pub test: Option<Test>,
+
+    #[serde(flatten, serialize_with = "toml::ser::tables_last")]
+    /// Configuration for testing variants
+    pub configs: HashMap<String, GenericConfig>,
+}
+
+impl TestConfig {
+    /// Deserializes a TestConfig from a given path
+    pub fn from_path<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        let test_config_str = fs::read_to_string(path).context(error::FileSnafu { path })?;
+        toml::from_str(&test_config_str).context(error::InvalidTomlSnafu { path })
+    }
+
+    /// Deserializes a TestConfig from a given path, if it exists, otherwise builds a default
+    /// config
+    pub fn from_path_or_default<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        if path.as_ref().exists() {
+            Self::from_path(path)
+        } else {
+            warn!(
+                "No test config was found at '{}'. Using the default config.",
+                path.as_ref().display()
+            );
+            Ok(Self::default())
+        }
+    }
+
+    /// Create a single config for the `variant` and `arch` from this test configuration by
+    /// determining a list of tables that contain information relevant to the arch, variant
+    /// combination. Then, the tables are reduced to a single config by selecting values from the
+    /// table based on the order of precedence. If `starting_config` is provided it will be used as
+    /// the config with the highest precedence.
+    pub fn reduced_config<S>(
+        &self,
+        variant: &Variant,
+        arch: S,
+        starting_config: Option<GenericVariantConfig>,
+    ) -> GenericVariantConfig
+    where
+        S: Into<String>,
+    {
+        let arch = arch.into();
+        // Starting with a list of keys ordered by precedence, return a single config with values
+        // selected by the order of the list.
+        config_keys(variant)
+            // Convert the vec of keys in to an iterator of keys.
+            .into_iter()
+            // Convert the iterator of keys to and iterator of Configs. If the key does not have a
+            // configuration in the config file, remove it from the iterator.
+            .filter_map(|key| self.configs.get(&key).cloned())
+            // Take the iterator of configurations and extract the arch specific config and the
+            // non-arch specific config for each config. Then, convert them into a single iterator.
+            .flat_map(|config| vec![config.for_arch(&arch), config.config])
+            // Take the iterator of configurations and merge them into a single config by populating
+            // each field with the first value that is not `None` while following the list of
+            // precedence.
+            .fold(
+                starting_config.unwrap_or_default(),
+                GenericVariantConfig::merge,
+            )
+    }
+}
+
+/// High level configurations for a test
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct Test {
+    /// The name of the repo in `Infra.toml` that should be used for testing
+    pub repo: Option<String>,
+
+    #[serde(flatten)]
+    /// The URI of TestSys images
+    pub testsys_images: TestsysImages,
+
+    /// A registry containing all TestSys images
+    pub testsys_image_registry: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct AwsK8sVariantConfig {
+    /// The names of all clusters this variant should be tested over. This is particularly useful
+    /// for testing Bottlerocket on ipv4 and ipv6 clusters.
+    pub cluster_names: Vec<String>,
+    /// The instance type that instances should be launched with
+    pub instance_type: Option<String>,
+    /// The secrets needed by the agents
+    pub secrets: BTreeMap<String, SecretName>,
+    /// The role that should be assumed for this particular variant
+    pub assume_role: Option<String>,
+    /// The kubernetes conformance image that should be used for this variant
+    pub kube_conformance_image: Option<String>,
+    /// The e2e repo containing sonobuoy images
+    pub e2e_repo_registry: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct AwsEcsVariantConfig {
+    /// The names of all clusters this variant should be tested over
+    pub cluster_names: Vec<String>,
+    /// The instance type that instances should be launched with
+    pub instance_type: Option<String>,
+    /// The secrets needed by the agents
+    pub secrets: BTreeMap<String, SecretName>,
+    /// The role that should be assumed for this particular variant
+    pub assume_role: Option<String>,
+}
+
+/// Create a vec of relevant keys for this variant ordered from most specific to least specific.
+fn config_keys(variant: &Variant) -> Vec<String> {
+    let (family_flavor, platform_flavor) = variant
+        .variant_flavor()
+        .map(|flavor| {
+            (
+                format!("{}-{}", variant.family(), flavor),
+                format!("{}-{}", variant.platform(), flavor),
+            )
+        })
+        .unwrap_or_default();
+
+    // The keys used to describe configuration (most specific -> least specific)
+    vec![
+        variant.to_string(),
+        family_flavor,
+        variant.family().to_string(),
+        platform_flavor,
+        variant.platform().to_string(),
+    ]
+}
+
+/// All configurations for a specific config level, i.e `<PLATFORM>-<FLAVOR>`
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct GenericConfig {
+    #[serde(default)]
+    aarch64: GenericVariantConfig,
+    #[serde(default)]
+    x86_64: GenericVariantConfig,
+    #[serde(default, flatten)]
+    config: GenericVariantConfig,
+}
+
+impl GenericConfig {
+    /// Get the configuration for a specific arch.
+    pub fn for_arch<S>(&self, arch: S) -> GenericVariantConfig
+    where
+        S: Into<String>,
+    {
+        match arch.into().as_str() {
+            "x86_64" => self.x86_64.clone(),
+            "aarch64" => self.aarch64.clone(),
+            _ => Default::default(),
+        }
+    }
+}
+
+/// The configuration for a specific config level (<PLATFORM>-<FLAVOR>). This may or may not be arch
+/// specific depending on it's location in `GenericConfig`.
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
+pub struct GenericVariantConfig {
+    /// The names of all clusters this variant should be tested over. This is particularly useful
+    /// for testing Bottlerocket on ipv4 and ipv6 clusters.
+    #[serde(default)]
+    pub cluster_names: Vec<String>,
+    /// The instance type that instances should be launched with
+    pub instance_type: Option<String>,
+    /// The secrets needed by the agents
+    #[serde(default)]
+    pub secrets: BTreeMap<String, SecretName>,
+    /// The role that should be assumed for this particular variant
+    pub agent_role: Option<String>,
+    /// The custom images used for conformance testing
+    pub conformance_image: Option<String>,
+    /// The custom registry used for conformance testing
+    pub conformance_registry: Option<String>,
+}
+
+impl GenericVariantConfig {
+    /// Overwrite the unset values of `self` with the set values of `other`
+    fn merge(self, other: Self) -> Self {
+        let cluster_names = if self.cluster_names.is_empty() {
+            other.cluster_names
+        } else {
+            self.cluster_names
+        };
+
+        let secrets = if self.secrets.is_empty() {
+            other.secrets
+        } else {
+            self.secrets
+        };
+
+        Self {
+            cluster_names,
+            instance_type: self.instance_type.or(other.instance_type),
+            secrets,
+            agent_role: self.agent_role.or(other.agent_role),
+            conformance_image: self.conformance_image.or(other.conformance_image),
+            conformance_registry: self.conformance_registry.or(other.conformance_registry),
+        }
+    }
+}
+
+impl From<GenericVariantConfig> for AwsK8sVariantConfig {
+    fn from(val: GenericVariantConfig) -> Self {
+        Self {
+            cluster_names: val.cluster_names,
+            instance_type: val.instance_type,
+            secrets: val.secrets,
+            assume_role: val.agent_role,
+            kube_conformance_image: val.conformance_image,
+            e2e_repo_registry: val.conformance_registry,
+        }
+    }
+}
+
+impl From<GenericVariantConfig> for AwsEcsVariantConfig {
+    fn from(val: GenericVariantConfig) -> Self {
+        Self {
+            cluster_names: val.cluster_names,
+            instance_type: val.instance_type,
+            secrets: val.secrets,
+            assume_role: val.agent_role,
+        }
+    }
+}
+
+/// Fill in the templated cluster name with `arch` and `variant`.
+pub fn rendered_cluster_name<S1, S2>(cluster_name: String, arch: S1, variant: S2) -> Result<String>
+where
+    S1: Into<String>,
+    S2: Into<String>,
+{
+    let mut cluster_template = Handlebars::new();
+    cluster_template.register_template_string("cluster_name", cluster_name)?;
+    Ok(cluster_template.render(
+        "cluster_name",
+        &btreemap! {"arch".to_string() => arch.into(), "variant".to_string() => variant.into()},
+    )?)
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
+pub struct TestsysImages {
+    pub eks_resource_agent_image: Option<String>,
+    pub ecs_resource_agent_image: Option<String>,
+    pub ec2_resource_agent_image: Option<String>,
+    pub sonobuoy_test_agent_image: Option<String>,
+    pub ecs_test_agent_image: Option<String>,
+    pub migration_test_agent_image: Option<String>,
+    pub testsys_agent_pull_secret: Option<String>,
+}
+
+const AGENT_VERSION: &str = "v0.0.2";
+
+impl TestsysImages {
+    /// Create an images config for a specific registry.
+    pub fn new<S>(registry: S) -> Self
+    where
+        S: Into<String>,
+    {
+        let registry = registry.into();
+        Self {
+            eks_resource_agent_image: Some(format!(
+                "{}/eks-resource-agent:{AGENT_VERSION}",
+                registry
+            )),
+            ecs_resource_agent_image: Some(format!(
+                "{}/ecs-resource-agent:{AGENT_VERSION}",
+                registry
+            )),
+            ec2_resource_agent_image: Some(format!(
+                "{}/ec2-resource-agent:{AGENT_VERSION}",
+                registry
+            )),
+            sonobuoy_test_agent_image: Some(format!(
+                "{}/sonobuoy-test-agent:{AGENT_VERSION}",
+                registry
+            )),
+            ecs_test_agent_image: Some(format!("{}/ecs-test-agent:{AGENT_VERSION}", registry)),
+            migration_test_agent_image: Some(format!(
+                "{}/migration-test-agent:{AGENT_VERSION}",
+                registry
+            )),
+            testsys_agent_pull_secret: None,
+        }
+    }
+
+    pub fn merge(self, other: Self) -> Self {
+        Self {
+            eks_resource_agent_image: self
+                .eks_resource_agent_image
+                .or(other.eks_resource_agent_image),
+            ecs_resource_agent_image: self
+                .ecs_resource_agent_image
+                .or(other.ecs_resource_agent_image),
+            ec2_resource_agent_image: self
+                .ec2_resource_agent_image
+                .or(other.ec2_resource_agent_image),
+            sonobuoy_test_agent_image: self
+                .sonobuoy_test_agent_image
+                .or(other.sonobuoy_test_agent_image),
+            ecs_test_agent_image: self.ecs_test_agent_image.or(other.ecs_test_agent_image),
+            migration_test_agent_image: self
+                .migration_test_agent_image
+                .or(other.migration_test_agent_image),
+            testsys_agent_pull_secret: self
+                .testsys_agent_pull_secret
+                .or(other.testsys_agent_pull_secret),
+        }
+    }
+
+    pub fn public_images() -> Self {
+        Self::new("public.ecr.aws/bottlerocket-test-system")
+    }
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::io;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub enum Error {
+        #[snafu(display("Failed to read '{}': {}", path.display(), source))]
+        File { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Invalid config file at '{}': {}", path.display(), source))]
+        InvalidToml {
+            path: PathBuf,
+            source: toml::de::Error,
+        },
+
+        #[snafu(display("Invalid lock file at '{}': {}", path.display(), source))]
+        InvalidLock {
+            path: PathBuf,
+            source: serde_yaml::Error,
+        },
+
+        #[snafu(display("Missing config: {}", what))]
+        MissingConfig { what: String },
+
+        #[snafu(display("Failed to get parent of path: {}", path.display()))]
+        Parent { path: PathBuf },
+
+        #[snafu(
+            context(false),
+            display("Failed to create template for cluster name: {}", source)
+        )]
+        TemplateError { source: handlebars::TemplateError },
+
+        #[snafu(
+            context(false),
+            display("Failed to render templated cluster name: {}", source)
+        )]
+        RenderError { source: handlebars::RenderError },
+    }
+}

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0"
 aws-config = "0.48"
 aws-sdk-ec2 = "0.18"
-bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", rev = "07b9ae8", version = "0.0.1"}
+bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.2", tag = "v0.0.2"}
 bottlerocket-variant = { version = "0.1", path = "../../sources/bottlerocket-variant" }
 clap = { version = "3", features = ["derive", "env"] }
 env_logger = "0.9"
@@ -18,7 +18,7 @@ futures = "0.3.8"
 k8s-openapi = { version = "0.15", features = ["v1_20", "api"], default-features = false }
 log = "0.4"
 maplit = "1.0.2"
-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", rev = "07b9ae8", version = "0.0.1"}
+model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.2", tag = "v0.0.2"}
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 anyhow = "1.0"
 aws-config = "0.48"
 aws-sdk-ec2 = "0.18"
+base64 = "0.13"
 bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.2", tag = "v0.0.2"}
 bottlerocket-variant = { version = "0.1", path = "../../sources/bottlerocket-variant" }
 clap = { version = "3", features = ["derive", "env"] }
@@ -24,5 +25,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
 term_size = "0.3"
+testsys-config = { path = "../testsys-config/", version = "0.1.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 unescape = "0.1.0"

--- a/tools/testsys/Test.toml.example
+++ b/tools/testsys/Test.toml.example
@@ -1,0 +1,119 @@
+# This is an example testing configuration for TestSys, the tool that is used to validate
+# Bottlerocket builds.
+
+# This section contains configuration details for all testing
+[test]
+
+# The repo from `Infra.toml` that should be used for Bottlerocket update images. It may be useful to
+# create a repo in `Infra.toml` that contains the infrastructure needed for testing
+repo = "default"
+
+# The registry containing alternate TestSys agent images
+testsys-images-registry = "public.ecr.aws/bottlerocket-test-system"
+
+# The URI for the EKS resource agent that should be used. An individual agent's provided URI will be
+# used even if `testsys-images-registry` is present.
+eks-resource-agent-image = "public.ecr.aws/bottlerocket-test-system/eks_resource_agent:v0.0.2"
+
+# Test Configurations
+#
+# Testing requirements tend to differ by variant and architecture. This configuration file provides
+# the ability to set values that apply generally to a broad group of similar variants, and to
+# override those values at a more granular level. For example, you can set a value for all `aws-k8s`
+# variants, then override that value for 'aws-k8s-nvidia' variants, and further override the value
+# for 'aws-k8s-nvidia'.aarch64 builds.
+#
+# The mechanism for resolving configuration values has the following order of precedence:
+#
+# '<VARIANT>'.ARCH
+# '<VARIANT>'
+# '<FAMILY>-<FLAVOR>'.ARCH
+# '<FAMILY>-<FLAVOR>'
+# '<FAMILY>'.ARCH
+# '<FAMILY>'
+# '<PLATFORM>-<FLAVOR>'.ARCH
+# '<PLATFORM>-<FLAVOR>'
+# '<PLATFORM>'.ARCH
+# '<PLATFORM>'
+#
+# For concrete example, given a variant such as `aws-k8s-1.23-nvidia` with the architecture
+# `x86_64`, configurations will have the following order of precedence:
+# ['aws-k8s-1.23-nvidia'.x86_64]
+# ['aws-k8s-1.23-nvidia']
+# ['aws-k8s-nvidia'.x86_64]
+# ['aws-k8s-nvidia']
+# ['aws-k8s'.x86_64]
+# ['aws-k8s']
+# ['aws-nvidia'.x86_64]
+# ['aws-nvidia']
+# ['aws'.x86_64]
+# ['aws']
+#
+# Note: values passed by command line argument will take precedence over those passed by environment
+# variable, and both take precedence over values set by `Test.toml`.
+
+# Example Configurations
+
+# Configuration for all variants with the `aws` platform.
+[aws]
+agent-role = "<AWS-TESTING-ROLE>"
+
+# Configuration for all nvidia AWS variants on x86_64 (platform-flavor level configuration)
+[aws-nvidia.x86_64]
+instance-type = "p3.2xlarge"
+
+# Configuration for all nvidia AWS variants on aarch64 (platform-flavor level configuration)
+[aws-nvidia.aarch64]
+instance-type = "g5g.2xlarge"
+
+# Configuration for all `aws-k8s` variants testing (family level configuration).
+[aws-k8s]
+# A single role can be assumed by agents to test all `aws-k8s` variants in a separate
+# testing account.
+agent-role = "arn:aws:iam::<ACCOUNT-ID>:role/<ROLE-NAME>"
+
+# The cluster name templating can be defined for all `aws-k8s` variants. To test on ipv4 and ipv6
+# clusters, the following templates could be used. Note: TestSys does not currently support creating
+# ipv6 clusters, so the ipv6 cluster must already exist.
+cluster-names = ["{{arch}}-{{variant}}", "{{arch}}-{{variant}}-ipv6"]
+
+# A custom conformance registry may be needed for testing if image pull reliability is a concern.
+conformance-registry = "<ACCOUNT>.dkr.ecr.cn-north-1.amazonaws.com.cn"
+
+# If testing using a kind cluster, AWS credentials need to be passed as a K8s secret.
+secrets = {"awsCreds" = "myAwsCredentials"}
+
+# Configuration for all nvidia AWS variants on x86_64 (family-flavor level configuration)
+[aws-ecs-nvidia.x86_64]
+instance-type = "p3.2xlarge"
+
+# Configuration for all nvidia AWS variants on aarch64 (family-flavor level configuration)
+[aws-ecs-nvidia.aarch64]
+instance-type = "g5g.2xlarge"
+
+# Configuration for only the `aws-k8s-1.21` variant (variant level configuration).
+["aws-k8s-1.21".aarch64]
+conformance-image = "<KUBERNETES-CONFORMANCE-IMAGE-URI>"
+
+# Configurable values:
+#
+# cluster-names: 
+#     All clusters the variant should be tested over. Cluster naming supports templated strings, and
+#     both `arch` and `variant` are provided as variables (`{{arch}}-{{variant}}`).
+#
+# instance-type:
+#     The instance type that should be used for testing.
+#
+# secrets:
+#     A map containing all secrets needed for resource creation and testing.
+#
+# agent-role:
+#     The role that should be assumed by each test and resource agent.
+#
+# conformance-image: (K8s only)
+#     Specify a custom image for conformance testing. For `aws-k8s` variants this will be used as a
+#     custom Kubernetes conformance image for Sonobuoy.
+#
+# conformance-registry: (K8s only)
+#     Specify a custom registry for conformance testing images.
+#     For `aws-k8s` variants this will be used as the Sonobuoy e2e registry.

--- a/tools/testsys/src/install.rs
+++ b/tools/testsys/src/install.rs
@@ -21,7 +21,7 @@ pub(crate) struct Install {
     #[clap(
         long = "controller-uri",
         env = "TESTSYS_CONTROLLER_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/controller:v0.0.1"
+        default_value = "public.ecr.aws/bottlerocket-test-system/controller:v0.0.2"
     )]
     controller_uri: String,
 }

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -272,7 +272,7 @@ pub(crate) struct TestsysImages {
     #[clap(
         long = "eks-resource-agent-image",
         env = "TESTSYS_EKS_RESOURCE_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v0.0.1"
+        default_value = "public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v0.0.2"
     )]
     pub(crate) eks_resource: String,
 
@@ -280,7 +280,7 @@ pub(crate) struct TestsysImages {
     #[clap(
         long = "ecs-resource-agent-image",
         env = "TESTSYS_ECS_RESOURCE_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v0.0.1"
+        default_value = "public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v0.0.2"
     )]
     pub(crate) ecs_resource: String,
 
@@ -288,7 +288,7 @@ pub(crate) struct TestsysImages {
     #[clap(
         long = "ec2-resource-agent-image",
         env = "TESTSYS_EC2_RESOURCE_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v0.0.1"
+        default_value = "public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v0.0.2"
     )]
     pub(crate) ec2_resource: String,
 
@@ -296,7 +296,7 @@ pub(crate) struct TestsysImages {
     #[clap(
         long = "sonobuoy-test-agent-image",
         env = "TESTSYS_SONOBUOY_TEST_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v0.0.1"
+        default_value = "public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v0.0.2"
     )]
     pub(crate) sonobuoy_test: String,
 
@@ -304,7 +304,7 @@ pub(crate) struct TestsysImages {
     #[clap(
         long = "ecs-test-agent-image",
         env = "TESTSYS_ECS_TEST_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/ecs-test-agent:v0.0.1"
+        default_value = "public.ecr.aws/bottlerocket-test-system/ecs-test-agent:v0.0.2"
     )]
     pub(crate) ecs_test: String,
 
@@ -312,7 +312,7 @@ pub(crate) struct TestsysImages {
     #[clap(
         long = "migration-test-agent-image",
         env = "TESTSYS_MIGRATION_TEST_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/migration-test-agent:v0.0.1"
+        default_value = "public.ecr.aws/bottlerocket-test-system/migration-test-agent:v0.0.2"
     )]
     pub(crate) migration_test: String,
 

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -12,6 +12,7 @@ use serde_plain::derive_fromstr_from_deserialize;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::PathBuf;
+use testsys_config::{AwsEcsVariantConfig, AwsK8sVariantConfig, GenericVariantConfig, TestConfig};
 
 /// Run a set of tests for a given arch and variant
 #[derive(Debug, Parser)]
@@ -31,9 +32,13 @@ pub(crate) struct Run {
     #[clap(long, env = "PUBLISH_INFRA_CONFIG_PATH", parse(from_os_str))]
     infra_config_path: PathBuf,
 
+    /// The path to `Test.toml`
+    #[clap(long, env = "TESTSYS_TEST_CONFIG_PATH", parse(from_os_str))]
+    test_config_path: PathBuf,
+
     /// Use this named repo infrastructure from Infra.toml for upgrade/downgrade testing.
-    #[clap(long, env = "PUBLISH_REPO", default_value = "default")]
-    repo: String,
+    #[clap(long, env = "PUBLISH_REPO")]
+    repo: Option<String>,
 
     /// The path to `amis.json`
     #[clap(long, env = "AMI_INPUT")]
@@ -45,34 +50,11 @@ pub(crate) struct Run {
     #[clap(long, env = "TESTSYS_TARGET_REGION")]
     target_region: Option<String>,
 
-    /// The name of the cluster for resource agents (EKS resource agent, ECS resource agent). Note:
-    /// This is not the name of the `testsys cluster` this is the name of the cluster that tests
-    /// should be run on. If no cluster name is provided, the bottlerocket cluster
-    /// naming convention `<arch>-<variant>` will be used.
-    #[clap(long, env = "TESTSYS_TARGET_CLUSTER_NAME")]
-    target_cluster_name: Option<String>,
-
-    /// The custom kube conformance image that should be used by sonobuoy. This is only applicable
-    /// for k8s variants. It can be omitted for non-k8s variants and it can be omitted to use the
-    /// default sonobuoy conformance image.
-    #[clap(long)]
-    kube_conformance_image: Option<String>,
-
-    /// The role that should be assumed by the agents
-    #[clap(long, env = "TESTSYS_ASSUME_ROLE")]
-    assume_role: Option<String>,
-
-    /// Specify the instance type that should be used. This is only applicable for aws-* variants.
-    /// It can be omitted for non-aws variants and can be omitted to use default instance types.
-    #[clap(long, env = "TESTSYS_INSTANCE_TYPE")]
-    instance_type: Option<String>,
-
-    /// Add secrets to the testsys agents (`--secret aws-credentials=my-secret`)
-    #[clap(long, short, parse(try_from_str = parse_key_val), number_of_values = 1)]
-    secret: Vec<(String, SecretName)>,
-
     #[clap(flatten)]
     agent_images: TestsysImages,
+
+    #[clap(flatten)]
+    config: CliConfig,
 
     // Migrations
     /// Override the starting image used for migrations. The image will be pulled from available
@@ -101,16 +83,65 @@ pub(crate) struct Run {
     migration_target_version: Option<String>,
 }
 
+/// This is a CLI parsable version of `testsys_config::GenericVariantConfig`.
+#[derive(Debug, Parser)]
+struct CliConfig {
+    /// The repo containing images necessary for conformance testing. It may be omitted to use the
+    /// default conformance image registry.
+    #[clap(long, env = "TESTSYS_CONFORMANCE_REGISTRY")]
+    conformance_registry: Option<String>,
+
+    /// The name of the cluster for resource agents (EKS resource agent, ECS resource agent). Note:
+    /// This is not the name of the `testsys cluster` this is the name of the cluster that tests
+    /// should be run on. If no cluster name is provided, the bottlerocket cluster
+    /// naming convention `{{arch}}-{{variant}}` will be used.
+    #[clap(long, env = "TESTSYS_TARGET_CLUSTER_NAME")]
+    target_cluster_name: Option<String>,
+
+    /// The image that should be used for conformance testing. It may be omitted to use the default
+    /// testing image.
+    #[clap(long, env = "TESTSYS_CONFORMANCE_IMAGE")]
+    conformance_image: Option<String>,
+
+    /// The role that should be assumed by the agents
+    #[clap(long, env = "TESTSYS_ASSUME_ROLE")]
+    assume_role: Option<String>,
+
+    /// Specify the instance type that should be used. This is only applicable for aws-* variants.
+    /// It can be omitted for non-aws variants and can be omitted to use default instance types.
+    #[clap(long, env = "TESTSYS_INSTANCE_TYPE")]
+    instance_type: Option<String>,
+
+    /// Add secrets to the testsys agents (`--secret aws-credentials=my-secret`)
+    #[clap(long, short, parse(try_from_str = parse_key_val), number_of_values = 1)]
+    secret: Vec<(String, SecretName)>,
+}
+
+impl From<CliConfig> for GenericVariantConfig {
+    fn from(val: CliConfig) -> Self {
+        GenericVariantConfig {
+            cluster_names: val.target_cluster_name.into_iter().collect(),
+            instance_type: val.instance_type,
+            secrets: val.secret.into_iter().collect(),
+            agent_role: val.assume_role,
+            conformance_image: val.conformance_image,
+            conformance_registry: val.conformance_registry,
+        }
+    }
+}
+
 impl Run {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
         let variant =
             Variant::new(&self.variant).context("The provided variant cannot be interpreted.")?;
         debug!("Using variant '{}'", variant);
-        let secrets = if self.secret.is_empty() {
-            None
-        } else {
-            Some(self.secret.into_iter().collect())
-        };
+
+        // Use Test.toml or default
+        let test_config = TestConfig::from_path_or_default(&self.test_config_path)
+            .context("Unable to read test config")?;
+
+        let test_opts = test_config.test.as_ref().cloned().unwrap_or_default();
+
         // If a lock file exists, use that, otherwise use Infra.toml or default
         let infra_config = InfraConfig::from_path_or_lock(&self.infra_config_path, true)
             .context("Unable to read infra config")?;
@@ -133,7 +164,12 @@ impl Run {
         let repo_config = infra_config
             .repo
             .unwrap_or_default()
-            .get(&self.repo)
+            .get(
+                &self
+                    .repo
+                    .or(test_opts.repo)
+                    .unwrap_or_else(|| "default".to_string()),
+            )
             .and_then(|repo| {
                 if let (Some(metadata_base_url), Some(targets_url)) =
                     (&repo.metadata_base_url, &repo.targets_url)
@@ -150,21 +186,32 @@ impl Run {
                 }
             });
 
+        let images = vec![
+            Some(self.agent_images.into()),
+            Some(test_opts.testsys_images),
+            test_opts
+                .testsys_image_registry
+                .map(testsys_config::TestsysImages::new),
+            Some(testsys_config::TestsysImages::public_images()),
+        ]
+        .into_iter()
+        .flatten()
+        .fold(Default::default(), testsys_config::TestsysImages::merge);
+
         let crds = match variant.family() {
             "aws-k8s" => {
                 debug!("Variant is in 'aws-k8s' family");
                 let bottlerocket_ami = ami(&self.ami_input, &region)?;
                 debug!("Using ami '{}'", bottlerocket_ami);
+                let config: AwsK8sVariantConfig = test_config
+                    .reduced_config(&variant, &self.arch, Some(self.config.into()))
+                    .into();
                 let aws_k8s = AwsK8s {
                     arch: self.arch,
                     variant: self.variant,
                     region,
-                    assume_role: self.assume_role,
-                    instance_type: self.instance_type,
+                    config,
                     ami: bottlerocket_ami.to_string(),
-                    secrets,
-                    kube_conformance_image: self.kube_conformance_image,
-                    target_cluster_name: self.target_cluster_name,
                     tuf_repo: repo_config,
                     starting_version: self.migration_starting_version,
                     starting_image_id: self.starting_image_id,
@@ -173,23 +220,22 @@ impl Run {
                     migrate_starting_commit: self.migration_starting_commit,
                 };
                 debug!("Creating crds for aws-k8s testing");
-                aws_k8s
-                    .create_crds(self.test_flavor, &self.agent_images)
-                    .await?
+
+                aws_k8s.create_crds(self.test_flavor, &images).await?
             }
             "aws-ecs" => {
                 debug!("Variant is in 'aws-ecs' family");
                 let bottlerocket_ami = ami(&self.ami_input, &region)?;
                 debug!("Using ami '{}'", bottlerocket_ami);
+                let config: AwsEcsVariantConfig = test_config
+                    .reduced_config(&variant, &self.arch, Some(self.config.into()))
+                    .into();
                 let aws_ecs = AwsEcs {
                     arch: self.arch,
                     variant: self.variant,
                     region,
-                    assume_role: self.assume_role,
-                    instance_type: self.instance_type,
+                    config,
                     ami: bottlerocket_ami.to_string(),
-                    secrets,
-                    target_cluster_name: self.target_cluster_name,
                     tuf_repo: repo_config,
                     starting_version: self.migration_starting_version,
                     starting_image_id: self.starting_image_id,
@@ -198,9 +244,7 @@ impl Run {
                     capabilities: None,
                 };
                 debug!("Creating crds for aws-ecs testing");
-                aws_ecs
-                    .create_crds(self.test_flavor, &self.agent_images)
-                    .await?
+                aws_ecs.create_crds(self.test_flavor, &images).await?
             }
             other => {
                 return Err(anyhow!(
@@ -266,55 +310,47 @@ pub(crate) struct Image {
     pub(crate) id: String,
 }
 
+/// This is a CLI parsable version of `testsys_config::TestsysImages`
 #[derive(Debug, Parser)]
 pub(crate) struct TestsysImages {
     /// EKS resource agent URI. If not provided the latest released resource agent will be used.
     #[clap(
         long = "eks-resource-agent-image",
-        env = "TESTSYS_EKS_RESOURCE_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v0.0.2"
+        env = "TESTSYS_EKS_RESOURCE_AGENT_IMAGE"
     )]
-    pub(crate) eks_resource: String,
+    pub(crate) eks_resource: Option<String>,
 
     /// ECS resource agent URI. If not provided the latest released resource agent will be used.
     #[clap(
         long = "ecs-resource-agent-image",
-        env = "TESTSYS_ECS_RESOURCE_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v0.0.2"
+        env = "TESTSYS_ECS_RESOURCE_AGENT_IMAGE"
     )]
-    pub(crate) ecs_resource: String,
+    pub(crate) ecs_resource: Option<String>,
 
     /// EC2 resource agent URI. If not provided the latest released resource agent will be used.
     #[clap(
         long = "ec2-resource-agent-image",
-        env = "TESTSYS_EC2_RESOURCE_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v0.0.2"
+        env = "TESTSYS_EC2_RESOURCE_AGENT_IMAGE"
     )]
-    pub(crate) ec2_resource: String,
+    pub(crate) ec2_resource: Option<String>,
 
     /// Sonobuoy test agent URI. If not provided the latest released test agent will be used.
     #[clap(
         long = "sonobuoy-test-agent-image",
-        env = "TESTSYS_SONOBUOY_TEST_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v0.0.2"
+        env = "TESTSYS_SONOBUOY_TEST_AGENT_IMAGE"
     )]
-    pub(crate) sonobuoy_test: String,
+    pub(crate) sonobuoy_test: Option<String>,
 
     /// ECS test agent URI. If not provided the latest released test agent will be used.
-    #[clap(
-        long = "ecs-test-agent-image",
-        env = "TESTSYS_ECS_TEST_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/ecs-test-agent:v0.0.2"
-    )]
-    pub(crate) ecs_test: String,
+    #[clap(long = "ecs-test-agent-image", env = "TESTSYS_ECS_TEST_AGENT_IMAGE")]
+    pub(crate) ecs_test: Option<String>,
 
     /// Migration test agent URI. If not provided the latest released test agent will be used.
     #[clap(
         long = "migration-test-agent-image",
-        env = "TESTSYS_MIGRATION_TEST_AGENT_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/migration-test-agent:v0.0.2"
+        env = "TESTSYS_MIGRATION_TEST_AGENT_IMAGE"
     )]
-    pub(crate) migration_test: String,
+    pub(crate) migration_test: Option<String>,
 
     /// Images pull secret. This is the name of a Kubernetes secret that will be used to
     /// pull the container image from a private registry. For example, if you created a pull secret
@@ -322,4 +358,18 @@ pub(crate) struct TestsysImages {
     /// `--images-pull-secret regcred`.
     #[clap(long = "images-pull-secret", env = "TESTSYS_IMAGES_PULL_SECRET")]
     pub(crate) secret: Option<String>,
+}
+
+impl From<TestsysImages> for testsys_config::TestsysImages {
+    fn from(val: TestsysImages) -> Self {
+        testsys_config::TestsysImages {
+            eks_resource_agent_image: val.eks_resource,
+            ecs_resource_agent_image: val.ecs_resource,
+            ec2_resource_agent_image: val.ec2_resource,
+            sonobuoy_test_agent_image: val.sonobuoy_test,
+            ecs_test_agent_image: val.ecs_test,
+            migration_test_agent_image: val.migration_test,
+            testsys_agent_pull_secret: val.secret,
+        }
+    }
 }

--- a/tools/testsys/src/status.rs
+++ b/tools/testsys/src/status.rs
@@ -46,7 +46,7 @@ impl Status {
         } else {
             let (width, _) = term_size::dimensions().unwrap_or((80, 0));
             debug!("Window width '{}'", width);
-            println!("{:width$}", status.to_string());
+            println!("{:width$}", status);
         }
         Ok(())
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # N/A

**Description of changes:**

Enables configuring testing through `Test.toml`. There are now 5 levels of configuration.

```
# The test configuration is broken up into different levels depending on the variant.
# Each configuration's value will be selected in the following order:
# Arguments from the command line
# Environment variables from the command line
# '{variant}' configuration in `Test.toml`
# '{family}-{flavor}' configuration in `Test.toml`
# '{family}' configuration in `Test.toml`
# '{platform}-{flavor}' configuration in `Test.toml`
# '{platform}' configuration in `Test.toml`
# TestSys default values
```

**Testing done:**

Testing workflow over many different configurations.
* Create a sample config file
* Run `cargo make test`
* Use `kubectl describe test <TEST-NAME>` and `kubectl describe resource <RESOURCE-NAME>` to see the `configuration`
* Verify that the values in the `configuration` match the values in the config file.

I tested this with a variety of different configurations making sure that each field was selected properly for each possible field. I then tested that the configuration values were placed in the correct spots in the crds.

I also tested `Test.toml.example` with the redacted fields filled in to make sure that the documentation was correct. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
