### PR TITLE
Update EKS-D to 1.23.9

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,7 +14,7 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/8/artifacts/kubernetes/v1.23.13/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/9/artifacts/kubernetes/v1.23.13/kubernetes-src.tar.gz"
 sha512 = "cee0c56f8af66c87f3d7d1873844ee180210fbccfbd7fbaf1338646073691b7fd3a2ece584682f084689ca40e9a1c325dc0d969a63bea09636cff79643c62f72"
 
 # RPM BuildRequires


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2627 

**Description of changes:**
Modify the artifact path to match the newest version of EKS-D. Kubernetes itself was not bumped during the release so the sha and versions remain the same.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
