### PR TITLE
During kubelet prestart, skip pause image pull if image exist

### DIFF
--- a/packages/kubernetes-1.21/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.21/prestart-pull-pause-ctr.conf
@@ -5,4 +5,5 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
-    --registry-config=/etc/host-containers/host-ctr.toml
+    --registry-config=/etc/host-containers/host-ctr.toml \
+    --skip-if-image-exists=true

--- a/packages/kubernetes-1.22/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.22/prestart-pull-pause-ctr.conf
@@ -5,4 +5,5 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
-    --registry-config=/etc/host-containers/host-ctr.toml
+    --registry-config=/etc/host-containers/host-ctr.toml \
+    --skip-if-image-exists=true

--- a/packages/kubernetes-1.23/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.23/prestart-pull-pause-ctr.conf
@@ -5,4 +5,5 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
-    --registry-config=/etc/host-containers/host-ctr.toml
+    --registry-config=/etc/host-containers/host-ctr.toml \
+    --skip-if-image-exists=true

--- a/packages/kubernetes-1.24/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.24/prestart-pull-pause-ctr.conf
@@ -5,4 +5,5 @@ ExecStartPre=/usr/bin/host-ctr \
     --namespace=k8s.io \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
-    --registry-config=/etc/host-containers/host-ctr.toml
+    --registry-config=/etc/host-containers/host-ctr.toml \
+    --skip-if-image-exists=true

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -261,7 +261,7 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 	}
 	defer client.Close()
 
-	// Parse the source ref if it looks like an ECR ref.
+	// Check if the image source is an ECR image. If it is, then we need to handle it with the ECR resolver.
 	isECRImage := ecrRegex.MatchString(source)
 	var img containerd.Image
 	if isECRImage {
@@ -506,18 +506,17 @@ func pullImageOnly(containerdSocket string, namespace string, source string, reg
 	}
 	defer client.Close()
 
-	// Parse the source ref if it looks like an ECR ref.
+	// Check if the image source is an ECR image. If it is, then we need to handle it with the ECR resolver.
 	isECRImage := ecrRegex.MatchString(source)
-	ref := source
 	if isECRImage {
 		_, err = fetchECRImage(ctx, source, client, registryConfigPath, useCachedImage)
 		if err != nil {
 			return err
 		}
 	} else {
-		_, err = fetchImage(ctx, ref, client, registryConfigPath, useCachedImage)
+		_, err = fetchImage(ctx, source, client, registryConfigPath, useCachedImage)
 		if err != nil {
-			log.G(ctx).WithField("ref", ref).Error(err)
+			log.G(ctx).WithField("ref", source).Error(err)
 			return err
 		}
 	}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket/issues/2567

**Description of changes:**
```
    kubernetes: during kubelet prestart, skip pause image pull if exist
    
    This makes it so that if the pause container image already exists in
    containerd's image store, host-ctr won't try to authenticate and pull
    the pause image and let kubelet use the cached image copy.
```
```
    host-ctr: add flag for skipping image pull if cached copy exists
    
    This adds a new flag to both `run` and `pull-image` subcommands to skip
    image pull and the associated registry authentications if a local cached
    copy of the image exists.
```


**Testing done:**
Testing locally:
Pull image when it doesn't exist locally
```bash
$ sudo ./host-ctr --containerd-socket=/run/containerd/containerd.sock --namespace=k8s.io pull-image --source=public.ecr.aws/eks-distro/kubernetes/pause:3.5 --skip-if-image-exist=true                                                                                                                                                                             
time="2022-11-16T15:52:29-08:00" level=info msg="Image does not exist, proceeding to pull image from source." ref="public.ecr.aws/eks-distro/kubernetes/pause:3.5"                                 
time="2022-11-16T15:52:35-08:00" level=warning msg="ecr-public: failed to get authorization token, falling back to default resolver (unauthenticated pull)"                                        
time="2022-11-16T15:52:36-08:00" level=info msg="pulled image successfully" img="public.ecr.aws/eks-distro/kubernetes/pause:3.5"                                                                   
time="2022-11-16T15:52:36-08:00" level=info msg="unpacking image..." img="public.ecr.aws/eks-distro/kubernetes/pause:3.5"                                                                          
```
After, pulling the same image with `--skip-if-image-exist=true`
```bash                                                                                                                  
$ sudo ./host-ctr --containerd-socket=/run/containerd/containerd.sock --namespace=k8s.io pull-image --source=public.ecr.aws/eks-distro/kubernetes/pause:3.5 --skip-if-image-exist=true             
time="2022-11-16T15:52:37-08:00" level=info msg="Image exists, fetching cached image from image store" ref="public.ecr.aws/eks-distro/kubernetes/pause:3.5"                                  
```

Testing on aws-k8s-1.22 built from this branch:
Launched with `settings.kubernetes.standalone-mode=true`, kubelet is running fine initally:
```bash
[root@admin]# sudo sheltie                                                                                                                                                                           bash-5.1# systemctl status kubelet                                                                                                                                                                   
● kubelet.service - Kubelet                                                                                                                                                                          
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)                                                               
    Drop-In: /etc/systemd/system/kubelet.service.d                                                                                                                                                   
             └─exec-start.conf                                                                                                                                                                       
             /aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d                                                                                                       
             └─load-ipvs-modules.conf, make-kubelet-dirs.conf, prestart-pull-pause-ctr.conf                                                                                                                  
Active: active (running) since Thu 2022-11-17 00:12:48 UTC; 1min 56s ago                                                                                               
...
```
Then I removed network egress from the instance's security group. Restarted kubelet and it comes up fine:
```bash
bash-5.1# systemctl status kubelet               
● kubelet.service - Kubelet                      
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)                                                               
    Drop-In: /etc/systemd/system/kubelet.service.d                                                
             └─exec-start.conf                   
             /aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d    
             └─load-ipvs-modules.conf, make-kubelet-dirs.conf, prestart-pull-pause-ctr.conf       
     Active: active (running) since Thu 2022-11-17 00:17:50 UTC; 3s ago                                                                                                                              
...
```
Then I manually tried pulling the pause container image and it skips the image pull as expected.
```bash
bash-5.1# /usr/bin/host-ctr \                    
>     --containerd-socket=/run/dockershim.sock \                                                  
>     --namespace=k8s.io \                       
>     pull-image \                               
>     --source=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.1-eksbuild.1 \            
>     --registry-config=/etc/host-containers/host-ctr.toml \                                      
>     --skip-if-image-exist=true                 
time="2022-11-17T00:18:40Z" level=info msg="Image exists, fetching cached image from image store" ref="ecr.aws/arn:aws:ecr:us-west-2:602401143452:repository/eks/pause:3.1-eksbuild.1"               
time="2022-11-17T00:18:40Z" level=info msg="tagging image" img="602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.1-eksbuild.1" 
```

Testing `host-ctr run --use-cached-image` and it works as expected. If the image is already there, start the host-container task without pulling the image again:
```
bash-5.1# /usr/bin/host-ctr run --container-id=admin2 --source=328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.9.3 --use-cached-image=true
time="2022-11-17T00:41:24Z" level=info msg="Image exists, fetching cached image from image store" ref="ecr.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-admin:v0.9.3"
time="2022-11-17T00:41:24Z" level=info msg="tagging image" img="328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.9.3"
time="2022-11-17T00:41:24Z" level=info msg="Container does not exist, proceeding to create it" ctr-id=admin2
time="2022-11-17T00:41:24Z" level=info msg="container task does not exist, proceeding to create it" container-id=admin2
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
