### PR TITLE
Bump tokio to latest LTS in sources and latest in tools

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -122,7 +122,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio 0.8.5",
+ "mio",
  "num_cpus",
  "socket2",
  "tokio",
@@ -2289,19 +2289,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
@@ -2310,15 +2297,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2406,15 +2384,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2588,37 +2557,12 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.5",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3755,20 +3699,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.1"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
+checksum = "664cf6576f16c0ad68184998f3c2d4be9903ede6b291a5b5cfc97d29e0057283"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio 0.7.14",
+ "mio",
  "num_cpus",
- "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 signal-hook = "0.3"
 simplelog = "0.12"
 snafu = { version = "0.7", features = ["futures"] }
-tokio = { version = "~1.14", default-features = false, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
 tokio-tungstenite = { version = "0.16", default-features = false, features = ["connect"] }
 toml = "0.5"
 unindent = "0.1"

--- a/sources/api/bootstrap-containers/Cargo.toml
+++ b/sources/api/bootstrap-containers/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
 x509-parser = "0.14"
 
 [dev-dependencies]

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -25,7 +25,7 @@ serde_plain = "1.0"
 serde-xml-rs = "0.6"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 toml = "0.5"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 models = { path = "../../models", version = "0.1.0" }
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1.0"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
 tokio-retry = "0.3"
 toml = { version = "0.5", features = ["preserve_order"] }
 

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -23,7 +23,7 @@ aws-types = "0.48.0"
 aws-smithy-client = { version = "0.48.0", default-features = false, features = ["rustls"] }
 serde_json = "1"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }

--- a/sources/api/prairiedog/Cargo.toml
+++ b/sources/api/prairiedog/Cargo.toml
@@ -20,7 +20,7 @@ signpost = { path = "../../updater/signpost", version = "0.1.0" }
 simplelog = "0.12"
 snafu = "0.7"
 serde_json = "1.0"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
 
 [dev-dependencies]
 maplit = "1.0"

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 url = "2.1"
 
 [build-dependencies]

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 toml = "0.5.1"
 
 [build-dependencies]

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
 tempfile = "3.2.0"
 
 [build-dependencies]

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -22,7 +22,7 @@ schnauzer = { path = "../schnauzer", version = "0.1.0" }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -29,7 +29,7 @@ signpost = { path = "../../updater/signpost", version = "0.1.0" }
 simplelog = "0.12"
 snafu = "0.7"
 tempfile = "3.1.0"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 update_metadata = { path = "../../updater/update_metadata", version = "0.1.0" }
 
 [build-dependencies]

--- a/sources/cfsignal/Cargo.toml
+++ b/sources/cfsignal/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 snafu = { version = "0.7" }
 toml = "0.5.1"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }
 aws-config = "0.48.0"
 aws-sdk-cloudformation = "0.18.0"
 aws-types = "0.48.0"

--- a/sources/imdsclient/Cargo.toml
+++ b/sources/imdsclient/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 reqwest = { version = "0.11.1", default-features = false }
 serde_json = "1"
 snafu = "0.7"
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
 tokio-retry = "0.3"
 url = "2.1.1"
 

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -21,7 +21,7 @@ shell-words = "1.0.0"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 tar = { version = "0.4", default-features = false }
 tempfile = { version = "3.1.0", default-features = false }
-tokio = { version = "~1.14", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.20", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 url = "2.1.1"
 walkdir = "2.3"
 

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3253,9 +3253,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",


### PR DESCRIPTION
**Description of changes:**

Switched the pinned `~1.14` LTS for `~1.20` LTS in **sources**.

Ran `cargo update -p tokio` for both **sources** and **tools**.

**Testing done:**

Built `aws-k8s-1.24`. Launched AMI and ran various host container / apiclient tests.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
