### PR TITLE
ignore initramfs from bootloader

### DIFF
--- a/packages/kernel-5.10/1002-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
+++ b/packages/kernel-5.10/1002-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
@@ -1,0 +1,50 @@
+From 4e00f4850eaf84e1e638c467f444b8f4fb8c67f8 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 18 Oct 2022 22:24:52 +0000
+Subject: [PATCH] initramfs: unlink INITRAMFS_FORCE from CMDLINE_{EXTEND,FORCE}
+
+The motivation given in cff75e0b6fe83 for tying INITRAMFS_FORCE to
+either of CMDLINE_{EXTEND,FORCE} was that these options imply an
+inflexible bootloader, and that overriding the initramfs image would
+also only be necessary for inflexible bootloaders.
+
+However, with the advent of Boot Config support, distributions that do
+not normally use an initramfs may still want to allow an "initrd" to be
+passed by the bootloader in order to accept boot configuration data. In
+such cases, the CMDLINE_{EXTEND,FORCE} options are not desired because
+the bootloader is actually expected to control the kernel command line.
+
+Unlinking the INITRAMFS_FORCE config option allows Boot Config data to
+be passed by the bootloader while still preventing an unexpected
+initramfs from overriding the built-in initramfs (if any).
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ usr/Kconfig | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/usr/Kconfig b/usr/Kconfig
+index 8bbcf699fe3b..06aac19063ee 100644
+--- a/usr/Kconfig
++++ b/usr/Kconfig
+@@ -24,7 +24,7 @@ config INITRAMFS_SOURCE
+ 
+ config INITRAMFS_FORCE
+ 	bool "Ignore the initramfs passed by the bootloader"
+-	depends on CMDLINE_EXTEND || CMDLINE_FORCE
++	default n
+ 	help
+ 	  This option causes the kernel to ignore the initramfs image
+ 	  (or initrd image) passed to it by the bootloader. This is
+@@ -32,6 +32,8 @@ config INITRAMFS_FORCE
+ 	  and is useful if you cannot or don't want to change the image
+ 	  your bootloader passes to the kernel.
+ 
++	  If unsure, say N.
++
+ config INITRAMFS_ROOT_UID
+ 	int "User ID to map to 0 (user root)"
+ 	depends on INITRAMFS_SOURCE!=""
+-- 
+2.37.2
+

--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -75,6 +75,15 @@ CONFIG_DEBUG_INFO_BTF=y
 # Bottlerocket uses a fairly custom setup that needs tight control over it.
 # CONFIG_CMDLINE_EXTEND is not set
 
+# We don't want to unpack the initramfs passed by the bootloader. The intent of
+# this option is to ensure that the built-in initramfs is used. Since we do not
+# have a built-in initramfs, in practice this means we will never unpack any
+# initramfs.
+#
+# We rely on `CONFIG_BLK_DEV_INITRD` for boot config support, so we can't just
+# disable the functionality altogether.
+CONFIG_INITRAMFS_FORCE=y
+
 # Enable ZSTD kernel image compression
 CONFIG_HAVE_KERNEL_ZSTD=y
 CONFIG_KERNEL_ZSTD=y

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -15,6 +15,8 @@ Source103: config-bottlerocket-vmware
 
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
+# Enable INITRAMFS_FORCE config option for our use case.
+Patch1002: 1002-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
 
 # Add zstd support for compressed kernel modules
 Patch2000: 2000-kbuild-move-module-strip-compression-code-into-scrip.patch

--- a/packages/kernel-5.15/1001-Makefile-add-prepare-target-for-external-modules.patch
+++ b/packages/kernel-5.15/1001-Makefile-add-prepare-target-for-external-modules.patch
@@ -1,7 +1,7 @@
-From 0f672709ce4e4dcce5e4f08e47169b9a18c0df08 Mon Sep 17 00:00:00 2001
+From fe8de462eb7edaccae54c31766dc5a2ffd254ab9 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Mon, 19 Apr 2021 18:46:04 +0000
-Subject: [PATCH 1001/1002] Makefile: add prepare target for external modules
+Subject: [PATCH] Makefile: add prepare target for external modules
 
 We need to ensure that native versions of programs like `objtool` are
 built before trying to build out-of-tree modules, or else the build
@@ -27,10 +27,10 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 9 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index 6192e6be4..473594c61 100644
+index 86b6ca862e39..fbe9b66f4f27 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1736,6 +1736,15 @@ else # KBUILD_EXTMOD
+@@ -1766,6 +1766,15 @@ else # KBUILD_EXTMOD
  KBUILD_BUILTIN :=
  KBUILD_MODULES := 1
  
@@ -47,5 +47,5 @@ index 6192e6be4..473594c61 100644
  $(MODORDER): descend
  	@:
 -- 
-2.33.1
+2.37.2
 

--- a/packages/kernel-5.15/1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
+++ b/packages/kernel-5.15/1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
@@ -1,8 +1,8 @@
-From 3d31def7545ae4e6fc33a5b648610fa9c1e06e68 Mon Sep 17 00:00:00 2001
+From 33d06503d0b131ca4475d77383d28f1569002ce0 Mon Sep 17 00:00:00 2001
 From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 Date: Wed, 22 Jun 2022 19:26:43 +0000
-Subject: [PATCH 1002/1002] Revert "kbuild: hide tools/ build targets from
- external module builds"
+Subject: [PATCH] Revert "kbuild: hide tools/ build targets from external
+ module builds"
 
 This reverts commit 1bb0b18a06dceee1fdc32161a72e28eab6f011c4 in which
 the targets to build "tools/*" were hidden for external modules, but
@@ -15,10 +15,10 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 14 insertions(+), 13 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 473594c61..da4f000ef 100644
+index fbe9b66f4f27..81191e5bffcb 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1357,19 +1357,6 @@ ifneq ($(wildcard $(resolve_btfids_O)),)
+@@ -1387,19 +1387,6 @@ ifneq ($(wildcard $(resolve_btfids_O)),)
  	$(Q)$(MAKE) -sC $(srctree)/tools/bpf/resolve_btfids O=$(resolve_btfids_O) clean
  endif
  
@@ -38,7 +38,7 @@ index 473594c61..da4f000ef 100644
  # ---------------------------------------------------------------------------
  # Kernel selftest
  
-@@ -1989,6 +1976,20 @@ kernelversion:
+@@ -2019,6 +2006,20 @@ kernelversion:
  image_name:
  	@echo $(KBUILD_IMAGE)
  
@@ -60,5 +60,5 @@ index 473594c61..da4f000ef 100644
        cmd_rmfiles = rm -rf $(rm-files)
  
 -- 
-2.33.1
+2.37.2
 

--- a/packages/kernel-5.15/1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
+++ b/packages/kernel-5.15/1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
@@ -1,0 +1,50 @@
+From 4e00f4850eaf84e1e638c467f444b8f4fb8c67f8 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 18 Oct 2022 22:24:52 +0000
+Subject: [PATCH] initramfs: unlink INITRAMFS_FORCE from CMDLINE_{EXTEND,FORCE}
+
+The motivation given in cff75e0b6fe83 for tying INITRAMFS_FORCE to
+either of CMDLINE_{EXTEND,FORCE} was that these options imply an
+inflexible bootloader, and that overriding the initramfs image would
+also only be necessary for inflexible bootloaders.
+
+However, with the advent of Boot Config support, distributions that do
+not normally use an initramfs may still want to allow an "initrd" to be
+passed by the bootloader in order to accept boot configuration data. In
+such cases, the CMDLINE_{EXTEND,FORCE} options are not desired because
+the bootloader is actually expected to control the kernel command line.
+
+Unlinking the INITRAMFS_FORCE config option allows Boot Config data to
+be passed by the bootloader while still preventing an unexpected
+initramfs from overriding the built-in initramfs (if any).
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ usr/Kconfig | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/usr/Kconfig b/usr/Kconfig
+index 8bbcf699fe3b..06aac19063ee 100644
+--- a/usr/Kconfig
++++ b/usr/Kconfig
+@@ -24,7 +24,7 @@ config INITRAMFS_SOURCE
+ 
+ config INITRAMFS_FORCE
+ 	bool "Ignore the initramfs passed by the bootloader"
+-	depends on CMDLINE_EXTEND || CMDLINE_FORCE
++	default n
+ 	help
+ 	  This option causes the kernel to ignore the initramfs image
+ 	  (or initrd image) passed to it by the bootloader. This is
+@@ -32,6 +32,8 @@ config INITRAMFS_FORCE
+ 	  and is useful if you cannot or don't want to change the image
+ 	  your bootloader passes to the kernel.
+ 
++	  If unsure, say N.
++
+ config INITRAMFS_ROOT_UID
+ 	int "User ID to map to 0 (user root)"
+ 	depends on INITRAMFS_SOURCE!=""
+-- 
+2.37.2
+

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -93,6 +93,15 @@ CONFIG_DEBUG_INFO_BTF=y
 # Bottlerocket uses a fairly custom setup that needs tight control over it.
 # CONFIG_CMDLINE_EXTEND is not set
 
+# We don't want to unpack the initramfs passed by the bootloader. The intent of
+# this option is to ensure that the built-in initramfs is used. Since we do not
+# have a built-in initramfs, in practice this means we will never unpack any
+# initramfs.
+#
+# We rely on `CONFIG_BLK_DEV_INITRD` for boot config support, so we can't just
+# disable the functionality altogether.
+CONFIG_INITRAMFS_FORCE=y
+
 # Enable ZSTD kernel image compression
 CONFIG_HAVE_KERNEL_ZSTD=y
 CONFIG_KERNEL_ZSTD=y

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -15,8 +15,10 @@ Source103: config-bottlerocket-vmware
 
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
-# Expose tools/* targets for out-of-tree module builds
+# Expose tools/* targets for out-of-tree module builds.
 Patch1002: 1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
+# Enable INITRAMFS_FORCE config option for our use case.
+Patch1003: 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Issue number:**

#2501

**Description of changes:**
For Secure Boot support, the GRUB configuration (grub.cfg) will need to be signed by a trusted key, so that the chain of trust extends to the kernel command line, which contains sensitive data such as the dm-verity root hash.

However, Bottlerocket also allows the boot config feature to be used to extend the kernel command line. Boot config data is passed by the bootloader using the "initrd" mechanism; it consists of a payload at the end of the initramfs cpio buffer list.

In normal use, the "initrd" file should only ever contain boot config data. However, because this file is locally generated, it cannot be signed by a key known to the chain of trust. Because it is treated as an initramfs, it could be leveraged to run an unverified userspace by prepending it with an actual initramfs.

This change causes the kernel to discard any initramfs or initrd data passed by the bootloader. Any boot config data remaining at the end of the input will still be processed, as intended.

Without Secure Boot support, ignoring the initramfs is not useful as a security measure, but it still improves robustness by preventing accidental usage that might lead to boot failures.


**Testing done:**
Tested on variants with a 5.10 (`aws-k8s-1.23`) and a 5.15 (`aws-k8s-1.24`) kernel.

As expected, `dmesg` no longer shows the "Trying to unpack rootfs image as initramfs..." message, and bootconfig data is still processed.

```
[fedora@admin]$ sudo dmesg|grep Unpack
[fedora@admin]$ sudo sheltie
bash-5.1# cat /proc/bootconfig 
kernel.foobar = "baz"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
