### PR TITLE
Enable IAM Roles Anywhere with the k8s  `ecr-credential-provider` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,23 @@ The following settings are optional and allow you to further configure your clus
   **Note:** `ecr-credential-provider` is currently the only supported provider.
   To manage its AWS credentials, see the `settings.aws.config` and `settings.aws.credentials` settings.
 
+  The `ecr-credential-provider` plugin can also be used for AWS IAM Roles Anywhere support.
+  IAM Roles Anywhere is configured using the `settings.aws.config` setting.
+  The content of that setting needs to configure the `credential_process` using the `aws_signing_helper` using your IAM Roles Anywhere settings, similar to the following:
+
+  ```ini
+  [default]
+  region = us-west-2
+  credential_process = aws_signing_helper credential-process \
+     --certificate /var/lib/kubelet/pki/kubelet-client-current.pem \
+     --private-key /var/lib/kubelet/pki/kubelet-client-current.pem \
+     --profile-arn [profile ARN]
+     --role-arn [role ARN]
+     --trust-anchor-arn [trust anchor ARN]
+  ```
+
+  See the [Roles Anywhere documentation](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html) for more details on the `aws_signing_helper` arguments.
+
 * `settings.kubernetes.event-burst`: The maximum size of a burst of event creations.
 * `settings.kubernetes.event-qps`: The maximum event creations per second.
 * `settings.kubernetes.eviction-hard`: The signals and thresholds that trigger pod eviction.

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aws-signing-helper"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.0.2/rolesanywhere-credential-helper-v1.0.2.tar.gz"
+sha512 = "b364bf8f73f33e7ac1db6a1153880ffa2e4af52a3d8f7b224cc5a9a2e545432a9bf408191048a406fdb995a034b997cdeeb752b4dfcea8288be5baeca8e69b9a"
+bundle-modules = [ "go" ]
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -1,0 +1,46 @@
+%global goproject github.com/aws
+%global gorepo rolesanywhere-credential-helper
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 1.0.2
+%global rpmver %{gover}
+
+%global _dwz_low_mem_die_limit 0
+
+Name: %{_cross_os}aws-signing-helper
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: AWS signing helper for IAM Roles Anywhere support
+License: Apache-2.0
+URL: https://github.com/aws/rolesanywhere-credential-helper
+
+Source: rolesanywhere-credential-helper-v%{gover}.tar.gz
+Source1: bundled-rolesanywhere-credential-helper-v%{gover}.tar.gz
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -n %{gorepo}-%{gover} -q
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
+
+%build
+%set_cross_go_flags
+
+go build ${GOFLAGS} -buildmode=pie -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper cmd/aws_signing_helper/main.go
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 aws-signing-helper %{buildroot}%{_cross_bindir}/aws_signing_helper
+ln -sf aws_signing_helper %{buildroot}%{_cross_bindir}/aws-signing-helper
+
+%cross_scan_attribution go-vendor vendor
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_bindir}/aws_signing_helper
+%{_cross_bindir}/aws-signing-helper

--- a/packages/aws-signing-helper/build.rs
+++ b/packages/aws-signing-helper/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/aws-signing-helper/pkg.rs
+++ b/packages/aws-signing-helper/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/kubernetes-1.21/Cargo.toml
+++ b/packages/kubernetes-1.21/Cargo.toml
@@ -24,6 +24,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+aws-signing-helper = { path = "../aws-signing-helper" }
 ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.

--- a/packages/kubernetes-1.21/kubernetes-1.21.spec
+++ b/packages/kubernetes-1.21/kubernetes-1.21.spec
@@ -63,6 +63,7 @@ Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
+Requires: %{_cross_os}aws-signing-helper
 
 %description -n %{_cross_os}kubelet-1.21
 %{summary}.

--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -23,6 +23,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+aws-signing-helper = { path = "../aws-signing-helper" }
 ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -60,6 +60,7 @@ Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
+Requires: %{_cross_os}aws-signing-helper
 
 %description -n %{_cross_os}kubelet-1.22
 %{summary}.

--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -23,6 +23,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+aws-signing-helper = { path = "../aws-signing-helper" }
 ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -61,6 +61,7 @@ Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
+Requires: %{_cross_os}aws-signing-helper
 
 %description -n %{_cross_os}kubelet-1.23
 %{summary}.

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -23,6 +23,7 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
+aws-signing-helper = { path = "../aws-signing-helper" }
 ecr-credential-provider = { path = "../ecr-credential-provider" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -69,6 +69,7 @@ Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
+Requires: %{_cross_os}aws-signing-helper
 
 %description -n %{_cross_os}kubelet-1.24
 %{summary}.

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -171,6 +171,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-signing-helper"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "bash"
 version = "0.1.0"
 dependencies = [
@@ -440,6 +447,7 @@ dependencies = [
 name = "kubernetes-1_21"
 version = "0.1.0"
 dependencies = [
+ "aws-signing-helper",
  "ecr-credential-provider",
  "glibc",
 ]
@@ -448,6 +456,7 @@ dependencies = [
 name = "kubernetes-1_22"
 version = "0.1.0"
 dependencies = [
+ "aws-signing-helper",
  "ecr-credential-provider",
  "glibc",
 ]
@@ -456,6 +465,7 @@ dependencies = [
 name = "kubernetes-1_23"
 version = "0.1.0"
 dependencies = [
+ "aws-signing-helper",
  "ecr-credential-provider",
  "glibc",
 ]
@@ -464,6 +474,7 @@ dependencies = [
 name = "kubernetes-1_24"
 version = "0.1.0"
 dependencies = [
+ "aws-signing-helper",
  "ecr-credential-provider",
  "glibc",
 ]


### PR DESCRIPTION
**Issue number:**

Closes #2310 

**Description of changes:**

This adds a new package to place the `aws_signing_helper` binary in the /usr/bin PATH to enable its use for k8s credential provider support of IAM Roles Anywhere.

Documentation also added to give an example of how to configure the AWS client settings to use this.

**Testing done:**

Deployed node and verified `aws_signing_helper` is present and executable in the `/usr/bin` directory.
Additional testing TBD with the EKS-A team to validate functionality.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
