### PR TITLE
schnauzer: Add any_enabled template helper

### DIFF
--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -137,6 +137,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     );
     template_registry.register_helper("localhost_aliases", Box::new(helpers::localhost_aliases));
     template_registry.register_helper("etc_hosts_entries", Box::new(helpers::etc_hosts_entries));
+    template_registry.register_helper("any_enabled", Box::new(helpers::any_enabled));
 
     Ok(template_registry)
 }


### PR DESCRIPTION
**Issue number:**

Related https://github.com/bottlerocket-os/bottlerocket/issues/1702

**Description of changes:**

This adds a new template helper called `any_enabled` that can be used in our templates to check if anything in a collection contains something with the property of `enabled` set to true.

The helper looks for an array, then checks that the objects within the array has an "enabled" property. If they do and if any of them are set to "true" the condition evaluates to be "truey" for conditional blocks within the template.

If the passed in value is not an array, does not have an "enabled" property, or has no elements with that property set to true it will evaluate to falsey.

**Testing done:**

See https://github.com/bottlerocket-os/bottlerocket/pull/2377 for complete testing details.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
