### PR TITLE
hotdog: update to `v1.0.4` release

### DIFF
--- a/packages/hotdog/Cargo.toml
+++ b/packages/hotdog/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bottlerocket-os/hotdog/archive/b85b75576adbbd7e133b54d71ebc11a28acf40db/hotdog-b85b755.tar.gz"
-sha512 = "9b2d5cb0e25d774d11dd6eb577e07af85f36fcd6e816b9df88d7ca1da273695f15ce6831026d28e68355512a07d0ac673b5ce9771d969f1c5ca4f14bc631deb8"
+url = "https://github.com/bottlerocket-os/hotdog/archive/v1.0.4/hotdog-1.0.4.tar.gz"
+sha512 = "fa6ae90ca7306e2d77cf7320cde773e08f3616e29cc44b6eda9a70d1270b30f9190707c40890146d023a417c13028ccf601a313ed8eb255ddc13072128ad7250"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/hotdog/hotdog.spec
+++ b/packages/hotdog/hotdog.spec
@@ -7,17 +7,14 @@
 %global gorepo hotdog
 %global goimport %{goproject}/%{gorepo}
 
-%global gitrev b85b75576adbbd7e133b54d71ebc11a28acf40db
-%global shortrev %(c=%{gitrev}; echo ${c:0:7})
-
 Name: %{_cross_os}hotdog
-Version: 1.0.1
+Version: 1.0.4
 Release: 1%{?dist}
 Summary: Tool with OCI hooks to run the Log4j Hot Patch in containers
 License: Apache-2.0
 URL: https://github.com/bottlerocket-os/hotdog
-Source0: %{gorepo}-%{shortrev}.tar.gz
-Source1: bundled-%{gorepo}-%{shortrev}.tar.gz
+Source0: %{gorepo}-%{version}.tar.gz
+Source1: bundled-%{gorepo}-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}log4j2-hotpatch
 
@@ -25,8 +22,8 @@ Requires: %{_cross_os}log4j2-hotpatch
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gitrev}
-%setup -T -D -n %{gorepo}-%{gitrev} -b 1
+%setup -n %{gorepo}-%{version}
+%setup -T -D -n %{gorepo}-%{version} -b 1
 
 %build
 %set_cross_go_flags


### PR DESCRIPTION
**Issue number:**

Related #2420

**Description of changes:**

Updates hotdog to latest tag which carries dependency updates and uses the `go 1.19` build directive.

Also switches to using the hotdog version instead of the long/short sha in the spec.

**Testing done:**

Updated lookaside cache with new hotdog package, builds locally 👍🏼 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
