### PR TITLE
Update `packages` for 1.11.0

### DIFF
--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v20.10.18/cli-20.10.18.tar.gz"
-sha512 = "fe5359015041f99bacf7b674a99ab7772d9e71eb6c6fefd6acb28f2afee4321a7517a53497627ae9cae8c6e0c253971a53d0579a630a3d71986edd7300a0a8ab"
+url = "https://github.com/docker/cli/archive/v20.10.20/cli-20.10.20.tar.gz"
+sha512 = "536c26b421fb0ca92a09ff67f4fa3afd64115ef9f748ae7fb6d3448c4c1acade72bef037f71017e9c3e039ecada95fb157d9f336ee3348be1f21874730bcb03e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 20.10.18
+%global gover 20.10.20
 %global rpmver %{gover}
-%global gitrev b40c2f6b5deeb11ac6c485c940865ee40664f0f0
+%global gitrev 9fdeb9c3de2f2d9f5799be373f27b2f9df44609d
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v20.10.18/moby-20.10.18.tar.gz"
-sha512 = "202f9f4d455329907e87bd95549aa433b6c773d3067cc89d0bd2e087bddfc66faddd6c2019843e42bf3fed6d6584ba4ab61d762f436f8bb164aa11e6280c91c5"
+url = "https://github.com/moby/moby/archive/v20.10.20/moby-20.10.20.tar.gz"
+sha512 = "f5e5bcf18fcdca8b7d5a2226091b22c14c144e632723a0ac0058d5f9bedba884cbba7bc16c06f30d9906713ec0cfa2a43839c64df9917e243122d125a4808bec"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 20.10.18
+%global gover 20.10.20
 %global rpmver %{gover}
-%global gitrev e42327a6d3c55ceda3bd5475be7aae6036d02db3
+%global gitrev 03df974ae9e6c219862907efdd76ec2e77ec930b
 
 %global source_date_epoch 1363394400
 

--- a/packages/libdbus/Cargo.toml
+++ b/packages/libdbus/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://dbus.freedesktop.org/releases/dbus"
 
 [[package.metadata.build-package.external-files]]
-url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.15.0.tar.xz"
-sha512 = "6f7e1d4ff525ce13c5f671f1b045a089c379cbfb777662ce7a55ffe4893a8ab2aaf38877a7b8f261823067a20f3b336437449eb353a97d30699496375e00bf1a"
+url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.15.2.tar.xz"
+sha512 = "486eab8c4f87d75e988558724bff1b0708c969341ecb62bcb9d0b0612a653ac2674aa7caa4d129dd81c00af7989b122ee7837599262c9a0c5c7f9335ed3dacaf"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libdbus
-Version: 1.15.0
+Version: 1.15.2
 Release: 1%{?dist}
 Summary: Library for a message bus
 License: AFL-2.1 OR GPL-2.0-or-later

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/libexpat/libexpat/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libexpat/libexpat/releases/download/R_2_4_9/expat-2.4.9.tar.xz"
-sha512 = "8508379b4915d84d50f3638678a90792179c98247d1cb5e6e6387d117af4dc148ac7031c1debea8b96e7b710ef436cf0dd5da91f3d22b8186a00cfafe1201169"
+url = "https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.xz"
+sha512 = "2da73b991b7c0c54440485c787e5edeb3567230204e31b3cac1c3a6713ec6f9f1554d3afffc0f8336168dfd5df02db4a69bcf21b4d959723d14162d13ab87516"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -1,4 +1,4 @@
-%global unversion 2_4_9
+%global unversion 2_5_0
 
 Name: %{_cross_os}libexpat
 Version: %(echo %{unversion} | sed 's/_/./g')

--- a/packages/libz/Cargo.toml
+++ b/packages/libz/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://www.zlib.net"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.zlib.net/zlib-1.2.12.tar.xz"
-sha512 = "12940e81e988f7661da52fa20bdc333314ae86a621fdb748804a20840b065a1d6d984430f2d41f3a057de0effc6ff9bcf42f9ee9510b88219085f59cbbd082bd"
+url = "https://www.zlib.net/zlib-1.2.13.tar.xz"
+sha512 = "9e7ac71a1824855ae526506883e439456b74ac0b811d54e94f6908249ba8719bec4c8d7672903c5280658b26cb6b5e93ecaaafe5cdc2980c760fa196773f0725"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libz/libz.spec
+++ b/packages/libz/libz.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libz
-Version: 1.2.12
+Version: 1.2.13
 Release: 1%{?dist}
 Summary: Library for zlib compression
 URL: https://www.zlib.net/


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
This PR only updates packages that have had CVE fixes since v1.10.0.

- zlib 1.2.12 -> 1.2.13 fixes [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434)
- libexpact 2.4.9 -> 2.5.0 fixes [CVE-2022-43680](https://nvd.nist.gov/vuln/detail/CVE-2022-43680)
- libdbus 1.15.0 -> 1.15.2 fixes [CVE-2022-42010](https://nvd.nist.gov/vuln/detail/CVE-2022-42010), [42011](https://nvd.nist.gov/vuln/detail/CVE-2022-42011), [42012](https://nvd.nist.gov/vuln/detail/CVE-2022-42012)
- docker-cli 20.10.18 -> 20.10.20 fixes a git [CVE-2022-39253](https://nvd.nist.gov/vuln/detail/CVE-2022-39253) in the docker client. Although 20.10.21 is out, we don't want to move to that just yet since it's using containerd v1.6.9 library and we're still on containerd v1.6.8.

For other non-critical third-party package updates we've decided to do those after the 1.11.0 release.

**Testing done:**
- [x] aws-k8s-1.21 `sonobuoy conformance-lite` testing
```
Plugin: e2e
Status: passed
Total: 5773
Passed: 277
Failed: 0
Skipped: 5496
```
- [x] aws-k8s-1.22 `sonobuoy conformance-lite` testing:
```                                                                                                                 
         PLUGIN     STATUS   RESULT   COUNT                 PROGRESS                                                                   
            e2e   complete   passed       1   Passed:144, Failed:  0
```
- [x] aws-k8s-1.23 `sonobuoy conformance-lite` testing:
```
         PLUGIN     STATUS   RESULT   COUNT                 PROGRESS
            e2e   complete   passed       1   Passed:145, Failed:  0
```
- [x] aws-k8s-1.23-nvidia workload test on g5g instances:
```
$ kubectl logs nvidia-smoke-test-9mj8w                          
Running sample vectorAdd                                        
[Vector addition of 50000 elements]                             
Copy input data from the host memory to the CUDA device         
CUDA kernel launch with 196 blocks of 256 threads                                                                               
Copy output data from the CUDA device to the host memory        
Test PASSED                                                                                                                     
Done                                                            
Running sample bandwidthTest                                                                                                    
[CUDA Bandwidth Test] - Starting...                             
...
Result = PASS 
...
Result = PASS
```
- [x] aws-k8s-1.24 `sonobuoy conformance-lite` testing
```
         PLUGIN     STATUS   RESULT   COUNT                 PROGRESS
            e2e   complete   passed       1   Passed:131, Failed:  0
```
- [x] aws-ecs-1 testing with nginx task
```
[ec2-user@admin]$ apiclient get /os
{
  "arch": "aarch64",
  "build_id": "39e62df3",
  "pretty_name": "Bottlerocket OS 1.10.1 (aws-ecs-1)",
  "variant_id": "aws-ecs-1",
  "version_id": "1.10.1"
}
[ec2-user@admin]$ curl localhost:80
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```
- [x] vmware-k8s testing with `eksctl anywhere`, can create a cluster with the vmware-k8s-1.23 ova just fine:
```bash
$ eksctl anywhere create cluster --kubeconfig ./mgmt-cluster/mgmt-cluster-eks-a-cluster.kubeconfig -f br-eksa-123.yaml -v 6
...
2022-11-14T15:59:39.379-0800    V0      Creating new workload cluster
...
2022-11-14T16:05:29.723-0800    V0      🎉 Cluster created! 
...
```
Then ran `sonobuoy conformance-lite`
```
         PLUGIN     STATUS   RESULT   COUNT                 PROGRESS
            e2e   complete   passed       1   Passed:145, Failed:  0
```
- [x] metal-k8s testing: successfully created cluster with `eksctl anywhere` and metal-k8s-1.23 image built with these commits. Ran conformance-lite and all tests passed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
