### PR TITLE
fix package rebuilds for feature flags

### DIFF
--- a/tools/buildsys/src/bin/bottlerocket-variant/main.rs
+++ b/tools/buildsys/src/bin/bottlerocket-variant/main.rs
@@ -1,5 +1,7 @@
 use bottlerocket_variant::Variant;
+use buildsys::manifest::ManifestInfo;
 use snafu::ResultExt;
+use std::path::PathBuf;
 use std::{env, process};
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -12,10 +14,12 @@ fn main() {
     }
 }
 
-/// Read `BUILDSYS_VARIANT` from the environment, parse into its components,
-/// and emit related environment variables to set.
+/// Read `BUILDSYS_VARIANT` from the environment, parse into its components, and emit related
+/// environment variables to set (or export). Do the same for features defined in the variant
+/// manifest.
 fn run() -> Result<()> {
-    let variant = Variant::new(getenv("BUILDSYS_VARIANT")?).context(error::VariantParseSnafu)?;
+    let env = getenv("BUILDSYS_VARIANT")?;
+    let variant = Variant::new(&env).context(error::VariantParseSnafu)?;
     println!("BUILDSYS_VARIANT_PLATFORM={}", variant.platform());
     println!("BUILDSYS_VARIANT_RUNTIME={}", variant.runtime());
     println!("BUILDSYS_VARIANT_FAMILY={}", variant.family());
@@ -23,6 +27,16 @@ fn run() -> Result<()> {
         "BUILDSYS_VARIANT_FLAVOR={}",
         variant.variant_flavor().unwrap_or("''")
     );
+    let manifest = PathBuf::from(getenv("BUILDSYS_ROOT_DIR")?)
+        .join("variants")
+        .join(&env)
+        .join("Cargo.toml");
+    let variant_manifest = ManifestInfo::new(manifest).context(error::ManifestParseSnafu)?;
+    if let Some(image_features) = variant_manifest.image_features() {
+        for image_feature in image_features {
+            println!("export BUILDSYS_VARIANT_IMAGE_FEATURE_{}=1", image_feature);
+        }
+    }
     Ok(())
 }
 
@@ -39,6 +53,10 @@ mod error {
     pub(super) enum Error {
         VariantParse {
             source: bottlerocket_variant::error::Error,
+        },
+
+        ManifestParse {
+            source: buildsys::manifest::Error,
         },
 
         #[snafu(display("Missing environment variable '{}'", var))]

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -74,7 +74,10 @@ pub(crate) struct PackageBuilder;
 
 impl PackageBuilder {
     /// Build RPMs for the specified package.
-    pub(crate) fn build(package: &str, image_features: Option<Vec<&ImageFeature>>) -> Result<Self> {
+    pub(crate) fn build(
+        package: &str,
+        image_features: Option<HashSet<&ImageFeature>>,
+    ) -> Result<Self> {
         let output_dir: PathBuf = getenv("BUILDSYS_PACKAGES_DIR")?.into();
         let arch = getenv("BUILDSYS_ARCH")?;
         let goarch = serde_plain::from_str::<SupportedArch>(&arch)
@@ -130,7 +133,7 @@ impl VariantBuilder {
         image_format: Option<&ImageFormat>,
         image_layout: Option<&ImageLayout>,
         kernel_parameters: Option<&Vec<String>>,
-        image_features: Option<Vec<&ImageFeature>>,
+        image_features: Option<HashSet<&ImageFeature>>,
     ) -> Result<Self> {
         let output_dir: PathBuf = getenv("BUILDSYS_OUTPUT_DIR")?.into();
 


### PR DESCRIPTION
**Issue number:**

Closes #2546

**Description of changes:**
```
buildsys: fix package rebuilds for feature flags

The previous approach for detecting changes to image feature flags
that should trigger a rebuild was incorrect. It would cause packages
to be rebuilt whenever the variant manifest that was the target at
the time of last rebuild changed.

This would happen regardless of whether image feature flags changed,
whether the same flags were set for the current variant manifest, or
whether the flags were even used by the package.

Fixing this requires two prerequisites.

First, the current image feature flags must be set in the environment
prior to invoking `cargo build`, or it will be too late to emit the
`cargo:rerun-if-env-changed` directives, since the environment that
`cargo` runs in is not influenced by changes from the build script.

Second, each package must declare which image feature flags it cares
about, if any, so that the correct cargo directive can be omitted.
The environment does not carry this information, since the absence of
a particular environment variable can also mean that a package needs
to be rebuilt to disable a previously-enabled feature.

With this functionality in place, each package build can emit the
directives needed for correct change detection. For robustness, only
the feature flags tracked by the package are passed through to the
build, meaning the feature will always be treated as "disabled" by
bconds in the spec file.
```

**Testing done:**
Verified that modifying the variant manifest no longer triggers a rebuild of all packages originally built for that variant.

On my Secure Boot branch, verified that switching back and forth between variants that have different feature flags trigger the expected rebuilds of `shim` and `grub`.

With `export CARGO_LOG=cargo::core::compiler::fingerprint=trace` set, I see messages like this when the switch causes a rebuild:
```
[2022-11-03T17:42:42Z INFO  cargo::core::compiler::fingerprint]     err: env var `BUILDSYS_VARIANT_IMAGE_FEATURE_UEFI_SECURE_BOOT` changed: previously Some("1"), now None
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
