### PR TITLE
feature: Enable configuration of Kubelet TLS certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,8 @@ The following settings are optional and allow you to further configure your clus
   ephemeral-storage= "1Gi"
   ```
 
+* `settings.kubernetes.server-certificate`: The base64 encoded content of an x509 certificate for the Kubelet web server, which is used for retrieving logs and executing commands.
+* `settings.kubernetes.server-key`: The base64 encoded content of an x509 private key for the Kubelet web server.
 * `settings.kubernetes.topology-manager-policy`: Specifies the topology manager policy. Possible values are `none`, `restricted`, `best-effort`, and `single-numa-node`. Defaults to `none`.
 * `settings.kubernetes.topology-manager-scope`: Specifies the topology manager scope. Possible values are `container` and `pod`. Defaults to `container`. If you want to group all containers in a pod to a common set of NUMA nodes, you can set this setting to `pod`.
 

--- a/Release.toml
+++ b/Release.toml
@@ -161,4 +161,6 @@ version = "1.10.1"
     "migrate_v1.11.0_aws-creds.lz4",
     "migrate_v1.11.0_aws-creds-metadata.lz4",
     "migrate_v1.11.0_credential-providers.lz4",
+    "migrate_v1.11.0_kubelet-tls-config.lz4",
+    "migrate_v1.11.0_kubelet-new-config-files.lz4",
 ]

--- a/packages/kubernetes-1.21/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.21/etc-kubernetes-pki.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/kubernetes/pki
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -113,7 +113,12 @@ featureGates:
   CSIMigration: false
 protectKernelDefaults: true
 serializeImagePulls: false
+{{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
+tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+{{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
+{{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"

--- a/packages/kubernetes-1.21/kubelet-server-crt
+++ b/packages/kubernetes-1.21/kubelet-server-crt
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-certificate~}}
+{{base64_decode settings.kubernetes.server-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.21/kubelet-server-key
+++ b/packages/kubernetes-1.21/kubelet-server-key
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-key~}}
+{{base64_decode settings.kubernetes.server-key}}
+{{~/if~}}

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -35,6 +35,9 @@ Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
 Source9: kubelet-sysctl.conf
 Source10: prepare-var-lib-kubelet.service
+Source11: kubelet-server-crt
+Source12: kubelet-server-key
+Source13: etc-kubernetes-pki.mount
 
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
@@ -90,7 +93,7 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
-install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
 install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
@@ -102,6 +105,8 @@ install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+install -m 0644 %{S:11} %{buildroot}%{_cross_templatedir}/kubelet-server-crt
+install -m 0644 %{S:12} %{buildroot}%{_cross_templatedir}/kubelet-server-key
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
@@ -123,6 +128,7 @@ ln -rs \
 %{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
+%{_cross_unitdir}/etc-kubernetes-pki.mount
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
@@ -134,6 +140,8 @@ ln -rs \
 %{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_templatedir}/kubelet-server-crt
+%{_cross_templatedir}/kubelet-server-key
 %{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_sysctldir}/90-kubelet.conf
 %dir %{_cross_libexecdir}/kubernetes

--- a/packages/kubernetes-1.22/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.22/etc-kubernetes-pki.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/kubernetes/pki
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -109,7 +109,12 @@ featureGates:
   CSIMigration: false
 protectKernelDefaults: true
 serializeImagePulls: false
+{{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
+tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+{{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
+{{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"

--- a/packages/kubernetes-1.22/kubelet-server-crt
+++ b/packages/kubernetes-1.22/kubelet-server-crt
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-certificate~}}
+{{base64_decode settings.kubernetes.server-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.22/kubelet-server-key
+++ b/packages/kubernetes-1.22/kubelet-server-key
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-key~}}
+{{base64_decode settings.kubernetes.server-key}}
+{{~/if~}}

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -35,6 +35,9 @@ Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
 Source9: kubelet-sysctl.conf
 Source10: prepare-var-lib-kubelet.service
+Source11: kubelet-server-crt
+Source12: kubelet-server-key
+Source13: etc-kubernetes-pki.mount
 
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
@@ -87,7 +90,7 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
-install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
 install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
@@ -99,6 +102,8 @@ install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+install -m 0644 %{S:11} %{buildroot}%{_cross_templatedir}/kubelet-server-crt
+install -m 0644 %{S:12} %{buildroot}%{_cross_templatedir}/kubelet-server-key
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
@@ -120,6 +125,7 @@ ln -rs \
 %{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
+%{_cross_unitdir}/etc-kubernetes-pki.mount
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
@@ -131,6 +137,8 @@ ln -rs \
 %{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_templatedir}/kubelet-server-crt
+%{_cross_templatedir}/kubelet-server-key
 %{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_sysctldir}/90-kubelet.conf
 %dir %{_cross_libexecdir}/kubernetes

--- a/packages/kubernetes-1.23/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.23/etc-kubernetes-pki.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/kubernetes/pki
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -111,7 +111,12 @@ featureGates:
   CSIMigrationvSphere: true
 protectKernelDefaults: true
 serializeImagePulls: false
+{{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
+tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+{{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
+{{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"

--- a/packages/kubernetes-1.23/kubelet-server-crt
+++ b/packages/kubernetes-1.23/kubelet-server-crt
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-certificate~}}
+{{base64_decode settings.kubernetes.server-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.23/kubelet-server-key
+++ b/packages/kubernetes-1.23/kubelet-server-key
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-key~}}
+{{base64_decode settings.kubernetes.server-key}}
+{{~/if~}}

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -35,6 +35,9 @@ Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
 Source9: kubelet-sysctl.conf
 Source10: prepare-var-lib-kubelet.service
+Source11: kubelet-server-crt
+Source12: kubelet-server-key
+Source13: etc-kubernetes-pki.mount
 
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
@@ -88,7 +91,7 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
-install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
 install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
@@ -100,6 +103,8 @@ install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+install -m 0644 %{S:11} %{buildroot}%{_cross_templatedir}/kubelet-server-crt
+install -m 0644 %{S:12} %{buildroot}%{_cross_templatedir}/kubelet-server-key
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
@@ -121,6 +126,7 @@ ln -rs \
 %{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
+%{_cross_unitdir}/etc-kubernetes-pki.mount
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
@@ -133,6 +139,8 @@ ln -rs \
 %{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_templatedir}/kubelet-server-crt
+%{_cross_templatedir}/kubelet-server-key
 %{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_sysctldir}/90-kubelet.conf
 %dir %{_cross_libexecdir}/kubernetes

--- a/packages/kubernetes-1.24/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.24/etc-kubernetes-pki.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/kubernetes/pki
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -111,7 +111,12 @@ featureGates:
   CSIMigrationvSphere: true
 protectKernelDefaults: true
 serializeImagePulls: false
+{{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
+tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+{{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
+{{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"

--- a/packages/kubernetes-1.24/kubelet-server-crt
+++ b/packages/kubernetes-1.24/kubelet-server-crt
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-certificate~}}
+{{base64_decode settings.kubernetes.server-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.24/kubelet-server-key
+++ b/packages/kubernetes-1.24/kubelet-server-key
@@ -1,0 +1,3 @@
+{{~#if settings.kubernetes.server-key~}}
+{{base64_decode settings.kubernetes.server-key}}
+{{~/if~}}

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -43,6 +43,9 @@ Source7: kubelet-bootstrap-kubeconfig
 Source8: kubernetes-tmpfiles.conf
 Source9: kubelet-sysctl.conf
 Source10: prepare-var-lib-kubelet.service
+Source11: kubelet-server-crt
+Source12: kubelet-server-key
+Source13: etc-kubernetes-pki.mount
 
 # ExecStartPre drop-ins
 Source20: prestart-pull-pause-ctr.conf
@@ -96,7 +99,7 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
-install -p -m 0644 %{S:1} %{S:10} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
 install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
@@ -108,6 +111,8 @@ install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
 install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+install -m 0644 %{S:11} %{buildroot}%{_cross_templatedir}/kubelet-server-crt
+install -m 0644 %{S:12} %{buildroot}%{_cross_templatedir}/kubelet-server-key
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
@@ -129,6 +134,7 @@ ln -rs \
 %{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
+%{_cross_unitdir}/etc-kubernetes-pki.mount
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
@@ -141,6 +147,8 @@ ln -rs \
 %{_cross_templatedir}/kubelet-bootstrap-kubeconfig
 %{_cross_templatedir}/kubelet-exec-start-conf
 %{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_templatedir}/kubelet-server-crt
+%{_cross_templatedir}/kubelet-server-key
 %{_cross_tmpfilesdir}/kubernetes.conf
 %{_cross_sysctldir}/90-kubelet.conf
 %dir %{_cross_libexecdir}/kubernetes

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2016,6 +2016,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-new-config-files"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kubelet-tls-config"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -31,6 +31,8 @@ members = [
     "api/migration/migrations/v1.11.0/aws-creds-metadata",
     "api/migration/migrations/v1.11.0/aws-config-settings",
     "api/migration/migrations/v1.11.0/credential-providers",
+    "api/migration/migrations/v1.11.0/kubelet-tls-config",
+    "api/migration/migrations/v1.11.0/kubelet-new-config-files",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.11.0/kubelet-new-config-files/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/kubelet-new-config-files/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-new-config-files"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.11.0/kubelet-new-config-files/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/kubelet-new-config-files/src/main.rs
@@ -1,0 +1,42 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// Handle new configuration files for kubelet configuration.
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "services.kubernetes.configuration-files",
+        old_vals: &[
+            "kubelet-env",
+            "kubelet-config",
+            "kubelet-kubeconfig",
+            "kubelet-bootstrap-kubeconfig",
+            "kubelet-exec-start-conf",
+            "kubernetes-ca-crt",
+            "proxy-env",
+        ],
+        new_vals: &[
+            "kubelet-env",
+            "kubelet-config",
+            "kubelet-kubeconfig",
+            "kubelet-bootstrap-kubeconfig",
+            "kubelet-exec-start-conf",
+            "kubernetes-ca-crt",
+            "proxy-env",
+            "kubelet-server-crt",
+            "kubelet-server-key",
+        ],
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.11.0/kubelet-tls-config/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/kubelet-tls-config/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-tls-config"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.11.0/kubelet-tls-config/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/kubelet-tls-config/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added a new setting for providing TLS certs.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.server-certificate",
+        "settings.kubernetes.server-key",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/kubernetes-services.toml
+++ b/sources/models/shared-defaults/kubernetes-services.toml
@@ -7,6 +7,8 @@ configuration-files = [
   "kubelet-exec-start-conf",
   "kubernetes-ca-crt",
   "proxy-env",
+  "kubelet-server-crt",
+  "kubelet-server-key",
 ]
 restart-commands = [
   "/usr/bin/systemctl try-restart kubelet.service"
@@ -31,6 +33,14 @@ template-path = "/usr/share/templates/kubelet-bootstrap-kubeconfig"
 [configuration-files.kubernetes-ca-crt]
 path = "/etc/kubernetes/pki/ca.crt"
 template-path = "/usr/share/templates/kubernetes-ca-crt"
+
+[configuration-files.kubelet-server-crt]
+path = "/etc/kubernetes/pki/kubelet-server.crt"
+template-path = "/usr/share/templates/kubelet-server-crt"
+
+[configuration-files.kubelet-server-key]
+path = "/etc/kubernetes/pki/kubelet-server.key"
+template-path = "/usr/share/templates/kubelet-server-key"
 
 [configuration-files.kubelet-exec-start-conf]
 path = "/etc/systemd/system/kubelet.service.d/exec-start.conf"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -208,6 +208,8 @@ struct KubernetesSettings {
     provider_id: Url,
     log_level: u8,
     credential_providers: HashMap<Identifier, CredentialProvider>,
+    server_certificate: ValidBase64,
+    server_key: ValidBase64,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
**Issue number:**

Closes #2481 

**Description of changes:**

This enables the ability to provide a TLS public and private key to be used by the kubelet process for HTTPS communication.
It adds `settings.kubernetes.server-certificate` and `settings.kubernetes.server-key`.

This corresponds to the `--tls-cert-file` and `--tls-key-file` arguments (or the `tlsCertFile` and `tlsPrivateKeyFile` config settings).

**Testing done:**

Generated an x509 public and private pair.
Used sample eksctl yaml and added the two new settings with the base64 contents of the generated certs.
Deployed cluster and verified creation successful.
Checked contents of generated `/etc/kubernetes/kubelet/config` file were correct.
`cat`'d contents of the two certificate files written out and made sure they matched my local copies of them.
Checked `systemctl status kubelet` and verified service was running and happy.
Checked `journalctl -u kubelet` to check if there were any errors.
Checked output from `kubectl get pods -A` and `kubectl get nodes` to make sure cluster was functional.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
