### PR TITLE
packages: Add AWS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,9 +951,25 @@ They can be overridden for testing purposes in [the same way as other settings](
 
 ##### AWS-specific settings
 
-AWS-specific settings are automatically set based on calls to the Instance MetaData Service (IMDS).
+* `settings.aws.config`: The base64 encoded content to use for AWS configuration (e.g. `base64 -w0 ~/.aws/config`).
+* `settings.aws.credentials`: The base64 encoded content to use for AWS credentials (e.g. `base64 -w0 ~/.aws/credentials`).
+* `settings.aws.profile`: The profile name to use from the provided `config` and `credentials` settings.
+
+  For example:
+
+  ```toml
+  [settings.aws]
+  profile = "myprofile"
+  ```
+
+  **Note**: If `settings.aws.profile` is not set, the setting will fallback to the "default" profile.
+
+  **Note:** The `config`, `credentials`, and `profile` are optional and do not need to be set when using an Instance Profile when running on an AWS instance.
 
 * `settings.aws.region`: This is set to the AWS region in which the instance is running, for example `us-west-2`.
+
+  The `region` setting is automatically inferred based on calls to the Instance MetaData Service (IMDS) when running within AWS.
+  It does not need to be explicitly set unless you have a reason to override this default value.
 
 ### Logs
 

--- a/Release.toml
+++ b/Release.toml
@@ -156,3 +156,8 @@ version = "1.10.1"
     "migrate_v1.10.1_container-runtime.lz4",
     "migrate_v1.10.1_container-runtime-metadata.lz4"
 ]
+"(1.10.1, 1.11.0)" = [
+    "migrate_v1.11.0_aws-config-settings.lz4",
+    "migrate_v1.11.0_aws-creds.lz4",
+    "migrate_v1.11.0_aws-creds-metadata.lz4",
+]

--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -28,9 +28,10 @@ mkdir -p %{buildroot}%{_cross_datadir}
 mkdir -p %{buildroot}%{_cross_infodir}
 mkdir -p %{buildroot}%{_cross_mandir}
 mkdir -p %{buildroot}%{_cross_localstatedir}
-mkdir -p %{buildroot}/{boot,dev,proc,root,run,sys,tmp}
+mkdir -p %{buildroot}/{boot,dev,proc,run,sys,tmp}
 mkdir -p %{buildroot}/{home,local,media,mnt,opt,srv}
 mkdir -p %{buildroot}/media/cdrom
+mkdir -p %{buildroot}/root/.aws
 
 ln -s .%{_cross_prefix} %{buildroot}%{_prefix}
 ln -s .%{_cross_bindir} %{buildroot}/bin

--- a/packages/release/aws-config
+++ b/packages/release/aws-config
@@ -1,0 +1,3 @@
+{{~#if settings.aws.config~}}
+{{base64_decode settings.aws.config}}
+{{~/if~}}

--- a/packages/release/aws-credentials
+++ b/packages/release/aws-credentials
@@ -1,0 +1,3 @@
+{{~#if settings.aws.credentials~}}
+{{base64_decode settings.aws.credentials}}
+{{~/if~}}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -19,6 +19,8 @@ Source202: hostname-env
 Source203: hosts.template
 Source204: modprobe-conf.template
 Source205: netdog.template
+Source206: aws-config
+Source207: aws-credentials
 
 Source1001: multi-user.target
 Source1002: configured.target
@@ -35,6 +37,7 @@ Source1009: etc-cni.mount
 Source1010: mnt.mount
 Source1012: opt-cni-bin.mount
 Source1013: local.mount
+Source1014: root-.aws.mount
 
 # CD-ROM mount & associated udev rules
 Source1015: media-cdrom.mount
@@ -136,7 +139,7 @@ install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} %{S:1006} %{S:1007} \
   %{S:1008} %{S:1009} %{S:1010} %{S:1011} %{S:1012} %{S:1013} %{S:1015} \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} %{S:1045} %{S:1046} \
-  %{S:1060} %{S:1061} %{S:1062} %{S:1080} \
+  %{S:1060} %{S:1061} %{S:1062} %{S:1080} %{S:1014} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d
@@ -169,6 +172,8 @@ install -p -m 0644 %{S:202} %{buildroot}%{_cross_templatedir}/hostname-env
 install -p -m 0644 %{S:203} %{buildroot}%{_cross_templatedir}/hosts
 install -p -m 0644 %{S:204} %{buildroot}%{_cross_templatedir}/modprobe-conf
 install -p -m 0644 %{S:205} %{buildroot}%{_cross_templatedir}/netdog-toml
+install -p -m 0644 %{S:206} %{buildroot}%{_cross_templatedir}/aws-config
+install -p -m 0644 %{S:207} %{buildroot}%{_cross_templatedir}/aws-credentials
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.rules
@@ -214,6 +219,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/mask-local-mnt.service
 %{_cross_unitdir}/mask-local-opt.service
 %{_cross_unitdir}/mask-local-var.service
+%{_cross_unitdir}/root-.aws.mount
 %dir %{_cross_unitdir}/systemd-tmpfiles-setup.service.d
 %{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
 %dir %{_cross_templatedir}
@@ -223,6 +229,8 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_templatedir}/proxy-env
 %{_cross_templatedir}/hostname-env
 %{_cross_templatedir}/hosts
+%{_cross_templatedir}/aws-config
+%{_cross_templatedir}/aws-credentials
 %{_cross_udevrulesdir}/61-mount-cdrom.rules
 
 %changelog

--- a/packages/release/root-.aws.mount
+++ b/packages/release/root-.aws.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=AWS configuration directory (/root/.aws)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/root/.aws
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
+
+[Install]
+WantedBy=preconfigured.target

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -486,6 +486,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "aws-creds"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
+name = "aws-creds-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-endpoint"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -27,6 +27,9 @@ members = [
     # "api/migration/migrations/vX.Y.Z/..."
     "api/migration/migrations/v1.10.1/container-runtime",
     "api/migration/migrations/v1.10.1/container-runtime-metadata",
+    "api/migration/migrations/v1.11.0/aws-creds",
+    "api/migration/migrations/v1.11.0/aws-creds-metadata",
+    "api/migration/migrations/v1.11.0/aws-config-settings",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.11.0/aws-config-settings/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/aws-config-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-config-settings"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/aws-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/aws-config-settings/src/main.rs
@@ -1,0 +1,26 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring the AWS client configuration. This
+/// can be used by any client expecting to find settings in the default
+/// `~/.aws/*` location.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "services.aws",
+        "configuration-files.aws-config",
+        "configuration-files.aws-credentials",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.11.0/aws-creds-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/aws-creds-metadata/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-creds-metadata"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/aws-creds-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/aws-creds-metadata/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for AWS credential configuration.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.aws",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.11.0/aws-creds/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/aws-creds/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-creds"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.11.0/aws-creds/build.rs
+++ b/sources/api/migration/migrations/v1.11.0/aws-creds/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.11.0/aws-creds/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/aws-creds/src/main.rs
@@ -1,0 +1,30 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddPrefixesMigration, AddSettingsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for AWS credential configuration.
+fn run() -> Result<()> {
+    if cfg!(variant_platform = "aws") {
+        migrate(AddSettingsMigration(&[
+            "settings.aws.config",
+            "settings.aws.credentials",
+            "settings.aws.profile",
+        ]))
+    } else {
+        // Non-AWS variants did not have any AWS setting until this point,
+        // so need to completely clean up on downgrade.
+        migrate(AddPrefixesMigration(vec!["settings.aws"]))
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-creds.toml
+++ b/sources/models/shared-defaults/aws-creds.toml
@@ -1,0 +1,20 @@
+[settings.aws]
+profile = "default"
+
+[services.aws]
+configuration-files = [
+  "aws-config",
+  "aws-credentials",
+]
+restart-commands = []
+
+[metadata.settings.aws]
+affected-services = ["aws"]
+
+[configuration-files.aws-config]
+path = "/root/.aws/config"
+template-path = "/usr/share/templates/aws-config"
+
+[configuration-files.aws-credentials]
+path = "/root/.aws/credentials"
+template-path = "/usr/share/templates/aws-credentials"

--- a/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/aws-k8s-1.22/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/aws-k8s-1.22/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/aws-k8s-1.24-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/aws-k8s-1.24-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/aws-k8s-1.24/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/aws-k8s-1.24/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -340,6 +340,9 @@ struct BootSettings {
 #[model]
 struct AwsSettings {
     region: SingleLineString,
+    config: ValidBase64,
+    credentials: ValidBase64,
+    profile: SingleLineString,
 }
 
 // Metrics settings

--- a/sources/models/src/metal-k8s-1.22/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/metal-k8s-1.22/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/metal-k8s-1.22/mod.rs
+++ b/sources/models/src/metal-k8s-1.22/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
+    AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
+    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -22,6 +22,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,
+    aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,

--- a/sources/models/src/metal-k8s-1.24/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/metal-k8s-1.24/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
+    AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
+    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -22,6 +22,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,
+    aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,

--- a/sources/models/src/vmware-k8s-1.22/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/vmware-k8s-1.22/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/vmware-k8s-1.22/mod.rs
+++ b/sources/models/src/vmware-k8s-1.22/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings,
-    KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    AwsSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
+    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
+    PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -21,6 +21,7 @@ struct Settings {
     ntp: NtpSettings,
     network: NetworkSettings,
     kernel: KernelSettings,
+    aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: RegistrySettings,

--- a/sources/models/src/vmware-k8s-1.24/defaults.d/40-aws-creds.toml
+++ b/sources/models/src/vmware-k8s-1.24/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::modeled_types::Identifier;
 use crate::{
-    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
+    AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
+    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -21,6 +21,7 @@ struct Settings {
     ntp: NtpSettings,
     network: NetworkSettings,
     kernel: KernelSettings,
+    aws: AwsSettings,
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,


### PR DESCRIPTION
**Issue number:**

Related #1702

**Description of changes:**

Adds configuration settings for controlling AWS credentials and configuration. This enables setting the `~/.aws/config` and `~/.aws/credentials` file contents so anything using an aws client can be configured to use something other than the default instance role.

This adds the AwsSettings to the non-AWS k8s variants in preparation of their use for configuring credential providers.

**Testing done:**

See https://github.com/bottlerocket-os/bottlerocket/pull/2377 for complete testing details.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
