### PR TITLE
Update EKS-D to 1.24.4

### DIFF
--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -14,9 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.24"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/3/artifacts/kubernetes/v1.24.6/kubernetes-src.tar.gz"
-sha512 = "6321c63199eef1a50e45ea4eec5e68925d2441091eac14ead7750a05dcf685c4392770d133739995b876e7f5a24bed98ca20f56956e56d12b26b7ec7c75d34fa"
-
+url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/4/artifacts/kubernetes/v1.24.7/kubernetes-src.tar.gz"
+sha512 = "179571a08738a42f6097844b01edbf5cf243e63efe9cc4c2a66de9090a57302c6e8f87e96d1fb3aba536f837210b6e7c0b7879722aba60f961084a3bfc01c537"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.24.6
+%global gover 1.24.7
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2629 

**Description of changes:**
Update EKS-D from 1.24.3 to 1.24.4. Update Kubernetes from 1.24.6 to 1.24.7


**Testing done:**
```
$ kubectl get nodes
NAME                                           STATUS   ROLES    AGE   VERSION
ip-192-168-17-167.us-west-2.compute.internal   Ready    <none>   24m   v1.24.7-eks-ebf40a6
ip-192-168-39-213.us-west-2.compute.internal   Ready    <none>   24m   v1.24.7-eks-ebf40a6
```
(@etungsten): Ran `sonobuoy run --mode=conformance-lite` and passed K8s conformance tests:
```
...
16:28:41       e2e   global   complete   passed   Passed:147, Failed:  0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
