### PR TITLE
build: clean up kernel command line

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -307,11 +307,31 @@ VERITY_SALT="$(grep '^Salt:' <<<"${veritysetup_output}" | awk '{ print $NF }')"
 veritysetup verify "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${VERITY_ROOT_HASH}"
 dd if="${VERITY_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[HASH-A]}"
 
+declare -a DM_VERITY_ROOT
+DM_VERITY_ROOT=(
+  "root,,,ro,0"
+  "${VERITY_DATA_512B_BLOCKS}"
+  "verity"
+  "${VERITY_VERSION}"
+  "PARTUUID=\$boot_uuid/PARTNROFF=1"
+  "PARTUUID=\$boot_uuid/PARTNROFF=2"
+  "${VERITY_DATA_BLOCK_SIZE}"
+  "${VERITY_HASH_BLOCK_SIZE}"
+  "${VERITY_DATA_4K_BLOCKS}"
+  "1"
+  "${VERITY_HASH_ALGORITHM}"
+  "${VERITY_ROOT_HASH}"
+  "${VERITY_SALT}"
+  "2"
+  "restart_on_corruption"
+  "ignore_zero_blocks"
+)
+
 # write GRUB config
 # If GRUB_SET_PRIVATE_VAR is set, include the parameters that support Boot Config
 if [ "${GRUB_SET_PRIVATE_VAR}" == "yes" ] ; then
    BOOTCONFIG='bootconfig'
-   INITRD='initrd ($private)/bootconfig.data'
+   INITRD="initrd (\$private)/bootconfig.data"
 else
    BOOTCONFIG=""
    INITRD=""
@@ -320,6 +340,7 @@ fi
 cat <<EOF > "${BOOT_MOUNT}/grub/grub.cfg"
 set default="0"
 set timeout="0"
+set dm_verity_root="${DM_VERITY_ROOT[@]}"
 
 menuentry "${PRETTY_NAME} ${VERSION_ID}" {
    linux (\$root)/vmlinuz \\
@@ -327,13 +348,13 @@ menuentry "${PRETTY_NAME} ${VERSION_ID}" {
        ${BOOTCONFIG} \\
        root=/dev/dm-0 rootwait ro \\
        raid=noautodetect \\
-       random.trust_cpu=on selinux=1 enforcing=1 \\
-       dm_verity.max_bios=-1 dm_verity.dev_wait=1 \\
-       dm-mod.create="root,,,ro,0 $VERITY_DATA_512B_BLOCKS verity $VERITY_VERSION PARTUUID=\$boot_uuid/PARTNROFF=1 PARTUUID=\$boot_uuid/PARTNROFF=2 \\
-       $VERITY_DATA_BLOCK_SIZE $VERITY_HASH_BLOCK_SIZE $VERITY_DATA_4K_BLOCKS 1 $VERITY_HASH_ALGORITHM $VERITY_ROOT_HASH $VERITY_SALT \\
-       2 restart_on_corruption ignore_zero_blocks" \\
+       random.trust_cpu=on \\
+       selinux=1 enforcing=1 \\
+       dm-mod.create="\$dm_verity_root" \\
        -- \\
-       systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true
+       systemd.log_target=journal-or-kmsg \\
+       systemd.log_color=0 \\
+       systemd.show_status=true
    ${INITRD}
 }
 EOF


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
This removes two `dm-verity` options that aren't actually supported - `dm_verity.max_bios=-1` and `dm_verity.dev_wait=1` - which came from the original, out-of-tree Chrome OS implementation.

The more significant change is to put the `dm-mod.create` options into a GRUB variable. This removes some extraneous whitespace, and makes it easier to implement the planned "resign" workflow, which will need to replace these options in `grub.cfg` after modifying the root image and recalculating the dm-verity parameters.


**Testing done:**

Before:
```
bash-5.1# cat /proc/cmdline
BOOT_IMAGE=(hd0,gpt3)/vmlinuz console=tty0 console=ttyS0,115200n8 crashkernel=2G-:256M net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? quiet bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing=1 dm_verity.max_bios=-1 dm_verity.dev_wait=1 "dm-mod.create=root,,,ro,0 1359912 verity 1 PARTUUID=cfd4dcbd-27df-416e-b3af-38c3036990d4/PARTNROFF=1 PARTUUID=cfd4dcbd-27df-416e-b3af-38c3036990d4/PARTNROFF=2        4096 4096 169989 1 sha256 74941a0af03bfc742d8cb12f72ddecded61551a75b02265ba73991827ee71236 1accea696d3d89909e3e3dff7d49074ff55df591c26fc209cc8fecbeb0ddf662        2 restart_on_corruption ignore_zero_blocks" -- systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true
```

After:
```
bash-5.1# cat /proc/cmdline
BOOT_IMAGE=(hd0,gpt3)/vmlinuz console=tty0 console=ttyS0,115200n8 crashkernel=2G-:256M net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? quiet bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing "dm-mod.create=root,,,ro,0 1359912 verity 1 PARTUUID=aa25f9a0-f230-4fc4-8963-05a23cb28154/PARTNROFF=1 PARTUUID=aa25f9a0-f230-4fc4-8963-05a23cb28154/PARTNROFF=2 4096 4096 169989 1 sha256 4b9468038dcf4ced397f82dfd7100870fe02c447311833bb34951d15a5327b45 4c9c6892c8711f45ef13a283a81446f8c661642bcd437dbb1c80e6b145bbf160 2 restart_on_corruption ignore_zero_blocks" -- systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true
```

Images still boot and the root filesystem is set up as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
