### PR TITLE
diff-kernel-config: handle absolute paths for output directory

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -211,7 +211,7 @@ for state in before after; do
                 # Extract kernel config
                 #
 
-                config_path=./${output_dir}/config-${arch}-${kver}-${variant}-${state}
+                config_path=${output_dir}/config-${arch}-${kver}-${variant}-${state}
                 rpm2cpio "${kernel_rpm}" \
                     | cpio --quiet --extract --to-stdout ./boot/config >"${config_path}"
                 [[ -s "${config_path}" ]] || bail "Failed to extract config for ${debug_id}"


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** When extracting the kernel config of a just built kernel diff-kernel-config would always treat the given output directory as a relative path due to a gratuitous "./" in the path it assembles. This would try to write to the wrong path when the script was actually invoked with an absolute path, most likely making it fail because parent directories wouldn't exist.

Correctly handle absolute paths by dropping the "./". Other parts of the code dealing with the output directory already don't care whether it's an absolute or relative path.


**Testing done:** Successfully ran `tools/diff-kernel-config` both with an absolute and a relative path for the output directory.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
