### PR TITLE
testsys: vmware-k8s for `cargo make test`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1367,15 +1367,15 @@ script = [
     '''
     set -eu
     ami_input="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${AMI_DATA_FILE_SUFFIX}"
-    if [ ! -s "${ami_input}" ]; then
-      echo "AMI input file doesn't exist for the current version/commit - ${BUILDSYS_VERSION_FULL} - please run 'cargo make ami'" >&2
-      exit 1
+    testsys_ami_input=""
+    if [ -s "${ami_input}" ]; then
+      testsys_ami_input="--ami-input ${ami_input}"
     fi
     export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
     # The ami that is selected from `amis.json` is determined by `TESTSYS_REGION` if set; otherwise,
     # it is the first region listed in `Infra.toml` (for aws variants).
     testsys ${CARGO_MAKE_TESTSYS_ARGS} run ${TESTSYS_TEST} \
-      --ami-input "${ami_input}" \
+      ${testsys_ami_input} \
       ${TESTSYS_AWS_SECRET_NAME:+--secret ${TESTSYS_AWS_SECRET_NAME}} \
       ${@}
     '''

--- a/TESTING.md
+++ b/TESTING.md
@@ -249,6 +249,64 @@ cargo make watch-test
 
 **Note:** For more information on publishing AMIs see [publishing](PUBLISHING.md).
 
+### vmware-k8s
+
+First, an initial management cluster needs to be created using [`EKS Anywhere`](https://anywhere.eks.amazonaws.com/docs/getting-started/production-environment/vsphere-getstarted/#create-an-initial-cluster).
+You can then set `TESTSYS_MGMT_CLUSTER_KUBECONFIG` to the path to the management clusters kubeconfig.
+You need to [build](BUILDING.md) Bottlerocket and a publicly accessible [TUF repository](https://github.com/bottlerocket-os/bottlerocket/blob/develop/PUBLISHING.md#repo-location) to test VMware variants.
+Either `Infra.toml` or your environment need to be configured.
+If using environment variables make sure to set the following environment variables:
+- GOVC_URL
+- GOVC_USERNAME
+- GOVC_PASSWORD
+- GOVC_DATACENTER
+- GOVC_DATASTORE
+- GOVC_NETWORK
+- GOVC_RESOURCE_POOL
+- GOVC_FOLDER
+
+Testsys will use the data center specified in `Test.toml` first.
+If no data center is specified in `Test.toml`, testsys will use the first data center listed in `Infra.toml`
+VMware testing also requires a `control-plane-endpoint` to be set in `Test.toml` for vSphere K8s cluster creation.
+Change the commands below to the desired `vmware-k8s` variant:
+
+First, build the VMware variant you want to test.
+
+```shell
+cargo make \
+  -e BUILDSYS_VARIANT="vmware-k8s-1.23" \
+  -e BUILDSYS_ARCH="x86_64" \
+  build
+```
+
+Build the TUF repo containing the OVA templates.
+
+```shell
+cargo make \
+  -e BUILDSYS_VARIANT="vmware-k8s-1.23" \
+  -e BUILDSYS_ARCH="x86_64" \
+  repo
+```
+
+Sync TUF repos containing the VMware variant's metadata and targets.
+Make sure the TUF repos are accessible via unauthenticated HTTP or HTTPS and match the URLs in `Infra.toml`.
+
+Now, you can run the test.
+
+```shell
+cargo make \
+  -e BUILDSYS_VARIANT="vmware-k8s-1.23" \
+  -e BUILDSYS_ARCH="x86_64" \
+  test \
+  --mgmt-cluster-kubeconfig ${TESTSYS_MGMT_CLUSTER_KUBECONFIG}
+```
+
+You can monitor the tests with:
+
+```shell
+cargo make watch-test
+```
+
 ## Migration Testing
 
 Migration testing is used to ensure Bottlerocket can update from one version to a new version and back.

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -97,6 +97,10 @@ pub struct Test {
     /// The name of the repo in `Infra.toml` that should be used for testing
     pub repo: Option<String>,
 
+    /// The name of the vSphere data center in `Infra.toml` that should be used for testing
+    /// If no data center is provided, the first one in `vmware.datacenters` will be used
+    pub datacenter: Option<String>,
+
     #[serde(flatten)]
     /// The URI of TestSys images
     pub testsys_images: TestsysImages,
@@ -187,6 +191,8 @@ pub struct GenericVariantConfig {
     pub conformance_image: Option<String>,
     /// The custom registry used for conformance testing
     pub conformance_registry: Option<String>,
+    /// The endpoint IP to reserve for the vSphere control plane VMs when creating a K8s cluster
+    pub control_plane_endpoint: Option<String>,
 }
 
 impl GenericVariantConfig {
@@ -211,6 +217,7 @@ impl GenericVariantConfig {
             agent_role: self.agent_role.or(other.agent_role),
             conformance_image: self.conformance_image.or(other.conformance_image),
             conformance_registry: self.conformance_registry.or(other.conformance_registry),
+            control_plane_endpoint: self.control_plane_endpoint.or(other.control_plane_endpoint),
         }
     }
 }
@@ -235,7 +242,9 @@ where
 pub struct TestsysImages {
     pub eks_resource_agent_image: Option<String>,
     pub ecs_resource_agent_image: Option<String>,
+    pub vsphere_k8s_cluster_resource_agent_image: Option<String>,
     pub ec2_resource_agent_image: Option<String>,
+    pub vsphere_vm_resource_agent_image: Option<String>,
     pub sonobuoy_test_agent_image: Option<String>,
     pub ecs_test_agent_image: Option<String>,
     pub migration_test_agent_image: Option<String>,
@@ -260,8 +269,16 @@ impl TestsysImages {
                 "{}/ecs-resource-agent:{AGENT_VERSION}",
                 registry
             )),
+            vsphere_k8s_cluster_resource_agent_image: Some(format!(
+                "{}/vsphere-k8s-cluster-resource-agent:{AGENT_VERSION}",
+                registry
+            )),
             ec2_resource_agent_image: Some(format!(
                 "{}/ec2-resource-agent:{AGENT_VERSION}",
+                registry
+            )),
+            vsphere_vm_resource_agent_image: Some(format!(
+                "{}/vsphere-vm-resource-agent:{AGENT_VERSION}",
                 registry
             )),
             sonobuoy_test_agent_image: Some(format!(
@@ -285,6 +302,12 @@ impl TestsysImages {
             ecs_resource_agent_image: self
                 .ecs_resource_agent_image
                 .or(other.ecs_resource_agent_image),
+            vsphere_k8s_cluster_resource_agent_image: self
+                .vsphere_k8s_cluster_resource_agent_image
+                .or(other.vsphere_k8s_cluster_resource_agent_image),
+            vsphere_vm_resource_agent_image: self
+                .vsphere_vm_resource_agent_image
+                .or(other.vsphere_vm_resource_agent_image),
             ec2_resource_agent_image: self
                 .ec2_resource_agent_image
                 .or(other.ec2_resource_agent_image),

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -41,7 +41,7 @@ impl<'a> CrdInput<'a> {
                 metadata_base_url, targets_url
             );
             Some(TufRepoConfig {
-                metadata_url: format!("{}{}/{}", metadata_base_url, &self.variant, &self.arch),
+                metadata_url: format!("{}{}/{}/", metadata_base_url, &self.variant, &self.arch),
                 targets_url: targets_url.to_string(),
             })
         } else {

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -13,6 +13,11 @@ pub enum Error {
     #[snafu(display("Unable to build '{}': {}", what, error))]
     Build { what: String, error: String },
 
+    #[snafu(display("Unable to build data center config: {}", source))]
+    DatacenterBuild {
+        source: pubsys_config::vmware::Error,
+    },
+
     #[snafu(context(false), display("{}", source))]
     DescribeImages {
         source: SdkError<DescribeImagesError>,

--- a/tools/testsys/src/main.rs
+++ b/tools/testsys/src/main.rs
@@ -27,6 +27,7 @@ mod secret;
 mod sonobuoy;
 mod status;
 mod uninstall;
+mod vmware_k8s;
 
 /// A program for running and controlling Bottlerocket tests in a Kubernetes cluster using
 /// bottlerocket-test-system

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -1,0 +1,242 @@
+use crate::aws_resources;
+use crate::crds::{
+    BottlerocketInput, ClusterInput, CrdCreator, CrdInput, CreateCrdOutput, MigrationInput,
+    TestInput,
+};
+use crate::error::{self, Result};
+use crate::sonobuoy::sonobuoy_crd;
+use bottlerocket_types::agent_config::{
+    CreationPolicy, K8sVersion, VSphereK8sClusterConfig, VSphereK8sClusterInfo, VSphereVmConfig,
+};
+use maplit::btreemap;
+use model::{Crd, DestructionPolicy};
+use pubsys_config::vmware::Datacenter;
+use snafu::OptionExt;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+/// A `CrdCreator` responsible for creating crd related to `vmware-k8s` variants.
+pub(crate) struct VmwareK8sCreator {
+    pub(crate) region: String,
+    pub(crate) datacenter: Datacenter,
+    pub(crate) ova_name: String,
+    pub(crate) encoded_mgmt_cluster_kubeconfig: String,
+}
+
+#[async_trait::async_trait]
+impl CrdCreator for VmwareK8sCreator {
+    /// Use the provided OVA name for the image id.
+    fn image_id(&self, _: &CrdInput) -> Result<String> {
+        Ok(self.ova_name.to_string())
+    }
+
+    /// Use standard naming conventions to predict the starting OVA.
+    async fn starting_image_id(&self, crd_input: &CrdInput) -> Result<String> {
+        Ok(format!(
+            "bottlerocket-{}-{}-{}",
+            crd_input.variant,
+            crd_input.arch,
+            crd_input
+                .starting_version
+                .as_ref()
+                .context(error::InvalidSnafu {
+                    what: "The starting version must be provided for migration testing"
+                })?
+        ))
+    }
+
+    /// Creates a vSphere K8s cluster CRD with the `cluster_name` in `cluster_input`.
+    async fn cluster_crd<'a>(&self, cluster_input: ClusterInput<'a>) -> Result<CreateCrdOutput> {
+        let control_plane_endpoint = cluster_input
+            .crd_input
+            .config
+            .control_plane_endpoint
+            .as_ref()
+            .context(error::InvalidSnafu {
+                what: "The control plane endpoint is required for VMware cluster creation.",
+            })?;
+        let labels = cluster_input.crd_input.labels(btreemap! {
+            "testsys/type".to_string() => "cluster".to_string(),
+            "testsys/cluster".to_string() => cluster_input.cluster_name.to_string(),
+            "testsys/controlPlaneEndpoint".to_string() => control_plane_endpoint.to_string(),
+        });
+
+        // Check if the cluster already has a CRD
+        if let Some(cluster_crd) = cluster_input
+            .crd_input
+            .existing_crds(
+                &labels,
+                &[
+                    "testsys/cluster",
+                    "testsys/type",
+                    "testsys/controlPlaneEndpoint",
+                ],
+            )
+            .await?
+            .pop()
+        {
+            return Ok(CreateCrdOutput::ExistingCrd(cluster_crd));
+        }
+
+        // Check if an existing cluster is using this endpoint
+        let existing_clusters = cluster_input
+            .crd_input
+            .existing_crds(&labels, &["testsys/type", "testsys/controlPlaneEndpoint"])
+            .await?;
+
+        let cluster_version =
+            K8sVersion::from_str(cluster_input.crd_input.variant.version().context(
+                error::MissingSnafu {
+                    item: "K8s version".to_string(),
+                    what: "aws-k8s variant".to_string(),
+                },
+            )?)
+            .map_err(|_| error::Error::K8sVersion {
+                version: cluster_input.crd_input.variant.to_string(),
+            })?;
+
+        let vsphere_k8s_crd = VSphereK8sClusterConfig::builder()
+            .name(cluster_input.cluster_name)
+            .set_labels(Some(labels))
+            .control_plane_endpoint_ip(control_plane_endpoint)
+            .creation_policy(CreationPolicy::IfNotExists)
+            .version(cluster_version)
+            .ova_name(self.image_id(cluster_input.crd_input)?)
+            .tuf_repo(
+                cluster_input
+                    .crd_input
+                    .tuf_metadata()
+                    .context(error::InvalidSnafu {
+                        what: "TUF repo information is required for VMware cluster creation.",
+                    })?,
+            )
+            .vcenter_host_url(&self.datacenter.vsphere_url)
+            .vcenter_datacenter(&self.datacenter.datacenter)
+            .vcenter_datastore(&self.datacenter.datastore)
+            .vcenter_network(&self.datacenter.network)
+            .vcenter_resource_pool(&self.datacenter.resource_pool)
+            .vcenter_workload_folder(&self.datacenter.folder)
+            .mgmt_cluster_kubeconfig_base64(&self.encoded_mgmt_cluster_kubeconfig)
+            .set_conflicts_with(Some(existing_clusters))
+            .destruction_policy(DestructionPolicy::OnTestSuccess)
+            .image(
+                cluster_input
+                    .crd_input
+                    .images
+                    .vsphere_k8s_cluster_resource_agent_image
+                    .as_ref()
+                    .expect(
+                        "The default vSphere K8s cluster resource provider image URI is missing.",
+                    ),
+            )
+            .set_image_pull_secret(
+                cluster_input
+                    .crd_input
+                    .images
+                    .testsys_agent_pull_secret
+                    .to_owned(),
+            )
+            .set_secrets(Some(cluster_input.crd_input.config.secrets.clone()))
+            .privileged(true)
+            .build(cluster_input.cluster_name)
+            .map_err(|e| error::Error::Build {
+                what: "vSphere K8s cluster CRD".to_string(),
+                error: e.to_string(),
+            })?;
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(
+            vsphere_k8s_crd,
+        ))))
+    }
+
+    /// Create a vSphere VM provider CRD to launch Bottlerocket VMs on the cluster created by
+    /// `cluster_crd`.
+    async fn bottlerocket_crd<'a>(
+        &self,
+        bottlerocket_input: BottlerocketInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        let cluster_name = bottlerocket_input
+            .cluster_crd_name
+            .as_ref()
+            .expect("A vSphere K8s cluster provider is required");
+        let labels = bottlerocket_input.crd_input.labels(btreemap! {
+            "testsys/type".to_string() => "vms".to_string(),
+            "testsys/cluster".to_string() => cluster_name.to_string(),
+        });
+
+        // Check if other VMs are using this cluster
+        let existing_clusters = bottlerocket_input
+            .crd_input
+            .existing_crds(&labels, &["testsys/type", "testsys/cluster"])
+            .await?;
+
+        let vsphere_vm_crd =
+            VSphereVmConfig::builder()
+                .ova_name(self.image_id(bottlerocket_input.crd_input)?)
+                .tuf_repo(bottlerocket_input.crd_input.tuf_metadata().context(
+                    error::InvalidSnafu {
+                        what: "TUF repo information is required for Bottlerocket vSphere VM creation.",
+                    },
+                )?)
+                .vcenter_host_url(&self.datacenter.vsphere_url)
+                .vcenter_datacenter(&self.datacenter.datacenter)
+                .vcenter_datastore(&self.datacenter.datastore)
+                .vcenter_network(&self.datacenter.network)
+                .vcenter_resource_pool(&self.datacenter.resource_pool)
+                .vcenter_workload_folder(&self.datacenter.folder)
+                .cluster(VSphereK8sClusterInfo {
+                    name: format!("${{{}.clusterName}}", cluster_name),
+                    control_plane_endpoint_ip: format!("${{{}.endpoint}}", cluster_name),
+                    kubeconfig_base64: format!("${{{}.encodedKubeconfig}}", cluster_name),
+                })
+                .assume_role(bottlerocket_input.crd_input.config.agent_role.clone())
+                .set_conflicts_with(Some(existing_clusters))
+                .destruction_policy(DestructionPolicy::OnTestSuccess)
+                .image(
+                    bottlerocket_input
+                        .crd_input
+                        .images
+                        .vsphere_vm_resource_agent_image
+                        .as_ref()
+                        .expect("The default vSphere VM resource provider image URI is missing."),
+                )
+                .set_image_pull_secret(
+                    bottlerocket_input
+                        .crd_input
+                        .images
+                        .testsys_agent_pull_secret
+                        .to_owned(),
+                )
+                .set_secrets(Some(bottlerocket_input.crd_input.config.secrets.clone()))
+                .depends_on(cluster_name)
+                .build(format!(
+                    "{}-vms-{}",
+                    cluster_name, bottlerocket_input.test_type
+                ))
+                .map_err(|e| error::Error::Build {
+                    what: "vSphere VM CRD".to_string(),
+                    error: e.to_string(),
+                })?;
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(
+            vsphere_vm_crd,
+        ))))
+    }
+
+    async fn migration_crd<'a>(
+        &self,
+        migration_input: MigrationInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(
+            aws_resources::migration_crd(migration_input)?,
+        ))))
+    }
+
+    async fn test_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(sonobuoy_crd(
+            test_input,
+        )?))))
+    }
+
+    fn additional_fields(&self, _test_type: &str) -> BTreeMap<String, String> {
+        btreemap! {"region".to_string() => self.region.clone()}
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2151 

**Description of changes:**

* amis.json check was moved from `Makefile.toml` to `aws` specific creators because `VMware` does not use it
* New `CrdCreator` for `vmware-k8s` variants
* `datacenter` and `cluster-ip-endpoint` added to `Test.toml` configuration
* `TufRepoConfig.metadata_url` had a `/` removed from the path so that it would work with `tuftool`
* Labels are used to reuse the same cluster if it exists. If 2 clusters require the same ip, they will be created as conflicting resources.

**Testing done:**

Ran `cargo make -e BUILDSYS_VARIANT="vmware-k8s-1.23" test --mgmt-cluster-kubeconfig=<PATH-TO-MANAGEMENT-KUBECONFIG>` with `GOVC_URL, GOVC_USERNAME, GOVC_PASSWORD, GOVC_DATACENTER, GOVC_DATASTORE, GOVC_NETWORK, GOVC_RESOURCE_POOL, GOVC_FOLDER` environment variables set.

```
NAME                                        TYPE           STATE         PASSED       SKIPPED       FAILED
 x86-64-vmware-k8s-123                       Resource       running
 x86-64-vmware-k8s-123-instances-quick       Resource       unknown
 x86-64-vmware-k8s-123-test                  Test           waiting
```

After testing completed and resources were cleaned up.

```
 NAME                             TYPE      STATE	PASSED      SKIPPED	 FAILED
 x86-64-vmware-k8s-123-test	  Test      passed	1           7049         0
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
