### PR TITLE
actions-workflow: switch to using 32-core github-hosted actions runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64]
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_32-core
     continue-on-error: ${{ matrix.supported }}
     strategy:
       matrix:
@@ -120,7 +122,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - run: rustup default 1.64.0
+      - run: rustup default 1.64.0 && rustup component add rustfmt && rustup component add clippy
       - run: cargo install --version 0.36.0 cargo-make
       - if: contains(matrix.variant, 'nvidia')
         run: |


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

I'll follow up this PR with another PR to add caching to our main `develop` branch so PR branches can use the cache to speed up workflows.

**Issue number:**
N/A

**Description of changes:**
```
    actions-workflow: switch to using 32-core github-hosted actions runners
    
    This switches our build workflow from using self-hosted runners to using
    32-core GitHub-hosted ubuntu runners. Currently they provide comparable
    performance and allow us to more easily use caching.
```

**Testing done:**
In this PR's Actions workflow. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
