### PR TITLE
ecs-gpu-init: Upgrade Go module `go` directive to 1.18

### DIFF
--- a/sources/ecs-gpu-init/go.mod
+++ b/sources/ecs-gpu-init/go.mod
@@ -1,5 +1,5 @@
 module ecs-gpu-init
 
-go 1.16
+go 1.18
 
 require github.com/NVIDIA/go-nvml v0.11.6-0


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

### Issue number:

Related: https://github.com/bottlerocket-os/bottlerocket/issues/2420

### Description of changes:

This upgrades the Go build directive in the go module for `ecs-gpu-init` to reflect the version we use in the SDK. Should be a very low risk change and [Go 1.16 has been out of support for awhile now](https://endoflife.date/go)

### Testing done:

Able to build Go the code: `go build ./cmd/ecs-gpu-init`  👍🏼 
Able to build the package: `cargo make -e PACKAGE=ecs-gpu-init pacakge` 👍🏼 

Not sure if this requires more extensive testing since it builds ok

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
