### PR TITLE
provide a better way to model enums in settings

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2972,6 +2972,7 @@ version = "0.1.0"
 dependencies = [
  "generate-readme",
  "serde",
+ "serde_plain",
 ]
 
 [[package]]
@@ -2984,6 +2985,7 @@ dependencies = [
  "quote",
  "scalar",
  "serde",
+ "serde_plain",
  "syn",
 ]
 

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -9,11 +9,9 @@ embedded lists.  The structure and names of fields in the document can be found
 */
 use constants;
 use log::debug;
-use model::modeled_types::ECSImagePullBehavior;
 use serde::Serialize;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{OptionExt, ResultExt};
-use std::convert::TryFrom;
 use std::fs;
 use std::path::Path;
 use std::{env, process};
@@ -124,10 +122,7 @@ async fn run() -> Result<()> {
             .collect(),
         spot_instance_draining_enabled: ecs.enable_spot_instance_draining,
         warm_pools_support: autoscaling.should_wait,
-        image_pull_behavior: ecs
-            .image_pull_behavior
-            .as_ref()
-            .map(|b| ECSImagePullBehavior::try_from(b.as_ref()).unwrap() as u8),
+        image_pull_behavior: ecs.image_pull_behavior.as_ref().map(|b| b.as_u8()),
 
         // Task role support is always enabled
         task_iam_role_enabled: true,

--- a/sources/models/scalar-derive/Cargo.toml
+++ b/sources/models/scalar-derive/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro2 = "1"
 quote = "1"
 scalar = { path = "../scalar", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
+serde_plain = "1"
 syn = { version = "1", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
 
 [build-dependencies]

--- a/sources/models/scalar/Cargo.toml
+++ b/sources/models/scalar/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 serde = "1"
+serde_plain = "1"
 
 [build-dependencies]
 generate-readme = { path = "../../generate-readme", version = "0.1.0" }

--- a/sources/models/scalar/src/lib.rs
+++ b/sources/models/scalar/src/lib.rs
@@ -188,3 +188,9 @@ impl Error for ValidationError {
         self.source.as_ref().map(|e| e.as_ref() as &(dyn Error))
     }
 }
+
+impl From<serde_plain::Error> for ValidationError {
+    fn from(e: serde_plain::Error) -> Self {
+        ValidationError::new_with_cause("Unable to convert from string", e)
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Provides a solution for #1501 
Follows the work of #2559

It doesn't close the issue because we have plenty of additional enums to convert after this PR.

**Description of changes:**

See `sources/models/src/modeled_types/ecs.rs` to understand why. This PR:

- Makes a small change to the datastore to support enum values.
- Augments the `Scalar` derive macro to generate some basic string conveniences for enum types.
- Eliminates the unnecessary `SomeStruct{ inner: String }` wrappers for the two enums found in `aws-ecs-1`.
- Doesn't convert modeled enums in other variants yet to limit blast radius.

# Testing done:

## Baseline with Good Values

I ran the latest production ECS ami, `ami-08cf4a2f9255f1cfb`

with this userdata:

```toml
[settings.ecs]
image-pull-behavior="once"
loglevel="warn"
```

Things I checked:

- `cat /etc/os-release` -> `VERSION="1.11.0 (aws-ecs-1)"` and `BUILD_ID=b530f308`
- ✅ `cat /etc/ecs/ecs.config` had `ECS_LOGLEVEL="warn"`
- ✅ `cat /etc/ecs/ecs.config.json` had `"ImagePullBehavior":2`
- ✅ `apiclient get settings.ecs.loglevel` -> `warn`
- ✅ `apiclient get settings.ecs.image-pull-behavior` -> `once`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/loglevel` -> `"warn"`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/image-pull-behavior` -> `"once"`
- ✅ `apiclient set settings.ecs.loglevel=badvalue` -> Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error deserializing scalar value: Unable to deserialize into ECSAgentLogLevel: Invalid input for field ecs.loglevel: unknown variant `badvalue`, expected one of `debug`, `info`, `warn`, `error`, `crit`
- ✅ `apiclient set settings.ecs.image-pull-behavior=badvalue` -> Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error deserializing scalar value: Unable to deserialize into ECSAgentImagePullBehavior: Invalid input for field ecs.image_pull_behavior: unknown variant `badvalue`, expected one of `default`, `always`, `once`, `prefer-cached`
- ✅ `apiclient set settings.ecs.loglevel=crit` -> Ok
- ✅ `cat /etc/ecs/ecs.config` had `ECS_LOGLEVEL="crit"`
- ✅ `apiclient get settings.ecs.loglevel` -> `crit`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/loglevel` -> `"crit"`
- ✅ `apiclient set settings.ecs.image-pull-behavior=prefer-cached` -> Ok
- ✅ `cat /etc/ecs/ecs.config.json` had `"ImagePullBehavior":3`
- ✅ `apiclient get settings.ecs.image-pull-behavior` -> `prefer-cached`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/image-pull-behavior` -> `"prefer-cached"`

## Baseline with a Bad Value

I ran the latest production ECS ami, `ami-08cf4a2f9255f1cfb`

with this userdata:

```toml
[settings.ecs]
image-pull-behavior="foo"
```

Failed boot as expected with:

```text
[    4.584971] early-boot-config[1492]: Error PATCHing '/settings?tx=bottlerocket-launch': Status 400 when PATCHing /settings?tx=bottlerocket-launch: Json deserialize error: Unable to deserialize into ECSAgentImagePullBehavior: Invalid input for field ecs.image_pull_behavior: unknown variant `foo`, expected one of `default`, `always`, `once`, `prefer-cached` at line 1 column 97
```

## My Changes with Good Values

I built and ran an ami from this PR (git commit 7060c7f)

with this userdata:

```toml
[settings.ecs]
image-pull-behavior="once"
loglevel="warn"
```

Things I checked:

- `cat /etc/os-release` -> `VERSION="1.12.0 (aws-ecs-1)"` and `BUILD_ID=7060c7f1`
- ✅ `cat /etc/ecs/ecs.config` had `ECS_LOGLEVEL="warn"`
- ✅ `cat /etc/ecs/ecs.config.json` had `"ImagePullBehavior":2`
- ✅ `apiclient get settings.ecs.loglevel` -> `warn`
- ✅ `apiclient get settings.ecs.image-pull-behavior` -> `once`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/loglevel` -> `"warn"`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/image-pull-behavior` -> `"once"`
- ✅ `apiclient set settings.ecs.loglevel=badvalue` -> Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error deserializing scalar value: unknown variant `badvalue`, expected one of `debug`, `info`, `warn`, `error`, `crit` at line 1 column 10
- ✅ `apiclient set settings.ecs.image-pull-behavior=badvalue` -> Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error deserializing scalar value: unknown variant `badvalue`, expected one of `default`, `always`, `once`, `prefer-cached` at line 1 column 10
- ✅ `apiclient set settings.ecs.loglevel=crit` -> Ok
- ✅ `cat /etc/ecs/ecs.config` had `ECS_LOGLEVEL="crit"`
- ✅ `apiclient get settings.ecs.loglevel` -> `crit`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/loglevel` -> `"crit"`
- ✅ `apiclient set settings.ecs.image-pull-behavior=prefer-cached` -> Ok
- ✅ `cat /etc/ecs/ecs.config.json` had `"ImagePullBehavior":3`
- ✅ `apiclient get settings.ecs.image-pull-behavior` -> `prefer-cached`
- ✅ `cat /var/lib/bottlerocket/datastore/current/live/settings/ecs/image-pull-behavior` -> `"prefer-cached"`


## My Changes with a Bad Value

I built and ran an ami from this PR (git commit 7060c7f)

with this userdata:

```toml
[settings.ecs]
image-pull-behavior="foo"
```

The console log had this:

```
[    7.364864] early-boot-config[1488]: Error PATCHing '/settings?tx=bottlerocket-launch': Status 400 when PATCHing /settings?tx=bottlerocket-launch: Json deserialize error: unknown variant `foo`, expected one of `default`, `always`, `once`, `prefer-cached` at line 1 column 96
```

## Using the Macro with an Ineligble Enum

The macro should not be used with enums that carry data.
The macro enforces this with a (hopefully) helpful message.

This enum:

```rust
#[derive(Debug, PartialEq, Serialize, Deserialize, Scalar)]
pub enum Broken {
    ThisIsFine,
    ThisIsAStruct { a: u8, b: u8 },
}
```

Results in this error:

```text
The enum 'Broken' cannot be used with the Scalar derive macro because it has non unit variants. No variants in the enum should carry any data. The 'ThisIsAStruct' variant was found to have one or more fields.
```

And this enum:

```rust
#[derive(Debug, PartialEq, Serialize, Deserialize, Scalar)]
pub enum Weeee {
    ThisIsFine,
    ThisIsAString(String),
}
```

```text
The enum 'Weeee' cannot be used with the Scalar derive macro because it has non unit variants. No variants in the enum should carry any data. The 'ThisIsAString' variant was found to have one or more fields.
```

## Downgrade Upgrade Test

- I ran an AMI from this PRs changes (ed52fc15) with .ecs.loglevel=warn and image-pull-behavior="once"
- Logged in and check the values in the config files and api server
- I downgraded to v1.10.1
- Logged in and check the values in the config files and api server
- I upgraded back to v1.99.0 (i.e. this PR)
- Logged in and check the values in the config files and api server
- I Ran a simple ECS task and it succeeded

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
