### PR TITLE
kubelet: Restrict access to TLS private key

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -171,4 +171,6 @@ version = "1.12.0"
     "migrate_v1.11.0_public-control-container-v0-6-4.lz4",
 ]
 "(1.11.0, 1.11.1)" = []
-"(1.11.1, 1.12.0)" = []
+"(1.11.1, 1.12.0)" = [
+    "migrate_v1.12.0_k8s-private-pki-path.lz4",
+]

--- a/packages/kubernetes-1.21/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.21/etc-kubernetes-pki.mount
@@ -1,5 +1,5 @@
 [Unit]
-Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+Description=Kubernetes PKI private directory (/etc/kubernetes/pki/private)
 DefaultDependencies=no
 Conflicts=umount.target
 Before=local-fs.target umount.target
@@ -8,7 +8,7 @@ Wants=selinux-policy-files.service
 
 [Mount]
 What=tmpfs
-Where=/etc/kubernetes/pki
+Where=/etc/kubernetes/pki/private
 Type=tmpfs
 Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
 

--- a/packages/kubernetes-1.21/kubelet-config
+++ b/packages/kubernetes-1.21/kubelet-config
@@ -116,7 +116,7 @@ protectKernelDefaults: true
 serializeImagePulls: false
 {{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
 tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
-tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/private/kubelet-server.key"
 {{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}

--- a/packages/kubernetes-1.22/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.22/etc-kubernetes-pki.mount
@@ -1,5 +1,5 @@
 [Unit]
-Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+Description=Kubernetes PKI private directory (/etc/kubernetes/pki/private)
 DefaultDependencies=no
 Conflicts=umount.target
 Before=local-fs.target umount.target
@@ -8,7 +8,7 @@ Wants=selinux-policy-files.service
 
 [Mount]
 What=tmpfs
-Where=/etc/kubernetes/pki
+Where=/etc/kubernetes/pki/private
 Type=tmpfs
 Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
 

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -112,7 +112,7 @@ protectKernelDefaults: true
 serializeImagePulls: false
 {{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
 tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
-tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/private/kubelet-server.key"
 {{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}

--- a/packages/kubernetes-1.23/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.23/etc-kubernetes-pki.mount
@@ -1,5 +1,5 @@
 [Unit]
-Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+Description=Kubernetes PKI private directory (/etc/kubernetes/pki/private)
 DefaultDependencies=no
 Conflicts=umount.target
 Before=local-fs.target umount.target
@@ -8,7 +8,7 @@ Wants=selinux-policy-files.service
 
 [Mount]
 What=tmpfs
-Where=/etc/kubernetes/pki
+Where=/etc/kubernetes/pki/private
 Type=tmpfs
 Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
 

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -114,7 +114,7 @@ protectKernelDefaults: true
 serializeImagePulls: false
 {{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
 tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
-tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/private/kubelet-server.key"
 {{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}

--- a/packages/kubernetes-1.24/etc-kubernetes-pki.mount
+++ b/packages/kubernetes-1.24/etc-kubernetes-pki.mount
@@ -1,5 +1,5 @@
 [Unit]
-Description=Kubernetes PKI directory (/etc/kubernetes/pki)
+Description=Kubernetes PKI private directory (/etc/kubernetes/pki/private)
 DefaultDependencies=no
 Conflicts=umount.target
 Before=local-fs.target umount.target
@@ -8,7 +8,7 @@ Wants=selinux-policy-files.service
 
 [Mount]
 What=tmpfs
-Where=/etc/kubernetes/pki
+Where=/etc/kubernetes/pki/private
 Type=tmpfs
 Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
 

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -113,7 +113,7 @@ protectKernelDefaults: true
 serializeImagePulls: false
 {{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
 tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
-tlsPrivateKeyFile: "/etc/kubernetes/pki/kubelet-server.key"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/private/kubelet-server.key"
 {{else}}
 serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1973,6 +1973,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-private-pki-path"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -25,7 +25,8 @@ members = [
     "api/prairiedog",
 
     # "api/migration/migrations/vX.Y.Z/..."
-    # (all migrations currently archived; replace this line with new ones)
+    # (all previous migrations archived; add new ones after this line)
+    "api/migration/migrations/v1.12.0/k8s-private-pki-path",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "k8s-private-pki-path"
+version = "0.1.0"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+serde_json = "1.0"

--- a/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/src/main.rs
@@ -1,0 +1,81 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use std::process;
+
+const SETTING: &'static str = "configuration-files.kubelet-server-key.path";
+const OLD_VALUE: &'static str = "/etc/kubernetes/pki/kubelet-server.key";
+const NEW_VALUE: &'static str = "/etc/kubernetes/pki/private/kubelet-server.key";
+
+/// We moved the render output location for the kubelet PKI private key to be in a restricted
+/// subdirectory. We need to update this output path in the stored configuration so updated nodes
+/// pick up the change.
+fn run() -> Result<()> {
+    migrate(KubeletServerKey {})
+}
+
+pub struct KubeletServerKey {}
+
+impl KubeletServerKey {
+    fn migrate(&mut self, mut input: MigrationData, action: &'static str) -> Result<MigrationData> {
+        let old_value;
+        let new_value;
+        if action == "upgrade" {
+            old_value = OLD_VALUE;
+            new_value = NEW_VALUE;
+        } else {
+            // Downgrade: everything old is new again
+            old_value = NEW_VALUE;
+            new_value = OLD_VALUE;
+        }
+
+        if let Some(data) = input.data.get_mut(SETTING) {
+            match data {
+                serde_json::Value::String(current_value) => {
+                    if current_value == old_value {
+                        *data = new_value.into();
+                        println!(
+                            "Changed '{}' from {:?} to {:?} on {}",
+                            SETTING, old_value, new_value, action
+                        );
+                    } else {
+                        println!(
+                            "'{}' is already set to {:?}, leaving alone",
+                            SETTING, new_value
+                        );
+                    }
+                }
+                _ => {
+                    println!(
+                        "'{}' is set to non-string value '{}'; KubeletServerKey only handles strings",
+                        SETTING, data
+                    );
+                }
+            }
+        } else {
+            println!("Found no setting '{}'", SETTING);
+        }
+
+        Ok(input)
+    }
+}
+
+impl Migration for KubeletServerKey {
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        self.migrate(input, "upgrade")
+    }
+
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        self.migrate(input, "downgrade")
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/kubernetes-services.toml
+++ b/sources/models/shared-defaults/kubernetes-services.toml
@@ -40,7 +40,7 @@ path = "/etc/kubernetes/pki/kubelet-server.crt"
 template-path = "/usr/share/templates/kubelet-server-crt"
 
 [configuration-files.kubelet-server-key]
-path = "/etc/kubernetes/pki/kubelet-server.key"
+path = "/etc/kubernetes/pki/private/kubelet-server.key"
 template-path = "/usr/share/templates/kubelet-server-key"
 
 [configuration-files.kubelet-exec-start-conf]


### PR DESCRIPTION
**Issue number:**

Closes #2638 

**Description of changes:**

This moves the `tlsPrivateKeyFile` to be under a `private` subdirectory. This allows us to keep the public cert files readable for non-system processes that expect to be able to read them while limiting access to the more sensitive private key.

**Testing done:**

Built and deployed cluster.
Ran `kubectl apply -f job.yaml` with contents of the [kube-bench sample job](https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml) with the exception of commenting out the mount of `/srv/kubernetes`.
Verified job completed successfully and no errors in the `kube-bench` logs:

```txt
...
== Summary total ==
14 checks PASS
0 checks FAIL
37 checks WARN
0 checks INFO
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
