### PR TITLE
update to SDK v0.29.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
           key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
-      - run: rustup default 1.64.0 && rustup component add rustfmt && rustup component add clippy
+      - run: rustup default 1.66.1 && rustup component add rustfmt && rustup component add clippy
       - run: cargo install --version 0.36.0 cargo-make
       - run: cargo install --version 0.6.2 cargo-sweep
       - run: |

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -45,7 +45,7 @@ jobs:
             tools/.crates2.json
             tools/target
           key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
-      - run: rustup default 1.64.0
+      - run: rustup default 1.66.1
       - run: cargo install --locked --version 0.36.0 cargo-make
       - run: cargo install --locked --version 0.8.3 --no-default-features --features ci-autoclean cargo-cache
       - run: cargo install --locked --version 0.6.2 cargo-sweep

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1311,12 +1311,11 @@ dependencies = [
 script_runner = "bash"
 script = [
 '''
-for ws in sources variants/* tools/{buildsys,pubsys}; do
+for ws in sources tools; do
   [ -d "${ws}" ] || continue
-  [ "${ws}" == "variants/shared" ] && continue
   cargo clean --manifest-path ${ws}/Cargo.toml
 done
-rm -f ${BUILDSYS_TOOLS_DIR}/bin/{buildsys,pubsys}
+rm -f ${BUILDSYS_TOOLS_DIR}/bin/*
 '''
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK name used for building
 BUILDSYS_SDK_NAME="bottlerocket"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.28.0"
+BUILDSYS_SDK_VERSION="v0.29.0"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 

--- a/macros/shared
+++ b/macros/shared
@@ -6,11 +6,14 @@
 %dist %{nil}
 
 %_cross_cflags %{shrink: \
-  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS \
+  -O2 -g -pipe -Wall \
+  -Werror=format-security -Werror=strict-aliasing \
+  -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS \
   -fexceptions -fstack-clash-protection -fno-semantic-interposition \
   %{nil}}
 %_cross_c_args %{shrink: \
-  '-O2', '-g', '-pipe', '-Wall', '-Werror=format-security', \
+  '-O2', '-g', '-pipe', '-Wall', \
+  '-Werror=format-security', '-Werror=strict-aliasing', \
   '-Wp,-D_FORTIFY_SOURCE=2', '-Wp,-D_GLIBCXX_ASSERTIONS', \
   '-fexceptions', '-fstack-clash-protection', '-fno-semantic-interposition' \
   %{nil}}

--- a/macros/shared
+++ b/macros/shared
@@ -237,3 +237,5 @@ CROSS_COMPILATION_CONF_EOF\
 %__arch_install_post \
   /usr/lib/rpm/check-buildroot \
   %cross_generate_attribution
+
+%source_date_epoch_from_changelog 0

--- a/packages/dbus-broker/0001-c-utf8-disable-strict-aliasing-optimizations.patch
+++ b/packages/dbus-broker/0001-c-utf8-disable-strict-aliasing-optimizations.patch
@@ -1,0 +1,32 @@
+From e3b30388140d3cd7cb53a2f28faae8847bb7490e Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 22 Dec 2022 17:21:23 +0000
+Subject: [PATCH] c-utf8: disable strict aliasing optimizations
+
+The current implementation of c_utf8_verify() violates aliasing rules
+when it calls into c_utf8_verify_ascii() with a type-punned pointer.
+
+Disable the strict aliasing optimization to prevent the compiler from
+optimizing the code under the assumption that accesses through the
+pointer are invalid, which breaks the function's contract.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ subprojects/libcutf8-1/src/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/subprojects/libcutf8-1/src/meson.build b/subprojects/libcutf8-1/src/meson.build
+index baeecb7..ad38633 100644
+--- a/subprojects/libcutf8-1/src/meson.build
++++ b/subprojects/libcutf8-1/src/meson.build
+@@ -16,6 +16,7 @@ libcutf8_both = both_libraries(
+         c_args: [
+                 '-fvisibility=hidden',
+                 '-fno-common',
++                '-fno-strict-aliasing',
+         ],
+         dependencies: libcutf8_deps,
+         install: not meson.is_subproject(),
+-- 
+2.37.1
+

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -18,6 +18,9 @@ Requires: %{_cross_os}libexpat
 Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}systemd
 
+# Work around an aliasing rules violation.
+Patch0001: 0001-c-utf8-disable-strict-aliasing-optimizations.patch
+
 %description
 %{summary}.
 


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Update SDK to v0.29.0. Includes changes from https://github.com/bottlerocket-os/bottlerocket-sdk/pull/87.

The major change in this update is to GCC 11, which initially miscompiled `dbus-broker` when built with `-fstrict-aliasing` (the default at the `-O2` optimization level). I added a patch to address that, and also elevated aliasing warnings into build errors to try to catch similar errors in the future. This didn't actually flag the `dbus-broker` problem, but still feels like a useful change.

There was also an update to `pahole` via the `dwarves` package in Fedora 37 which caused problems with the older kernel 5.10 and 5.15 builds; that's been fixed by #2569.


**Testing done:**
Built variants for both target architectures on both host architectures. Verified aws, vmware, and metal builds were reasonably clean - no alarming warnings across all the build output in `variants/target`, and no strange behavior at runtime.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
