### PR TITLE
Testsys status

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1423,8 +1423,24 @@ script = [
    '''
 ]
 
-# This task will call watch on the `status` testsys command to show the results of a test.
+# This task will call watch on the `status` testsys command to show the results of all tests.
+# To see all passed tests use `cargo make watch-test --passed`
+# To see all failed tests use `cargo make watch-test --failed`
+# To see all incomplete tests use `cargo make watch-test --running`
 [tasks.watch-test]
+dependencies = ["test-tools"]
+script = [
+   '''
+   set -eu
+   export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+   watch -- testsys ${CARGO_MAKE_TESTSYS_ARGS} status --test ${@}
+   '''
+]
+
+# This task will call watch on the `status` testsys command to show the results of all tests and
+# resources.
+# To see all incomplete crds use `cargo make watch-test-all --running` 
+[tasks.watch-test-all]
 dependencies = ["test-tools"]
 script = [
    '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1416,7 +1416,7 @@ script = [
 ]
 
 # This task will clear all tests and resources from the testsys cluster.
-[tasks.clean-test-all]
+[tasks.reset-test]
 dependencies = ["test-tools"]
 script = [
     '''
@@ -1436,6 +1436,10 @@ script = [
    testsys ${CARGO_MAKE_TESTSYS_ARGS} uninstall
    '''
 ]
+
+# This task will clear all testsys components from the testsys cluster.
+[tasks.purge-test]
+dependencies = ["test-tools","reset-test","uninstall-test"]
 
 # This task will call watch on the `status` testsys command to show the results of all tests.
 # To see all passed tests use `cargo make watch-test --passed`

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1401,14 +1401,28 @@ script = [
     '''
 ]
 
-# This task will clear all tests and resources from the testsys cluster.
+# This task will clear all tests from the testsys cluster.
+# To delete all passed tests use `cargo make clean-test --passed`
+# To delete all failed tests use `cargo make clean-test --failed`
+# To delete all incomplete tests use `cargo make clean-test --running`
 [tasks.clean-test]
 dependencies = ["test-tools"]
 script = [
     '''
     set -eu
     export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
-    testsys ${CARGO_MAKE_TESTSYS_ARGS} delete
+    testsys ${CARGO_MAKE_TESTSYS_ARGS} delete --test ${@}
+    '''
+]
+
+# This task will clear all tests and resources from the testsys cluster.
+[tasks.clean-test-all]
+dependencies = ["test-tools"]
+script = [
+    '''
+    set -eu
+    export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+    testsys ${CARGO_MAKE_TESTSYS_ARGS} delete ${@}
     '''
 ]
 

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3117,6 +3117,7 @@ dependencies = [
  "bottlerocket-variant",
  "clap 3.2.23",
  "env_logger",
+ "fastrand",
  "futures",
  "handlebars",
  "k8s-openapi",

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4"
 maplit = "1.0.2"
 model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.5", tag = "v0.0.5"}
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
+fastrand = "1.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::fs::File;
+use std::iter::repeat_with;
 
 /// Get the AMI for the given `region` from the `ami_input` file.
 pub(crate) fn ami(ami_input: &str, region: &str) -> Result<String> {
@@ -189,11 +190,9 @@ pub(crate) async fn ec2_crd<'a>(
             .security_groups(Vec::new());
     }
 
+    let suffix: String = repeat_with(fastrand::lowercase).take(4).collect();
     ec2_builder
-        .build(format!(
-            "{}-instances-{}",
-            cluster_name, bottlerocket_input.test_type
-        ))
+        .build(format!("{}-instances-{}", cluster_name, suffix))
         .map_err(|e| error::Error::Build {
             what: "EC2 instance provider CRD".to_string(),
             error: e.to_string(),

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -1,5 +1,5 @@
 use crate::error::{self, Result};
-use crate::run::KnownTestType;
+use crate::run::{KnownTestType, TestType};
 use bottlerocket_types::agent_config::TufRepoConfig;
 use bottlerocket_variant::Variant;
 use handlebars::Handlebars;
@@ -27,6 +27,7 @@ pub struct CrdInput<'a> {
     /// `CrdCreator::starting_image_id` function should be used instead of using this field, so
     /// it is not externally visible.
     pub(crate) starting_image_id: Option<String>,
+    pub(crate) test_type: TestType,
     pub images: TestsysImages,
 }
 
@@ -57,6 +58,7 @@ impl<'a> CrdInput<'a> {
             "testsys/arch".to_string() => self.arch.to_string(),
             "testsys/variant".to_string() => self.variant.to_string(),
             "testsys/build-id".to_string() => self.build_id.to_owned().unwrap_or_default(),
+            "testsys/test-type".to_string() => self.test_type.to_string(),
         };
         let mut add_labels = additional_labels;
         labels.append(&mut add_labels);

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -23,6 +23,7 @@ pub struct CrdInput<'a> {
     pub repo_config: RepoConfig,
     pub starting_version: Option<String>,
     pub migrate_to_version: Option<String>,
+    pub build_id: Option<String>,
     /// `CrdCreator::starting_image_id` function should be used instead of using this field, so
     /// it is not externally visible.
     pub(crate) starting_image_id: Option<String>,
@@ -55,6 +56,7 @@ impl<'a> CrdInput<'a> {
         let mut labels = btreemap! {
             "testsys/arch".to_string() => self.arch.to_string(),
             "testsys/variant".to_string() => self.variant.to_string(),
+            "testsys/build-id".to_string() => self.build_id.to_owned().unwrap_or_default(),
         };
         let mut add_labels = additional_labels;
         labels.append(&mut add_labels);

--- a/tools/testsys/src/delete.rs
+++ b/tools/testsys/src/delete.rs
@@ -2,15 +2,70 @@ use crate::error::Result;
 use clap::Parser;
 use futures::TryStreamExt;
 use log::info;
-use model::test_manager::{DeleteEvent, TestManager};
+use model::test_manager::{CrdState, CrdType, DeleteEvent, SelectionParams, TestManager};
 
 /// Delete all tests and resources from a testsys cluster.
 #[derive(Debug, Parser)]
-pub(crate) struct Delete {}
+pub(crate) struct Delete {
+    /// Only delete tests
+    #[clap(long)]
+    test: bool,
+
+    /// Focus status on a particular arch
+    #[clap(long)]
+    arch: Option<String>,
+
+    /// Focus status on a particular variant
+    #[clap(long)]
+    variant: Option<String>,
+
+    /// Only delete passed tests
+    #[clap(long, conflicts_with_all=&["failed", "running"])]
+    passed: bool,
+
+    /// Only delete failed tests
+    #[clap(long, conflicts_with_all=&["passed", "running"])]
+    failed: bool,
+
+    /// Only CRD's that haven't finished
+    #[clap(long, conflicts_with_all=&["passed", "failed"])]
+    running: bool,
+}
 
 impl Delete {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
-        let mut stream = client.delete_all().await?;
+        let state = if self.running {
+            info!("Deleting all running tests and resources");
+            Some(CrdState::NotFinished)
+        } else if self.passed {
+            info!("Deleting all passed tests");
+            Some(CrdState::Passed)
+        } else if self.failed {
+            info!("Deleting all failed tests");
+            Some(CrdState::Failed)
+        } else {
+            info!("Deleting all tests and resources");
+            None
+        };
+        let crd_type = self.test.then_some(CrdType::Test);
+        let mut labels = Vec::new();
+        if let Some(arch) = self.arch {
+            labels.push(format!("testsys/arch={}", arch))
+        };
+        if let Some(variant) = self.variant {
+            labels.push(format!("testsys/variant={}", variant))
+        };
+        let mut stream = client
+            .delete(
+                &SelectionParams {
+                    labels: Some(labels.join(",")),
+                    state,
+                    crd_type,
+                    ..Default::default()
+                },
+                false,
+            )
+            .await?;
 
         while let Some(delete) = stream.try_next().await? {
             match delete {

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -70,6 +70,9 @@ pub(crate) struct Run {
     #[clap(long, env = "TESTSYS_TARGET_REGION")]
     target_region: Option<String>,
 
+    #[clap(long, env = "BUILDSYS_VERSION_BUILD")]
+    build_id: Option<String>,
+
     #[clap(flatten)]
     agent_images: TestsysImages,
 
@@ -331,6 +334,7 @@ impl Run {
             client: &client,
             arch: self.arch,
             variant,
+            build_id: self.build_id,
             config: variant_config,
             repo_config,
             starting_version: self.migration_starting_version,

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -340,6 +340,7 @@ impl Run {
             starting_version: self.migration_starting_version,
             migrate_to_version: self.migration_target_version,
             starting_image_id: self.starting_image_id,
+            test_type: self.test_flavor.clone(),
             images,
         };
 
@@ -384,7 +385,7 @@ fn parse_key_val(s: &str) -> Result<(String, SecretName)> {
     ))
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum KnownTestType {
     /// Conformance testing is a full integration test that asserts that Bottlerocket is working for
@@ -403,7 +404,7 @@ pub enum KnownTestType {
 
 /// If a test type is one that is supported by TestSys it will be created as `Known(KnownTestType)`.
 /// All other test types will be stored as `Custom(<TEST-TYPE>)`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub(crate) enum TestType {
     Known(KnownTestType),

--- a/tools/testsys/src/status.rs
+++ b/tools/testsys/src/status.rs
@@ -1,7 +1,7 @@
 use crate::error::{self, Result};
 use clap::Parser;
 use log::{debug, info};
-use model::test_manager::{SelectionParams, TestManager};
+use model::test_manager::{CrdState, CrdType, SelectionParams, TestManager};
 use snafu::ResultExt;
 
 /// Check the status of testsys objects.
@@ -22,10 +22,36 @@ pub(crate) struct Status {
     /// Focus status on a particular variant
     #[clap(long)]
     variant: Option<String>,
+
+    /// Only show tests
+    #[clap(long)]
+    test: bool,
+
+    /// Only show passed tests
+    #[clap(long, conflicts_with_all=&["failed", "running"])]
+    passed: bool,
+
+    /// Only show failed tests
+    #[clap(long, conflicts_with_all=&["passed", "running"])]
+    failed: bool,
+
+    /// Only CRD's that haven't finished
+    #[clap(long, conflicts_with_all=&["passed", "failed"])]
+    running: bool,
 }
 
 impl Status {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
+        let state = if self.running {
+            Some(CrdState::NotFinished)
+        } else if self.passed {
+            Some(CrdState::Passed)
+        } else if self.failed {
+            Some(CrdState::Failed)
+        } else {
+            None
+        };
+        let crd_type = self.test.then_some(CrdType::Test);
         let mut labels = Vec::new();
         if let Some(arch) = self.arch {
             labels.push(format!("testsys/arch={}", arch))
@@ -37,6 +63,8 @@ impl Status {
             .status(
                 &SelectionParams {
                     labels: Some(labels.join(",")),
+                    state,
+                    crd_type,
                     ..Default::default()
                 },
                 self.controller,

--- a/tools/testsys/src/status.rs
+++ b/tools/testsys/src/status.rs
@@ -33,7 +33,7 @@ impl Status {
         if let Some(variant) = self.variant {
             labels.push(format!("testsys/variant={}", variant))
         };
-        let status = client
+        let mut status = client
             .status(
                 &SelectionParams {
                     labels: Some(labels.join(",")),
@@ -42,6 +42,9 @@ impl Status {
                 self.controller,
             )
             .await?;
+        status.new_column("BUILD ID", |crd| {
+            crd.labels().get("testsys/build-id").cloned()
+        });
 
         if self.json {
             info!(


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2422 
Closes #2423 
Closes #2572 

**Description of changes:**

This pr contains a set of commits that are designed to improve the user experience with `cargo make test`

```
e19242b1 testsys: Provide status output options
58b3eee9 testsys: Improve delete filtering control
a219ea5d testsys: Improve filtering of `watch-test`
41486b7a testsys: Add unique suffix to vm resource
b28f0551 testsys: Add unique suffix to ec2 instances
3ec9cae0 testsys: Add `testsys/test-type` label
caeae492 testsys: Add `BUILD ID` to status output.
43635515 testsys: Add label for build id
```

`e19242b1`
Allows users to customize the status output to fit their screen size (or json).

`58b3eee9`
Changed `cargo make clean-test` to delete all passing tests. Resources will automatically be cleaned up, this reduces the execution time of `cargo make clean-test` significantly. `cargo make clean-test-all` is now used to delete everything from a cluster.

 `a219ea5d`
Changed `cargo make watch-test` to only show test status, `cargo make watch-test-all` can be used to show all tests and resources. Also, `cargo make watch-test-all --passed` can be used to watch all passed tests, `--failed` and `--running` can also be used (separately).

`41486b7a`, `b28f0551`
Instances and VM resources are now given a suffix to their name. This prevents collisions with a resource that is being deleted.

`3ec9cae0`
Adds an additional label for `SelectionParams` filtering, `testsys/test-type`

`caeae492`
Adds a column to `cargo make watch-test` for the `BUILD ID` that is being tested.

`43635515`
Adds a label for the build id that is being tested.

**Testing done:**

Sample output:
`cargo make watch-test`

```
NAME                          TYPE       STATE         PASSED       SKIPPED       FAILED      LAST UPDATE                 BUILD ID
 x86-64-aws-k8s-124-test       Test       waiting                                               2023-01-04T14:32:25Z       3ebb33a9
 ```

`cargo make watch-test-all`

```
NAME                                  TYPE         STATE          PASSED     SKIPPED     FAILED    LAST UPDATE               BUILD ID
 x86-64-aws-k8s-124                    Resource     completed                                        2023-01-04T14:32:28Z     3ebb33a9
 x86-64-aws-k8s-124-instances-kpsq     Resource     completed                                        2023-01-04T14:32:36Z     3ebb33a9
 x86-64-aws-k8s-124-test               Test         inProgress     0          0           0          2023-01-04T14:33:41Z     3ebb33a9
```

`cargo make watch-test-all -o wide`

```
 NAME                               TYPE      STATE       PASSE   SKIPPE   FAILE  STATUS               LAST UPDATE             BUILD ID
 x86-64-aws-k8s-124                 Resourc   completed                            Cluster ready        2023-01-04T14:32:28Z   3ebb33a9
 x86-64-aws-k8s-124-instances-kps   Resourc   completed                            Instance(s) create   2023-01-04T14:32:36Z   3ebb33a9
 x86-64-aws-k8s-124-test            Test      inProgres   0       0        0       Starting Test        2023-01-04T14:36:12Z   3ebb33a9
 ```
 
`cargo make watch-test -o wide`

 ```
  NAME                        TYPE     STATE          PASSED     SKIPPED    FAILED   STATUS           LAST UPDATE              BUILD ID
 x86-64-aws-k8s-124-test     Test     inProgress     0          0          0         Starting Test    2023-01-04T14:36:42Z    3ebb33a9
```

`cargo make watch-test-all -o narrow`
```
 NAME                                         TYPE               STATE                PASSED           SKIPPED           FAILED
 x86-64-aws-k8s-124                           Resource           completed
 x86-64-aws-k8s-124-instances-kpsq            Resource           completed
 x86-64-aws-k8s-124-test                      Test               inProgress           0                0                 0
 ```

`cargo make purge-test`

```
$ cargo make purge-test
[cargo-make] INFO - cargo make 0.36.1
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: purge-test
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: test-tools
[cargo-make] INFO - Running Task: reset-test
[2023-01-06T14:58:07Z INFO  testsys::delete] Deleting all tests and resources
Starting delete for x86-64-aws-k8s-124-test
Delete finished for x86-64-aws-k8s-124-test
Starting delete for x86-64-aws-k8s-124
Delete finished for x86-64-aws-k8s-124
[2023-01-06T14:58:27Z INFO  testsys::delete] Delete finished
[cargo-make] INFO - Running Task: uninstall-test
[2023-01-06T14:58:28Z INFO  testsys::uninstall] testsys components were successfully uninstalled.
[cargo-make] INFO - Build Done in 23.04 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
