### PR TITLE
Upgraded to Kubernetes v1.23.9 with EKS-D 1.23-5

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/3/artifacts/kubernetes/v1.23.7/kubernetes-src.tar.gz"
-sha512 = "aa3862ad4145f42a2f9701acaa0ac25be93ce4a8e316fe7ce182bf1d9feb03a6fc0225228fd3c3fcd97aeb08ce34722dacdb1479ee2be07a79c01ba34e49feea"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/5/artifacts/kubernetes/v1.23.9/kubernetes-src.tar.gz"
+sha512 = "730df4089fbc7ec52c9dc2bb886d010e56346d1475b46c471319f5e1a75f7c0b6767133d65ec8cd1afd0536dee649e964dbe32078e3cde099fddbc45efc90c47"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.23.7
+%global gover 1.23.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/5/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**

Closes #2396
Closes https://github.com/aws/eks-distro/issues/1229

**Description of changes:**

This PR updates EKS-D to 1.23-5, which is the latest release. This version includes:
* An upgrade from Kubernetes v1.23.7 to v1.23.9
* Three new patches, which were cherry-picked from upstream.

**Testing done:**
etungsten: 
Build image without problem.
Launched `aws-k8s-1.23` as a single node in a K8s 1.23 cluster.
The node comes up fine and pods get scheduled onto the node and runs fine:
```
$ kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE    VERSION               INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                               KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-13-145.us-west-2.compute.internal   Ready    <none>   105s   v1.23.9-eks-68c1cba   192.168.13.145   35.163.151.208   Bottlerocket OS 1.9.2 (aws-k8s-1.23)   5.10.130         containerd://1.6.6+bottlerocket

$ kubectl get pods -A
NAMESPACE     NAME                                               READY   STATUS    RESTARTS   AGE
default       csi-secrets-store-secrets-store-csi-driver-hnjb7   3/3     Running   0          83s
default       nginx-deployment-66b6c48dd5-7pxt6                  1/1     Running   0          66s
default       nginx-deployment-66b6c48dd5-v5vbb                  1/1     Running   0          66s
default       nginx-deployment-66b6c48dd5-wmv9q                  1/1     Running   0          66s
kube-system   aws-node-q6rc2                                     1/1     Running   0          113s
kube-system   coredns-559b5db75d-k6ws5                           1/1     Running   0          66s
kube-system   coredns-559b5db75d-qn7rm                           1/1     Running   0          67s
kube-system   ebs-csi-controller-985774447-7cxgn                 6/6     Running   0          66s
kube-system   ebs-csi-controller-985774447-qdhjp                 6/6     Running   0          66s
kube-system   ebs-csi-node-9wffg                                 3/3     Running   0          83s
kube-system   kube-proxy-qv82w                                   1/1     Running   0          113s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
