### PR TITLE
testsys: Enable multiple tests on a cluster

### DIFF
--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -7,8 +7,8 @@ use log::{debug, info};
 use model::test_manager::TestManager;
 use model::SecretName;
 use pubsys_config::InfraConfig;
-use serde::Deserialize;
-use serde_plain::derive_fromstr_from_deserialize;
+use serde::{Deserialize, Serialize};
+use serde_plain::{derive_display_from_serialize, derive_fromstr_from_deserialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::PathBuf;
@@ -217,7 +217,9 @@ impl Run {
                 };
                 debug!("Creating crds for aws-k8s testing");
 
-                aws_k8s.create_crds(self.test_flavor, &images).await?
+                aws_k8s
+                    .create_crds(&client, self.test_flavor, &images)
+                    .await?
             }
             "aws-ecs" => {
                 debug!("Variant is in 'aws-ecs' family");
@@ -282,7 +284,7 @@ fn parse_key_val(s: &str) -> Result<(String, SecretName)> {
     Ok((key.to_string(), SecretName::new(value)?))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum TestType {
     /// Conformance testing is a full integration test that asserts that Bottlerocket is working for
@@ -300,6 +302,7 @@ pub(crate) enum TestType {
 }
 
 derive_fromstr_from_deserialize!(TestType);
+derive_display_from_serialize!(TestType);
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Image {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2531 

**Description of changes:**

TestSys uses labels on the crd's to determine which EC2 resources rely on a specific EKS cluster. If a new instance provider requires a cluster that is already created, TestSys marks the new instance provider as conflicting with all other ones which prevents the new instances from being created until the other instance providers have been deleted.


**Testing done:**

Tested with
```bash
cargo make TESTSYS_TEST=migration test
cargo make test
```

The migration test ran first and the quick test started once the migration test was finished.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
