### PR TITLE
Add additional ECS API configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,8 @@ These settings can be changed at any time.
 * `settings.ecs.allow-privileged-containers`: Whether launching privileged containers is allowed on the container instance.
   If this value is set to false, privileged containers are not permitted.
   Bottlerocket sets this value to false by default.
+* `settings.ecs.container-stop-timeout`: Time to wait for the task's containers to stop on their own before they are forcefully stopped.
+Valid time units include `s`, `m`, and `h`, e.g. `1h`, `1m1s`.
 * `settings.ecs.enable-spot-instance-draining`: If the instance receives a spot termination notice, the agent will set the instance's state to `DRAINING`, so the workload can be moved gracefully before the instance is removed. Defaults to `false`.
 * `settings.ecs.image-pull-behavior`: The behavior used to customize the [pull image process](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-agent-availparam) for your container instances.
   Supported values are `default`, `always`, `once`, `prefer-cached`, and the default is `default`.
@@ -541,6 +543,13 @@ These settings can be changed at any time.
   Bottlerocket enables the `json-file`, `awslogs`, and `none` drivers by default.
 * `settings.ecs.loglevel`: The level of verbosity for the ECS agent's logs.
   Supported values are `debug`, `info`, `warn`, `error`, and `crit`, and the default is `info`.
+* `settings.ecs.metadata-service-rps`: The steady state rate limit of the throttling configurations set for the task metadata service.
+* `settings.ecs.metadata-service-burst`: The burst rate limit of the throttling configurations set for the task metadata service.
+* `settings.ecs.reserved-memory`: The amount of memory, in MiB, reserved for critical system processes.
+* `settings.ecs.task-cleanup-wait`: Time to wait before the task's containers are removed after they are stopped.
+Valid time units are `s`, `m`, and `h`, e.g. `1h`, `1m1s`.
+
+  **Note**: `metadata-service-rps` and `metadata-service-burst` directly map to the values set by the `ECS_TASK_METADATA_RPS_LIMIT` environment variable.
 
 #### CloudFormation signal helper settings
 

--- a/Release.toml
+++ b/Release.toml
@@ -163,4 +163,5 @@ version = "1.10.1"
     "migrate_v1.11.0_credential-providers.lz4",
     "migrate_v1.11.0_kubelet-tls-config.lz4",
     "migrate_v1.11.0_kubelet-new-config-files.lz4",
+    "migrate_v1.11.0_ecs-additional-configurations.lz4",
 ]

--- a/packages/ecs-agent/ecs.config
+++ b/packages/ecs-agent/ecs.config
@@ -16,3 +16,9 @@ ECS_ENGINE_AUTH_DATA='{
         {{~#if password~}},"password": "{{{password}}}"}{{/if}}
     {{~/each~}}}}'
 {{/if}}
+{{#if settings.ecs.container-stop-timeout}}
+ECS_CONTAINER_STOP_TIMEOUT="{{settings.ecs.container-stop-timeout}}"
+{{/if}}
+{{#if settings.ecs.task-cleanup-wait}}
+ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION="{{settings.ecs.task-cleanup-wait}}"
+{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1368,6 +1368,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecs-additional-configurations"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "ecs-settings-applier"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "api/migration/migrations/v1.11.0/credential-providers",
     "api/migration/migrations/v1.11.0/kubelet-tls-config",
     "api/migration/migrations/v1.11.0/kubelet-new-config-files",
+    "api/migration/migrations/v1.11.0/ecs-additional-configurations",
 
     "bottlerocket-release",
 

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -62,6 +62,21 @@ struct ECSConfig {
 
     #[serde(rename = "GPUSupportEnabled")]
     gpu_support_enabled: bool,
+
+    #[serde(
+        rename = "TaskMetadataSteadyStateRate",
+        skip_serializing_if = "Option::is_none"
+    )]
+    metadata_service_rps: Option<i64>,
+
+    #[serde(
+        rename = "TaskMetadataBurstRate",
+        skip_serializing_if = "Option::is_none"
+    )]
+    metadata_service_burst: Option<i64>,
+
+    #[serde(rename = "ReservedMemory", skip_serializing_if = "Option::is_none")]
+    reserved_memory: Option<u16>,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -129,6 +144,9 @@ async fn run() -> Result<()> {
         task_eni_enabled: true,
 
         gpu_support_enabled: cfg!(variant_flavor = "nvidia"),
+        reserved_memory: ecs.reserved_memory,
+        metadata_service_rps: ecs.metadata_service_rps,
+        metadata_service_burst: ecs.metadata_service_burst,
         ..Default::default()
     };
     if let Some(os) = settings.os {

--- a/sources/api/migration/migrations/v1.11.0/ecs-additional-configurations/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/ecs-additional-configurations/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ecs-additional-configurations"
+version = "0.1.0"
+edition = "2018"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/ecs-additional-configurations/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/ecs-additional-configurations/src/main.rs
@@ -1,0 +1,26 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added additional configurations for the ECS agent
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.ecs.container-stop-timeout",
+        "settings.ecs.task-cleanup-wait",
+        "settings.ecs.metadata-service-rps",
+        "settings.ecs.metadata-service-burst",
+        "settings.ecs.reserved-memory",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -147,7 +147,7 @@ use crate::de::{deserialize_mirrors, deserialize_node_taints};
 use crate::modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, CredentialProvider,
     DNSDomain, ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
-    EtcHostsEntries, FriendlyVersion, Identifier, ImageGCHighThresholdPercent,
+    ECSDurationValue, EtcHostsEntries, FriendlyVersion, Identifier, ImageGCHighThresholdPercent,
     ImageGCLowThresholdPercent, KmodKey, KubernetesAuthenticationMode, KubernetesBootstrapToken,
     KubernetesCloudProvider, KubernetesClusterDnsIp, KubernetesClusterName,
     KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
@@ -230,6 +230,11 @@ struct ECSSettings {
     loglevel: ECSAgentLogLevel,
     enable_spot_instance_draining: bool,
     image_pull_behavior: ECSAgentImagePullBehavior,
+    container_stop_timeout: ECSDurationValue,
+    task_cleanup_wait: ECSDurationValue,
+    metadata_service_rps: i64,
+    metadata_service_burst: i64,
+    reserved_memory: u16,
 }
 
 #[model]

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -141,6 +141,9 @@ pub mod error {
         #[snafu(display("Invalid imageGCLowThresholdPercent '{}': {}", input, msg))]
         InvalidImageGCLowThresholdPercent { input: String, msg: String },
 
+        #[snafu(display("Invalid ECS duration value '{}'", input))]
+        InvalidECSDurationValue { input: String },
+
         #[snafu(display("Could not parse '{}' as an integer", input))]
         ParseInt {
             input: String,


### PR DESCRIPTION
**Issue number:**

Closes #2483

**Description of changes:**

With this, the following configurations will be supported through API settings:

- ECS_CONTAINER_STOP_TIMEOUT
- ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION
- ECS_TASK_METADATA_RPS_LIMIT
- ECS_RESERVED_MEMORY

For `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION` and `ECS_CONTAINER_STOP_TIMEOUT`, I added the new `ECSDurationValue` struct used to represent a `time.Duration` string. I decided to use a new struct instead of refactoring `KubernetesDurationValue` to keep both duration values decoupled from one another, in case the type of any of them changes in future releases. The two aforementioned configurations are rendered in the `/etc/ecs/ecs.config` file, which holds environment variables passed to the ECS agent's daemon. This is because parsing valid `time.Duration` strings in golang requires calls to `time.ParseDuration` which isn't called by the `json.Unmarshall` function used by the ECS agent to parse the JSON formatted configuration at `/etc/ecs/ecs.config.json`. Even though it is possible to deserialize `time.Duration` values from a JSON string, I decided against this since the values in the JSON file must be of type [`int64`] which isn't as user friendly as the duration strings `1m`, `1s`, `1h`, etc.

`ECS_TASK_METADATA_RPS_LIMIT` contains a comma-separated string with two values used to set up the throttling configurations of the ECS agent's metadata service. The two values are assigned to [two fields] of the struct type used to represent the agent's configuration. These two values are independent from one another, meaning that a) the agent doesn't perform [coupled validations] on the values, and b) if any of them is missing or is zero, the agent will use [default values]. Since both values must be [integers], they can be deserialized without any helper functions (unlike `time.Duration`). As a result, I decided to keep these two values as separate settings in the API (`metadata-service-rps` and `metadata-service-burst`) instead of one single configuration, and render them in `/etc/ecs/ecs.config.json` . The [official AWS documentation] for the agent's configurations clearly states what each value in the tuple represents, so it should be relatively simple for users to migrate from the comma-separated configuration. No validation is required to verify that the new configurations are positive integers since the ECS agent won't fail to start, also a [useful message] is printed.

`ECS_RESERVED_MEMORY` represents the amount of memory (in MB) that the agent won't use for the allocated tasks. Since this configuration is of type `unit16` and it can be serialized without any helper functions, I decided to render it in `/etc/ecs/ecs.config.json`.

TODO:
- [x] Add documentation for the new ECS settings.

[`int64`]: https://pkg.go.dev/time#Duration
[two fields]: https://github.com/aws/amazon-ecs-agent/blob/5fb8e801e9d11630c3470abb778291913ebb9d7f/agent/config/config.go#L515
[coupled validations]: https://github.com/aws/amazon-ecs-agent/blob/5fb8e801e9d11630c3470abb778291913ebb9d7f/agent/config/config.go#L360
[default values]: https://github.com/aws/amazon-ecs-agent/blob/5fb8e801e9d11630c3470abb778291913ebb9d7f/agent/config/config.go#L195
[official AWS documentation]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html
[integers]: https://github.com/aws/amazon-ecs-agent/blob/5fb8e801e9d11630c3470abb778291913ebb9d7f/agent/config/config.go#L360
[datastore serializer]: https://github.com/bottlerocket-os/bottlerocket/blob/2a202f877fefbbfc54e689b164460ced6d66dacc/sources/api/datastore/src/serialization/pairs.rs#L172
[useful message]: https://github.com/aws/amazon-ecs-agent/blob/5fb8e801e9d11630c3470abb778291913ebb9d7f/agent/config/config.go#L361


**Testing done:**

- In my own 1.11.0 variant, I verified I could set the new API settings, and that the ECS agent picked them up:
  - `task-cleanup-wait`: I confirmed that the container resources were cleaned up after the specified time
  -  `container-stop-timeout`: I created a container with a process that ignored `SIGTERM` signals; the agent sent `SIGKILL` after the specified time
  - `metadata-service-rps`, `metadata-service-burst`: I used `-1` as the values for the settings and confirmed that the ECS agent logged a warning
  - `reserved-memory`: I confirmed the ECS agent logged the [remaining memory]
- I did upgrade/downgrade testing and confirmed the host came back up

[remaining memory]: https://github.com/aws/amazon-ecs-agent/blob/5fb8e801e9d11630c3470abb778291913ebb9d7f/agent/api/ecsclient/client.go#L274

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
