### PR TITLE
packages: add ecr-credential-provider

### DIFF
--- a/packages/ecr-credential-provider/Cargo.toml
+++ b/packages/ecr-credential-provider/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ecr-credential-provider"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.25.1/cloud-provider-aws-1.25.1.tar.gz"
+sha512 = "ceb80d66d9dedaebf8955477837652bde81b2bc3949e8efbc9c4b7b9722fe1c2bd2faa151aaa1a162e3c174424e92e2c2bee9f25f8123e74de2ee7eb7881d40e"
+bundle-modules = [ "go" ]
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/ecr-credential-provider/build.rs
+++ b/packages/ecr-credential-provider/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/ecr-credential-provider/clarify.toml
+++ b/packages/ecr-credential-provider/clarify.toml
@@ -1,0 +1,5 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xcdf3ae00 },
+]

--- a/packages/ecr-credential-provider/ecr-credential-provider.spec
+++ b/packages/ecr-credential-provider/ecr-credential-provider.spec
@@ -1,0 +1,48 @@
+%global goproject github.com/kubernetes
+%global gorepo cloud-provider-aws
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 1.25.1
+%global rpmver %{gover}
+
+%global _dwz_low_mem_die_limit 0
+
+%global gitrev 704b05de2c8633e4acaae62bd81c5575e1e5c1d6
+%global shortrev %(c=%{gitrev}; echo ${c:0:7})
+
+Name: %{_cross_os}ecr-credential-provider
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: Container image registry credential provider for AWS ECR
+License: Apache-2.0
+URL: https://github.com/kubernetes/cloud-provider-aws
+
+Source: cloud-provider-aws-%{gover}.tar.gz
+Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
+Source1000: clarify.toml
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -n %{gorepo}-%{gover} -q
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
+
+%build
+%set_cross_go_flags
+
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider/pkg.rs
+++ b/packages/ecr-credential-provider/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/kubernetes-1.21/Cargo.toml
+++ b/packages/kubernetes-1.21/Cargo.toml
@@ -24,6 +24,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.
 # conntrack-tools = { path = "../conntrack-tools" }

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -58,6 +58,7 @@ Summary: Container cluster node agent
 Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
+Requires: %{_cross_os}ecr-credential-provider
 
 %description -n %{_cross_os}kubelet-1.21
 %{summary}.

--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -23,6 +23,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.
 # conntrack-tools = { path = "../conntrack-tools" }

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -55,6 +55,7 @@ Summary: Container cluster node agent
 Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
+Requires: %{_cross_os}ecr-credential-provider
 
 %description -n %{_cross_os}kubelet-1.22
 %{summary}.

--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -23,6 +23,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.
 # conntrack-tools = { path = "../conntrack-tools" }

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -56,6 +56,7 @@ Summary: Container cluster node agent
 Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
+Requires: %{_cross_os}ecr-credential-provider
 
 %description -n %{_cross_os}kubelet-1.23
 %{summary}.

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -23,6 +23,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.
 # conntrack-tools = { path = "../conntrack-tools" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -64,6 +64,7 @@ Summary: Container cluster node agent
 Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
+Requires: %{_cross_os}ecr-credential-provider
 
 %description -n %{_cross_os}kubelet-1.24
 %{summary}.

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -298,6 +298,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecr-credential-provider"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "ecs-agent"
 version = "0.1.0"
 dependencies = [
@@ -433,6 +440,7 @@ dependencies = [
 name = "kubernetes-1_21"
 version = "0.1.0"
 dependencies = [
+ "ecr-credential-provider",
  "glibc",
 ]
 
@@ -440,6 +448,7 @@ dependencies = [
 name = "kubernetes-1_22"
 version = "0.1.0"
 dependencies = [
+ "ecr-credential-provider",
  "glibc",
 ]
 
@@ -447,6 +456,7 @@ dependencies = [
 name = "kubernetes-1_23"
 version = "0.1.0"
 dependencies = [
+ "ecr-credential-provider",
  "glibc",
 ]
 
@@ -454,6 +464,7 @@ dependencies = [
 name = "kubernetes-1_24"
 version = "0.1.0"
 dependencies = [
+ "ecr-credential-provider",
  "glibc",
 ]
 


### PR DESCRIPTION
**Issue number:**

Related #1702 

**Description of changes:**

The ecr-credential-provider is a Kubernetes credential provider plugin from the cloud-provider-aws project. It uses AWS credentials or an IAM role to authenticate against an ECR registry.

**Testing done:**

Built and deployed instance, verified the binary was in the expected location on the filesystem.

See #2377 for complete testing details.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
