### PR TITLE
testsys: Change `tuf_metadata` to `tuf_repo_config`

### DIFF
--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -239,7 +239,7 @@ pub(crate) fn migration_crd(migration_input: MigrationInput) -> Result<Test> {
         .aws_region_template(cluster_resource_name, "region")
         .instance_ids_template(bottlerocket_resource_name, "ids")
         .migrate_to_version(migration_version)
-        .tuf_repo(migration_input.crd_input.tuf_metadata())
+        .tuf_repo(migration_input.crd_input.tuf_repo_config())
         .assume_role(migration_input.crd_input.config.agent_role.clone())
         .resources(bottlerocket_resource_name)
         .resources(cluster_resource_name)

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -30,8 +30,8 @@ pub struct CrdInput<'a> {
 }
 
 impl<'a> CrdInput<'a> {
-    /// Retrieve the TUF metadata from `Infra.toml`
-    pub fn tuf_metadata(&self) -> Option<TufRepoConfig> {
+    /// Retrieve the TUF repo information from `Infra.toml`
+    pub fn tuf_repo_config(&self) -> Option<TufRepoConfig> {
         if let (Some(metadata_base_url), Some(targets_url)) = (
             &self.repo_config.metadata_base_url,
             &self.repo_config.targets_url,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

The original function name `tuf_metadata` could be confused to return the `metadata_base_url` instead of the config for a tuf repo.

**Testing done:**

Code builds.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
