### PR TITLE
trivial: format imports and fix comment

### DIFF
--- a/sources/models/src/modeled_types/shared.rs
+++ b/sources/models/src/modeled_types/shared.rs
@@ -1,10 +1,9 @@
+use super::error;
 use lazy_static::lazy_static;
 use regex::Regex;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-// Just need serde's Error in scope to get its trait methods
-use super::error;
 use semver::Version;
 use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use snafu::{ensure, ResultExt};
 use std::borrow::Borrow;
 use std::convert::TryFrom;


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

I noticed while doing some other work that a couple imports ended up being inserted between a comment and the import it was commenting on. This moves that comment back to where it was supposed to be and runs format on the file to organize those imports.

**Testing done:**

Ran `cargo make` to make sure there were no errors or warnings.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
