### PR TITLE
actions-workflow: add caching to develop and PR build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,9 +121,40 @@ jobs:
             fetch-upstream: "true"
       fail-fast: false
     steps:
+      - run: |
+          echo "OS_ARCH=`uname -m`" >> $GITHUB_ENV
       - uses: actions/checkout@v3
+      # Cache `cargo-make`, `cargo-cache`, `cargo-sweep`
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}
+      # Cache first-party rust code crate dependencies
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .cargo
+          key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('sources/Cargo.lock') }}-${{ hashFiles('.github/workflows/build.yml') }}
+          restore-keys: |
+            ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('sources/Cargo.lock') }}
+      # Cache 'tools/' dependencies and build artifacts
+      - uses: actions/cache@v3
+        with:
+          path: |
+            tools/bin
+            tools/.crates.toml
+            tools/.crates2.json
+            tools/target
+          key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}-${{ hashFiles('.github/workflows/build.yml') }}
+          restore-keys: |
+            ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
       - run: rustup default 1.64.0 && rustup component add rustfmt && rustup component add clippy
       - run: cargo install --version 0.36.0 cargo-make
+      - run: cargo install --version 0.6.2 cargo-sweep
+      - run: |
+          cargo sweep -i -r tools/
+          cargo sweep -t 7 -r tools/
       - if: contains(matrix.variant, 'nvidia')
         run: |
           cat <<-EOF > Licenses.toml

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,58 @@
+# This workflow caches crate dependencies and build artifacts for tools (except 'test-tools' since we don't use them in build workflows).
+# The cache is only usable by workflows started from pull requests against the develop branch.
+name: CacheDepsAndTools
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '.github/**'
+      - 'sources/Cargo.lock'
+      - 'tools/buildsys/**'
+      - 'tools/pubsys*/**'
+      - '!tools/pubsys/policies/**'
+      - '!tools/pubsys/**.example'
+      - '!tools/pubsys/**.template'
+      - 'tools/Cargo.lock'
+jobs:
+  cache:
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
+    continue-on-error: true
+    steps:
+      - run: |
+          echo "OS_ARCH=`uname -m`" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      # Cache `cargo-make`, `cargo-cache`, `cargo-sweep`
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}
+      # Cache first-party code dependencies
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .cargo
+          key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('sources/Cargo.lock') }}
+      # Cache 'tools/' dependencies and build artifacts
+      - uses: actions/cache@v3
+        with:
+          path: |
+            tools/bin
+            tools/.crates.toml
+            tools/.crates2.json
+            tools/target
+          key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
+      - run: rustup default 1.64.0
+      - run: cargo install --locked --version 0.36.0 cargo-make
+      - run: cargo install --locked --version 0.8.3 --no-default-features --features ci-autoclean cargo-cache
+      - run: cargo install --locked --version 0.6.2 cargo-sweep
+      - run: |
+          cargo sweep -i -r tools/
+          cargo sweep -t 7 -r tools/
+      - run: cargo make publish-setup-tools
+      - run: cargo make publish-tools
+      - run: cargo make build-tools
+      # This cleans the cargo cache in ~/.cargo
+      - run: cargo-cache

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -484,7 +484,7 @@ done'''
 ]
 
 [tasks.build-tools]
-dependencies = ["fetch"]
+dependencies = ["setup", "fetch-sources"]
 script = [
 '''
 cargo install \
@@ -616,7 +616,7 @@ docker run --rm \
 
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["check-cargo-version", "build-tools", "publish-setup", "fetch-licenses"]
+dependencies = ["check-cargo-version", "fetch-sdk", "build-tools", "publish-setup", "fetch-licenses"]
 script_runner = "bash"
 script = [
 '''
@@ -649,7 +649,7 @@ cargo build \
 ]
 
 [tasks.build-variant]
-dependencies = ["build-tools", "publish-setup"]
+dependencies = ["fetch-sdk", "build-tools", "publish-setup"]
 script = [
 '''
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
    actions-workflow: add caching to build workflow for PRs
    
    This adds caching for `tools/`, `cargo-make`, `cargo-sweep`, and
    first-party crate dependencies. This should allow PRs to use the cache
    created by the 'cache' workflow on the develop branch and maintain their
    own separate branch caches.
```
```

    actions-workflow: add new cache workflow for develop
    
    This adds a caching workflow for the develop branch so PRs against
    develop can use the cache for 'tools/' and crate dependencies to save
    time when running through the build workflow.
```
```

    Makefile: simplify build-tools task dep
    
    We don't have a hard dependency on the bottlerocket-sdk for building
    buildsys. Removed `fetch-sdk` from `build-tools` dependencies and filled
    them in places where `build-tools` is an dependency.
    
    This makes it faster for us to build and cache buildsys for CI purposes

```


**Testing done:**
Tested in a separate repository. To see what cache is being used, take note of the cache key.

## First `cache` run on the default (develop) branch, expected cache miss and creates cache:
<details>

`cargo-make`, `cargo-sweep` and other 3rd party rust tools
```
Run actions/cache@v3
  with:
    path: ~/.cargo
  
    key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64
  env:
    OS_ARCH: x86_64
Cache not found for input keys: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64
...
Post job cleanup.
/usr/bin/tar --posix --use-compress-program zstdmt -cf cache.tzst --exclude cache.tzst -P -C  --files-from manifest.txt
Cache Size: ~364 MB (381604335 B)
Cache saved successfully
Cache saved with key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64
```
First-party crate dependency
```
Run actions/cache@v3
  with:
    path: .cargo
  
    key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-086c0ca2db45943dfabf3c82ff10899cbfe3560e6842327bf758d69f13e18d65
  env:
    OS_ARCH: x86_64
Cache not found for input keys: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-086c0ca2db45943dfabf3c82ff10899cbfe3560e6842327bf758d69f13e18d65
...
Post job cleanup.
/usr/bin/tar --posix --use-compress-program zstdmt -cf cache.tzst --exclude cache.tzst -P -C  --files-from manifest.txt
Cache Size: ~409 MB (429074235 B)
Cache saved successfully
Cache saved with key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-086c0ca2db45943dfabf3c82ff10899cbfe3560e6842327bf758d69f13e18d65
```
`tools/` build artifacts etc
```
Run actions/cache@v3
  with:
    path: tools/bin
  tools/.crates.toml
  tools/.crates2.json
  tools/target
  
    key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-951366615b3f3e5ca8be9c8279f05caf260bfe5321442cf109f622b96f902b27
  env:
    OS_ARCH: x86_64
Cache not found for input keys: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-951366615b3f3e5ca8be9c8279f05caf260bfe5321442cf109f622b96f902b27
...
..
Post job cleanup.
/usr/bin/tar --posix --use-compress-program zstdmt -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/ --files-from manifest.txt
Cache Size: ~443 MB (464083304 B)
Cache saved successfully
Cache saved with key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-951366615b3f3e5ca8be9c8279f05caf260bfe5321442cf109f622b96f902b27
```

**Total time: 11m 30s**
</details>

## `build` workflow on a PR against the default (develop) branch, gets cache-hit on the cache created by the `cache` workflow on initial run as expected. Creates a cache specific to the PR `build` workflow as expected:

<details>

`cargo-make`, `cargo-sweep` and other 3rd party rust tools
```
Run actions/cache@v3
Received 272629760 of 381604335 (71.4%), 259.7 MBs/sec
Received 381604335 of 381604335 (100.0%), 205.8 MBs/sec
Cache Size: ~364 MB (381604335 B)
/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/1632a57b-55a0-43cf-99b2-90a28b57d40d/cache.tzst -P -C ...
Cache restored successfully
Cache restored from key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64
...
...
 Post job cleanup.
Cache hit occurred on the primary key 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64, not saving cache.
```

First-party crate dependency
```
Run actions/cache@v3
Received 226492416 of 429074235 (52.8%), 215.8 MBs/sec
Received 429074235 of 429074235 (100.0%), 196.9 MBs/sec
Cache Size: ~409 MB (429074235 B)
/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/8704c94c-43d1-408d-84dc-57db97421e72/cache.tzst -P -C ...
Cache restored successfully
Cache restored from key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-086c0ca2db45943dfabf3c82ff10899cbfe3560e6842327bf758d69f13e18d65
...
Post job cleanup.
/usr/bin/tar --posix --use-compress-program zstdmt -cf cache.tzst --exclude cache.tzst -P -C ... --files-from manifest.txt
Cache Size: ~409 MB (429151951 B)
Cache saved successfully
Cache saved with key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-086c0ca2db45943dfabf3c82ff10899cbfe3560e6842327bf758d69f13e18d65-8157c59e0b7bc35821d0fa73af60a658fcf07b607c9bfbdc924539841d3114d7-cache-test-kick
```

`tools/` build artifacts etc
```
Run actions/cache@v3
Received 226492416 of 464083304 (48.8%), 214.9 MBs/sec
Received 464083304 of 464083304 (100.0%), 191.1 MBs/sec
Cache Size: ~443 MB (464083304 B)
/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/4d51eea0-8913-4c0a-9cef-7f7763a53fa7/cache.tzst -P -C ...
Cache restored successfully
Cache restored from key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-951366615b3f3e5ca8be9c8279f05caf260bfe5321442cf109f622b96f902b27
...
...
Post job cleanup.
/usr/bin/tar --posix --use-compress-program zstdmt -cf cache.tzst --exclude cache.tzst -P -C ... --files-from manifest.txt
Cache Size: ~782 MB (820347345 B)
Cache saved successfully
Cache saved with key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-951366615b3f3e5ca8be9c8279f05caf260bfe5321442cf109f622b96f902b27-8157c59e0b7bc35821d0fa73af60a658fcf07b607c9bfbdc924539841d3114d7-cache-test-kick
```
**Total runtime: 19 min 54 secs**

</details>

## Second `build` workflow run on the same PR against the default (develop) branch, gets cache-hit on the PR-specific cache as expected:

<details>

```
Run actions/cache@v3
Received 268435456 of 381604335 (70.3%), 255.5 MBs/sec
Received 381604335 of 381604335 (100.0%), 226.9 MBs/sec
Cache Size: ~364 MB (381604335 B)
/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/07055670-d4a7-4c76-9229-f5a71e88afa4/cache.tzst -P -C ...
Cache restored successfully
Cache restored from key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64
```
```
Run actions/cache@v3
Received 209715200 of 429151951 (48.9%), 199.8 MBs/sec
Received 429151951 of 429151951 (100.0%), 194.1 MBs/sec
Cache Size: ~409 MB (429151951 B)
/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/85651a97-2674-4ae0-90c7-7117fe0dcce5/cache.tzst -P -C...
Cache restored successfully
Cache restored from key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-086c0ca2db45943dfabf3c82ff10899cbfe3560e6842327bf758d69f13e18d65-8157c59e0b7bc35821d0fa73af60a658fcf07b607c9bfbdc924539841d3114d7-cache-test-kick
```
```

Run actions/cache@v3
Received 234881024 of 820347345 (28.6%), 223.8 MBs/sec
Received 473956352 of 820347345 (57.8%), 225.8 MBs/sec
Received 713031680 of 820347345 (86.9%), 226.4 MBs/sec
Received 820347345 of 820347345 (100.0%), 196.4 MBs/sec
Cache Size: ~782 MB (820347345 B)
/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/d05265df-8537-4f91-be86-d17e8455f321/cache.tzst -P -C ...
Cache restored successfully
Cache restored from key: 62035382743f7a544e93cbb11afa03977cb023b80037dd93cdda145a65605d4a-Linux-x86_64-951366615b3f3e5ca8be9c8279f05caf260bfe5321442cf109f622b96f902b27-8157c59e0b7bc35821d0fa73af60a658fcf07b607c9bfbdc924539841d3114d7-cache-test-kick
```
**Total runtime: 19m 59s**
</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
