### PR TITLE
Allow bootstrap containers to manage swap

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -642,6 +642,7 @@ func withBootstrap() oci.SpecOpts {
 		// container's capabilities.
 		seccomp.WithDefaultProfile(),
 		oci.WithAllDevicesAllowed,
+		withSwapManagement,
 	)
 }
 
@@ -837,6 +838,18 @@ func withRootFsShared() oci.SpecOpts {
 		}
 		return nil
 	}
+}
+
+// withSwapManagement allows the swapon and swapoff syscalls
+func withSwapManagement(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+	if s.Linux != nil && s.Linux.Seccomp != nil && s.Linux.Seccomp.Syscalls != nil {
+		s.Linux.Seccomp.Syscalls = append(s.Linux.Seccomp.Syscalls, runtimespec.LinuxSyscall{
+			Names:  []string{"swapon", "swapoff"},
+			Action: runtimespec.ActAllow,
+			Args:   []runtimespec.LinuxSeccompArg{},
+		})
+	}
+	return nil
 }
 
 // withProxyEnv reads proxy environment variables and returns a spec option for passing said proxy environment variables


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

~~Closes~~ Provides a workaround for #1911

I don't really want to close #1911 because I think configuring swap should be possible without a bootstrap container. It should be as simple as configuring one or more `[[swap]]` section with a location and size. Doing that would probably require packaging `mkswap` and `swapon` though, and that is currently not something I know how to do.


**Description of changes:**

Allows bootstrap containers to manage swap by allowing the `swapon` and `swapoff` syscalls.


**Testing done:**

I built my own ami with this change and tested that a bootstrap container is able to set up swap. I created [a docker image that just runs whatever you give it as user data](https://github.com/stefansundin/bottlerocket-bootstrap-exec-user-data), to make it easy to change the script.

This is my script:

```shell
#!/bin/bash -ex
if [[ ! -f /.bottlerocket/rootfs/var/swapfile ]]; then
  dd if=/dev/zero of=/.bottlerocket/rootfs/var/swapfile bs=1M count=300
  chmod 600 /.bottlerocket/rootfs/var/swapfile
  mkswap /.bottlerocket/rootfs/var/swapfile
fi
swapon /.bottlerocket/rootfs/var/swapfile
```

In the OS configuration I run it with:

```toml
[settings.bootstrap-containers.swap]
source = "public.ecr.aws/stefansundin/bottlerocket-bootstrap-exec-user-data:latest"
mode = "always"
essential = false
user-data = "IyEvYmluL2Jhc2ggLWV4CmlmIFtbICEgLWYgLy5ib3R0bGVyb2NrZXQvcm9vdGZzL3Zhci9zd2FwZmlsZSBdXTsgdGhlbgogIGRkIGlmPS9kZXYvemVybyBvZj0vLmJvdHRsZXJvY2tldC9yb290ZnMvdmFyL3N3YXBmaWxlIGJzPTFNIGNvdW50PTMwMAogIGNobW9kIDYwMCAvLmJvdHRsZXJvY2tldC9yb290ZnMvdmFyL3N3YXBmaWxlCiAgbWtzd2FwIC8uYm90dGxlcm9ja2V0L3Jvb3Rmcy92YXIvc3dhcGZpbGUKZmkKc3dhcG9uIC8uYm90dGxlcm9ja2V0L3Jvb3Rmcy92YXIvc3dhcGZpbGU="
```

On the instance I can see that it works:

```
bash-5.1# free -m
               total        used        free      shared  buff/cache   available
Mem:             410         234           5           0         170         165
Swap:            299          30         269
```

Would be great to allow for swap. It is currently the only thing blocking me from utilizing Bottlerocket to a greater extent. Thanks!


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
