### PR TITLE
actions-workflow: use free github runners for golang lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -12,9 +12,7 @@ on:
 jobs:
   golangci-lint:
     name: lint
-    runs-on:
-      group: bottlerocket
-      labels: bottlerocket_ubuntu-latest_8-core
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
Instead of using 8-core github runners, which costs a bit of money. The default ubuntu runner should do the job just fine.


**Testing done:**
See Actions workflow


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
