### PR TITLE
Update Kubernetes version to 1.23.13

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/6/artifacts/kubernetes/v1.23.12/kubernetes-src.tar.gz"
-sha512 = "503e7c54d50e71f9bc16ad1a338f50115cfa427e82ae80e4b74b3bce9cae2497508b97e596bbf26f8dd4705dba545ecd3a8746b506ec10ca8f549e609b026a65"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/8/artifacts/kubernetes/v1.23.13/kubernetes-src.tar.gz"
+sha512 = "cee0c56f8af66c87f3d7d1873844ee180210fbccfbd7fbaf1338646073691b7fd3a2ece584682f084689ca40e9a1c325dc0d969a63bea09636cff79643c62f72"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -2,7 +2,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.23.12
+%global gover 1.23.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/6/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/8/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/2577

**Description of changes:**
Updates 1.23 to 1.23.13 of eks-distro


**Testing done:**
I (@etungsten) rolled up all the K8s the testing in https://github.com/bottlerocket-os/bottlerocket/pull/2583.

`sonobuoy run conformance-lite` on two aws-k8s-1.23 nodes; AMIs built with this commit :
```
         PLUGIN     STATUS   RESULT   COUNT                 PROGRESS
            e2e   complete   passed       1   Passed:145, Failed:  0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
