### PR TITLE
Building docs: fix positional fetch-license argument

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -138,7 +138,7 @@ licenses = [
 2. Fetch the licenses with this command:
 
 ```shell
-cargo make fetch-licenses -e BUILDSYS_UPSTREAM_LICENSE_FETCH=true
+cargo make -e BUILDSYS_UPSTREAM_LICENSE_FETCH=true fetch-licenses
 ```
 
 3. Build your image, setting the `BUILDSYS_UPSTREAM_SOURCE_FALLBACK` flag to `true`, if you haven't cached the driver's sources:


### PR DESCRIPTION
**Description of changes:**

When going through the `BUILDING.md` docs and attempting to run the `fetch-license` target, the positonal arg is out of order, causing fetch license task to be skipped:
```
❯ cargo make fetch-licenses -e BUILDSYS_UPSTREAM_LICENSE_FETCH="true"
[cargo-make] INFO - cargo make 0.35.16
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fetch-licenses
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: setup-build
[cargo-make] INFO - Running Task: fetch-sdk
[cargo-make] INFO - Running Task: fetch-toolchain
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: fetch-vendored
[cargo-make] INFO - Running Task: fetch-licenses
Skipping fetching licenses
[cargo-make] INFO - Build Done in 3.88 seconds.
```

Here it is working as intended with the right ordering:
```
❯ cargo make -e BUILDSYS_UPSTREAM_LICENSE_FETCH="true" fetch-licenses
[cargo-make] INFO - cargo make 0.35.16
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fetch-licenses
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: setup-build
[cargo-make] INFO - Running Task: fetch-sdk
[cargo-make] INFO - Running Task: fetch-toolchain
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: fetch-vendored
[cargo-make] INFO - Running Task: fetch-licenses
Skipping copying file from /home/fedora/workspace/bottlerocket-os/bottlerocket/Licenses.toml
[cargo-make] INFO - Build Done in 4.14 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
