### PR TITLE
Go: implements golangci-lint makefile target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,9 @@ jobs:
           EOF
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} unit-tests
       - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-fmt
-      - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-lints
+      # Avoid running Go lint check via `cargo make check-lints` since there's a separate golangci-lint workflow
+      - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-clippy
+      - run: cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} check-shell
       - run: |
           cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} \
             -e BUILDSYS_ARCH=${{ matrix.arch }} \

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,29 @@
+name: golangci-lint
+on:
+  pull_request:
+    branches: [develop]
+    # Only run this workflow if Go files have been modified
+    paths:
+      - '**.go'
+      - '*/go.mod'
+      - '*/go.sum'
+
+jobs:
+  golangci-lint:
+    name: lint
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - name: lint-host-ctr
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: sources/host-ctr
+      - name: lint-ecs-gpu-init
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: sources/ecs-gpu-init

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+linters:
+  enable:
+    - errcheck
+    - goimports
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+    - vet
+
+run:
+  timeout: 3m
+  skip-dirs:
+    - vendor
+    - .gomodcache

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -349,7 +349,7 @@ dependencies = [
    "unit-tests",
    "check-fmt",
    "check-lints",
-   ]
+]
 
 [tasks.check-fmt]
 script = [
@@ -402,6 +402,7 @@ fi
 dependencies = [
    "check-clippy",
    "check-shell",
+   "check-golangci-lint",
 ]
 
 [tasks.check-clippy]
@@ -461,6 +462,25 @@ if [ "${rc}" -ne 0 ]; then
   exit $rc
 fi
 '''
+]
+
+[tasks.check-golangci-lint]
+script = [
+'''
+top_path=$(pwd)
+config_path="${top_path}/.golangci.yaml"
+
+for m in ${GO_MODULES}; do
+    cd "sources/${m}"
+    mod_name=$(pwd)
+    docker run --rm \
+        -v "${mod_name}":/"${mod_name}" \
+        -v "${config_path}":/"${config_path}" \
+        -w /"${mod_name}" \
+        golangci/golangci-lint \
+        golangci-lint run --config "${config_path}"
+    cd "${top_path}"
+done'''
 ]
 
 [tasks.build-tools]

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -475,7 +475,7 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 
 	// Return error if container exists with non-zero status
 	if code != 0 {
-		return errors.New(fmt.Sprintf("Container %s exited with non-zero status", containerID))
+		return fmt.Errorf("Container %s exited with non-zero status", containerID)
 	}
 
 	return nil
@@ -714,14 +714,14 @@ func withDefaultMounts(containerID string, persistentDir string) oci.SpecOpts {
 		// Bottlerocket release information for the container
 		{
 			Options:     []string{"bind", "ro"},
-			Destination: fmt.Sprintf("/etc/bottlerocket-release"),
-			Source:      fmt.Sprintf("/etc/os-release"),
+			Destination: "/etc/bottlerocket-release",
+			Source:      "/etc/os-release",
 		},
 		// Bottlerocket RPM inventory available to the container
 		{
 			Options:     []string{"bind", "ro"},
-			Destination: fmt.Sprintf("/var/lib/bottlerocket/inventory/application.json"),
-			Source:      fmt.Sprintf("/usr/share/bottlerocket/application-inventory.json"),
+			Destination: "/var/lib/bottlerocket/inventory/application.json",
+			Source:      "/usr/share/bottlerocket/application-inventory.json",
 		},
 		// Bottlerocket logs
 		{
@@ -871,15 +871,15 @@ func withProxyEnv() oci.SpecOpts {
 	noOp := func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error { return nil }
 	httpsProxy, httpsProxySet := os.LookupEnv("HTTPS_PROXY")
 	noProxy, noProxySet := os.LookupEnv("NO_PROXY")
-	withHttpsProxy := noOp
+	withHTTPSProxy := noOp
 	withNoProxy := noOp
 	if httpsProxySet {
-		withHttpsProxy = oci.WithEnv([]string{"HTTPS_PROXY=" + httpsProxy, "https_proxy=" + httpsProxy})
+		withHTTPSProxy = oci.WithEnv([]string{"HTTPS_PROXY=" + httpsProxy, "https_proxy=" + httpsProxy})
 	}
 	if noProxySet {
 		withNoProxy = oci.WithEnv([]string{"NO_PROXY=" + noProxy, "no_proxy=" + noProxy})
 	}
-	return oci.Compose(withHttpsProxy, withNoProxy)
+	return oci.Compose(withHTTPSProxy, withNoProxy)
 }
 
 // pullImage pulls an image from the specified source.

--- a/sources/host-ctr/cmd/host-ctr/main_test.go
+++ b/sources/host-ctr/cmd/host-ctr/main_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // Test RegistryHosts with valid endpoints URLs


### PR DESCRIPTION
**Issue number:**

Closes - n/a

Related to reviewing: https://github.com/bottlerocket-os/bottlerocket/pull/2604

**Description of changes:**

```
Go: implements golangci-lint makefile target & GitHub actions workflow

Now, when `cargo make check-lints` is run, golangci-lint will run on
all go modules via docker with a `.golangci.yaml` config file.

Adds workflow for Go linting when Go files change.

Avoids running Go lints in our GitHub actions build.

Fixes the following Go linting errors:
- Unnecessary `fmt.Sprintf`
- Fix `Https` var name with `HTTPS`
- Fix un-`goimports`-ed test file

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

**Testing done:**

Able to `cargo make` and run golangci-lint with `cargo make check-golangci-lint` or `cargo make check-lints`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
