### PR TITLE
hotdog: Upgrade to v1.0.5

### DIFF
--- a/packages/hotdog/Cargo.toml
+++ b/packages/hotdog/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bottlerocket-os/hotdog/archive/v1.0.4/hotdog-1.0.4.tar.gz"
-sha512 = "fa6ae90ca7306e2d77cf7320cde773e08f3616e29cc44b6eda9a70d1270b30f9190707c40890146d023a417c13028ccf601a313ed8eb255ddc13072128ad7250"
+url = "https://github.com/bottlerocket-os/hotdog/archive/v1.0.5/hotdog-1.0.5.tar.gz"
+sha512 = "6bd4d2701b51e27cf39ef4fca5573d7343c1dc9def299f7f19deadb37cc38f5dc2576e54475c972ff2b590ed3293af4ca9a39eb4d202aec1be49e8c74cf52d29"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/hotdog/hotdog.spec
+++ b/packages/hotdog/hotdog.spec
@@ -8,7 +8,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}hotdog
-Version: 1.0.4
+Version: 1.0.5
 Release: 1%{?dist}
 Summary: Tool with OCI hooks to run the Log4j Hot Patch in containers
 License: Apache-2.0


### PR DESCRIPTION
**Issue number:**

N/a

Related to: https://github.com/bottlerocket-os/hotdog/pull/11

**Description of changes:**

Upgrades to the newest `hotdog` tag v1.0.5 which has a few Go module dependency bumps.

**Testing done:**

`cargo make`. The above PR has further in depth testing of hotdog itself.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
