### PR TITLE
kernel-5.15: make iSCSI support available to all variants

### DIFF
--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -171,3 +171,12 @@ CONFIG_EXT4_USE_FOR_EXT2=y
 # Disable unused qdiscs
 #   - sch_cake targets home routers and residential links
 # CONFIG_NET_SCH_CAKE is not set
+
+# Provide minimal iSCSI via TCP support for initiator and target mode
+# initiator side
+CONFIG_ISCSI_TCP=m
+CONFIG_ISCSI_BOOT_SYSFS=m
+CONFIG_SCSI_ISCSI_ATTRS=m
+# target side
+CONFIG_ISCSI_TARGET=m
+# CONFIG_INFINIBAND_ISERT is not set

--- a/packages/kernel-5.15/config-bottlerocket-metal
+++ b/packages/kernel-5.15/config-bottlerocket-metal
@@ -119,12 +119,3 @@ CONFIG_MEGARAID_SAS=y
 
 # Microsemi PQI controllers
 CONFIG_SCSI_SMARTPQI=y
-
-# provide minimal iscsi via tcp support for initiator and target mode
-# initiator side
-CONFIG_ISCSI_TCP=m
-CONFIG_ISCSI_BOOT_SYSFS=m
-CONFIG_SCSI_ISCSI_ATTRS=m
-# target side
-CONFIG_ISCSI_TARGET=m
-# CONFIG_INFINIBAND_ISERT is not set


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** [The previous kernel update for the 5.15 series](https://github.com/bottlerocket-os/bottlerocket/pull/2569/) made the kernel bits of iSCSI support available only to the metal variants. However, they can be useful in virtualized environments as well, hence move them to the generic config fragment.

**Testing done:**

Created a config change report via `tools/diff-kernel-config` which built numerous variants. Summary:

```
config-aarch64-5.15-aws-dev-diff:         0 removed,   1 added,   4 changed
config-aarch64-5.15-metal-dev-diff:       0 removed,   0 added,   0 changed
config-x86_64-5.15-aws-dev-diff:          0 removed,   1 added,   4 changed
config-x86_64-5.15-metal-dev-diff:        0 removed,   0 added,   0 changed
```

Detailed changes are available in [this Gist](https://gist.github.com/markusboehme/fe71073db7767946d20e75f381d068df). As expected, there are no changes to the metal variants as their config is just replicated to the other variants.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
