### PR TITLE
Improve reliability of `settings.network.hostname` generator

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2253,10 +2253,12 @@ name = "netdog"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "bottlerocket-variant",
  "dns-lookup",
  "envy",
  "generate-readme",
  "handlebars",
+ "imdsclient",
  "indexmap",
  "ipnet",
  "lazy_static",
@@ -2268,6 +2270,8 @@ dependencies = [
  "serde_plain",
  "snafu",
  "tempfile",
+ "tokio",
+ "tokio-retry",
  "toml",
 ]
 

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["README.md"]
 argh = "0.1.4"
 dns-lookup = "1.0"
 ipnet = { version = "2.0", features = ["serde"] }
+imdsclient = { path = "../../imdsclient", version = "0.1.0" }
 indexmap = { version = "1.8", features = ["serde"]}
 envy = "0.4"
 lazy_static = "1.2"
@@ -22,6 +23,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1.0"
 snafu = "0.7"
+tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
+tokio-retry = "0.3"
 toml = { version = "0.5", features = ["preserve_order"] }
 
 [dev-dependencies]
@@ -29,4 +32,5 @@ tempfile = "3.2.0"
 handlebars = "4.3"
 
 [build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/netdog/build.rs
+++ b/sources/api/netdog/build.rs
@@ -1,3 +1,19 @@
+use bottlerocket_variant::{Variant, VARIANT_ENV};
+
 fn main() {
+    let variant = match Variant::from_env() {
+        Ok(variant) => variant,
+        Err(e) => {
+            eprintln!(
+                "For local builds, you must set the '{}' environment variable so we know \
+                which data provider to build. Valid values are the directories in \
+                models/src/variants/, for example 'aws-ecs-1': {}",
+                VARIANT_ENV, e,
+            );
+            std::process::exit(1);
+        }
+    };
+    variant.emit_cfgs();
+
     generate_readme::from_main().unwrap();
 }

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -75,13 +75,13 @@ enum SubCommand {
     WriteResolvConf(cli::WriteResolvConfArgs),
 }
 
-fn run() -> cli::Result<()> {
+async fn run() -> cli::Result<()> {
     let args: Args = argh::from_env();
     match args.subcommand {
         SubCommand::Install(args) => cli::install::run(args)?,
         SubCommand::Remove(args) => cli::remove::run(args)?,
         SubCommand::NodeIp(_) => cli::node_ip::run()?,
-        SubCommand::GenerateHostname(_) => cli::generate_hostname::run()?,
+        SubCommand::GenerateHostname(_) => cli::generate_hostname::run().await?,
         SubCommand::GenerateNetConfig(_) => cli::generate_net_config::run()?,
         SubCommand::SetHostname(args) => cli::set_hostname::run(args)?,
         SubCommand::PreparePrimaryInterface(_) => cli::prepare_primary_interface::run()?,
@@ -93,8 +93,9 @@ fn run() -> cli::Result<()> {
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
 // https://github.com/shepmaster/snafu/issues/110
-fn main() {
-    if let Err(e) = run() {
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
         eprintln!("{}", e);
         process::exit(1);
     }

--- a/sources/api/sundog/src/main.rs
+++ b/sources/api/sundog/src/main.rs
@@ -350,7 +350,14 @@ where
         // Match on the generator's exit code. This code lays the foundation
         // for handling alternative exit codes from generators.
         match result.status.code() {
-            Some(0) => {}
+            Some(0) => {
+                if !result.stderr.is_empty() {
+                    let cmd_stderr = String::from_utf8_lossy(&result.stderr);
+                    for line in cmd_stderr.lines() {
+                        info!("Setting generator command '{}' stderr: {}", command, line);
+                    }
+                }
+            }
             Some(1) => {
                 return error::FailedSettingGeneratorSnafu {
                     program: generator.as_str(),

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -220,6 +220,12 @@ impl ImdsClient {
         Ok(Some(public_keys))
     }
 
+    /// Gets the hostname from instance metadata.
+    pub async fn fetch_hostname(&mut self) -> Result<Option<String>> {
+        let hostname_target = "meta-data/local-hostname";
+        self.fetch_string(&hostname_target).await
+    }
+
     /// Helper to fetch bytes from IMDS using the pinned schema version.
     async fn fetch_bytes<S>(&mut self, end_target: S) -> Result<Option<Vec<u8>>>
     where


### PR DESCRIPTION
**Issue number:**

Closes #2585
Closes #2600

**Description of Changes:**
Alongside the title, this also introduces improved settings-generator logging from sundog.

```

    netdog: try harder to determine the hostname
    
    Failure scenarios when resolving a host's hostname are common enough to
    cause issues. This adds retries to our DNS queries for the current
    hostname.
    
    On AWS variants, we also attempt to query IMDS as a fallback mechanism.

---

    imdsclient: add method for fetching hostname

---

    sundog: always log settings generators' stderr

```

Just as a note, adding `tokio` and `imdsclient` moves netdog's binary size from `1.4M` -> `1.6M`.

**Testing done:**
I blocked DNS resolution in my Bottlerocket VPC at the network level, then ran `netdog generate-hostname` on the `aws-ecs-1` variant, noting that hostname generation succeeded despite DNS resolution failing.

Note that the first line is output to stderr, and the second to stdout.

```
bash-5.1# netdog generate-hostname
Reverse DNS lookup failed: failed to lookup address information: Temporary failure in name resolution
"ip-192-168-19-221.us-west-2.compute.internal"
```

I also tested sundog logging by attempting to boot with partial DNS blocking and checking the systemd journal:

```
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Sundog started
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Retrieving setting generators
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Retrieving settings values
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] shibaken started
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Received meta-data/services/partition
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] shibaken started
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Connecting to IMDS
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Fetching list of available public keys from IMDS
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Received meta-data/public-keys
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Generating targets to fetch text of available public keys
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Fetching public key (1/1)
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Received meta-data/public-keys/0/openssh-key
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Generating user-data
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Encoding user-data
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Setting generator command 'shibaken' stderr: 23:38:50 [INFO] Outputting base64-encoded user-data
Dec 09 23:38:50 localhost sundog[400]: 23:38:50 [INFO] Sending settings values to the API
Dec 09 23:38:50 localhost systemd[1]: Finished User-specified setting generators.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
