### PR TITLE
housekeeping: Remove `unneeded_borrow` errors

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -87,7 +87,7 @@ impl PackageBuilder {
         let mut args = Vec::new();
         args.build_arg("PACKAGE", package);
         args.build_arg("ARCH", &arch);
-        args.build_arg("GOARCH", &goarch);
+        args.build_arg("GOARCH", goarch);
 
         // Pass certain environment variables into the build environment. These variables aren't
         // automatically used to trigger rebuilds when they change, because most packages aren't
@@ -157,7 +157,7 @@ impl VariantBuilder {
         let mut args = Vec::new();
         args.build_arg("PACKAGES", packages.join(" "));
         args.build_arg("ARCH", &arch);
-        args.build_arg("GOARCH", &goarch);
+        args.build_arg("GOARCH", goarch);
         args.build_arg("VARIANT", &variant);
         args.build_arg("VERSION_ID", getenv("BUILDSYS_VERSION_IMAGE")?);
         args.build_arg("BUILD_ID", getenv("BUILDSYS_VERSION_BUILD")?);
@@ -422,7 +422,7 @@ where
         let parent_dir = output_file
             .parent()
             .context(error::BadDirectorySnafu { path: &output_file })?;
-        fs::create_dir_all(&parent_dir)
+        fs::create_dir_all(parent_dir)
             .context(error::DirectoryCreateSnafu { path: &parent_dir })?;
 
         fs::rename(&artifact_file, &output_file).context(error::FileRenameSnafu {
@@ -462,7 +462,7 @@ where
         if !path.exists() && !path.is_symlink() {
             return Ok(());
         }
-        std::fs::remove_file(&path).context(error::FileRemoveSnafu { path })?;
+        std::fs::remove_file(path).context(error::FileRemoveSnafu { path })?;
         let mut parent = path.parent();
         while let Some(p) = parent {
             if p == top || dirs.contains(p) {
@@ -487,7 +487,7 @@ where
 
     for marker_file in find_files(&build_dir, has_markers) {
         let mut output_file: PathBuf = output_dir.into();
-        output_file.push(marker_file.strip_prefix(&build_dir).context(
+        output_file.push(marker_file.strip_prefix(build_dir).context(
             error::StripPathPrefixSnafu {
                 path: &marker_file,
                 prefix: build_dir,

--- a/tools/infrasys/src/main.rs
+++ b/tools/infrasys/src/main.rs
@@ -183,7 +183,7 @@ async fn create_infra(toml_path: &Path, root_role_path: &Path) -> Result<()> {
                 .context(error::ParseUrlSnafu { input: &bucket_rdn })?,
             );
         }
-        let root_role_data = fs::read_to_string(&root_role_path).context(error::FileReadSnafu {
+        let root_role_data = fs::read_to_string(root_role_path).context(error::FileReadSnafu {
             path: root_role_path,
         })?;
         let mut d = Sha512::new();

--- a/tools/pubsys-setup/src/main.rs
+++ b/tools/pubsys-setup/src/main.rs
@@ -109,7 +109,7 @@ fn run() -> Result<()> {
             }
 
             let temp_root_role =
-                NamedTempFile::new_in(&role_dir).context(error::TempFileCreateSnafu {
+                NamedTempFile::new_in(role_dir).context(error::TempFileCreateSnafu {
                     purpose: "root role",
                 })?;
             let temp_root_role_path = temp_root_role.path().display();


### PR DESCRIPTION
**Issue number:**

Closes #2701

**Description of changes:**

The 1.66 toolchain has started emitting linting errors when variables are unnecessarily borrowed. This addresses those errors by updating the instances where this was happing.

**Testing done:**

Ran `cargo make check` and verified all warnings and errors have gone away.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
