### PR TITLE
k8s: increase the kube-api-server QPS from 5/10 to 10/20

### DIFF
--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -56,12 +56,8 @@ eventRecordQPS: {{settings.kubernetes.event-qps}}
 {{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{/if}}
-{{#if settings.kubernetes.kube-api-qps includeZero=true}}
-kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{/if}}
-{{#if settings.kubernetes.kube-api-burst includeZero=true}}
-kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{/if}}
+kubeAPIQPS: {{default 10 settings.kubernetes.kube-api-qps}}
+kubeAPIBurst: {{default 20 settings.kubernetes.kube-api-burst}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{#if settings.kubernetes.kube-reserved.memory}}

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -56,12 +56,8 @@ eventRecordQPS: {{settings.kubernetes.event-qps}}
 {{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{/if}}
-{{#if settings.kubernetes.kube-api-qps includeZero=true}}
-kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{/if}}
-{{#if settings.kubernetes.kube-api-burst includeZero=true}}
-kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{/if}}
+kubeAPIQPS: {{default 10 settings.kubernetes.kube-api-qps}}
+kubeAPIBurst: {{default 20 settings.kubernetes.kube-api-burst}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{#if settings.kubernetes.kube-reserved.memory}}


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This changes the default setting for EKS v1.22+ where API Priority & Fairness is available and there is a specific queue for kubelet health.

**Testing done:**

`cargo make unit-tests` and 

- Built a custom K8s v1.23 Bottlerocket AMI
- Launched a node using that AMI
- Verified that the config changes were applied by logging in via SSM
```
bash-5.1# cat /etc/kubernetes/kubelet/config  | grep kubeAPI
kubeAPIQPS: 10
kubeAPIBurst: 20
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
