### PR TITLE
gitignore: add my/ scratch pad directory to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /Licenses.toml
 /licenses
 *.run
+/my/


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** Checked out repositories tend to accumulate files related to personal workflows. Add a `my/` directory in the repo root to the git ignore list so there's a dedicated area for those files while keeping "git status" output clean.

Examples of files I keep there `my/net.toml`, `my/kernel-update-1.10-diff`, `my/k8s-migration-user-data.toml`, ... The name may be a bit on the cute side, but arguably has some benefits:

1. It's short to type
2. It's easy to remember
3. It's leading to copy-pastable commands that show the reader where to substitute their own files

**Testing done:** Moved all my valuables to `my/` and rejoiced in clean `git status` output.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
