### PR TITLE
Update EKS-D to 1.23-6

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/5/artifacts/kubernetes/v1.23.9/kubernetes-src.tar.gz"
-sha512 = "730df4089fbc7ec52c9dc2bb886d010e56346d1475b46c471319f5e1a75f7c0b6767133d65ec8cd1afd0536dee649e964dbe32078e3cde099fddbc45efc90c47"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/6/artifacts/kubernetes/v1.23.12/kubernetes-src.tar.gz"
+sha512 = "503e7c54d50e71f9bc16ad1a338f50115cfa427e82ae80e4b74b3bce9cae2497508b97e596bbf26f8dd4705dba545ecd3a8746b506ec10ca8f549e609b026a65"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.23.9
+%global gover 1.23.12
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/5/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/6/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**

Closes #2487

**Description of changes:**
Updates Kubernetes version to 1.23.12 and adds some patches. See [changelog](https://github.com/aws/eks-distro/blob/main/docs/contents/releases/1-23/6/CHANGELOG-v1-23-eks-6.md) for more information.


**Testing done:**
Passes conformance tests in EKS-D

Built and launched aws-k8s-1.23 nodes in 1.23 cluster. Ran `sonobuoy run --mode conformance-lite` and passed all tests:

```
11:06:35 Sonobuoy plugins have completed. Preparing results for download.
11:06:55             e2e                                         global   complete   passed   Passed:154, Failed:  0

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
