### PR TITLE
systemd: add patch for CVE-2022-3821

### DIFF
--- a/packages/systemd/0002-time-util-fix-buffer-over-run.patch
+++ b/packages/systemd/0002-time-util-fix-buffer-over-run.patch
@@ -1,0 +1,43 @@
+From 9102c625a673a3246d7e73d8737f3494446bad4e Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Thu, 7 Jul 2022 18:27:02 +0900
+Subject: [PATCH] time-util: fix buffer-over-run
+
+Fixes #23928.
+---
+ src/basic/time-util.c     | 2 +-
+ src/test/test-time-util.c | 5 +++++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/basic/time-util.c b/src/basic/time-util.c
+index abbc4ad5cd..26d59de123 100644
+--- a/src/basic/time-util.c
++++ b/src/basic/time-util.c
+@@ -591,7 +591,7 @@ char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
+                         t = b;
+                 }
+ 
+-                n = MIN((size_t) k, l);
++                n = MIN((size_t) k, l-1);
+ 
+                 l -= n;
+                 p += n;
+diff --git a/src/test/test-time-util.c b/src/test/test-time-util.c
+index e8e4e2a67b..58c5fa9be4 100644
+--- a/src/test/test-time-util.c
++++ b/src/test/test-time-util.c
+@@ -238,6 +238,11 @@ TEST(format_timespan) {
+         test_format_timespan_accuracy(1);
+         test_format_timespan_accuracy(USEC_PER_MSEC);
+         test_format_timespan_accuracy(USEC_PER_SEC);
++
++        /* See issue #23928. */
++        _cleanup_free_ char *buf;
++        assert_se(buf = new(char, 5));
++        assert_se(buf == format_timespan(buf, 5, 100005, 1000));
+ }
+ 
+ TEST(verify_timezone) {
+-- 
+2.37.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -16,6 +16,9 @@ Source4: issue
 # Add fix for glibc 2.36+
 Patch0001: 0001-glibc-Remove-include-linux-fs.h-to-resolve-fsconfig_.patch
 
+# Upstream patch for CVE-2022-3821
+Patch0002: 0002-time-util-fix-buffer-over-run.patch
+
 # Local patch to work around the fact that /var is a bind mount from
 # /local/var, and we want the /local/var/run symlink to point to /run.
 Patch9001: 9001-use-absolute-path-for-var-run-symlink.patch


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:**
This backports [this commit](https://github.com/systemd/systemd/commit/9102c625a673a3246d7e73d8737f3494446bad4e) from systemd to version `250.4`.


**Testing done:** Basic validation of behavior of the `aws-k8s-1.23` variant.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
