### PR TITLE
kubelet: add image credential provider settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,26 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.container-log-max-size`: The maximum size of container log file before it is rotated.
 * `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`. If you want to allow pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node, you can set this setting to `static`. You should reboot if you change this setting after startup - try `apiclient reboot`.
 * `settings.kubernetes.cpu-manager-reconcile-period`: Specifies the CPU manager reconcile period, which controls how often updated CPU assignments are written to cgroupfs. The value is a duration like `30s` for 30 seconds or `1h5m` for 1 hour and 5 minutes.
+* `settings.kubernetes.credential-providers`: Contains a collection of Kubelet image credential provider settings.
+  Each name under `credential-providers` is the name of the plugin to configure.
+
+  Example user data for configuring the `ecr-credential-provider` credential provider plugin:
+
+  ```toml
+  [settings.kubernetes.credential-providers.ecr-credential-provider]
+  enabled = true
+  # (optional - defaults to "12h")
+  cache-duration = "30m"
+  image-patterns = [
+    # One or more URL paths to match an image prefix. Supports globbing of subdomains.
+    "*.dkr.ecr.us-east-2.amazonaws.com",
+    "*.dkr.ecr.us-west-2.amazonaws.com"
+  ]
+  ```
+
+  **Note:** `ecr-credential-provider` is currently the only supported provider.
+  To manage its AWS credentials, see the `settings.aws.config` and `settings.aws.credentials` settings.
+
 * `settings.kubernetes.event-burst`: The maximum size of a burst of event creations.
 * `settings.kubernetes.event-qps`: The maximum event creations per second.
 * `settings.kubernetes.eviction-hard`: The signals and thresholds that trigger pod eviction.

--- a/Release.toml
+++ b/Release.toml
@@ -160,4 +160,5 @@ version = "1.10.1"
     "migrate_v1.11.0_aws-config-settings.lz4",
     "migrate_v1.11.0_aws-creds.lz4",
     "migrate_v1.11.0_aws-creds-metadata.lz4",
+    "migrate_v1.11.0_credential-providers.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1142,6 +1142,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "credential-providers"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "api/migration/migrations/v1.11.0/aws-creds",
     "api/migration/migrations/v1.11.0/aws-creds-metadata",
     "api/migration/migrations/v1.11.0/aws-config-settings",
+    "api/migration/migrations/v1.11.0/credential-providers",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.11.0/credential-providers/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/credential-providers/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "credential-providers"
+version = "0.1.0"
+edition = "2018"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/credential-providers/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/credential-providers/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring kubelet's image credential
+/// provider plugins. Initially this is only to support ecr-credential-provider,
+/// but others may be added as needed.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.credential-providers",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -145,8 +145,8 @@ use std::net::IpAddr;
 
 use crate::de::{deserialize_mirrors, deserialize_node_taints};
 use crate::modeled_types::{
-    BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, DNSDomain,
-    ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
+    BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, CredentialProvider,
+    DNSDomain, ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
     EtcHostsEntries, FriendlyVersion, Identifier, ImageGCHighThresholdPercent,
     ImageGCLowThresholdPercent, KmodKey, KubernetesAuthenticationMode, KubernetesBootstrapToken,
     KubernetesCloudProvider, KubernetesClusterDnsIp, KubernetesClusterName,
@@ -207,6 +207,7 @@ struct KubernetesSettings {
     image_gc_low_threshold_percent: ImageGCLowThresholdPercent,
     provider_id: Url,
     log_level: u8,
+    credential_providers: HashMap<Identifier, CredentialProvider>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use std::net::IpAddr;
 use std::ops::Deref;
 
+use crate::SingleLineString;
+
 // Declare constant values usable by any type
 const IMAGE_GC_THRESHOLD_MAX: i32 = 100;
 const IMAGE_GC_THRESHOLD_MIN: i32 = 0;
@@ -1257,4 +1259,14 @@ mod test_cluster_dns_ip {
             Some(&IpAddr::from_str("127.0.0.1").unwrap())
         );
     }
+}
+
+/// CredentialProvider contains the settings for a credential provider for use
+/// in CredentialProviderConfig.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CredentialProvider {
+    enabled: bool,
+    image_patterns: Vec<SingleLineString>,
+    cache_duration: Option<KubernetesDurationValue>,
 }


### PR DESCRIPTION
**Issue number:**

Related #1702

**Description of changes:**

Add kubelet config option `credential-providers` to allow configuring image credential provider settings.
Mention of the new settings have been added to the README.

**Testing done:**

Deployed instance. Testing settings by running:

```bash
apiclient set -j '{"kubernetes": {"credential-providers": {"ecr-credential-provider": {"enabled": true, "image-patterns": []}}}}'
apiclient get settings.kubernetes
```

See https://github.com/bottlerocket-os/bottlerocket/pull/2377 for complete testing details.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
