### PR TITLE
grub: update to grub-2.06-42.amzn2022

### DIFF
--- a/packages/grub/0002-gpt-start-new-GPT-module.patch
+++ b/packages/grub/0002-gpt-start-new-GPT-module.patch
@@ -1,4 +1,4 @@
-From 6635d2ce6f2b2a0be4049af3ce271cdab3fbd97b Mon Sep 17 00:00:00 2001
+From b0aec16d82a40c58ed47235c8b10612d07645eaa Mon Sep 17 00:00:00 2001
 From: Michael Marineau <michael.marineau@coreos.com>
 Date: Sun, 28 Sep 2014 21:26:21 -0700
 Subject: [PATCH] gpt: start new GPT module
@@ -47,10 +47,10 @@ index 3f191aa..c7efe17 100644
    name = grub-menulst2cfg;
    mansection = 1;
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 9cff83f..3443e9c 100644
+index 5212faf..e9cce06 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -932,6 +932,11 @@ module = {
+@@ -942,6 +942,11 @@ module = {
    common = commands/gptsync.c;
  };
  
@@ -919,5 +919,5 @@ index 0000000..a824cd9
 +  grub_fini_all ();
 +}
 -- 
-2.21.3
+2.36.1
 

--- a/packages/grub/0007-gpt-add-write-function-and-gptrepair-command.patch
+++ b/packages/grub/0007-gpt-add-write-function-and-gptrepair-command.patch
@@ -1,4 +1,4 @@
-From b6fdf2155967411d35ebf7667f0495ec741ad055 Mon Sep 17 00:00:00 2001
+From 822c0cb2c9d6cd7b0e4be0362bbc5804417e479f Mon Sep 17 00:00:00 2001
 From: Michael Marineau <michael.marineau@coreos.com>
 Date: Sun, 19 Oct 2014 14:21:29 -0700
 Subject: [PATCH] gpt: add write function and gptrepair command
@@ -36,10 +36,10 @@ index c7efe17..a2ca51d 100644
    testcase;
    name = file_filter_test;
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 3443e9c..72d485f 100644
+index e9cce06..c040652 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -932,6 +932,11 @@ module = {
+@@ -942,6 +942,11 @@ module = {
    common = commands/gptsync.c;
  };
  
@@ -363,5 +363,5 @@ index 0000000..80b2de6
 +cmp "${img1}" "${img2}"
 +echo
 -- 
-2.21.3
+2.36.1
 

--- a/packages/grub/0009-gpt-new-gptprio.next-command-for-selecting-priority-.patch
+++ b/packages/grub/0009-gpt-new-gptprio.next-command-for-selecting-priority-.patch
@@ -1,4 +1,4 @@
-From ad528de92162a7aaa2666782c5cd18a9ab14d7e2 Mon Sep 17 00:00:00 2001
+From 06eff592def149c09fa42fee4e5d98b7abf00717 Mon Sep 17 00:00:00 2001
 From: Michael Marineau <michael.marineau@coreos.com>
 Date: Mon, 3 Nov 2014 17:14:37 -0800
 Subject: [PATCH] gpt: new gptprio.next command for selecting priority based
@@ -42,10 +42,10 @@ index a2ca51d..eb4bc90 100644
    testcase;
    name = file_filter_test;
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 72d485f..78c64a8 100644
+index c040652..393aecd 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -937,6 +937,11 @@ module = {
+@@ -947,6 +947,11 @@ module = {
    common = commands/gptrepair.c;
  };
  
@@ -525,5 +525,5 @@ index 0000000..f4aea0d
 +check_prio 2 3 0 0
 +check_prio 3 2 0 0
 -- 
-2.21.3
+2.36.1
 

--- a/packages/grub/0014-gpt-add-search-by-partition-label-and-uuid-commands.patch
+++ b/packages/grub/0014-gpt-add-search-by-partition-label-and-uuid-commands.patch
@@ -1,19 +1,25 @@
-From 0fceffa51b087c1f3f19f470f08e9378d71ddb2d Mon Sep 17 00:00:00 2001
+From 334b58a122bad34c7efa1b1ea6d58389477fd255 Mon Sep 17 00:00:00 2001
 From: Michael Marineau <michael.marineau@coreos.com>
 Date: Thu, 27 Nov 2014 16:34:21 -0800
 Subject: [PATCH] gpt: add search by partition label and uuid commands
 
 Builds on the existing filesystem search code. Only for GPT right now.
+
+[markubo: Update to grub-2.06-42.amzn2022. Search functions take a more
+general search_flags parameter now instead of a no_floppy flag.]
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+
 ---
  Makefile.util.def                      |  2 +
  grub-core/Makefile.core.def            | 10 +++
  grub-core/commands/search.c            | 49 +++++++++++++++
  grub-core/commands/search_part_label.c |  5 ++
  grub-core/commands/search_part_uuid.c  |  5 ++
- grub-core/commands/search_wrap.c       | 12 ++++
+ grub-core/commands/search_wrap.c       | 10 +++
  grub-core/lib/gpt.c                    | 64 ++++++++++++++++++++
  include/grub/gpt_partition.h           | 16 +++++
- include/grub/search.h                  |  4 ++
+ include/grub/search.h                  |  6 ++
  tests/gpt_unit_test.c                  | 84 ++++++++++++++++++++++++++
  10 files changed, 251 insertions(+)
  create mode 100644 grub-core/commands/search_part_label.c
@@ -33,10 +39,10 @@ index eb4bc90..8f74405 100644
    common = grub-core/kern/emu/hostfs.c;
    common = grub-core/lib/gpt.c;
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 78c64a8..fb4b1a1 100644
+index 393aecd..3cde624 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -1136,6 +1136,16 @@ module = {
+@@ -1152,6 +1152,16 @@ module = {
    common = commands/search_label.c;
  };
  
@@ -54,7 +60,7 @@ index 78c64a8..fb4b1a1 100644
    name = setpci;
    common = commands/setpci.c;
 diff --git a/grub-core/commands/search.c b/grub-core/commands/search.c
-index ed090b3..4ad72c5 100644
+index 57d26ce..bb0c7cb 100644
 --- a/grub-core/commands/search.c
 +++ b/grub-core/commands/search.c
 @@ -30,6 +30,9 @@
@@ -67,7 +73,7 @@ index ed090b3..4ad72c5 100644
  
  GRUB_MOD_LICENSE ("GPLv3+");
  
-@@ -90,6 +93,44 @@ iterate_device (const char *name, void *data)
+@@ -109,6 +112,44 @@ iterate_device (const char *name, void *data)
  	}
        grub_free (buf);
      }
@@ -112,7 +118,7 @@ index ed090b3..4ad72c5 100644
  #else
      {
        /* SEARCH_FS_UUID or SEARCH_LABEL */
-@@ -313,6 +354,10 @@ static grub_command_t cmd;
+@@ -332,6 +373,10 @@ static grub_command_t cmd;
  
  #ifdef DO_SEARCH_FILE
  GRUB_MOD_INIT(search_fs_file)
@@ -123,7 +129,7 @@ index ed090b3..4ad72c5 100644
  #elif defined (DO_SEARCH_FS_UUID)
  GRUB_MOD_INIT(search_fs_uuid)
  #else
-@@ -327,6 +372,10 @@ GRUB_MOD_INIT(search_label)
+@@ -346,6 +391,10 @@ GRUB_MOD_INIT(search_label)
  
  #ifdef DO_SEARCH_FILE
  GRUB_MOD_FINI(search_fs_file)
@@ -157,7 +163,7 @@ index 0000000..2d1d3d0
 +#define HELP_MESSAGE N_("Search devices by partition UUID. If VARIABLE is specified, the first device found is set to a variable.")
 +#include "search.c"
 diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
-index 47fc8eb..d357454 100644
+index 0b62acf..82f8e63 100644
 --- a/grub-core/commands/search_wrap.c
 +++ b/grub-core/commands/search_wrap.c
 @@ -36,6 +36,10 @@ static const struct grub_arg_option options[] =
@@ -171,7 +177,7 @@ index 47fc8eb..d357454 100644
      {"set",		's', GRUB_ARG_OPTION_OPTIONAL,
       N_("Set a variable to the first device found."), N_("VARNAME"),
       ARG_TYPE_STRING},
-@@ -71,6 +75,8 @@ enum options
+@@ -72,6 +76,8 @@ enum options
      SEARCH_FILE,
      SEARCH_LABEL,
      SEARCH_FS_UUID,
@@ -179,20 +185,18 @@ index 47fc8eb..d357454 100644
 +    SEARCH_PART_UUID,
      SEARCH_SET,
      SEARCH_NO_FLOPPY,
-     SEARCH_HINT,
-@@ -186,6 +192,12 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+     SEARCH_EFIDISK_ONLY,
+@@ -193,6 +199,10 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+     grub_search_label (id, var, flags, hints, nhints);
    else if (state[SEARCH_FS_UUID].set)
-     grub_search_fs_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
- 			 hints, nhints);
+     grub_search_fs_uuid (id, var, flags, hints, nhints);
 +  else if (state[SEARCH_PART_LABEL].set)
-+    grub_search_part_label (id, var, state[SEARCH_NO_FLOPPY].set,
-+			    hints, nhints);
++    grub_search_part_label (id, var, flags, hints, nhints);
 +  else if (state[SEARCH_PART_UUID].set)
-+    grub_search_part_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
-+			   hints, nhints);
++    grub_search_part_uuid (id, var, flags, hints, nhints);
    else if (state[SEARCH_FILE].set)
-     grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
- 			 hints, nhints);
+     grub_search_fs_file (id, var, flags, hints, nhints);
+   else
 diff --git a/grub-core/lib/gpt.c b/grub-core/lib/gpt.c
 index 9a1835b..10a4b85 100644
 --- a/grub-core/lib/gpt.c
@@ -309,16 +313,18 @@ index a44c0d5..7b04080 100644
 +
  #endif /* ! GRUB_GPT_PARTITION_HEADER */
 diff --git a/include/grub/search.h b/include/grub/search.h
-index d80347d..c2f40ab 100644
+index 4190aeb..66722a6 100644
 --- a/include/grub/search.h
 +++ b/include/grub/search.h
-@@ -25,5 +25,9 @@ void grub_search_fs_uuid (const char *key, const char *var, int no_floppy,
- 			  char **hints, unsigned nhints);
- void grub_search_label (const char *key, const char *var, int no_floppy,
+@@ -34,5 +34,11 @@ void grub_search_fs_uuid (const char *key, const char *var,
+ void grub_search_label (const char *key, const char *var,
+ 			enum search_flags flags,
  			char **hints, unsigned nhints);
-+void grub_search_part_uuid (const char *key, const char *var, int no_floppy,
++void grub_search_part_uuid (const char *key, const char *var,
++			    enum search_flags flags,
 +			    char **hints, unsigned nhints);
-+void grub_search_part_label (const char *key, const char *var, int no_floppy,
++void grub_search_part_label (const char *key, const char *var,
++			     enum search_flags flags,
 +			     char **hints, unsigned nhints);
  
  #endif
@@ -442,5 +448,5 @@ index 5692a5a..deb55a9 100644
    grub_fini_all ();
  }
 -- 
-2.21.3
+2.36.1
 

--- a/packages/grub/0017-gpt-add-search-by-disk-uuid-command.patch
+++ b/packages/grub/0017-gpt-add-search-by-disk-uuid-command.patch
@@ -1,17 +1,22 @@
-From 9963416869afbe7fa9e671fa6ffd0871aec994f8 Mon Sep 17 00:00:00 2001
+From a4ecd2c5ff6cb23af51977a622dca5fc2a9b7cef Mon Sep 17 00:00:00 2001
 From: Alex Crawford <alex.crawford@coreos.com>
 Date: Mon, 31 Aug 2015 15:15:48 -0700
 Subject: [PATCH] gpt: add search by disk uuid command
+
+[markubo: Update to grub-2.06-42.amzn2022. Search functions take a more
+general search_flags parameter now instead of a no_floppy flag.]
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
 
 ---
  Makefile.util.def                     |  1 +
  grub-core/Makefile.core.def           |  5 ++++
  grub-core/commands/search.c           | 28 +++++++++++++++++++++--
  grub-core/commands/search_disk_uuid.c |  5 ++++
- grub-core/commands/search_wrap.c      |  6 +++++
+ grub-core/commands/search_wrap.c      |  5 ++++
  grub-core/lib/gpt.c                   | 21 +++++++++++++++++
  include/grub/gpt_partition.h          |  4 ++++
- include/grub/search.h                 |  2 ++
+ include/grub/search.h                 |  3 +++
  tests/gpt_unit_test.c                 | 33 +++++++++++++++++++++++++++
  9 files changed, 103 insertions(+), 2 deletions(-)
  create mode 100644 grub-core/commands/search_disk_uuid.c
@@ -29,10 +34,10 @@ index 8f74405..33ce60d 100644
    common = grub-core/kern/emu/hostfs.c;
    common = grub-core/lib/gpt.c;
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index fb4b1a1..b9c0494 100644
+index 3cde624..3096cd4 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -1146,6 +1146,11 @@ module = {
+@@ -1162,6 +1162,11 @@ module = {
    common = commands/search_part_label.c;
  };
  
@@ -45,7 +50,7 @@ index fb4b1a1..b9c0494 100644
    name = setpci;
    common = commands/setpci.c;
 diff --git a/grub-core/commands/search.c b/grub-core/commands/search.c
-index 4ad72c5..fd411ce 100644
+index bb0c7cb..ec03c75 100644
 --- a/grub-core/commands/search.c
 +++ b/grub-core/commands/search.c
 @@ -30,7 +30,8 @@
@@ -58,9 +63,9 @@ index 4ad72c5..fd411ce 100644
  #include <grub/gpt_partition.h>
  #endif
  
-@@ -69,7 +70,7 @@ iterate_device (const char *name, void *data)
-       name[0] == 'f' && name[1] == 'd' && name[2] >= '0' && name[2] <= '9')
-     return 1;
+@@ -88,7 +89,7 @@ iterate_device (const char *name, void *data)
+       grub_device_close (dev);
+     }
  
 -#ifdef DO_SEARCH_FS_UUID
 +#if defined(DO_SEARCH_FS_UUID) || defined(DO_SEARCH_DISK_UUID)
@@ -93,7 +98,7 @@ index 4ad72c5..fd411ce 100644
  	  grub_device_close (dev);
  	}
      }
-@@ -360,6 +380,8 @@ GRUB_MOD_INIT(search_part_uuid)
+@@ -379,6 +399,8 @@ GRUB_MOD_INIT(search_part_uuid)
  GRUB_MOD_INIT(search_part_label)
  #elif defined (DO_SEARCH_FS_UUID)
  GRUB_MOD_INIT(search_fs_uuid)
@@ -102,7 +107,7 @@ index 4ad72c5..fd411ce 100644
  #else
  GRUB_MOD_INIT(search_label)
  #endif
-@@ -378,6 +400,8 @@ GRUB_MOD_FINI(search_part_uuid)
+@@ -397,6 +419,8 @@ GRUB_MOD_FINI(search_part_uuid)
  GRUB_MOD_FINI(search_part_label)
  #elif defined (DO_SEARCH_FS_UUID)
  GRUB_MOD_FINI(search_fs_uuid)
@@ -123,7 +128,7 @@ index 0000000..fba96f6
 +#define HELP_MESSAGE N_("Search devices by disk UUID. If VARIABLE is specified, the first device found is set to a variable.")
 +#include "search.c"
 diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
-index d357454..fc149cd 100644
+index 82f8e63..c8152b1 100644
 --- a/grub-core/commands/search_wrap.c
 +++ b/grub-core/commands/search_wrap.c
 @@ -40,6 +40,8 @@ static const struct grub_arg_option options[] =
@@ -135,24 +140,23 @@ index d357454..fc149cd 100644
      {"set",		's', GRUB_ARG_OPTION_OPTIONAL,
       N_("Set a variable to the first device found."), N_("VARNAME"),
       ARG_TYPE_STRING},
-@@ -77,6 +79,7 @@ enum options
+@@ -78,6 +80,7 @@ enum options
      SEARCH_FS_UUID,
      SEARCH_PART_LABEL,
      SEARCH_PART_UUID,
 +    SEARCH_DISK_UUID,
      SEARCH_SET,
      SEARCH_NO_FLOPPY,
-     SEARCH_HINT,
-@@ -198,6 +201,9 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+     SEARCH_EFIDISK_ONLY,
+@@ -203,6 +206,8 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+     grub_search_part_label (id, var, flags, hints, nhints);
    else if (state[SEARCH_PART_UUID].set)
-     grub_search_part_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
- 			   hints, nhints);
+     grub_search_part_uuid (id, var, flags, hints, nhints);
 +  else if (state[SEARCH_DISK_UUID].set)
-+    grub_search_disk_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
-+			   hints, nhints);
++    grub_search_disk_uuid (id, var, flags, hints, nhints);
    else if (state[SEARCH_FILE].set)
-     grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
- 			 hints, nhints);
+     grub_search_fs_file (id, var, flags, hints, nhints);
+   else
 diff --git a/grub-core/lib/gpt.c b/grub-core/lib/gpt.c
 index aedc4f7..e162baf 100644
 --- a/grub-core/lib/gpt.c
@@ -199,14 +203,15 @@ index 1eb2f7b..16fdd7f 100644
 +
  #endif /* ! GRUB_GPT_PARTITION_HEADER */
 diff --git a/include/grub/search.h b/include/grub/search.h
-index c2f40ab..7f69d25 100644
+index 66722a6..a5f56b2 100644
 --- a/include/grub/search.h
 +++ b/include/grub/search.h
-@@ -29,5 +29,7 @@ void grub_search_part_uuid (const char *key, const char *var, int no_floppy,
- 			    char **hints, unsigned nhints);
- void grub_search_part_label (const char *key, const char *var, int no_floppy,
+@@ -40,5 +40,8 @@ void grub_search_part_uuid (const char *key, const char *var,
+ void grub_search_part_label (const char *key, const char *var,
+ 			     enum search_flags flags,
  			     char **hints, unsigned nhints);
-+void grub_search_disk_uuid (const char *key, const char *var, int no_floppy,
++void grub_search_disk_uuid (const char *key, const char *var,
++			    enum search_flags flags,
 +			    char **hints, unsigned nhints);
  
  #endif
@@ -268,5 +273,5 @@ index 7a1af46..60f6017 100644
    grub_fini_all ();
  }
 -- 
-2.21.3
+2.36.1
 

--- a/packages/grub/Cargo.toml
+++ b/packages/grub/Cargo.toml
@@ -9,5 +9,5 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.amazonlinux.com/blobstore/21d0df3b06c1c5cc9e5cf3bb559dad713335e782ac3a46b57c5d0097e22c0aec/grub2-2.06-9.amzn2.0.1.src.rpm"
-sha512 = "f27b4005e789ce1e0e792133f6adfbdbf221245c03b27c25285ff5b81e53065385536971934744f33c52a924022480aa15cd25e8d5ded9f4999c753e8394ae36"
+url = "https://al2022-repos-us-west-2-9761ab97.s3.dualstack.us-west-2.amazonaws.com/blobstore/aa41fdf9982b65a4c4dad5df5b49ba143b1710d60f82688221966f3c790c6c63/grub2-2.06-42.amzn2022.0.1.src.rpm"
+sha512 = "3dbfc0cc48dc7125dca445ca9b6538ecb2c548cadc77714b930eb9992697e6eaef6c5eaece6a367b232d20a2d693a4fbd93b537d79596de4791c576f3b8ecc18"

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -6,7 +6,7 @@
 
 # This is specific to the upstream source RPM, and will likely need to be
 # updated for each new version.
-%global gnulib_fixes gnulib-fixes-0e9febb5e
+%global gnulib_version gnulib-9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
 Name: %{_cross_os}grub
 Version: 2.06
@@ -14,7 +14,7 @@ Release: 1%{?dist}
 Summary: Bootloader with support for Linux and more
 License: GPL-3.0-or-later AND Unicode-DFS-2015
 URL: https://www.gnu.org/software/grub/
-Source0: https://cdn.amazonlinux.com/blobstore/21d0df3b06c1c5cc9e5cf3bb559dad713335e782ac3a46b57c5d0097e22c0aec/grub2-2.06-9.amzn2.0.1.src.rpm
+Source0: https://al2022-repos-us-west-2-9761ab97.s3.dualstack.us-west-2.amazonaws.com/blobstore/aa41fdf9982b65a4c4dad5df5b49ba143b1710d60f82688221966f3c790c6c63/grub2-2.06-42.amzn2022.0.1.src.rpm
 Source1: bios.cfg
 Source2: efi.cfg
 Patch0001: 0001-setup-Add-root-device-argument-to-grub-setup.patch
@@ -83,7 +83,7 @@ Summary: Tools for the bootloader with support for Linux and more
 %prep
 rpm2cpio %{S:0} | cpio -iu grub-%{version}.tar.xz \
   bootstrap bootstrap.conf \
-  gitignore %{gnulib_fixes}.tar.gz \
+  gitignore %{gnulib_version}.tar.gz \
   "*.patch"
 
 # Mimic prep from upstream spec to prepare for patching.
@@ -91,12 +91,8 @@ tar -xof grub-%{version}.tar.xz; rm grub-%{version}.tar.xz
 %setup -TDn grub-%{version}
 mv ../bootstrap{,.conf} .
 mv ../gitignore .gitignore
-tar -xof ../%{gnulib_fixes}.tar.gz; rm ../%{gnulib_fixes}.tar.gz
-mv %{gnulib_fixes} gnulib
-pushd gnulib
-patch -p1 < ../../gnulib-amzn2-cflags.patch
-rm ../../gnulib-amzn2-cflags.patch
-popd
+tar -xof ../%{gnulib_version}.tar.gz; rm ../%{gnulib_version}.tar.gz
+mv %{gnulib_version} gnulib
 cp unicode/COPYING COPYING.unicode
 rm -f configure
 
@@ -107,6 +103,11 @@ git config user.name 'user'
 git add .
 git commit -a -q -m "base"
 git am --whitespace=nowarn ../*.patch %{patches}
+
+# Let bootstrap start from a clean slate and freshly copy in the relevant
+# parts from gnulib. In particular remove the configure macros that aren't
+# compatible with the copied in version of gnulib.
+rm -r build-aux m4
 
 ./bootstrap
 

--- a/packages/grub/latest-srpm-url.sh
+++ b/packages/grub/latest-srpm-url.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
-docker run --rm amazonlinux:2 sh -c 'yum install -q -y yum-utils && yumdownloader -q --source --urls grub2 | grep ^http'
+cmd='dnf install -q -y --releasever=latest yum-utils && yumdownloader -q --releasever=latest --source --urls grub2'
+docker run --rm amazonlinux:2022 sh -c "${cmd}" \
+    | grep '^http' \
+    | xargs --max-args=1 --no-run-if-empty realpath --canonicalize-missing --relative-to=. \
+    | sed 's_:/_://_'


### PR DESCRIPTION
**Issue number:** No dedicated issue, but related to #2501

**Description of changes:** Update GRUB to grub-2.06-42.amzn2022. This also switches Bottlerocket's immediate upstream from Amazon Linux 2 to Amazon Linux 2022, which more closely tracks the GRUB project.

This picks up the fixes for the CVEs dubbed BootHole 3. These are relevant for eventually supporting Secure Boot (#2501).

**Testing done:** I used the metal-dev variant to test the following aspects and scenarios:

* [x] Architecture/Firmware Support:
	* [X] x86:
		* [X] BIOS
		* [X] UEFI
		* [X] UEFI with Secure Boot enabled (integrated with on-going work from #2501)
	* [X] aarch64:
		* [X] UEFI
		* [X] UEFI with Secure Boot enabled (integrated with on-going work from #2501)
* [X] GPT Priority:
	* [X] First time boot
	* [X] Update into new version
	* [X] Manual rollback to old version
	* [X] Automated rollback to old version in case of boot failure
* [x] Console output/boot menu:
	* [x] x86:
		* [X] metal-dev
		* [x] vmware-dev
		* [X] aws-dev
	* [X] aarch64:
		* [X] metal-dev
		* [X] aws-dev


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
