### PR TITLE
docs: Add example of mounting API socket

### DIFF
--- a/sources/api/README.md
+++ b/sources/api/README.md
@@ -28,6 +28,26 @@ It's available in Bottlerocket, whether you're accessing it through a control ch
 
 Rust code can use the `apiclient` library to make requests to the Unix-domain socket of the [apiserver](#apiserver).
 
+The API socket can be mounted and accessed from a privileged container.
+An example pod specification to expose API access would be similar to:
+
+```yaml
+containers:
+- name: my-api-access
+  image: my-api-access
+  volumeMounts:
+  - name: socket
+    mountPath: /run/api.sock
+  privileged: true
+volumes:
+- name: socket
+  hostPath:
+  path: /run/api.sock
+```
+
+**NOTE:** There are some security considerations that you should be aware of when running privileged containers.
+Refer to the [Security Guidance](https://github.com/bottlerocket-os/bottlerocket/blob/develop/SECURITY_GUIDANCE.md#restrict-access-to-the-host-api-socket) notes for more details.
+
 ## API system components
 
 ![API system boot diagram](api-system.png)


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds a small example to the API docs to show how a pod would need to be defined in order to access the API socket. We mention it in a couple places in the docs, but there are no concrete examples of how this is accomplished.

**Testing done:**

Viewed rendered output of markdown changes.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
