### PR TITLE
Update EKS-D to 1.22-11

### DIFF
--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.22"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/10/artifacts/kubernetes/v1.22.12/kubernetes-src.tar.gz"
-sha512 = "9856612e69c64f7420603d76c8075542104c8b00b90913f8ee04a17f6cecf3b8a187cadf91754d588fa2ed0fbc065d91a2bd7de34774bdac3f6b43240107bab1"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/11/artifacts/kubernetes/v1.22.15/kubernetes-src.tar.gz"
+sha512 = "b0bb0338ede41ed90e711fe3835b0f86a061aed19b9a2555146ea9f402246e1776ddc5f04beb6e8b74f32756726993582391827910507dc169dabc7c339b2ab2"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.22.12
+%global gover 1.22.15
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/10/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/11/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**

Closes #2489

**Description of changes:**
Updates Kubernetes version to 1.22.15 and adds some patches. See [changelog](https://github.com/aws/eks-distro/blob/main/docs/contents/releases/1-22/11/CHANGELOG-v1-22-eks-11.md) for more information.

**Testing done:**
Passes conformance tests in EKS-D

Built and launched aws-k8s-1.22 variant in 1.22 cluster. Ran `sonobuoy run --mode conformance-lite` and passed all tests:
```
10:44:02 Sonobuoy plugins have completed. Preparing results for download.
10:44:22             e2e     global   complete   passed   Passed:143, Failed:  0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
