### PR TITLE
Update version for 1.22

### DIFF
--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.22"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/11/artifacts/kubernetes/v1.22.15/kubernetes-src.tar.gz"
-sha512 = "b0bb0338ede41ed90e711fe3835b0f86a061aed19b9a2555146ea9f402246e1776ddc5f04beb6e8b74f32756726993582391827910507dc169dabc7c339b2ab2"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/13/artifacts/kubernetes/v1.22.15/kubernetes-src.tar.gz"
+sha512 = "15e25db6fe08b852b6f640d421ecf8bd1669f5bd61f7ca74b8fb0a46bcaa92cd98da85ee23670db68f9474174c513989b41fb3ddf7626d953cc00227c71576ab"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/11/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/13/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/2579

**Description of changes:**
Updates to latest patch version of Kubernetes 1.22. Version is the same, but this release includes additional patches. 


**Testing done:**
@etungsten rolled up all the K8s the testing in https://github.com/bottlerocket-os/bottlerocket/pull/2583.

`sonobuoy run conformance-lite` on 3 aws-k8s-1.22 nodes; AMIs built with this commit:

```
         PLUGIN     STATUS   RESULT   COUNT                 PROGRESS                                                                   
            e2e   complete   passed       1   Passed:144, Failed:  0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
