### PR TITLE
early-boot-config: set constant lifetimes for compatibility

### DIFF
--- a/sources/api/early-boot-config/src/provider/aws.rs
+++ b/sources/api/early-boot-config/src/provider/aws.rs
@@ -15,8 +15,8 @@ use crate::provider::local_file::{local_file_user_data, USER_DATA_FILE};
 pub(crate) struct AwsDataProvider;
 
 impl AwsDataProvider {
-    const IDENTITY_DOCUMENT_FILE: &str = "/etc/early-boot-config/identity-document";
-    const FALLBACK_REGION: &str = "us-east-1";
+    const IDENTITY_DOCUMENT_FILE: &'static str = "/etc/early-boot-config/identity-document";
+    const FALLBACK_REGION: &'static str = "us-east-1";
 
     /// Fetches user data, which is expected to be in TOML form and contain a `[settings]` section,
     /// returning a SettingsJson representing the inside of that section.


### PR DESCRIPTION
**Description of changes:**

The `IDENTITY_DOCUMENT_FILE` and `FALLBACK_REGION` constants require a named lifetime parameter when building with Rust toolchains older than **1.64.0**.

This fixes an edge-case regression introduced in #2493.

**Testing done:**
- `cargo +1.63 check`
- `cargo +1.61 check`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
