### PR TITLE
build: fix EFI file system to fit partition size

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -195,7 +195,7 @@ fi
 mv "${ROOT_MOUNT}/boot/efi"/* "${EFI_MOUNT}"
 
 dd if=/dev/zero of="${EFI_IMAGE}" bs=1M count="${partsize[EFI-A]}"
-mkfs.vfat -I -S 512 "${EFI_IMAGE}" $((partsize[EFI-A] * 2048))
+mkfs.vfat -I -S 512 "${EFI_IMAGE}" $((partsize[EFI-A] * 1024))
 mmd -i "${EFI_IMAGE}" ::/EFI
 mmd -i "${EFI_IMAGE}" ::/EFI/BOOT
 mcopy -i "${EFI_IMAGE}" "${EFI_MOUNT}/EFI/BOOT"/*.efi ::/EFI/BOOT


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** rpm2img creates the various file systems comprising a Bottlerocket image, among them the FAT file system that serves as the EFI System Partition (ESP). rpm2img invokes mkfs.vfat to create the ESP, but accidentally causes it to size the file system structures for double the size of the actual ESP.

The mistake is mostly harmless as proven by working images and current mode of operation that is essentially read-only. However, it can lead to unexpected problems when trying to write to the ESP. Depending on the attempted action, failure modes include receiving SIGBUS, receiving EIO, receiving EINVAL, corrupting files, seeing messages like "lost async page write" or "attempt to access beyond end of device" in the kernel log.

The cause of the bug is a somewhat unfortunate interpretation of the file system size by mkfs.vfat. While its second argument is referred to as a block count, it is not actually related to the requested sector size, but always expressed in units of 1 KiB. rpm2img expressed the file system size in units of sectors (512 bytes), thereby oversizing the file system by a factor of two.

**Testing done:** I built images of the metal-dev variant with and without this patch. Setting up a loopback device with the resulting image and looking at the EFI System Partition produces the following output for...

...the image created without the patch

```
$ sudo file -s /dev/loop0p2
/dev/loop0p2: DOS/MBR boot sector, code offset 0x3c+2, OEM-ID "mkfs.fat", sectors/cluster 4, reserved sectors 4, root entries 512, sectors 20480 (volumes <=32 MB), Media descriptor 0xf8, sectors/FAT 20, sectors/track 32, serial number 0x3d1d549f, unlabeled, FAT (16 bit)
```

...and the image created with the patch

```
$ sudo file -s /dev/loop1p2
/dev/loop1p2: DOS/MBR boot sector, code offset 0x3c+2, OEM-ID "mkfs.fat", sectors/cluster 4, reserved sectors 4, root entries 512, sectors 10240 (volumes <=32 MB), Media descriptor 0xf8, sectors/FAT 8, sectors/track 32, serial number 0xdf82f540, unlabeled, FAT (12 bit)
```

Note that the file system is believed to have 20480 sectors in the image created without the patch instead of 10240 sectors in the image created with the patch. Since each sector contains 512 bytes, and the ESP is only allocated 5 MiB, the file system for the ESP is wrongly sized to fit a 10 MiB partition without the patch.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
