### PR TITLE
testsys: Test.toml.example fix

### DIFF
--- a/tools/testsys/Test.toml.example
+++ b/tools/testsys/Test.toml.example
@@ -9,10 +9,10 @@
 repo = "default"
 
 # The registry containing alternate TestSys agent images
-testsys-images-registry = "public.ecr.aws/bottlerocket-test-system"
+testsys-image-registry = "public.ecr.aws/bottlerocket-test-system"
 
 # The URI for the EKS resource agent that should be used. An individual agent's provided URI will be
-# used even if `testsys-images-registry` is present.
+# used even if `testsys-image-registry` is present.
 eks-resource-agent-image = "public.ecr.aws/bottlerocket-test-system/eks_resource_agent:v0.0.2"
 
 # Test Configurations

--- a/tools/testsys/Test.toml.example
+++ b/tools/testsys/Test.toml.example
@@ -49,6 +49,29 @@ eks-resource-agent-image = "public.ecr.aws/bottlerocket-test-system/eks_resource
 # ['aws'.x86_64]
 # ['aws']
 #
+# Configurable values:
+#
+# cluster-names:
+#     All clusters the variant should be tested over. Cluster naming supports templated strings, and
+#     both `arch` and `variant` are provided as variables (`{{arch}}-{{variant}}`).
+#
+# instance-type:
+#     The instance type that should be used for testing.
+#
+# secrets:
+#     A map containing the names of all kubernetes secrets needed for resource creation and testing.
+#
+# agent-role:
+#     The role that should be assumed by each test and resource agent.
+#
+# conformance-image: (K8s only)
+#     Specify a custom image for conformance testing. For `aws-k8s` variants this will be used as a
+#     custom Kubernetes conformance image for Sonobuoy.
+#
+# conformance-registry: (K8s only)
+#     Specify a custom registry for conformance testing images.
+#     For `aws-k8s` variants this will be used as the Sonobuoy e2e registry.
+#
 # Note: values passed by command line argument will take precedence over those passed by environment
 # variable, and both take precedence over values set by `Test.toml`.
 
@@ -94,26 +117,3 @@ instance-type = "g5g.2xlarge"
 # Configuration for only the `aws-k8s-1.21` variant (variant level configuration).
 ["aws-k8s-1.21".aarch64]
 conformance-image = "<KUBERNETES-CONFORMANCE-IMAGE-URI>"
-
-# Configurable values:
-#
-# cluster-names:
-#     All clusters the variant should be tested over. Cluster naming supports templated strings, and
-#     both `arch` and `variant` are provided as variables (`{{arch}}-{{variant}}`).
-#
-# instance-type:
-#     The instance type that should be used for testing.
-#
-# secrets:
-#     A map containing all secrets needed for resource creation and testing.
-#
-# agent-role:
-#     The role that should be assumed by each test and resource agent.
-#
-# conformance-image: (K8s only)
-#     Specify a custom image for conformance testing. For `aws-k8s` variants this will be used as a
-#     custom Kubernetes conformance image for Sonobuoy.
-#
-# conformance-registry: (K8s only)
-#     Specify a custom registry for conformance testing images.
-#     For `aws-k8s` variants this will be used as the Sonobuoy e2e registry.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
The example configuration for Test.toml has a typo for the `testsys-image-registry` field
I also moved the documentation for each configurable field to the top of the file so it's more easily discoverable.


**Testing done:**
If I use `testsys-images-repository`, then I get
```
[cargo-make] INFO - cargo make 0.36.3
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: test
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: test-tools
[cargo-make] INFO - Running Task: test
[2022-12-09T00:17:44Z ERROR testsys] Invalid config file at '/home/etung/bottlerocket_release_scri
pts/Test.toml.cn': unknown field `testsys-images-registry` for key `test` at line 20 column 1
```

After change to `testsys-image-registry` the error goes away.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
