### PR TITLE
Bump host containers

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -167,4 +167,6 @@ version = "1.10.1"
     "migrate_v1.11.0_ecs-additional-configurations.lz4",
     "migrate_v1.10.0_aws-admin-container-v0-9-3.lz4",
     "migrate_v1.10.0_public-admin-container-v0-9-3.lz4",
+    "migrate_v1.10.0_aws-control-container-v0-6-4.lz4",
+    "migrate_v1.10.0_public-control-container-v0-6-4.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -165,4 +165,6 @@ version = "1.10.1"
     "migrate_v1.11.0_kubelet-tls-files.lz4",
     "migrate_v1.11.0_kubelet-new-config-files.lz4",
     "migrate_v1.11.0_ecs-additional-configurations.lz4",
+    "migrate_v1.10.0_aws-admin-container-v0-9-3.lz4",
+    "migrate_v1.10.0_public-admin-container-v0-9-3.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -500,6 +500,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-6-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-creds"
 version = "0.1.0"
 dependencies = [
@@ -2796,6 +2803,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-9-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-6-4"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -458,6 +458,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-admin-container-v0-9-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-config"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2792,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "public-admin-container-v0-9-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -37,6 +37,8 @@ members = [
     "api/migration/migrations/v1.11.0/ecs-additional-configurations",
     "api/migration/migrations/v1.11.0/aws-admin-container-v0-9-3",
     "api/migration/migrations/v1.11.0/public-admin-container-v0-9-3",
+    "api/migration/migrations/v1.11.0/aws-control-container-v0-6-4",
+    "api/migration/migrations/v1.11.0/public-control-container-v0-6-4",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -35,6 +35,8 @@ members = [
     "api/migration/migrations/v1.11.0/kubelet-tls-files",
     "api/migration/migrations/v1.11.0/kubelet-new-config-files",
     "api/migration/migrations/v1.11.0/ecs-additional-configurations",
+    "api/migration/migrations/v1.11.0/aws-admin-container-v0-9-3",
+    "api/migration/migrations/v1.11.0/public-admin-container-v0-9-3",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.11.0/aws-admin-container-v0-9-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/aws-admin-container-v0-9-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-9-3"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/aws-admin-container-v0-9-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/aws-admin-container-v0-9-3/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.2";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.3";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.11.0/aws-control-container-v0-6-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/aws-control-container-v0-6-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-6-4"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/aws-control-container-v0-6-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/aws-control-container-v0-6-4/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.3";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.4";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.11.0/public-admin-container-v0-9-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/public-admin-container-v0-9-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-9-3"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/public-admin-container-v0-9-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/public-admin-container-v0-9-3/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.3";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.11.0/public-control-container-v0-6-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.11.0/public-control-container-v0-6-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-6-4"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.11.0/public-control-container-v0-6-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.11.0/public-control-container-v0-6-4/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.4";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.3"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.4"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.3"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.3"
 
 [settings.host-containers.control]
 enabled = false

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.3"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.4"


### PR DESCRIPTION
**Description of changes:**

- Update and migrate from admin container v0.9.2 to v0.9.3.
- Update and migrate from control container v0.6.3 to v0.6.4.

**Testing done:**

Migration test in the comments below (thanks @ecpullen)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
