### PR TITLE
Add fallback region to early-boot-config

### DIFF
--- a/sources/api/early-boot-config/src/main.rs
+++ b/sources/api/early-boot-config/src/main.rs
@@ -15,7 +15,6 @@ Currently, Amazon EC2 is supported through the IMDSv1 HTTP API.  Data will be ta
 #[macro_use]
 extern crate log;
 
-use constants;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ensure, ResultExt};
 use std::fs;
@@ -92,7 +91,7 @@ fn parse_args(args: env::Args) -> Args {
     }
 
     Args {
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }
@@ -177,7 +176,7 @@ mod error {
         },
 
         #[snafu(display("Provider error: {}", source))]
-        ProviderError { source: Box<dyn std::error::Error> },
+        Provider { source: Box<dyn std::error::Error> },
 
         #[snafu(display("Error {} when {}ing '{}': {}", code, method, uri, response_body))]
         Response {

--- a/sources/api/early-boot-config/src/provider/aws.rs
+++ b/sources/api/early-boot-config/src/provider/aws.rs
@@ -15,7 +15,7 @@ use crate::provider::local_file::{local_file_user_data, USER_DATA_FILE};
 pub(crate) struct AwsDataProvider;
 
 impl AwsDataProvider {
-    const IDENTITY_DOCUMENT_FILE: &'static str = "/etc/early-boot-config/identity-document";
+    const IDENTITY_DOCUMENT_FILE: &str = "/etc/early-boot-config/identity-document";
     const FALLBACK_REGION: &str = "us-east-1";
 
     /// Fetches user data, which is expected to be in TOML form and contain a `[settings]` section,

--- a/sources/api/early-boot-config/src/provider/local_file.rs
+++ b/sources/api/early-boot-config/src/provider/local_file.rs
@@ -5,7 +5,7 @@ use crate::compression::expand_file_maybe;
 use snafu::ResultExt;
 use std::path::Path;
 
-pub(crate) const USER_DATA_FILE: &'static str = "/var/lib/bottlerocket/user-data.toml";
+pub(crate) const USER_DATA_FILE: &str = "/var/lib/bottlerocket/user-data.toml";
 
 pub(crate) fn local_file_user_data(
 ) -> std::result::Result<Option<SettingsJson>, Box<dyn std::error::Error>> {

--- a/sources/api/early-boot-config/src/settings.rs
+++ b/sources/api/early-boot-config/src/settings.rs
@@ -39,7 +39,7 @@ impl SettingsJson {
         S2: Into<String>,
     {
         let mut val: toml::Value =
-            toml::from_str(&data.as_ref()).context(error::TOMLUserDataParseSnafu)?;
+            toml::from_str(data.as_ref()).context(error::TOMLUserDataParseSnafu)?;
         let table = val
             .as_table_mut()
             .context(error::UserDataNotTomlTableSnafu)?;


### PR DESCRIPTION
**Description of changes:**

Replace `ImdsMissingRegion` panic with a fallback value in certain development scenarios without IMDS.

Also addresses some clippy warnings for general housekeeping.

**Testing done:**

- [x] Build `aws-k8s` variant and launch in an environment without IMDS.
- [x] Build `aws-k8s` variant and launch in EC2.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
