### PR TITLE
Allow bootstrap containers to manage network configuration

### DIFF
--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -134,7 +134,7 @@
 
 ; Subjects that are allowed to manage network interfaces.
 (typeattribute network_s)
-(typeattributeset network_s (network_t system_t super_t))
+(typeattributeset network_s (network_t system_t super_t control_t))
 
 ; Subjects that are allowed to control system files.
 (typeattribute control_s)

--- a/sources/api/netdog/src/cli/generate_net_config.rs
+++ b/sources/api/netdog/src/cli/generate_net_config.rs
@@ -1,5 +1,8 @@
 use super::{error, Result};
-use crate::{net_config, DEFAULT_NET_CONFIG_FILE, KERNEL_CMDLINE, PRIMARY_INTERFACE};
+use crate::{
+    net_config, DEFAULT_NET_CONFIG_FILE, KERNEL_CMDLINE, OVERRIDE_NET_CONFIG_FILE,
+    PRIMARY_INTERFACE,
+};
 use argh::FromArgs;
 use snafu::{OptionExt, ResultExt};
 use std::{fs, path::Path};
@@ -11,7 +14,11 @@ pub(crate) struct GenerateNetConfigArgs {}
 
 /// Generate configuration for network interfaces.
 pub(crate) fn run() -> Result<()> {
-    let maybe_net_config = if Path::exists(Path::new(DEFAULT_NET_CONFIG_FILE)) {
+    let maybe_net_config = if Path::exists(Path::new(OVERRIDE_NET_CONFIG_FILE)) {
+        net_config::from_path(OVERRIDE_NET_CONFIG_FILE).context(error::NetConfigParseSnafu {
+            path: OVERRIDE_NET_CONFIG_FILE,
+        })?
+    } else if Path::exists(Path::new(DEFAULT_NET_CONFIG_FILE)) {
         net_config::from_path(DEFAULT_NET_CONFIG_FILE).context(error::NetConfigParseSnafu {
             path: DEFAULT_NET_CONFIG_FILE,
         })?

--- a/sources/api/netdog/src/interface_name.rs
+++ b/sources/api/netdog/src/interface_name.rs
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn invalid_interface_name() {
         let bad_str = [
-            &std::iter::repeat("a").take(16).collect::<String>(),
+            &"a".repeat(16),
             "",
             ".",
             "..",
@@ -132,13 +132,7 @@ mod tests {
 
     #[test]
     fn valid_interface_name() {
-        let ok_str = [
-            &std::iter::repeat("a").take(15).collect::<String>(),
-            "eno1",
-            "eth0",
-            "enp5s0",
-            "enx0eb36944b633",
-        ];
+        let ok_str = [&"a".repeat(15), "eno1", "eth0", "enp5s0", "enx0eb36944b633"];
         for ok in ok_str {
             assert!(InterfaceName::try_from(ok).is_ok())
         }

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -50,6 +50,7 @@ static CURRENT_IP: &str = "/var/lib/netdog/current_ip";
 static KERNEL_CMDLINE: &str = "/proc/cmdline";
 static PRIMARY_INTERFACE: &str = "/var/lib/netdog/primary_interface";
 static DEFAULT_NET_CONFIG_FILE: &str = "/var/lib/bottlerocket/net.toml";
+static OVERRIDE_NET_CONFIG_FILE: &str = "/var/lib/netdog/net.toml";
 static PRIMARY_SYSCTL_CONF: &str = "/etc/sysctl.d/90-primary_interface.conf";
 static SYSTEMD_SYSCTL: &str = "/usr/lib/systemd/systemd-sysctl";
 static LEASE_DIR: &str = "/run/wicked";

--- a/sources/api/netdog/src/wicked/mod.rs
+++ b/sources/api/netdog/src/wicked/mod.rs
@@ -149,7 +149,7 @@ mod tests {
             "eno8:dhcp4?,dhcp6?",
         ];
         for ok_str in ok {
-            let net_config = NetConfigV1::from_str(&ok_str).unwrap();
+            let net_config = NetConfigV1::from_str(ok_str).unwrap();
 
             let wicked_interfaces = net_config.as_wicked_interfaces();
             for interface in wicked_interfaces {
@@ -166,13 +166,14 @@ mod tests {
 
     // Test the end to end trip: "net config -> wicked -> serialized XML"
     #[test]
+    #[allow(clippy::to_string_in_format_args)]
     fn net_config_to_interface_config() {
         let net_config_path = wicked_config().join("net_config.toml");
 
         for version in NET_CONFIG_VERSIONS {
             let temp_config = tempfile::NamedTempFile::new().unwrap();
 
-            render_config_template(&net_config_path, &temp_config, &version);
+            render_config_template(&net_config_path, &temp_config, version);
             let net_config = net_config::from_path(&temp_config).unwrap().unwrap();
             let wicked_interfaces = net_config.as_wicked_interfaces();
             for interface in wicked_interfaces {


### PR DESCRIPTION
**Description of changes:**

Gives bootstrap containers the ability to write files to `/var/lib/netdog`. This can serve as an alternative/overriding location to store a `net.toml`.

Also cleans up some `clippy` warnings.

**Testing done:**

Bootstrap container was able to configure network by outputting a `/var/lib/netdog/net.toml` file.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
