### PR TITLE
widen access to filesystem relabel in SELinux policy

### DIFF
--- a/packages/selinux-policy/files.cil
+++ b/packages/selinux-policy/files.cil
@@ -345,3 +345,7 @@
     execute ioctl getattr map open read execmod
     relabelfrom relabelto mounton quotaon
     watch watch_mount watch_reads watch_sb watch_with_perm))))
+
+; Permission group for filesystems.
+(classmap filesystems (relabel))
+(classmapping filesystems relabel (filesystem (relabelfrom relabelto)))

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -1,7 +1,7 @@
 ; Label inodes by using xattrs for supported filesystems.
-(fsuse xattr ext4 any)
-(fsuse xattr overlay any)
-(fsuse xattr xfs any)
+(fsuse xattr ext4 local)
+(fsuse xattr overlay local)
+(fsuse xattr xfs local)
 
 ; Label inodes by using the type of the creating task.
 (fsuse task eventpollfs any)

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -136,6 +136,10 @@
 (typeattribute shared_o)
 (typeattributeset shared_o (local_t data_t cni_exec_t))
 
+; Unshared objects are all other files.
+(typeattribute unshared_o)
+(typeattributeset unshared_o (xor (all_o) (shared_o)))
+
 ; Constrained objects are files where MCS constraints apply.
 (typeattribute constrained_o)
 (typeattributeset constrained_o (data_t))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -244,9 +244,15 @@
 ; new labels to match exactly.
 (allow container_s constrained_o (files (relabel)))
 
-; Untrusted components are not allowed to relabel most files.
+; Containers are also allowed to "relabel" filesystems at mount time
+; using "*context=" options, but only to and from "local_t".
+(allow container_s local_t (filesystems (relabel)))
+
+; Untrusted components are not allowed to relabel most files, and
+; cannot use "*context=" options to impose arbitrary labels.
 (neverallow untrusted_s all_s (files (relabel)))
 (neverallow untrusted_s unconstrained_o (files (relabel)))
+(neverallow untrusted_s unshared_o (filesystems (relabel)))
 
 ; Containers may copy or move files from constrained directories
 ; into unconstrained ones, such as tmpfs mounts. If they attempt to

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -234,8 +234,10 @@
 ; Unprivileged components are not allowed to use the API socket.
 (neverallow unprivileged_s api_socket_t (files (mutate)))
 
-; Only trusted components are allowed to relabel all files.
+; Only trusted components are allowed to relabel all files, and to
+; override filesystem labels through "*context=" mount options.
 (allow trusted_s global (files (relabel)))
+(allow trusted_s global (filesystems (relabel)))
 
 ; Containers are allowed to "relabel" constrained files, but are
 ; governed by additional MCS constraints that require the old and

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -270,9 +270,9 @@
 ; Protected object labels can be used on local storage.
 (allow protected_o local_t (filesystem (associate)))
 
-; The data object label can also be used, so that volume types like
+; Shared object labels can also be used, so that volume types like
 ; emptyDir can be relabeled on behalf of containers.
-(allow data_t local_t (filesystem (associate)))
+(allow shared_o local_t (filesystem (associate)))
 
 ; Containers are allowed to relax security constraints, since we
 ; don't control what code they run or how it's built.

--- a/packages/selinux-policy/systems.cil
+++ b/packages/selinux-policy/systems.cil
@@ -5,7 +5,6 @@
 (classmapping systems manage (capability2 (mac_override mac_admin)))
 (classmapping systems manage (cap2_userns (mac_override mac_admin)))
 (classmapping systems manage (dbus (all)))
-(classmapping systems manage (filesystem (relabelfrom relabelto)))
 (classmapping systems manage (kernel_service (all)))
 (classmapping systems manage (security (all)))
 (classmapping systems manage (service (all)))


### PR DESCRIPTION
**Issue number:**
#2556, #2656

**Description of changes:**
Adjust the default label for filesystems using extended attributes to store SELinux labels from `any_t` to `local_t`, partly for consistency with the rest of the policy, and partly because I'm more comfortable allowing a "no-op" relabel from `local_t` to `local_t` than allowing an actual label change.

Split out filesystem relabel permissions into a separate permission set, so they can be granted independently from the systems management permissions.

Add a rule to allow containers to use filesystem mount options to "relabel" from `local_t` to `local_t`. A filesystem relabeled with the `context=` option won't be subsequently relabeled by `containerd`.

This can be useful in cases like #2556, where relabeling files isn't permitted by the SELinux policy, and in cases like #2656, where relabeling files may take an excessively long time.

**Testing done:**
Verified that `aws-k8s-1.24` and `aws-ecs-1` can boot and run containers with no AVC denials.

Confirmed that the EBS CSI driver could create `ext4` and `xfs` volumes where the context is specified as a mount option in the storage class, like this:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-sc
provisioner: ebs.csi.aws.com
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
mountOptions:
  - context=system_u:object_r:local_t:s0
parameters:
  fsType: ext4
```

Verified that other context options, such as `context=system_u:object_r:any_t:s0`, are blocked by the SELinux policy.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
