### PR TITLE
housekeeping: remove clippy warnings

### DIFF
--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -1353,7 +1353,7 @@ fn ecr_registry<S: AsRef<str>>(region: S) -> String {
         Some(registry_id) => (region.as_ref(), *registry_id),
     };
     let partition = match ALT_PARTITION_MAP.borrow().get(region) {
-        None => (STANDARD_PARTITION),
+        None => STANDARD_PARTITION,
         Some(partition) => *partition,
     };
     match partition {
@@ -1371,7 +1371,7 @@ fn pause_registry<S: AsRef<str>>(region: S) -> String {
         Some(registry_id) => (region.as_ref(), *registry_id),
     };
     let partition = match ALT_PARTITION_MAP.borrow().get(region) {
-        None => (STANDARD_PARTITION),
+        None => STANDARD_PARTITION,
         Some(partition) => *partition,
     };
     match partition {
@@ -1385,11 +1385,11 @@ fn pause_registry<S: AsRef<str>>(region: S) -> String {
 fn tuf_repository<S: AsRef<str>>(region: S) -> String {
     // lookup the repository endpoint or fallback to the public url
     let (region, endpoint) = match TUF_ENDPOINT_MAP.borrow().get(region.as_ref()) {
-        None => (return TUF_PUBLIC_REPOSITORY.to_string()),
+        None => return TUF_PUBLIC_REPOSITORY.to_string(),
         Some(endpoint) => (region.as_ref(), *endpoint),
     };
     let partition = match ALT_PARTITION_MAP.borrow().get(region) {
-        None => (STANDARD_PARTITION),
+        None => STANDARD_PARTITION,
         Some(partition) => *partition,
     };
     match partition {


### PR DESCRIPTION
**Description of changes:**

This addresses warning emitted with the 1.64.0 toolchain:

```
warning: unnecessary parentheses around match arm expression
```

These parenthesis are not needed, so they are just removed.

##### Build Errors

```bash
warning: unnecessary parentheses around match arm expression
    --> api/schnauzer/src/helpers.rs:1390:17
     |
1390 |         None => (STANDARD_PARTITION),
     |                 ^                  ^
     |
     = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
     |
1390 -         None => (STANDARD_PARTITION),
1390 +         None => STANDARD_PARTITION,
     |

warning: unnecessary parentheses around match arm expression
    --> api/schnauzer/src/helpers.rs:1408:17
     |
1408 |         None => (STANDARD_PARTITION),
     |                 ^                  ^
     |
help: remove these parentheses
     |
1408 -         None => (STANDARD_PARTITION),
1408 +         None => STANDARD_PARTITION,
     |

warning: unnecessary parentheses around match arm expression
    --> api/schnauzer/src/helpers.rs:1422:17
     |
1422 |         None => (return TUF_PUBLIC_REPOSITORY.to_string()),
     |                 ^                                        ^
     |
help: remove these parentheses
     |
1422 -         None => (return TUF_PUBLIC_REPOSITORY.to_string()),
1422 +         None => return TUF_PUBLIC_REPOSITORY.to_string(),
     |

warning: unnecessary parentheses around match arm expression
    --> api/schnauzer/src/helpers.rs:1426:17
     |
1426 |         None => (STANDARD_PARTITION),
     |                 ^                  ^
     |
help: remove these parentheses
     |
1426 -         None => (STANDARD_PARTITION),
1426 +         None => STANDARD_PARTITION,
     |
```

**Testing done:**

Local build.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
