### PR TITLE
Update kernels to 5.10.135 and 5.15.59

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/04a89d2664b3be51cad04255bde6ff8ee1620a5281b0dc1f2f4707e1e6cfe150/kernel-5.10.130-118.517.amzn2.src.rpm"
-sha512 = "3047b80f7f8d703b3c0ab9785493245d01b27faa5948fddbcb9d0843c5bfcfa0972b61afa70551a2cc3d2c8b92ec0069993ed92ca12459f7ec67d03a00a031b7"
+url = "https://cdn.amazonlinux.com/blobstore/5ae72bc0cd79c8b003ee349c75c2f23292306528a387d4fba338d0627a7f0d4f/kernel-5.10.135-122.509.amzn2.src.rpm"
+sha512 = "2c76a56b784355dcca30f06bd343f067691d97e09fbf80bb071a79e874f05a4dd75e3e2431aed0351fc9b4845a6b6310121828127166a3bc5d15fd9bdb5c7336"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -133,3 +133,10 @@ CONFIG_EXT4_USE_FOR_EXT2=y
 
 # Disable USB-attached network interfaces, unused in the cloud and on server-grade hardware.
 # CONFIG_USB_NET_DRIVERS is not set
+
+# Disable obsolete NIC drivers
+# CONFIG_QLGE is not set
+
+# Disable unused qdiscs
+#   - sch_cake targets home routers and residential links
+# CONFIG_NET_SCH_CAKE is not set

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.130
+Version: 5.10.135
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/04a89d2664b3be51cad04255bde6ff8ee1620a5281b0dc1f2f4707e1e6cfe150/kernel-5.10.130-118.517.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/5ae72bc0cd79c8b003ee349c75c2f23292306528a387d4fba338d0627a7f0d4f/kernel-5.10.135-122.509.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/47fc1797c6cf0a9ee2cb4c2ccba9c73a47c0ff75bdb22bf19e939083029881dc/kernel-5.15.54-25.126.amzn2.src.rpm"
-sha512 = "5c08b5cd682adccd1bb9e2a418ae5bbb24ddcdc53e6ae46ea9760415989a25e02066db9e1aa6240455523189fb319f3aa0cb5b1f9ae8b5bccda8f4c46f2cb7a8"
+url = "https://cdn.amazonlinux.com/blobstore/ca3121c2e3966f8f7d542365e234f8a143c622dfbf6cfbbbe7793c2e8105ad64/kernel-5.15.59-33.133.amzn2.src.rpm"
+sha512 = "5358583e50f58a56f29ef306435593f8511b822387386739ca9c6c01942870bb989af0250b33073d5fec08ca32dbcbafcccd9ff46db1f7ee524b7dd11be2d764"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -134,3 +134,7 @@ CONFIG_EXT4_USE_FOR_EXT2=y
 
 # Disable USB-attached network interfaces, unused in the cloud and on server-grade hardware.
 # CONFIG_USB_NET_DRIVERS is not set
+
+# Disable unused qdiscs
+#   - sch_cake targets home routers and residential links
+# CONFIG_NET_SCH_CAKE is not set

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.54
+Version: 5.15.59
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/47fc1797c6cf0a9ee2cb4c2ccba9c73a47c0ff75bdb22bf19e939083029881dc/kernel-5.15.54-25.126.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/ca3121c2e3966f8f7d542365e234f8a143c622dfbf6cfbbbe7793c2e8105ad64/kernel-5.15.59-33.133.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** This rebases the Bottlerocket kernels in preparation for the 1.10 release. The new kernels are based on 5.10.135 and 5.15.59, respectively.

Note that this picks up the mitigations against retbleed, an attack targeting previous Spectre mitigations. The configuration for these mitigations matches upstream defaults. 


**Testing done:**

Report from `tools/diff-kernel-config`:

```
config-aarch64-5.10-aws-k8s-1.23-diff:    0 removed,   0 added,   1 changed
config-aarch64-5.15-aws-dev-diff:         0 removed,   0 added,   0 changed
config-aarch64-5.15-metal-dev-diff:       0 removed,   0 added,   0 changed
config-x86_64-5.10-aws-k8s-1.23-diff:     0 removed,   6 added,   1 changed
config-x86_64-5.10-metal-k8s-1.23-diff:   0 removed,   6 added,   1 changed
config-x86_64-5.15-aws-dev-diff:          0 removed,   6 added,   1 changed
config-x86_64-5.15-metal-dev-diff:        0 removed,   6 added,   1 changed
```

You can find the full report [in this Gist](https://gist.github.com/markusboehme/320cbcc348b0d1202ba65d4583d0fdc5).

The newly added options for x86 builds are related to the retbleed mitigations. The upstream community used this as an opportunity to also restructure the configuration of various hardware vulnerability mitigations, which can be seen in the full report.

The changed option in some kernel builds relates to the Amazon Linux kernel dropping the `qlge` NIC driver, and me deciding to follow suit for the Bottlerocket kernels. The driver has known deficiencies which is the reason it lives in the staging tree of the kernel. Given that its hardware has been EOL'd more than 8 years ago, there is likely to be little interest in the driver in its current form, let alone in fixing its quality problems.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
