### PR TITLE
migrations: fix typo in 1.11.0 host container migrations

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -165,8 +165,8 @@ version = "1.11.0"
     "migrate_v1.11.0_kubelet-tls-files.lz4",
     "migrate_v1.11.0_kubelet-new-config-files.lz4",
     "migrate_v1.11.0_ecs-additional-configurations.lz4",
-    "migrate_v1.10.0_aws-admin-container-v0-9-3.lz4",
-    "migrate_v1.10.0_public-admin-container-v0-9-3.lz4",
-    "migrate_v1.10.0_aws-control-container-v0-6-4.lz4",
-    "migrate_v1.10.0_public-control-container-v0-6-4.lz4",
+    "migrate_v1.11.0_aws-admin-container-v0-9-3.lz4",
+    "migrate_v1.11.0_public-admin-container-v0-9-3.lz4",
+    "migrate_v1.11.0_aws-control-container-v0-6-4.lz4",
+    "migrate_v1.11.0_public-control-container-v0-6-4.lz4",
 ]


### PR DESCRIPTION
**Description of changes:**

Fixes a typo in the following migrations as the version was set to **1.10.0** and not **1.11.0**.

- aws-admin-container-v0-9-3
- public-admin-container-v0-9-3
- aws-control-container-v0-6-4
- public-control-container-v0-6-4

**Testing done:**

Migration test in the comments below (thanks @ecpullen)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
