### PR TITLE
Fix kubelet log level

### DIFF
--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -216,7 +216,7 @@ struct KubernetesSettings {
     image_gc_high_threshold_percent: ImageGCHighThresholdPercent,
     image_gc_low_threshold_percent: ImageGCLowThresholdPercent,
     provider_id: Url,
-    kubelet_log_level: u8,
+    log_level: u8,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION


Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>

**Issue number:**
N / A

**Description of changes:**

In b696d6f, the new `kubernetes.log-level` setting was implemented but in the actual model the name of the new setting was `kubelet_log_level`. This renames it to `log_level` since that's what is used in the templated configuration files and in the documentation.

If I attempt to set the log level, the drop-in file for the kubelet isn't updated:

```bash
bash-5.1# apiclient set kubernetes.kubelet-log-level=8
bash-5.1# cat /etc/systemd/system/kubelet.service.d/exec-start.conf
[Service]
ExecStart=
ExecStart=/usr/bin/kubelet \
    --cloud-provider aws \
    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
    --config /etc/kubernetes/kubelet/config \
    --container-runtime=remote \
    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
    --containerd=/run/containerd/containerd.sock \
    --root-dir /var/lib/kubelet \
    --cert-dir /var/lib/kubelet/pki \
    --node-ip ${NODE_IP} \
    --node-labels "${NODE_LABELS}" \
    --register-with-taints "${NODE_TAINTS}" \
    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
```

`-v <level>` is missing which should be after `--register-with-taints` as shown [here].

[here]: https://github.com/bottlerocket-os/bottlerocket/blob/b122ea1c9140fc6dd10f464307d5a6aef2b5b603/packages/kubernetes-1.23/kubelet-exec-start-conf#L24

**Testing done:**
I started an `aws-k8s-1.22` instance and run the following commands while tailing the journal logs:

```bash
# Turns off the logs
bash-5.1# apiclient set kubernetes.log-level=0
# Enables some logs
bash-5.1# apiclient set kubernetes.log-level=3
# Enables all the logs
bash-5.1# apiclient set kubernetes.log-level=9
```

I didn't see any errors and I confirmed the setting was used, whereas with the previous configuration this setting wasn't rendered:

```bash
bash-5.1# cat /etc/systemd/system/kubelet.service.d/exec-start.conf
[Service]
ExecStart=
ExecStart=/usr/bin/kubelet \
    --cloud-provider aws \
    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
    --config /etc/kubernetes/kubelet/config \
    --container-runtime=remote \
    --container-runtime-endpoint=unix:///run/dockershim.sock \
    --containerd=/run/dockershim.sock \
    --network-plugin cni \
    --root-dir /var/lib/kubelet \
    --cert-dir /var/lib/kubelet/pki \
    --node-ip ${NODE_IP} \
    --node-labels "${NODE_LABELS}" \
    --register-with-taints "${NODE_TAINTS}" \
    # This wasn't rendered
    -v 9 \
    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
