### PR TITLE
testsys: Fix typo in test setup command

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -79,7 +79,7 @@ kind get kubeconfig --name testsys > $TESTSYS_KUBECONFIG
 Install the testsys cluster components:
 
 ```shell
-cargo make setup-testsys
+cargo make setup-test
 ```
 
 Testsys containers will need AWS credentials.


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Trivial update. Our testing docs say to use `cargo make setup-testsys`, but the make target is actually `cargo make setup-test`.

**Testing done:**

:eyes: 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
