### PR TITLE
testsys: Automatically create vSphere secret

### DIFF
--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -13,6 +13,11 @@ pub enum Error {
     #[snafu(display("Unable to build '{}': {}", what, error))]
     Build { what: String, error: String },
 
+    #[snafu(display("Unable to build datacenter credentials: {}", source))]
+    CredsBuild {
+        source: pubsys_config::vmware::Error,
+    },
+
     #[snafu(display("Unable to build data center config: {}", source))]
     DatacenterBuild {
         source: pubsys_config::vmware::Error,
@@ -93,5 +98,10 @@ pub enum Error {
     Variant {
         variant: String,
         source: bottlerocket_variant::error::Error,
+    },
+
+    #[snafu(display("Error reading config: {}", source))]
+    VmwareConfig {
+        source: pubsys_config::vmware::Error,
     },
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

Note: This PR is dependent on TestSys v0.0.4

**Issue number:**

Closes #2658

**Description of changes:**

If a `vsphereCredential` secret is not in `Test.toml`, the secret will be automatically created.

**Testing done:**
Successfully kicked-off vsphere tests and saw that testsys created the vsphere creds automatically
```bash
$     cargo make       -e TESTSYS_KUBECONFIG=./mytestsys.kubeconfig       -e TESTSYS_TEST=quick       -e BUILDSYS_VARIANT=vmware-k8s-1.24       -e BUILDSYS_ARCH="x8                                                                                          
6_64"       -e TESTSYS_TEST_CONFIG_PATH="./Test.toml"       test       --mgmt-cluster-kubeconfig=mgmt-clust                                                                                      er-eks-a-cluster.kubeconfig                                                                                                                                                                                                                                   
[cargo-make] INFO - cargo make 0.35.12                                                                                                                                                                                                                        
[cargo-make] INFO - Build File: Makefile.toml                                                                                  
[cargo-make] INFO - Task: test                                                                                                 
[cargo-make] INFO - Profile: development                                                                                       
[cargo-make] INFO - Running Task: setup                                                                                                                                                                                                                       
[cargo-make] INFO - Running Task: fetch-sources                                                                                
[cargo-make] INFO - Running Task: test-tools                                                                                   
[cargo-make] INFO - Running Task: test                         
[2022-12-16T20:25:36Z INFO  testsys::run] Creating vSphere secret, 'vsphereCreds'                                              
[2022-12-16T20:25:36Z INFO  testsys::run] vSphere credentials file not found, will attempt to use environment                                                                                                                                                 
[2022-12-16T20:25:36Z INFO  testsys::run] Successfully added 'x86-64-vmware-k8s-124'                                                                                                                                                                          
[2022-12-16T20:25:37Z INFO  testsys::run] Successfully added 'x86-64-vmware-k8s-124-vms-quick'                                                                                                                                                                
[2022-12-16T20:25:37Z INFO  testsys::run] Successfully added 'x86-64-vmware-k8s-124-test'   
```
Verified that the vsphere resource agent was able to use said secret to talk to vsphere
```bash
$ cargo make -e TESTSYS_KUBECONFIG=./mytestsys.kubeconfig  testsys logs  --resource x86-64-vmware-k8s-124 --state=creation -f
[cargo-make] INFO - cargo make 0.35.12
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: testsys
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: test-tools
[cargo-make] INFO - Running Task: testsys
[2022-12-16T20:25:42Z INFO  resource_agent::agent] Initializing Agent
[2022-12-16T20:25:42Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Getting vSphere secret
[2022-12-16T20:25:42Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating working directory
[2022-12-16T20:25:42Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Checking existing cluster
[2022-12-16T20:25:42Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creation policy is 'IfNotExists' and cluster 'x86-64-vmware-k8s-124' does not exist: creating cluster
[2022-12-16T20:25:42Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating cluster
[2022-12-16T20:25:42Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Downloading OVA 'bottlerocket-vmware-k8s-1.24-x86_64-v1.11.1.ova'
[2022-12-16T20:25:49Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Importing OVA and creating a VM template out of it
[2022-12-16T20:26:02Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Tagging VM template
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
