### PR TITLE
host-ctr: Unmask `/sys/firmware` from host containers

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -288,6 +288,20 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 			oci.WithHostNamespace(runtimespec.NetworkNamespace),
 			oci.WithHostHostsFile,
 			oci.WithHostResolvconf,
+			// Unmask `/sys/firmware` by passing an alternate list of masked paths
+			// List is based on the DefaultUnixSpec's MaskedPaths for Linux
+			// (https://github.com/containerd/containerd/blob/e9af808/oci/spec.go#L164)
+			oci.WithMaskedPaths([]string{
+				"/proc/acpi",
+				"/proc/asound",
+				"/proc/kcore",
+				"/proc/keys",
+				"/proc/latency_stats",
+				"/proc/timer_list",
+				"/proc/timer_stats",
+				"/proc/sched_debug",
+				"/proc/scsi",
+			}),
 			// Pass proxy environment variables to this container
 			withProxyEnv(),
 			// Add a default set of mounts regardless of the container type


### PR DESCRIPTION
**Description of changes:**

This provides extra insight into the hardware of the underlying Bottlerocket host, such as the number of CPU sockets on aarch64 variants.

_NOTE: List of masked paths come's from containerd's [`oci/spec.go`](https://github.com/containerd/containerd/blob/6906b57c721f9114377ceb069662b196876915c0/oci/spec.go#L164)._

**Testing done:**

Built and launched an aarch64 k8s variant on a `c6g.large` and ran `lscpu` from the control container.

```
Architecture:           aarch64
  CPU op-mode(s):       32-bit, 64-bit
  Byte Order:           Little Endian
CPU(s):                 2
  On-line CPU(s) list:  0,1
Vendor ID:              ARM
  Model name:           Neoverse-N1
    Model:              1
    Thread(s) per core: 1
    Core(s) per socket: 2
    Socket(s):          1
    Stepping:           r3p1
    BogoMIPS:           243.75
    Flags:              fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid
                         asimdrdm lrcpc dcpop asimddp ssbs
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
