### PR TITLE
Add ShellCheck to `check-lints` (for tools)

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -332,7 +332,12 @@ done
 
 # A top level target for devs to ensure review and patch readiness
 [tasks.check]
-dependencies = ["check-cargo-version", "unit-tests", "check-fmt", "check-lints"]
+dependencies = [
+   "check-cargo-version",
+   "unit-tests",
+   "check-fmt",
+   "check-lints",
+   ]
 
 [tasks.check-fmt]
 script = [
@@ -382,6 +387,12 @@ fi
 ]
 
 [tasks.check-lints]
+dependencies = [
+   "check-clippy",
+   "check-shell",
+]
+
+[tasks.check-clippy]
 script = [
 '''
 rc=0
@@ -397,6 +408,44 @@ fi
 
 if [ "${rc}" -ne 0 ]; then
   echo "Found lint warnings. First-party source code is checked with clippy." >&2
+  exit $rc
+fi
+'''
+]
+
+[tasks.check-shell]
+script = [
+'''
+rc=0
+
+# For bash first-party shell code
+if ! docker run --rm \
+  --network=none \
+  --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
+  -v "${BUILDSYS_TOOLS_DIR}":/tmp/tools \
+  "${BUILDSYS_SDK_IMAGE}" \
+  bash -c \
+    'flagged_scripts=0 && \
+    cd /tmp/tools && \
+    for shell_script in $(grep -l --directories=skip --regexp="^#\!.*bash$" * ); do
+      if ! shellcheck \
+        --external-sources \
+        --source-path=SCRIPTDIR \
+        --format=gcc \
+        --severity=warning \
+        "${shell_script}"; then
+        ((++flagged_scripts))
+      fi
+    done && \
+    if [ "${flagged_scripts}" -ne 0 ]; then
+      exit 1
+    fi'; then
+  rc=1
+fi
+
+if [ "${rc}" -ne 0 ]; then
+  echo "Found lint warnings. First-party shell code is checked with ShellCheck." >&2
   exit $rc
 fi
 '''

--- a/tools/docker-go
+++ b/tools/docker-go
@@ -30,6 +30,7 @@ required_arg() {
    fi
 }
 
+# shellcheck disable=SC2124  # TODO: improve command interface (#2534)
 parse_args() {
   while [ ${#} -gt 0 ] ; do
     case "${1}" in

--- a/tools/partyplanner
+++ b/tools/partyplanner
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2034  # Variables are used externally by rpm2img
 
 ###############################################################################
 # Section 1: partition type GUIDs

--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2054  # Arrays are formatted for passing args to other tools
 
 shopt -s nullglob
 
@@ -14,12 +15,16 @@ current_images=()
 boot_image=
 data_image=
 
-readonly repo_root=$(git rev-parse --show-toplevel)
-
 bail() {
     >&2 echo "$@"
     exit 1
 }
+
+if ! git_toplevel=$(git rev-parse --show-toplevel); then
+    bail "Failed to get the root of the repo."
+else
+    readonly repo_root="${git_toplevel}"
+fi
 
 show_usage() {
     echo "\
@@ -116,8 +121,9 @@ parse_args() {
     [[ -n ${arch} ]] || usage_error 'Architecture needs to be set via either --arch or BUILDSYS_ARCH.'
     [[ -n ${variant} ]] || usage_error 'Variant needs to be set via either --variant or BUILDSYS_VARIANT.'
 
-    local host_arch=$(uname -m)
-    [[ ${arch} = ${host_arch} ]] || bail "Architecture needs to match host architecture (${host_arch}) for hardware virtualization."
+    declare -l host_arch
+    host_arch=$(uname -m)
+    [[ ${arch} == "${host_arch}" ]] || bail "Architecture needs to match host architecture (${host_arch}) for hardware virtualization."
 
     for path in "${!extra_files[@]}"; do
         [[ -e ${path} ]] || bail "Cannot find local file '${path}' to inject."


### PR DESCRIPTION
**Description of changes:**

During the `check-lints` stage of the build, **ShellCheck** will analyze any bash scripts under the `tools` directory and raise an error for any findings with a severity of `warning` or above.

For more targeted linting, `check-lints` was also split into `check-clippy` and `check-shell` which can be called individually.

Also addressed several warnings to avoid breaking the build.

**Testing done:**

Ran with and without the `tools: fix ShellCheck warnings` commit.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
