### PR TITLE
Add Autoscaling Warm Pool Support for K8S Variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,12 @@ For AWS variants, these settings allow you to set up CloudFormation signaling to
 #### Auto Scaling group settings
 
 * `settings.autoscaling.should-wait`: Whether to wait for the instance to reach the `InService` state before the orchestrator agent joins the cluster. Defaults to `false`. Set this to `true` only if the instance is part of an Auto Scaling group, or will be attached to one later.
+  For example:
+
+  ```toml
+  [settings.autoscaling]
+  should-wait = true
+  ```
 
 #### OCI Hooks settings
 

--- a/Release.toml
+++ b/Release.toml
@@ -173,4 +173,6 @@ version = "1.12.0"
 "(1.11.0, 1.11.1)" = []
 "(1.11.1, 1.12.0)" = [
     "migrate_v1.12.0_k8s-private-pki-path.lz4",
+    "migrate_v1.12.0_add-k8s-autoscaling-warm-pool-setting.lz4",
+    "migrate_v1.12.0_add-k8s-autoscaling-warm-pool-setting-metadata.lz4",
 ]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -25,6 +25,7 @@ Source6: metricdog-toml
 Source7: host-ctr-toml
 Source8: oci-default-hooks-json
 Source9: cfsignal-toml
+Source10: warm-pool-wait-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -44,6 +45,7 @@ Source116: load-kernel-modules.service.in
 Source117: cfsignal.service
 Source118: generate-network-config.service
 Source119: reboot-if-required.service
+Source120: warm-pool-wait.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -239,7 +241,7 @@ Summary: Manages user-defined K8S static pods
 
 %if %{with aws_platform}
 %package -n %{_cross_os}shibaken
-Summary: Setting generator for populating admin container user-data from IMDS.
+Summary: Run tasks reliant on IMDS
 %description -n %{_cross_os}shibaken
 %{summary}.
 
@@ -415,6 +417,10 @@ install -p -m 0644 \
 %endif
 
 %if %{with aws_platform}
+%if %{with aws_k8s_family}
+install -p -m 0644 %{S:10} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:120} %{buildroot}%{_cross_unitdir}
+%endif
 install -p -m 0644 %{S:9} %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:117} %{buildroot}%{_cross_unitdir}
 %endif
@@ -529,6 +535,11 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %if %{with aws_platform}
 %files -n %{_cross_os}shibaken
 %{_cross_bindir}/shibaken
+%dir %{_cross_templatedir}
+%if %{with aws_k8s_family}
+%{_cross_templatedir}/warm-pool-wait-toml
+%{_cross_unitdir}/warm-pool-wait.service
+%endif
 
 %files -n %{_cross_os}cfsignal
 %{_cross_bindir}/cfsignal

--- a/packages/os/warm-pool-wait-toml
+++ b/packages/os/warm-pool-wait-toml
@@ -1,0 +1,2 @@
+should_wait = {{settings.autoscaling.should-wait}}
+marker_path = "/var/lib/bottlerocket/warm-pool-wait.ran"

--- a/packages/os/warm-pool-wait.service
+++ b/packages/os/warm-pool-wait.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Wait for the instance to be in service
+After=configured.target
+Wants=configured.target
+Before=kubelet.service
+# We only want to run once, at first boot. This file is created by shibaken
+# after a successful run.
+ConditionPathExists=!/var/lib/bottlerocket/warm-pool-wait.ran
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/shibaken warm-pool-wait
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+RequiredBy=kubelet.service

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -55,6 +55,7 @@
 (filecon "/.*/usr/bin/docker.*" file runtime_exec)
 (filecon "/.*/usr/bin/host-ctr" file runtime_exec)
 (filecon "/.*/usr/sbin/runc" file runtime_exec)
+(filecon "/.*/usr/bin/shibaken" file api_exec)
 
 ; Label local storage mounts.
 (filecon "/local" any local)

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3295,7 +3295,9 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tempfile",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -217,6 +217,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-k8s-autoscaling-warm-pool-setting"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
+name = "add-k8s-autoscaling-warm-pool-setting-metadata"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -27,6 +27,8 @@ members = [
     # "api/migration/migrations/vX.Y.Z/..."
     # (all previous migrations archived; add new ones after this line)
     "api/migration/migrations/v1.12.0/k8s-private-pki-path",
+    "api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting",
+    "api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "add-k8s-autoscaling-warm-pool-setting-metadata"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/build.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and `affected-services` metadata for `settings.autoscaling`
+fn run() -> Result<()> {
+    if cfg!(variant_family = "aws-k8s") {
+        migrate(AddMetadataMigration(&[SettingMetadata {
+            metadata: &["affected-services"],
+            setting: "settings.autoscaling",
+        }]));
+    };
+
+    Ok(())
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "add-k8s-autoscaling-warm-pool-setting"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/build.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting prefix for configuring autoscaling in k8s variants.
+/// Remove the whole `settings.autoscaling` prefix if we downgrade.
+fn run() -> Result<()> {
+    if cfg!(variant_family = "aws-k8s") {
+        migrate(AddPrefixesMigration(vec![
+            "settings.autoscaling",
+            "services.autoscaling-warm-pool",
+            "configuration-files.warm-pool-wait-toml",
+        ]));
+    };
+
+    Ok(())
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -19,6 +19,10 @@ serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
 tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+toml = "0.5.1"
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }
+
+[dev-dependencies]
+tempfile = { version = "3.1.0", default-features = false }

--- a/sources/api/shibaken/README.md
+++ b/sources/api/shibaken/README.md
@@ -11,6 +11,7 @@ shibaken is used to fetch data from the instance metadata service (IMDS) in AWS.
 shibaken can:
 * Fetch and populate the admin container's user-data with authorized ssh keys from the IMDS.
 * Perform boolean queries about the AWS partition in which the host is located.
+* Wait in a warm pool until the instance is marked as InService before starting the orchestrator.
 
 (The name "shibaken" comes from the fact that Shiba are small, but agile, hunting dogs.)
 

--- a/sources/api/shibaken/src/error.rs
+++ b/sources/api/shibaken/src/error.rs
@@ -1,3 +1,4 @@
+use crate::warmpool::error::WarmPoolCheckError;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
@@ -27,6 +28,9 @@ pub(crate) enum Error {
 
     #[snafu(display("Error serializing to JSON: {}", source))]
     SerializeJson { source: serde_json::error::Error },
+
+    #[snafu(display("Failed to check autoscaling warm pool: {}", source))]
+    WarmPoolCheckFailed { source: WarmPoolCheckError },
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sources/api/shibaken/src/warmpool/autoscaling_warm_pool.rs
+++ b/sources/api/shibaken/src/warmpool/autoscaling_warm_pool.rs
@@ -1,0 +1,122 @@
+/// This module contains utilities for waiting until the instance on warm pool to be
+/// marked as InService.
+use crate::warmpool::error::{self, Result};
+use argh::FromArgs;
+use imdsclient::ImdsClient;
+use serde::Deserialize;
+use snafu::{OptionExt, ResultExt};
+use std::fs;
+use std::path::Path;
+use tokio::time::{sleep, Duration};
+
+// Path to config file containing host's autoscaling.should-wait setting
+const CONFIG_PATH: &str = "/etc/warm-pool-wait.toml";
+const FETCH_LIFECYCLE_INTERVAL_SECS: Duration = Duration::from_secs(5);
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "warm-pool-wait")]
+/// Wait until the instance reaches the `InService` state
+pub(crate) struct WarmPoolWait {}
+
+impl WarmPoolWait {
+    pub(crate) async fn run(self) -> Result<()> {
+        let config_parse = get_config().await?;
+
+        let should_wait_value = config_parse.should_wait;
+        let marker_file_path = config_parse.marker_path;
+
+        println!("autoscaling.should-wait value is {}", should_wait_value);
+        if should_wait_value {
+            wait_until_inservice().await?;
+        }
+
+        fs::write(&marker_file_path, "").unwrap_or_else(|e| {
+            log::warn!("Failed to create marker file '{}', warm-pool-wait service may unexpectedly run again: '{}'",
+            &marker_file_path, e);
+        });
+        println!("Marker file path is {}", marker_file_path);
+
+        Ok(())
+    }
+}
+
+/// Continuously fetches lifecycle state of the host.
+/// Returns from function when host is "InService"
+async fn wait_until_inservice() -> Result<()> {
+    let mut client = ImdsClient::new();
+
+    loop {
+        let lifecycle_state = client
+            .fetch_autoscaling_lifecycle_state()
+            .await
+            .context(error::ImdsRequestSnafu)?;
+
+        if let Some(lifecycle_state) = lifecycle_state {
+            if lifecycle_state == "InService" {
+                println!("Lifecycle state is {} ... exiting.", lifecycle_state);
+                return Ok(());
+            }
+        }
+
+        sleep(FETCH_LIFECYCLE_INTERVAL_SECS).await;
+        continue;
+    }
+}
+
+/// Parses config file for autoscaling.should-wait setting.
+async fn get_config() -> Result<Config> {
+    Config::from_file(CONFIG_PATH)
+}
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    should_wait: bool,
+    marker_path: String,
+}
+
+impl Config {
+    /// Parses configuration file at passed in path and returns struct containing settings value.
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let string_parse = fs::read_to_string(path).context(error::ConfigReadSnafu { path })?;
+        let config: Config =
+            toml::from_str(&string_parse).context(error::ConfigParseSnafu { path })?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod config_test {
+    use super::Config;
+    use tempfile::TempDir;
+
+    // Example config file where user sets autoscaling.should-wait to false.
+    const FALSE_SHOULD_WAIT: &str = r#"
+    should_wait = false
+    marker_path = "/var/lib/bottlerocket/warm-pool-wait.ran"
+    "#;
+
+    // Example config file where user sets autoscaling.should-wait to true.
+    const TRUE_SHOULD_WAIT: &str = r#"
+    should_wait = true
+    marker_path = "/var/lib/bottlerocket/warm-pool-wait.ran"
+    "#;
+
+    #[test]
+    fn false_should_wait_test() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, FALSE_SHOULD_WAIT).unwrap();
+        let config = Config::from_file(&path).unwrap();
+        assert!(!config.should_wait);
+    }
+
+    #[test]
+    fn true_should_wait_test() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, TRUE_SHOULD_WAIT).unwrap();
+        let config = Config::from_file(&path).unwrap();
+        assert!(config.should_wait);
+    }
+}

--- a/sources/api/shibaken/src/warmpool/error.rs
+++ b/sources/api/shibaken/src/warmpool/error.rs
@@ -1,0 +1,33 @@
+use snafu::Snafu;
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, WarmPoolCheckError>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+pub enum WarmPoolCheckError {
+    #[snafu(display("Command '{}' with args '{:?}' failed: {}", command, args, source))]
+    Command {
+        command: String,
+        args: Vec<String>,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]
+    ConfigParse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[snafu(display("Failed to read config file {}: {}", path.display(), source))]
+    ConfigRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("IMDS request failed: {}", source))]
+    ImdsRequest { source: imdsclient::Error },
+
+    #[snafu(display("Logger setup error: {}", source))]
+    Logger { source: log::SetLoggerError },
+}

--- a/sources/api/shibaken/src/warmpool/mod.rs
+++ b/sources/api/shibaken/src/warmpool/mod.rs
@@ -1,0 +1,2 @@
+pub mod autoscaling_warm_pool;
+pub mod error;

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -168,6 +168,12 @@ impl ImdsClient {
         self.fetch_string(&instance_type_target).await
     }
 
+    /// Get lifecycle state from instance metadata.
+    pub async fn fetch_autoscaling_lifecycle_state(&mut self) -> Result<Option<String>> {
+        let instance_type_target = "meta-data/autoscaling/target-lifecycle-state";
+        self.fetch_string(&instance_type_target).await
+    }
+
     /// Returns a list of public ssh keys skipping any keys that do not start with 'ssh'.
     pub async fn fetch_public_ssh_keys(&mut self) -> Result<Option<Vec<String>>> {
         info!("Fetching list of available public keys from IMDS");

--- a/sources/models/shared-defaults/aws-autoscaling.toml
+++ b/sources/models/shared-defaults/aws-autoscaling.toml
@@ -1,0 +1,3 @@
+# Autoscaling warm pool support
+[settings.autoscaling]
+should-wait = false

--- a/sources/models/shared-defaults/ecs.toml
+++ b/sources/models/shared-defaults/ecs.toml
@@ -27,7 +27,3 @@ affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-con
 # Image registry credentials
 [metadata.settings.container-registry.credentials]
 affected-services = ["ecs", "host-containers", "bootstrap-containers"]
-
-# AutoScaling
-[settings.autoscaling]
-should-wait = false

--- a/sources/models/shared-defaults/kubernetes-aws.toml
+++ b/sources/models/shared-defaults/kubernetes-aws.toml
@@ -21,3 +21,14 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kube
 
 [metadata.settings.network]
 affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers"]
+
+[services.autoscaling-warm-pool]
+configuration-files = ["warm-pool-wait-toml"]
+restart-commands = []
+
+[configuration-files.warm-pool-wait-toml]
+path = "/etc/warm-pool-wait.toml"
+template-path = "/usr/share/templates/warm-pool-wait-toml"
+
+[metadata.settings.autoscaling]
+affected-services = ["autoscaling-warm-pool"]

--- a/sources/models/src/aws-ecs-1-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-ecs-1-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-ecs-1/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-ecs-1/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-k8s-1.22-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-k8s-1.22-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.22-nvidia/mod.rs
@@ -1,13 +1,13 @@
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
+
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::modeled_types::Identifier;
-use crate::{
-    AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
-};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -28,4 +28,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.22/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-k8s-1.22/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-k8s-1.22/mod.rs
+++ b/sources/models/src/aws-k8s-1.22/mod.rs
@@ -1,13 +1,14 @@
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
+    MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
+    UpdatesSettings,
+};
+
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::modeled_types::Identifier;
-use crate::{
-    AwsSettings, BootstrapContainer, CloudFormationSettings, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
-};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -29,4 +30,5 @@ struct Settings {
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.24-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-k8s-1.24-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,13 +1,13 @@
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
+    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
+
 use model_derive::model;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::modeled_types::Identifier;
-use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
-};
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -29,4 +29,5 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.24/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-k8s-1.24/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,14 +1,14 @@
-use model_derive::model;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
 use crate::modeled_types::Identifier;
 use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
     MetricsSettings, NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings,
     UpdatesSettings,
 };
+
+use model_derive::model;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
 // that uses its name in serialization; internal structures use the field name that points to it
@@ -31,4 +31,5 @@ struct Settings {
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,
+    autoscaling: AutoScalingSettings,
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #1788

**Description of changes:**
Refactor PR #2322 

updated: 

- Add warm pool help program to shibaken (they both need fetch IMDS so not need for a new binary)
- Boot autoscaling warm pool part on shibaken to become a service


**Testing done:**

- [x] Unit test
- [x] Test new setting `autoscaling.should-wait=false` and `autoscaling.should-wait=false`
- [x] Migration test new setting `autoscaling.should-wait` 
- [x] Integration test on warm pool 

Integration test deatails
1. create autoscaling group
2. create warm pool on autoscaling group
3. check if the instances on warm pool don't join the eks cluster
4. set a one time autoscaling scale up
5. monitor it those instances on warm pool have been added to autoscaling group and successfully join to eks cluster

<img width="881" alt="Screen Shot 2022-11-08 at 3 20 24 PM" src="https://user-images.githubusercontent.com/45469883/200697321-a71ac827-4bd6-4652-a6d7-544ea391a20b.png">

<img width="900" alt="Screen Shot 2022-11-08 at 3 20 33 PM" src="https://user-images.githubusercontent.com/45469883/200697357-48966140-e3af-41d0-b5e5-daea95fa17c7.png">

<img width="1073" alt="Screen Shot 2022-11-08 at 3 22 27 PM" src="https://user-images.githubusercontent.com/45469883/200697371-152ee7d0-e1ce-4497-88f1-5e450bc76a1c.png">

<img width="1152" alt="Screen Shot 2022-11-08 at 3 24 13 PM" src="https://user-images.githubusercontent.com/45469883/200697556-500a00dc-ca23-43fa-a92e-f211d93fc017.png">

<img width="678" alt="Screen Shot 2022-11-08 at 3 24 27 PM" src="https://user-images.githubusercontent.com/45469883/200697568-fd61a5df-d70c-4fb4-ad2a-bc87d8362baa.png">



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
