### PR TITLE
testsys: Use `Test.toml` for controller install

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -252,6 +252,7 @@ pub struct TestsysImages {
     pub sonobuoy_test_agent_image: Option<String>,
     pub ecs_test_agent_image: Option<String>,
     pub migration_test_agent_image: Option<String>,
+    pub controller_image: Option<String>,
     pub testsys_agent_pull_secret: Option<String>,
 }
 
@@ -278,6 +279,7 @@ impl TestsysImages {
             sonobuoy_test_agent_image: Some(format!("{}/sonobuoy-test-agent:{tag}", registry)),
             ecs_test_agent_image: Some(format!("{}/ecs-test-agent:{tag}", registry)),
             migration_test_agent_image: Some(format!("{}/migration-test-agent:{tag}", registry)),
+            controller_image: Some(format!("{}/controller:{tag}", registry)),
             testsys_agent_pull_secret: None,
         }
     }
@@ -306,6 +308,7 @@ impl TestsysImages {
             migration_test_agent_image: self
                 .migration_test_agent_image
                 .or(other.migration_test_agent_image),
+            controller_image: self.controller_image.or(other.controller_image),
             testsys_agent_pull_secret: self
                 .testsys_agent_pull_secret
                 .or(other.testsys_agent_pull_secret),

--- a/tools/testsys/src/install.rs
+++ b/tools/testsys/src/install.rs
@@ -1,40 +1,57 @@
 use crate::error::Result;
+use crate::run::TestsysImages;
 use clap::Parser;
 use log::{info, trace};
 use model::test_manager::{ImageConfig, TestManager};
+use std::path::PathBuf;
+use testsys_config::TestConfig;
 
 /// The install subcommand is responsible for putting all of the necessary components for testsys in
 /// a k8s cluster.
 #[derive(Debug, Parser)]
 pub(crate) struct Install {
-    /// Controller image pull secret. This is the name of a Kubernetes secret that will be used to
-    /// pull the container image from a private registry. For example, if you created a pull secret
-    /// with `kubectl create secret docker-registry regcred` then you would pass
-    /// `--controller-pull-secret regcred`.
-    #[clap(
-        long = "controller-pull-secret",
-        env = "TESTSYS_CONTROLLER_PULL_SECRET"
-    )]
-    secret: Option<String>,
+    /// The path to `Test.toml`
+    #[clap(long, env = "TESTSYS_TEST_CONFIG_PATH", parse(from_os_str))]
+    test_config_path: PathBuf,
 
-    /// Controller image uri. If not provided the latest released controller image will be used.
-    #[clap(
-        long = "controller-uri",
-        env = "TESTSYS_CONTROLLER_IMAGE",
-        default_value = "public.ecr.aws/bottlerocket-test-system/controller:v0.0.5"
-    )]
-    controller_uri: String,
+    #[clap(flatten)]
+    agent_images: TestsysImages,
 }
 
 impl Install {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
+        // Use Test.toml or default
+        let test_config = TestConfig::from_path_or_default(&self.test_config_path)?;
+
+        let test_opts = test_config.test.to_owned().unwrap_or_default();
+
+        let images = vec![
+            Some(self.agent_images.into()),
+            Some(test_opts.testsys_images),
+            test_opts.testsys_image_registry.map(|registry| {
+                testsys_config::TestsysImages::new(registry, test_opts.testsys_image_tag)
+            }),
+            Some(testsys_config::TestsysImages::public_images()),
+        ]
+        .into_iter()
+        .flatten()
+        .fold(Default::default(), testsys_config::TestsysImages::merge);
+
+        let controller_uri = images
+            .controller_image
+            .expect("The default controller image is missing.");
+
         trace!(
             "Installing testsys using controller image '{}'",
-            &self.controller_uri
+            controller_uri
         );
-        let controller_image = match (self.secret, self.controller_uri) {
-            (Some(secret), image) => ImageConfig::WithCreds { secret, image },
-            (None, image) => ImageConfig::Image(image),
+
+        let controller_image = match images.testsys_agent_pull_secret {
+            Some(secret) => ImageConfig::WithCreds {
+                secret,
+                image: controller_uri,
+            },
+            None => ImageConfig::Image(controller_uri),
         };
         client.install(controller_image).await?;
 

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -471,6 +471,10 @@ pub(crate) struct TestsysImages {
     )]
     pub(crate) migration_test: Option<String>,
 
+    /// TestSys controller URI. If not provided the latest released controller will be used.
+    #[clap(long = "controller-image", env = "TESTSYS_CONTROLLER_IMAGE")]
+    pub(crate) controller_uri: Option<String>,
+
     /// Images pull secret. This is the name of a Kubernetes secret that will be used to
     /// pull the container image from a private registry. For example, if you created a pull secret
     /// with `kubectl create secret docker-registry regcred` then you would pass
@@ -490,6 +494,7 @@ impl From<TestsysImages> for testsys_config::TestsysImages {
             sonobuoy_test_agent_image: val.sonobuoy_test,
             ecs_test_agent_image: val.ecs_test,
             migration_test_agent_image: val.migration_test,
+            controller_image: val.controller_uri,
             testsys_agent_pull_secret: val.secret,
         }
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2571 

**Description of changes:**

This pr allows setting the testsys controller uri with `Test.toml`.

**Testing done:**

Tested `cargo make setup-test` with a custom uri in `Test.toml` and the default uri.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
