### PR TITLE
sources: clarify crossbeam license

### DIFF
--- a/sources/clarify.toml
+++ b/sources/clarify.toml
@@ -38,7 +38,7 @@ license-files = [
 ]
 
 [clarify.crossbeam-queue]
-expression = "(MIT OR Apache-2.0) AND BSD-2-Clause-FreeBSD"
+expression = "MIT OR Apache-2.0"
 license-files = [
     { path = "LICENSE-APACHE", hash = 0x24b54f4b },
     { path = "LICENSE-MIT", hash = 0x386ca1bc },
@@ -46,7 +46,7 @@ license-files = [
 ]
 
 [clarify.crossbeam-channel]
-expression = "(MIT OR Apache-2.0) AND BSD-2-Clause-FreeBSD"
+expression = "MIT OR Apache-2.0"
 license-files = [
     { path = "LICENSE-APACHE", hash = 0x24b54f4b },
     { path = "LICENSE-MIT", hash = 0xbc436f08 },


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
The BSD-2-Clause license is not listed upstream since this change:
  https://github.com/crossbeam-rs/crossbeam/pull/537


**Testing done:**
Built `aws-k8s-1.23` and checked the attribution statement:
```
bash-5.0# cat /usr/share/licenses/os/vendor/crossbeam-channel-0.5.6/attribution.txt
crossbeam-channel
SPDX-License-Identifier: MIT OR Apache-2.0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
