### PR TITLE
Third-party package updates after 1.11 release

### DIFF
--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -12,5 +12,5 @@ path = "pkg.rs"
 releases-url = "https://curl.se/docs/caextract.html"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2022-07-19.pem"
-sha512 = "8584106fbbaa8af36466d1aea8ff61c358bed2bed270c2e7dca105bed7a3c5fe738b9e844e0c9f250e66f24a3eaf496eddefff52c884a11ab815227a04f302a5"
+url = "https://curl.haxx.se/ca/cacert-2022-10-11.pem"
+sha512 = "fbbd8d33932a5d65dd548d91927fc5bac5218d5a44b8d992591bef2eab22b09cc2154b6effb2df1c61e1aa233816e3c3e7acfb27b3e3f90672a7752bb05b710f"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2022.07.19
+Version: 2022.10.11
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2022-07-19.pem
+Source0: https://curl.haxx.se/ca/cacert-2022-10-11.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description

--- a/packages/conntrack-tools/Cargo.toml
+++ b/packages/conntrack-tools/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://www.netfilter.org/projects/conntrack-tools/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.netfilter.org/projects/conntrack-tools/files/conntrack-tools-1.4.6.tar.bz2"
-sha512 = "a48260308a12b11b584fcf4658ec2c4c1adb2801c9cf9a73fc259e5c30d2fbe401aca21e931972413f03e415f98fbf9bd678d2126faa6c6d5748e8a652e58f1a"
+url = "https://www.netfilter.org/projects/conntrack-tools/files/conntrack-tools-1.4.7.tar.bz2"
+sha512 = "3d37a6b8cd13fd3c149ab80009d686d2184920ba2d0d5c1b57abed6e92e0dd92cba868bfe22f1a155479fe5ab2e291b8bb8a7e72123a73788032202ac142653b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/conntrack-tools/conntrack-tools.spec
+++ b/packages/conntrack-tools/conntrack-tools.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}conntrack-tools
-Version: 1.4.6
+Version: 1.4.7
 Release: 1%{?dist}
 Summary: Tools for managing Linux kernel connection tracking
 # src/utils.c contains GPLv2-only code from linux

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.8/containerd-1.6.8.tar.gz"
-sha512 = "c204c028cdfd76537d1da01c66526fc85b29b02d2412569bb9b265375603614b037356c61846025a72281398f0f46df326a5ea3df97f57901cce85f2f728f0ba"
+url = "https://github.com/containerd/containerd/archive/v1.6.10/containerd-1.6.10.tar.gz"
+sha512 = "02312a8d127b523944e9583433ec87cdc1fc30988b107a8d83438985a010b06c57e93017adb4fcf9db6ec80c1e28327101d7496d63d3832ea9cbfe54d17e3a6c"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.8
+%global gover 1.6.10
 %global rpmver %{gover}
-%global gitrev 9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
+%global gitrev 770bd0108c32f3fb5c73ae1264f7e503fe7b2661
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v20.10.20/cli-20.10.20.tar.gz"
-sha512 = "536c26b421fb0ca92a09ff67f4fa3afd64115ef9f748ae7fb6d3448c4c1acade72bef037f71017e9c3e039ecada95fb157d9f336ee3348be1f21874730bcb03e"
+url = "https://github.com/docker/cli/archive/v20.10.21/cli-20.10.21.tar.gz"
+sha512 = "951100d75c833e1c844203fe86d73d25c3164eba4fce87cc05a0ac3691851fc5341c3b32ce3814dd61bd3700d8e8e1d045a7a5651c6dc5ddc0a39c58db9bd7b3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 20.10.20
+%global gover 20.10.21
 %global rpmver %{gover}
-%global gitrev 9fdeb9c3de2f2d9f5799be373f27b2f9df44609d
+%global gitrev baeda1f82a10204ec5708d5fbba130ad76cfee49
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v20.10.20/moby-20.10.20.tar.gz"
-sha512 = "f5e5bcf18fcdca8b7d5a2226091b22c14c144e632723a0ac0058d5f9bedba884cbba7bc16c06f30d9906713ec0cfa2a43839c64df9917e243122d125a4808bec"
+url = "https://github.com/moby/moby/archive/v20.10.21/moby-20.10.21.tar.gz"
+sha512 = "de8186d191884ff678c84fefb11833205b5a46face266d432c7640bcda2677da331f74e835026c05c90df2a19d88b6e5f5acb004891049ebdec52a101d130375"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 20.10.20
+%global gover 20.10.21
 %global rpmver %{gover}
-%global gitrev 03df974ae9e6c219862907efdd76ec2e77ec930b
+%global gitrev 3056208812eb5e792fa99736c9167d1e10f4ab49
 
 %global source_date_epoch 1363394400
 

--- a/packages/ecs-agent/0005-bottlerocket-fix-procfs-path-on-host.patch
+++ b/packages/ecs-agent/0005-bottlerocket-fix-procfs-path-on-host.patch
@@ -1,4 +1,4 @@
-From baf491ab24fb2dfc1c4a98c8492fc32769475cc6 Mon Sep 17 00:00:00 2001
+From a2d84c6d919ac637150ac36e0b5f104213f7dcc5 Mon Sep 17 00:00:00 2001
 From: Samuel Karp <skarp@amazon.com>
 Date: Fri, 26 Mar 2021 17:48:28 -0700
 Subject: [PATCH 5/5] bottlerocket: fix procfs path on host
@@ -14,12 +14,12 @@ ECS agent in a container, the ECS agent can directly read the host's
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/agent/ecscni/types_linux.go b/agent/ecscni/types_linux.go
-index 729acac..74ac96c 100644
+index 6d6ce353..1f2d0914 100644
 --- a/agent/ecscni/types_linux.go
 +++ b/agent/ecscni/types_linux.go
-@@ -40,7 +40,7 @@ const (
- 	// ECSBranchENIPluginName is the binary of the branch-eni plugin
- 	ECSBranchENIPluginName = "vpc-branch-eni"
+@@ -47,7 +47,7 @@ const (
+ 	// ECSServiceConnectPluginName is the binary of the service connect plugin
+ 	ECSServiceConnectPluginName = "ecs-serviceconnect"
  	// NetnsFormat is used to construct the path to cotainer network namespace
 -	NetnsFormat = "/host/proc/%s/ns/net"
 +	NetnsFormat = "/proc/%s/ns/net"

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,20 +13,22 @@ path = "pkg.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.63.1/amazon-ecs-agent-1.63.1.tar.gz"
-sha512 = "0e6b123ed7b1287daa9fb97f49c50258e13585adf776bb6b5e1d30c2f2235c1712a801bee743951e673d26fa95a5a821646f80bd5923ed68036630cc78eaa996"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.66.2/amazon-ecs-agent-1.66.2.tar.gz"
+sha512 = "586e0ec1f68e03829253283779860f303382cb271b3aadc3b8bfc3af7a2dd8e0c24673cdc674dceb36d67eac612243380f1d19ca2166a30b0e59d5524b2d0267"
 
 # The ECS agent repository includes two CNI plugins as git submodules.  git
 # archive does not include submodules, so the tarball above does not include
 # the source of those plugins.  Instead, we include the CNI plugin source
 # directly.
+# You can get the commit SHA for the submodules for a particular ecs-agent release here:
+# https://github.com/aws/amazon-ecs-agent/blob/ECS_AGENT_VERSION/agent/ecscni/plugin_test.go#L29-L34
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/db5864722987c34ba309e6e7a7628fd1ccad1520/amazon-ecs-cni-plugins.tar.gz"
 sha512 = "550681f5cd9bdf46dd1a3353b9d328217a4d1b8697633fb70c19a0e2ddd839fb08bc764b63b1c23bc77b0d1c125ee8fbb5de0ad55628b1449261e9700e486387"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/199bfc65cced4951cbb6a38e6e828afa8c2b023c/amazon-vpc-cni-plugins.tar.gz"
-sha512 = "ee1c2230c43fa7b8b9a25319bd334abfc08210ea8956ccc4525fe936b48b22b85df778823138d58687e847762b436daa0e0ba69c210a00b173f9b933f656386d"
+url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/24d6bd87707d1b1801086fc507ebab8d32067412/amazon-vpc-cni-plugins.tar.gz"
+sha512 = "70ee8b238ba05528c89042b2cf3102c77bd71ea3a3fef6d7645f420842d82da1c2b3798022b02feec73253c130497b706ea24ae1088f53730baa415cdcfcd606"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,9 +2,9 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.63.1
+%global agent_gover 1.66.2
 # git rev-parse --short=8
-%global agent_gitrev 637446af
+%global agent_gitrev 06008fa1
 
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
@@ -14,8 +14,8 @@
 %global vpccni_goproject github.com/aws
 %global vpccni_gorepo amazon-vpc-cni-plugins
 %global vpccni_goimport %{vpccni_goproject}/%{vpccni_gorepo}
-%global vpccni_gitrev 199bfc65cced4951cbb6a38e6e828afa8c2b023c
-%global vpccni_gover 1.2
+%global vpccni_gitrev 24d6bd87707d1b1801086fc507ebab8d32067412
+%global vpccni_gover 1.3
 
 # Construct reproducible tar archives
 # See https://reproducible-builds.org/docs/archives/

--- a/packages/libelf/Cargo.toml
+++ b/packages/libelf/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://sourceware.org/elfutils/ftp/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/elfutils/ftp/0.187/elfutils-0.187.tar.bz2"
-sha512 = "a9b9e32b503b8b50a62d4e4001097ed2721d3475232a6380e6b9853bd1647aec016440c0ca7ceb950daf1144f8db9814ab43cf33cc0ebef7fc91e9e775c9e874"
+url = "https://sourceware.org/elfutils/ftp/0.188/elfutils-0.188.tar.bz2"
+sha512 = "585551b2d937d19d1becfc2f28935db1dd1a3d25571a62f322b70ac8da98c1a741a55d070327705df6c3e2ee026652e0b9a3c733b050a0b0ec5f2fc75d5b74b5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libelf/libelf.spec
+++ b/packages/libelf/libelf.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libelf
-Version: 0.187
+Version: 0.188
 Release: 1%{?dist}
 Summary: Library for ELF files
 License: GPL-2.0-or-later OR LGPL-3.0-or-later

--- a/packages/libffi/Cargo.toml
+++ b/packages/libffi/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/libffi/libffi/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libffi/libffi/releases/download/v3.4.3/libffi-3.4.3.tar.gz"
-sha512 = "6e3620d3842ae0f983c47c3268364be32b6eeb2fc708b23d141531730e9149abb035c618b295be834999eadef64fabfa39df21c955c40473f3bbc9fd3170bad8"
+url = "https://github.com/libffi/libffi/releases/download/v3.4.4/libffi-3.4.4.tar.gz"
+sha512 = "88680aeb0fa0dc0319e5cd2ba45b4b5a340bc9b4bcf20b1e0613b39cd898f177a3863aa94034d8e23a7f6f44d858a53dcd36d1bb8dee13b751ef814224061889"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libffi/libffi.spec
+++ b/packages/libffi/libffi.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libffi
-Version: 3.4.3
+Version: 3.4.4
 Release: 1%{?dist}
 Summary: Library for FFI
 License: MIT

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://download.gnome.org/sources/glib"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.74/glib-2.74.0.tar.xz"
-sha512 = "5cdadd2f4568c0c3d45083b4d39699abf651e42e020f7bc880cce3ff33d28943118388d17a0632777e843f48009c1f97d5634fde3cb8c69c7c7f35b278ac8225"
+url = "https://download.gnome.org/sources/glib/2.75/glib-2.75.0.tar.xz"
+sha512 = "0402c063975680ff2385876f521b37aa4cc599d2570eb79976ad2a1b530e47a086d514fe122fd870b4a8f7358f48c926285694d153cc2c32cf6963ed2d5da9d9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,11 +1,11 @@
 Name: %{_cross_os}libglib
-Version: 2.74.0
+Version: 2.75.0
 Release: 1%{?dist}
 Summary: The GLib libraries
 # glib2 is LGPL-2.1-only
 License: LGPL-2.1-only
 URL: https://www.gtk.org/
-Source0: https://download.gnome.org/sources/glib/2.74/glib-%{version}.tar.xz
+Source0: https://download.gnome.org/sources/glib/2.75/glib-%{version}.tar.xz
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libffi-devel

--- a/packages/liblzma/Cargo.toml
+++ b/packages/liblzma/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://tukaani.org/xz"
 
 [[package.metadata.build-package.external-files]]
-url = "https://tukaani.org/xz/xz-5.2.6.tar.xz"
-sha512 = "5c69a492227c0ff72836d7a87e6372dc2e62bedfffb33f057263e28a6341825cef67834a863ed6ac02c5368c86da89f8affbe767f8bb914064cfa478f653e935"
+url = "https://tukaani.org/xz/xz-5.2.9.tar.xz"
+sha512 = "fa844d63ceedf3b35c38f82532dc3b847543ac37b9e56db774c234af73d1385a300ba1033154689059031f18793d791c8cdb65bbeb031691d837f76e673372a7"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/liblzma/liblzma.spec
+++ b/packages/liblzma/liblzma.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}liblzma
-Version: 5.2.6
+Version: 5.2.9
 Release: 1%{?dist}
 Summary: Library for XZ and LZMA compressed files
 URL: https://tukaani.org/xz

--- a/packages/libnftnl/Cargo.toml
+++ b/packages/libnftnl/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://netfilter.org/projects/libnftnl/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://netfilter.org/projects/libnftnl/files/libnftnl-1.2.3.tar.bz2"
-sha512 = "e2d16cbc062eb8900f0472abb8fe6b22910cc5a8efbb47445fe6ce6e2713a0637f74b46b2bf2031ba9ecb2e5eed932e3bbb49b015c7b7207591249de23d5149d"
+url = "https://netfilter.org/projects/libnftnl/files/libnftnl-1.2.4.tar.bz2"
+sha512 = "5375d1d15627aabf25129433630395f53009b22a255fcd113b302af7f2f0a234fd54c827b0ef1c8fd3a13e272a1696f780560672d4af6abad0e19805f9d56326"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnftnl/libnftnl.spec
+++ b/packages/libnftnl/libnftnl.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnftnl
-Version: 1.2.3
+Version: 1.2.4
 Release: 1%{?dist}
 Summary: Library for nftables netlink
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/besser82/libxcrypt/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/archive/v4.4.28/libxcrypt-4.4.28.tar.gz"
-sha512 = "1ba699345c6437ce32210e07fdce8fdb3ce813133ca4f0ba1950dec0067fa7c2d67ee11d196815b4f9a800796f9273c622f71118ce2e9bbb391f8e0214b6e455"
+url = "https://github.com/besser82/libxcrypt/archive/v4.4.31/libxcrypt-4.4.31.tar.gz"
+sha512 = "b8a9d4d08d62af9ed8632f257467366e28635ffdcace9409b465e2a1506b7920c43d935827e50c948c62ec9919f73b14a3077a7b5ca998f3a2a6d8a2aa5fbd17"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.28
+Version: 4.4.31
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/makedumpfile/makedumpfile/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.1/makedumpfile-1.7.1.tar.gz"
-sha512 = "93e36487b71f567d3685b151459806cf36017e52bf3ee68dd448382b279a422d1a8abef72e291ccb8206f2149ccd08ba484ec0027d1caab3fa1edbc3d28c3632"
+url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.2/makedumpfile-1.7.2.tar.gz"
+sha512 = "324e303dd5f507703f66e2bd5dc9d24f9f50ba797be70c05702008ba77078f61ffcc884796ddf9ab737de1d124c3a9d881ab5ce4f3f459690ec00055af25ea9e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/makedumpfile/makedumpfile.spec
+++ b/packages/makedumpfile/makedumpfile.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}makedumpfile
-Version: 1.7.1
+Version: 1.7.2
 Release: 1%{?dist}
 Summary: Tool to create dumps from kernel memory images
 License: GPL-2.0-or-later AND GPL-2.0-only


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**
We're updating third party packages earlier in the release cycle to so they're sufficiently exercised by our regular development testing up to the next release.

```
5dea53cc packages: update makedumpfile
9a2358e4 packages: update libxcrypt
b80d70b5 packages: update libnftnl
823ebc9a packages: update liblzma
779256b6 packages: update libglib
2f0ceb9e packages: update libffi
ec2fda3f packages: update libelf
a2fc1915 packages: update ecs-agent
fedfc7ac packages: update docker-cli
53692f6c packages: update docker-engine
7abd7397 packages: update containerd
627053f4 packages: update conntrack-tools
250c90e0 packages: update ca-certificates
```

Regenerated patch that don't cleanly apply for `ecs-agent` 

I left out the following package updates in this PR:

- binutils 2.38 -> 2.39. `bottlerocket-sdk` has to move to 2.39 first.
- ncurses 6.2 -> 6.3. See https://github.com/bottlerocket-os/bottlerocket/issues/1813
- cni/cni-plugins 0.8.1 -> 1.1.2. See https://github.com/bottlerocket-os/bottlerocket/issues/1745
- systemd 250.4 -> 251/252. See https://github.com/bottlerocket-os/bottlerocket/issues/2410
- wicked 0.6.68 -> 0.6.70. See comment: https://github.com/bottlerocket-os/bottlerocket/pull/2588#issuecomment-1319342336 Created an issue here: https://github.com/bottlerocket-os/bottlerocket/issues/2591

**Testing done:**
Built aws-ecs-1 and aws-k8s-1.23 without problems.

Testing:

- [x] aws-k8s-1.24 can run pods fine
- [x] aws-k8s-1.24-nvidia can run sample K8s GPU workloads
- [x] aws-ecs-1 can run an simple ECS nginx task
- [x] aws-ecs-1-nvidia can run simple GPU workloads
- [x] vmware-k8s, created cluster with eks-a with OVA built from changes and can run workloads fine
- [x] metal-k8s, created cluster with eks-a with image built from changes and can run workloads fine


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
