### PR TITLE
ecs-gpu-init: upgrade go build directive to 1.19

### DIFF
--- a/sources/ecs-gpu-init/go.mod
+++ b/sources/ecs-gpu-init/go.mod
@@ -1,5 +1,5 @@
 module ecs-gpu-init
 
-go 1.18
+go 1.19
 
 require github.com/NVIDIA/go-nvml v0.11.6-0


### PR DESCRIPTION
**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket/issues/2420

**Description of changes:**

Upgrades the go build directive to [1.19 which is the latest version in the SDK](https://github.com/bottlerocket-os/bottlerocket-sdk/pull/82#discussion_r978830565). This can be upgraded out of band from what version of the SDK is being used in bottlerocket since older versions of go can still build modules with newer build directives (as long as there aren't breaking changes in go):

```
cd sources/ecs-gpu-init && go1.18.6 build cmd/
```

**Testing done:**

Built the ECS nvidia variant ami, used it with a p2.xlarge instance (1 GPU) and see that the GPU info was generated correctly:

```
bash-5.1# cat /var/lib/ecs/gpu/nvidia-gpu-info.json
{"DriverVersion":"470.82.01","GPUIDs":["<GPU-ID>"]}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.