### PR TITLE
migrator: keep only one intermediate datastore

### DIFF
--- a/sources/api/migration/migrator/src/test.rs
+++ b/sources/api/migration/migrator/src/test.rs
@@ -5,7 +5,7 @@ use crate::run;
 use chrono::{DateTime, Utc};
 use semver::Version;
 use std::fs;
-use std::fs::File;
+use std::fs::{DirEntry, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -26,6 +26,28 @@ fn root() -> PathBuf {
         .unwrap()
 }
 
+enum TestType {
+    /// The test will raise an error in the last migration when running forward.
+    ForwardFailure,
+    /// The test will raise an error in the last migration when running backward.
+    BackwardFailure,
+    /// The test is not expected to raise an error in migrator.
+    Success,
+}
+
+impl TestType {
+    fn migration_names(&self) -> Vec<String> {
+        match self {
+            TestType::ForwardFailure => [FIRST_MIGRATION, SECOND_MIGRATION, FAILING_MIGRATION],
+            TestType::BackwardFailure => [FAILING_MIGRATION, SECOND_MIGRATION, THIRD_MIGRATION],
+            TestType::Success => [FIRST_MIGRATION, SECOND_MIGRATION, THIRD_MIGRATION],
+        }
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+}
+
 /// Returns the filepath to a private key, stored in tree and used only for testing.
 fn pem() -> PathBuf {
     test_data().join("snakeoil.pem").canonicalize().unwrap()
@@ -37,6 +59,12 @@ const FIRST_MIGRATION: &str = "b-first-migration";
 /// The name of a test migration. The prefix `a-` ensures we are not alphabetically sorting.
 const SECOND_MIGRATION: &str = "a-second-migration";
 
+/// The name of another test migration.
+const THIRD_MIGRATION: &str = "third-migration";
+
+/// A migration that will fail and exit with a non-zero code.
+const FAILING_MIGRATION: &str = "failing-migration";
+
 /// Creates a script that will serve as a migration during testing. The script writes its migrations
 /// name to a file named `result.txt` in the parent directory of the datastore. `pentacle` does not
 /// retain the name of the executing binary or script, so we take the `migration_name` as input,
@@ -47,8 +75,14 @@ fn create_test_migration<S: AsRef<str>>(migration_name: S) -> String {
 set -eo pipefail
 migration_name="{}"
 datastore_parent_dir="$(dirname "${{3}}")"
+target_datastore="$5"
 outfile="${{datastore_parent_dir}}/result.txt"
 echo "${{migration_name}}:" "${{@}}" >> "${{outfile}}"
+mkdir -p $5
+if [[ "${{migration_name}}" = "failing-migration" ]]; then
+  >&2 echo "this migration is supposed to fail: exit 1"
+  exit 1
+fi
 "#,
         migration_name.as_ref()
     )
@@ -94,7 +128,7 @@ fn compress(source: &[u8], destination: &Path) {
 
 /// Creates a test repository with a couple of versions defined in the manifest and a couple of
 /// migrations. See the test description for for more info.
-fn create_test_repo() -> TestRepo {
+fn create_test_repo(test_type: TestType) -> TestRepo {
     // This is where the signed TUF repo will exist when we are done. It is the
     // root directory of the `TestRepo` we will return when we are done.
     let test_repo_dir = TempDir::new().unwrap();
@@ -111,9 +145,10 @@ fn create_test_repo() -> TestRepo {
     // later than the second migration alphabetically. this is to help ensure that migrations
     // are running in their listed order (rather than sorted order as in previous
     // implementations).
+    let migration_names = test_type.migration_names();
     manifest.migrations.insert(
         (Version::new(0, 99, 0), Version::new(0, 99, 1)),
-        vec![FIRST_MIGRATION.into(), SECOND_MIGRATION.into()],
+        migration_names.clone(),
     );
     update_metadata::write_file(tuf_indir.join("manifest.json").as_path(), &manifest).unwrap();
 
@@ -123,12 +158,12 @@ fn create_test_repo() -> TestRepo {
     // order. Note that tests are sensitive to the order and number of arguments passed. If
     // --source-datastore is given at a different position then the tests will fail and the script
     // will need to be updated.
-    let migration_a = create_test_migration(FIRST_MIGRATION);
-    let migration_b = create_test_migration(SECOND_MIGRATION);
-
-    // Save lz4 compressed copies of the migration script into the tuftool_indir.
-    compress(migration_a.as_bytes(), &tuf_indir.join(FIRST_MIGRATION));
-    compress(migration_b.as_bytes(), &tuf_indir.join(SECOND_MIGRATION));
+    for migration_name in &migration_names {
+        // Create a script to use as a migration.
+        let data = create_test_migration(migration_name);
+        // Save an lz4 compressed copy of the migration script into the tuftool_indir.
+        compress(data.as_bytes(), &tuf_indir.join(migration_name))
+    }
 
     // Create and sign the TUF repository.
     let mut editor = tough::editor::RepositoryEditor::new(root()).unwrap();
@@ -182,6 +217,112 @@ fn create_test_repo() -> TestRepo {
     }
 }
 
+/// Asserts that the expected directories and files are in the datastore directory after a
+/// failed migration. Returns the absolute path that the `current` symlink is pointing to.
+fn assert_directory_structure_with_failed_migration(
+    dir: &Path,
+    from: &Version,
+    to: &Version,
+) -> PathBuf {
+    let dir_entries: Vec<DirEntry> = fs::read_dir(dir)
+        .unwrap()
+        .map(|item| item.unwrap())
+        .collect();
+
+    let from_ver = format!("v{}", from);
+    let from_ver_unique_prefix = format!("v{}_", from);
+    let to_ver_unique_prefix = format!("v{}_", to);
+
+    assert_eq!(dir_entries.len(), 8);
+    assert_dir_entry_exists(&dir_entries, "current");
+    assert_dir_entry_exists(&dir_entries, "result.txt");
+    assert_dir_entry_exists(&dir_entries, "v0");
+    assert_dir_entry_exists(&dir_entries, "v0.99");
+    assert_dir_entry_exists(&dir_entries, &from_ver);
+    assert_dir_starting_with_exists(&dir_entries, &from_ver_unique_prefix);
+
+    // There are two datastores that start with the target version followed by an underscore. This
+    // is because the datastore we intended to promote (target_datastore) and one intermediate
+    // datastore are expected to be left behind for debugging after a migration failure.
+    let left_behind_count = dir_entries
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .path()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with(&to_ver_unique_prefix)
+                .then(|| ())
+        })
+        .collect::<Vec<()>>()
+        .len();
+
+    assert_eq!(
+        left_behind_count, 2,
+        "expected 2 directories to be left behind after migration failure, but found {}",
+        left_behind_count
+    );
+
+    let symlink = dir_entries
+        .iter()
+        .find(|entry| entry.path().file_name().unwrap().to_str().unwrap() == "current")
+        .unwrap()
+        .path();
+    symlink.canonicalize().unwrap()
+}
+
+/// Asserts that the expected directories and files are in the datastore directory after a
+/// successful migration. Returns the absolute path that the `current` symlink is pointing to.
+fn assert_directory_structure(dir: &Path) -> PathBuf {
+    let dir_entries: Vec<DirEntry> = fs::read_dir(dir)
+        .unwrap()
+        .map(|item| item.unwrap())
+        .collect();
+
+    assert_eq!(dir_entries.len(), 8);
+    assert_dir_entry_exists(&dir_entries, "current");
+    assert_dir_entry_exists(&dir_entries, "result.txt");
+    assert_dir_entry_exists(&dir_entries, "v0");
+    assert_dir_entry_exists(&dir_entries, "v0.99");
+    assert_dir_entry_exists(&dir_entries, "v0.99.0");
+    assert_dir_entry_exists(&dir_entries, "v0.99.1");
+    assert_dir_starting_with_exists(&dir_entries, "v0.99.0_");
+    assert_dir_starting_with_exists(&dir_entries, "v0.99.1_");
+
+    let symlink = dir_entries
+        .iter()
+        .find(|entry| entry.path().file_name().unwrap().to_str().unwrap() == "current")
+        .unwrap()
+        .path();
+    symlink.canonicalize().unwrap()
+}
+
+fn assert_dir_entry_exists(dir_entries: &[DirEntry], exact_name: &str) {
+    assert!(
+        dir_entries
+            .iter()
+            .any(|entry| entry.path().file_name().unwrap().to_str().unwrap() == exact_name),
+        "'{}' not found",
+        exact_name
+    );
+}
+
+fn assert_dir_starting_with_exists(dir_entries: &[DirEntry], starts_with: &str) {
+    assert!(
+        dir_entries.iter().any(|entry| entry
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with(starts_with)),
+        "entry starting with '{}' not found",
+        starts_with
+    );
+}
+
 /// Tests the migrator program end-to-end using the `run` function. Creates a TUF repo in a
 /// tempdir which includes a  `manifest.json` with a couple of migrations:
 /// ```
@@ -201,7 +342,7 @@ fn migrate_forward() {
     let from_version = Version::parse("0.99.0").unwrap();
     let to_version = Version::parse("0.99.1").unwrap();
     let test_datastore = TestDatastore::new(from_version);
-    let test_repo = create_test_repo();
+    let test_repo = create_test_repo(TestType::Success);
     let args = Args {
         datastore_path: test_datastore.datastore.clone(),
         log_level: log::LevelFilter::Info,
@@ -215,7 +356,7 @@ fn migrate_forward() {
     let output_file = test_datastore.tmp.path().join("result.txt");
     let contents = std::fs::read_to_string(&output_file).unwrap();
     let lines: Vec<&str> = contents.split('\n').collect();
-    assert_eq!(lines.len(), 3);
+    assert_eq!(lines.len(), 4);
     let first_line = *lines.get(0).unwrap();
     let want = format!("{}: --forward", FIRST_MIGRATION);
     let got: String = first_line.chars().take(want.len()).collect();
@@ -224,6 +365,22 @@ fn migrate_forward() {
     let want = format!("{}: --forward", SECOND_MIGRATION);
     let got: String = second_line.chars().take(want.len()).collect();
     assert_eq!(got, want);
+    let third_line = *lines.get(2).unwrap();
+    let want = format!("{}: --forward", THIRD_MIGRATION);
+    let got: String = third_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+
+    // Check the directory.
+    let current = assert_directory_structure(test_datastore.tmp.path());
+
+    // We have successfully migrated so current should be pointing to a directory that starts with
+    // v0.99.1.
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.1"));
 }
 
 /// This test ensures that migrations run when migrating from a newer to an older version.
@@ -233,7 +390,7 @@ fn migrate_backward() {
     let from_version = Version::parse("0.99.1").unwrap();
     let to_version = Version::parse("0.99.0").unwrap();
     let test_datastore = TestDatastore::new(from_version);
-    let test_repo = create_test_repo();
+    let test_repo = create_test_repo(TestType::Success);
     let args = Args {
         datastore_path: test_datastore.datastore.clone(),
         log_level: log::LevelFilter::Info,
@@ -246,13 +403,132 @@ fn migrate_backward() {
     let output_file = test_datastore.tmp.path().join("result.txt");
     let contents = std::fs::read_to_string(&output_file).unwrap();
     let lines: Vec<&str> = contents.split('\n').collect();
-    assert_eq!(lines.len(), 3);
+    assert_eq!(lines.len(), 4);
     let first_line = *lines.get(0).unwrap();
-    let want = format!("{}: --backward", SECOND_MIGRATION);
+    let want = format!("{}: --backward", THIRD_MIGRATION);
     let got: String = first_line.chars().take(want.len()).collect();
     assert_eq!(got, want);
     let second_line = *lines.get(1).unwrap();
+    let want = format!("{}: --backward", SECOND_MIGRATION);
+    let got: String = second_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+    let second_line = *lines.get(2).unwrap();
     let want = format!("{}: --backward", FIRST_MIGRATION);
     let got: String = second_line.chars().take(want.len()).collect();
     assert_eq!(got, want);
+
+    // Check the directory.
+    let current = assert_directory_structure(test_datastore.tmp.path());
+
+    // We have successfully migrated so current should be pointing to a directory that starts with
+    // v0.99.0.
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.0"));
+}
+
+#[test]
+fn migrate_forward_with_failed_migration() {
+    let from_version = Version::parse("0.99.0").unwrap();
+    let to_version = Version::parse("0.99.1").unwrap();
+    let test_datastore = TestDatastore::new(from_version.clone());
+    let test_repo = create_test_repo(TestType::ForwardFailure);
+    let args = Args {
+        datastore_path: test_datastore.datastore.clone(),
+        log_level: log::LevelFilter::Info,
+        migration_directory: test_repo.targets_path.clone(),
+        migrate_to_version: to_version.clone(),
+        root_path: root(),
+        metadata_directory: test_repo.metadata_path.clone(),
+    };
+    let result = run(&args);
+    assert!(result.is_err());
+
+    // the migrations should write to a file named result.txt.
+    let output_file = test_datastore.tmp.path().join("result.txt");
+    let contents = std::fs::read_to_string(&output_file).unwrap();
+    let lines: Vec<&str> = contents.split('\n').collect();
+    assert_eq!(lines.len(), 4);
+    let first_line = *lines.get(0).unwrap();
+    let want = format!("{}: --forward", FIRST_MIGRATION);
+    let got: String = first_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+    let second_line = *lines.get(1).unwrap();
+    let want = format!("{}: --forward", SECOND_MIGRATION);
+    let got: String = second_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+    let third_line = *lines.get(2).unwrap();
+    let want = format!("{}: --forward", FAILING_MIGRATION);
+    let got: String = third_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+
+    // Check the directory.
+    let current = assert_directory_structure_with_failed_migration(
+        test_datastore.tmp.path(),
+        &from_version,
+        &to_version,
+    );
+
+    // We have not successfully migrated to v0.99.1 so we should still be pointing at the "from"
+    // version.
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.0"));
+}
+
+#[test]
+fn migrate_backward_with_failed_migration() {
+    let from_version = Version::parse("0.99.1").unwrap();
+    let to_version = Version::parse("0.99.0").unwrap();
+    let test_datastore = TestDatastore::new(from_version.clone());
+    let test_repo = create_test_repo(TestType::BackwardFailure);
+    let args = Args {
+        datastore_path: test_datastore.datastore.clone(),
+        log_level: log::LevelFilter::Info,
+        migration_directory: test_repo.targets_path.clone(),
+        migrate_to_version: to_version.clone(),
+        root_path: root(),
+        metadata_directory: test_repo.metadata_path.clone(),
+    };
+    let result = run(&args);
+    assert!(result.is_err());
+
+    let output_file = test_datastore.tmp.path().join("result.txt");
+    let contents = std::fs::read_to_string(&output_file).unwrap();
+    let lines: Vec<&str> = contents.split('\n').collect();
+    assert_eq!(lines.len(), 4);
+    let first_line = *lines.get(0).unwrap();
+    let want = format!("{}: --backward", THIRD_MIGRATION);
+    let got: String = first_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+    let second_line = *lines.get(1).unwrap();
+    let want = format!("{}: --backward", SECOND_MIGRATION);
+    let got: String = second_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+    let second_line = *lines.get(2).unwrap();
+    let want = format!("{}: --backward", FAILING_MIGRATION);
+    let got: String = second_line.chars().take(want.len()).collect();
+    assert_eq!(got, want);
+
+    // Check the directory.
+    let current = assert_directory_structure_with_failed_migration(
+        test_datastore.tmp.path(),
+        &from_version,
+        &to_version,
+    );
+
+    // We have not successfully migrated to v0.99.0 so we should still be pointing at the "from"
+    // version.
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.1"));
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2589

**Description of changes:**

```
    If we keep a copy of the datastore for every migration during the
    migrator loop, then we may run out of space. Instead we now keep only
    one intermediate copy.
```


# Testing

In order to facilitate testing, I built a TUF repo that has all Bottlerocket versions and migrations from v1.3.0 to v1.11.1.
I did this by checking out each tag, building, and adding it to the repo.

I proceeded with a "red/green" testing strategy, first reproducing the issue, then proving that my changes fixed it.

Note: without a "repo pivot" there is no way to fix this for downgrading into a version that does not have this migrator change.
Thus, in my testing I did an additional "Green" case (*Green 2*) where I upgraded/downgraded with a recent version.
A recent version will not exhibit the issue, so the additional the *Green 2* case is to ensure there is no regression with downgrades that were already working fine.

## Red

This testing scenario reproduced the issue that we are trying to fix.

I ran a privately built v1.3.0 AMI

```
AMI name bottlerocket-aws-ecs-1-x86_64-v1.3.0-395b459c
AMI_ID=ami-0647b6c6e4e950053
VARIANT_ID=aws-ecs-1
VERSION_ID=1.3.0
BUILD_ID=395b459c
```

I used updog to initiate an update into v1.11.1 and encountered the issue:

```
[    3.438430] migrator[1442]: 19:27:36 [ERROR] Migration stderr: Unable to write to data store: IO error on '/var/lib/bottlerocket/datastore/v1.11.1_sxeUipS10aqU7Z20/live/settings/host-containers/admin/superpowered': No space left on device (os error 28)
[    3.442839] migrator[1442]: Migration returned '1' - stderr: Unable to write to data store: IO error on '/var/lib/bottlerocket/datastore/v1.11.1_sxeUipS10aqU7Z20/live/settings/host-containers/admin/superpowered': No space left on device (os error 28)
[FAILED] Failed to start Bottlerocket data store migrator.
```

## Green

* I build the changes in 8d77db9 and added them to the update repo as v1.99.0.
* I ran the v1.3.0 AMI.
* I ran a simple ECS task.
* I upgraded to v1.99.0. It worked!
* I ran a simple ECS task on v1.99.0.
* I downgraded to v1.3.0
* The downgrade to v1.3.0 failed, as expected since my migrator changes do not exist there.

<!--
The AMI that has my changes:

ami-08280f913e6e314df
8d77db9-dirty

The repo with my changes
metadata-base-url = "https://brigmatt-public-2022-q4.s3-us-west-2.amazonaws.com/test/52a0593c-4abe-45f8-b1c6-43c0d7b49107/metadata/aws-ecs-1/x86_64/"
targets-base-url = "https://brigmatt-public-2022-q4.s3-us-west-2.amazonaws.com/keep/targets/"
-->

## Green 2

This test shows that we can downgrade and upgrade with a version that was already working.
This is a regression test to make sure that upgrade/downgrade with "nearby" versions still works.

* I build the changes in 8d77db9 and added them to the update repo as v1.99.0.
* I ran the v1.99.0.
* I ran a simple ECS task.
* This file exists on the host, (added in v1.10)
  [https://github.com/bottlerocket-os/bottlerocket/blob/8d1ddbb5be6edb6f60ebf34e627403d3ec0108fb/sources/api/migration/migrations/archived/v1.10.0/dns-settings-metadata/src/main.rs#L10]:
  `cat /var/lib/bottlerocket/datastore/current/live/settings/dns.affected-services` -> `["dns"]`
* I downgraded to v1.9.0.
* I ran a simple ECS task on v1.9.0.
* This file does not exist on the host
  (because it was removed by a [migration]
  (https://github.com/bottlerocket-os/bottlerocket/blob/8d1ddbb5be6edb6f60ebf34e627403d3ec0108fb/sources/api/migration/migrations/archived/v1.10.0/dns-settings-metadata/src/main.rs#L10)):
  `cat /var/lib/bottlerocket/datastore/current/live/settings/dns.affected-services` -> `No such file or directory`
* I upgraded to v1.99.0
* I ran a simple ECS task on v1.99.0.
* This file does exist on the host
  (because it was added by a [migration]
  (https://github.com/bottlerocket-os/bottlerocket/blob/8d1ddbb5be6edb6f60ebf34e627403d3ec0108fb/sources/api/migration/migrations/archived/v1.10.0/dns-settings-metadata/src/main.rs#L10)):
  `cat /var/lib/bottlerocket/datastore/current/live/settings/dns.affected-services` -> `["dns"]`




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
