### PR TITLE
apply two fixes for GRUB build

### DIFF
--- a/packages/grub/Cargo.toml
+++ b/packages/grub/Cargo.toml
@@ -11,6 +11,3 @@ path = "pkg.rs"
 [[package.metadata.build-package.external-files]]
 url = "https://cdn.amazonlinux.com/blobstore/21d0df3b06c1c5cc9e5cf3bb559dad713335e782ac3a46b57c5d0097e22c0aec/grub2-2.06-9.amzn2.0.1.src.rpm"
 sha512 = "f27b4005e789ce1e0e792133f6adfbdbf221245c03b27c25285ff5b81e53065385536971934744f33c52a924022480aa15cd25e8d5ded9f4999c753e8394ae36"
-
-[build-dependencies]
-glibc = { path = "../glibc" }

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -63,7 +63,6 @@ BuildRequires: automake
 BuildRequires: bison
 BuildRequires: flex
 BuildRequires: gettext-devel
-BuildRequires: %{_cross_os}glibc-devel
 
 %description
 %{summary}.

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -109,7 +109,6 @@ git commit -a -q -m "base"
 git am --whitespace=nowarn ../*.patch %{patches}
 
 ./bootstrap
-./autogen.sh
 
 %global grub_cflags -pipe -fno-stack-protector -fno-strict-aliasing
 %global grub_ldflags -static

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -350,9 +350,6 @@ dependencies = [
 [[package]]
 name = "grub"
 version = "0.1.0"
-dependencies = [
- "glibc",
-]
 
 [[package]]
 name = "host-ctr"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**
Removes an unnecessary dependency on the target's C library, and an unnecessary invocation of `autogen.sh`.


**Testing done:**
GRUB still builds.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
