### PR TITLE
Fix link to settings in QUICKSTART-EKS

### DIFF
--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -34,7 +34,7 @@ We have sample configuration files in the repo:
 * [`sample-eksctl-ssh.yaml`](sample-eksctl-ssh.yaml) - for test clusters where you know you'll want SSH access.  Make sure to change the `publicKeyName` setting to the name of the SSH key pair you have registered with EC2.
 
 Pick the file most appropriate for you and make a copy, for example `my-eksctl.yaml`.
-In this file you can change your desired numbered of nodes and even set Bottlerocket settings in advance if you like.  The 'settings' section under 'bottlerocket' can include any [Bottlerocket settings](https://github.com/bottlerocket-os/bottlerocket/#description-of-settings).
+In this file you can change your desired numbered of nodes and even set Bottlerocket settings in advance if you like.  The 'settings' section under 'bottlerocket' can include any [Bottlerocket settings](https://github.com/bottlerocket-os/bottlerocket#description-of-settings).
 
 Note that the configuration file includes the AWS region, so change it from `us-west-2` if you operate in another region.
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Fixing a typo in QUICKSTART-EKS.md where the fragment to Bottlerocket settings is broken due to an extra `/` in the url.


**Testing done:**
Verified that clicking the link navigates directly to the description-of-settings section in the root README.md.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
