### PR TITLE
wicked: allow interface configuration via Ethernet permanent address

### DIFF
--- a/packages/wicked/1005-client-validate-ethernet-namespace-node.patch
+++ b/packages/wicked/1005-client-validate-ethernet-namespace-node.patch
@@ -1,0 +1,109 @@
+From 63bd7bb45b45ef7a44afb4190a7f04bf83e841f5 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Tue, 25 Oct 2022 18:05:20 +0000
+Subject: [PATCH] client: validate ethernet namespace node
+
+Validate the ethernet namespace node in config files to identify
+interfaces via other means than their name, here via their hardware
+address. This restores a previously existing feature (see
+samples/wicked/eth0-identify.xml) that stopped working due to extra
+validation added at a later point.
+
+Fixes: ad7b47d0a ("client: Check for config priorities at reading stage")
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ client/read-config.c | 56 ++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 51 insertions(+), 5 deletions(-)
+
+diff --git a/client/read-config.c b/client/read-config.c
+index 231d656..8965848 100644
+--- a/client/read-config.c
++++ b/client/read-config.c
+@@ -327,19 +327,23 @@ __ifconfig_read_get_ifname(xml_node_t *ifnode, unsigned int *ifindex)
+ 	const char *namespace;
+ 	char *ifname = NULL;
+ 
+-	/* Check for   <name> node */
++	/* Check for <name> node */
+ 	nnode = xml_node_get_child(ifnode, "name");
+-	if (!nnode || ni_string_empty(nnode->cdata)) {
++	if (!nnode) {
+ 		ni_debug_ifconfig("cannot get interface name - "
+-			"config has no valid <name> node");
++			"config has no <name> node");
+ 		goto error;
+ 	}
+ 
+-	ifname = nnode->cdata;
+-
+ 	/* Resolve a namespace if specified */
+ 	namespace = xml_node_get_attr(nnode, "namespace");
+ 	if (ni_string_empty(namespace)) {
++		if (ni_string_empty(nnode->cdata)) {
++			ni_debug_ifconfig("config is missing an interface name in <name> node");
++			goto error;
++		}
++		ifname = nnode->cdata;
++
+ 		if (ifindex)
+ 			*ifindex = if_nametoindex(ifname);
+ 	}
+@@ -347,6 +351,12 @@ __ifconfig_read_get_ifname(xml_node_t *ifnode, unsigned int *ifindex)
+ 		unsigned int value;
+ 		char name_buf[IF_NAMESIZE+1];
+ 
++		if (ni_string_empty(nnode->cdata)) {
++			ni_debug_ifconfig("config is missing an interface name in <name> node");
++			goto error;
++		}
++		ifname = nnode->cdata;
++
+ 		if (ni_parse_uint(ifname, &value, 10) < 0) {
+ 			ni_debug_ifconfig("unable to parse ifindex value "
+ 				" specified via <name namespace=\"ifindex\">");
+@@ -366,6 +376,42 @@ __ifconfig_read_get_ifname(xml_node_t *ifnode, unsigned int *ifindex)
+ 		if (ifindex)
+ 			*ifindex = value;
+ 	}
++	else if (ni_string_eq(namespace, "ethernet")) {
++		xml_node_t *addrnode = NULL;
++		ni_string_array_t all_ifnames = NI_STRING_ARRAY_INIT;
++		unsigned int i;
++
++		addrnode = xml_node_get_child(nnode, "permanent-address");
++		if (!addrnode || ni_string_empty(addrnode->cdata)) {
++			ni_debug_ifconfig("cannot get interface name - "
++				"config has no valid <name> node");
++			goto error;
++		}
++
++		if (ni_scandir("/sys/class/net", NULL, &all_ifnames) <= 0) {
++			ni_debug_ifconfig("unable to enumerate network interfaces in sysfs");
++			goto error;
++		}
++
++		for (i = 0; i < all_ifnames.count; i++) {
++			const char *cur_ifname = all_ifnames.data[i];
++			char *cur_address = NULL;
++			ni_bool_t address_matches = FALSE;
++
++			if (ni_sysfs_netif_get_string(cur_ifname, "address", &cur_address) < 0)
++				continue;
++			cur_address = ni_string_strip_suffix(cur_address, "\n");
++
++			address_matches = ni_string_eq_nocase(cur_address, addrnode->cdata);
++			ni_string_free(&cur_address);
++			if (address_matches) {
++				ni_string_dup(&ifname, cur_ifname);
++				break;
++			}
++		}
++
++		ni_string_array_destroy(&all_ifnames);
++	}
+ 	else {
+ 		/* TODO: Implement other namespaces */;
+ 	}
+-- 
+2.36.1
+

--- a/packages/wicked/1006-server-discover-hardware-address-of-unconfigured-int.patch
+++ b/packages/wicked/1006-server-discover-hardware-address-of-unconfigured-int.patch
@@ -1,0 +1,39 @@
+From acec9e1b2ece15c0c2cceeef3339dc41384373f3 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Tue, 25 Oct 2022 19:34:25 +0000
+Subject: [PATCH] server: discover hardware address of unconfigured interface
+
+When restarting wickedd while an interface is left unconfigured, its
+hardware address will not be discovered and hence the interface cannot
+be identified (and subsequently brought up) via its hardware address.
+
+During start, the server requests a dump of all interfaces from the
+kernel via netlink. Hardware addresses are queried for if the interface
+is marked ready. However, the interface will only be marked ready at a
+later point during start, when the interface state is discovered via
+calls to udev.
+
+Fix this by (re-)querying the hardware address when the interface state
+is discovered, not only when the kernel informs wicked about interface
+changes.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ server/main.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/server/main.c b/server/main.c
+index 375a808..3e5c707 100644
+--- a/server/main.c
++++ b/server/main.c
+@@ -328,6 +328,7 @@ discover_udev_netdev_state(ni_netdev_t *dev)
+ 	 * flag (rules processed / already renamed by udev)
+ 	 * as ethtool is a query by ifname...
+ 	 */
++	__ni_system_ethernet_refresh(dev);
+ 	ni_system_ethtool_refresh(dev);
+ }
+ 
+-- 
+2.36.1
+

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -44,6 +44,8 @@ Patch1001: 1001-avoid-gcrypt-dependency.patch
 Patch1002: 1002-exclude-unused-components.patch
 Patch1003: 1003-ship-mkconst-and-schema-sources-for-runtime-use.patch
 Patch1004: 1004-adjust-safeguard-for-dhcp6-defer-timeout.patch
+Patch1005: 1005-client-validate-ethernet-namespace-node.patch
+Patch1006: 1006-server-discover-hardware-address-of-unconfigured-int.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libdbus-devel


### PR DESCRIPTION
**Issue number:** #2293 


**Description of changes:** Add support for identifying Ethernet interfaces to configure via their permanent/hardware/MAC address to wicked. For example, allow the following:

```xml
<interface>
    <name namespace="ethernet">
        <permanent-address>52:54:00:12:34:56</permanent-address>
    </name>
    <ipv4:dhcp>
        <enabled>true</enabled>
    </ipv4:dhcp>
</interface>
```

to configure the Ethernet interface with MAC address 52:54:00:12:34:56 via DHCP.

Note that:

1. These are downstream patches to wicked, eventually also to be proposed to the upstream project.
2. These only prepare being able to configure interfaces via other means than interface name. Components like netdog will still need to be adapted.

**Testing done:** In a local VM, I successfully configured interfaces both via interface name and MAC address (at first by modifying `/etc/wicked/ifconfig/` and restarting wicked components, later by just having netdog write the above XML snippet on boot).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
