### PR TITLE
kubelet: Add setting to change log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.image-gc-high-threshold-percent`: The percent of disk usage after which image garbage collection is always run.
 * `settings.kubernetes.image-gc-low-threshold-percent`: The percent of disk usage before which image garbage collection is never run.
 * `settings.kubernetes.provider-id`: This sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node.
+* `settings.kubernetes.log-level`: Adjust the logging verbosity of the `kubelet` process.
+  The default log level is 2, with higher numbers enabling more verbose logging.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -146,4 +146,5 @@ version = "1.10.0"
     "migrate_v1.10.0_dns-settings.lz4",
     "migrate_v1.10.0_dns-settings-metadata.lz4",
     "migrate_v1.10.0_reboot-to-reconcile-setting.lz4",
+    "migrate_v1.10.0_kubelet-log-level.lz4",
 ]

--- a/packages/kubernetes-1.20/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.20/kubelet-exec-start-conf
@@ -20,4 +20,7 @@ ExecStart=/usr/bin/kubelet \
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \
+{{#if settings.kubernetes.log-level includeZero=true}}
+    -v {{settings.kubernetes.log-level}} \
+{{/if}}
     --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.21/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.21/kubelet-exec-start-conf
@@ -20,4 +20,7 @@ ExecStart=/usr/bin/kubelet \
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \
+{{#if settings.kubernetes.log-level includeZero=true}}
+    -v {{settings.kubernetes.log-level}} \
+{{/if}}
     --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.22/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.22/kubelet-exec-start-conf
@@ -20,4 +20,7 @@ ExecStart=/usr/bin/kubelet \
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \
+{{#if settings.kubernetes.log-level includeZero=true}}
+    -v {{settings.kubernetes.log-level}} \
+{{/if}}
     --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/packages/kubernetes-1.23/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.23/kubelet-exec-start-conf
@@ -20,4 +20,7 @@ ExecStart=/usr/bin/kubelet \
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \
+{{#if settings.kubernetes.log-level includeZero=true}}
+    -v {{settings.kubernetes.log-level}} \
+{{/if}}
     --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2044,6 +2044,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-log-level"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "api/migration/migrations/v1.10.0/dns-settings",
     "api/migration/migrations/v1.10.0/dns-settings-metadata",
     "api/migration/migrations/v1.10.0/reboot-to-reconcile-setting",
+    "api/migration/migrations/v1.10.0/kubelet-log-level",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.10.0/kubelet-log-level/Cargo.toml
+++ b/sources/api/migration/migrations/v1.10.0/kubelet-log-level/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kubelet-log-level"
+version = "0.1.0"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.10.0/kubelet-log-level/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.0/kubelet-log-level/src/main.rs
@@ -1,0 +1,21 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new settings for configuring kubelet logging verbosity:
+/// `settings.kubernetes.log-level`.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&["settings.kubernetes.log-level"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -216,6 +216,7 @@ struct KubernetesSettings {
     image_gc_high_threshold_percent: ImageGCHighThresholdPercent,
     image_gc_low_threshold_percent: ImageGCLowThresholdPercent,
     provider_id: Url,
+    kubelet_log_level: u8,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
**Issue number:**

Closes #1931 

**Description of changes:**

This adds a new `kubernetes.log-level` setting to allow configuration of the kubelet logging verbosity. With this, an end user can turn up verbosity if they are trying to troubleshoot something, or turn down verbosity if they don't need as many log messages.

**Testing done:**

Created EKS cluster using development build.
Checked `kubelet` command line arguments from `systemctl status kubelet` and verified no `-v` setting.
Ran `apiclient set -j '{"kubernetes": {"log-level": 0}}'`
Ran `apiclient get settings.kubernetes` and verified correct value for `log-level`.
Checked `systemctl status kubelet` and verified `-v 0` was one of the arguments used to launch the process.
Ran `journalctl -u kubelet -f` and watched output to see if any additional log messages were being emitted.
Ran `apiclient set -j '{"kubernetes": {"log-level": 9}}'` and checked setting with `apiclient get`.
Checked `systemctl status kubelet` and verified `-v 9` was one of the arguments used to launch the process.
Ran `journalctl -u kubelet -f` and watched additional recurring log messages showing all activity.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
