### PR TITLE
Match existing kubelet-config`s in kubernetes-1.24

### DIFF
--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -56,12 +56,8 @@ eventRecordQPS: {{settings.kubernetes.event-qps}}
 {{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{/if}}
-{{#if settings.kubernetes.kube-api-qps includeZero=true}}
-kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
-{{/if}}
-{{#if settings.kubernetes.kube-api-burst includeZero=true}}
-kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
-{{/if}}
+kubeAPIQPS: {{default 10 settings.kubernetes.kube-api-qps}}
+kubeAPIBurst: {{default 20 settings.kubernetes.kube-api-burst}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{#if settings.kubernetes.kube-reserved.memory}}


### PR DESCRIPTION
**Issue number:**

Closes #2538

**Description of changes:**

In #2437, we added support for kubernetes 1.24, but I missed the change introduced by #2436.

**Testing done:**

- I checked the default values for `kubeAPIQPS` and `kubeAPIBurst` were used when none were provided in the API
- I checked the configuration file was re-rendered when the API changed

```bash
# Default
bash-5.1# cat /etc/kubernetes/kubelet/config  | grep QPS
kubeAPIQPS: 10
# New value
bash-5.1# apiclient set kubernetes.kube-api-qps=20
bash-5.1# cat /etc/kubernetes/kubelet/config  | grep QPS
kubeAPIQPS: 20
# New value
bash-5.1# apiclient set kubernetes.kube-api-burst=30
bash-5.1# cat /etc/kubernetes/kubelet/config  | grep Burst
kubeAPIBurst: 30
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
