### PR TITLE
variants: move wicked out of release

### DIFF
--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -44,4 +44,3 @@ procps = { path = "../procps" }
 selinux-policy = { path = "../selinux-policy" }
 systemd = { path = "../systemd" }
 util-linux = { path = "../util-linux" }
-wicked = { path = "../wicked" }

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "release",
  "strace",
  "tcpdump",
+ "wicked",
 ]
 
 [[package]]
@@ -37,6 +38,7 @@ dependencies = [
  "ecs-agent",
  "kernel-5_10",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -53,6 +55,7 @@ dependencies = [
  "kmod-5_10-nvidia",
  "nvidia-container-toolkit",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -72,6 +75,7 @@ dependencies = [
  "kernel-5_10",
  "kubernetes-1_21",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -87,6 +91,7 @@ dependencies = [
  "nvidia-container-toolkit",
  "nvidia-k8s-device-plugin",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -99,6 +104,7 @@ dependencies = [
  "kernel-5_10",
  "kubernetes-1_22",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -114,6 +120,7 @@ dependencies = [
  "nvidia-container-toolkit",
  "nvidia-k8s-device-plugin",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -126,6 +133,7 @@ dependencies = [
  "kernel-5_10",
  "kubernetes-1_23",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -141,6 +149,7 @@ dependencies = [
  "nvidia-container-toolkit",
  "nvidia-k8s-device-plugin",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -153,6 +162,7 @@ dependencies = [
  "kernel-5_15",
  "kubernetes-1_24",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -168,6 +178,7 @@ dependencies = [
  "nvidia-container-toolkit",
  "nvidia-k8s-device-plugin",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -769,6 +780,7 @@ dependencies = [
  "release",
  "strace",
  "tcpdump",
+ "wicked",
 ]
 
 [[package]]
@@ -780,6 +792,7 @@ dependencies = [
  "kernel-5_10",
  "kubernetes-1_21",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -791,6 +804,7 @@ dependencies = [
  "kernel-5_10",
  "kubernetes-1_22",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -802,6 +816,7 @@ dependencies = [
  "kernel-5_10",
  "kubernetes-1_23",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -813,6 +828,7 @@ dependencies = [
  "kernel-5_15",
  "kubernetes-1_24",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -926,7 +942,6 @@ dependencies = [
  "selinux-policy",
  "systemd",
  "util-linux",
- "wicked",
 ]
 
 [[package]]
@@ -998,6 +1013,7 @@ dependencies = [
  "release",
  "strace",
  "tcpdump",
+ "wicked",
 ]
 
 [[package]]
@@ -1010,6 +1026,7 @@ dependencies = [
  "kubernetes-1_21",
  "open-vm-tools",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -1022,6 +1039,7 @@ dependencies = [
  "kubernetes-1_22",
  "open-vm-tools",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -1034,6 +1052,7 @@ dependencies = [
  "kubernetes-1_23",
  "open-vm-tools",
  "release",
+ "wicked",
 ]
 
 [[package]]
@@ -1046,6 +1065,7 @@ dependencies = [
  "kubernetes-1_24",
  "open-vm-tools",
  "release",
+ "wicked",
 ]
 
 [[package]]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -11,15 +11,6 @@ exclude = ["README.md"]
 grub-set-private-var = true
 
 [package.metadata.build-variant]
-kernel-parameters = [
-    "console=tty0",
-    "console=ttyS0,115200n8",
-    # Only reserve if there are at least 2GB
-    "crashkernel=2G-:256M",
-    "net.ifnames=0",
-    "netdog.default-interface=eth0:dhcp4,dhcp6?",
-    "quiet",
-]
 included-packages = [
 # core
     "release",
@@ -35,6 +26,15 @@ included-packages = [
     "strace",
     "tcpdump",
     "chrony-tools",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -15,6 +15,8 @@ included-packages = [
 # core
     "release",
     "kernel-5.15",
+# networking
+    "wicked",
 # docker
     "docker-cli",
     "docker-engine",
@@ -44,6 +46,8 @@ path = "lib.rs"
 # core
 release = { path = "../../packages/release" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -13,6 +13,8 @@ included-packages = [
 # core
     "release",
     "kernel-5.10",
+# networking
+    "wicked",
 # docker
     "docker-cli",
     "docker-engine",
@@ -40,6 +42,8 @@ path = "lib.rs"
 # core
 release = { path = "../../packages/release" }
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -9,13 +9,6 @@ build = "build.rs"
 os-image-size-gib = 4
 
 [package.metadata.build-variant]
-kernel-parameters = [
-    "console=tty0",
-    "console=ttyS0,115200n8",
-    "net.ifnames=0",
-    "netdog.default-interface=eth0:dhcp4,dhcp6?",
-    "quiet",
-]
 included-packages = [
 # core
     "release",
@@ -31,6 +24,13 @@ included-packages = [
     "ecs-gpu-init",
     "nvidia-container-toolkit",
     "kmod-5.10-nvidia-tesla-470",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -6,13 +6,6 @@ publish = false
 build = "build.rs"
 
 [package.metadata.build-variant]
-kernel-parameters = [
-    "console=tty0",
-    "console=ttyS0,115200n8",
-    "net.ifnames=0",
-    "netdog.default-interface=eth0:dhcp4,dhcp6?",
-    "quiet",
-]
 included-packages = [
 # core
     "release",
@@ -24,6 +17,13 @@ included-packages = [
     "docker-proxy",
 # ecs
     "ecs-agent",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
 ]
 
 [lib]

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -10,6 +10,8 @@ included-packages = [
 # core
     "release",
     "kernel-5.10",
+# networking
+    "wicked",
 # docker
     "docker-cli",
     "docker-engine",
@@ -33,6 +35,8 @@ path = "lib.rs"
 # core
 release = { path = "../../packages/release" }
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/aws-k8s-1.21-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.21-nvidia/Cargo.toml
@@ -14,12 +14,15 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.10",
     "kubelet-1.21",
-    "release",
+# NVIDIA
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
     "kmod-5.10-nvidia-tesla-470",
@@ -36,12 +39,15 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_21 = { path = "../../packages/kubernetes-1.21" }
-release = { path = "../../packages/release" }
+# NVIDIA
 nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
 nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
 kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }

--- a/variants/aws-k8s-1.21-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.21-nvidia/Cargo.toml
@@ -17,6 +17,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s
     "aws-iam-authenticator",
     "cni",
@@ -41,7 +43,9 @@ path = "lib.rs"
 [build-dependencies]
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
-release = { path = "../../packages/release" }
+release = { path = "../../packages/release" } 
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.21/Cargo.toml
+++ b/variants/aws-k8s-1.21/Cargo.toml
@@ -11,12 +11,14 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.10",
     "kubelet-1.21",
-    "release",
 ]
 kernel-parameters = [
     "console=tty0",
@@ -30,9 +32,11 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+# k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_21 = { path = "../../packages/kubernetes-1.21" }
-release = { path = "../../packages/release" }

--- a/variants/aws-k8s-1.21/Cargo.toml
+++ b/variants/aws-k8s-1.21/Cargo.toml
@@ -14,6 +14,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s
     "aws-iam-authenticator",
     "cni",
@@ -35,6 +37,8 @@ path = "lib.rs"
 # core
 release = { path = "../../packages/release" }
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.22-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.22-nvidia/Cargo.toml
@@ -17,6 +17,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s
     "aws-iam-authenticator",
     "cni",
@@ -42,6 +44,8 @@ path = "lib.rs"
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.22-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.22-nvidia/Cargo.toml
@@ -14,12 +14,15 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.10",
     "kubelet-1.22",
-    "release",
+# NVIDIA
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
     "kmod-5.10-nvidia-tesla-470",
@@ -36,12 +39,15 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
-release = { path = "../../packages/release" }
+# NVIDIA
 nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
 nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
 kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }

--- a/variants/aws-k8s-1.22/Cargo.toml
+++ b/variants/aws-k8s-1.22/Cargo.toml
@@ -14,6 +14,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s 
     "aws-iam-authenticator",
     "cni",
@@ -35,6 +37,8 @@ path = "lib.rs"
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.22/Cargo.toml
+++ b/variants/aws-k8s-1.22/Cargo.toml
@@ -11,12 +11,14 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s 
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.10",
     "kubelet-1.22",
-    "release",
 ]
 kernel-parameters = [
     "console=tty0",
@@ -30,9 +32,12 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
-release = { path = "../../packages/release" }
+

--- a/variants/aws-k8s-1.23-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.23-nvidia/Cargo.toml
@@ -17,12 +17,15 @@ grub-set-private-var = true
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s 
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.10",
     "kubelet-1.23",
-    "release",
+# NVIDIA
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
     "kmod-5.10-nvidia-tesla-470",
@@ -39,12 +42,15 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
-release = { path = "../../packages/release" }
+# NVIDIA
 nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
 nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
 kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }

--- a/variants/aws-k8s-1.23-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.23-nvidia/Cargo.toml
@@ -20,6 +20,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s 
     "aws-iam-authenticator",
     "cni",
@@ -45,6 +47,8 @@ path = "lib.rs"
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.23/Cargo.toml
+++ b/variants/aws-k8s-1.23/Cargo.toml
@@ -17,6 +17,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s
     "aws-iam-authenticator",
     "cni",
@@ -38,6 +40,8 @@ path = "lib.rs"
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s 
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.23/Cargo.toml
+++ b/variants/aws-k8s-1.23/Cargo.toml
@@ -14,12 +14,14 @@ grub-set-private-var = true
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.10",
     "kubelet-1.23",
-    "release",
 ]
 kernel-parameters = [
     "console=tty0",
@@ -33,9 +35,12 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s 
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_23= { path = "../../packages/kubernetes-1.23" }
-release = { path = "../../packages/release" }
+

--- a/variants/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.24-nvidia/Cargo.toml
@@ -20,6 +20,8 @@ included-packages = [
 # core
     "kernel-5.15",
     "release",
+# networking
+    "wicked",
 # k8s
     "aws-iam-authenticator",
     "cni",
@@ -45,6 +47,8 @@ path = "lib.rs"
 # core
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s 
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.24-nvidia/Cargo.toml
@@ -17,12 +17,15 @@ grub-set-private-var = true
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.15",
+    "release",
+# k8s
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.15",
     "kubelet-1.24",
-    "release",
+# NVIDIA
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
     "kmod-5.15-nvidia-tesla-515",
@@ -39,12 +42,15 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+release = { path = "../../packages/release" }
+# k8s 
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_15 = { path = "../../packages/kernel-5.15" }
 kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
-release = { path = "../../packages/release" }
+# NVIDIA
 nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
 nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
 kmod-5_15-nvidia = { path = "../../packages/kmod-5.15-nvidia" }

--- a/variants/aws-k8s-1.24/Cargo.toml
+++ b/variants/aws-k8s-1.24/Cargo.toml
@@ -17,6 +17,8 @@ included-packages = [
 # core
     "kernel-5.15",
     "release",
+# networking
+    "wicked",
 # k8s
     "aws-iam-authenticator",
     "cni",
@@ -38,6 +40,8 @@ path = "lib.rs"
 # core
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.24/Cargo.toml
+++ b/variants/aws-k8s-1.24/Cargo.toml
@@ -14,12 +14,14 @@ grub-set-private-var = true
 
 [package.metadata.build-variant]
 included-packages = [
+# core
+    "kernel-5.15",
+    "release",
+# k8s
     "aws-iam-authenticator",
     "cni",
     "cni-plugins",
-    "kernel-5.15",
     "kubelet-1.24",
-    "release",
 ]
 kernel-parameters = [
     "console=tty0",
@@ -33,9 +35,12 @@ kernel-parameters = [
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+release = { path = "../../packages/release" }
+# k8s
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_15 = { path = "../../packages/kernel-5.15" }
 kubernetes-1_24= { path = "../../packages/kubernetes-1.24" }
-release = { path = "../../packages/release" }
+

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -15,10 +15,6 @@ grub-set-private-var = true
 
 [package.metadata.build-variant]
 image-format = "raw"
-kernel-parameters = [
-    # Only reserve if there are at least 2GB
-    "crashkernel=2G-:256M"
-]
 included-packages = [
 # core
     "release",
@@ -34,6 +30,10 @@ included-packages = [
     "strace",
     "tcpdump",
     "chrony-tools",
+]
+kernel-parameters = [
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M"
 ]
 
 [lib]

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -19,6 +19,8 @@ included-packages = [
 # core
     "release",
     "kernel-5.15",
+# networking
+    "wicked",
 # docker
     "docker-cli",
     "docker-engine",
@@ -43,6 +45,8 @@ path = "lib.rs"
 # core
 release = { path = "../../packages/release" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/metal-k8s-1.21/Cargo.toml
+++ b/variants/metal-k8s-1.21/Cargo.toml
@@ -23,6 +23,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -40,6 +42,8 @@ path = "lib.rs"
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/metal-k8s-1.21/Cargo.toml
+++ b/variants/metal-k8s-1.21/Cargo.toml
@@ -19,24 +19,29 @@ grub-set-private-var = true
 [package.metadata.build-variant]
 image-format = "raw"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.21",
+]
 kernel-parameters = [
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"
-]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.10",
-    "kubelet-1.21",
-    "release",
 ]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_21 = { path = "../../packages/kubernetes-1.21" }
-release = { path = "../../packages/release" }
+

--- a/variants/metal-k8s-1.22/Cargo.toml
+++ b/variants/metal-k8s-1.22/Cargo.toml
@@ -23,6 +23,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -40,6 +42,8 @@ path = "lib.rs"
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked"}
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/metal-k8s-1.22/Cargo.toml
+++ b/variants/metal-k8s-1.22/Cargo.toml
@@ -19,24 +19,29 @@ grub-set-private-var = true
 [package.metadata.build-variant]
 image-format = "raw"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.22",
+]
 kernel-parameters = [
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"
-]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.10",
-    "kubelet-1.22",
-    "release",
 ]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
-release = { path = "../../packages/release" }
+

--- a/variants/metal-k8s-1.23/Cargo.toml
+++ b/variants/metal-k8s-1.23/Cargo.toml
@@ -19,24 +19,28 @@ grub-set-private-var = true
 [package.metadata.build-variant]
 image-format = "raw"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.10",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.23",
+]
 kernel-parameters = [
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"
-]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.10",
-    "kubelet-1.23",
-    "release",
 ]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+release = { path = "../../packages/release" }
+# k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_10 = { path = "../../packages/kernel-5.10" }
 kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
-release = { path = "../../packages/release" }

--- a/variants/metal-k8s-1.23/Cargo.toml
+++ b/variants/metal-k8s-1.23/Cargo.toml
@@ -23,6 +23,8 @@ included-packages = [
 # core
     "kernel-5.10",
     "release",
+# networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -40,6 +42,8 @@ path = "lib.rs"
 # core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked"}
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/metal-k8s-1.24/Cargo.toml
+++ b/variants/metal-k8s-1.24/Cargo.toml
@@ -23,6 +23,8 @@ included-packages = [
 # core
     "kernel-5.15",
     "release",
+# networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -40,6 +42,8 @@ path = "lib.rs"
 # core
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/metal-k8s-1.24/Cargo.toml
+++ b/variants/metal-k8s-1.24/Cargo.toml
@@ -19,24 +19,29 @@ grub-set-private-var = true
 [package.metadata.build-variant]
 image-format = "raw"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.15",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.24",
+]
 kernel-parameters = [
     # Only reserve if there are at least 2GB
     "crashkernel=2G-:256M"
-]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.15",
-    "kubelet-1.24",
-    "release",
 ]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
+# core
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+release = { path = "../../packages/release" }
+# k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
-kernel-5_15 = { path = "../../packages/kernel-5.15" }
 kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
-release = { path = "../../packages/release" }
+

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -29,6 +29,8 @@ included-packages = [
     "release",
     "kernel-5.15",
     "open-vm-tools",
+# networking
+    "wicked",
 # docker
     "docker-cli",
     "docker-engine",
@@ -50,6 +52,8 @@ path = "lib.rs"
 release = { path = "../../packages/release" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/vmware-k8s-1.21/Cargo.toml
+++ b/variants/vmware-k8s-1.21/Cargo.toml
@@ -12,6 +12,16 @@ exclude = ["README.md"]
 [package.metadata.build-variant]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.10",
+    "open-vm-tools",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.21",
+]
 kernel-parameters = [
     "console=tty1",
     # Only reserve if there are at least 2GB
@@ -20,22 +30,17 @@ kernel-parameters = [
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
 ]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.10",
-    "kubelet-1.21",
-    "open-vm-tools",
-    "release",
-]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
-cni = { path = "../../packages/cni" }
-cni-plugins = { path = "../../packages/cni-plugins" }
+# core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
-kubernetes-1_21 = { path = "../../packages/kubernetes-1.21" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# k8s
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kubernetes-1_21 = { path = "../../packages/kubernetes-1.21" }
+

--- a/variants/vmware-k8s-1.21/Cargo.toml
+++ b/variants/vmware-k8s-1.21/Cargo.toml
@@ -17,6 +17,8 @@ included-packages = [
     "kernel-5.10",
     "open-vm-tools",
     "release",
+# networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -39,6 +41,8 @@ path = "lib.rs"
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/vmware-k8s-1.22/Cargo.toml
+++ b/variants/vmware-k8s-1.22/Cargo.toml
@@ -20,6 +20,8 @@ included-packages = [
     "kernel-5.10",
     "open-vm-tools",
     "release",
+ # networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -42,6 +44,8 @@ path = "lib.rs"
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/vmware-k8s-1.22/Cargo.toml
+++ b/variants/vmware-k8s-1.22/Cargo.toml
@@ -15,6 +15,16 @@ partition-plan = "unified"
 [package.metadata.build-variant]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.10",
+    "open-vm-tools",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.22",
+]
 kernel-parameters = [
     "console=tty1",
     # Only reserve if there are at least 2GB
@@ -23,22 +33,18 @@ kernel-parameters = [
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
 ]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.10",
-    "kubelet-1.22",
-    "open-vm-tools",
-    "release",
-]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
-cni = { path = "../../packages/cni" }
-cni-plugins = { path = "../../packages/cni-plugins" }
+# core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
-kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# k8s
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
+
+

--- a/variants/vmware-k8s-1.23/Cargo.toml
+++ b/variants/vmware-k8s-1.23/Cargo.toml
@@ -18,6 +18,16 @@ grub-set-private-var = true
 [package.metadata.build-variant]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.10",
+    "open-vm-tools",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.23",
+]
 kernel-parameters = [
     "console=tty1",
     # Only reserve if there are at least 2GB
@@ -26,22 +36,18 @@ kernel-parameters = [
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
 ]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.10",
-    "kubelet-1.23",
-    "open-vm-tools",
-    "release",
-]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
-cni = { path = "../../packages/cni" }
-cni-plugins = { path = "../../packages/cni-plugins" }
+# core
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
-kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# k8s
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
+
+

--- a/variants/vmware-k8s-1.23/Cargo.toml
+++ b/variants/vmware-k8s-1.23/Cargo.toml
@@ -23,6 +23,8 @@ included-packages = [
     "kernel-5.10",
     "open-vm-tools",
     "release",
+# networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -45,6 +47,8 @@ path = "lib.rs"
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/vmware-k8s-1.24/Cargo.toml
+++ b/variants/vmware-k8s-1.24/Cargo.toml
@@ -22,6 +22,8 @@ included-packages = [
 # core
     "kernel-5.15",
     "release",
+# networking
+    "wicked",
 # k8s
     "cni",
     "cni-plugins",
@@ -46,6 +48,8 @@ path = "lib.rs"
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# networking
+wicked = { path = "../../packages/wicked" }
 # k8s
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }

--- a/variants/vmware-k8s-1.24/Cargo.toml
+++ b/variants/vmware-k8s-1.24/Cargo.toml
@@ -18,6 +18,17 @@ grub-set-private-var = true
 [package.metadata.build-variant]
 image-format = "vmdk"
 supported-arches = ["x86_64"]
+included-packages = [
+# core
+    "kernel-5.15",
+    "release",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.24",
+# tools
+    "open-vm-tools",
+]
 kernel-parameters = [
     "console=tty1",
     # Only reserve if there are at least 2GB
@@ -26,22 +37,18 @@ kernel-parameters = [
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
 ]
-included-packages = [
-    "cni",
-    "cni-plugins",
-    "kernel-5.15",
-    "kubelet-1.24",
-    "open-vm-tools",
-    "release",
-]
 
 [lib]
 path = "lib.rs"
 
 [build-dependencies]
-cni = { path = "../../packages/cni" }
-cni-plugins = { path = "../../packages/cni-plugins" }
+# core
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
-kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 release = { path = "../../packages/release" }
+# k8s
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
+
+


### PR DESCRIPTION

**Issue number:** [ 2449](https://github.com/bottlerocket-os/bottlerocket/issues/2449)

Closes #

**Description of changes:** 
We need to move wicked out of release so that we can toggle what network backend a variant uses while working on networkd enablement. This makes it possible to remove wicked from one variant without affecting others or have a variant just for networkd testing. This commit also makes the variant Cargo.toml ordering consistent with all variants for clarity and consistency.

The diff is lousy because of the shifting of the files. The only changes should be the addition of wicked to packages included and wicked for dependencies. The rest is commenting and sorting to get them all consistent. 

**Testing done:**
Built all the variants. This should not actually affect the resulting images at all.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
