### PR TITLE
modeled-types: constrain kubelet log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,8 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.kube-api-burst`: The burst to allow while talking with kubernetes.
 * `settings.kubernetes.kube-api-qps`: The QPS to use while talking with kubernetes apiserver.
 * `settings.kubernetes.log-level`: Adjust the logging verbosity of the `kubelet` process.
-  The default log level is 2, with higher numbers enabling more verbose logging.
+  Valid values are 0-8 with higher numbers enabling more verbose logging.
+  The default log level is 2.
 * `settings.kubernetes.pod-pids-limit`: The maximum number of processes per pod.
 * `settings.kubernetes.provider-id`: This sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node.
 * `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -148,12 +148,13 @@ use crate::modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, CredentialProvider,
     DNSDomain, ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
     ECSDurationValue, EtcHostsEntries, FriendlyVersion, Identifier, ImageGCHighThresholdPercent,
-    ImageGCLowThresholdPercent, KmodKey, KubernetesAuthenticationMode, KubernetesBootstrapToken,
-    KubernetesCloudProvider, KubernetesClusterDnsIp, KubernetesClusterName,
-    KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
-    KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
-    KubernetesThresholdValue, Lockdown, PemCertificateString, SingleLineString, SysctlKey,
-    TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
+    ImageGCLowThresholdPercent, KmodKey, KubeletLogLevel, KubernetesAuthenticationMode,
+    KubernetesBootstrapToken, KubernetesCloudProvider, KubernetesClusterDnsIp,
+    KubernetesClusterName, KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey,
+    KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
+    KubernetesTaintValue, KubernetesThresholdValue, Lockdown, PemCertificateString,
+    SingleLineString, SysctlKey, TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64,
+    ValidLinuxHostname,
 };
 
 // Kubernetes static pod manifest settings
@@ -206,7 +207,7 @@ struct KubernetesSettings {
     image_gc_high_threshold_percent: ImageGCHighThresholdPercent,
     image_gc_low_threshold_percent: ImageGCLowThresholdPercent,
     provider_id: Url,
-    log_level: u8,
+    log_level: KubeletLogLevel,
     credential_providers: HashMap<Identifier, CredentialProvider>,
     server_certificate: ValidBase64,
     server_key: ValidBase64,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2463

**Description of changes:**

Background: we have had challenges validating non-string values such as numeric ranges. See:
- https://github.com/bottlerocket-os/bottlerocket/pull/2527#discussion_r1007653722
- https://github.com/bottlerocket-os/bottlerocket/pull/2527#issuecomment-1295126294
- #2257 
- https://github.com/bottlerocket-os/bottlerocket/pull/2460#discussion_r981182921
- Enabled by #2559

**Testing done:**

- Ran a k8s variant with `log-level=255`. Boot failed with `[    9.093943] early-boot-config[1489]: Error PATCHing '/settings?tx=bottlerocket-launch': Status 400 when PATCHing /settings?tx=bottlerocket-launch: Json deserialize error: Unable to deserialize into KubeletLogLevel: KubeletLogLevel value '255' is invalid, should be 0-8 at line 1 column 62`
- Ran a k8s variant with `log-level=8`. Succeeded. Checked `/etc/systemd/system/kubelet.service.d/exec-start.conf` and saw `-v 8`.
- Ran a k8s variant with `log-level=0`. Succeeded. Checked /etc/systemd/system/kubelet.service.d/exec-start.conf and saw `-v 0`. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
