### PR TITLE
testsys: Use `builder` for EKS CRD creation

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1708,12 +1708,9 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "chrono",
- "http",
- "percent-encoding",
  "serde",
  "serde-value",
  "serde_json",
- "url",
 ]
 
 [[package]]
@@ -3120,7 +3117,6 @@ dependencies = [
  "fastrand",
  "futures",
  "handlebars",
- "k8s-openapi",
  "kube-client",
  "log",
  "maplit",

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -17,7 +17,6 @@ clap = { version = "3", features = ["derive", "env"] }
 env_logger = "0.9"
 futures = "0.3.8"
 handlebars = "4.3"
-k8s-openapi = { version = "0.16", features = ["v1_20", "api"], default-features = false }
 kube-client = { version = "0.75"}
 log = "0.4"
 maplit = "1.0.2"

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -9,7 +9,7 @@ use bottlerocket_types::agent_config::{ClusterType, EcsClusterConfig, EcsTestCon
 use log::debug;
 use maplit::btreemap;
 use model::{Crd, DestructionPolicy};
-use snafu::OptionExt;
+use snafu::{OptionExt, ResultExt};
 use std::collections::BTreeMap;
 
 /// A `CrdCreator` responsible for creating crd related to `aws-ecs` variants.
@@ -91,9 +91,8 @@ impl CrdCreator for AwsEcsCreator {
             )
             .set_secrets(Some(cluster_input.crd_input.config.secrets.clone()))
             .build(cluster_input.cluster_name)
-            .map_err(|e| error::Error::Build {
-                what: "ECS cluster CRD".to_string(),
-                error: e.to_string(),
+            .context(error::BuildSnafu {
+                what: "ECS cluster CRD",
             })?;
 
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(ecs_crd))))
@@ -169,9 +168,8 @@ impl CrdCreator for AwsEcsCreator {
                 cluster_resource_name,
                 test_input.name_suffix.unwrap_or_default()
             ))
-            .map_err(|e| error::Error::Build {
-                what: "ECS test CRD".to_string(),
-                error: e.to_string(),
+            .context(error::BuildSnafu {
+                what: "ECS test CRD",
             })?;
 
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(test_crd))))

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -193,8 +193,7 @@ pub(crate) async fn ec2_crd<'a>(
     let suffix: String = repeat_with(fastrand::lowercase).take(4).collect();
     ec2_builder
         .build(format!("{}-instances-{}", cluster_name, suffix))
-        .map_err(|e| error::Error::Build {
-            what: "EC2 instance provider CRD".to_string(),
-            error: e.to_string(),
+        .context(error::BuildSnafu {
+            what: "EC2 instance provider CRD",
         })
 }

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -10,8 +10,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     // `error` must be used instead of `source` because the build function returns
     // `std::error::Error` but not `std::error::Error + Sync + Send`.
-    #[snafu(display("Unable to build '{}': {}", what, error))]
-    Build { what: String, error: String },
+    #[snafu(display("Unable to build '{}': {}", what, source))]
+    Build {
+        what: String,
+        source: Box<dyn std::error::Error + Sync + Send>,
+    },
 
     #[snafu(display("Unable to build datacenter credentials: {}", source))]
     CredsBuild {

--- a/tools/testsys/src/migration.rs
+++ b/tools/testsys/src/migration.rs
@@ -3,7 +3,7 @@ use crate::error::{self, Result};
 use bottlerocket_types::agent_config::MigrationConfig;
 use maplit::btreemap;
 use model::Test;
-use snafu::OptionExt;
+use snafu::{OptionExt, ResultExt};
 
 /// Create a CRD for migrating Bottlerocket instances using SSM commands.
 /// `aws_region_override` allows the region that's normally derived from the cluster resource CRD to be overridden
@@ -88,8 +88,7 @@ pub(crate) fn migration_crd(
             cluster_resource_name,
             migration_input.name_suffix.unwrap_or_default()
         ))
-        .map_err(|e| error::Error::Build {
-            what: "migration CRD".to_string(),
-            error: e.to_string(),
+        .context(error::BuildSnafu {
+            what: "migration CRD",
         })
 }

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -4,6 +4,7 @@ use crate::run::KnownTestType;
 use bottlerocket_types::agent_config::{SonobuoyConfig, SonobuoyMode};
 use maplit::btreemap;
 use model::Test;
+use snafu::ResultExt;
 use std::fmt::Display;
 
 /// Create a Sonobuoy CRD for K8s conformance and quick testing.
@@ -67,9 +68,8 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
             cluster_resource_name,
             test_input.name_suffix.unwrap_or("-test")
         ))
-        .map_err(|e| error::Error::Build {
-            what: "sonobuoy CRD".to_string(),
-            error: e.to_string(),
+        .context(error::BuildSnafu {
+            what: "Sonobuoy CRD",
         })
 }
 

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -11,7 +11,7 @@ use bottlerocket_types::agent_config::{
 use maplit::btreemap;
 use model::{Crd, DestructionPolicy, SecretName};
 use pubsys_config::vmware::Datacenter;
-use snafu::OptionExt;
+use snafu::{OptionExt, ResultExt};
 use std::collections::BTreeMap;
 use std::iter::repeat_with;
 use std::str::FromStr;
@@ -150,9 +150,8 @@ impl CrdCreator for VmwareK8sCreator {
             ))
             .privileged(true)
             .build(cluster_input.cluster_name)
-            .map_err(|e| error::Error::Build {
-                what: "vSphere K8s cluster CRD".to_string(),
-                error: e.to_string(),
+            .context(error::BuildSnafu {
+                what: "vSphere K8s cluster CRD",
             })?;
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(
             vsphere_k8s_crd,
@@ -230,9 +229,8 @@ impl CrdCreator for VmwareK8sCreator {
             ))
             .depends_on(cluster_name)
             .build(format!("{}-vms-{}", cluster_name, suffix))
-            .map_err(|e| error::Error::Build {
-                what: "vSphere VM CRD".to_string(),
-                error: e.to_string(),
+            .context(error::BuildSnafu {
+                what: "vSphere VM CRD",
             })?;
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(
             vsphere_vm_crd,


### PR DESCRIPTION
Previously there was a bug with the builder that prevented it from being used with for EKS crd creation. That bug was resolved in v0.0.5. The error type from the builder was also fixed, so snafu could be used.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

```
 testsys: Use `builder` for EKS CRD creation
    
    Previously there was a bug with the builder that prevented it from being
    used with for EKS crd creation. That bug was resolved in v0.0.5. The
    error type from the builder was also fixed, so snafu could be used.
```

**Testing done:**

`cargo make test`

```
 NAME                                 TYPE        STATE        PASSED    SKIPPED    FAILED   LAST UPDATE              BUILD ID
 x86-64-aws-k8s-124                   Resource    completed                                   2023-01-10T14:58:48Z    3ebb33a9
 x86-64-aws-k8s-124-instances-hdji    Resource    completed                                   2023-01-10T14:58:59Z    3ebb33a9
 x86-64-aws-k8s-124-test              Test        pass         1         6972       0         2023-01-10T15:00:32Z    3ebb33a9
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
