### PR TITLE
pubsys: update to AWS SDK Rust

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -187,6 +187,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-ebs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702e6f505ce8d61f0bef4d2b2747f156dcbd6ba23b2a870ad9aa868830f026c5"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
 name = "aws-sdk-ec2"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +225,51 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-types",
  "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fee45083be6f062676aaeab0fe16c931a4e188d2ddce6f2c8d17399c014dc81"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-ssm"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d41b62dcea814079c2f6540c465b6d45210b20a4e30efdcd24cc5dcf4aec"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
@@ -633,22 +701,22 @@ dependencies = [
 
 [[package]]
 name = "coldsnap"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415be2bbdb84dd0d33de3099c74b9f96bd78157fe54c2073683c2b4c4811463d"
+checksum = "111badfcdc635ecbffc73bfa46ad0a83ae0c41bc01e09c4045ca3ffb1046c5c5"
 dependencies = [
  "argh",
  "async-trait",
+ "aws-config",
+ "aws-sdk-ebs",
+ "aws-sdk-ec2",
+ "aws-smithy-http",
+ "aws-types",
  "base64",
  "bytes",
  "futures",
  "indicatif",
  "nix",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_ebs",
- "rusoto_ec2",
- "rusoto_signature",
  "sha2 0.10.2",
  "snafu",
  "tempfile",
@@ -1673,7 +1741,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -1984,11 +2051,21 @@ name = "pubsys"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-sdk-ebs",
+ "aws-sdk-ec2",
+ "aws-sdk-kms",
+ "aws-sdk-ssm",
+ "aws-sdk-sts",
+ "aws-smithy-types",
+ "aws-types",
  "chrono",
  "clap 3.2.15",
  "coldsnap",
  "duct",
+ "env_logger",
  "futures",
+ "http",
  "indicatif",
  "lazy_static",
  "log",
@@ -1997,18 +2074,9 @@ dependencies = [
  "pubsys-config",
  "rayon",
  "reqwest",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_ebs",
- "rusoto_ec2",
- "rusoto_kms",
- "rusoto_signature",
- "rusoto_ssm",
- "rusoto_sts",
  "semver",
  "serde",
  "serde_json",
- "simplelog",
  "snafu",
  "structopt",
  "tempfile",
@@ -2278,49 +2346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusoto_ebs"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab3b70d6e2b9e8550bc50a42fd03e5cf43b1146b3a2a4f73fae867c08787b2"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "rusoto_core",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "rusoto_ec2"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666c2f36b125e43229892f1a0d81ad28c0d0231d3b8b00ab0e8120975d6138ca"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "rusoto_core",
- "serde_urlencoded",
- "xml-rs",
-]
-
-[[package]]
-name = "rusoto_kms"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1fc19cfcfd9f6b2f96e36d5b0dddda9004d2cbfc2d17543e3b9f10cc38fce8"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "rusoto_core",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "rusoto_s3"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,35 +2382,6 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "tokio",
-]
-
-[[package]]
-name = "rusoto_ssm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166034bb4835e1e6a7ac1cc659c9798e751cd75d7244f37beeaa12f2bbdda30b"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "rusoto_core",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rusoto_sts"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1643f49aa67cb7cb895ebac5a2ff3f991c6dbdc58ad98b28158cd5706aecd1d"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "rusoto_core",
- "serde_urlencoded",
- "xml-rs",
 ]
 
 [[package]]
@@ -3181,15 +3177,14 @@ dependencies = [
 
 [[package]]
 name = "tough-kms"
-version = "0.3.6"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baafc5e2a7f5207043f0a7e50f5c5163571c751c6a2d61a642bb8d3acdcc9659"
+checksum = "52e17edfb12e2c08c9ac3fe6ebb43fafc82fa9ffbfffbe50030b7623f8f42f34"
 dependencies = [
+ "aws-config",
+ "aws-sdk-kms",
  "pem",
  "ring",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_kms",
  "snafu",
  "tokio",
  "tough",
@@ -3197,13 +3192,12 @@ dependencies = [
 
 [[package]]
 name = "tough-ssm"
-version = "0.6.6"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a8be927f383be49de8e032532b72e82e7129f248c742bfa47247435bc7cdfb"
+checksum = "71e423321963b68b425bc844c01a16bfcab3b8300ab768dad46992201026421e"
 dependencies = [
- "rusoto_core",
- "rusoto_credential",
- "rusoto_ssm",
+ "aws-config",
+ "aws-sdk-ssm",
  "serde",
  "serde_json",
  "snafu",

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -58,14 +58,17 @@ multiple-versions = "deny"
 wildcards = "deny"
 
 skip-tree = [
-    # temporarily using a different version of snafu
-    { name = "parse-datetime", version = "0.1.0" },
-
     # rusoto_signature uses an older version of sha2
     { name = "rusoto_signature" },
 
-    # reqwest uses an older rustls-pemfile
-    { name = "reqwest", version = "0.11.10" },
+    # argh_derive pulls in an older version of heck
+    { name = "argh_derive", version = "0.1.8" },
+
+    # structopt pulls in an older version of clap
+    { name = "structopt", version = "0.3.26" },
+
+    # aws-smithy-client uses an older hyper-rustls
+    { name = "aws-smithy-client", version = "0.46.0" },
 ]
 
 [sources]

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -134,7 +134,6 @@ pub struct AwsConfig {
 #[serde(deny_unknown_fields)]
 pub struct AwsRegionConfig {
     pub role: Option<String>,
-    pub endpoint: Option<String>,
 }
 
 /// Location of signing keys

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -8,12 +8,22 @@ publish = false
 
 [dependencies]
 async-trait = "0.1.53"
+aws-config = "0.46.0"
+aws-sdk-ebs = "0.16.0"
+aws-sdk-ec2 = "0.16.0"
+aws-sdk-kms = "0.16.0"
+aws-sdk-ssm = "0.16.0"
+aws-sdk-sts = "0.16.0"
+aws-smithy-types = "0.46.0"
+aws-types = "0.46.0"
 chrono = "0.4"
 clap = "3.1"
-coldsnap = { version = "0.3", default-features = false, features = ["rusoto-rustls"]}
+coldsnap = { version = "0.4", default-features = false, features = ["aws-sdk-rust-rustls"] }
 duct = "0.13.0"
+env_logger = "0.9"
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 futures = "0.3.5"
+http = "0.2.8"
 indicatif = "0.16.0"
 lazy_static = "1.4"
 log = "0.4"
@@ -22,15 +32,6 @@ parse-datetime = { path = "../../sources/parse-datetime", version = "0.1.0" }
 rayon = "1"
 # Need to bring in reqwest with a TLS feature so tough can support TLS repos.
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "blocking"] }
-rusoto_core = { version = "0.48.0", default-features = false, features = ["rustls"] }
-rusoto_credential = "0.48.0"
-rusoto_ebs = { version = "0.48.0", default-features = false, features = ["rustls"] }
-rusoto_ec2 = { version = "0.48.0", default-features = false, features = ["rustls"] }
-rusoto_kms = { version = "0.48.0", default-features = false, features = ["rustls"] }
-rusoto_signature = "0.48.0"
-rusoto_ssm = { version = "0.48.0", default-features = false, features = ["rustls"] }
-rusoto_sts = { version = "0.48.0", default-features = false, features = ["rustls"] }
-simplelog = "0.12"
 snafu = "0.7"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"]  }
@@ -41,8 +42,8 @@ tokio = { version = "1", features = ["full"] }  # LTS
 tokio-stream = { version = "0.1", features = ["time"] }
 toml = "0.5"
 tough = { version = "0.12", features = ["http"] }
-tough-kms = "0.3"
-tough-ssm = "0.6"
+tough-kms = "0.4"
+tough-ssm = "0.7"
 update_metadata = { path = "../../sources/updater/update_metadata/", version = "0.1.0" }
 url = { version = "2.1.0", features = ["serde"] }
 tempfile = "3.1"

--- a/tools/pubsys/src/aws/ami/snapshot.rs
+++ b/tools/pubsys/src/aws/ami/snapshot.rs
@@ -46,6 +46,7 @@ mod error {
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
+    #[allow(clippy::large_enum_variant)]
     pub(crate) enum Error {
         #[snafu(display("Invalid image path '{}'", path.display()))]
         InvalidImagePath { path: PathBuf },

--- a/tools/pubsys/src/aws/client.rs
+++ b/tools/pubsys/src/aws/client.rs
@@ -1,92 +1,36 @@
-use async_trait::async_trait;
-use pubsys_config::AwsConfig;
-use rusoto_core::{request::DispatchSignedRequest, HttpClient, Region};
-use rusoto_credential::{
-    AutoRefreshingProvider, AwsCredentials, CredentialsError, DefaultCredentialsProvider,
-    ProfileProvider, ProvideAwsCredentials,
-};
-use rusoto_ebs::EbsClient;
-use rusoto_ec2::Ec2Client;
-use rusoto_ssm::SsmClient;
-use rusoto_sts::{StsAssumeRoleSessionCredentialsProvider, StsClient};
-use snafu::ResultExt;
+use aws_config::default_provider::credentials::default_provider;
+use aws_config::profile::ProfileFileCredentialsProvider;
+use aws_config::sts::AssumeRoleProvider;
+use aws_config::SdkConfig;
+use aws_types::credentials::SharedCredentialsProvider;
+use aws_types::region::Region;
+use pubsys_config::AwsConfig as PubsysAwsConfig;
 
-pub(crate) trait NewWith {
-    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
-    where
-        P: ProvideAwsCredentials + Send + Sync + 'static,
-        D: DispatchSignedRequest + Send + Sync + 'static;
-}
-
-impl NewWith for EbsClient {
-    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
-    where
-        P: ProvideAwsCredentials + Send + Sync + 'static,
-        D: DispatchSignedRequest + Send + Sync + 'static,
-    {
-        Self::new_with(request_dispatcher, credentials_provider, region)
-    }
-}
-
-impl NewWith for Ec2Client {
-    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
-    where
-        P: ProvideAwsCredentials + Send + Sync + 'static,
-        D: DispatchSignedRequest + Send + Sync + 'static,
-    {
-        Self::new_with(request_dispatcher, credentials_provider, region)
-    }
-}
-
-impl NewWith for SsmClient {
-    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
-    where
-        P: ProvideAwsCredentials + Send + Sync + 'static,
-        D: DispatchSignedRequest + Send + Sync + 'static,
-    {
-        Self::new_with(request_dispatcher, credentials_provider, region)
-    }
-}
-
-impl NewWith for StsClient {
-    fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
-    where
-        P: ProvideAwsCredentials + Send + Sync + 'static,
-        D: DispatchSignedRequest + Send + Sync + 'static,
-    {
-        Self::new_with(request_dispatcher, credentials_provider, region)
-    }
-}
-
-/// Create a rusoto client of the given type using the given region and configuration.
-pub(crate) fn build_client<T: NewWith>(
+/// Create an AWS client config using the given regions and pubsys config.
+pub(crate) async fn build_client_config(
     region: &Region,
     sts_region: &Region,
-    aws: &AwsConfig,
-) -> Result<T> {
-    let maybe_regional_role = aws.region.get(region.name()).and_then(|r| r.role.clone());
-    let assume_roles = aws.role.iter().chain(maybe_regional_role.iter()).cloned();
-    let provider = build_provider(
-        sts_region,
-        assume_roles.clone(),
-        base_provider(&aws.profile)?,
-    )?;
-    Ok(T::new_with(
-        rusoto_core::HttpClient::new().context(error::HttpClientSnafu)?,
-        provider,
-        region.clone(),
-    ))
-}
+    pubsys_aws_config: &PubsysAwsConfig,
+) -> SdkConfig {
+    let maybe_profile = pubsys_aws_config.profile.clone();
+    let maybe_role = pubsys_aws_config.role.clone();
+    let maybe_regional_role = pubsys_aws_config
+        .region
+        .get(region.as_ref())
+        .and_then(|r| r.role.clone());
+    let base_provider = base_provider(&maybe_profile).await;
 
-/// Wrapper for trait object that implements ProvideAwsCredentials to simplify return values.
-/// Might be able to remove if rusoto implements ProvideAwsCredentials for
-/// Box<ProvideAwsCredentials>.
-struct CredentialsProvider(Box<dyn ProvideAwsCredentials + Send + Sync + 'static>);
-#[async_trait]
-impl ProvideAwsCredentials for CredentialsProvider {
-    async fn credentials(&self) -> std::result::Result<AwsCredentials, CredentialsError> {
-        self.0.credentials().await
-    }
+    let config = match (&maybe_role, &maybe_regional_role) {
+        (None, None) => aws_config::from_env().credentials_provider(base_provider),
+        _ => {
+            let assume_roles = maybe_role.iter().chain(maybe_regional_role.iter()).cloned();
+            let provider =
+                build_provider(sts_region, assume_roles.clone(), base_provider.clone()).await;
+            aws_config::from_env().credentials_provider(provider)
+        }
+    };
+
+    config.region(region.clone()).load().await
 }
 
 /// Chains credentials providers to assume the given roles in order.
@@ -94,68 +38,34 @@ impl ProvideAwsCredentials for CredentialsProvider {
 /// credentials, not the region in which you want to talk to a service endpoint like EC2.  This is
 /// needed because you may be assuming a role in an opt-in region from an account that has not
 /// opted-in to that region, and you need to get session credentials from an STS endpoint in a
-/// region to which you have access in the base account.
-fn build_provider<P>(
+/// region to which you have access in the base account
+async fn build_provider(
     sts_region: &Region,
     assume_roles: impl Iterator<Item = String>,
-    base_provider: P,
-) -> Result<CredentialsProvider>
-where
-    P: ProvideAwsCredentials + Send + Sync + 'static,
-{
-    let mut provider = CredentialsProvider(Box::new(base_provider));
+    base_provider: SharedCredentialsProvider,
+) -> SharedCredentialsProvider {
+    let mut provider = base_provider;
     for assume_role in assume_roles {
-        let sts = StsClient::new_with(
-            HttpClient::new().context(error::HttpClientSnafu)?,
-            provider,
-            sts_region.clone(),
-        );
-        let expiring_provider = StsAssumeRoleSessionCredentialsProvider::new(
-            sts,
-            assume_role,
-            "pubsys".to_string(), // session name
-            None,                 // external ID
-            None,                 // session duration
-            None,                 // scope down policy
-            None,                 // MFA serial
-        );
-        provider = CredentialsProvider(Box::new(
-            AutoRefreshingProvider::new(expiring_provider).context(error::ProviderSnafu)?,
-        ));
+        provider = SharedCredentialsProvider::new(
+            AssumeRoleProvider::builder(assume_role)
+                .region(sts_region.clone())
+                .session_name("pubsys")
+                .build(provider.clone()),
+        )
     }
-    Ok(provider)
+    provider
 }
 
-/// If the user specified a profile, have rusoto use that, otherwise use Rusoto's default
+/// If the user specified a profile, use that, otherwise use the default
 /// credentials mechanisms.
-fn base_provider(maybe_profile: &Option<String>) -> Result<CredentialsProvider> {
+async fn base_provider(maybe_profile: &Option<String>) -> SharedCredentialsProvider {
     if let Some(profile) = maybe_profile {
-        let mut p = ProfileProvider::new().context(error::ProviderSnafu)?;
-        p.set_profile(profile);
-        Ok(CredentialsProvider(Box::new(p)))
+        SharedCredentialsProvider::new(
+            ProfileFileCredentialsProvider::builder()
+                .profile_name(profile)
+                .build(),
+        )
     } else {
-        Ok(CredentialsProvider(Box::new(
-            DefaultCredentialsProvider::new().context(error::ProviderSnafu)?,
-        )))
+        SharedCredentialsProvider::new(default_provider().await)
     }
 }
-
-pub(crate) mod error {
-    use snafu::Snafu;
-
-    #[derive(Debug, Snafu)]
-    #[snafu(visibility(pub(super)))]
-    pub(crate) enum Error {
-        #[snafu(display("Failed to create HTTP client: {}", source))]
-        HttpClient {
-            source: rusoto_core::request::TlsError,
-        },
-
-        #[snafu(display("Failed to create AWS credentials provider: {}", source))]
-        Provider {
-            source: rusoto_credential::CredentialsError,
-        },
-    }
-}
-pub(crate) use error::Error;
-type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/mod.rs
+++ b/tools/pubsys/src/aws/mod.rs
@@ -1,6 +1,5 @@
-use pubsys_config::AwsConfig;
-use rusoto_core::Region;
-use snafu::ResultExt;
+use aws_sdk_ec2::model::ArchitectureValues;
+use aws_sdk_ec2::Region;
 
 #[macro_use]
 pub(crate) mod client;
@@ -10,24 +9,16 @@ pub(crate) mod promote_ssm;
 pub(crate) mod publish_ami;
 pub(crate) mod ssm;
 
-/// Builds a Region from the given region name, and uses the custom endpoint from the AWS config,
-/// if specified in aws.region.REGION.endpoint.
-fn region_from_string(name: &str, aws: &AwsConfig) -> Result<Region> {
-    let maybe_endpoint = aws.region.get(name).and_then(|r| r.endpoint.clone());
-    Ok(match maybe_endpoint {
-        Some(endpoint) => Region::Custom {
-            name: name.to_string(),
-            endpoint,
-        },
-        None => name.parse().context(error::ParseRegionSnafu { name })?,
-    })
+/// Builds a Region from the given region name.
+fn region_from_string(name: &str) -> Region {
+    Region::new(name.to_owned())
 }
 
 /// Parses the given string as an architecture, mapping values to the ones used in EC2.
-pub(crate) fn parse_arch(input: &str) -> Result<String> {
+pub(crate) fn parse_arch(input: &str) -> Result<ArchitectureValues> {
     match input {
-        "x86_64" | "amd64" => Ok("x86_64".to_string()),
-        "arm64" | "aarch64" => Ok("arm64".to_string()),
+        "x86_64" | "amd64" => Ok(ArchitectureValues::X8664),
+        "arm64" | "aarch64" => Ok(ArchitectureValues::Arm64),
         _ => error::ParseArchSnafu {
             input,
             msg: "unknown architecture",
@@ -44,13 +35,6 @@ mod error {
     pub(crate) enum Error {
         #[snafu(display("Failed to parse arch '{}': {}", input, msg))]
         ParseArch { input: String, msg: String },
-
-        #[snafu(display("Failed to parse region '{}': {}", name, source))]
-        ParseRegion {
-            name: String,
-            source: rusoto_signature::region::ParseRegionError,
-        },
     }
 }
-pub(crate) use error::Error;
 type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ssm/template.rs
+++ b/tools/pubsys/src/aws/ssm/template.rs
@@ -3,8 +3,8 @@
 
 use super::{BuildContext, SsmKey, SsmParameters};
 use crate::aws::ami::Image;
+use aws_sdk_ssm::Region;
 use log::trace;
-use rusoto_core::Region;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt};
 use std::collections::HashMap;
@@ -95,7 +95,7 @@ pub(crate) fn render_parameters(
             image_id: &image.id,
             image_name: &image.name,
             image_version: build_context.image_version,
-            region: region.name(),
+            region: region.as_ref(),
         };
 
         for tp in &template_parameters.parameters {


### PR DESCRIPTION
**Issue number:**

#1968

**Description of changes:**

Replaces **rusoto** with **aws-sdk-for-rust** in **pubsys**.

**Testing done:**
- [x] publish ami to us-west-2
- [x] publish multiple amis with chained assumed roles (2 different accounts, 3 regions)
- [x] grant ami access
- [x] revoke ami access
- [x] publish ssm parameters
- [x] promote ssm parameters

**TUF testing done:**
_Thanks, @etungsten!_
- [x] use KMS key when creating TUF repo
- [x] check TUF repo expirations
- [x] validate TUF repo
- [x] refresh TUF repo

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
