### PR TITLE
Bump host containers

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -179,4 +179,6 @@ version = "1.12.0"
     "migrate_v1.12.0_oci-defaults-setting-metadata.lz4",
     "migrate_v1.12.0_aws-admin-container-v0-9-4.lz4",
     "migrate_v1.12.0_public-admin-container-v0-9-4.lz4",
+    "migrate_v1.12.0_aws-control-container-v0-7-0.lz4",
+    "migrate_v1.12.0_public-control-container-v0-7-0.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -177,4 +177,6 @@ version = "1.12.0"
     "migrate_v1.12.0_add-k8s-autoscaling-warm-pool-setting-metadata.lz4",
     "migrate_v1.12.0_oci-defaults-setting.lz4",
     "migrate_v1.12.0_oci-defaults-setting-metadata.lz4",
+    "migrate_v1.12.0_aws-admin-container-v0-9-4.lz4",
+    "migrate_v1.12.0_public-admin-container-v0-9-4.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -474,6 +474,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-admin-container-v0-9-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-config"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,6 +2840,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "public-admin-container-v0-9-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -509,6 +509,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-endpoint"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2851,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-9-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-0"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -31,6 +31,8 @@ members = [
     "api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata",
     "api/migration/migrations/v1.12.0/oci-defaults-setting",
     "api/migration/migrations/v1.12.0/oci-defaults-setting-metadata",
+    "api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4",
+    "api/migration/migrations/v1.12.0/public-admin-container-v0-9-4",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -33,6 +33,8 @@ members = [
     "api/migration/migrations/v1.12.0/oci-defaults-setting-metadata",
     "api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4",
     "api/migration/migrations/v1.12.0/public-admin-container-v0-9-4",
+    "api/migration/migrations/v1.12.0/aws-control-container-v0-7-0",
+    "api/migration/migrations/v1.12.0/public-control-container-v0-7-0",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-9-4"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.3";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.4";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-0"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/src/main.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.4";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.0";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-9-4"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.3";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-0"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/src/main.rs
@@ -1,0 +1,27 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.4";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.3"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.4"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.6.4"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.0"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.3"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4"
 
 [settings.host-containers.control]
 enabled = false

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.4"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0"


### PR DESCRIPTION
**Description of changes:**

- Update and migrate from admin container v0.9.3 to v0.9.4.
- Update and migrate from control container v0.6.4 to v0.7.0.

**Testing done:**

Migration test in the comments below (thanks @ecpullen)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
