### PR TITLE
Update kubernetes version for 1.24

### DIFF
--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.24"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/1/artifacts/kubernetes/v1.24.6/kubernetes-src.tar.gz"
-sha512 = "7d0bfb8af0b9e744dacd9e13ff3f90b5ba01959cf9dc137329f6e1fb1b5259573c904a9c568aa5ced08bfb8687e0fbb29a1abb5ea6b947596d37d4c488ea952c"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/3/artifacts/kubernetes/v1.24.6/kubernetes-src.tar.gz"
+sha512 = "6321c63199eef1a50e45ea4eec5e68925d2441091eac14ead7750a05dcf685c4392770d133739995b876e7f5a24bed98ca20f56956e56d12b26b7ec7c75d34fa"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/1/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/2581

**Description of changes:**



**Testing done:**

@etungsten rolled up all the K8s the testing in https://github.com/bottlerocket-os/bottlerocket/pull/2583.

`sonobuoy run conformance-lite` on two aws-k8s-1.24 nodes; AMIs built with this commit:

```
         PLUGIN     STATUS   RESULT   COUNT                 PROGRESS
            e2e   complete   passed       1   Passed:131, Failed:  0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
