### PR TITLE
sync file timestamps for module bundle

### DIFF
--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -67,6 +67,7 @@ popd
 
 tar czf __OUTPUT__ "${targetdir}"/vendor
 rm -rf "${targetdir}"
+touch -r __LOCAL_FILE_NAME__ __OUTPUT__
 "###;
 
 impl GoMod {

--- a/tools/buildsys/src/gomod/error.rs
+++ b/tools/buildsys/src/gomod/error.rs
@@ -28,6 +28,30 @@ pub(crate) enum Error {
         var: String,
         source: std::env::VarError,
     },
+
+    #[snafu(display("Failed to create '{}': {}", path.display(), source))]
+    CreateFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to set permissions on '{}': {}", path.display(), source))]
+    SetFilePermissions {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to write contents to '{}': {}", path.display(), source))]
+    WriteFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to remove '{}': {}", path.display(), source))]
+    RemoveFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 }
 
 pub(super) type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
**Issue number:**
Fixes #2429

**Description of changes:**
Avoid spurious rebuilds by syncing the bundle's timestamp with the input file.

Also, replace all `unwrap()` calls with structured errors that have context-specific messages. 


**Testing done:**
Repeated `cargo make` invocations no longer cause an unnecessary rebuild.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
