### PR TITLE
testsys: refactor and allow overrides in shared 'migration_crd' generation

### DIFF
--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -1,9 +1,10 @@
-use crate::aws_resources::{ami, ami_name, ec2_crd, get_ami_id, migration_crd};
+use crate::aws_resources::{ami, ami_name, ec2_crd, get_ami_id};
 use crate::crds::{
     BottlerocketInput, ClusterInput, CrdCreator, CrdInput, CreateCrdOutput, MigrationInput,
     TestInput,
 };
 use crate::error::{self, Result};
+use crate::migration::migration_crd;
 use bottlerocket_types::agent_config::{ClusterType, EcsClusterConfig, EcsTestConfig};
 use log::debug;
 use maplit::btreemap;
@@ -115,6 +116,7 @@ impl CrdCreator for AwsEcsCreator {
     ) -> Result<CreateCrdOutput> {
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(migration_crd(
             migration_input,
+            None,
         )?))))
     }
 

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -117,6 +117,7 @@ impl CrdCreator for AwsEcsCreator {
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(migration_crd(
             migration_input,
             None,
+            "ids",
         )?))))
     }
 

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -1,9 +1,10 @@
-use crate::aws_resources::{ami, ami_name, ec2_crd, get_ami_id, migration_crd};
+use crate::aws_resources::{ami, ami_name, ec2_crd, get_ami_id};
 use crate::crds::{
     BottlerocketInput, ClusterInput, CrdCreator, CrdInput, CreateCrdOutput, MigrationInput,
     TestInput,
 };
 use crate::error::{self, Result};
+use crate::migration::migration_crd;
 use crate::sonobuoy::sonobuoy_crd;
 use bottlerocket_types::agent_config::{
     ClusterType, CreationPolicy, EksClusterConfig, EksctlConfig, K8sVersion,
@@ -147,6 +148,7 @@ impl CrdCreator for AwsK8sCreator {
     ) -> Result<CreateCrdOutput> {
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(migration_crd(
             migration_input,
+            None,
         )?))))
     }
 

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -149,6 +149,7 @@ impl CrdCreator for AwsK8sCreator {
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(migration_crd(
             migration_input,
             None,
+            "ids",
         )?))))
     }
 

--- a/tools/testsys/src/main.rs
+++ b/tools/testsys/src/main.rs
@@ -21,6 +21,7 @@ mod delete;
 mod error;
 mod install;
 mod logs;
+mod migration;
 mod restart_test;
 mod run;
 mod secret;

--- a/tools/testsys/src/migration.rs
+++ b/tools/testsys/src/migration.rs
@@ -6,9 +6,12 @@ use model::Test;
 use snafu::OptionExt;
 
 /// Create a CRD for migrating Bottlerocket instances using SSM commands.
+/// `aws_region_override` allows the region that's normally derived from the cluster resource CRD to be overridden
+/// `instance_id_field_name` specifies the VM/Instance resource CRD field name for retrieving the instances IDs of the created instances
 pub(crate) fn migration_crd(
     migration_input: MigrationInput,
     aws_region_override: Option<String>,
+    instance_id_field_name: &str,
 ) -> Result<Test> {
     let cluster_resource_name = migration_input
         .cluster_crd_name
@@ -45,7 +48,7 @@ pub(crate) fn migration_crd(
     // Construct the migration CRD.
     let mut migration_config = MigrationConfig::builder();
 
-    // Use the specified aws-region for the migration test.
+    // Use the specified AWS region for the migration test.
     // If no region is specified, derive the appropriate region based on the region of the
     // cluster resource CRD (assuming it's an ECS or EKS cluster).
     if let Some(aws_region) = aws_region_override {
@@ -55,7 +58,7 @@ pub(crate) fn migration_crd(
     };
 
     migration_config
-        .instance_ids_template(bottlerocket_resource_name, "ids")
+        .instance_ids_template(bottlerocket_resource_name, instance_id_field_name)
         .migrate_to_version(migration_version)
         .tuf_repo(migration_input.crd_input.tuf_repo_config())
         .assume_role(migration_input.crd_input.config.agent_role.clone())

--- a/tools/testsys/src/migration.rs
+++ b/tools/testsys/src/migration.rs
@@ -1,0 +1,92 @@
+use crate::crds::{MigrationDirection, MigrationInput};
+use crate::error::{self, Result};
+use bottlerocket_types::agent_config::MigrationConfig;
+use maplit::btreemap;
+use model::Test;
+use snafu::OptionExt;
+
+/// Create a CRD for migrating Bottlerocket instances using SSM commands.
+pub(crate) fn migration_crd(
+    migration_input: MigrationInput,
+    aws_region_override: Option<String>,
+) -> Result<Test> {
+    let cluster_resource_name = migration_input
+        .cluster_crd_name
+        .as_ref()
+        .expect("A cluster name is required for migrations");
+    let bottlerocket_resource_name = migration_input
+        .bottlerocket_crd_name
+        .as_ref()
+        .expect("A cluster name is required for migrations");
+
+    let labels = migration_input.crd_input.labels(btreemap! {
+        "testsys/type".to_string() => "migration".to_string(),
+        "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+    });
+
+    // Determine which version should be migrated to from `migration_input`.
+    let migration_version = match migration_input.migration_direction {
+        MigrationDirection::Upgrade => migration_input
+            .crd_input
+            .migrate_to_version
+            .as_ref()
+            .context(error::InvalidSnafu {
+                what: "The target migration version is required",
+            }),
+        MigrationDirection::Downgrade => migration_input
+            .crd_input
+            .starting_version
+            .as_ref()
+            .context(error::InvalidSnafu {
+                what: "The starting migration version is required",
+            }),
+    }?;
+
+    // Construct the migration CRD.
+    let mut migration_config = MigrationConfig::builder();
+
+    // Use the specified aws-region for the migration test.
+    // If no region is specified, derive the appropriate region based on the region of the
+    // cluster resource CRD (assuming it's an ECS or EKS cluster).
+    if let Some(aws_region) = aws_region_override {
+        migration_config.aws_region(aws_region)
+    } else {
+        migration_config.aws_region_template(cluster_resource_name, "region")
+    };
+
+    migration_config
+        .instance_ids_template(bottlerocket_resource_name, "ids")
+        .migrate_to_version(migration_version)
+        .tuf_repo(migration_input.crd_input.tuf_repo_config())
+        .assume_role(migration_input.crd_input.config.agent_role.clone())
+        .resources(bottlerocket_resource_name)
+        .resources(cluster_resource_name)
+        .set_depends_on(Some(migration_input.prev_tests))
+        .image(
+            migration_input
+                .crd_input
+                .images
+                .migration_test_agent_image
+                .as_ref()
+                .expect("Missing default image for migration test agent"),
+        )
+        .set_image_pull_secret(
+            migration_input
+                .crd_input
+                .images
+                .testsys_agent_pull_secret
+                .to_owned(),
+        )
+        .keep_running(true)
+        .set_secrets(Some(migration_input.crd_input.config.secrets.to_owned()))
+        .set_labels(Some(labels))
+        .build(format!(
+            "{}{}",
+            cluster_resource_name,
+            migration_input.name_suffix.unwrap_or_default()
+        ))
+        .map_err(|e| error::Error::Build {
+            what: "migration CRD".to_string(),
+            error: e.to_string(),
+        })
+}

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -248,6 +248,7 @@ impl CrdCreator for VmwareK8sCreator {
             // Let the migration test's SSM RunDocuments and RunCommand invocations happen in 'us-west-2'
             // FIXME: Do we need to allow this to be configurable?
             Some("us-west-2".to_string()),
+            "instanceIds",
         )?))))
     }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
    testsys: refactor and allow aws region override in 'migration_crd'
    
    Migration testing for VMware variants require a region for SSM to
    dispatch upgrade/downgrade RunCommands to managed instances in vSphere.
    
    Unlike ECS or EKS, TestSys cannot assume the cluster resource CRD
    includes a region for vmware-k8s testing. Therefore we pass 'us-west-2'
    as the override region when creating the migration test CRD.
```
```
    testsys: add param to 'migration_crd' to specify instance id field name
    
    The TestSys EC2 resource CRD stores the instance IDs of created
    instances in a field named "ids", but the vSphere VM resource CRD stores
    the instance IDs of the managed instances in a field named
    "instance_ids".
```

Before these changes, migration testing on vSphere will fail because the templated fields for migration test don't exist in the VM resource CRD:
```
[2022-12-21T21:17:05Z ERROR migration_test_agent] client error: Unable to resolve config templates: An error occured while resolving the config: No field 'region' in created resource

```


**Testing done:**

The migration tests successfully kick-off and finish:
```
Every 2.0s: testsys --kubeconfig /home/etung/1.12.0-release/testsys_kubeconfig.yaml status                                                                                   Thu Dec 22 00:09:47 2022

 NAME                                                      TYPE                         STATE                         PASSED                     SKIPPED                     FAILED
 x86-64-vmware-k8s-124                                     Resource                     completed
 x86-64-vmware-k8s-124-1-initial                           Test                         pass                          1                          6972                        0
 x86-64-vmware-k8s-124-2-migrate                           Test                         pass                          2                          0                           0
 x86-64-vmware-k8s-124-3-migrated                          Test                         pass                          1                          6972                        0
 x86-64-vmware-k8s-124-4-migrate                           Test                         pass                          2                          0                           0
 x86-64-vmware-k8s-124-5-final                             Test                         pass                          1                          6972                        0
 x86-64-vmware-k8s-124-test                                Test                         running                       2                          0                           0
 x86-64-vmware-k8s-124-vms-conformance                     Resource                     completed

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
