### PR TITLE
Control container v0.6.3

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -149,4 +149,6 @@ version = "1.10.0"
     "migrate_v1.10.0_kubelet-log-level.lz4",
     "migrate_v1.10.0_aws-admin-container-v0-9-2.lz4",
     "migrate_v1.10.0_public-admin-container-v0-9-2.lz4",
+    "migrate_v1.10.0_aws-control-container-v0-6-3.lz4",
+    "migrate_v1.10.0_public-control-container-v0-6-3.lz4"
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -493,6 +493,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-6-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-endpoint"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2753,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-9-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-6-3"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -31,6 +31,8 @@ members = [
     "api/migration/migrations/v1.10.0/kubelet-log-level",
     "api/migration/migrations/v1.10.0/aws-admin-container-v0-9-2",
     "api/migration/migrations/v1.10.0/public-admin-container-v0-9-2",
+    "api/migration/migrations/v1.10.0/aws-control-container-v0-6-3",
+     "api/migration/migrations/v1.10.0/public-control-container-v0-6-3",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.10.0/aws-control-container-v0-6-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.10.0/aws-control-container-v0-6-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-6-3"
+version = "0.1.0"
+authors = ["Ethan Pullen <pullenep@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.10.0/aws-control-container-v0-6-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.0/aws-control-container-v0-6-3/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.1";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.3";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.10.0/public-control-container-v0-6-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.10.0/public-control-container-v0-6-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-6-3"
+version = "0.1.0"
+authors = ["Ethan Pullen <pullenep@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.10.0/public-control-container-v0-6-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.0/public-control-container-v0-6-3/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.1";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.1"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.3"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.1"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3"


### PR DESCRIPTION
Description of changes:

Update and migrate from control container v0.6.1 to v0.6.3.

### 0.6.3
* Update SSM agent to 3.1.1767.0 ([#34])

[#34]: https://github.com/bottlerocket-os/bottlerocket-control-container/pull/34

Testing done:

~~Coming soon!~~
Tested this pr along with #2471 using testsys.
```
NAME                            TYPE       STATE       PASSED   SKIPPED   FAILED
 x86-64-aws-k8s-121              Resource   completed
 x86-64-aws-k8s-121-1-initial    Test       passed      1        5772      0
 x86-64-aws-k8s-121-2-migrate    Test       passed      2        0         0
 x86-64-aws-k8s-121-3-migrated   Test       passed      1        5772      0
 x86-64-aws-k8s-121-4-migrate    Test       passed      2        0         0
 x86-64-aws-k8s-121-5-final      Test       passed      1        5772      0
 x86-64-aws-k8s-121-instances    Resource   completed
 ```
Migration test passed successfully.

Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.