### PR TITLE
sundog: generate dynamic settings in parallel

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "libc",
  "log",
  "models",
- "nix",
+ "nix 0.26.1",
  "rand",
  "reqwest",
  "retry-read",
@@ -326,7 +326,7 @@ dependencies = [
  "log",
  "maplit",
  "models",
- "nix",
+ "nix 0.26.1",
  "num",
  "percent-encoding",
  "rand",
@@ -1126,6 +1126,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.7.1",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,7 +1683,7 @@ checksum = "6db844b8efc35d17ae7929747118d9e4450a448e662437db9751e3627fe2675c"
 dependencies = [
  "bincode",
  "crc",
- "nix",
+ "nix 0.24.3",
  "serde",
  "thiserror",
 ]
@@ -2173,6 +2197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "merge-toml"
 version = "0.1.0"
 dependencies = [
@@ -2222,7 +2255,7 @@ dependencies = [
  "generate-readme",
  "log",
  "lz4",
- "nix",
+ "nix 0.26.1",
  "pentacle",
  "rand",
  "regex",
@@ -2365,7 +2398,21 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2761,7 +2808,7 @@ dependencies = [
  "log",
  "maplit",
  "models",
- "nix",
+ "nix 0.26.1",
  "schnauzer",
  "serde_json",
  "signpost",
@@ -2850,6 +2897,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -3304,7 +3373,7 @@ version = "0.1.0"
 dependencies = [
  "generate-readme",
  "log",
- "nix",
+ "nix 0.26.1",
  "simplelog",
  "snafu",
 ]
@@ -3428,6 +3497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "storewolf"
 version = "0.1.0"
 dependencies = [
@@ -3494,6 +3569,7 @@ dependencies = [
  "http",
  "log",
  "models",
+ "rayon",
  "serde",
  "serde_json",
  "simplelog",
@@ -3579,7 +3655,7 @@ dependencies = [
  "log",
  "maplit",
  "models",
- "nix",
+ "nix 0.26.1",
  "schnauzer",
  "serde_json",
  "simplelog",
@@ -3600,7 +3676,7 @@ dependencies = [
  "http",
  "log",
  "models",
- "nix",
+ "nix 0.26.1",
  "num-derive",
  "num-traits",
  "semver",

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -21,7 +21,7 @@ hyper-unix-connector = "0.2"
 libc = "0.2"
 log = "0.4"
 models = { path = "../../models", version = "0.1.0" }
-nix = "0.24"
+nix = "0.26"
 rand = "0.8"
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls-native-roots"] }
 retry-read = { path = "../../retry-read", version = "0.1.0" }

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -23,7 +23,7 @@ http = "0.2.1"
 libc = "0.2"
 log = "0.4"
 models = { path = "../../models", version = "0.1.0" }
-nix = "0.24"
+nix = "0.26"
 num = "0.4"
 percent-encoding = "2.1"
 rand = "0.8"

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["README.md"]
 bottlerocket-release = { path = "../../../bottlerocket-release", version = "0.1.0" }
 log = "0.4"
 lz4 = "1.23.1"
-nix = "0.24"
+nix = "0.26"
 pentacle = "1.0.0"
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 regex = "1.1"

--- a/sources/api/prairiedog/Cargo.toml
+++ b/sources/api/prairiedog/Cargo.toml
@@ -13,7 +13,7 @@ argh = "0.1.3"
 bytes = "1.1"
 constants = { path = "../../constants", version = "0.1.0" }
 log = "0.4"
-nix = "0.24"
+nix = "0.26"
 models =  { path = "../../models", version = "0.1.0" }
 schnauzer = { path = "../schnauzer", version = "0.1.0" }
 signpost = { path = "../../updater/signpost", version = "0.1.0" }

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -16,6 +16,7 @@ datastore = { path = "../datastore", version = "0.1.0" }
 http = "0.2"
 log = "0.4"
 models = { path = "../../models", version = "0.1.0" }
+rayon = "1.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -17,7 +17,7 @@ http = "0.2"
 itertools = "0.10"
 log = "0.4"
 models = { path = "../../models", version = "0.1.0" }
-nix = "0.24"
+nix = "0.26"
 schnauzer = { path = "../schnauzer", version = "0.1.0" }
 serde_json = "1"
 simplelog = "0.12"

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -18,7 +18,7 @@ fs2 = "0.4.3"
 http = "0.2.1"
 log = "0.4.8"
 models = { path = "../../models", version = "0.1.0" }
-nix = "0.24"
+nix = "0.26"
 num-derive = "0.3.0"
 num-traits = "0.2.12"
 semver = { version = "1.0", features = [ "serde" ] }

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -72,7 +72,9 @@ skip-tree = [
     # are using different versions of windows-sys. we skip the
     # dependency tree because windows-sys has many sub-crates
     # that differ in major version.
-    { name = "windows-sys", version = "=0.36.1" }
+    { name = "windows-sys", version = "=0.36.1" },
+    # gptman is using an older version of nix
+    { name = "nix", version = "=0.24.3" },
 ]
 
 [sources]

--- a/sources/shimpei/Cargo.toml
+++ b/sources/shimpei/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["README.md"]
 log = "0.4"
 simplelog = "0.12"
 snafu = "0.7"
-nix = "0.24"
+nix = "0.26"
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../generate-readme" }


### PR DESCRIPTION
**Issue number:**
n/a

**Description of changes:**
I was looking at `systemd-analyze plot` for bottlerocket and noted that we are quite bottlenecked by `sundog.service` and occassionally `settings-applier.service`.

Taking a closer peek at those, we sequentially perform settings generation and service re-starting in both cases, which are IO-bound. We don't otherwise enforce ordering on these tasks, so they should be embarrassingly parallel.

This change focuses only on `sundog` for now.

```
sundog: generate dynamic settings in parallel

This also updates nix to the latest version, which is required to use
the latest rayon.
```


**Testing done:**
Initial testing suggests that `sundog` completes on the order of a few hundred milliseconds, instead of a few thousand:

**Before:**
![before](https://user-images.githubusercontent.com/990370/211432234-ca4d3233-87ef-44c4-a0b5-51803fa9a945.png)


**After:**
![after](https://user-images.githubusercontent.com/990370/211432253-0b194f03-6787-423a-ba33-95e1970fd9f0.png)

* Confirmed that generated settings are present after making the change
* Confirmed that `thar-be-settings` is still restarting all services. Despite not making  changes to this code, it seems like the systemd service is quite variable in its timing.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
