### PR TITLE
honor environment vars for variant and arch

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,7 +2,7 @@
 skip_core_tasks = true
 
 [env]
-BUILDSYS_ARCH = { script = ["uname -m"] }
+BUILDSYS_ARCH = { script = ['echo "${BUILDSYS_ARCH:-$(uname -m)}"'] }
 BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 BUILDSYS_BUILD_DIR = "${BUILDSYS_ROOT_DIR}/build"
 BUILDSYS_PACKAGES_DIR = "${BUILDSYS_BUILD_DIR}/rpms"
@@ -18,7 +18,7 @@ BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*
 BUILDSYS_RELEASE_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Release.toml"
 BUILDSYS_VERSION_IMAGE = { script = ["awk -F '[ =\"]+' '$1 == \"version\" {print $2}' ${BUILDSYS_RELEASE_CONFIG_PATH}"] }
 # This can be overridden with -e to build a different variant from the variants/ directory
-BUILDSYS_VARIANT = "aws-k8s-1.21"
+BUILDSYS_VARIANT = { script = ['echo "${BUILDSYS_VARIANT:-aws-k8s-1.21}"'] }
 # Product name used for file and directory naming
 BUILDSYS_NAME = "bottlerocket"
 # "Pretty" name used to identify OS in os-release, bootloader, etc.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,7 +18,7 @@ BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*
 BUILDSYS_RELEASE_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Release.toml"
 BUILDSYS_VERSION_IMAGE = { script = ["awk -F '[ =\"]+' '$1 == \"version\" {print $2}' ${BUILDSYS_RELEASE_CONFIG_PATH}"] }
 # This can be overridden with -e to build a different variant from the variants/ directory
-BUILDSYS_VARIANT = { script = ['echo "${BUILDSYS_VARIANT:-aws-k8s-1.21}"'] }
+BUILDSYS_VARIANT = { script = ['echo "${BUILDSYS_VARIANT:-aws-k8s-1.23}"'] }
 # Product name used for file and directory naming
 BUILDSYS_NAME = "bottlerocket"
 # "Pretty" name used to identify OS in os-release, bootloader, etc.


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
If `BUILDSYS_VARIANT` or `BUILDSYS_ARCH` are set in the environment, use those values instead of the defaults.

Also update the default variant to `aws-k8s-1.23`, since it hasn't been updated in over a year.

**Testing done:**
Verified that the environment variables are used automatically in invocations like:
```
# builds aws-ecs-1 for aarch64 on an x86_64 build host
(export BUILDSYS_VARIANT=aws-ecs-1 BUILDSYS_ARCH=aarch64 ; cargo make && cargo make ami)
```

Verified that the overrides are used if specified:
```
# builds aws-dev for x86_64
(export BUILDSYS_VARIANT=aws-ecs-1 BUILDSYS_ARCH=aarch64 ; cargo make -e BUILDSYS_ARCH=x86_64 -e BUILDSYS_VARIANT=aws-dev)
```

Verified that the defaults are still used if the environment variables are unset.
```
# builds aws-k8s-1.23 for x86_64
cargo make
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
