### PR TITLE
testsys: Accept custom userdata

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -197,6 +197,8 @@ pub struct GenericVariantConfig {
     pub conformance_registry: Option<String>,
     /// The endpoint IP to reserve for the vSphere control plane VMs when creating a K8s cluster
     pub control_plane_endpoint: Option<String>,
+    /// The path to userdata that should be used for Bottlerocket launch
+    pub userdata: Option<String>,
 }
 
 impl GenericVariantConfig {
@@ -222,6 +224,7 @@ impl GenericVariantConfig {
             conformance_image: self.conformance_image.or(other.conformance_image),
             conformance_registry: self.conformance_registry.or(other.conformance_registry),
             control_plane_endpoint: self.control_plane_endpoint.or(other.control_plane_endpoint),
+            userdata: self.userdata.or(other.userdata),
         }
     }
 }

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -2,7 +2,7 @@ use crate::crds::BottlerocketInput;
 use crate::error::{self, Result};
 use aws_sdk_ec2::model::{Filter, Image};
 use aws_sdk_ec2::Region;
-use bottlerocket_types::agent_config::{ClusterType, Ec2Config};
+use bottlerocket_types::agent_config::{ClusterType, CustomUserData, Ec2Config};
 use maplit::btreemap;
 use model::{DestructionPolicy, Resource};
 use serde::Deserialize;
@@ -145,6 +145,12 @@ pub(crate) async fn ec2_crd<'a>(
                 .iter()
                 .cloned()
                 .collect(),
+        )
+        .custom_user_data(
+            bottlerocket_input
+                .crd_input
+                .encoded_userdata()?
+                .map(|encoded_userdata| CustomUserData::Merge { encoded_userdata }),
         )
         .cluster_name_template(cluster_name, "clusterName")
         .region_template(cluster_name, "region")

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -98,6 +98,20 @@ impl<'a> CrdInput<'a> {
             .collect())
     }
 
+    /// Use the provided userdata path to create the encoded userdata.
+    pub fn encoded_userdata(&self) -> Result<Option<String>> {
+        let userdata_path = match self.config.userdata.as_ref() {
+            Some(path) => path,
+            None => return Ok(None),
+        };
+
+        let userdata = std::fs::read_to_string(userdata_path).context(error::FileSnafu {
+            path: userdata_path,
+        })?;
+
+        Ok(Some(base64::encode(userdata)))
+    }
+
     /// Fill in the templated cluster name with `arch` and `variant`.
     fn rendered_cluster_name(&self, raw_cluster_name: String) -> Result<String> {
         Ok(rendered_cluster_name(

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -142,6 +142,10 @@ struct CliConfig {
     /// The endpoint IP to reserve for the vSphere control plane VMs when creating a K8s cluster
     #[clap(long, env = "TESTSYS_CONTROL_PLANE_ENDPOINT")]
     pub control_plane_endpoint: Option<String>,
+
+    /// Specify the path to the userdata that should be added for Bottlerocket launch
+    #[clap(long, env = "TESTSYS_USERDATA")]
+    pub userdata: Option<String>,
 }
 
 impl From<CliConfig> for GenericVariantConfig {
@@ -154,6 +158,7 @@ impl From<CliConfig> for GenericVariantConfig {
             conformance_image: val.conformance_image,
             conformance_registry: val.conformance_registry,
             control_plane_endpoint: val.control_plane_endpoint,
+            userdata: val.userdata,
         }
     }
 }

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -6,7 +6,8 @@ use crate::error::{self, Result};
 use crate::migration::migration_crd;
 use crate::sonobuoy::sonobuoy_crd;
 use bottlerocket_types::agent_config::{
-    CreationPolicy, K8sVersion, VSphereK8sClusterConfig, VSphereK8sClusterInfo, VSphereVmConfig,
+    CreationPolicy, CustomUserData, K8sVersion, VSphereK8sClusterConfig, VSphereK8sClusterInfo,
+    VSphereVmConfig,
 };
 use maplit::btreemap;
 use model::{Crd, DestructionPolicy, SecretName};
@@ -199,6 +200,12 @@ impl CrdCreator for VmwareK8sCreator {
                 control_plane_endpoint_ip: format!("${{{}.endpoint}}", cluster_name),
                 kubeconfig_base64: format!("${{{}.encodedKubeconfig}}", cluster_name),
             })
+            .custom_user_data(
+                bottlerocket_input
+                    .crd_input
+                    .encoded_userdata()?
+                    .map(|encoded_userdata| CustomUserData::Merge { encoded_userdata }),
+            )
             .assume_role(bottlerocket_input.crd_input.config.agent_role.clone())
             .set_labels(Some(labels))
             .set_conflicts_with(Some(existing_clusters))


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Enables using custom userdata with `cargo make test`. Userdata is passed via file and is base64 encoded by the `crd_input` struct. On the TestSys side, the userdata is merged with the minimal necessary [userdata](https://github.com/bottlerocket-os/bottlerocket-test-system/blob/2e198984092a2596314cdb21d4e87392f3affc17/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs#L433) and [merged](https://github.com/bottlerocket-os/bottlerocket-test-system/blob/develop/bottlerocket/agents/src/userdata.rs) with the same logic as [Bottlerocket](https://github.com/bottlerocket-os/bottlerocket/blob/v1.11.1/sources/api/storewolf/merge-toml/src/lib.rs)

**Testing done:**

Created `admin_userdata.toml`

```toml
[settings.host-containers.admin]
enabled = true
```

Ran the test

```shell
cargo make  -e TESTSYS_USERDATA=admin_userdata.toml test
```

Verified that the userdata in EC2 console had the new userdata.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
