### PR TITLE
buildsys: Use bundle name setting for output

### DIFF
--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -126,7 +126,7 @@ impl GoMod {
         let script_contents = GO_MOD_SCRIPT_TMPL
             .replace("__LOCAL_FILE_NAME__", &local_file_name.to_string_lossy())
             .replace("__MOD_DIR__", &mod_dir.to_string_lossy())
-            .replace("__OUTPUT__", &default_output_path.to_string_lossy());
+            .replace("__OUTPUT__", &output_path_arg.to_string_lossy());
         let script_path = format!(
             "{}/{}",
             package_dir.to_string_lossy(),


### PR DESCRIPTION
**Issue number:**

Closes #2402 

**Description of changes:**

The `bundled-output-path` setting for external files had a small error when processing the output bundle for Go project dependencies where it would always use the default value, even when a different value was provided. This fixes the name of the variable used so it uses the provided name instead. This already handles setting this to the default value if the package maintainer has not provided an overridden value.

**Testing done:**

Made local change in #2377 and made sure it would try to use the specified name instead of the default.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
