### PR TITLE
testsys: Refactor code base

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -45,12 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
-
-[[package]]
 name = "argh"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1390,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-openssl"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
+dependencies = [
+ "http",
+ "hyper",
+ "linked_hash_set",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "parking_lot",
+ "tokio",
+ "tokio-openssl",
+ "tower-layer",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1634,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-openssl",
  "hyper-timeout",
  "hyper-tls",
  "jsonpath_lib",
@@ -1693,6 +1706,15 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "lock_api"
@@ -2916,7 +2938,7 @@ dependencies = [
 name = "testsys"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "async-trait",
  "aws-config",
  "aws-sdk-ec2",
  "base64",
@@ -2926,6 +2948,7 @@ dependencies = [
  "env_logger",
  "futures",
  "k8s-openapi",
+ "kube-client",
  "log",
  "maplit",
  "model",
@@ -2933,6 +2956,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "snafu",
  "term_size",
  "testsys-config",
  "tokio",
@@ -3094,6 +3118,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
  "tokio",
 ]
 

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -102,35 +102,6 @@ pub struct Test {
     pub testsys_image_registry: Option<String>,
 }
 
-#[derive(Debug, Default)]
-pub struct AwsK8sVariantConfig {
-    /// The names of all clusters this variant should be tested over. This is particularly useful
-    /// for testing Bottlerocket on ipv4 and ipv6 clusters.
-    pub cluster_names: Vec<String>,
-    /// The instance type that instances should be launched with
-    pub instance_type: Option<String>,
-    /// The secrets needed by the agents
-    pub secrets: BTreeMap<String, SecretName>,
-    /// The role that should be assumed for this particular variant
-    pub assume_role: Option<String>,
-    /// The kubernetes conformance image that should be used for this variant
-    pub kube_conformance_image: Option<String>,
-    /// The e2e repo containing sonobuoy images
-    pub e2e_repo_registry: Option<String>,
-}
-
-#[derive(Debug, Default)]
-pub struct AwsEcsVariantConfig {
-    /// The names of all clusters this variant should be tested over
-    pub cluster_names: Vec<String>,
-    /// The instance type that instances should be launched with
-    pub instance_type: Option<String>,
-    /// The secrets needed by the agents
-    pub secrets: BTreeMap<String, SecretName>,
-    /// The role that should be assumed for this particular variant
-    pub assume_role: Option<String>,
-}
-
 /// Create a vec of relevant keys for this variant ordered from most specific to least specific.
 fn config_keys(variant: &Variant) -> Vec<String> {
     let (family_flavor, platform_flavor) = variant
@@ -224,30 +195,6 @@ impl GenericVariantConfig {
             agent_role: self.agent_role.or(other.agent_role),
             conformance_image: self.conformance_image.or(other.conformance_image),
             conformance_registry: self.conformance_registry.or(other.conformance_registry),
-        }
-    }
-}
-
-impl From<GenericVariantConfig> for AwsK8sVariantConfig {
-    fn from(val: GenericVariantConfig) -> Self {
-        Self {
-            cluster_names: val.cluster_names,
-            instance_type: val.instance_type,
-            secrets: val.secrets,
-            assume_role: val.agent_role,
-            kube_conformance_image: val.conformance_image,
-            e2e_repo_registry: val.conformance_registry,
-        }
-    }
-}
-
-impl From<GenericVariantConfig> for AwsEcsVariantConfig {
-    fn from(val: GenericVariantConfig) -> Self {
-        Self {
-            cluster_names: val.cluster_names,
-            instance_type: val.instance_type,
-            secrets: val.secrets,
-            assume_role: val.agent_role,
         }
     }
 }

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0"
+async-trait = "0.1"
 aws-config = "0.48"
 aws-sdk-ec2 = "0.18"
 base64 = "0.13"
@@ -17,6 +17,7 @@ clap = { version = "3", features = ["derive", "env"] }
 env_logger = "0.9"
 futures = "0.3.8"
 k8s-openapi = { version = "0.16", features = ["v1_20", "api"], default-features = false }
+kube-client = { version = "0.75"}
 log = "0.4"
 maplit = "1.0.2"
 model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.3", tag = "v0.0.3"}
@@ -24,6 +25,7 @@ pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
+snafu = "0.7"
 term_size = "0.3"
 testsys-config = { path = "../testsys-config/", version = "0.1.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -1,0 +1,175 @@
+use crate::aws_resources::{ami, ami_name, ec2_crd, get_ami_id, migration_crd};
+use crate::crds::{
+    BottlerocketInput, ClusterInput, CrdCreator, CrdInput, CreateCrdOutput, MigrationInput,
+    TestInput,
+};
+use crate::error::{self, Result};
+use bottlerocket_types::agent_config::{ClusterType, EcsClusterConfig, EcsTestConfig};
+use log::debug;
+use maplit::btreemap;
+use model::{Crd, DestructionPolicy};
+use snafu::OptionExt;
+
+/// A `CrdCreator` responsible for creating crd related to `aws-ecs` variants.
+pub(crate) struct AwsEcsCreator {
+    pub(crate) region: String,
+    pub(crate) ami_input: String,
+    pub(crate) migrate_starting_commit: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl CrdCreator for AwsEcsCreator {
+    /// Determine the AMI from `amis.json`.
+    fn image_id(&self, _: &CrdInput) -> Result<String> {
+        ami(&self.ami_input, &self.region)
+    }
+
+    /// Determine the starting image from EC2 using standard Bottlerocket naming conventions.
+    async fn starting_image_id(&self, crd_input: &CrdInput) -> Result<String> {
+        get_ami_id(ami_name(&crd_input.arch,&crd_input.variant,crd_input.starting_version
+            .as_ref()
+            .context(error::InvalidSnafu{
+                what: "The starting version must be provided for migration testing"
+            })?, self.migrate_starting_commit
+            .as_ref()
+            .context(error::InvalidSnafu{
+                what: "The commit for the starting version must be provided if the starting image id is not"
+            })?)
+           , &crd_input.arch,
+           & self.region,
+        )
+        .await
+    }
+
+    /// Create an ECS cluster CRD with the `cluster_name` in `cluster_input`.
+    async fn cluster_crd<'a>(&self, cluster_input: ClusterInput<'a>) -> Result<CreateCrdOutput> {
+        debug!("Creating ECS cluster CRD");
+        // Create labels that will be used for identifying existing CRDs for an ECS cluster.
+        let labels = cluster_input.crd_input.labels(btreemap! {
+            "testsys/type".to_string() => "cluster".to_string(),
+            "testsys/cluster".to_string() => cluster_input.cluster_name.to_string(),
+            "testsys/region".to_string() => self.region.clone()
+        });
+
+        // Check if the cluster already has a CRD in the TestSys cluster.
+        if let Some(cluster_crd) = cluster_input
+            .crd_input
+            .existing_crds(
+                &labels,
+                &["testsys/cluster", "testsys/type", "testsys/region"],
+            )
+            .await?
+            .pop()
+        {
+            // Return the name of the existing CRD for the cluster.
+            debug!("ECS cluster CRD already exists with name '{}'", cluster_crd);
+            return Ok(CreateCrdOutput::ExistingCrd(cluster_crd));
+        }
+
+        // Create the CRD for ECS cluster creation.
+        let ecs_crd = EcsClusterConfig::builder()
+            .cluster_name(cluster_input.cluster_name)
+            .region(Some(self.region.to_owned()))
+            .assume_role(cluster_input.crd_input.config.agent_role.clone())
+            .destruction_policy(DestructionPolicy::OnTestSuccess)
+            .image(
+                cluster_input
+                    .crd_input
+                    .images
+                    .ecs_resource_agent_image
+                    .as_ref()
+                    .expect("The default ecs resource provider image uri is missing."),
+            )
+            .set_image_pull_secret(
+                cluster_input
+                    .crd_input
+                    .images
+                    .testsys_agent_pull_secret
+                    .to_owned(),
+            )
+            .set_secrets(Some(cluster_input.crd_input.config.secrets.clone()))
+            .build(cluster_input.cluster_name)
+            .map_err(|e| error::Error::Build {
+                what: "ECS cluster CRD".to_string(),
+                error: e.to_string(),
+            })?;
+
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(ecs_crd))))
+    }
+
+    /// Create an EC2 provider CRD to launch Bottlerocket instances on the cluster created by
+    /// `cluster_crd`.
+    async fn bottlerocket_crd<'a>(
+        &self,
+        bottlerocket_input: BottlerocketInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(
+            ec2_crd(bottlerocket_input, ClusterType::Ecs, &self.region).await?,
+        ))))
+    }
+
+    async fn migration_crd<'a>(
+        &self,
+        migration_input: MigrationInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(migration_crd(
+            migration_input,
+        )?))))
+    }
+
+    async fn test_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        let cluster_resource_name = test_input
+            .cluster_crd_name
+            .as_ref()
+            .expect("A cluster name is required for migrations");
+        let bottlerocket_resource_name = test_input
+            .bottlerocket_crd_name
+            .as_ref()
+            .expect("A cluster name is required for migrations");
+
+        // Create labels that are used to help filter status.
+        let labels = test_input.crd_input.labels(btreemap! {
+            "testsys/type".to_string() => test_input.test_type.to_string(),
+            "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+        });
+
+        let test_crd = EcsTestConfig::builder()
+            .cluster_name_template(cluster_resource_name, "clusterName")
+            .region(Some(self.region.to_owned()))
+            .task_count(1)
+            .assume_role(test_input.crd_input.config.agent_role.to_owned())
+            .resources(bottlerocket_resource_name)
+            .resources(cluster_resource_name)
+            .set_depends_on(Some(test_input.prev_tests))
+            .set_retries(Some(5))
+            .image(
+                test_input
+                    .crd_input
+                    .images
+                    .ecs_test_agent_image
+                    .to_owned()
+                    .expect("The default ECS testing image is missing"),
+            )
+            .set_image_pull_secret(
+                test_input
+                    .crd_input
+                    .images
+                    .testsys_agent_pull_secret
+                    .to_owned(),
+            )
+            .keep_running(true)
+            .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))
+            .set_labels(Some(labels))
+            .build(format!(
+                "{}-test{}",
+                cluster_resource_name,
+                test_input.name_suffix.unwrap_or_default()
+            ))
+            .map_err(|e| error::Error::Build {
+                what: "ECS test CRD".to_string(),
+                error: e.to_string(),
+            })?;
+
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(test_crd))))
+    }
+}

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -1,0 +1,157 @@
+use crate::aws_resources::{ami, ami_name, ec2_crd, get_ami_id, migration_crd};
+use crate::crds::{
+    BottlerocketInput, ClusterInput, CrdCreator, CrdInput, CreateCrdOutput, MigrationInput,
+    TestInput,
+};
+use crate::error::{self, Result};
+use crate::sonobuoy::sonobuoy_crd;
+use bottlerocket_types::agent_config::{
+    ClusterType, CreationPolicy, EksClusterConfig, EksctlConfig, K8sVersion,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use maplit::btreemap;
+use model::constants::NAMESPACE;
+use model::{Agent, Configuration, Crd, DestructionPolicy, Resource, ResourceSpec};
+use snafu::{OptionExt, ResultExt};
+use std::str::FromStr;
+
+/// A `CrdCreator` responsible for creating crd related to `aws-k8s` variants.
+pub(crate) struct AwsK8sCreator {
+    pub(crate) region: String,
+    pub(crate) ami_input: String,
+    pub(crate) migrate_starting_commit: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl CrdCreator for AwsK8sCreator {
+    /// Determine the AMI from `amis.json`.
+    fn image_id(&self, _: &CrdInput) -> Result<String> {
+        ami(&self.ami_input, &self.region)
+    }
+
+    /// Determine the starting image from EC2 using standard Bottlerocket naming conventions.
+    async fn starting_image_id(&self, crd_input: &CrdInput) -> Result<String> {
+        get_ami_id(ami_name(&crd_input.arch,&crd_input.variant,crd_input.starting_version
+            .as_ref()
+            .context(error::InvalidSnafu{
+                what: "The starting version must be provided for migration testing"
+            })?, self.migrate_starting_commit
+            .as_ref()
+            .context(error::InvalidSnafu{
+                what: "The commit for the starting version must be provided if the starting image id is not"
+            })?)
+           , &crd_input.arch,
+           & self.region,
+        )
+        .await
+    }
+
+    /// Create an EKS cluster CRD with the `cluster_name` in `cluster_input`.
+    async fn cluster_crd<'a>(&self, cluster_input: ClusterInput<'a>) -> Result<CreateCrdOutput> {
+        let labels = cluster_input.crd_input.labels(btreemap! {
+            "testsys/type".to_string() => "cluster".to_string(),
+            "testsys/cluster".to_string() => cluster_input.cluster_name.to_string(),
+            "testsys/region".to_string() => self.region.clone()
+        });
+
+        // Check if the cluster already has a crd
+        if let Some(cluster_crd) = cluster_input
+            .crd_input
+            .existing_crds(
+                &labels,
+                &["testsys/cluster", "testsys/type", "testsys/region"],
+            )
+            .await?
+            .pop()
+        {
+            return Ok(CreateCrdOutput::ExistingCrd(cluster_crd));
+        }
+
+        let cluster_version =
+            K8sVersion::from_str(cluster_input.crd_input.variant.version().context(
+                error::MissingSnafu {
+                    item: "K8s version".to_string(),
+                    what: "aws-k8s variant".to_string(),
+                },
+            )?)
+            .map_err(|_| error::Error::K8sVersion {
+                version: cluster_input.crd_input.variant.to_string(),
+            })?;
+
+        let eks_crd = Resource {
+            metadata: ObjectMeta {
+                name: Some(cluster_input.cluster_name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                labels: Some(labels),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: None,
+                conflicts_with: None,
+                agent: Agent {
+                    name: "eks-provider".to_string(),
+                    image: cluster_input
+                        .crd_input
+                        .images
+                        .eks_resource_agent_image
+                        .to_owned()
+                        .expect("Missing default image for EKS resource agent"),
+                    pull_secret: cluster_input
+                        .crd_input
+                        .images
+                        .testsys_agent_pull_secret
+                        .clone(),
+                    keep_running: false,
+                    timeout: None,
+                    configuration: Some(
+                        EksClusterConfig {
+                            creation_policy: Some(CreationPolicy::IfNotExists),
+                            assume_role: cluster_input.crd_input.config.agent_role.clone(),
+                            config: EksctlConfig::Args {
+                                cluster_name: cluster_input.cluster_name.to_string(),
+                                region: Some(self.region.clone()),
+                                zones: None,
+                                version: Some(cluster_version),
+                            },
+                        }
+                        .into_map()
+                        .context(error::IntoMapSnafu {
+                            what: "eks crd config".to_string(),
+                        })?,
+                    ),
+                    secrets: Some(cluster_input.crd_input.config.secrets.clone()),
+                    ..Default::default()
+                },
+                destruction_policy: DestructionPolicy::Never,
+            },
+            status: None,
+        };
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(eks_crd))))
+    }
+
+    /// Create an EC2 provider CRD to launch Bottlerocket instances on the cluster created by
+    /// `cluster_crd`.
+    async fn bottlerocket_crd<'a>(
+        &self,
+        bottlerocket_input: BottlerocketInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(
+            ec2_crd(bottlerocket_input, ClusterType::Eks, &self.region).await?,
+        ))))
+    }
+
+    async fn migration_crd<'a>(
+        &self,
+        migration_input: MigrationInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(migration_crd(
+            migration_input,
+        )?))))
+    }
+
+    async fn test_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(sonobuoy_crd(
+            test_input,
+        )?))))
+    }
+}

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -1,0 +1,402 @@
+use crate::error::{self, Result};
+use crate::run::{KnownTestType, TestType};
+use bottlerocket_types::agent_config::TufRepoConfig;
+use bottlerocket_variant::Variant;
+use log::{debug, warn};
+use maplit::btreemap;
+use model::test_manager::{SelectionParams, TestManager};
+use model::Crd;
+use pubsys_config::RepoConfig;
+use snafu::OptionExt;
+use std::collections::BTreeMap;
+use testsys_config::{rendered_cluster_name, GenericVariantConfig, TestsysImages};
+
+/// A type that is used for the creation of all CRDs.
+pub struct CrdInput<'a> {
+    pub client: &'a TestManager,
+    pub arch: String,
+    pub variant: Variant,
+    pub config: GenericVariantConfig,
+    pub repo_config: RepoConfig,
+    pub starting_version: Option<String>,
+    pub migrate_to_version: Option<String>,
+    /// `CrdCreator::starting_image_id` function should be used instead of using this field, so
+    /// it is not externally visible.
+    pub(crate) starting_image_id: Option<String>,
+    pub images: TestsysImages,
+}
+
+impl<'a> CrdInput<'a> {
+    /// Retrieve the TUF metadata from `Infra.toml`
+    pub fn tuf_metadata(&self) -> Option<TufRepoConfig> {
+        if let (Some(metadata_base_url), Some(targets_url)) = (
+            &self.repo_config.metadata_base_url,
+            &self.repo_config.targets_url,
+        ) {
+            debug!(
+                "Using TUF metadata from Infra.toml, metadata: '{}', targets: '{}'",
+                metadata_base_url, targets_url
+            );
+            Some(TufRepoConfig {
+                metadata_url: format!("{}{}/{}", metadata_base_url, &self.variant, &self.arch),
+                targets_url: targets_url.to_string(),
+            })
+        } else {
+            warn!("No TUF metadata was found in Infra.toml using the default TUF repos");
+            None
+        }
+    }
+
+    /// Create a set of labels for the CRD by adding `additional_labels` to the standard labels.
+    pub fn labels(&self, additional_labels: BTreeMap<String, String>) -> BTreeMap<String, String> {
+        let mut labels = btreemap! {
+            "testsys/arch".to_string() => self.arch.to_string(),
+            "testsys/variant".to_string() => self.variant.to_string(),
+        };
+        let mut add_labels = additional_labels;
+        labels.append(&mut add_labels);
+        labels
+    }
+
+    /// Determine all CRDs that have the same value for each `id_labels` as `labels`.
+    pub async fn existing_crds(
+        &self,
+        labels: &BTreeMap<String, String>,
+        id_labels: &[&str],
+    ) -> Result<Vec<String>> {
+        // Create a single string containing all `label=value` pairs.
+        let checks = id_labels
+            .iter()
+            .map(|label| {
+                labels
+                    .get(&label.to_string())
+                    .map(|value| format!("{}={}", label, value))
+                    .context(error::InvalidSnafu {
+                        what: format!("The label '{}' was missing", label),
+                    })
+            })
+            .collect::<Result<Vec<String>>>()?
+            .join(",");
+
+        // Create a list of all CRD names that match all of the specified labels.
+        Ok(self
+            .client
+            .list(&SelectionParams::Label(checks))
+            .await?
+            .iter()
+            .filter_map(Crd::name)
+            .collect())
+    }
+
+    /// Fill in the templated cluster name with `arch` and `variant`.
+    fn rendered_cluster_name(&self, raw_cluster_name: String) -> Result<String> {
+        Ok(rendered_cluster_name(
+            raw_cluster_name,
+            self.kube_arch(),
+            self.kube_variant(),
+        )?)
+    }
+
+    /// Get the k8s safe architecture name
+    fn kube_arch(&self) -> String {
+        self.arch.replace('_', "-")
+    }
+
+    /// Get the k8s safe variant name
+    fn kube_variant(&self) -> String {
+        self.variant.to_string().replace('.', "")
+    }
+
+    /// Bottlerocket cluster naming convention.
+    fn default_cluster_name(&self) -> String {
+        format!("{}-{}", self.kube_arch(), self.kube_variant())
+    }
+
+    /// Get a list of cluster_names for this variant. If there are no cluster names, the default
+    /// cluster name will be used.
+    fn cluster_names(&self) -> Result<Vec<String>> {
+        Ok(if self.config.cluster_names.is_empty() {
+            vec![self.default_cluster_name()]
+        } else {
+            self.config
+                .cluster_names
+                .iter()
+                .map(String::to_string)
+                // Fill the template fields in the clusters name before using it.
+                .map(|cluster_name| self.rendered_cluster_name(cluster_name))
+                .collect::<Result<Vec<String>>>()?
+        })
+    }
+}
+
+/// The `CrdCreator` trait is used to create CRDs. Each variant family should have a `CrdCreator`
+/// that is responsible for creating the CRDs needed for testing.
+#[async_trait::async_trait]
+pub(crate) trait CrdCreator: Sync {
+    /// Return the image id that should be used for normal testing.
+    fn image_id(&self, crd_input: &CrdInput) -> Result<String>;
+
+    /// Return the image id that should be used as the starting point for migration testing.
+    async fn starting_image_id(&self, crd_input: &CrdInput) -> Result<String>;
+
+    /// Create a CRD for the cluster needed to launch Bottlerocket. If no cluster CRD is
+    /// needed, `CreateCrdOutput::None` can be returned.
+    async fn cluster_crd<'a>(&self, cluster_input: ClusterInput<'a>) -> Result<CreateCrdOutput>;
+
+    /// Create a CRD to launch Bottlerocket. `CreateCrdOutput::None` can be returned if this CRD is
+    /// not needed.
+    async fn bottlerocket_crd<'a>(
+        &self,
+        bottlerocket_input: BottlerocketInput<'a>,
+    ) -> Result<CreateCrdOutput>;
+
+    /// Create a CRD that migrates Bottlerocket from one version to another.
+    async fn migration_crd<'a>(
+        &self,
+        migration_input: MigrationInput<'a>,
+    ) -> Result<CreateCrdOutput>;
+
+    /// Create a testing CRD for this variant of Bottlerocket.
+    async fn test_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput>;
+
+    /// Creates a set of CRDs for the specified variant and test type that can be added to a TestSys
+    /// cluster.
+    async fn create_crds(&self, test_type: TestType, crd_input: &CrdInput) -> Result<Vec<Crd>> {
+        let mut crds = Vec::new();
+        for cluster_name in &crd_input.cluster_names()? {
+            match &test_type {
+                TestType::Known(test_type) => {
+                    let cluster_output = self
+                        .cluster_crd(ClusterInput {
+                            cluster_name,
+                            crd_input,
+                        })
+                        .await?;
+                    let cluster_crd_name = cluster_output.crd_name();
+                    if let Some(crd) = cluster_output.crd() {
+                        debug!("Cluster crd was created for '{}'", cluster_name);
+                        crds.push(crd)
+                    }
+                    match &test_type {
+                        KnownTestType::Conformance | KnownTestType::Quick => {
+                            let bottlerocket_output = self
+                                .bottlerocket_crd(BottlerocketInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    image_id: self.image_id(crd_input)?,
+                                    test_type,
+                                    crd_input,
+                                })
+                                .await?;
+                            let bottlerocket_crd_name = bottlerocket_output.crd_name();
+                            if let Some(crd) = bottlerocket_output.crd() {
+                                debug!("Bottlerocket crd was created for '{}'", cluster_name);
+                                crds.push(crd)
+                            }
+                            let test_output = self
+                                .test_crd(TestInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    bottlerocket_crd_name: &bottlerocket_crd_name,
+                                    test_type,
+                                    crd_input,
+                                    prev_tests: Default::default(),
+                                    name_suffix: None,
+                                })
+                                .await?;
+                            if let Some(crd) = test_output.crd() {
+                                crds.push(crd)
+                            }
+                        }
+                        KnownTestType::Migration => {
+                            let image_id = if let Some(image_id) = &crd_input.starting_image_id {
+                                debug!("Using the provided starting image id for migration testing '{}'", image_id);
+                                image_id.to_string()
+                            } else {
+                                let image_id = self.starting_image_id(crd_input).await?;
+                                debug!("A starting image id was not provided, '{}' will be used instead.", image_id);
+                                image_id
+                            };
+                            let bottlerocket_output = self
+                                .bottlerocket_crd(BottlerocketInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    image_id,
+                                    test_type,
+                                    crd_input,
+                                })
+                                .await?;
+                            let bottlerocket_crd_name = bottlerocket_output.crd_name();
+                            if let Some(crd) = bottlerocket_output.crd() {
+                                debug!("Bottlerocket crd was created for '{}'", cluster_name);
+                                crds.push(crd)
+                            }
+                            let mut tests = Vec::new();
+                            let test_output = self
+                                .test_crd(TestInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    bottlerocket_crd_name: &bottlerocket_crd_name,
+                                    test_type,
+                                    crd_input,
+                                    prev_tests: tests.clone(),
+                                    name_suffix: "-1-initial".into(),
+                                })
+                                .await?;
+                            if let Some(name) = test_output.crd_name() {
+                                tests.push(name)
+                            }
+                            if let Some(crd) = test_output.crd() {
+                                crds.push(crd)
+                            }
+                            let migration_output = self
+                                .migration_crd(MigrationInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    bottlerocket_crd_name: &bottlerocket_crd_name,
+                                    crd_input,
+                                    prev_tests: tests.clone(),
+                                    name_suffix: "-2-migrate".into(),
+                                    migration_direction: MigrationDirection::Upgrade,
+                                })
+                                .await?;
+                            if let Some(name) = migration_output.crd_name() {
+                                tests.push(name)
+                            }
+                            if let Some(crd) = migration_output.crd() {
+                                crds.push(crd)
+                            }
+                            let test_output = self
+                                .test_crd(TestInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    bottlerocket_crd_name: &bottlerocket_crd_name,
+                                    test_type,
+                                    crd_input,
+                                    prev_tests: tests.clone(),
+                                    name_suffix: "-3-migrated".into(),
+                                })
+                                .await?;
+                            if let Some(name) = test_output.crd_name() {
+                                tests.push(name)
+                            }
+                            if let Some(crd) = test_output.crd() {
+                                crds.push(crd)
+                            }
+                            let migration_output = self
+                                .migration_crd(MigrationInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    bottlerocket_crd_name: &bottlerocket_crd_name,
+                                    crd_input,
+                                    prev_tests: tests.clone(),
+                                    name_suffix: "-4-migrate".into(),
+                                    migration_direction: MigrationDirection::Downgrade,
+                                })
+                                .await?;
+                            if let Some(name) = migration_output.crd_name() {
+                                tests.push(name)
+                            }
+                            if let Some(crd) = migration_output.crd() {
+                                crds.push(crd)
+                            }
+                            let test_output = self
+                                .test_crd(TestInput {
+                                    cluster_crd_name: &cluster_crd_name,
+                                    bottlerocket_crd_name: &bottlerocket_crd_name,
+                                    test_type,
+                                    crd_input,
+                                    prev_tests: tests,
+                                    name_suffix: "-5-final".into(),
+                                })
+                                .await?;
+                            if let Some(crd) = test_output.crd() {
+                                crds.push(crd)
+                            }
+                        }
+                    }
+                }
+                TestType::Unknown(_) => {
+                    return Err(error::Error::Unsupported {
+                        what: "Custom test types".to_string(),
+                    })
+                }
+            }
+        }
+        Ok(crds)
+    }
+}
+
+/// The input used for cluster crd creation
+pub struct ClusterInput<'a> {
+    pub cluster_name: &'a String,
+    pub crd_input: &'a CrdInput<'a>,
+}
+
+/// The input used for bottlerocket crd creation
+pub struct BottlerocketInput<'a> {
+    pub cluster_crd_name: &'a Option<String>,
+    /// The image id that should be used by this CRD
+    pub image_id: String,
+    pub test_type: &'a KnownTestType,
+    pub crd_input: &'a CrdInput<'a>,
+}
+
+/// The input used for test crd creation
+pub struct TestInput<'a> {
+    pub cluster_crd_name: &'a Option<String>,
+    pub bottlerocket_crd_name: &'a Option<String>,
+    pub test_type: &'a KnownTestType,
+    pub crd_input: &'a CrdInput<'a>,
+    /// The set of tests that have already been created that are related to this test
+    pub prev_tests: Vec<String>,
+    /// The suffix that should be appended to the end of the test name to prevent naming conflicts
+    pub name_suffix: Option<&'a str>,
+}
+
+/// The input used for migration crd creation
+pub struct MigrationInput<'a> {
+    pub cluster_crd_name: &'a Option<String>,
+    pub bottlerocket_crd_name: &'a Option<String>,
+    pub crd_input: &'a CrdInput<'a>,
+    /// The set of tests that have already been created that are related to this test
+    pub prev_tests: Vec<String>,
+    /// The suffix that should be appended to the end of the test name to prevent naming conflicts
+    pub name_suffix: Option<&'a str>,
+    pub migration_direction: MigrationDirection,
+}
+
+pub enum MigrationDirection {
+    Upgrade,
+    Downgrade,
+}
+
+pub enum CreateCrdOutput {
+    /// A new CRD was created and needs to be applied to the cluster.
+    NewCrd(Box<Crd>),
+    /// An existing CRD is already representing this object.
+    ExistingCrd(String),
+    /// There is no CRD to create for this step of this family.
+    None,
+}
+
+impl Default for CreateCrdOutput {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl CreateCrdOutput {
+    /// Get the name of the CRD that was created or already existed
+    pub(crate) fn crd_name(&self) -> Option<String> {
+        match self {
+            CreateCrdOutput::NewCrd(crd) => {
+                Some(crd.name().expect("A CRD is missing the name field."))
+            }
+            CreateCrdOutput::ExistingCrd(name) => Some(name.to_string()),
+            CreateCrdOutput::None => None,
+        }
+    }
+
+    /// Get the CRD if it was created
+    pub(crate) fn crd(self) -> Option<Crd> {
+        match self {
+            CreateCrdOutput::NewCrd(crd) => Some(*crd),
+            CreateCrdOutput::ExistingCrd(_) => None,
+            CreateCrdOutput::None => None,
+        }
+    }
+}

--- a/tools/testsys/src/delete.rs
+++ b/tools/testsys/src/delete.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::error::Result;
 use clap::Parser;
 use futures::TryStreamExt;
 use log::info;
@@ -10,13 +10,9 @@ pub(crate) struct Delete {}
 
 impl Delete {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
-        let mut stream = client.delete_all().await.context("Unable to delete all")?;
+        let mut stream = client.delete_all().await?;
 
-        while let Some(delete) = stream
-            .try_next()
-            .await
-            .context("A deletion error occured")?
-        {
+        while let Some(delete) = stream.try_next().await? {
             match delete {
                 DeleteEvent::Starting(crd) => println!("Starting delete for {}", crd.name()),
                 DeleteEvent::Deleted(crd) => println!("Delete finished for {}", crd.name()),

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -1,0 +1,70 @@
+use aws_sdk_ec2::error::DescribeImagesError;
+use aws_sdk_ec2::types::SdkError;
+use snafu::Snafu;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+pub enum Error {
+    // `error` must be used instead of `source` because the build function returns
+    // `std::error::Error` but not `std::error::Error + Sync + Send`.
+    #[snafu(display("Unable to build '{}': {}", what, error))]
+    Build { what: String, error: String },
+
+    #[snafu(context(false), display("{}", source))]
+    DescribeImages {
+        source: SdkError<DescribeImagesError>,
+    },
+
+    #[snafu(display("Unable to create map from {}: {}", what, source))]
+    IntoMap { what: String, source: model::Error },
+
+    #[snafu(display("{}", what))]
+    Invalid { what: String },
+
+    #[snafu(display("{}: {}", what, source))]
+    IO {
+        what: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Unable to parse K8s version '{}'", version))]
+    K8sVersion { version: String },
+
+    #[snafu(display("{}", source))]
+    KubeClient { source: kube_client::error::Error },
+
+    #[snafu(display("{} was missing from {}", item, what))]
+    Missing { item: String, what: String },
+
+    #[snafu(context(false), display("{}", source))]
+    PubsysConfig { source: pubsys_config::Error },
+
+    #[snafu(display("Unable to create secret name for '{}': {}", secret_name, source))]
+    SecretName {
+        secret_name: String,
+        source: model::Error,
+    },
+
+    #[snafu(display("{}: {}", what, source))]
+    SerdeJson {
+        what: String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(context(false), display("{}", source))]
+    TestManager { source: model::test_manager::Error },
+
+    #[snafu(context(false), display("{}", source))]
+    TestsysConfig { source: testsys_config::Error },
+
+    #[snafu(display("{} is not supported.", what))]
+    Unsupported { what: String },
+
+    #[snafu(display("Unable to create `Variant` from `{}`: {}", variant, source))]
+    Variant {
+        variant: String,
+        source: bottlerocket_variant::error::Error,
+    },
+}

--- a/tools/testsys/src/install.rs
+++ b/tools/testsys/src/install.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::error::Result;
 use clap::Parser;
 use log::{info, trace};
 use model::test_manager::{ImageConfig, TestManager};
@@ -36,9 +36,7 @@ impl Install {
             (Some(secret), image) => ImageConfig::WithCreds { secret, image },
             (None, image) => ImageConfig::Image(image),
         };
-        client.install(controller_image).await.context(
-            "Unable to install testsys to the cluster. (Some artifacts may be left behind)",
-        )?;
+        client.install(controller_image).await?;
 
         info!("testsys components were successfully installed.");
 

--- a/tools/testsys/src/restart_test.rs
+++ b/tools/testsys/src/restart_test.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::error::Result;
 use clap::Parser;
 use model::test_manager::TestManager;
 
@@ -13,9 +13,6 @@ pub(crate) struct RestartTest {
 
 impl RestartTest {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
-        client
-            .restart_test(&self.test_name)
-            .await
-            .context(format!("Unable to restart test '{}'", self.test_name))
+        Ok(client.restart_test(&self.test_name).await?)
     }
 }

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -1,0 +1,91 @@
+use crate::crds::TestInput;
+use crate::error::{self, Result};
+use crate::run::KnownTestType;
+use bottlerocket_types::agent_config::{SonobuoyConfig, SonobuoyMode};
+use maplit::btreemap;
+use model::Test;
+use std::fmt::Display;
+
+/// Create a Sonobuoy CRD for K8s conformance and quick testing.
+pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
+    let cluster_resource_name = test_input
+        .cluster_crd_name
+        .as_ref()
+        .expect("A cluster name is required for migrations");
+    let bottlerocket_resource_name = test_input
+        .bottlerocket_crd_name
+        .as_ref()
+        .expect("A cluster name is required for migrations");
+    let sonobuoy_mode = match test_input.test_type {
+        KnownTestType::Conformance => SonobuoyMode::CertifiedConformance,
+        KnownTestType::Quick | KnownTestType::Migration => SonobuoyMode::Quick,
+    };
+
+    let labels = test_input.crd_input.labels(btreemap! {
+        "testsys/type".to_string() => test_input.test_type.to_string(),
+        "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+    });
+
+    SonobuoyConfig::builder()
+        .resources(bottlerocket_resource_name)
+        .resources(cluster_resource_name)
+        .set_depends_on(Some(test_input.prev_tests))
+        .set_retries(Some(5))
+        .image(
+            test_input
+                .crd_input
+                .images
+                .sonobuoy_test_agent_image
+                .to_owned()
+                .expect("The default Sonobuoy testing image is missing"),
+        )
+        .set_image_pull_secret(
+            test_input
+                .crd_input
+                .images
+                .testsys_agent_pull_secret
+                .to_owned(),
+        )
+        .keep_running(true)
+        .kubeconfig_base64_template(cluster_resource_name, "encodedKubeconfig")
+        .plugin("e2e")
+        .mode(sonobuoy_mode)
+        .e2e_repo_config_base64(
+            test_input
+                .crd_input
+                .config
+                .conformance_registry
+                .to_owned()
+                .map(e2e_repo_config_base64),
+        )
+        .kube_conformance_image(test_input.crd_input.config.conformance_image.to_owned())
+        .assume_role(test_input.crd_input.config.agent_role.to_owned())
+        .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))
+        .set_labels(Some(labels))
+        .build(format!(
+            "{}{}",
+            cluster_resource_name,
+            test_input.name_suffix.unwrap_or("-test")
+        ))
+        .map_err(|e| error::Error::Build {
+            what: "sonobuoy CRD".to_string(),
+            error: e.to_string(),
+        })
+}
+
+fn e2e_repo_config_base64<S>(e2e_registry: S) -> String
+where
+    S: Display,
+{
+    base64::encode(format!(
+        r#"buildImageRegistry: {e2e_registry}
+dockerGluster: {e2e_registry}
+dockerLibraryRegistry: {e2e_registry}
+e2eRegistry: {e2e_registry}
+e2eVolumeRegistry: {e2e_registry}
+gcRegistry: {e2e_registry}
+gcEtcdRegistry: {e2e_registry}
+promoterE2eRegistry: {e2e_registry}
+sigStorageRegistry: {e2e_registry}"#
+    ))
+}

--- a/tools/testsys/src/uninstall.rs
+++ b/tools/testsys/src/uninstall.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::error::Result;
 use clap::Parser;
 use log::{info, trace};
 use model::test_manager::TestManager;
@@ -12,9 +12,7 @@ impl Uninstall {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
         trace!("Uninstalling testsys");
 
-        client.uninstall().await.context(
-            "Unable to uninstall testsys from the cluster. (Some artifacts may be left behind)",
-        )?;
+        client.uninstall().await?;
 
         info!("testsys components were successfully uninstalled.");
 


### PR DESCRIPTION
Changes the way TestSys crd's are created while keeping the same interface.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2533 

**Description of changes:**

* The basis of the changes revolve around `CrdCreator`. The `CrdCreator` is responsible for creating all CRDs for a given variant family (`aws-k8s`, `aws-ecs`). The `CrdCreator` has a few functions that need to be implemented that enables support for the standard testing types. To add a new testing family, only a `CrdCreator` needs to be created.
* CRD creation is done based on structs instead of function parameters (`OrchestratorInput`, `BottlerocketInput`, etc).
* Additional labels are added, and support for conflicting resources has been streamlined using `CrdInput::existing_resources()`.
* EC2 CRD creation has been de-duped for `aws-k8s` and `aws-ecs`


**Testing done:**

Created ECS and EKS testing with:
```
cargo make -e BUILDSYS_VARIANT="aws-ecs-1" test
cargo make -e TESTSYS_TEST="migration" test
cargo make test
```

After testing was complete the following status was left:
```
 NAME                                TYPE           STATE           PASSED       SKIPPED      FAILED
 x86-64-aws-ecs-1-test               Test           passed          1            0            0
 x86-64-aws-k8s-123                  Resource       completed
 x86-64-aws-k8s-123-1-initial        Test           passed          1            7051         0
 x86-64-aws-k8s-123-2-migrate        Test           passed          2            0            0
 x86-64-aws-k8s-123-3-migrated       Test           passed          1            7051         0
 x86-64-aws-k8s-123-4-migrate        Test           passed          2            0            0
 x86-64-aws-k8s-123-5-final          Test           passed          1            7051         0
 x86-64-aws-k8s-123-test             Test           passed          1            7051         0
 ```
 
 Note: The instance providers are not in the status because `DestructionPolicy::OnTestSuccess` was used.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
