### PR TITLE
[wicked] Include MAC address in the lease files

### DIFF
--- a/packages/wicked/1007-include-mac-address-in-leaseinfo.patch
+++ b/packages/wicked/1007-include-mac-address-in-leaseinfo.patch
@@ -1,0 +1,31 @@
+diff --git a/src/leaseinfo.c b/src/leaseinfo.c
+index c47241f5..86265b45 100644
+--- a/src/leaseinfo.c
++++ b/src/leaseinfo.c
+@@ -692,7 +692,26 @@ __ni_leaseinfo_dump(FILE *out, const ni_addrconf_lease_t *lease,
+ {
+ 	unsigned int i;
+ 	char *key = NULL;
++	ni_netconfig_t *nc;
++	ni_netdev_t *dev;
+ 
++	/* Find the network device using the name, and print the MAC in the
++	 * lease file */
++	if (!(nc = ni_global_state_handle(0))) {
++		ni_warn("Unable to query global network interface state");
++		goto write_lease;
++	}
++
++	if (!(dev = ni_netdev_by_name(nc, ifname))) {
++		ni_warn("Unable to find interface with name %s", ifname);
++		goto write_lease;
++	}
++
++	__ni_leaseinfo_print_string(out, prefix, "MACADDR",
++			ni_link_address_print(&dev->link.hwaddr),
++			"", 0);
++
++write_lease:
+ 	__ni_leaseinfo_print_string(out, prefix, "INTERFACE", ifname, "", 0);
+ 
+ 	/* wicked specific vars */

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -46,6 +46,7 @@ Patch1003: 1003-ship-mkconst-and-schema-sources-for-runtime-use.patch
 Patch1004: 1004-adjust-safeguard-for-dhcp6-defer-timeout.patch
 Patch1005: 1005-client-validate-ethernet-namespace-node.patch
 Patch1006: 1006-server-discover-hardware-address-of-unconfigured-int.patch
+Patch1007: 1007-include-mac-address-in-leaseinfo.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libdbus-devel


### PR DESCRIPTION
**Issue number:**
Related to/enables #2293

**Description of changes:**
Adds a patch to `wicked` which includes the MAC address of the interface to the DHCP and static lease files.

Adding the MAC address to these lease files enables us to correlate a MAC with an interface name.


**Testing done:**
* Boot an `aws-k8s-1.22` variant: joins the cluster and runs pods just fine.  Verify the MAC shows up in the DHCP lease file:
```
 bash-5.1# cat /run/wicked/leaseinfo.eth0.dhcp.ipv4 
MACADDR='0a:17:17:fb:71:bd'
INTERFACE='eth0'
...
```
* Boot a `metal-dev` variant with static address settings and verify the mac shows up in the static lease file
```
bash-5.1# cat /run/wicked/leaseinfo.eno1.static.ipv4
MACADDR='3c:ec:ef:79:ae:ac'
INTERFACE='eno1'
```




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
