### PR TITLE
housekeeping: Cancel GH Action on new push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ on:
       # Sample config files and OpenAPI docs
       - '**.yaml'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: [self-hosted, linux, x64]


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

When a PR is proposed to the develop branch, a set of GitHub Action jobs are kicked off to test the various configuration we need to cover. With the current configuration of our workflow, if the developer notices an issue and pushes updates to the source branch it will kick off a new set of jobs for that updates code, but the jobs running for the previous revision will keep running.

These jobs take a lot of time and resources to run. Once a new change is pushed to the source branch, there is no need to continue testing the older version of the code as it is no longer relevant.

This updates our workflow definition to cancel and currently running jobs for the same source (`github.ref`) to avoid unnecessary runner load that may slow down getting results for current PRs.

**Testing done:**

Testing will be done by GitHub Action runs. If any issues are found we can quickly revert the change.

Ref:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenv

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
