### PR TITLE
Upgraded to Kubernetes v1.22.12 with EKS-D 1.22-10

### DIFF
--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.22"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/8/artifacts/kubernetes/v1.22.10/kubernetes-src.tar.gz"
-sha512 = "c3791c28898358ffe656aeeb9bf3a0d00806f76f37cc7c835e9b36f50646b55f2e0fa5b52349e064594e0e84f6ffdd90f1718db4d67428db1561d1d5f2f42974"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/10/artifacts/kubernetes/v1.22.12/kubernetes-src.tar.gz"
+sha512 = "9856612e69c64f7420603d76c8075542104c8b00b90913f8ee04a17f6cecf3b8a187cadf91754d588fa2ed0fbc065d91a2bd7de34774bdac3f6b43240107bab1"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.22.10
+%global gover 1.22.12
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/8/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/10/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**

Closes #2395 
Closes https://github.com/aws/eks-distro/issues/1228

**Description of changes:**

This PR updates EKS-D to 1.22-10, which is the latest release. This version includes:
  * An upgrade from Kubernetes v1.22.10 to v1.22.12
  * Four new patches, which were cherry-picked from upstream.  The patch [0013-EKS-PATCH-Overlaid-OS-s-environment-variables-with-t.patch](https://github.com/aws/eks-distro/blob/main/projects/kubernetes/kubernetes/1-22/patches/0013-EKS-PATCH-Overlaid-OS-s-environment-variables-with-t.patch) was requested by Bottlerocket for this version. It is not needed for Kubernetes 1.23+, as [it is included](ttps://github.com/kubernetes/kubernetes/pull/103231) by upstream Kubernetes.


**Testing done:**
etungsten: 
Build image without problem.
Launched `aws-k8s-1.22` as a single node in a K8s 1.23 cluster.
The node comes up fine and pods get scheduled onto the node and runs fine:
```
$ kubectl get nodes -o wide
NAME                                          STATUS   ROLES    AGE     VERSION                INTERNAL-IP     EXTERNAL-IP     OS-IMAGE                               KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-7-125.us-west-2.compute.internal   Ready    <none>   2m24s   v1.22.12-eks-db8a1f5   192.168.7.125   54.185.30.129   Bottlerocket OS 1.9.2 (aws-k8s-1.22)   5.10.130         containerd://1.6.6+bottlerocket

$ kubectl get pods -A
NAMESPACE     NAME                                               READY   STATUS    RESTARTS   AGE
default       csi-secrets-store-secrets-store-csi-driver-mswcq   3/3     Running   0          23s
default       nginx-deployment-66b6c48dd5-4pwmt                  1/1     Running   0          21d
default       nginx-deployment-66b6c48dd5-htctk                  1/1     Running   0          21d
default       nginx-deployment-66b6c48dd5-z8hgc                  1/1     Running   0          21d
kube-system   aws-node-7bh2h                                     1/1     Running   0          53s
kube-system   coredns-559b5db75d-8hg49                           1/1     Running   0          21d
kube-system   coredns-559b5db75d-kv6jc                           1/1     Running   0          21d
kube-system   ebs-csi-controller-985774447-94n4f                 6/6     Running   0          21d
kube-system   ebs-csi-controller-985774447-xz7hp                 6/6     Running   0          21d
kube-system   ebs-csi-node-bf4kv                                 3/3     Running   0          23s
kube-system   kube-proxy-x2vrt                                   1/1     Running   0          53s
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
