### PR TITLE
rpm2img: Fix OVA manifest checksum format

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -447,13 +447,16 @@ if [ "${OUTPUT_FMT}" == "vmdk" ] ; then
   # Create the manifest file with the hashes of the VMDKs and the OVF.
   manifest="${OS_IMAGE_NAME}.mf"
   pushd "${OUTPUT_DIR}" >/dev/null
-  sha256sum --tag "${os_vmdk}" > "${ova_dir}/${manifest}"
+  os_sha256="$(sha256sum ${os_vmdk} | awk '{print $1}')"
+  echo "SHA256(${os_vmdk})= ${os_sha256}" > "${ova_dir}/${manifest}"
   if [ -s "${DATA_IMAGE}" ] ; then
-    sha256sum --tag "${data_vmdk}" >> "${ova_dir}/${manifest}"
+    data_sha256="$(sha256sum ${data_vmdk} | awk '{print $1}')"
+    echo "SHA256(${data_vmdk})= ${data_sha256}" >> "${ova_dir}/${manifest}"
   fi
   popd >/dev/null
   pushd "${ova_dir}" >/dev/null
-  sha256sum --tag "${ovf}" >> "${manifest}"
+  ovf_sha256="$(sha256sum ${ovf} | awk '{print $1}')"
+  echo "SHA256(${ovf})= ${ovf_sha256}" >> "${manifest}"
   popd >/dev/null
 
   # According to the OVF spec:


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
In #2505 , the format of the manifest (`*.mf`) file on the VMware OVA was changed slightly, using `sha256sum --tag` output.  This output includes spaces that appear to cause issues for some users trying to upload Bottlerocket OVAs to vSphere.  This PR reverts back to the logic and format previously used.

**Testing done:**
Built and uploaded a vmware-k8s-1.22 OVA to vSphere, which joined the cluster and ran normally.

Ensure the manifest has the desired output, i.e no spaces between `SHA256` and (...):
```
$ cat bottlerocket-vmware-k8s-1.22-x86_64-1.12.0-ffdc2553.mf 

SHA256(bottlerocket-vmware-k8s-1.22-x86_64-1.12.0-ffdc2553.vmdk)= 293c7cbdcd411d8a47738e2adc3fd5d5e64a867aaba247691727ad5a651f78dc
SHA256(bottlerocket-vmware-k8s-1.22-x86_64-1.12.0-ffdc2553.ovf)= 90312d632d1ad8fb004c03cb5c50c84be9ea3952ec62b892e60ab46911baee18
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
