### PR TITLE
pubsys: improve messages for publish-ami command

### DIFF
--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -182,7 +182,11 @@ mod error {
         #[snafu(display("Logger setup error: {}", source))]
         Logger { source: log::SetLoggerError },
 
-        #[snafu(display("Failed to publish AMI: {}", source))]
+        #[snafu(display(
+            "Error during publish-ami command: {}: {}",
+            publish_ami_message(source),
+            source
+        ))]
         PublishAmi {
             source: crate::aws::publish_ami::Error,
         },
@@ -220,6 +224,14 @@ mod error {
         UploadOva {
             source: crate::vmware::upload_ova::Error,
         },
+    }
+
+    fn publish_ami_message(error: &crate::aws::publish_ami::Error) -> String {
+        match error.amis_affected() {
+            0 => String::from("No AMI permissions were updated"),
+            1 => String::from("Permissions for 1 AMI were updated, the rest failed"),
+            n => format!("Permissions for {} AMIs were updated, the rest failed", n),
+        }
     }
 }
 type Result<T> = std::result::Result<T, error::Error>;


### PR DESCRIPTION
Reduce verbosity and clarify error conditions in publish-ami.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

## Issue number:

Closes #2688

## Description of changes:

For the `publish-ami` command:
- Slightly reduce logging verbosity
- Clarify some log messages
- Clarify error conditions that lead to zero AMIs being published


## Testing done:

### Before these Changes

**Error Path**

```
20:23:13 [INFO] Using AMI data from path: /home/x/repos/bottlerocket/build/images/x86_64-aws-k8s-1.23/1.12.0-aeb95d83/bottlerocket-aws-k8s-1.23-x86_64-1.12.0-aeb95d83-amis.json
20:23:13 [INFO] Waiting for AMIs to be available...
20:23:13 [INFO] Waiting for ami-04e85be49d294275c in us-west-2 to be available... (attempt 1 of 90)
20:23:19 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 1 of 90)
20:23:21 [INFO] provider returned CredentialsNotLoaded, ignoring
20:23:21 [INFO] Waiting for ami-0c6efd0a3cf83b6c0 in us-west-1 to be available... (attempt 1 of 90)
20:23:23 [INFO] Waiting for ami-04a38d08dfee9430e in ap-northeast-1 to be available... (attempt 1 of 90)
20:23:25 [INFO] Found ami-05489572a30afaae3 available in af-south-1
20:23:25 [INFO] provider returned CredentialsNotLoaded, ignoring
20:23:31 [INFO] provider returned CredentialsNotLoaded, ignoring
20:23:36 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 6 of 90)
20:23:48 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 11 of 90)
20:23:59 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 16 of 90)
20:24:11 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 21 of 90)
20:24:22 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 26 of 90)
20:24:34 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 31 of 90)
20:24:46 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 36 of 90)
20:24:57 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 41 of 90)
20:25:09 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 46 of 90)
20:25:20 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 51 of 90)
20:25:32 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 56 of 90)
20:25:43 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 61 of 90)
20:25:55 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 66 of 90)
20:26:06 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 71 of 90)
20:26:18 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 76 of 90)
20:26:29 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 81 of 90)
20:26:41 [INFO] Waiting for ami-0fb30279737b04eb5 in us-east-1 to be available... (attempt 86 of 90)
Failed to publish AMI: AMI 'ami-04e85be49d294275c' in us-west-2 did not become available: Failed to describe images in us-west-2: failed to construct request: No credentials in the property bag
```

**Happy Path**

```
20:35:01 [INFO] Using AMI data from path: /home/x/repos/bottlerocket/build/images/x86_64-aws-k8s-1.23/1.12.0-aeb95d83/bottlerocket-aws-k8s-1.23-x86_64-1.12.0-aeb95d83-amis.json
20:35:01 [INFO] Waiting for AMIs to be available...
20:35:02 [INFO] Found ami-04e85be49d294275c available in us-west-2
20:35:02 [INFO] Found ami-0c6efd0a3cf83b6c0 available in us-west-1
20:35:02 [INFO] Found ami-0fb30279737b04eb5 available in us-east-1
20:35:02 [INFO] Found ami-04a38d08dfee9430e available in ap-northeast-1
20:35:03 [INFO] Found ami-05489572a30afaae3 available in af-south-1
20:35:04 [INFO] Updating snapshot permissions - granting access
20:35:05 [INFO] Updating image permissions - granting access
20:35:05 [INFO] Modified permissions of image ami-0c6efd0a3cf83b6c0 in us-west-1
20:35:05 [INFO] Modified permissions of image ami-0fb30279737b04eb5 in us-east-1
20:35:05 [INFO] Modified permissions of image ami-04a38d08dfee9430e in ap-northeast-1
20:35:05 [INFO] Modified permissions of image ami-05489572a30afaae3 in af-south-1
20:35:05 [INFO] Modified permissions of image ami-04e85be49d294275c in us-west-2
```

### After these Changes

**Error Path**

```
20:19:07 [INFO] Using AMI data from path: /home/x/repos/bottlerocket/build/images/x86_64-aws-k8s-1.23/1.12.0-11f46927/bottlerocket-aws-k8s-1.23-x86_64-1.12.0-11f46927-amis.json
20:19:07 [INFO] Waiting for all 5 AMIs to be available before changing any of their permissions
20:19:07 [INFO] Waiting for ami-077e452dff44ef3ca in us-west-2 to be available... (attempt 1 of 90)
20:19:09 [INFO] Waiting for ami-0b029c3d70ad88c0a in us-west-1 to be available... (attempt 1 of 90)
20:19:11 [INFO] provider returned CredentialsNotLoaded, ignoring
20:19:11 [INFO] Waiting for ami-0896fc4409dc0b916 in us-east-1 to be available... (attempt 1 of 90)
20:19:15 [INFO] provider returned CredentialsNotLoaded, ignoring
20:19:17 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 1 of 90)
20:19:19 [INFO] provider returned CredentialsNotLoaded, ignoring
20:19:20 [INFO] Found ami-03e1123698e77270d available in af-south-1
20:19:30 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 6 of 90)
20:19:42 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 11 of 90)
20:19:54 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 16 of 90)
20:20:06 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 21 of 90)
20:20:19 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 26 of 90)
20:20:31 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 31 of 90)
20:20:43 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 36 of 90)
20:20:55 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 41 of 90)
20:21:07 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 46 of 90)
20:21:20 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 51 of 90)
20:21:32 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 56 of 90)
20:21:44 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 61 of 90)
20:21:56 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 66 of 90)
20:22:08 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 71 of 90)
20:22:21 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 76 of 90)
20:22:33 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 81 of 90)
20:22:45 [INFO] Waiting for ami-0d9a51431f7c2cdf0 in ap-northeast-1 to be available... (attempt 86 of 90)
Error during publish-ami command: No AMI permissions were updated: AMI 'ami-077e452dff44ef3ca' in us-west-2 did not become available: Failed to describe images in us-west-2: failed to construct request: No credentials in the property bag
```

**Happy Path**

```
20:24:32 [INFO] Using AMI data from path: /home/x/repos/bottlerocket/build/images/x86_64-aws-k8s-1.23/1.12.0-11f46927/bottlerocket-aws-k8s-1.23-x86_64-1.12.0-11f46927-amis.json
20:24:32 [INFO] Waiting for all 5 AMIs to be available before changing any of their permissions
20:24:32 [INFO] Found ami-077e452dff44ef3ca available in us-west-2
20:24:32 [INFO] Found ami-0b029c3d70ad88c0a available in us-west-1
20:24:32 [INFO] Found ami-0896fc4409dc0b916 available in us-east-1
20:24:32 [INFO] Found ami-0d9a51431f7c2cdf0 available in ap-northeast-1
20:24:33 [INFO] Found ami-03e1123698e77270d available in af-south-1
20:24:34 [INFO] Updating all snapshot permissions before changing any AMI permissions - granting access
20:24:35 [INFO] Updating AMI permissions - granting access
20:24:36 [INFO] Modified permissions of image ami-077e452dff44ef3ca in us-west-2
20:24:36 [INFO] Modified permissions of image ami-0b029c3d70ad88c0a in us-west-1
20:24:36 [INFO] Modified permissions of image ami-0d9a51431f7c2cdf0 in ap-northeast-1
20:24:36 [INFO] Modified permissions of image ami-03e1123698e77270d in af-south-1
20:24:36 [INFO] Modified permissions of image ami-0896fc4409dc0b916 in us-east-1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
