### PR TITLE
adds roadmap markdown

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,35 @@
+# Roadmap
+
+The Bottlerocket roadmap is public and hosted as a GitHub Project at the following URL:
+
+https://github.com/orgs/bottlerocket-os/projects/18
+
+GitHub Projects allows for multiple views that represent different ways of looking at the same data. 
+In the case of Bottlerocket, there are four views (represented as tabs):
+
+* [All Items](https://github.com/orgs/bottlerocket-os/projects/18/views/1): a list of all the issues being actively worked on. 
+* [Upcoming Releases](https://github.com/orgs/bottlerocket-os/projects/18/views/2): the issues sorted into columns that represent an upcoming release.
+* [Feature Highlights](https://github.com/orgs/bottlerocket-os/projects/18/views/4): selected issues sorted into columns that represent particular features.
+* [Themes](https://github.com/orgs/bottlerocket-os/projects/18/views/5):  selected issues sorted into columns as they align to overarching thematic changes. 
+
+## What does the roadmap represent?
+
+The roadmap is best understood as a point-in-time snapshot of what is being worked on and the intentions for upcoming releases. 
+Each item on the roadmap links back to a GitHub issue; issues represent a problem (i.e. a bug) or a change from the current functional state (i.e. an enhancement). 
+
+Both bug and enhancements can take a non-linear path to resolution. 
+The work to resolve these can take more or less effort than anticipated as paths are explored and complexity is thoughtfully considered. 
+Releases in Bottlerocket follow a loose release train model with each being spaced out about six weeks apart. 
+So, roadmap items are continuously reconsidered and roadmap adjustments may be required.
+
+## How do I follow a specific change to the roadmap?
+
+For individual items, the best way to find out more information is to subscribe to notifications on GitHub for the specific issues linked in the roadmap. 
+This will give you insight into both the development and any large changes to how the issue gets packaged into a release. 
+Additionally, you can ask questions, provide feedback, and, hopefully, contribute. 
+
+## Can I see a log of all the changes to the roadmap?
+
+This was supported in [GitHub Projects classic](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/tracking-work-with-project-boards/tracking-progress-on-your-project-board) however, Bottlerocket uses the newer version of this GitHub feature which lacks this particular log-like view. 
+In the future, it would be great to see this feature return to GitHub Projects or similar functionality through the  [Bottlerocket website](https://github.com/bottlerocket-os/project-website) initiative.
+


### PR DESCRIPTION
**Issue number:** N/A

Closes # N/A

**Description of changes:**

Adds a markdown document describing the GitHub Project's based roadmap as well as instructions on how it should be used.

**Testing done:** Proofreading

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
