### PR TITLE
Remove use of io/ioutil in go code

### DIFF
--- a/sources/ecs-gpu-init/cmd/ecs-gpu-init/main.go
+++ b/sources/ecs-gpu-init/cmd/ecs-gpu-init/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -80,7 +79,7 @@ func writeGPUInfo(version string, gpuIDs []string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(NvidiaGPUInfoFilePath, nvidiaInfoJSON, 0700)
+	return os.WriteFile(NvidiaGPUInfoFilePath, nvidiaInfoJSON, 0700)
 }
 
 // getDeviceUUID returns the UUID for the GPU at index `id`

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -43,7 +43,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 	// Dispatch logging output instead of writing all levels' messages to
 	// stderr.
-	log.L.Logger.SetOutput(ioutil.Discard)
+	log.L.Logger.SetOutput(io.Discard)
 	log.L.Logger.AddHook(&LogSplitHook{os.Stdout, []logrus.Level{
 		logrus.WarnLevel, logrus.InfoLevel, logrus.DebugLevel, logrus.TraceLevel}})
 	log.L.Logger.AddHook(&LogSplitHook{os.Stderr, []logrus.Level{

--- a/sources/host-ctr/cmd/host-ctr/registry.go
+++ b/sources/host-ctr/cmd/host-ctr/registry.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
-	"io/ioutil"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -36,7 +36,7 @@ type RegistryConfig struct {
 
 // NewRegistryConfig unmarshalls a registry configuration file and sets up a RegistryConfig
 func NewRegistryConfig(registryConfigFile string) (*RegistryConfig, error) {
-	raw, err := ioutil.ReadFile(registryConfigFile)
+	raw, err := os.ReadFile(registryConfigFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The `io/ioutil` package was [deprecated in Go 1.16](https://go.dev/doc/go1.16#ioutil). Since we now use go 1.19 it is safe to migrate away from the deprecated modules so there are no issues once they are actually removed.

This updates the few instances we had where we were importing and using `io/ioutil`.

**Testing done:**

Built code.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
