### PR TITLE
testsys: Accept `TESTSYS_STARTING_IMAGE_ID` environment variable

### DIFF
--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -94,20 +94,18 @@ impl AwsK8s {
         cluster_name: &str,
         testsys_images: &TestsysImages,
     ) -> Result<Vec<Crd>> {
-        let ami = self
-            .starting_image_id
-            .as_ref()
-            .unwrap_or(
-                &get_ami_id(
+        let ami = if let Some(ami) = self.starting_image_id.to_owned() {
+            ami
+        } else {
+            get_ami_id(
                     format!(
                         "bottlerocket-{}-{}-{}-{}",
                         self.variant, self.arch, self.starting_version.as_ref().context("The starting version must be provided for migration testing")?, self.migrate_starting_commit.as_ref().context("The commit for the starting version must be provided if the starting image id is not")?
                     ), & self.arch,
                     self.region.to_string(),
                 )
-                .await?,
-            )
-            .to_string();
+                .await?
+        };
         let eks = self.eks_crd(cluster_name, testsys_images)?;
         let ec2 = self.ec2_crd(cluster_name, testsys_images, Some(ami))?;
         let instance_provider = ec2

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -70,11 +70,7 @@ pub(crate) struct Run {
     /// The commit id of the starting version for migrations. This is required for all migrations
     /// tests unless `starting-image-id` is provided. This is the version that will be created and
     /// migrated to `migration-target-version`.
-    #[clap(
-        long,
-        env = "TESTSYS_STARTING_COMMIT",
-        conflicts_with = "starting-image-id"
-    )]
+    #[clap(long, env = "TESTSYS_STARTING_COMMIT")]
     migration_starting_commit: Option<String>,
 
     /// The target version for migrations. This is required for all migration tests. This is the


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2526 

**Description of changes:**

testsys the cli was able to handle using the `starting_image_id` argument, but with `cargo make`, the env variable
`TESTSYS_STARTING_COMMIT` is always passed in, so the conflicting args made `TESTSYS_STARTING_IMAGE_ID` un-usable. This fix removes the conflicts with, and uses the `TESTSYS_STARTING_IMAGE_ID` whenever it is provided.

**Testing done:**

Ran `cargo make -e TESTSYS_TEST=migration -e TESTSYS_STARTING_IMAGE_ID=<AMI> test` and instances were created using the AMI specified.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
