### PR TITLE
testsys: Add support for a `tests` directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 /build/rpms/*-debuginfo-*.rpm
 /build/rpms/*-debugsource-*.rpm
 **/target/*
+/tests

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /Licenses.toml
 /licenses
 *.run
+/tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -123,6 +123,7 @@ CARGO_MAKE_DEFAULT_TESTSYS_KUBECONFIG_PATH = "${BUILDSYS_ROOT_DIR}/testsys.kubec
 TESTSYS_STARTING_VERSION = { script = ["git tag --list --sort=version:refname 'v*' | tail -1"] }
 # The commit for the last release of bottlerocket.
 TESTSYS_STARTING_COMMIT = { script = ["git describe --tag ${TESTSYS_STARTING_VERSION} --always --exclude '*' || echo 00000000"] }
+TESTSYS_TESTS_DIR = "${BUILDSYS_ROOT_DIR}/tests"
 TESTSYS_TEST_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Test.toml"
 
 [env.development]
@@ -183,10 +184,17 @@ BOOT_CONFIG = "${BUILDSYS_ROOT_DIR}/bootconfig.data"
 # default kubeconfig location does not exist, use the users default kubeconfig.
 CARGO_MAKE_TESTSYS_KUBECONFIG_ARG = {script = [
 '''
+if ! [ -n "${TESTSYS_KUBECONFIG}" ] && [ -s "${TESTSYS_TESTS_DIR}/testsys.kubeconfig" ] && [ -s "${CARGO_MAKE_DEFAULT_TESTSYS_KUBECONFIG_PATH}" ];then
+   echo "No kubeconfig was specified and a kubeconfig was found in 2 possible locations: '${TESTSYS_TESTS_DIR}/testsys.kubeconfig' and '${CARGO_MAKE_DEFAULT_TESTSYS_KUBECONFIG_PATH}'"
+   exit 1
+fi
 if [ -n "${TESTSYS_KUBECONFIG}" ]; then
    # If the user provides a kubeconfig path it should be used.
    echo "--kubeconfig ${TESTSYS_KUBECONFIG}"
-elif [ -f "${CARGO_MAKE_DEFAULT_TESTSYS_KUBECONFIG_PATH}" ]; then
+elif [ -s "${TESTSYS_TESTS_DIR}/testsys.kubeconfig" ]; then
+   # If the kubeconfig is in the TESTSYS_TESTS_DIR it should be used.
+   echo "--kubeconfig ${TESTSYS_TESTS_DIR}/testsys.kubeconfig"
+elif [ -s "${CARGO_MAKE_DEFAULT_TESTSYS_KUBECONFIG_PATH}" ]; then
    # If the default kubeconfig exists it should be used.
    echo "--kubeconfig ${CARGO_MAKE_DEFAULT_TESTSYS_KUBECONFIG_PATH}"
 fi
@@ -195,6 +203,24 @@ fi
 
 # Args that will be passed into all testsys invocations.
 CARGO_MAKE_TESTSYS_ARGS = "${CARGO_MAKE_TESTSYS_KUBECONFIG_ARG}"
+
+TESTSYS_TEST_CONFIG_PATH = { script = [
+'''
+if [ -s "${TESTSYS_TEST_CONFIG_PATH}" ] && [ -s "${TESTSYS_TESTS_DIR}/Test.toml" ];then
+   echo "There can only be 1 config file. 2 config files were found: '${TESTSYS_TEST_CONFIG_PATH}' and '${TESTSYS_TESTS_DIR}/Test.toml'"
+   exit 1
+fi
+if [ -s "${TESTSYS_TEST_CONFIG_PATH}" ]; then
+   # If the config path exists
+   echo "${TESTSYS_TEST_CONFIG_PATH}"
+elif [ -s "${TESTSYS_TESTS_DIR}/Test.toml" ]; then
+   # If the test config is in the TESTSYS_TESTS_DIR it should be used.
+   echo "${TESTSYS_TESTS_DIR}/Test.toml"
+else
+   echo "${TESTSYS_TEST_CONFIG_PATH}"
+fi
+'''
+] }
 
 [tasks.setup]
 script = [

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -1,7 +1,7 @@
 use bottlerocket_variant::Variant;
 pub use error::Error;
 use handlebars::Handlebars;
-use log::warn;
+use log::{debug, trace, warn};
 use maplit::btreemap;
 use model::constants::TESTSYS_VERSION;
 use model::SecretName;
@@ -72,31 +72,47 @@ impl TestConfig {
         arch: S,
         starting_config: Option<GenericVariantConfig>,
         test_type: &str,
-    ) -> GenericVariantConfig
+    ) -> (GenericVariantConfig, String)
     where
         S: Into<String>,
     {
         let arch = arch.into();
         // Starting with a list of keys ordered by precedence, return a single config with values
         // selected by the order of the list.
-        config_keys(variant)
+        let (test_type, configs) = config_keys(variant)
             // Convert the vec of keys in to an iterator of keys.
             .into_iter()
             // Convert the iterator of keys to and iterator of Configs. If the key does not have a
             // configuration in the config file, remove it from the iterator.
             .filter_map(|key| self.configs.get(&key).cloned())
-            // Expand the `test_type` configuration
-            .flat_map(|config| vec![config.test(test_type), config])
-            // Take the iterator of configurations and extract the arch specific config and the
-            // non-arch specific config for each config. Then, convert them into a single iterator.
-            .flat_map(|config| vec![config.for_arch(&arch), config.config])
-            // Take the iterator of configurations and merge them into a single config by populating
-            // each field with the first value that is not `None` while following the list of
-            // precedence.
+            // Reverse the iterator
+            .rev()
             .fold(
-                starting_config.unwrap_or_default(),
-                GenericVariantConfig::merge,
-            )
+                (test_type.to_string(), Vec::new()),
+                |(test_type, mut configs), config| {
+                    let (ordered_configs, test_type) = config.test_configs(test_type);
+                    configs.push(ordered_configs);
+                    (test_type, configs)
+                },
+            );
+        debug!("Resolved test-type '{}'", test_type);
+        (
+            configs
+                .into_iter()
+                .rev()
+                .flatten()
+                // Take the iterator of configurations and extract the arch specific config and the
+                // non-arch specific config for each config. Then, convert them into a single iterator.
+                .flat_map(|config| vec![config.for_arch(&arch), config.config])
+                // Take the iterator of configurations and merge them into a single config by populating
+                // each field with the first value that is not `None` while following the list of
+                // precedence.
+                .fold(
+                    starting_config.unwrap_or_default(),
+                    GenericVariantConfig::merge,
+                ),
+            test_type,
+        )
     }
 }
 
@@ -161,6 +177,8 @@ pub struct GenericConfig {
     config: GenericVariantConfig,
     #[serde(default)]
     configuration: HashMap<String, GenericConfig>,
+    #[serde(rename = "test-type")]
+    test_type: Option<String>,
 }
 
 impl GenericConfig {
@@ -185,6 +203,36 @@ impl GenericConfig {
             .get(test_type.as_ref())
             .cloned()
             .unwrap_or_default()
+    }
+
+    /// Get a set of `GenericConfig`s following test types (test_type -> generic config).
+    fn test_configs<S>(&self, test_type: S) -> (Vec<GenericConfig>, String)
+    where
+        S: AsRef<str>,
+    {
+        // A vec containing all relevant test configs for this `GenericConfig` starting with
+        // `test_type` and ending with the `GenericConfig` itself.
+        let mut configs = Vec::new();
+        // Track the last test_type that we added to `configs`
+        let mut cur_test_type = test_type.as_ref().to_string();
+        loop {
+            // Add the config for the current test type (if the config doesn't exist, an empty
+            // config is added)
+            let test_config = self.test(&cur_test_type);
+            configs.push(test_config.clone());
+            // If the current test config specifies another test type, that test type needs to be
+            // added to the configurations.
+            if let Some(test_type) = test_config.test_type.to_owned() {
+                trace!("Test-type '{}' resolves to '{}'", cur_test_type, test_type);
+                cur_test_type = test_type;
+            } else {
+                break;
+            }
+        }
+
+        // Add the `self` config
+        configs.push(self.clone());
+        (configs, cur_test_type)
     }
 }
 

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -164,9 +164,11 @@ impl CrdCreator for AwsEcsCreator {
             .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))
             .set_labels(Some(labels))
             .build(format!(
-                "{}-test{}",
+                "{}-{}",
                 cluster_resource_name,
-                test_input.name_suffix.unwrap_or_default()
+                test_input
+                    .name_suffix
+                    .unwrap_or(test_input.crd_input.test_flavor.as_str())
             ))
             .context(error::BuildSnafu {
                 what: "ECS test CRD",

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -23,6 +23,7 @@ pub struct CrdInput<'a> {
     pub variant: Variant,
     pub config: GenericVariantConfig,
     pub repo_config: RepoConfig,
+    pub test_flavor: String,
     pub starting_version: Option<String>,
     pub migrate_to_version: Option<String>,
     pub build_id: Option<String>,
@@ -394,7 +395,7 @@ pub(crate) trait CrdCreator: Sync {
                             test_type,
                             crd_input,
                             prev_tests: tests.clone(),
-                            name_suffix: "-1-initial".into(),
+                            name_suffix: "1-initial".into(),
                         })
                         .await?;
                     if let Some(name) = test_output.crd_name() {
@@ -409,7 +410,7 @@ pub(crate) trait CrdCreator: Sync {
                             bottlerocket_crd_name: &bottlerocket_crd_name,
                             crd_input,
                             prev_tests: tests.clone(),
-                            name_suffix: "-2-migrate".into(),
+                            name_suffix: "2-migrate".into(),
                             migration_direction: MigrationDirection::Upgrade,
                         })
                         .await?;
@@ -426,7 +427,7 @@ pub(crate) trait CrdCreator: Sync {
                             test_type,
                             crd_input,
                             prev_tests: tests.clone(),
-                            name_suffix: "-3-migrated".into(),
+                            name_suffix: "3-migrated".into(),
                         })
                         .await?;
                     if let Some(name) = test_output.crd_name() {
@@ -441,7 +442,7 @@ pub(crate) trait CrdCreator: Sync {
                             bottlerocket_crd_name: &bottlerocket_crd_name,
                             crd_input,
                             prev_tests: tests.clone(),
-                            name_suffix: "-4-migrate".into(),
+                            name_suffix: "4-migrate".into(),
                             migration_direction: MigrationDirection::Downgrade,
                         })
                         .await?;
@@ -458,7 +459,7 @@ pub(crate) trait CrdCreator: Sync {
                             test_type,
                             crd_input,
                             prev_tests: tests,
-                            name_suffix: "-5-final".into(),
+                            name_suffix: "5-final".into(),
                         })
                         .await?;
                     if let Some(crd) = test_output.crd() {
@@ -479,6 +480,7 @@ pub(crate) trait CrdCreator: Sync {
         crd_input: &CrdInput,
         override_crd_template: Option<PathBuf>,
     ) -> Result<Vec<Crd>> {
+        debug!("Creating custom CRDs for '{}' test", test_type);
         let crd_template_file_path = &override_crd_template
             .or_else(|| crd_input.custom_crd_template_file_path())
             .context(error::InvalidSnafu {

--- a/tools/testsys/src/migration.rs
+++ b/tools/testsys/src/migration.rs
@@ -84,9 +84,11 @@ pub(crate) fn migration_crd(
         .set_secrets(Some(migration_input.crd_input.config.secrets.to_owned()))
         .set_labels(Some(labels))
         .build(format!(
-            "{}{}",
+            "{}-{}",
             cluster_resource_name,
-            migration_input.name_suffix.unwrap_or_default()
+            migration_input
+                .name_suffix
+                .unwrap_or(migration_input.crd_input.test_flavor.as_str())
         ))
         .context(error::BuildSnafu {
             what: "migration CRD",

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -24,6 +24,7 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
 
     let labels = test_input.crd_input.labels(btreemap! {
         "testsys/type".to_string() => test_input.test_type.to_string(),
+        "testsys/flavor".to_string() => test_input.crd_input.test_flavor.clone(),
         "testsys/cluster".to_string() => cluster_resource_name.to_string(),
     });
 
@@ -64,9 +65,11 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
         .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))
         .set_labels(Some(labels))
         .build(format!(
-            "{}{}",
+            "{}-{}",
             cluster_resource_name,
-            test_input.name_suffix.unwrap_or("-test")
+            test_input
+                .name_suffix
+                .unwrap_or(test_input.crd_input.test_flavor.as_str())
         ))
         .context(error::BuildSnafu {
             what: "Sonobuoy CRD",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

```bash
dea965a8 testsys: Add userdata files to `tests`
b4228725 testsys: Enable test-type dependencies
2fd6b870 testsys: Allow configs in `test` table
874bd083 testsys: Eksctl config file support
1bb95e14 testsys: Support custom tests from `tests` dir
74295e5a testsys: kubeconfig and test config in tests dir
08411e14 testsys: Add `tests` to .gitignore
```

`dea965a8 testsys: Add userdata files to 'tests'`
Allow users to add files to the testsys directory either in `tests/test_type`, `tests/shared`, `tests/shared/userdata`

`b4228725 testsys: Enable test-type dependencies`
Allows a test type to provide configuration beyond an existing test type.

```toml
# Test.toml

[tests.configuration.foo]
# Tell TestSys that this is just another configuration of quick testing and the quick testing crds should be used.
test-type = "quick"
# Use `foo.toml` for userdata for this test type.
userdata = "foo"
```

`2fd6b870 testsys: Allow configs in `test` table`
Before, configurations had to be in a variant based table. Now configurations can also be present in the top level table.

`874bd083 testsys: Eksctl config file support`
Add support for eksctl config files.

```yaml
# `tests/shared/cluster-config/basic-cluster.yaml`

apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: "{{kube-arch}}-{{kube-variant}}-test"
  version: "{{version}}"
  region: "{{region}}"
kubernetesNetworkConfig:
  ipFamily: IPv4
vpc:
  clusterEndpoints:
    publicAccess: true
    privateAccess: true
iam:
  withOIDC: true
addons:
  - name: vpc-cni
    version: latest
  - name: coredns
    version: latest
  - name: kube-proxy
    version: latest
managedNodeGroups:
  - name: br-mng-{{kube-arch}}-{{kube-variant}}
    availabilityZones: []
    minSize: 0
    desiredCapacity: 0
    maxSize: 1
```

```toml
# Test.toml

[aws-k8s]
# TestSys will see that `basic-cluster.yaml` exists in `tests/shared/cluster-config` and use that in the crd. Since `existing-cluster.yaml` doesn't exist, it will handle `existing-cluster` without a cluster config.
cluster-names = ["basic-cluster", "existing-cluster"]
```

`1bb95e14 testsys: Support custom tests from `tests` dir`
A custom tests yaml configuration can be added to `tests/<TEST_TYPE>/test.yaml` (or a few other options)

`74295e5a testsys: kubeconfig and test config in tests dir`

Add support to `Makefile.toml` for `Test.toml` and `testsys.kubeconfig` in the `tests` directory _or_ in the top level directory.

`08411e14 testsys: Add `tests` to .gitignore`

Add the `tests` directory to the projects `.gitignore`.

**Testing done:**

Tested various configurations of userdata, cluster config and custom test locations and verified that the correct file was used. Tested various nested configurations in `Test.toml` and verified that they were resolved properly.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
