### PR TITLE
testsys: change deletionpolicy for ECS clusters to 'onDeletion'

### DIFF
--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -72,7 +72,7 @@ impl CrdCreator for AwsEcsCreator {
             .cluster_name(cluster_input.cluster_name)
             .region(Some(self.region.to_owned()))
             .assume_role(cluster_input.crd_input.config.agent_role.clone())
-            .destruction_policy(DestructionPolicy::OnTestSuccess)
+            .destruction_policy(DestructionPolicy::OnDeletion)
             .image(
                 cluster_input
                     .crd_input


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**
```
    testsys: change deletionpolicy for ecs cluster to 'onDeletion'
    
    Prior to this change, there was a chance of a race-condition between a
    ECS cluster destruction job and a ECS instance destruction job where ECS
    cluster desctruction would fail because the ECS instances aren't fully
    deleted yet.

```


When the default deletion policy was set to `onTestSuccess` all resources destruction jobs would trigger at the same time and the testsys controller seems to ignore the dependencies between the ECS instance resource and the ECS cluster resource. This would in turn cause a race condition within ECS resource deletion where ECS cluster destruction might trigger before ECS instances are fully cleaned-up and cause the process to fail. 

The end result is an ECS cluster testsys resource that have to be manually removed.

**Testing done:**
Tests kick off fine:
```bash
[cargo-make] INFO - cargo make 0.36.3
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: test
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: test-tools
[cargo-make] INFO - Running Task: test
[2022-12-17T00:07:35Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1'
[2022-12-17T00:07:35Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-instances-migration'
[2022-12-17T00:07:36Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-test-1-initial'
[2022-12-17T00:07:36Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-2-migrate'
[2022-12-17T00:07:36Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-test-3-migrated'
[2022-12-17T00:07:36Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-4-migrate'
[2022-12-17T00:07:36Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-test-5-final'
[cargo-make] INFO - Build Done in 3.69 seconds.
[cargo-make] INFO - cargo make 0.36.3
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: test
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: test-tools
[cargo-make] INFO - Running Task: test
[2022-12-17T00:07:40Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-nvidia'
[2022-12-17T00:07:40Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-nvidia-instances-migration'
[2022-12-17T00:07:40Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-nvidia-test-1-initial'
[2022-12-17T00:07:41Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-nvidia-2-migrate'
[2022-12-17T00:07:41Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-nvidia-test-3-migrated'
[2022-12-17T00:07:41Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-nvidia-4-migrate'
[2022-12-17T00:07:41Z INFO  testsys::run] Successfully added 'x86-64-aws-ecs-1-nvidia-test-5-final'
[cargo-make] INFO - Build Done in 3.76 seconds.
[cargo-make] INFO - cargo make 0.36.3
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: test
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: test-tools
[cargo-make] INFO - Running Task: test
[2022-12-17T00:07:45Z INFO  testsys::run] Successfully added 'aarch64-aws-ecs-1'
[2022-12-17T00:07:45Z INFO  testsys::run] Successfully added 'aarch64-aws-ecs-1-instances-migration'
[2022-12-17T00:07:45Z INFO  testsys::run] Successfully added 'aarch64-aws-ecs-1-test-1-initial'
[2022-12-17T00:07:46Z INFO  testsys::run] Successfully added 'aarch64-aws-ecs-1-2-migrate'
[2022-12-17T00:07:46Z INFO  testsys::run] Successfully added 'aarch64-aws-ecs-1-test-3-migrated'
[2022-12-17T00:07:46Z INFO  testsys::run] Successfully added 'aarch64-aws-ecs-1-4-migrate'
[2022-12-17T00:07:46Z INFO  testsys::run] Successfully added 'aarch64-aws-ecs-1-test-5-final'
```

After all the tests passes, the resources stay around as expected:
```bash
[cargo-make] INFO - Running Task: testsys
 NAME                                                    TYPE                 STATE                PASSED            SKIPPED            FAILED          
 aarch64-aws-ecs-1                                       Resource             completed                                                                 
 aarch64-aws-ecs-1-2-migrate                             Test                 pass                 2                 0                  0               
 aarch64-aws-ecs-1-4-migrate                             Test                 pass                 2                 0                  0               
 aarch64-aws-ecs-1-instances-migration                   Resource             completed                                                                 
 aarch64-aws-ecs-1-test-1-initial                        Test                 pass                 1                 0                  0               
 aarch64-aws-ecs-1-test-3-migrated                       Test                 pass                 1                 0                  0               
 aarch64-aws-ecs-1-test-5-final                          Test                 pass                 1                 0                  0               
 x86-64-aws-ecs-1                                        Resource             completed                                                                 
 x86-64-aws-ecs-1-2-migrate                              Test                 pass                 2                 0                  0               
 x86-64-aws-ecs-1-4-migrate                              Test                 pass                 2                 0                  0                x86-64-aws-ecs-1-instances-migration                    Resource             completed                                                                 
 x86-64-aws-ecs-1-nvidia                                 Resource             completed                                                                 
 x86-64-aws-ecs-1-nvidia-2-migrate                       Test                 pass                 2                 0                  0               
 x86-64-aws-ecs-1-nvidia-4-migrate                       Test                 pass                 2                 0                  0               
 x86-64-aws-ecs-1-nvidia-instances-migration             Resource             completed                                                                 
 x86-64-aws-ecs-1-nvidia-test-1-initial                  Test                 pass                 1                 0                  0               
 x86-64-aws-ecs-1-nvidia-test-3-migrated                 Test                 pass                 1                 0                  0               
 x86-64-aws-ecs-1-nvidia-test-5-final                    Test                 pass                 1                 0                  0               
 x86-64-aws-ecs-1-test-1-initial                         Test                 pass                 1                 0                  0               
 x86-64-aws-ecs-1-test-3-migrated                        Test                 pass                 1                 0                  0               
 x86-64-aws-ecs-1-test-5-final                           Test                 pass                 1                 0                  0 
```
Then test deletion works as expected. TestSys properly first kicks off instance deletion and waits until that's done before deleting the ECS clusters. Everything gets cleaned up in the end as expected:
```bash
[cargo-make] INFO - cargo make 0.36.3
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: clean-test
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: test-tools
[cargo-make] INFO - Running Task: clean-test
Starting delete for x86-64-aws-ecs-1-test-3-migrated
Starting delete for aarch64-aws-ecs-1-test-1-initial
Starting delete for x86-64-aws-ecs-1-nvidia-4-migrate
Starting delete for x86-64-aws-ecs-1-nvidia-test-5-final
Starting delete for x86-64-aws-ecs-1-test-5-final
Starting delete for aarch64-aws-ecs-1-4-migrate
Starting delete for aarch64-aws-ecs-1-test-3-migrated
Starting delete for x86-64-aws-ecs-1-test-1-initial
Starting delete for x86-64-aws-ecs-1-nvidia-test-3-migrated
Starting delete for x86-64-aws-ecs-1-nvidia-2-migrate
Starting delete for x86-64-aws-ecs-1-2-migrate
Starting delete for x86-64-aws-ecs-1-nvidia-test-1-initial
Starting delete for aarch64-aws-ecs-1-2-migrate
Starting delete for aarch64-aws-ecs-1-test-5-final
Starting delete for x86-64-aws-ecs-1-4-migrate
Delete finished for x86-64-aws-ecs-1-test-3-migrated
Delete finished for aarch64-aws-ecs-1-test-1-initial
Delete finished for x86-64-aws-ecs-1-nvidia-4-migrate
Delete finished for x86-64-aws-ecs-1-nvidia-test-5-final
Delete finished for x86-64-aws-ecs-1-test-5-final
Delete finished for aarch64-aws-ecs-1-4-migrate
Delete finished for aarch64-aws-ecs-1-test-3-migrated
Delete finished for x86-64-aws-ecs-1-test-1-initial
Delete finished for x86-64-aws-ecs-1-nvidia-test-3-migrated
Delete finished for x86-64-aws-ecs-1-nvidia-2-migrate
Delete finished for x86-64-aws-ecs-1-2-migrate
Delete finished for x86-64-aws-ecs-1-nvidia-test-1-initial
Delete finished for aarch64-aws-ecs-1-2-migrate
Delete finished for aarch64-aws-ecs-1-test-5-final
Delete finished for x86-64-aws-ecs-1-4-migrate
Starting delete for x86-64-aws-ecs-1-nvidia-instances-migration
Starting delete for x86-64-aws-ecs-1-instances-migration
Starting delete for aarch64-aws-ecs-1-instances-migration
Delete finished for aarch64-aws-ecs-1-instances-migration
Delete finished for x86-64-aws-ecs-1-instances-migration
Delete finished for x86-64-aws-ecs-1-nvidia-instances-migration
Starting delete for x86-64-aws-ecs-1
Starting delete for x86-64-aws-ecs-1-nvidia
Starting delete for aarch64-aws-ecs-1
Delete finished for x86-64-aws-ecs-1
Delete finished for x86-64-aws-ecs-1-nvidia
Delete finished for aarch64-aws-ecs-1
[2022-12-17T00:06:53Z INFO  testsys::delete] Delete finished
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
