### PR TITLE
docs, build: Update default variant to aws-k8s-1.24

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,7 +72,7 @@ To build an image, run:
 cargo make
 ```
 
-This will build an image for the default variant, `aws-k8s-1.21`.
+This will build an image for the default variant, `aws-k8s-1.24`.
 All packages will be built in turn, and then compiled into an `img` file in the `build/images/` directory.
 
 The version number in [Release.toml](Release.toml) will be used in naming the file, and will be used inside the image as the release version.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,7 +18,7 @@ BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*
 BUILDSYS_RELEASE_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Release.toml"
 BUILDSYS_VERSION_IMAGE = { script = ["awk -F '[ =\"]+' '$1 == \"version\" {print $2}' ${BUILDSYS_RELEASE_CONFIG_PATH}"] }
 # This can be overridden with -e to build a different variant from the variants/ directory
-BUILDSYS_VARIANT = { script = ['echo "${BUILDSYS_VARIANT:-aws-k8s-1.23}"'] }
+BUILDSYS_VARIANT = { script = ['echo "${BUILDSYS_VARIANT:-aws-k8s-1.24}"'] }
 # Product name used for file and directory naming
 BUILDSYS_NAME = "bottlerocket"
 # "Pretty" name used to identify OS in os-release, bootloader, etc.

--- a/PUBLISHING-AWS.md
+++ b/PUBLISHING-AWS.md
@@ -91,7 +91,7 @@ This isn't very discoverable yet, but it's useful for testing.
 As an example, a parameter might look like this:
 
 ```
-/your/prefix/here/aws-k8s-1.21/x86_64/1.0.1-dafe3b16/image_id
+/your/prefix/here/aws-k8s-1.24/x86_64/1.11.0-b530f30/image_id
 ```
 
 Once you're satisfied with your image and parameters, you can promote the parameters to simpler names (for example, "latest") using the [instructions below](#promoting-ssm-parameters).
@@ -133,12 +133,12 @@ cargo make -e SSM_TARGET=latest promote-ssm
 This will copy the fully versioned parameter from earlier, something like:
 
 ```
-/your/prefix/here/aws-k8s-1.21/x86_64/1.0.1-dafe3b16/image_id
+/your/prefix/here/aws-k8s-1.24/x86_64/1.11.0-b530f30/image_id
 ```
 
 ...to a simpler parameter name:
 ```
-/your/prefix/here/aws-k8s-1.21/x86_64/latest/image_id
+/your/prefix/here/aws-k8s-1.24/x86_64/latest/image_id
 ```
 
 You can then use this parameter name to get the latest AMI ID.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -215,12 +215,12 @@ These default settings will be applied to your hosts at startup, meaning any hos
 
 The easiest way to change your repo URLs at run time is to include the settings changes in user data.
 This method is covered [in README](README.md#using-user-data).
-For example, if you built the `aws-k8s-1.21` variant for `x86_64` and uploaded to the public S3 bucket `my-bucket`, your URLs could look like:
+For example, if you built the `aws-k8s-1.24` variant for `x86_64` and uploaded to the public S3 bucket `my-bucket`, your URLs could look like:
 
 ```toml
 [settings.updates]
 targets-base-url = "https://my-bucket.s3-us-west-2.amazonaws.com/targets/"
-metadata-base-url = "https://my-bucket.s3-us-west-2.amazonaws.com/aws-k8s-1.21/x86_64/"
+metadata-base-url = "https://my-bucket.s3-us-west-2.amazonaws.com/aws-k8s-1.24/x86_64/"
 ```
 
 ### Waves

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -129,18 +129,18 @@ us-gov-west-1
 ```
 
 The official AMI IDs are stored in [public SSM parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters.html).
-The parameter names look like this: `/aws/service/bottlerocket/aws-k8s-1.21/x86_64/latest/image_id`
+The parameter names look like this: `/aws/service/bottlerocket/aws-k8s-1.24/x86_64/latest/image_id`
 
-Just change the variant (`aws-k8s-1.21`) and architecture (`x86_64`) to the ones you want to use.
+Just change the variant (`aws-k8s-1.24`) and architecture (`x86_64`) to the ones you want to use.
 Supported variants and architectures are described in the [README](README.md#variants).
 For the purposes of SSM parameters, the valid architecture names are `x86_64` and `arm64` (also known as `aarch64`).
-Also, if you know a specific Bottlerocket version you'd like to use, for example `1.0.6`, you can replace `latest` with that version.
+Also, if you know a specific Bottlerocket version you'd like to use, for example `1.11.0`, you can replace `latest` with that version.
 
 Once you have the parameter name you want to use, the easiest way to use it is to pass it directly to EC2.
 (You can also use this method for CloudFormation and other services that launch EC2 instances for you.)
 Just prefix the parameter name with `resolve:ssm:` and EC2 will fetch the current value for you.
 
-For example, to use the parameter above, you would pass this as the AMI ID in your launch request: `resolve:ssm:/aws/service/bottlerocket/aws-k8s-1.21/x86_64/latest/image_id`
+For example, to use the parameter above, you would pass this as the AMI ID in your launch request: `resolve:ssm:/aws/service/bottlerocket/aws-k8s-1.24/x86_64/latest/image_id`
 
 #### Manually querying SSM
 
@@ -148,14 +148,14 @@ If you prefer to fetch the AMI ID yourself, you can use [aws-cli](https://aws.am
 To fetch the example parameter above, for the us-west-2 region, you could run this:
 
 ```
-aws ssm get-parameter --region us-west-2 --name "/aws/service/bottlerocket/aws-k8s-1.21/x86_64/latest/image_id" --query Parameter.Value --output text
+aws ssm get-parameter --region us-west-2 --name "/aws/service/bottlerocket/aws-k8s-1.24/x86_64/latest/image_id" --query Parameter.Value --output text
 ```
 
 If you have `jq` and would like a bit more information, try this:
 ```
 aws ssm get-parameters --region us-west-2 \
-   --names "/aws/service/bottlerocket/aws-k8s-1.21/x86_64/latest/image_id" \
-           "/aws/service/bottlerocket/aws-k8s-1.21/x86_64/latest/image_version" \
+   --names "/aws/service/bottlerocket/aws-k8s-1.24/x86_64/latest/image_id" \
+           "/aws/service/bottlerocket/aws-k8s-1.24/x86_64/latest/image_version" \
    --output json | jq -r '.Parameters | .[] | "\(.Name): \(.Value) (updated \(.LastModifiedDate | gmtime | strftime("%c")) UTC)"'
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We’re excited to get early feedback and to continue working on more use cases!
 Bottlerocket is architected such that different cloud environments and container orchestrators can be supported in the future.
 A build of Bottlerocket that supports different features or integration characteristics is known as a 'variant'.
 The artifacts of a build will include the architecture and variant name.
-For example, an `x86_64` build of the `aws-k8s-1.21` variant will produce an image named `bottlerocket-aws-k8s-1.21-x86_64-<version>-<commit>.img`.
+For example, an `x86_64` build of the `aws-k8s-1.24` variant will produce an image named `bottlerocket-aws-k8s-1.24-x86_64-<version>-<commit>.img`.
 
 The following variants support EKS, as described above:
 
@@ -1098,7 +1098,7 @@ We currently package the following major third-party components:
 * systemd as init ([background](https://en.wikipedia.org/wiki/Systemd), [packaging](packages/systemd/))
 * wicked for networking ([background](https://github.com/openSUSE/wicked), [packaging](packages/wicked/))
 * containerd ([background](https://containerd.io/), [packaging](packages/containerd/))
-* Kubernetes ([background](https://kubernetes.io/), [packaging](packages/kubernetes-1.21/))
+* Kubernetes ([background](https://kubernetes.io/), [packaging](packages/kubernetes-1.24/))
 * aws-iam-authenticator ([background](https://github.com/kubernetes-sigs/aws-iam-authenticator), [packaging](packages/aws-iam-authenticator/))
 * Amazon ECS agent ([background](https://github.com/aws/amazon-ecs-agent), [packaging](packages/ecs-agent/))
 

--- a/sample-eksctl-ssh.yaml
+++ b/sample-eksctl-ssh.yaml
@@ -5,7 +5,7 @@ kind: ClusterConfig
 metadata:
   name: bottlerocket
   region: us-west-2
-  version: '1.21'
+  version: '1.24'
 
 nodeGroups:
   - name: ng-bottlerocket

--- a/sample-eksctl.yaml
+++ b/sample-eksctl.yaml
@@ -5,7 +5,7 @@ kind: ClusterConfig
 metadata:
   name: bottlerocket
   region: us-west-2
-  version: '1.21'
+  version: '1.24'
 
 nodeGroups:
   - name: ng-bottlerocket


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

- Update Makefile.toml to build aws-k8s-1.24 by default instead of 1.21
- Update documentation and examples to reference aws-k8s-1.24 and latest BR version (v1.11)

**Testing done:**
`cargo make` builds 1.24 as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
