### PR TITLE
testsys: Add `testsys-image-tag` to  `Test.toml`

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -108,6 +108,9 @@ pub struct Test {
 
     /// A registry containing all TestSys images
     pub testsys_image_registry: Option<String>,
+
+    /// The tag that should be used for TestSys images
+    pub testsys_image_tag: Option<String>,
 }
 
 /// Create a vec of relevant keys for this variant ordered from most specific to least specific.
@@ -254,42 +257,27 @@ pub struct TestsysImages {
 
 impl TestsysImages {
     /// Create an images config for a specific registry.
-    pub fn new<S>(registry: S) -> Self
+    pub fn new<S>(registry: S, tag: Option<String>) -> Self
     where
         S: Into<String>,
     {
         let registry = registry.into();
-        let agent_version = format!("v{}", TESTSYS_VERSION);
+        let tag = tag.unwrap_or_else(|| format!("v{}", TESTSYS_VERSION));
         Self {
-            eks_resource_agent_image: Some(format!(
-                "{}/eks-resource-agent:{agent_version}",
-                registry
-            )),
-            ecs_resource_agent_image: Some(format!(
-                "{}/ecs-resource-agent:{agent_version}",
-                registry
-            )),
+            eks_resource_agent_image: Some(format!("{}/eks-resource-agent:{tag}", registry)),
+            ecs_resource_agent_image: Some(format!("{}/ecs-resource-agent:{tag}", registry)),
             vsphere_k8s_cluster_resource_agent_image: Some(format!(
-                "{}/vsphere-k8s-cluster-resource-agent:{agent_version}",
+                "{}/vsphere-k8s-cluster-resource-agent:{tag}",
                 registry
             )),
-            ec2_resource_agent_image: Some(format!(
-                "{}/ec2-resource-agent:{agent_version}",
-                registry
-            )),
+            ec2_resource_agent_image: Some(format!("{}/ec2-resource-agent:{tag}", registry)),
             vsphere_vm_resource_agent_image: Some(format!(
-                "{}/vsphere-vm-resource-agent:{agent_version}",
+                "{}/vsphere-vm-resource-agent:{tag}",
                 registry
             )),
-            sonobuoy_test_agent_image: Some(format!(
-                "{}/sonobuoy-test-agent:{agent_version}",
-                registry
-            )),
-            ecs_test_agent_image: Some(format!("{}/ecs-test-agent:{agent_version}", registry)),
-            migration_test_agent_image: Some(format!(
-                "{}/migration-test-agent:{agent_version}",
-                registry
-            )),
+            sonobuoy_test_agent_image: Some(format!("{}/sonobuoy-test-agent:{tag}", registry)),
+            ecs_test_agent_image: Some(format!("{}/ecs-test-agent:{tag}", registry)),
+            migration_test_agent_image: Some(format!("{}/migration-test-agent:{tag}", registry)),
             testsys_agent_pull_secret: None,
         }
     }
@@ -325,7 +313,7 @@ impl TestsysImages {
     }
 
     pub fn public_images() -> Self {
-        Self::new("public.ecr.aws/bottlerocket-test-system")
+        Self::new("public.ecr.aws/bottlerocket-test-system", None)
     }
 }
 

--- a/tools/testsys/Test.toml.example
+++ b/tools/testsys/Test.toml.example
@@ -11,6 +11,9 @@ repo = "default"
 # The registry containing alternate TestSys agent images
 testsys-images-registry = "public.ecr.aws/bottlerocket-test-system"
 
+# The tag that should be used with `testsys-images-registry` for image pulls
+testsys-images-registry = "latest"
+
 # The URI for the EKS resource agent that should be used. An individual agent's provided URI will be
 # used even if `testsys-images-registry` is present.
 eks-resource-agent-image = "public.ecr.aws/bottlerocket-test-system/eks_resource_agent:v0.0.2"

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -189,9 +189,9 @@ impl Run {
         let images = vec![
             Some(self.agent_images.into()),
             Some(test_opts.testsys_images),
-            test_opts
-                .testsys_image_registry
-                .map(testsys_config::TestsysImages::new),
+            test_opts.testsys_image_registry.map(|registry| {
+                testsys_config::TestsysImages::new(registry, test_opts.testsys_image_tag)
+            }),
             Some(testsys_config::TestsysImages::public_images()),
         ]
         .into_iter()


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Allow users to specify the tag that should be used for testsys image pulls when using an alternate `testsys-image-registry`. This is especially useful for `bottlerocket-test-system` when testing new images.

**Testing done:**

I ran `cargo make test` on custom testing images with `latest` tag and verified that the images used by the agent were the ones with the correct tag.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
