### PR TITLE
pubsys: Do not allow private AMIs to be published to SSM parameters in the public namespace

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -977,6 +977,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1258,24 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "governor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c390a940a5d157878dd057c78680a33ce3415bcd05b4799509ea44210914b4d5"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand",
+ "smallvec",
 ]
 
 [[package]]
@@ -1736,6 +1773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +1897,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nonzero_ext"
@@ -2212,10 +2264,12 @@ dependencies = [
  "coldsnap",
  "duct",
  "futures",
+ "governor",
  "http",
  "indicatif",
  "lazy_static",
  "log",
+ "nonzero_ext",
  "num_cpus",
  "parse-datetime",
  "pubsys-config",
@@ -2274,6 +2328,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -12,7 +12,7 @@ confidence-threshold = 0.93
 # Commented license types are allowed but not currently used
 allow = [
     "Apache-2.0",
-    # "BSD-2-Clause",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
     # "CC0-1.0",

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -65,15 +65,15 @@ impl InfraConfig {
     /// Deserializes an InfraConfig from Infra.lock, if it exists, otherwise uses Infra.toml
     /// If the default flag is true, will create a default config if Infra.toml doesn't exist
     pub fn from_path_or_lock(path: &Path, default: bool) -> Result<Self> {
-        let lock_path = Self::compute_lock_path(&path)?;
+        let lock_path = Self::compute_lock_path(path)?;
         if lock_path.exists() {
             info!("Found infra config at path: {}", lock_path.display());
             Self::from_lock_path(lock_path)
         } else if default {
-            Self::from_path_or_default(&path)
+            Self::from_path_or_default(path)
         } else {
             info!("Found infra config at path: {}", path.display());
-            Self::from_path(&path)
+            Self::from_path(path)
         }
     }
 

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -105,7 +105,7 @@ impl InfraConfig {
 }
 
 /// S3-specific TUF infrastructure configuration
-#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
 pub struct S3Config {
     pub region: Option<String>,
     #[serde(default)]
@@ -116,7 +116,7 @@ pub struct S3Config {
 }
 
 /// AWS-specific infrastructure configuration
-#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct AwsConfig {
     #[serde(default)]
@@ -130,7 +130,7 @@ pub struct AwsConfig {
 }
 
 /// AWS region-specific configuration
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct AwsRegionConfig {
     pub role: Option<String>,

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -22,10 +22,12 @@ clap = "3.1"
 coldsnap = { version = "0.4", default-features = false, features = ["aws-sdk-rust-rustls"] }
 duct = "0.13.0"
 futures = "0.3.5"
+governor = "0.5"
 http = "0.2.8"
 indicatif = "0.17.1"
 lazy_static = "1.4"
 log = "0.4"
+nonzero_ext = "0.3"
 num_cpus = "1"
 parse-datetime = { path = "../../sources/parse-datetime", version = "0.1.0" }
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -1,6 +1,7 @@
 //! The ami module owns the 'ami' subcommand and controls the process of registering and copying
 //! EC2 AMIs.
 
+pub(crate) mod public;
 mod register;
 mod snapshot;
 pub(crate) mod wait;
@@ -370,7 +371,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
 /// If JSON output was requested, we serialize out a mapping of region to AMI information; this
 /// struct holds the information we save about each AMI.  The `ssm` subcommand uses this
 /// information to populate templates representing SSM parameter names and values.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub(crate) struct Image {
     pub(crate) id: String,
     pub(crate) name: String,

--- a/tools/pubsys/src/aws/ami/public.rs
+++ b/tools/pubsys/src/aws/ami/public.rs
@@ -1,0 +1,64 @@
+use aws_sdk_ec2::Client as Ec2Client;
+use snafu::{ensure, OptionExt, ResultExt};
+
+/// Returns whether or not the given AMI ID refers to a public AMI.
+pub(crate) async fn ami_is_public(
+    ec2_client: &Ec2Client,
+    region: &str,
+    ami_id: &str,
+) -> Result<bool> {
+    let ec2_response = ec2_client
+        .describe_images()
+        .image_ids(ami_id.to_string())
+        .send()
+        .await
+        .context(error::DescribeImagesSnafu {
+            ami_id: ami_id.to_string(),
+            region: region.to_string(),
+        })?;
+
+    let returned_images = ec2_response.images().unwrap_or_default();
+
+    ensure!(
+        returned_images.len() <= 1,
+        error::TooManyImagesSnafu {
+            ami_id: ami_id.to_string(),
+            region: region.to_string(),
+        }
+    );
+
+    Ok(returned_images
+        .first()
+        .context(error::NoSuchImageSnafu {
+            ami_id: ami_id.to_string(),
+            region: region.to_string(),
+        })?
+        .public()
+        .unwrap_or(false))
+}
+
+mod error {
+    use aws_sdk_ec2::error::DescribeImagesError;
+    use aws_sdk_ec2::types::SdkError;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub(crate) enum Error {
+        #[snafu(display("Error describing AMI {} in {}: {}", ami_id, region, source))]
+        DescribeImages {
+            ami_id: String,
+            region: String,
+            #[snafu(source(from(SdkError<DescribeImagesError>, Box::new)))]
+            source: Box<SdkError<DescribeImagesError>>,
+        },
+
+        #[snafu(display("AMI {} not found in {}", ami_id, region))]
+        NoSuchImage { ami_id: String, region: String },
+
+        #[snafu(display("Multiples AMIs with ID {} found in  {}", ami_id, region))]
+        TooManyImages { ami_id: String, region: String },
+    }
+}
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ssm/template.rs
+++ b/tools/pubsys/src/aws/ssm/template.rs
@@ -40,7 +40,7 @@ pub(crate) fn get_parameters(
     template_path: &Path,
     build_context: &BuildContext<'_>,
 ) -> Result<TemplateParameters> {
-    let templates_str = fs::read_to_string(&template_path).context(error::FileSnafu {
+    let templates_str = fs::read_to_string(template_path).context(error::FileSnafu {
         op: "read",
         path: &template_path,
     })?;

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -244,7 +244,7 @@ where
     for target_path in targets {
         debug!("Adding target from path: {}", target_path.display());
         editor
-            .add_target_path(&target_path)
+            .add_target_path(target_path)
             .context(error::AddTargetSnafu { path: &target_path })?;
     }
 

--- a/tools/pubsys/src/repo/refresh_repo/mod.rs
+++ b/tools/pubsys/src/repo/refresh_repo/mod.rs
@@ -97,7 +97,7 @@ fn refresh_repo(
     .context(repo_error::RepoLoadSnafu {
         metadata_base_url: metadata_url.clone(),
     })?;
-    let mut repo_editor = RepositoryEditor::from_repo(&root_role_path, repo)
+    let mut repo_editor = RepositoryEditor::from_repo(root_role_path, repo)
         .context(repo_error::EditorFromRepoSnafu)?;
     info!("Loaded TUF repo: {}", metadata_url);
 
@@ -114,11 +114,11 @@ fn refresh_repo(
 
     // Write out the metadata files for the repository
     info!("Writing repo metadata to: {}", metadata_out_dir.display());
-    fs::create_dir_all(&metadata_out_dir).context(repo_error::CreateDirSnafu {
+    fs::create_dir_all(metadata_out_dir).context(repo_error::CreateDirSnafu {
         path: &metadata_out_dir,
     })?;
     signed_repo
-        .write(&metadata_out_dir)
+        .write(metadata_out_dir)
         .context(repo_error::RepoWriteSnafu {
             path: &metadata_out_dir,
         })?;


### PR DESCRIPTION
**Description of changes:**
This change by default will disallow publishing SSM parameters to the public `/aws/` SSM namespace if they refer to private AMIs.



**Testing done:**

* Here's a sample run where I tried to set some of my own private AMIs to the `/aws/service/doggierocket` namespace. ( :dog: )
```
03:58:05 [INFO] Using AMI data from path: ../../build/images/aarch64-aws-k8s-1.21/bottlerocket-aws-k8s-1.21-aarch64-1.10.0-867fbbda-amis.json
03:58:05 [INFO] Parsing SSM parameter templates from policies/ssm/defaults.toml
03:58:05 [INFO] Ensuring that only public images are published to public parameters.
03:58:05 [ERROR] Attempted to set parameter '/aws/service/doggierocket/aws-k8s-1.21/arm64/1.10.0/image_version' in us-west-2 to '1.10.0', based on AMI ami-0bc2a2c72b2ce0a28. That AMI is not marked public!
03:58:05 [ERROR] Attempted to set parameter '/aws/service/doggierocket/aws-k8s-1.21/arm64/1.10.0/image_id' in us-west-2 to 'ami-0bc2a2c72b2ce0a28', based on AMI ami-0bc2a2c72b2ce0a28. That AMI is not marked public!
Failed to update SSM: Cowardly refusing to publish private image to public namespace without ALLOW_PRIVATE_IMAGES

[ec2-user@ip-10-0-0-27 pubsys]$ echo $?
1
```

* Using `--allow-private-images` passes this check (but then fails because we are trying to update parameters that don't exist)

Originally I sought to use Traits and fakes to provide additional automated testing here, but it was pretty difficult to do it in a way that didn't require more significant refactoring.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
