### PR TITLE
switch to latest Dockerfile frontend for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1.3-experimental
+# syntax=docker/dockerfile:1.4.3
 # This Dockerfile has two sections which are used to build rpm.spec packages and to create
 # Bottlerocket images, respectively. They are marked as Section 1 and Section 2. buildsys
 # uses Section 1 during build-package calls and Section 2 during build-variant calls.


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Update the Dockerfile from `1.1.3-experimental` to `1.4.3`. (It's been a while!)

My goal is to enable the Dockerfile syntax for `RUN --mount=type=secret`, since these secrets will be used for Secure Boot signing.

It's possible there will be some backwards compatibility headaches here for older versions of Docker, so I'd like to get this merged early in a release cycle to shake out any problems.

**Testing done:**
Builds for me!


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
