### PR TITLE
host-ctr: use user-provided reg creds for 'public.ecr.aws'

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -1036,6 +1036,11 @@ func withDynamicResolver(ctx context.Context, ref string, registryConfig *Regist
 		}
 	// For Amazon ECR Public registries, we should try and fetch credentials before resolving the image reference
 	case strings.HasPrefix(ref, "public.ecr.aws/"):
+		// ... not if the user has specified their own registry credentials for 'public.ecr.aws'; In that case we use the default resolver.
+		if _, found := registryConfig.Credentials["public.ecr.aws"]; found {
+			return defaultResolver
+		}
+
 		// Try to get credentials for authenticated pulls from ECR Public
 		session := session.Must(session.NewSession())
 		// The ECR Public API is only available in us-east-1 today


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket/issues/2671

**Description of changes:**
```bash
    host-ctr: use user-provided reg creds for 'public.ecr.aws'
    
    If users provide their own registry credential for 'public.ecr.aws' then
    use that credential instead of the fetched credentials from ECR public.
```


**Testing done:**

Validated by @ahreehong and @vignesh-goutham.

To summarize:
On `vmware-k8s-1.23`, specified a private registry mirror for `public.ecr.aws` and specified registry creds for the registry mirror.

```toml
[settings.container-registry.mirrors]
"public.ecr.aws" = ["https://198.18.34.118:443"]
[settings.pki.registry-mirror-ca]
data = "<redacted>"
trusted=true
[[settings.container-registry.credentials]]
registry = "public.ecr.aws"
username = "<redacted>"
password = "<redacted>"
```

`host-ctr` is able to pull images from the registry mirror at `198.18.34.118` and start host containers and bootstrap containers.

There is a separate issue we discovered as part of this validation. `cri-containerd` requires the registry creds to be set for the registry mirror itself (`198.18.34.118`) and not the destination registry host (`public.ecr.aws` in this case). There needs to be a follow-up fix to align `host-ctr`'s way of constructing the image resolver with `cri-containerd`'s. See https://github.com/bottlerocket-os/bottlerocket/issues/2677 for more info.

This PR is still valid on it's own regardless; Users might still want to be able to get public ECR creds themselves and pass it manually through `settings.container-registry.credentials` for `public.ecr.aws`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
