### PR TITLE
lint: Remove unnecessary return

### DIFF
--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -391,11 +391,9 @@ impl AwsEcs {
         testsys_images: &TestsysImages,
     ) -> Result<Vec<Crd>> {
         match test {
-            TestType::Conformance => {
-                return Err(anyhow!(
-                    "Conformance testing for ECS variants is not supported."
-                ))
-            }
+            TestType::Conformance => Err(anyhow!(
+                "Conformance testing for ECS variants is not supported."
+            )),
             TestType::Quick => self.ecs_test_crds(testsys_images),
             TestType::Migration => self.migration_test_crds(testsys_images).await,
         }


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

With the 1.63.0 versions of rustc/cargo, there is a clippy error due to `return` being used when it is not needed. This removes the return statement to make the linter happy.

**Testing done:**

Local build to make sure everything was still happy.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
