### PR TITLE
settings: Add container-runtime settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,27 @@ It is recommended to programmatically set these settings via `apiclient` through
 
 In addition to the container runtime daemons, these credential settings will also apply to [host-container](#host-containers-settings) and [bootstrap-container](#bootstrap-containers-settings) image pulls as well.
 
+#### Container runtime settings
+
+Some behavior of the container runtime (currently `containerd`) can be modified with the following settings:
+
+* `settings.container-runtime.enable-unprivileged-icmp`: Allow unprivileged containers to open ICMP echo sockets.
+* `settings.container-runtime.enable-unprivileged-ports`: Allow unprivileged containers to bind to ports < 1024.
+* `settings.container-runtime.max-concurrent-downloads`: Restricts the number of concurrent layer downloads for each image.
+* `settings.container-runtime.max-container-log-line-size`: Controls how long container log messages can be.
+  If the log output is longer than the limit, the log message will be broken into multiple lines.
+
+Example container runtime settings:
+
+```toml
+[settings.container-runtime]
+# Set log line length to unlimited
+max-container-log-line-size = -1
+max-concurrent-downloads = 4
+enable-unprivileged-icmp = true
+enable-unprivileged-ports = true
+```
+
 #### Updates settings
 
 * `settings.updates.metadata-base-url`: The common portion of all URIs used to download update metadata.

--- a/packages/containerd/containerd-config-toml_k8s
+++ b/packages/containerd/containerd-config-toml_k8s
@@ -16,6 +16,18 @@ address = "/run/dockershim.sock"
 enable_selinux = true
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 sandbox_image = "{{settings.kubernetes.pod-infra-container-image}}"
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
 default_runtime_name = "shimpei"

--- a/packages/containerd/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd/containerd-config-toml_k8s_containerd_sock
@@ -16,6 +16,18 @@ address = "/run/containerd/containerd.sock"
 enable_selinux = true
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 sandbox_image = "{{settings.kubernetes.pod-infra-container-image}}"
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
 default_runtime_name = "shimpei"

--- a/packages/containerd/containerd-config-toml_k8s_nvidia
+++ b/packages/containerd/containerd-config-toml_k8s_nvidia
@@ -16,6 +16,18 @@ address = "/run/dockershim.sock"
 enable_selinux = true
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 sandbox_image = "{{settings.kubernetes.pod-infra-container-image}}"
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
 default_runtime_name = "nvidia"

--- a/packages/containerd/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -16,6 +16,18 @@ address = "/run/containerd/containerd.sock"
 enable_selinux = true
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 sandbox_image = "{{settings.kubernetes.pod-infra-container-image}}"
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
 default_runtime_name = "nvidia"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1048,6 +1048,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "container-runtime"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "container-runtime-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -32,7 +32,9 @@ members = [
     "api/migration/migrations/v1.10.0/aws-admin-container-v0-9-2",
     "api/migration/migrations/v1.10.0/public-admin-container-v0-9-2",
     "api/migration/migrations/v1.10.0/aws-control-container-v0-6-3",
-     "api/migration/migrations/v1.10.0/public-control-container-v0-6-3",
+    "api/migration/migrations/v1.10.0/public-control-container-v0-6-3",
+    "api/migration/migrations/v1.10.1/container-runtime",
+    "api/migration/migrations/v1.10.1/container-runtime-metadata",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.10.1/container-runtime-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.10.1/container-runtime-metadata/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "container-runtime-metadata"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.10.1/container-runtime-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.1/container-runtime-metadata/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.container-runtime",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.10.1/container-runtime/Cargo.toml
+++ b/sources/api/migration/migrations/v1.10.1/container-runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "container-runtime"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.10.1/container-runtime/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.1/container-runtime/src/main.rs
@@ -1,0 +1,20 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&["settings.container-runtime"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -29,6 +29,11 @@ restart-commands = ["/bin/systemctl try-restart containerd.service"]
 path = "/etc/containerd/config.toml"
 template-path = "/usr/share/templates/containerd-config-toml_basic"
 
+# Container runtime settings.
+
+[metadata.settings.container-runtime]
+affected-services = ["containerd"]
+
 # Host-container runtime
 
 [services.host-containerd]

--- a/sources/models/src/aws-k8s-1.22/mod.rs
+++ b/sources/models/src/aws-k8s-1.22/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
+    AwsSettings, BootstrapContainer, CloudFormationSettings, ContainerRuntimeSettings, DnsSettings,
+    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -28,4 +28,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
+    MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
+    UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -29,4 +30,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -374,6 +374,15 @@ struct AutoScalingSettings {
     should_wait: bool,
 }
 
+// Container runtime settings
+#[model]
+struct ContainerRuntimeSettings {
+    max_container_log_line_size: i32,
+    max_concurrent_downloads: i32,
+    enable_unprivileged_ports: bool,
+    enable_unprivileged_icmp: bool,
+}
+
 ///// Internal services
 
 // Note: Top-level objects that get returned from the API should have a "rename" attribute

--- a/sources/models/src/metal-k8s-1.22/mod.rs
+++ b/sources/models/src/metal-k8s-1.22/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings,
-    KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
+    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
+    PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -27,4 +27,5 @@ struct Settings {
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings,
-    KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
+    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
+    PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -27,4 +27,5 @@ struct Settings {
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/models/src/vmware-k8s-1.22/mod.rs
+++ b/sources/models/src/vmware-k8s-1.22/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootstrapContainer, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings,
+    KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
+    RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -26,4 +26,5 @@ struct Settings {
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings,
-    KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
+    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
+    PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -27,4 +27,5 @@ struct Settings {
     container_registry: RegistrySettings,
     oci_hooks: OciHooks,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
 }


### PR DESCRIPTION
**Issue number:**

Closes #2292
Closes: #2466

**Description of changes:**

This adds `settings.container-runtime` settings. The affect how containerd is configured.

`max-container-log-line-size` controls how long a log line can be from a container before containerd breaks it into multiple separate lines.

`max-concurrent-downloads` controls how many concurrent downloads will be done in parallel to download an image.

`settings.container-runtime.enable-unprivileged-icmp`: Allow unprivileged containers to open ICMP echo sockets.

`settings.container-runtime.enable-unprivileged-ports`: Allow unprivileged containers to bind to ports < 1024.

**Testing done:**

Created EKS cluster with custom build, checked setting and retrieving settings via `apiclient get settings.container-runtime`. Verified containerd service config would get updated and service restarted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
