### PR TITLE
testsys: added comment on how to use k8s secret

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -102,6 +102,12 @@ cargo make testsys add secret map  \
  "secret-access-key=$(aws configure get aws_secret_access_key --profile ${PROFILE})"
 ```
 
+If you added a secret, you then need to pass the secret's name to testsys
+through an environment variable:
+```shell
+export TESTSYS_AWS_SECRET_NAME="awsCredentials=<Name of your secret>"
+```
+
 ### Conveniences
 
 All testsys commands can be run using cargo make to eliminate the chance of 2 different versions of
@@ -112,7 +118,7 @@ Testsys requires the controller and the agent images to be of the same testsys v
 cargo make testsys <arguments>
 ```
 
-The Bottlerocket components are found in the `testsys-bottlerocket-aws` Kubernetes namespace.
+The Bottlerocket components are found in the `testsys` Kubernetes namespace.
 
 ## Run
 

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -108,7 +108,7 @@ struct CliConfig {
     #[clap(long, env = "TESTSYS_INSTANCE_TYPE")]
     instance_type: Option<String>,
 
-    /// Add secrets to the testsys agents (`--secret aws-credentials=my-secret`)
+    /// Add secrets to the testsys agents (`--secret awsCredentials=my-secret`)
     #[clap(long, short, parse(try_from_str = parse_key_val), number_of_values = 1)]
     secret: Vec<(String, SecretName)>,
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Added instructions to `TESTING.md` on how to pass the k8s secret to TestSys using an environment variable, for which the code was already present in `Makefile.toml`. Also fixed the comment about the TestSys namespace, which was changed recently here: https://github.com/bottlerocket-os/bottlerocket-test-system/pull/633.

**Testing done:**

Confirmed that instructions worked by running `cargo make test` in a `kind` cluster after setting the secret using the environment variable and examining the CRD to make sure secret was present.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
