### PR TITLE
makes file name consistent with metal provisioning

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -188,7 +188,7 @@ Note this down as the INSTANCE_PROFILE_NAME for the final launch command.
 
 For the instance to be able to communicate with ECS, we need to make sure to configure the instance with the name of the cluster.
 
-Create a file called `userdata.toml` with the following contents, where CLUSTER_NAME is the name of the cluster you created above (for example, "bottlerocket").
+Create a file called `user-data.toml` with the following contents, where CLUSTER_NAME is the name of the cluster you created above (for example, "bottlerocket").
 
 ```
 [settings.ecs]
@@ -206,7 +206,7 @@ There are a few values to make sure you change in this command:
 * SUBNET_ID: the subnet you selected earlier
   * If you chose a public subnet, either add `--associate-public-ip-address` to the command, or attach an Elastic IP afterward.
 * BOTTLEROCKET_AMI_ID: the Amazon-provided AMI ID you found above, or the ID of an AMI you registered
-* userdata.toml: the path to the user data file you created earlier
+* user-data.toml: the path to the user data file you created earlier
 * INSTANCE_PROFILE_NAME: the IAM instance profile you created, e.g. `ecsInstanceRole`
 
 ```
@@ -216,7 +216,7 @@ aws ec2 run-instances --key-name YOUR_KEY_NAME \
    --instance-type c3.large \
    --region us-west-2 \
    --tag-specifications 'ResourceType=instance,Tags=[{Key=bottlerocket,Value=quickstart}]' \
-   --user-data file://userdata.toml \
+   --user-data file://user-data.toml \
    --iam-instance-profile Name=INSTANCE_PROFILE_NAME
 ```
 

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -189,10 +189,10 @@ This can include the configuration of the Kubernetes cluster we just created.
 Run this to generate the configuration file with the relevant cluster config, including the API endpoint and base64-encoded certificate authority.
 ```
 eksctl get cluster --region us-west-2 --name bottlerocket -o json \
-   | jq --raw-output '.[] | "[settings.kubernetes]\napi-server = \"" + .Endpoint + "\"\ncluster-certificate =\"" + .CertificateAuthority.Data + "\"\ncluster-name = \"bottlerocket\""' > userdata.toml
+   | jq --raw-output '.[] | "[settings.kubernetes]\napi-server = \"" + .Endpoint + "\"\ncluster-certificate =\"" + .CertificateAuthority.Data + "\"\ncluster-name = \"bottlerocket\""' > user-data.toml
 ```
 
-This will save the TOML-formatted configuration data into a file named `userdata.toml`.
+This will save the TOML-formatted configuration data into a file named `user-data.toml`.
 This will be used at the end, in the instance launch command.
 
 #### Subnet info
@@ -351,7 +351,7 @@ There are a few values to make sure you change in this command:
   * If you chose a public subnet, either add `--associate-public-ip-address` to the command, or attach an Elastic IP afterward.
 * SECURITY_GROUP_ID_1, SECURITY_GROUP_ID_2: the two security groups you found earlier
 * BOTTLEROCKET_AMI_ID: the ID of the AMI you registered, or an Amazon-provided AMI ID
-* userdata.toml: the path to the user data file you created earlier
+* user-data.toml: the path to the user data file you created earlier
 * INSTANCE_PROFILE_NAME: the instance profile created by `eksctl` for the cluster nodegroups.
 
 ```
@@ -362,7 +362,7 @@ aws ec2 run-instances --key-name YOUR_KEY_NAME \
    --instance-type c3.large \
    --region us-west-2 \
    --tag-specifications 'ResourceType=instance,Tags=[{Key=kubernetes.io/cluster/bottlerocket,Value=owned}]' \
-   --user-data file://userdata.toml \
+   --user-data file://user-data.toml \
    --iam-instance-profile Name=INSTANCE_PROFILE_NAME
 ```
 

--- a/QUICKSTART-VMWARE.md
+++ b/QUICKSTART-VMWARE.md
@@ -143,9 +143,9 @@ export CLUSTER_CERTIFICATE="$(kubectl config view --raw -o=jsonpath='{.clusters[
 In order to join Bottlerocket to your cluster, it must be configured via user data.
 There are multiple methods of passing user data to Bottlerocket in VMware; we will demonstrate all of them.
 
-Create a file called `userdata.toml` and populate it with the values you just retrieved.
+Create a file called `user-data.toml` and populate it with the values you just retrieved.
 ```
-cat <<EOF > userdata.toml
+cat <<EOF > user-data.toml
 [settings.kubernetes]
 api-server = "${API_SERVER}"
 cluster-dns-ip = "${CLUSTER_DNS_IP}"
@@ -163,12 +163,12 @@ You can use our [admin](https://github.com/bottlerocket-os/bottlerocket-admin-co
 #### Admin container
 If you would like to use the admin container, you will need to create some base64 encoded user data which will be passed to the container at runtime.
 Full details are covered in the [admin container documentation](https://github.com/bottlerocket-os/bottlerocket-admin-container#authenticating-with-the-admin-container).
-If we assume you have a public key at `${HOME}/.ssh/id_rsa.pub`, the below will add the correct user data to your `userdata.toml`.
+If we assume you have a public key at `${HOME}/.ssh/id_rsa.pub`, the below will add the correct user data to your `user-data.toml`.
 ```
 PUBKEY="${HOME}/.ssh/id_rsa.pub"
 ADMIN_USER_DATA="$(echo '{"ssh":{"authorized-keys":["'"$(cat ${PUBKEY})"'"]}}' | base64 -w 0)"
 
-cat <<EOF >>userdata.toml
+cat <<EOF >>user-data.toml
 [settings.host-containers.admin]
 enabled = true
 user-data = "${ADMIN_USER_DATA}"
@@ -222,7 +222,7 @@ SSM_ACTIVATION_ID="$(jq -r '.ActivationId' <<< ${SSM_ACTIVATION})"
 SSM_ACTIVATION_CODE="$(jq -r '.ActivationCode' <<< ${SSM_ACTIVATION})"
 CONTROL_USER_DATA="$(echo '{"ssm":{"activation-id":"'${SSM_ACTIVATION_ID}'","activation-code":"'${SSM_ACTIVATION_CODE}'","region":"us-west-2"}}' | base64 -w0)"
 
-cat <<EOF >>userdata.toml
+cat <<EOF >>user-data.toml
 [settings.host-containers.control]
 enabled = true
 user-data = "${CONTROL_USER_DATA}"
@@ -238,9 +238,9 @@ These extended attributes are `guestinfo.userdata` and `guestinfo.userdata.encod
 `guestinfo.userdata` may be passed as base64, gzipped base64, or (least desirable) raw TOML.
 Valid values for `guestinfo.userdata.encoding` are: `base64`, `b64`, `gzip+base64`, and `gz+b64`.
 
-Given the above file `userdata.toml`, base64 encode and set user data for your VM:
+Given the above file `user-data.toml`, base64 encode and set user data for your VM:
 ```
-export BR_USERDATA=$(base64 -w0 userdata.toml)
+export BR_USERDATA=$(base64 -w0 user-data.toml)
 
 for node in 1 2 3; do
   govc vm.change -vm "${VM_NAME}-${node}" \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # n/a

**Description of changes:** Various markdown files use `userdata.toml` and `user-data.toml` during configuration instructions. These are local files on the developer machine in most cases. However, on bare metal the name with the hyphen is relevant as it's on the host.. This PR removes the hyphen-less filename to make it consistent with bare metal.


**Testing done:** eyeballs



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
