### PR TITLE
specify mode for tmpfs mounts

### DIFF
--- a/packages/containerd/etc-containerd.mount
+++ b/packages/containerd/etc-containerd.mount
@@ -10,7 +10,7 @@ Wants=selinux-policy-files.service
 What=tmpfs
 Where=/etc/containerd
 Type=tmpfs
-Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0
+Options=nosuid,nodev,noexec,noatime,mode=0750,context=system_u:object_r:secret_t:s0
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/ecs-agent/etc-ecs.mount
+++ b/packages/ecs-agent/etc-ecs.mount
@@ -10,7 +10,7 @@ Wants=selinux-policy-files.service
 What=tmpfs
 Where=/etc/ecs
 Type=tmpfs
-Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0
+Options=nosuid,nodev,noexec,noatime,mode=0750,context=system_u:object_r:secret_t:s0
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/host-ctr/etc-host-containers.mount.in
+++ b/packages/host-ctr/etc-host-containers.mount.in
@@ -10,7 +10,7 @@ Wants=selinux-policy-files.service
 What=tmpfs
 Where=/etc/host-containers
 Type=tmpfs
-Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0
+Options=nosuid,nodev,noexec,noatime,mode=0750,context=system_u:object_r:secret_t:s0
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/release/etc-cni.mount
+++ b/packages/release/etc-cni.mount
@@ -8,7 +8,7 @@ Before=local-fs.target umount.target
 What=tmpfs
 Where=/etc/cni
 Type=tmpfs
-Options=nosuid,nodev,noexec,noatime
+Options=nosuid,nodev,noexec,noatime,mode=0755
 
 [Install]
 WantedBy=preconfigured.target


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**
Specify the mode for all tmpfs mounts. In practice, the mode didn't really matter because the SELinux label would enforce the expected permissions, but the "wide open" default mode for tmpfs mounts could trigger an alert from scanning tools.


**Testing done:**
Verified that `aws-ecs-1` and `aws-k8s-1.22` quick tests passed:
```
 NAME                            TYPE       STATE       PASSED   SKIPPED   FAILED
 aarch64-aws-ecs-1               Resource   completed
 aarch64-aws-ecs-1-instances     Resource   completed
 aarch64-aws-ecs-1-test          Test       passed      1        0         0
 aarch64-aws-k8s-122             Resource   completed
 aarch64-aws-k8s-122-instances   Resource   completed
 aarch64-aws-k8s-122-test        Test       passed      1        6441	   0
```

Confirmed that each mount had the expected permissions.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
