### PR TITLE
Add default labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/build.md
+++ b/.github/ISSUE_TEMPLATE/build.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report - build process
 about: Let us know about a problem with the build process
+labels: status/needs-triage, type/bug
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Request a change to to the project
+labels: status/needs-triage, type/enhancement
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/image.md
+++ b/.github/ISSUE_TEMPLATE/image.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report - Bottlerocket image
 about: Let us know about a problem with Bottlerocket
+labels: status/needs-triage, type/bug
 ---
 
 <!--


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds the `status/needs-triage` label to all issues and `type/bug` or `type/enhancement` to their respective issue types. This allows us to clearly mark new issues as needing triage and helps us start to categorize the types of issues being filed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
