### PR TITLE
docs: Update release table for network versions

### DIFF
--- a/PROVISIONING-METAL.md
+++ b/PROVISIONING-METAL.md
@@ -263,7 +263,7 @@ Older networking configuration versions (such as `1` or `2`) are supported in ne
 |-------------------------------|---------------------------------------------------------------------------------|
 | Version 1                     | [v1.9.0](https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.9.0)   |
 | Version 2                     | [v1.10.0](https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.10.0) |
-| Version 3                     | Unreleased                                                                      |
+| Version 3                     | [v1.12.0](https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.12.0) |
 
 ### Boot Configuration
 


### PR DESCRIPTION
Updates the table for users to track when version 3 of networking configuration is available.

**Description of changes:**

Docs update for network version release table. 

**Testing done:**
NA


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
