### PR TITLE
CI: extract checks from build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,6 @@ jobs:
             { path = "NVIDIA", license-url = "https://www.nvidia.com/en-us/drivers/nvidia-license/" }
           ]
           EOF
-      - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
-      - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-fmt
-      - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-lints
       - run: |
           cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} \
             -e BUILDSYS_ARCH=${{ matrix.arch }} \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,30 @@
+name: Check
+on:
+  pull_request:
+    branches: [develop]
+    # Here we list file types that don't affect the build and don't need to use
+    # up our Actions runners.
+    paths-ignore:
+      # draw.io (diagrams.net) files, the source of png images for docs
+      - '**.drawio'
+      # Example configuration files
+      - '**.example'
+      # Markdown documentation
+      - '**.md'
+      # Images for documentation
+      - '**.png'
+      # Templates for README files
+      - '**.tpl'
+      # Sample config files and OpenAPI docs
+      - '**.yaml'
+
+jobs:
+  check:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup default 1.61.0
+      - run: cargo install --version 0.35.12 cargo-make
+      - run: cargo make unit-tests
+      - run: cargo make check-fmt
+      - run: cargo make check-lints


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

We currently have one workflow defined for our GitHub Actions. This workflow uses a matrix to run tests for every variant defined. In addition to performing the actual build for these variants, this also runs unit tests, checks formatting, and checks lint issues. Since these checks do not change based on the variant, this results in a lot of duplicated testing and adds a significant delay to how long it takes to get results.

This change extracts these common checks into a separate workflow so they are only run once. This also has the benefit of being able to run in parallel with some of the variant builds and may allow for faster feedback if there is something like a formatting issue.

**Testing done:**

Will be validated via GitHub Action runs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
