### PR TITLE
Revert "modeled_types: Use FromStr instead of TryFrom"

### DIFF
--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -563,9 +563,8 @@ mod test {
     use datastore::memory::MemoryDataStore;
     use datastore::{Committed, DataStore, Key, KeyType};
     use maplit::{hashmap, hashset};
-    use model::modeled_types::SingleLineString;
     use model::{ConfigurationFile, Service};
-    use std::str::FromStr;
+    use std::convert::TryInto;
 
     #[test]
     fn get_settings_works() {
@@ -580,10 +579,7 @@ mod test {
 
         // Retrieve with helper
         let settings = get_settings(&ds, &Committed::Live).unwrap();
-        assert_eq!(
-            settings.motd,
-            Some(("json string").parse::<String>().unwrap())
-        );
+        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
     }
 
     #[test]
@@ -601,19 +597,13 @@ mod test {
         let settings = get_settings_prefix(&ds, "settings.", &Committed::Live)
             .unwrap() // Result Ok
             .unwrap(); // got Some result
-        assert_eq!(
-            settings.motd,
-            Some(("json string").parse::<String>().unwrap())
-        );
+        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
 
         // Retrieve with more specific prefix OK
         let settings = get_settings_prefix(&ds, "settings.mot", &Committed::Live)
             .unwrap() // Result Ok
             .unwrap(); // got Some result
-        assert_eq!(
-            settings.motd,
-            Some(("json string").parse::<String>().unwrap())
-        );
+        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
 
         // No match should return None; the "view" layer of the API, in mod.rs, turns this into an
         // empty object if desired.
@@ -646,10 +636,7 @@ mod test {
         // Retrieve with helper
         let settings =
             get_settings_keys(&ds, &hashset!("settings.motd"), &Committed::Live).unwrap();
-        assert_eq!(
-            settings.motd,
-            Some(("json string 1").parse::<String>().unwrap())
-        );
+        assert_eq!(settings.motd, Some("json string 1".try_into().unwrap()));
         assert_eq!(settings.ntp, None);
     }
 
@@ -676,7 +663,7 @@ mod test {
         assert_eq!(
             services,
             hashmap!("foo".to_string() => Service {
-                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap()],
+                configuration_files: vec!["file1".try_into().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             })
         );
@@ -707,7 +694,7 @@ mod test {
         assert_eq!(
             services,
             hashmap!("foo".to_string() => Service {
-                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap()],
+                configuration_files: vec!["file1".try_into().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             })
         );
@@ -748,8 +735,8 @@ mod test {
         assert_eq!(
             configuration_files,
             hashmap!("foo".to_string() => ConfigurationFile {
-                path: ("file").parse::<SingleLineString>().unwrap(),
-                template_path: ("template").parse::<SingleLineString>().unwrap(),
+                path: "file".try_into().unwrap(),
+                template_path: "template".try_into().unwrap(),
             })
         );
 
@@ -767,7 +754,7 @@ mod test {
     #[test]
     fn set_settings_works() {
         let mut settings = Settings::default();
-        settings.motd = Some(("tz").parse::<String>().unwrap());
+        settings.motd = Some("tz".try_into().unwrap());
 
         // Set with helper
         let mut ds = MemoryDataStore::new();
@@ -845,10 +832,7 @@ mod test {
 
         // Confirm pending
         let settings = get_settings(&ds, &pending).unwrap();
-        assert_eq!(
-            settings.motd,
-            Some(("json string").parse::<String>().unwrap())
-        );
+        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
         // No live settings yet
         get_settings(&ds, &Committed::Live).unwrap_err();
 
@@ -859,9 +843,6 @@ mod test {
         get_settings(&ds, &pending).unwrap_err();
         // Confirm live
         let settings = get_settings(&ds, &Committed::Live).unwrap();
-        assert_eq!(
-            settings.motd,
-            Some(("json string").parse::<String>().unwrap())
-        );
+        assert_eq!(settings.motd, Some("json string".try_into().unwrap()));
     }
 }

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -80,6 +80,7 @@ use datastore::{serialize_scalar, Key, KeyType};
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Write;
@@ -242,8 +243,7 @@ fn parse_mark_bootstrap_args(args: Vec<String>) -> Result<Subcommand> {
     Ok(Subcommand::MarkBootstrap(MarkBootstrapArgs {
         container_id: container_id,
         // Fail if 'mode' is invalid
-        mode: mode
-            .parse::<BootstrapContainerMode>()
+        mode: BootstrapContainerMode::try_from(mode.to_string())
             .context(error::BootstrapContainerModeSnafu)?,
     }))
 }

--- a/sources/api/certdog/src/main.rs
+++ b/sources/api/certdog/src/main.rs
@@ -301,8 +301,8 @@ mod test_certdog {
     use model;
     use model::modeled_types::{Identifier, PemCertificateString};
     use std::collections::HashMap;
+    use std::convert::TryFrom;
     use std::fs::File;
-    use std::str::FromStr;
 
     static TEST_PEM: &str = include_str!("../../../models/tests/data/test-pem");
 
@@ -310,23 +310,23 @@ mod test_certdog {
     fn bundles_splitted() {
         let mut bundle = HashMap::new();
         bundle.insert(
-            ("trusted").parse::<Identifier>().unwrap(),
+            Identifier::try_from("trusted").unwrap(),
             model::PemCertificate {
-                data: Some(PemCertificateString::from_str(TEST_PEM).unwrap()),
+                data: Some(PemCertificateString::try_from(TEST_PEM).unwrap()),
                 trusted: Some(true),
             },
         );
         bundle.insert(
-            ("distrusted").parse::<Identifier>().unwrap(),
+            Identifier::try_from("distrusted").unwrap(),
             model::PemCertificate {
-                data: Some(PemCertificateString::from_str(TEST_PEM).unwrap()),
+                data: Some(PemCertificateString::try_from(TEST_PEM).unwrap()),
                 trusted: Some(false),
             },
         );
         bundle.insert(
-            ("distrusted-without-flag").parse::<Identifier>().unwrap(),
+            Identifier::try_from("distrusted-without-flag").unwrap(),
             model::PemCertificate {
-                data: Some(PemCertificateString::from_str(TEST_PEM).unwrap()),
+                data: Some(PemCertificateString::try_from(TEST_PEM).unwrap()),
                 trusted: None,
             },
         );

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -16,7 +16,6 @@ use snafu::{OptionExt, ResultExt};
 use std::convert::TryFrom;
 use std::fs;
 use std::path::Path;
-use std::str::FromStr;
 use std::{env, process};
 
 const DEFAULT_ECS_CONFIG_PATH: &str = "/etc/ecs/ecs.config.json";
@@ -113,7 +112,7 @@ async fn run() -> Result<()> {
         image_pull_behavior: ecs
             .image_pull_behavior
             .as_ref()
-            .map(|b| b.parse::<ECSImagePullBehavior>().unwrap() as u8),
+            .map(|b| ECSImagePullBehavior::try_from(b.as_ref()).unwrap() as u8),
 
         // Task role support is always enabled
         task_iam_role_enabled: true,

--- a/sources/api/prairiedog/src/bootconfig.rs
+++ b/sources/api/prairiedog/src/bootconfig.rs
@@ -5,8 +5,8 @@ use model::modeled_types::{BootConfigKey, BootConfigValue};
 use model::BootSettings;
 use snafu::{ensure, ResultExt};
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::path::Path;
-use std::str::FromStr;
 use tokio::io;
 
 // Boot config related consts
@@ -142,8 +142,7 @@ fn parse_value(input: &str) -> Result<BootConfigValue> {
     } else {
         input
     };
-    s.parse::<BootConfigValue>()
-        .context(error::ParseBootConfigValueSnafu)
+    s.try_into().context(error::ParseBootConfigValueSnafu)
 }
 
 /// Takes a string and parse it into a list of valid bootconfig values
@@ -194,29 +193,30 @@ fn parse_boot_config_to_boot_settings(bootconfig: &str) -> Result<BootSettings> 
     for line in bootconfig.trim().lines() {
         let mut kv = line.trim().split('=').map(|kv| kv.trim());
         // Ensure the key is a valid boot config key
-        let key: BootConfigKey = (kv.next().ok_or(error::Error::InvalidBootConfig)?)
-            .parse::<BootConfigKey>()
+        let key: BootConfigKey = kv
+            .next()
+            .ok_or(error::Error::InvalidBootConfig)?
+            .try_into()
             .context(error::ParseBootConfigKeySnafu)?;
         let values = parse_boot_config_values(kv.next().ok_or(error::Error::InvalidBootConfig)?)?;
 
         if key != "kernel" && key.starts_with("kernel") {
             kernel_params.insert(
-                (&key["kernel.".len()..])
-                    .parse::<BootConfigKey>()
+                key["kernel.".len()..]
+                    .try_into()
                     .context(error::ParseBootConfigKeySnafu)?,
                 values,
             );
         } else if key != "init" && key.starts_with("init") {
             init_params.insert(
-                (&key["init.".len()..])
-                    .parse::<BootConfigKey>()
+                key["init.".len()..]
+                    .try_into()
                     .context(error::ParseBootConfigKeySnafu)?,
                 values,
             );
         } else if key == "kernel" || key == "init" {
-            let empty_value_list: Vec<BootConfigValue> = vec![("")
-                .parse::<BootConfigValue>()
-                .context(error::ParseBootConfigValueSnafu)?];
+            let empty_value_list: Vec<BootConfigValue> =
+                vec!["".try_into().context(error::ParseBootConfigValueSnafu)?];
             // `BootSettings` does not support `kernel` or `init` as parent keys to non-null values.
             if values != empty_value_list {
                 return error::ParentBootConfigKeySnafu.fail();
@@ -256,11 +256,10 @@ mod boot_settings_tests {
         DEFAULT_BOOTCONFIG_STR,
     };
     use maplit::hashmap;
-    use model::modeled_types::{BootConfigKey, BootConfigValue};
     use model::BootSettings;
     use serde_json::json;
     use serde_json::value::Value;
-    use std::str::FromStr;
+    use std::convert::TryInto;
 
     #[test]
     fn boot_settings_to_string() {
@@ -272,10 +271,8 @@ mod boot_settings_tests {
                 .into_iter()
                 .map(|(k, v)| {
                     (
-                        k.parse::<BootConfigKey>().unwrap(),
-                        v.into_iter()
-                            .map(|s| s.parse::<BootConfigValue>().unwrap())
-                            .collect(),
+                        k.try_into().unwrap(),
+                        v.into_iter().map(|s| s.try_into().unwrap()).collect(),
                     )
                 })
                 .collect(),
@@ -289,10 +286,8 @@ mod boot_settings_tests {
                 .into_iter()
                 .map(|(k, v)| {
                     (
-                        k.parse::<BootConfigKey>().unwrap(),
-                        v.into_iter()
-                            .map(|s| s.parse::<BootConfigValue>().unwrap())
-                            .collect(),
+                        k.try_into().unwrap(),
+                        v.into_iter().map(|s| s.try_into().unwrap()).collect(),
                     )
                 })
                 .collect(),
@@ -342,10 +337,8 @@ mod boot_settings_tests {
                 .into_iter()
                 .map(|(k, v)| {
                     (
-                        k.parse::<BootConfigKey>().unwrap(),
-                        v.into_iter()
-                            .map(|s| s.parse::<BootConfigValue>().unwrap())
-                            .collect(),
+                        k.try_into().unwrap(),
+                        v.into_iter().map(|s| s.try_into().unwrap()).collect(),
                     )
                 })
                 .collect(),

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -15,6 +15,7 @@ use semver::Version;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 use std::io;
 use std::path::Path;
 use std::str::FromStr;
@@ -185,12 +186,10 @@ fn parse_metadata_toml(md_toml_val: toml::Value) -> Result<Vec<model::Metadata>>
                 );
 
                 // Ensure the metadata/data keys don't contain newline chars
-                let md = md_key
-                    .parse::<SingleLineString>()
-                    .context(error::SingleLineStringSnafu)?;
-                let key = data_key
-                    .parse::<SingleLineString>()
-                    .context(error::SingleLineStringSnafu)?;
+                let md =
+                    SingleLineString::try_from(md_key).context(error::SingleLineStringSnafu)?;
+                let key =
+                    SingleLineString::try_from(data_key).context(error::SingleLineStringSnafu)?;
 
                 // Create the Metadata struct
                 def_metadatas.push(model::Metadata { key, md, val })

--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -165,17 +165,17 @@ mod test {
     use super::*;
     use crate::service::Services;
     use maplit::{hashmap, hashset};
-    use model::modeled_types::SingleLineString;
+    use std::convert::TryInto;
 
     #[test]
     fn test_get_config_file_names() {
         let input_map = hashmap!(
             "foo".to_string() => model::Service {
-                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap()],
+                configuration_files: vec!["file1".try_into().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             },
             "bar".to_string() => model::Service {
-                configuration_files: vec![("file1").parse::<SingleLineString>().unwrap(), ("file2").parse::<SingleLineString>().unwrap()],
+                configuration_files: vec!["file1".try_into().unwrap(), "file2".try_into().unwrap()],
                 restart_commands: vec!["echo hi".to_string()]
             },
         );

--- a/sources/models/src/de.rs
+++ b/sources/models/src/de.rs
@@ -3,6 +3,7 @@ use serde::de::value::SeqAccessDeserializer;
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::fmt::Formatter;
 use toml::Value;
 
@@ -34,8 +35,7 @@ where
                     Value::String(taint_val) => {
                         node_taints.insert(
                             k,
-                            vec![taint_val
-                                .parse::<KubernetesTaintValue>()
+                            vec![KubernetesTaintValue::try_from(taint_val)
                                 .map_err(M::Error::custom)?],
                         );
                     }
@@ -65,6 +65,7 @@ where
 #[cfg(test)]
 mod node_taint_tests {
     use crate::{KubernetesSettings, KubernetesTaintValue};
+    use std::convert::TryFrom;
     static TEST_NODE_TAINT_LIST: &str = include_str!("../tests/data/node-taint-list-val");
     static TEST_NODE_TAINT_SINGLE: &str = include_str!("../tests/data/node-taint-single-val");
     static TEST_NODE_TAINT_EMPTY_LIST: &str = include_str!("../tests/data/node-taint-empty-list");
@@ -81,12 +82,8 @@ mod node_taint_tests {
                 .unwrap()
                 .to_owned(),
             vec![
-                ("value1:NoSchedule")
-                    .parse::<KubernetesTaintValue>()
-                    .unwrap(),
-                ("value1:NoExecute")
-                    .parse::<KubernetesTaintValue>()
-                    .unwrap()
+                KubernetesTaintValue::try_from("value1:NoSchedule").unwrap(),
+                KubernetesTaintValue::try_from("value1:NoExecute").unwrap()
             ]
         );
         assert_eq!(
@@ -97,9 +94,7 @@ mod node_taint_tests {
                 .get("key2")
                 .unwrap()
                 .to_owned(),
-            vec![("value2:NoSchedule")
-                .parse::<KubernetesTaintValue>()
-                .unwrap()]
+            vec![KubernetesTaintValue::try_from("value2:NoSchedule").unwrap()]
         );
     }
 
@@ -114,9 +109,7 @@ mod node_taint_tests {
                 .get("key1")
                 .unwrap()
                 .to_owned(),
-            vec![("value1:NoSchedule")
-                .parse::<KubernetesTaintValue>()
-                .unwrap()]
+            vec![KubernetesTaintValue::try_from("value1:NoSchedule").unwrap()]
         );
         assert_eq!(
             k8s_settings
@@ -126,9 +119,7 @@ mod node_taint_tests {
                 .get("key2")
                 .unwrap()
                 .to_owned(),
-            vec![("value2:NoExecute")
-                .parse::<KubernetesTaintValue>()
-                .unwrap()]
+            vec![KubernetesTaintValue::try_from("value2:NoExecute").unwrap()]
         );
     }
 

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -10,7 +10,6 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::net::IpAddr;
 use std::ops::Deref;
-use std::str::FromStr;
 
 // Declare constant values usable by any type
 const IMAGE_GC_THRESHOLD_MAX: i32 = 100;
@@ -28,10 +27,10 @@ lazy_static! {
     pub(crate) static ref KUBERNETES_NAME: Regex = Regex::new(r"^[0-9a-z.-]{1,253}$").unwrap();
 }
 
-impl FromStr for KubernetesName {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesName {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             KUBERNETES_NAME.is_match(input),
             error::PatternSnafu {
@@ -51,18 +50,19 @@ string_impls_for!(KubernetesName, "KubernetesName");
 #[cfg(test)]
 mod test_kubernetes_name {
     use super::KubernetesName;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_names() {
         for ok in &["howdy", "42", "18-eighteen."] {
-            ok.parse::<KubernetesName>().unwrap();
+            KubernetesName::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_names() {
         for err in &["", "HOWDY", "@", "hi/there", &"a".repeat(254)] {
-            err.parse::<KubernetesName>().unwrap_err();
+            KubernetesName::try_from(*err).unwrap_err();
         }
     }
 }
@@ -93,10 +93,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl FromStr for KubernetesLabelKey {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesLabelKey {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             KUBERNETES_LABEL_KEY.is_match(input),
             error::BigPatternSnafu {
@@ -115,6 +115,7 @@ string_impls_for!(KubernetesLabelKey, "KubernetesLabelKey");
 #[cfg(test)]
 mod test_kubernetes_label_key {
     use super::KubernetesLabelKey;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_keys() {
@@ -125,7 +126,7 @@ mod test_kubernetes_label_key {
             &"a".repeat(63),
             &format!("{}/{}", "a".repeat(253), "name"),
         ] {
-            ok.parse::<KubernetesLabelKey>().unwrap();
+            KubernetesLabelKey::try_from(*ok).unwrap();
         }
     }
 
@@ -137,7 +138,7 @@ mod test_kubernetes_label_key {
             &"a".repeat(64),
             &format!("{}/{}", "a".repeat(254), "name"),
         ] {
-            err.parse::<KubernetesLabelKey>().unwrap_err();
+            KubernetesLabelKey::try_from(*err).unwrap_err();
         }
     }
 }
@@ -168,10 +169,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl FromStr for KubernetesLabelValue {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesLabelValue {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             KUBERNETES_LABEL_VALUE.is_match(input),
             error::BigPatternSnafu {
@@ -190,18 +191,19 @@ string_impls_for!(KubernetesLabelValue, "KubernetesLabelValue");
 #[cfg(test)]
 mod test_kubernetes_label_value {
     use super::KubernetesLabelValue;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_values() {
         for ok in &["", "more-chars_here.now", &"a".repeat(63)] {
-            ok.parse::<KubernetesLabelValue>().unwrap();
+            KubernetesLabelValue::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_values() {
         for err in &[".bad", "bad.", &"a".repeat(64)] {
-            err.parse::<KubernetesLabelValue>().unwrap_err();
+            KubernetesLabelValue::try_from(*err).unwrap_err();
         }
     }
 }
@@ -240,10 +242,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl FromStr for KubernetesTaintValue {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesTaintValue {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             KUBERNETES_TAINT_VALUE.is_match(input),
             error::BigPatternSnafu {
@@ -262,6 +264,7 @@ string_impls_for!(KubernetesTaintValue, "KubernetesTaintValue");
 #[cfg(test)]
 mod test_kubernetes_taint_value {
     use super::KubernetesTaintValue;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_values() {
@@ -274,7 +277,7 @@ mod test_kubernetes_taint_value {
             "a:NoSchedule",
             "a-b:NoSchedule",
         ] {
-            ok.parse::<KubernetesTaintValue>().unwrap();
+            KubernetesTaintValue::try_from(*ok).unwrap();
         }
     }
 
@@ -289,7 +292,7 @@ mod test_kubernetes_taint_value {
             "-a:NoSchedule",
             "a-:NoSchedule",
         ] {
-            err.parse::<KubernetesTaintValue>().unwrap_err();
+            KubernetesTaintValue::try_from(*err).unwrap_err();
         }
     }
 }
@@ -306,10 +309,10 @@ pub struct KubernetesClusterName {
     inner: String,
 }
 
-impl FromStr for KubernetesClusterName {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesClusterName {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             !input.is_empty(),
             error::InvalidClusterNameSnafu {
@@ -318,7 +321,7 @@ impl FromStr for KubernetesClusterName {
             }
         );
         ensure!(
-            input.parse::<KubernetesLabelValue>().is_ok(),
+            KubernetesLabelValue::try_from(input).is_ok(),
             error::InvalidClusterNameSnafu {
                 name: input,
                 msg: "cluster names must be valid Kubernetes label values"
@@ -336,18 +339,19 @@ string_impls_for!(KubernetesClusterName, "KubernetesClusterName");
 #[cfg(test)]
 mod test_kubernetes_cluster_name {
     use super::KubernetesClusterName;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_cluster_names() {
         for ok in &["more-chars_here.now", &"a".repeat(63)] {
-            ok.parse::<KubernetesClusterName>().unwrap();
+            KubernetesClusterName::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_values() {
         for err in &["", ".bad", "bad.", &"a".repeat(64)] {
-            err.parse::<KubernetesClusterName>().unwrap_err();
+            KubernetesClusterName::try_from(*err).unwrap_err();
         }
     }
 }
@@ -361,10 +365,10 @@ pub struct KubernetesAuthenticationMode {
     inner: String,
 }
 
-impl FromStr for KubernetesAuthenticationMode {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesAuthenticationMode {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         ensure!(
             matches!(input, "aws" | "tls"),
             error::InvalidAuthenticationModeSnafu { input }
@@ -380,18 +384,19 @@ string_impls_for!(KubernetesAuthenticationMode, "KubernetesAuthenticationMode");
 #[cfg(test)]
 mod test_kubernetes_authentication_mode {
     use super::KubernetesAuthenticationMode;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_modes() {
         for ok in &["aws", "tls"] {
-            ok.parse::<KubernetesAuthenticationMode>().unwrap();
+            KubernetesAuthenticationMode::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_modes() {
         for err in &["", "anonymous"] {
-            err.parse::<KubernetesAuthenticationMode>().unwrap_err();
+            KubernetesAuthenticationMode::try_from(*err).unwrap_err();
         }
     }
 }
@@ -411,10 +416,10 @@ lazy_static! {
         Regex::new(r"^[a-z0-9]{6}\.[a-z0-9]{16}$").unwrap();
 }
 
-impl FromStr for KubernetesBootstrapToken {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesBootstrapToken {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             KUBERNETES_BOOTSTRAP_TOKEN.is_match(input),
             error::PatternSnafu {
@@ -434,18 +439,19 @@ string_impls_for!(KubernetesBootstrapToken, "KubernetesBootstrapToken");
 #[cfg(test)]
 mod test_kubernetes_bootstrap_token {
     use super::KubernetesBootstrapToken;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_tokens() {
         for ok in &["abcdef.0123456789abcdef", "07401b.f395accd246ae52d"] {
-            ok.parse::<KubernetesBootstrapToken>().unwrap();
+            KubernetesBootstrapToken::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_names() {
         for err in &["", "ABCDEF.0123456789ABCDEF", "secret", &"a".repeat(23)] {
-            err.parse::<KubernetesBootstrapToken>().unwrap_err();
+            KubernetesBootstrapToken::try_from(*err).unwrap_err();
         }
     }
 }
@@ -477,11 +483,11 @@ enum EvictionSignal {
     PidAvailable,
 }
 
-impl FromStr for KubernetesEvictionHardKey {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesEvictionHardKey {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str::<EvictionSignal>(input).context(error::InvalidPlainValueSnafu {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<EvictionSignal>(&input).context(error::InvalidPlainValueSnafu {
             field: "Eviction Hard key",
         })?;
         Ok(KubernetesEvictionHardKey {
@@ -494,6 +500,7 @@ string_impls_for!(KubernetesEvictionHardKey, "KubernetesEvictionHardKey");
 #[cfg(test)]
 mod test_kubernetes_eviction_hard_key {
     use super::KubernetesEvictionHardKey;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_eviction_hard_key() {
@@ -505,14 +512,14 @@ mod test_kubernetes_eviction_hard_key {
             "imagefs.inodesFree",
             "pid.available",
         ] {
-            ok.parse::<KubernetesEvictionHardKey>().unwrap();
+            KubernetesEvictionHardKey::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_eviction_hard_key() {
         for err in &["", "storage.available", ".bad", "bad.", &"a".repeat(64)] {
-            err.parse::<KubernetesEvictionHardKey>().unwrap_err();
+            KubernetesEvictionHardKey::try_from(*err).unwrap_err();
         }
     }
 }
@@ -542,10 +549,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl FromStr for KubernetesThresholdValue {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesThresholdValue {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         if input.ends_with("%") {
             let input_f32 = input[..input.len() - 1]
                 .parse::<f32>()
@@ -575,13 +582,14 @@ string_impls_for!(KubernetesThresholdValue, "KubernetesThresholdValue");
 #[cfg(test)]
 mod test_kubernetes_threshold_value {
     use super::KubernetesThresholdValue;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_kubernetes_threshold_value() {
         for ok in &[
             "10%", "129e6", "10Mi", "1024M", "1Gi", "120Ki", "1Ti", "1000n", "100m",
         ] {
-            ok.parse::<KubernetesThresholdValue>().unwrap();
+            KubernetesThresholdValue::try_from(*ok).unwrap();
         }
     }
 
@@ -597,7 +605,7 @@ mod test_kubernetes_threshold_value {
             "1000i",
             &"a".repeat(64),
         ] {
-            err.parse::<KubernetesThresholdValue>().unwrap_err();
+            KubernetesThresholdValue::try_from(*err).unwrap_err();
         }
     }
 }
@@ -622,11 +630,11 @@ enum ReservedResources {
     EphemeralStorage,
 }
 
-impl FromStr for KubernetesReservedResourceKey {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesReservedResourceKey {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str::<ReservedResources>(input).context(
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<ReservedResources>(&input).context(
             error::InvalidPlainValueSnafu {
                 field: "Reserved sources key",
             },
@@ -644,18 +652,19 @@ string_impls_for!(
 #[cfg(test)]
 mod test_reserved_resources_key {
     use super::KubernetesReservedResourceKey;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_reserved_resources_key() {
         for ok in &["cpu", "memory", "ephemeral-storage"] {
-            ok.parse::<KubernetesReservedResourceKey>().unwrap();
+            KubernetesReservedResourceKey::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_reserved_resources_key() {
         for err in &["", "cpa", ".bad", "bad.", &"a".repeat(64)] {
-            err.parse::<KubernetesReservedResourceKey>().unwrap_err();
+            KubernetesReservedResourceKey::try_from(*err).unwrap_err();
         }
     }
 }
@@ -670,10 +679,10 @@ pub struct KubernetesQuantityValue {
     inner: String,
 }
 
-impl FromStr for KubernetesQuantityValue {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesQuantityValue {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             KUBERNETES_QUANTITY.is_match(input),
             error::PatternSnafu {
@@ -693,13 +702,14 @@ string_impls_for!(KubernetesQuantityValue, "KubernetesQuantityValue");
 #[cfg(test)]
 mod test_kubernetes_quantity_value {
     use super::KubernetesQuantityValue;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_kubernetes_quantity_value() {
         for ok in &[
             "129e6", "10Mi", "1024M", "1Gi", "120Ki", "1Ti", "1000n", "100m",
         ] {
-            ok.parse::<KubernetesQuantityValue>().unwrap();
+            KubernetesQuantityValue::try_from(*ok).unwrap();
         }
     }
 
@@ -716,7 +726,7 @@ mod test_kubernetes_quantity_value {
             "1000i",
             &"a".repeat(64),
         ] {
-            err.parse::<KubernetesQuantityValue>().unwrap_err();
+            KubernetesQuantityValue::try_from(*err).unwrap_err();
         }
     }
 }
@@ -730,10 +740,10 @@ pub struct KubernetesCloudProvider {
     inner: String,
 }
 
-impl FromStr for KubernetesCloudProvider {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesCloudProvider {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         // Kubelet expects the empty string to be double-quoted when be passed to `--cloud-provider`
         let cloud_provider = if input.is_empty() { "\"\"" } else { input };
         ensure!(
@@ -753,18 +763,19 @@ string_impls_for!(KubernetesCloudProvider, "KubernetesCloudProvider");
 #[cfg(test)]
 mod test_kubernetes_cloud_provider {
     use super::KubernetesCloudProvider;
+    use std::convert::TryFrom;
 
     #[test]
     fn allowed_providers() {
         for ok in &["aws", "external", "\"\"", ""] {
-            ok.parse::<KubernetesCloudProvider>().unwrap();
+            KubernetesCloudProvider::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn disallowed_providers() {
         for err in &["internal"] {
-            err.parse::<KubernetesCloudProvider>().unwrap_err();
+            KubernetesCloudProvider::try_from(*err).unwrap_err();
         }
     }
 }
@@ -785,11 +796,11 @@ enum ValidCpuManagerPolicy {
     None,
 }
 
-impl FromStr for CpuManagerPolicy {
-    type Err = error::Error;
+impl TryFrom<&str> for CpuManagerPolicy {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str::<ValidCpuManagerPolicy>(input)
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<ValidCpuManagerPolicy>(&input)
             .context(error::InvalidCpuManagerPolicySnafu { input })?;
         Ok(CpuManagerPolicy {
             inner: input.to_string(),
@@ -801,18 +812,19 @@ string_impls_for!(CpuManagerPolicy, "CpuManagerPolicy");
 #[cfg(test)]
 mod test_cpu_manager_policy {
     use super::CpuManagerPolicy;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_cpu_manager_policy() {
         for ok in &["static", "none"] {
-            ok.parse::<CpuManagerPolicy>().unwrap();
+            CpuManagerPolicy::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_cpu_manager_policy() {
         for err in &["", "bad", "100", &"a".repeat(64)] {
-            err.parse::<CpuManagerPolicy>().unwrap_err();
+            CpuManagerPolicy::try_from(*err).unwrap_err();
         }
     }
 }
@@ -832,10 +844,10 @@ lazy_static! {
     .unwrap();
 }
 
-impl FromStr for KubernetesDurationValue {
-    type Err = error::Error;
+impl TryFrom<&str> for KubernetesDurationValue {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             !input.is_empty(),
             error::InvalidKubernetesDurationValueSnafu { input }
@@ -855,6 +867,7 @@ string_impls_for!(KubernetesDurationValue, "KubernetesDurationValue");
 #[cfg(test)]
 mod test_kubernetes_duration_value {
     use super::KubernetesDurationValue;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_tokens() {
@@ -868,7 +881,7 @@ mod test_kubernetes_duration_value {
             "2h3s10ms",
             "1.5h3.5m",
         ] {
-            ok.parse::<KubernetesDurationValue>().unwrap();
+            KubernetesDurationValue::try_from(*ok).unwrap();
         }
     }
 
@@ -884,7 +897,7 @@ mod test_kubernetes_duration_value {
             "9ns",
             &"a".repeat(23),
         ] {
-            err.parse::<KubernetesDurationValue>().unwrap_err();
+            KubernetesDurationValue::try_from(*err).unwrap_err();
         }
     }
 }
@@ -905,11 +918,11 @@ enum ValidTopologyManagerScope {
     Pod,
 }
 
-impl FromStr for TopologyManagerScope {
-    type Err = error::Error;
+impl TryFrom<&str> for TopologyManagerScope {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str::<ValidTopologyManagerScope>(input)
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<ValidTopologyManagerScope>(&input)
             .context(error::InvalidTopologyManagerScopeSnafu { input })?;
         Ok(TopologyManagerScope {
             inner: input.to_string(),
@@ -921,18 +934,19 @@ string_impls_for!(TopologyManagerScope, "TopologyManagerScope");
 #[cfg(test)]
 mod test_topology_manager_scope {
     use super::TopologyManagerScope;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_topology_manager_scope() {
         for ok in &["container", "pod"] {
-            ok.parse::<TopologyManagerScope>().unwrap();
+            TopologyManagerScope::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_topology_manager_scope() {
         for err in &["", "bad", "100", &"a".repeat(64)] {
-            err.parse::<TopologyManagerScope>().unwrap_err();
+            TopologyManagerScope::try_from(*err).unwrap_err();
         }
     }
 }
@@ -957,11 +971,11 @@ enum ValidTopologyManagerPolicy {
     SingleNumaNode,
 }
 
-impl FromStr for TopologyManagerPolicy {
-    type Err = error::Error;
+impl TryFrom<&str> for TopologyManagerPolicy {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str::<ValidTopologyManagerPolicy>(input)
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<ValidTopologyManagerPolicy>(&input)
             .context(error::InvalidTopologyManagerPolicySnafu { input })?;
         Ok(TopologyManagerPolicy {
             inner: input.to_string(),
@@ -973,18 +987,19 @@ string_impls_for!(TopologyManagerPolicy, "TopologyManagerPolicy");
 #[cfg(test)]
 mod test_topology_manager_policy {
     use super::TopologyManagerPolicy;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_topology_manager_policy() {
         for ok in &["none", "restricted", "best-effort", "single-numa-node"] {
-            ok.parse::<TopologyManagerPolicy>().unwrap();
+            TopologyManagerPolicy::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_topology_manager_policy() {
         for err in &["", "bad", "100", &"a".repeat(64)] {
-            err.parse::<TopologyManagerPolicy>().unwrap_err();
+            TopologyManagerPolicy::try_from(*err).unwrap_err();
         }
     }
 }
@@ -1003,10 +1018,10 @@ pub struct ImageGCHighThresholdPercent {
     inner: String,
 }
 
-impl FromStr for ImageGCHighThresholdPercent {
-    type Err = error::Error;
+impl TryFrom<&str> for ImageGCHighThresholdPercent {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let parsed_input: i32 = input
             .parse::<i32>()
             .context(error::ParseIntSnafu { input })?;
@@ -1035,25 +1050,26 @@ string_impls_for!(ImageGCHighThresholdPercent, "ImageGCHighThresholdPercent");
 #[cfg(test)]
 mod test_image_gc_high_threshold_percent {
     use super::ImageGCHighThresholdPercent;
+    use std::convert::TryFrom;
 
     // test 1: good values should succeed
     #[test]
     fn image_gc_high_threshold_percent_between_0_and_100_inclusive() {
         for ok in &["0", "1", "99", "100"] {
-            ok.parse::<ImageGCHighThresholdPercent>().unwrap();
+            ImageGCHighThresholdPercent::try_from(*ok).unwrap();
         }
     }
 
     // test 2: values too low should return Errors
     #[test]
     fn image_gc_high_threshold_percent_less_than_0_fails() {
-        ("-1").parse::<ImageGCHighThresholdPercent>().unwrap_err();
+        ImageGCHighThresholdPercent::try_from("-1").unwrap_err();
     }
 
     // test 3: values too high should return Errors
     #[test]
     fn image_gc_high_threshold_percent_greater_than_100_fails() {
-        ("101").parse::<ImageGCHighThresholdPercent>().unwrap_err();
+        ImageGCHighThresholdPercent::try_from("101").unwrap_err();
     }
 }
 
@@ -1072,10 +1088,10 @@ pub struct ImageGCLowThresholdPercent {
     inner: String,
 }
 
-impl FromStr for ImageGCLowThresholdPercent {
-    type Err = error::Error;
+impl TryFrom<&str> for ImageGCLowThresholdPercent {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let parsed_input: i32 = input
             .parse::<i32>()
             .context(error::ParseIntSnafu { input })?;
@@ -1104,25 +1120,26 @@ string_impls_for!(ImageGCLowThresholdPercent, "ImageGCLowThresholdPercent");
 #[cfg(test)]
 mod test_image_gc_low_threshold_percent {
     use super::ImageGCLowThresholdPercent;
+    use std::convert::TryFrom;
 
     // test 1: good values should succeed
     #[test]
     fn image_gc_low_threshold_percent_between_0_and_100_inclusive() {
         for ok in &["0", "1", "99", "100"] {
-            ok.parse::<ImageGCLowThresholdPercent>().unwrap();
+            ImageGCLowThresholdPercent::try_from(*ok).unwrap();
         }
     }
 
     // test 2: values too low should return Errors
     #[test]
     fn image_gc_low_threshold_percent_less_than_0_fails() {
-        ("-1").parse::<ImageGCLowThresholdPercent>().unwrap_err();
+        ImageGCLowThresholdPercent::try_from("-1").unwrap_err();
     }
 
     // test 3: values too high should return Errors
     #[test]
     fn image_gc_low_threshold_percent_greater_than_100_fails() {
-        ("101").parse::<ImageGCLowThresholdPercent>().unwrap_err();
+        ImageGCLowThresholdPercent::try_from("101").unwrap_err();
     }
 }
 

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -158,7 +158,7 @@ macro_rules! string_impls_for {
             type Error = $crate::modeled_types::error::Error;
 
             fn try_from(input: String) -> Result<Self, Self::Error> {
-                input.parse::<Self>()
+                Self::try_from(input.as_ref())
             }
         }
 
@@ -168,7 +168,7 @@ macro_rules! string_impls_for {
                 D: Deserializer<'de>,
             {
                 let original = String::deserialize(deserializer)?;
-                original.parse::<Self>().map_err(|e| {
+                Self::try_from(original).map_err(|e| {
                     D::Error::custom(format!("Unable to deserialize into {}: {}", $for_str, e))
                 })
             }

--- a/sources/models/src/modeled_types/shared.rs
+++ b/sources/models/src/modeled_types/shared.rs
@@ -26,10 +26,10 @@ pub struct ValidBase64 {
 }
 
 /// Validate base64 format before we accept the input.
-impl FromStr for ValidBase64 {
-    type Err = error::Error;
+impl TryFrom<&str> for ValidBase64 {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         base64::decode(&input).context(error::InvalidBase64Snafu)?;
         Ok(ValidBase64 {
             inner: input.to_string(),
@@ -42,10 +42,11 @@ string_impls_for!(ValidBase64, "ValidBase64");
 #[cfg(test)]
 mod test_valid_base64 {
     use super::ValidBase64;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_base64() {
-        let v = ("aGk=").parse::<ValidBase64>().unwrap();
+        let v = ValidBase64::try_from("aGk=").unwrap();
         let decoded_bytes = base64::decode(v.as_ref()).unwrap();
         let decoded = std::str::from_utf8(&decoded_bytes).unwrap();
         assert_eq!(decoded, "hi");
@@ -53,7 +54,7 @@ mod test_valid_base64 {
 
     #[test]
     fn invalid_base64() {
-        assert!(("invalid base64").parse::<ValidBase64>().is_err());
+        assert!(ValidBase64::try_from("invalid base64").is_err());
     }
 }
 
@@ -68,10 +69,10 @@ pub struct SingleLineString {
     inner: String,
 }
 
-impl FromStr for SingleLineString {
-    type Err = error::Error;
+impl TryFrom<&str> for SingleLineString {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         // Rust does not treat all Unicode line terminators as starting a new line, so we check for
         // specific characters here, rather than just counting from lines().
         // https://en.wikipedia.org/wiki/Newline#Unicode
@@ -101,29 +102,30 @@ string_impls_for!(SingleLineString, "SingleLineString");
 #[cfg(test)]
 mod test_single_line_string {
     use super::SingleLineString;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_single_line_string() {
-        assert!(("").parse::<SingleLineString>().is_ok());
-        assert!(("hi").parse::<SingleLineString>().is_ok());
+        assert!(SingleLineString::try_from("").is_ok());
+        assert!(SingleLineString::try_from("hi").is_ok());
         let long_string = std::iter::repeat(" ").take(9999).collect::<String>();
         let json_long_string = format!("{}", &long_string);
-        assert!((&json_long_string).parse::<SingleLineString>().is_ok());
+        assert!(SingleLineString::try_from(json_long_string).is_ok());
     }
 
     #[test]
     fn invalid_single_line_string() {
-        assert!(("Hello\nWorld").parse::<SingleLineString>().is_err());
+        assert!(SingleLineString::try_from("Hello\nWorld").is_err());
 
-        assert!(("\n").parse::<SingleLineString>().is_err());
-        assert!(("\r").parse::<SingleLineString>().is_err());
-        assert!(("\r\n").parse::<SingleLineString>().is_err());
+        assert!(SingleLineString::try_from("\n").is_err());
+        assert!(SingleLineString::try_from("\r").is_err());
+        assert!(SingleLineString::try_from("\r\n").is_err());
 
-        assert!(("\u{000B}").parse::<SingleLineString>().is_err()); // vertical tab
-        assert!(("\u{000C}").parse::<SingleLineString>().is_err()); // form feed
-        assert!(("\u{0085}").parse::<SingleLineString>().is_err()); // next line
-        assert!(("\u{2028}").parse::<SingleLineString>().is_err()); // line separator
-        assert!(("\u{2029}").parse::<SingleLineString>().is_err());
+        assert!(SingleLineString::try_from("\u{000B}").is_err()); // vertical tab
+        assert!(SingleLineString::try_from("\u{000C}").is_err()); // form feed
+        assert!(SingleLineString::try_from("\u{0085}").is_err()); // next line
+        assert!(SingleLineString::try_from("\u{2028}").is_err()); // line separator
+        assert!(SingleLineString::try_from("\u{2029}").is_err());
         // paragraph separator
     }
 }
@@ -144,10 +146,10 @@ lazy_static! {
     pub(crate) static ref VALID_LINUX_HOSTNAME: Regex = Regex::new(r"^[0-9a-z.-]{1,253}$").unwrap();
 }
 
-impl FromStr for ValidLinuxHostname {
-    type Err = error::Error;
+impl TryFrom<&str> for ValidLinuxHostname {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         ensure!(
             VALID_LINUX_HOSTNAME.is_match(input),
             error::InvalidLinuxHostnameSnafu {
@@ -189,40 +191,41 @@ string_impls_for!(ValidLinuxHostname, "ValidLinuxHostname");
 #[cfg(test)]
 mod test_valid_linux_hostname {
     use super::ValidLinuxHostname;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_linux_hostname() {
-        assert!(("hello").parse::<ValidLinuxHostname>().is_ok());
-        assert!(("hello1234567890").parse::<ValidLinuxHostname>().is_ok());
+        assert!(ValidLinuxHostname::try_from("hello").is_ok());
+        assert!(ValidLinuxHostname::try_from("hello1234567890").is_ok());
 
         let segment_limit = std::iter::repeat("a").take(63).collect::<String>();
-        assert!(segment_limit.parse::<ValidLinuxHostname>().is_ok());
+        assert!(ValidLinuxHostname::try_from(segment_limit.clone()).is_ok());
 
         let segment = std::iter::repeat("a").take(61).collect::<String>();
         let long_name = format!(
             "{}.{}.{}.{}",
             &segment_limit, &segment_limit, &segment_limit, &segment
         );
-        assert!((&long_name).parse::<ValidLinuxHostname>().is_ok());
+        assert!(ValidLinuxHostname::try_from(long_name).is_ok());
     }
 
     #[test]
     fn invalid_linux_hostname() {
-        assert!((" ").parse::<ValidLinuxHostname>().is_err());
-        assert!(("-a").parse::<ValidLinuxHostname>().is_err());
-        assert!((".a").parse::<ValidLinuxHostname>().is_err());
-        assert!(("@a").parse::<ValidLinuxHostname>().is_err());
-        assert!(("a..a").parse::<ValidLinuxHostname>().is_err());
-        assert!(("a.a.-a.a1234").parse::<ValidLinuxHostname>().is_err());
+        assert!(ValidLinuxHostname::try_from(" ").is_err());
+        assert!(ValidLinuxHostname::try_from("-a").is_err());
+        assert!(ValidLinuxHostname::try_from(".a").is_err());
+        assert!(ValidLinuxHostname::try_from("@a").is_err());
+        assert!(ValidLinuxHostname::try_from("a..a").is_err());
+        assert!(ValidLinuxHostname::try_from("a.a.-a.a1234").is_err());
 
         let long_segment = std::iter::repeat("a").take(64).collect::<String>();
-        assert!(long_segment.parse::<ValidLinuxHostname>().is_err());
+        assert!(ValidLinuxHostname::try_from(long_segment.clone()).is_err());
 
         let long_name = format!(
             "{}.{}.{}.{}",
             &long_segment, &long_segment, &long_segment, &long_segment
         );
-        assert!((&long_name).parse::<ValidLinuxHostname>().is_err());
+        assert!(ValidLinuxHostname::try_from(long_name).is_err());
     }
 }
 
@@ -383,10 +386,10 @@ pub struct Identifier {
 
 const CONTAINERD_ID_LENGTH: usize = 76;
 
-impl FromStr for Identifier {
-    type Err = error::Error;
+impl TryFrom<&str> for Identifier {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         let valid_identifier = input
             .chars()
             .all(|c| (c.is_ascii() && c.is_alphanumeric()) || c == '-')
@@ -403,32 +406,29 @@ string_impls_for!(Identifier, "Identifier");
 #[cfg(test)]
 mod test_valid_identifier {
     use super::{Identifier, CONTAINERD_ID_LENGTH};
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_identifier() {
-        assert!(("hello-world").parse::<Identifier>().is_ok());
-        assert!(("helloworld").parse::<Identifier>().is_ok());
-        assert!(("123321hello").parse::<Identifier>().is_ok());
-        assert!(("hello-1234").parse::<Identifier>().is_ok());
-        assert!(("--------").parse::<Identifier>().is_ok());
-        assert!(("11111111").parse::<Identifier>().is_ok());
-        assert!((&vec!["X"; CONTAINERD_ID_LENGTH].join(""))
-            .parse::<Identifier>()
-            .is_ok());
+        assert!(Identifier::try_from("hello-world").is_ok());
+        assert!(Identifier::try_from("helloworld").is_ok());
+        assert!(Identifier::try_from("123321hello").is_ok());
+        assert!(Identifier::try_from("hello-1234").is_ok());
+        assert!(Identifier::try_from("--------").is_ok());
+        assert!(Identifier::try_from("11111111").is_ok());
+        assert!(Identifier::try_from(vec!["X"; CONTAINERD_ID_LENGTH].join("")).is_ok());
     }
 
     #[test]
     fn invalid_identifier() {
-        assert!(("../").parse::<Identifier>().is_err());
-        assert!(("{}").parse::<Identifier>().is_err());
-        assert!(("hello|World").parse::<Identifier>().is_err());
-        assert!(("hello\nWorld").parse::<Identifier>().is_err());
-        assert!(("hello_world").parse::<Identifier>().is_err());
-        assert!(("タール").parse::<Identifier>().is_err());
-        assert!(("💝").parse::<Identifier>().is_err());
-        assert!((&vec!["X"; CONTAINERD_ID_LENGTH + 1].join(""))
-            .parse::<Identifier>()
-            .is_err());
+        assert!(Identifier::try_from("../").is_err());
+        assert!(Identifier::try_from("{}").is_err());
+        assert!(Identifier::try_from("hello|World").is_err());
+        assert!(Identifier::try_from("hello\nWorld").is_err());
+        assert!(Identifier::try_from("hello_world").is_err());
+        assert!(Identifier::try_from("タール").is_err());
+        assert!(Identifier::try_from("💝").is_err());
+        assert!(Identifier::try_from(vec!["X"; CONTAINERD_ID_LENGTH + 1].join("")).is_err());
     }
 }
 
@@ -443,10 +443,10 @@ pub struct Url {
     inner: String,
 }
 
-impl FromStr for Url {
-    type Err = error::Error;
+impl TryFrom<&str> for Url {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         if let Ok(_) = input.parse::<url::Url>() {
             return Ok(Url {
                 inner: input.to_string(),
@@ -470,6 +470,7 @@ string_impls_for!(Url, "Url");
 #[cfg(test)]
 mod test_url {
     use super::Url;
+    use std::convert::TryFrom;
 
     #[test]
     fn good_urls() {
@@ -490,14 +491,14 @@ mod test_url {
             ".internal",
             ".cluster.local",
         ] {
-            ok.parse::<Url>().unwrap();
+            Url::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn bad_urls() {
         for err in &["how are you", "weird@"] {
-            err.parse::<Url>().unwrap_err();
+            Url::try_from(*err).unwrap_err();
         }
     }
 }
@@ -512,10 +513,10 @@ pub struct FriendlyVersion {
     inner: String,
 }
 
-impl FromStr for FriendlyVersion {
-    type Err = error::Error;
+impl TryFrom<&str> for FriendlyVersion {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         if input == "latest" {
             return Ok(FriendlyVersion {
                 inner: input.to_string(),
@@ -547,7 +548,7 @@ impl TryFrom<FriendlyVersion> for semver::Version {
         } else {
             &input.inner
         };
-        version.parse::<Version>()
+        Version::from_str(version)
     }
 }
 
@@ -573,7 +574,7 @@ mod test_version {
             "v1.1.0-rc.1.1",
             "latest",
         ] {
-            ok.parse::<FriendlyVersion>().unwrap();
+            FriendlyVersion::try_from(*ok).unwrap();
             // Test conversion to semver::Version
             if *ok != "latest" {
                 let _: Version = FriendlyVersion {
@@ -598,7 +599,7 @@ mod test_version {
             "1.0.3-beta.1.01",
             "v1.0.3-beta.1.01",
         ] {
-            err.parse::<FriendlyVersion>().unwrap_err();
+            FriendlyVersion::try_from(*err).unwrap_err();
             let res: Result<Version, semver::Error> = Version::try_from(FriendlyVersion {
                 inner: err.to_string(),
             });
@@ -618,10 +619,10 @@ pub struct DNSDomain {
     inner: String,
 }
 
-impl FromStr for DNSDomain {
-    type Err = error::Error;
+impl TryFrom<&str> for DNSDomain {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         ensure!(
             !input.starts_with('.'),
             error::InvalidDomainNameSnafu {
@@ -655,11 +656,12 @@ string_impls_for!(DNSDomain, "DNSDomain");
 #[cfg(test)]
 mod test_dns_domain {
     use super::DNSDomain;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_dns_domain() {
         for ok in &["cluster.local", "dev.eks", "stage.eks", "prod.eks"] {
-            assert!(ok.parse::<DNSDomain>().is_ok());
+            assert!(DNSDomain::try_from(*ok).is_ok());
         }
     }
 
@@ -671,7 +673,7 @@ mod test_dns_domain {
             "123.123.123.123",
             "[2001:db8::ff00:42:8329]",
         ] {
-            assert!(err.parse::<DNSDomain>().is_err());
+            assert!(DNSDomain::try_from(*err).is_err());
         }
     }
 }
@@ -692,10 +694,10 @@ lazy_static! {
     pub(crate) static ref SYSCTL_KEY: Regex = Regex::new(r"^[a-zA-Z0-9./_-]{1,128}$").unwrap();
 }
 
-impl FromStr for SysctlKey {
-    type Err = error::Error;
+impl TryFrom<&str> for SysctlKey {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         // Basic directory traversal checks; corndog also checks
         ensure!(
             !input.contains(".."),
@@ -729,6 +731,7 @@ string_impls_for!(SysctlKey, "SysctlKey");
 #[cfg(test)]
 mod test_sysctl_key {
     use super::SysctlKey;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_sysctl_key() {
@@ -748,7 +751,7 @@ mod test_sysctl_key {
             // All allowed characters
             "-./0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
         ] {
-            ok.parse::<SysctlKey>().unwrap();
+            SysctlKey::try_from(*ok).unwrap();
         }
     }
 
@@ -781,7 +784,7 @@ mod test_sysctl_key {
             "~",
             "`",
         ] {
-            err.parse::<SysctlKey>().unwrap_err();
+            SysctlKey::try_from(*err).unwrap_err();
         }
     }
 }
@@ -796,10 +799,10 @@ pub struct BootConfigKey {
     inner: String,
 }
 
-impl FromStr for BootConfigKey {
-    type Err = error::Error;
+impl TryFrom<&str> for BootConfigKey {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         // Each individual keyword must be valid
         let valid_key = input.split('.').all(|keyword| {
             !keyword.is_empty()
@@ -819,6 +822,7 @@ string_impls_for!(BootConfigKey, "BootConfigKey");
 #[cfg(test)]
 mod test_bootconfig_key {
     use super::BootConfigKey;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_bootconfig_key() {
@@ -832,7 +836,7 @@ mod test_bootconfig_key {
             "keyword1-",
             "keyword2_",
         ] {
-            ok.parse::<BootConfigKey>().unwrap();
+            BootConfigKey::try_from(*ok).unwrap();
         }
     }
 
@@ -842,7 +846,7 @@ mod test_bootconfig_key {
             "", "①", ".", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "\"", "'", "\\", "|",
             "~", "`",
         ] {
-            err.parse::<BootConfigKey>().unwrap_err();
+            BootConfigKey::try_from(*err).unwrap_err();
         }
     }
 }
@@ -860,10 +864,10 @@ pub struct BootConfigValue {
     inner: String,
 }
 
-impl FromStr for BootConfigValue {
-    type Err = error::Error;
+impl TryFrom<&str> for BootConfigValue {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         ensure!(
             input.chars().all(|c| c.is_ascii() && !c.is_ascii_control())
             // Values containing both single quotes and double quotes are inherently invalid since quotes
@@ -882,6 +886,7 @@ string_impls_for!(BootConfigValue, "BootConfigValue");
 #[cfg(test)]
 mod test_bootconfig_value {
     use super::BootConfigValue;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_bootconfig_value() {
@@ -895,14 +900,14 @@ mod test_bootconfig_value {
             "hello.goodbye",
             "",
         ] {
-            ok.parse::<BootConfigValue>().unwrap();
+            BootConfigValue::try_from(*ok).unwrap();
         }
     }
 
     #[test]
     fn invalid_bootconfig_value() {
         for err in &["'\"", "bottlerocket①", "💝", "Ï", "—"] {
-            err.parse::<BootConfigValue>().unwrap_err();
+            BootConfigValue::try_from(*err).unwrap_err();
         }
     }
 }
@@ -916,10 +921,10 @@ pub struct Lockdown {
     inner: String,
 }
 
-impl FromStr for Lockdown {
-    type Err = error::Error;
+impl TryFrom<&str> for Lockdown {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         ensure!(
             matches!(input, "none" | "integrity" | "confidentiality"),
             error::InvalidLockdownSnafu { input }
@@ -939,10 +944,10 @@ pub struct BootstrapContainerMode {
     inner: String,
 }
 
-impl FromStr for BootstrapContainerMode {
-    type Err = error::Error;
+impl TryFrom<&str> for BootstrapContainerMode {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         ensure!(
             matches!(input, "off" | "once" | "always"),
             error::InvalidBootstrapContainerModeSnafu { input }
@@ -966,17 +971,18 @@ string_impls_for!(BootstrapContainerMode, "BootstrapContainerMode");
 #[cfg(test)]
 mod test_valid_container_mode {
     use super::BootstrapContainerMode;
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_container_mode() {
         for ok in &["off", "once", "always"] {
-            assert!(ok.parse::<BootstrapContainerMode>().is_ok());
+            assert!(BootstrapContainerMode::try_from(*ok).is_ok());
         }
     }
 
     #[test]
     fn invalid_container_mode() {
-        assert!(("invalid").parse::<BootstrapContainerMode>().is_err());
+        assert!(BootstrapContainerMode::try_from("invalid").is_err());
     }
 }
 
@@ -986,10 +992,10 @@ pub struct PemCertificateString {
     inner: String,
 }
 
-impl FromStr for PemCertificateString {
-    type Err = error::Error;
+impl TryFrom<&str> for PemCertificateString {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, error::Error> {
         // Empty strings are valid to allow deleting bundles
         if input.trim().len() == 0 {
             return Ok(PemCertificateString {
@@ -1032,33 +1038,31 @@ string_impls_for!(PemCertificateString, "PemCertificateString");
 #[cfg(test)]
 mod test_valid_pem_certificate_string {
     use super::PemCertificateString;
+    use std::convert::TryFrom;
 
     static TEST_PEM: &str = include_str!("../../tests/data/test-pem");
     static TEST_INCOMPLETE_PEM: &str = include_str!("../../tests/data/test-incomplete-pem");
 
     #[test]
     fn valid_pem_certificate() {
-        assert!((TEST_PEM).parse::<PemCertificateString>().is_ok());
-        assert!(("").parse::<PemCertificateString>().is_ok());
+        assert!(PemCertificateString::try_from(TEST_PEM).is_ok());
+        assert!(PemCertificateString::try_from("").is_ok());
     }
 
     #[test]
     fn invalid_pem_certificate() {
         // PEM with valid markers but with invalid content
-        assert!(
-            ("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tIGJhZCAtLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==")
-                .parse::<PemCertificateString>()
-                .is_err()
-        );
+        assert!(PemCertificateString::try_from(
+            "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tIGJhZCAtLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        )
+        .is_err());
         // PEM with valid content but without footer marker
-        assert!((TEST_INCOMPLETE_PEM)
-            .parse::<PemCertificateString>()
-            .is_err());
+        assert!(PemCertificateString::try_from(TEST_INCOMPLETE_PEM).is_err());
 
         // PEM without any valid certificate
-        assert!((
+        assert!(PemCertificateString::try_from(
             "77yc44Kz77ya44OfIOOBj+OCszrlvaEg77yc44Kz77ya44OfIOOBj+OCszrlvaEg77yc44Kz77ya44OfCg=="
-        ).parse::<PemCertificateString>()
+        )
         .is_err())
     }
 }
@@ -1081,10 +1085,10 @@ pub struct KmodKey {
 //     #define MAX_PARAM_PREFIX_LEN (64 - sizeof(unsigned long))
 const KMOD_KEY_LENGTH: usize = 56;
 
-impl FromStr for KmodKey {
-    type Err = error::Error;
+impl TryFrom<&str> for KmodKey {
+    type Error = error::Error;
 
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
         // The kernel allows modules to have any name that's a valid filename,
         // but real module names seem to be limited to this character set.
         let valid_key = input
@@ -1103,28 +1107,25 @@ string_impls_for!(KmodKey, "KmodKey");
 #[cfg(test)]
 mod test_valid_kmod_key {
     use super::{KmodKey, KMOD_KEY_LENGTH};
+    use std::convert::TryFrom;
 
     #[test]
     fn valid_kmod_key() {
-        assert!(("kmod").parse::<KmodKey>().is_ok());
-        assert!(("i8042").parse::<KmodKey>().is_ok());
-        assert!(("xt_XT").parse::<KmodKey>().is_ok());
-        assert!(("dm-block").parse::<KmodKey>().is_ok());
-        assert!(("blowfish-x86_64").parse::<KmodKey>().is_ok());
-        assert!((&vec!["a"; KMOD_KEY_LENGTH].join(""))
-            .parse::<KmodKey>()
-            .is_ok());
+        assert!(KmodKey::try_from("kmod").is_ok());
+        assert!(KmodKey::try_from("i8042").is_ok());
+        assert!(KmodKey::try_from("xt_XT").is_ok());
+        assert!(KmodKey::try_from("dm-block").is_ok());
+        assert!(KmodKey::try_from("blowfish-x86_64").is_ok());
+        assert!(KmodKey::try_from(vec!["a"; KMOD_KEY_LENGTH].join("")).is_ok());
     }
 
     #[test]
     fn invalid_kmod_key() {
-        assert!(("../").parse::<KmodKey>().is_err());
-        assert!(("{}").parse::<KmodKey>().is_err());
-        assert!(("kernel|Module").parse::<KmodKey>().is_err());
-        assert!(("kernel\nModule").parse::<KmodKey>().is_err());
-        assert!(("🐡").parse::<KmodKey>().is_err());
-        assert!((&vec!["z"; KMOD_KEY_LENGTH + 1].join(""))
-            .parse::<KmodKey>()
-            .is_err());
+        assert!(KmodKey::try_from("../").is_err());
+        assert!(KmodKey::try_from("{}").is_err());
+        assert!(KmodKey::try_from("kernel|Module").is_err());
+        assert!(KmodKey::try_from("kernel\nModule").is_err());
+        assert!(KmodKey::try_from("🐡").is_err());
+        assert!(KmodKey::try_from(vec!["z"; KMOD_KEY_LENGTH + 1].join("")).is_err());
     }
 }

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -17,7 +17,7 @@ use signal_hook::iterator::Signals;
 use signpost::State;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ErrorCompat, OptionExt, ResultExt};
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::Path;
@@ -181,11 +181,9 @@ fn update_required<'a>(
     if version_lock != "latest" {
         // Make sure the version string from the config is a valid version string that might be prefixed with 'v'
         let friendly_version_lock =
-            version_lock
-                .parse::<FriendlyVersion>()
-                .context(error::BadVersionConfigSnafu {
-                    version_str: version_lock,
-                })?;
+            FriendlyVersion::try_from(version_lock).context(error::BadVersionConfigSnafu {
+                version_str: version_lock,
+            })?;
         // Convert back to semver::Version
         let semver_version_lock =
             friendly_version_lock


### PR DESCRIPTION
This reverts commit cf7a49a705883bf5377f3a6de746aa8642a0a2ca.

**Issue number:**

Re-opens #1061 

**Description of changes:**

Reverts my FromStr PR so that I may add in missing commits and perform additional testing before re-submitting a PR for those changes.

**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
