### PR TITLE
containerd: update to v1.6.12

### DIFF
--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.10/containerd-1.6.10.tar.gz"
-sha512 = "02312a8d127b523944e9583433ec87cdc1fc30988b107a8d83438985a010b06c57e93017adb4fcf9db6ec80c1e28327101d7496d63d3832ea9cbfe54d17e3a6c"
+url = "https://github.com/containerd/containerd/archive/v1.6.12/containerd-1.6.12.tar.gz"
+sha512 = "adec6b28bfeea591af8204341dbdf1477f878be28c318745cacdf1b8de2831e3b4d832ad2026fbd9800d6452b5eb186bd94fe78d4dfed163b1cb32e9a92f38fa"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.10
+%global gover 1.6.12
 %global rpmver %{gover}
-%global gitrev 770bd0108c32f3fb5c73ae1264f7e503fe7b2661
+%global gitrev a05d175400b1145e5e6a735a6710579d181e7fb0
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION
**Issue number:**

Closes #2648 

**Description of changes:**

- Upgrades containerd package to v1.6.12
- Updated lookaside cache

**Testing done:**

Built bottlerocket with `cargo make clean && cargo make -e BUILDSYS_VARIANT=aws-ecs-1` and tested ami 👍🏼 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
