### PR TITLE
Fix `settings.container-runtime` migration

### DIFF
--- a/sources/api/migration/migrations/v1.10.1/container-runtime/src/main.rs
+++ b/sources/api/migration/migrations/v1.10.1/container-runtime/src/main.rs
@@ -1,12 +1,12 @@
 #![deny(rust_2018_idioms)]
 
-use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;
 
 /// We added a new setting for configuring container runtime (containerd) settings.
 fn run() -> Result<()> {
-    migrate(AddSettingsMigration(&["settings.container-runtime"]))
+    migrate(AddPrefixesMigration(vec!["settings.container-runtime"]))
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu


### PR DESCRIPTION
**Issue number:**

Closes #2522 

**Description of changes:**

This migration used `AddSettingsMigration` when it actually should have been using `AddPrefixesMigration` to properly remove anything set on downgrade.

**Testing done:**

Built all source and verified no errors.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
