### PR TITLE
diff-kernel-config: pass new required env vars for package build

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -171,6 +171,11 @@ for state in before after; do
 
                 debug_id="state=${state} arch=${arch} variant=${variant}"
 
+                IFS=- read -ra variant_parts <<<"${variant}"
+                variant_platform="${variant_parts[0]}"
+                variant_runtime="${variant_parts[1]}"
+                variant_family="${variant_platform}-${variant_runtime}"
+
                 #
                 # Run build
                 #
@@ -178,6 +183,9 @@ for state in before after; do
                 cargo make \
                         -e BUILDSYS_ARCH="${arch}" \
                         -e BUILDSYS_VARIANT="${variant}" \
+                        -e BUILDSYS_VARIANT_PLATFORM="${variant_platform}" \
+                        -e BUILDSYS_VARIANT_RUNTIME="${variant_runtime}" \
+                        -e BUILDSYS_VARIANT_FAMILY="${variant_family}" \
                         -e PACKAGE="kernel-${kver/./_}" \
                         build-package \
                     || bail "Build failed for ${debug_id}"


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:**

```
diff-kernel-config: pass new required env vars for package build

Commit 24a7161 ("build: pass variant-related variables into builds")
started requiring three new environment variables to be set for a direct
package build to denote the platform, runtime, and family of a variant.
Adapt diff-kernel-config to pass those when building the kernel
packages to avoid build failures.
```


**Testing done:** I used this change to create the kernel config diffs for #2554. ShellCheck also still is happy.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
