### PR TITLE
Enable `systemd-networkd` development via build flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ ARG VARIANT_FAMILY
 ARG VARIANT_FLAVOR
 ARG REPO
 ARG GRUB_SET_PRIVATE_VAR
+ARG SYSTEMD_NETWORKD
 ENV VARIANT=${VARIANT}
 WORKDIR /home/builder
 
@@ -99,6 +100,7 @@ RUN rpmdev-setuptree \
    && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> .bconds \
    && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> .bconds \
    && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> .bconds \
+   && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> .bconds \
    && cat .bconds ${PACKAGE}.spec >> rpmbuild/SPECS/${PACKAGE}.spec \
    && find . -maxdepth 1 -not -path '*/\.*' -type f -exec mv {} rpmbuild/SOURCES/ \; \
    && echo ${NOCACHE}

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -22,6 +22,7 @@ source-groups = [
     "driverdog",
     "cfsignal",
 ]
+package-features = [ "systemd-networkd" ]
 
 [lib]
 path = "pkg.rs"
@@ -43,3 +44,6 @@ glibc = { path = "../glibc" }
 # binutils = { path = "../binutils" }
 # oci-add-hooks required for shimpei functionality
 # oci-add-hooks = { path = "../oci-add-hooks" }
+# wicked and systemd-networkd required for netdog functionality
+# wicked = { path = "../wicked" }
+# systemd-networkd = { path = "../systemd" }

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -121,6 +121,11 @@ Summary: Bottlerocket userdata configuration system
 
 %package -n %{_cross_os}netdog
 Summary: Bottlerocket network configuration helper
+%if %{with systemd_networkd}
+Requires: %{_cross_os}systemd-networkd
+%else
+Requires: %{_cross_os}wicked
+%endif
 %description -n %{_cross_os}netdog
 %{summary}.
 

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -101,7 +101,6 @@ Requires: %{_cross_os}procps
 Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}util-linux
-Requires: %{_cross_os}wicked
 
 %description
 %{summary}.

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -95,6 +95,12 @@ Requires: %{name}
 %description devel
 %{summary}.
 
+%package networkd
+Summary: Files for networkd
+
+%description networkd
+%{summary}.
+
 %prep
 %autosetup -n systemd-stable-%{version} -p1
 
@@ -139,7 +145,7 @@ CONFIGURE_OPTS=(
  -Dsysext=false
  -Duserdb=false
  -Dhomed=false
- -Dnetworkd=false
+ -Dnetworkd=true
  -Dtimedated=false
  -Dtimesyncd=false
  -Dremote=false
@@ -321,6 +327,12 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_libdir}/sysusers.d/*
 %{_cross_libdir}/systemd/*
 %{_cross_libdir}/udev/*
+%exclude %{_cross_libdir}/sysusers.d/systemd-network.conf
+%exclude %{_cross_libdir}/systemd/systemd-networkd
+%exclude %{_cross_libdir}/systemd/systemd-networkd-wait-online
+%exclude %{_cross_libdir}/systemd/system/systemd-networkd.service
+%exclude %{_cross_libdir}/systemd/system/systemd-networkd-wait-online.service
+%exclude %{_cross_libdir}/systemd/system/systemd-networkd.socket
 
 %{_cross_tmpfilesdir}/*
 %exclude %{_cross_tmpfilesdir}/x11.conf
@@ -332,6 +344,8 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 
 %{_cross_datadir}/dbus-1/*
 %exclude %{_cross_datadir}/polkit-1
+%exclude %{_cross_datadir}/dbus-1/system-services/org.freedesktop.network1.service
+%exclude %{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
 
 %dir %{_cross_factorydir}
 %{_cross_factorydir}%{_cross_sysconfdir}/issue
@@ -396,5 +410,16 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_includedir}/systemd/*.h
 %{_cross_pkgconfigdir}/*.pc
 %exclude %{_cross_libdir}/rpm/macros.d
+
+%files networkd
+%{_cross_bindir}/networkctl
+%{_cross_libdir}/systemd/system/systemd-networkd.service
+%{_cross_libdir}/systemd/system/systemd-networkd-wait-online.service
+%{_cross_libdir}/systemd/system/systemd-networkd.socket
+%{_cross_libdir}/systemd/systemd-networkd
+%{_cross_libdir}/systemd/systemd-networkd-wait-online
+%{_cross_libdir}/sysusers.d/systemd-network.conf
+%{_cross_datadir}/dbus-1/system-services/org.freedesktop.network1.service
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
 
 %changelog

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -197,6 +197,13 @@ config file to consume. This feature flag is a prerequisite for Boot Config supp
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
 ```
+
+`systemd-networkd` uses the `systemd-networkd` network backend in place of `wicked`.  This feature
+flag is meant primarily for development, and will be removed when development has completed.
+```
+[package.metadata.build-variant.image-features]
+systemd-networkd = true
+```
 */
 
 mod error;
@@ -486,6 +493,7 @@ impl SupportedArch {
 #[serde(try_from = "String")]
 pub enum ImageFeature {
     GrubSetPrivateVar,
+    SystemdNetworkd,
 }
 
 impl TryFrom<String> for ImageFeature {
@@ -493,6 +501,7 @@ impl TryFrom<String> for ImageFeature {
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
             "grub-set-private-var" => Ok(ImageFeature::GrubSetPrivateVar),
+            "systemd-networkd" => Ok(ImageFeature::SystemdNetworkd),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -502,6 +511,7 @@ impl fmt::Display for ImageFeature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ImageFeature::GrubSetPrivateVar => write!(f, "GRUB_SET_PRIVATE_VAR"),
+            ImageFeature::SystemdNetworkd => write!(f, "SYSTEMD_NETWORKD"),
         }
     }
 }


### PR DESCRIPTION
**Issue number:**
Related to: #2449 

**Description of changes:**
This initial set of commits enables development for the project's transition to `systemd-networkd`, allowing developers to conditionally include `systemd-networkd` (and exclude `wicked`) in any variant.

A new subpackage `networkd` has been added to the `systemd` package and contains all of the relevant files, excluding them from the broader `systemd` build.  At least for now, it appears we can continue to avoid `polkit` so those files continue to be excluded.  

A new build flag `systemd-networkd` has been added, which can be tacked on to the `image-features` of a variant to disable wicked and enable `systemd-networkd`.  Under the hood, the flag conditionally builds `systemd-networkd` in the `os` package.  Sample variant config snippet:
```
[package.metadata.build-variant.image-features]
grub-set-private-var = true
systemd-networkd = true
```


**Testing done:**
* Build and boot an `aws-dev` and `aws-k8s-1.22` variant without the build flag to ensure it works as expected and only `wicked` artifacts are included
* Build and locally boot an `aws-dev` variant with the build flag enabled to ensure the `os` package gets rebuilt and `systemd-networkd` is added instead of `wicked`.  I added an early dependency on `console-getty.service` to the `preconfigured.target` since I knew early services would be broken but I still wanted to be able to poke around and verify the above.
:tada: 
```
bash-5.1# networkctl 
IDX LINK TYPE     OPERATIONAL SETUP    
  1 lo   loopback carrier     unmanaged
  2 eth0 ether    off         unmanaged

2 links listed.

bash-5.1# find / -name "*wicked*"
bash-5.1# 
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
