### PR TITLE
actions-workflow: install build deps before running build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,8 +121,10 @@ jobs:
             fetch-upstream: "true"
       fail-fast: false
     steps:
-      - run: |
+      - name: Preflight step to set up the runner
+        run: |
           echo "OS_ARCH=`uname -m`" >> $GITHUB_ENV
+          sudo apt -y install build-essential openssl libssl-dev pkg-config liblz4-tool
       - uses: actions/checkout@v3
       # Cache `cargo-make`, `cargo-cache`, `cargo-sweep`
       - uses: actions/cache@v3


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
    actions-workflow: install build deps before running build workflow
    
    Ensure that build dependencies are installed on the runner before the
    build workflow.

```


**Testing done:**
To be seen in the build workflow


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
