### PR TITLE
actions-workflow: user github runners for golang lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -2,16 +2,19 @@ name: golangci-lint
 on:
   pull_request:
     branches: [develop]
-    # Only run this workflow if Go files have been modified
+    # Only run this workflow if Go files or this workflow have been modified
     paths:
       - '**.go'
       - '*/go.mod'
       - '*/go.sum'
+      - '.github/workflows/golangci-lint.yaml'
 
 jobs:
   golangci-lint:
     name: lint
-    runs-on: [self-hosted, linux, x64]
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_8-core
     steps:
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
We no longer have self-hosted runners.
Use 8-core github-hosted runners for the golang-lint check in actions workflow.

**Testing done:**
See Actions for this PR

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
