### PR TITLE
migrations: add migration for 'configuration-files.kubelet-server*'

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -162,6 +162,7 @@ version = "1.10.1"
     "migrate_v1.11.0_aws-creds-metadata.lz4",
     "migrate_v1.11.0_credential-providers.lz4",
     "migrate_v1.11.0_kubelet-tls-config.lz4",
+    "migrate_v1.11.0_kubelet-tls-files.lz4",
     "migrate_v1.11.0_kubelet-new-config-files.lz4",
     "migrate_v1.11.0_ecs-additional-configurations.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2037,6 +2037,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-tls-files"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "api/migration/migrations/v1.11.0/aws-config-settings",
     "api/migration/migrations/v1.11.0/credential-providers",
     "api/migration/migrations/v1.11.0/kubelet-tls-config",
+    "api/migration/migrations/v1.11.0/kubelet-tls-files",
     "api/migration/migrations/v1.11.0/kubelet-new-config-files",
     "api/migration/migrations/v1.11.0/ecs-additional-configurations",
 

--- a/sources/api/migration/migrations/v1.11.0/kubelet-tls-files/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/kubelet-tls-files/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-tls-files"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.11.0/kubelet-tls-files/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/kubelet-tls-files/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added support for adding new kubelet TLS certs/keys for communicating with the Kubernetes API server.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "configuration-files.kubelet-server-crt",
+        "configuration-files.kubelet-server-key",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
    migrations: add migration for 'configuration-files.kubelet-server*'
```


**Testing done:**
Performed upgrade downgrade testing.
On v1.11.0, I verified `configuration-files.kubelet-server-*` are in the datastore:
```bash
bash-5.1# apiclient get /os                                                                       
{
  "arch": "x86_64",
  "build_id": "ba64a2b1-dirty",
  "pretty_name": "Bottlerocket OS 1.11.0 (aws-k8s-1.23)",
  "variant_id": "aws-k8s-1.23",
  "version_id": "1.11.0"
}
bash-5.1# ls -al /var/lib/bottlerocket/datastore/v1.11.0/live/configuration-files/kubelet-server-*
/var/lib/bottlerocket/datastore/v1.11.0/live/configuration-files/kubelet-server-crt:
total 16
drwxr-xr-x.  2 root root 4096 Nov  7 19:04 .
drwxr-xr-x. 26 root root 4096 Nov  7 19:04 ..
-rw-r--r--.  1 root root   40 Nov  7 19:04 path
-rw-r--r--.  1 root root   41 Nov  7 19:04 template-path

/var/lib/bottlerocket/datastore/v1.11.0/live/configuration-files/kubelet-server-key:
total 16
drwxr-xr-x.  2 root root 4096 Nov  7 19:04 .
drwxr-xr-x. 26 root root 4096 Nov  7 19:04 ..
-rw-r--r--.  1 root root   40 Nov  7 19:04 path
-rw-r--r--.  1 root root   41 Nov  7 19:04 template-path
bash-5.1# 
```

Then I downgraded back to v1.10.1, host comes back up fine and I verified that the migration successfully removed those paths on downgrade:
```bash
[ec2-user@admin]$ sudo sheltie
bash-5.1# apiclient get /os
{
  "arch": "x86_64",
  "build_id": "5d27ae74",
  "pretty_name": "Bottlerocket OS 1.10.1 (aws-k8s-1.23)",
  "variant_id": "aws-k8s-1.23",
  "version_id": "1.10.1"
}
bash-5.1# ls -al /var/lib/bottlerocket/datastore/current/live/configuration-files/kubelet-server-*
ls: cannot access '/var/lib/bottlerocket/datastore/current/live/configuration-files/kubelet-server-*': No such file or directory
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
