### PR TITLE
fix clippy warnings for sources

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -410,6 +410,8 @@ script = [
 '''
 rc=0
 
+export VARIANT="${BUILDSYS_VARIANT}"
+
 # For rust first-party source code
 if ! cargo clippy \
   --manifest-path ${BUILDSYS_TOOLS_DIR}/Cargo.toml \
@@ -417,7 +419,11 @@ if ! cargo clippy \
   rc=1
 fi
 
-# TODO: fix clippy lints in "sources" and check that too
+if ! cargo clippy \
+  --manifest-path ${BUILDSYS_SOURCES_DIR}/Cargo.toml \
+  --locked -- -D warnings --no-deps; then
+  rc=1
+fi
 
 if [ "${rc}" -ne 0 ]; then
   echo "Found lint warnings. First-party source code is checked with clippy." >&2

--- a/sources/api/apiclient/src/apply.rs
+++ b/sources/api/apiclient/src/apply.rs
@@ -35,7 +35,7 @@ where
     let mut changes = Vec::with_capacity(get_responses.len());
     for (input_source, get_response) in get_responses {
         let response = get_response?;
-        let json = format_change(&response, &input_source)?;
+        let json = format_change(&response, input_source)?;
         changes.push((input_source, json));
     }
 
@@ -113,7 +113,7 @@ where
 /// it to JSON for sending to the API.
 fn format_change(input: &str, input_source: &str) -> Result<String> {
     // Try to parse the input as (arbitrary) TOML.  If that fails, try to parse it as JSON.
-    let mut json_val = match toml::from_str::<toml::Value>(&input) {
+    let mut json_val = match toml::from_str::<toml::Value>(input) {
         Ok(toml_val) => {
             // We need JSON for the API.  serde lets us convert between Deserialize-able types by
             // reusing the deserializer.  Turn the TOML value into a JSON value.
@@ -123,7 +123,7 @@ fn format_change(input: &str, input_source: &str) -> Result<String> {
         Err(toml_err) => {
             // TOML failed, try JSON; include the toml parsing error, because if they intended to
             // give TOML we should still tell them what was wrong with it.
-            serde_json::from_str(&input).context(error::InputTypeSnafu {
+            serde_json::from_str(input).context(error::InputTypeSnafu {
                 input_source,
                 toml_err,
             })

--- a/sources/api/apiclient/src/apply.rs
+++ b/sources/api/apiclient/src/apply.rs
@@ -154,7 +154,11 @@ mod error {
     #[snafu(visibility(pub(super)))]
     pub enum Error {
         #[snafu(display("Failed to commit combined settings to '{}': {}", uri, source))]
-        CommitApply { uri: String, source: crate::Error },
+        CommitApply {
+            uri: String,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
+        },
 
         #[snafu(display("Failed to read given file '{}': {}", input_source, source))]
         FileRead {
@@ -217,7 +221,8 @@ mod error {
             input_source: String,
             uri: String,
             method: String,
-            source: crate::Error,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
         },
 
         #[snafu(display("Failed {} request to '{}': {}", method, uri, source))]

--- a/sources/api/apiclient/src/exec.rs
+++ b/sources/api/apiclient/src/exec.rs
@@ -600,7 +600,7 @@ impl HandleSignals {
         // Set up the signal handler; do this before starting a thread so we can die quickly on
         // failure.
         use signal::*;
-        let signals = Signals::new(&[SIGWINCH, SIGTERM, SIGINT, SIGQUIT])
+        let signals = Signals::new([SIGWINCH, SIGTERM, SIGINT, SIGQUIT])
             .context(error::HandleSignalsSnafu)?;
 
         debug!("Spawning thread to manage signals");

--- a/sources/api/apiclient/src/get.rs
+++ b/sources/api/apiclient/src/get.rs
@@ -58,7 +58,8 @@ mod error {
         Request {
             method: String,
             uri: String,
-            source: crate::Error,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
         },
 
         #[snafu(display("Response contained invalid JSON '{}' - {}", body, source))]

--- a/sources/api/apiclient/src/lib.rs
+++ b/sources/api/apiclient/src/lib.rs
@@ -130,7 +130,7 @@ where
         .method(method)
         .uri(&uri)
         .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(request_data))
+        .body(request_data)
         .context(error::RequestSetupSnafu)?;
 
     // Send request.

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -788,7 +788,8 @@ mod error {
         Request {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Unable to serialize data: {}", source))]

--- a/sources/api/apiclient/src/reboot.rs
+++ b/sources/api/apiclient/src/reboot.rs
@@ -27,7 +27,8 @@ mod error {
         Request {
             method: String,
             uri: String,
-            source: crate::Error,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
         },
     }
 }

--- a/sources/api/apiclient/src/set.rs
+++ b/sources/api/apiclient/src/set.rs
@@ -44,7 +44,8 @@ mod error {
         Request {
             method: String,
             uri: String,
-            source: crate::Error,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
         },
     }
 }

--- a/sources/api/apiclient/src/update.rs
+++ b/sources/api/apiclient/src/update.rs
@@ -131,7 +131,7 @@ fn response_field(
     field: impl IntoIterator<Item = &'static &'static str>,
     response_str: &str,
 ) -> Option<String> {
-    let response: serde_json::Value = match serde_json::from_str(&response_str) {
+    let response: serde_json::Value = match serde_json::from_str(response_str) {
         Ok(json) => json,
         Err(_) => return None,
     };
@@ -305,8 +305,7 @@ where
                         &["most_recent_command", "exit_status"],
                         &status_body
                     )
-                    .map(|s| s.parse().ok())
-                    .flatten()
+                    .and_then(|s| s.parse().ok())
                     .unwrap_or(-1),
                 }
             );

--- a/sources/api/apiclient/src/update.rs
+++ b/sources/api/apiclient/src/update.rs
@@ -335,7 +335,10 @@ mod error {
         },
 
         #[snafu(display("Failed getting update status: {}", source))]
-        GetStatus { source: crate::Error },
+        GetStatus {
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
+        },
 
         #[snafu(display("Unable to check initial update status, got code '{}': {}", code, body))]
         MissingStatus {
@@ -360,7 +363,8 @@ mod error {
         #[snafu(display("Failed to make {} request: {}", command_name, source))]
         Request {
             command_name: String,
-            source: crate::Error,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
         },
 
         #[snafu(display(

--- a/sources/api/apiserver/src/bin/apiserver.rs
+++ b/sources/api/apiserver/src/bin/apiserver.rs
@@ -136,7 +136,7 @@ fn parse_args(args: env::Args) -> Args {
     Args {
         socket_gid,
         datastore_path: datastore_path.unwrap_or_else(|| usage()),
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| DEFAULT_BIND_PATH.to_string()),
         exec_socket_path: exec_socket_path.unwrap_or_else(|| DEFAULT_EXEC_SOCKET.to_string()),
     }

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -73,7 +73,8 @@ pub enum Error {
     #[snafu(display("Data store error during {}: {}", op, source))]
     DataStore {
         op: String,
-        source: datastore::Error,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
     },
 
     #[snafu(display("Error deserializing {}: {} ", given, source))]
@@ -98,7 +99,8 @@ pub enum Error {
     NewKey {
         key_type: String,
         name: String,
-        source: datastore::Error,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
     },
 
     #[snafu(display("Metadata '{}' is not valid JSON: {}", key, source))]

--- a/sources/api/apiserver/src/server/exec/child.rs
+++ b/sources/api/apiserver/src/server/exec/child.rs
@@ -101,7 +101,7 @@ impl ChildHandles {
         command.arg(exec_socket_path.as_ref());
 
         // Ask ctr to exec into an existing task, with a TTY if requested by the user.
-        command.args(&["task", "exec", "--exec-id", &exec_id]);
+        command.args(["task", "exec", "--exec-id", &exec_id]);
         if init.tty.is_some() {
             command.arg("--tty");
         }

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -258,7 +258,7 @@ async fn get_settings(
             prefix = &with_prefix;
         }
         controller::get_settings_prefix(&*datastore, prefix, &Committed::Live)
-            .map(|opt| opt.unwrap_or_else(|| Settings::default()))
+            .map(|opt| opt.unwrap_or_default())
     } else {
         controller::get_settings(&*datastore, &Committed::Live)
     }?;
@@ -397,7 +397,7 @@ async fn get_affected_services(
 
         Ok(MetadataResponse(resp))
     } else {
-        return error::MissingInputSnafu { input: "keys" }.fail();
+        error::MissingInputSnafu { input: "keys" }.fail()
     }
 }
 
@@ -420,7 +420,7 @@ async fn get_templates(
 
         Ok(MetadataResponse(resp))
     } else {
-        return error::MissingInputSnafu { input: "keys" }.fail();
+        error::MissingInputSnafu { input: "keys" }.fail()
     }
 }
 
@@ -445,8 +445,7 @@ async fn get_services(
         if !prefix.starts_with("services") {
             prefix = &with_prefix;
         }
-        controller::get_services_prefix(&*datastore, prefix)
-            .map(|opt| opt.unwrap_or_else(|| Services::default()))
+        controller::get_services_prefix(&*datastore, prefix).map(|opt| opt.unwrap_or_default())
     } else {
         controller::get_services(&*datastore)
     }?;
@@ -477,7 +476,7 @@ async fn get_configuration_files(
             prefix = &with_prefix;
         }
         controller::get_configuration_files_prefix(&*datastore, prefix)
-            .map(|opt| opt.unwrap_or_else(|| ConfigurationFiles::default()))
+            .map(|opt| opt.unwrap_or_default())
     } else {
         controller::get_configuration_files(&*datastore)
     }?;

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -75,7 +75,6 @@ journalctl -u bootstrap-containers@bear.service
 #[macro_use]
 extern crate log;
 
-use constants;
 use datastore::{serialize_scalar, Key, KeyType};
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ensure, OptionExt, ResultExt};
@@ -188,18 +187,14 @@ fn parse_args(args: env::Args) -> Result<(Args, Subcommand)> {
     match subcommand.as_deref() {
         Some("create-containers") => Ok((global_args, Subcommand::CreateContainers {})),
         Some("mark-bootstrap") => Ok((global_args, parse_mark_bootstrap_args(subcommand_args)?)),
-        None => {
-            return error::UsageSnafu {
-                message: format!("Missing subcommand"),
-            }
-            .fail()
+        None => error::UsageSnafu {
+            message: "Missing subcommand".to_string(),
         }
-        Some(x) => {
-            return error::UsageSnafu {
-                message: format!("Unknown subcommand '{}'", x),
-            }
-            .fail()
+        .fail(),
+        Some(x) => error::UsageSnafu {
+            message: format!("Unknown subcommand '{}'", x),
         }
+        .fail(),
     }
 }
 
@@ -233,18 +228,17 @@ fn parse_mark_bootstrap_args(args: Vec<String>) -> Result<Subcommand> {
     }
 
     let container_id = container_id.context(error::UsageSnafu {
-        message: format!("Did not give argument to --container-id"),
+        message: "Did not give argument to --container-id".to_string(),
     })?;
 
     let mode = mode.context(error::UsageSnafu {
-        message: format!("Did not give argument to --mode"),
+        message: "Did not give argument to --mode".to_string(),
     })?;
 
     Ok(Subcommand::MarkBootstrap(MarkBootstrapArgs {
-        container_id: container_id,
+        container_id,
         // Fail if 'mode' is invalid
-        mode: BootstrapContainerMode::try_from(mode.to_string())
-            .context(error::BootstrapContainerModeSnafu)?,
+        mode: BootstrapContainerMode::try_from(mode).context(error::BootstrapContainerModeSnafu)?,
     }))
 }
 
@@ -271,7 +265,7 @@ where
 
     let mode = container_details.mode.clone().unwrap_or_default();
 
-    let essential = container_details.essential.unwrap_or_else(|| false);
+    let essential = container_details.essential.unwrap_or(false);
 
     // Create the directory regardless if user data was provided for the container
     let dir = Path::new(PERSISTENT_STORAGE_DIR).join(name);
@@ -309,7 +303,7 @@ where
             debug!("Cleaning up container '{}'", name);
             command(
                 constants::HOST_CTR_BIN,
-                &[
+                [
                     "clean-up",
                     "--container-id",
                     format!("boot.{}", name).as_ref(),
@@ -323,7 +317,7 @@ where
         if host_containerd_unit.is_active()? && !systemd_unit.is_enabled()? {
             command(
                 constants::HOST_CTR_BIN,
-                &[
+                [
                     "clean-up",
                     "--container-id",
                     format!("boot.{}", name).as_ref(),
@@ -422,7 +416,7 @@ impl<'a> SystemdUnit<'a> {
     }
 
     fn is_enabled(&self) -> Result<bool> {
-        match command(constants::SYSTEMCTL_BIN, &["is-enabled", &self.unit]) {
+        match command(constants::SYSTEMCTL_BIN, ["is-enabled", self.unit]) {
             Ok(()) => Ok(true),
             Err(e) => {
                 // If the systemd unit is not enabled, then `systemctl is-enabled` will return a
@@ -439,7 +433,7 @@ impl<'a> SystemdUnit<'a> {
     }
 
     fn is_active(&self) -> Result<bool> {
-        match command(constants::SYSTEMCTL_BIN, &["is-active", &self.unit]) {
+        match command(constants::SYSTEMCTL_BIN, ["is-active", self.unit]) {
             Ok(()) => Ok(true),
             Err(e) => {
                 // If the systemd unit is not active(running), then `systemctl is-active` will
@@ -461,7 +455,7 @@ impl<'a> SystemdUnit<'a> {
         // until then.
         command(
             constants::SYSTEMCTL_BIN,
-            &["enable", &self.unit, "--no-reload"],
+            ["enable", self.unit, "--no-reload"],
         )
     }
 
@@ -470,7 +464,7 @@ impl<'a> SystemdUnit<'a> {
         // `apiclient`, so there is no need to add `--now` to stop them, and no need to reload.
         command(
             constants::SYSTEMCTL_BIN,
-            &["disable", &self.unit, "--no-reload"],
+            ["disable", self.unit, "--no-reload"],
         )
     }
 }

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -605,7 +605,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display(
@@ -647,7 +648,8 @@ mod error {
         ))]
         KeyFormat {
             key: String,
-            source: datastore::Error,
+            #[snafu(source(from(datastore::Error, Box::new)))]
+            source: Box<datastore::Error>,
         },
 
         #[snafu(display("Logger setup error: {}", source))]

--- a/sources/api/certdog/src/main.rs
+++ b/sources/api/certdog/src/main.rs
@@ -244,7 +244,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Unable to decode base64 from certificate '{}': {}", name, source))]

--- a/sources/api/certdog/src/main.rs
+++ b/sources/api/certdog/src/main.rs
@@ -10,7 +10,6 @@
 extern crate log;
 
 use argh::FromArgs;
-use constants;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::ResultExt;
 use std::collections::HashMap;
@@ -20,7 +19,6 @@ use std::io::BufReader;
 use std::io::{BufRead, Seek};
 use std::path::Path;
 use std::process;
-use x509_parser;
 
 use model::modeled_types::Identifier;
 
@@ -140,7 +138,7 @@ where
     trusted_bundle.retain(|pem| !cert_bundle.distrusted_certs.contains(pem));
 
     // Write a PEM formatted bundle from trusted certificates
-    fs::write(&trusted_store, pems_to_string(&trusted_bundle)?)
+    fs::write(trusted_store, pems_to_string(&trusted_bundle)?)
         .context(error::UpdateTrustedStoreSnafu)?;
 
     Ok(())
@@ -175,7 +173,7 @@ fn pem_to_string(pem: &x509_parser::pem::Pem) -> Result<String> {
     let mut out = String::new();
 
     // A comment will be added before the PEM formatted string to identify the certificate.
-    if let Some(comment) = comment_for_pem(&pem)? {
+    if let Some(comment) = comment_for_pem(pem)? {
         writeln!(out, "# {}", comment).context(error::WritePemStringSnafu)?;
     }
 
@@ -204,9 +202,7 @@ fn comment_for_pem(pem: &x509_parser::pem::Pem) -> Result<Option<String>> {
         .chain(subject.iter_organization())
         .next();
 
-    Ok(comment
-        .and_then(|c| c.as_str().ok())
-        .and_then(|c| Some(c.to_string())))
+    Ok(comment.and_then(|c| c.as_str().ok()).map(|c| c.to_string()))
 }
 
 async fn run() -> Result<()> {
@@ -298,7 +294,6 @@ type Result<T> = std::result::Result<T, error::Error>;
 #[cfg(test)]
 mod test_certdog {
     use super::*;
-    use model;
     use model::modeled_types::{Identifier, PemCertificateString};
     use std::collections::HashMap;
     use std::convert::TryFrom;
@@ -344,8 +339,7 @@ mod test_certdog {
         let (_, pem) =
             x509_parser::pem::parse_x509_pem(&base64::decode(TEST_PEM.as_bytes()).unwrap())
                 .unwrap();
-        let mut trusted_certs: Vec<x509_parser::pem::Pem> = Vec::new();
-        trusted_certs.push(pem);
+        let trusted_certs: Vec<x509_parser::pem::Pem> = vec![pem];
         let certs_bundle = CertBundle {
             trusted_certs,
             distrusted_certs: Vec::new(),

--- a/sources/api/corndog/src/main.rs
+++ b/sources/api/corndog/src/main.rs
@@ -256,7 +256,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Error {} when {}ing to {}: {}", code, method, uri, response_body))]

--- a/sources/api/corndog/src/main.rs
+++ b/sources/api/corndog/src/main.rs
@@ -7,7 +7,6 @@ It sets kernel-related settings, for example:
 
 #![deny(rust_2018_idioms)]
 
-use constants;
 use log::{debug, error, info, trace, warn};
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::ResultExt;
@@ -108,7 +107,7 @@ where
     for (key, value) in sysctls {
         let key = key.as_ref();
         let path = sysctl_path(key);
-        if let Err(e) = fs::write(&path, value) {
+        if let Err(e) = fs::write(path, value) {
             // We don't fail because sysctl keys can vary between kernel versions and depend on
             // loaded modules.  It wouldn't be possible to deploy settings to a mixed-kernel fleet
             // if newer sysctl values failed on your older kernels, for example, and we believe
@@ -227,7 +226,7 @@ fn parse_args(args: env::Args) -> Args {
 
     Args {
         subcommand: subcommand.unwrap_or_else(|| usage_msg("Must specify a subcommand.")),
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }

--- a/sources/api/datastore/src/deserialization/error.rs
+++ b/sources/api/datastore/src/deserialization/error.rs
@@ -28,13 +28,15 @@ pub enum Error {
     StripPrefix {
         prefix: String,
         name: String,
-        source: DataStoreError,
+        #[snafu(source(from(DataStoreError, Box::new)))]
+        source: Box<DataStoreError>,
     },
 
     #[snafu(display("Prefix '{}' is not a valid key: {}", prefix, source))]
     InvalidPrefix {
         prefix: String,
-        source: DataStoreError,
+        #[snafu(source(from(DataStoreError, Box::new)))]
+        source: Box<DataStoreError>,
     },
 }
 

--- a/sources/api/datastore/src/deserialization/pairs.rs
+++ b/sources/api/datastore/src/deserialization/pairs.rs
@@ -253,7 +253,7 @@ where
             trace!("Keys before path strip: {:?}", self.keys);
             let mut new_keys = HashSet::new();
             for key in self.keys {
-                new_keys.insert(key.strip_prefix_segments(&path.segments()).context(
+                new_keys.insert(key.strip_prefix_segments(path.segments()).context(
                     error::StripPrefixSnafu {
                         prefix: path.name(),
                         name: key.name(),
@@ -342,7 +342,7 @@ where
                         keys
                     );
                     Some((
-                        struct_name.to_owned(),
+                        struct_name,
                         ValueDeserializer::Compound(CompoundDeserializer::new(
                             self.map,
                             keys,

--- a/sources/api/datastore/src/filesystem.rs
+++ b/sources/api/datastore/src/filesystem.rs
@@ -447,7 +447,7 @@ impl DataStore for FilesystemDataStore {
 
     fn get_key(&self, key: &Key, committed: &Committed) -> Result<Option<String>> {
         let path = self.data_path(key, committed)?;
-        read_file_for_key(&key, &path)
+        read_file_for_key(key, &path)
     }
 
     fn set_key<S: AsRef<str>>(&mut self, key: &Key, value: S, committed: &Committed) -> Result<()> {
@@ -462,7 +462,7 @@ impl DataStore for FilesystemDataStore {
 
     fn get_metadata_raw(&self, metadata_key: &Key, data_key: &Key) -> Result<Option<String>> {
         let path = self.metadata_path(metadata_key, data_key, &Committed::Live)?;
-        read_file_for_key(&metadata_key, &path)
+        read_file_for_key(metadata_key, &path)
     }
 
     fn set_metadata<S: AsRef<str>>(
@@ -523,7 +523,7 @@ impl DataStore for FilesystemDataStore {
         let pending_data = self.get_prefix("settings.", &pending)?;
 
         // Pull out just the keys so we can log them and return them
-        let pending_keys = pending_data.into_iter().map(|(key, _val)| key).collect();
+        let pending_keys = pending_data.into_keys().collect();
         debug!("Found pending keys: {:?}", &pending_keys);
 
         // Delete pending from the filesystem, same as a commit

--- a/sources/api/datastore/src/key.rs
+++ b/sources/api/datastore/src/key.rs
@@ -79,9 +79,9 @@ impl Key {
     where
         S: AsRef<str>,
     {
-        let name = Self::encode_name_segments(&segments)?;
+        let name = Self::encode_name_segments(segments)?;
 
-        Self::check_key(key_type, &name, &segments)?;
+        Self::check_key(key_type, &name, segments)?;
 
         Ok(Self {
             name,
@@ -208,7 +208,7 @@ impl Key {
         match key_type {
             KeyType::Data => {
                 ensure!(
-                    segments.len() >= 1,
+                    !segments.is_empty(),
                     error::InvalidKeySnafu {
                         name,
                         msg: "data keys must have at least one segment",
@@ -232,10 +232,7 @@ impl Key {
     /// Determines whether a character is acceptable within a segment of a key name.  This is
     /// separate from quoting; if a character isn't valid, it isn't valid quoted, either.
     fn valid_character(c: char) -> bool {
-        match c {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '/' => true,
-            _ => false,
-        }
+        matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '/')
     }
 
     /// Given a key name, returns a list of its name segments, separated by KEY_SEPARATOR.

--- a/sources/api/datastore/src/memory.rs
+++ b/sources/api/datastore/src/memory.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::{Committed, DataStore, Key, Result};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MemoryDataStore {
     // Transaction name -> (key -> data)
     pending: HashMap<String, HashMap<Key, String>>,
@@ -20,11 +20,7 @@ pub struct MemoryDataStore {
 
 impl MemoryDataStore {
     pub fn new() -> Self {
-        Self {
-            pending: HashMap::new(),
-            live: HashMap::new(),
-            metadata: HashMap::new(),
-        }
+        Default::default()
     }
 
     fn dataset(&self, committed: &Committed) -> Option<&HashMap<Key, String>> {
@@ -75,7 +71,7 @@ impl DataStore for MemoryDataStore {
             }
 
             let mut meta_for_data = HashSet::new();
-            for (meta_key, _value) in meta_map {
+            for meta_key in meta_map.keys() {
                 // Confirm metadata key matches requested name, if any.
                 if let Some(name) = metadata_key_name {
                     if name.as_ref() != meta_key.name() {

--- a/sources/api/datastore/src/serialization/pairs.rs
+++ b/sources/api/datastore/src/serialization/pairs.rs
@@ -309,7 +309,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
 /// Helper that combines the existing prefix, if any, with a separator and the new key.
 fn key_append_or_create(old_prefix: &Option<Key>, key: &Key) -> Result<Key> {
     if let Some(old_prefix) = old_prefix {
-        old_prefix.append_key(&key).map_err(|e| {
+        old_prefix.append_key(key).map_err(|e| {
             error::InvalidKeySnafu {
                 msg: format!(
                     "appending '{}' to '{}' is invalid as Key: {}",

--- a/sources/api/early-boot-config/src/main.rs
+++ b/sources/api/early-boot-config/src/main.rs
@@ -172,7 +172,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Provider error: {}", source))]

--- a/sources/api/early-boot-config/src/provider/vmware.rs
+++ b/sources/api/early-boot-config/src/provider/vmware.rs
@@ -130,7 +130,7 @@ impl VmwareDataProvider {
         }
 
         // Base64 decode the &str
-        let decoded_bytes = base64::decode(&base64_str).context(error::Base64DecodeSnafu {
+        let decoded_bytes = base64::decode(base64_str).context(error::Base64DecodeSnafu {
             what: "OVF user data",
         })?;
 
@@ -205,7 +205,7 @@ impl VmwareDataProvider {
             }
         };
 
-        let json = SettingsJson::from_toml_str(&user_data_string, "user data from guestinfo")
+        let json = SettingsJson::from_toml_str(user_data_string, "user data from guestinfo")
             .context(error::SettingsToJsonSnafu { from: "guestinfo" })?;
         Ok(Some(json))
     }

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -7,7 +7,6 @@ The configuration file for ECS is a JSON-formatted document with conditionally-d
 embedded lists.  The structure and names of fields in the document can be found
 [here](https://github.com/aws/amazon-ecs-agent/blob/a250409cf5eb4ad84a7b889023f1e4d2e274b7ab/agent/config/types.go).
 */
-use constants;
 use log::debug;
 use serde::Serialize;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
@@ -80,7 +79,7 @@ struct ECSConfig {
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
 // https://github.com/shepmaster/snafu/issues/110
-pub(crate) async fn main() -> () {
+pub(crate) async fn main() {
     if let Err(e) = run().await {
         eprintln!("{}", e);
         process::exit(1);

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -48,7 +48,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]

--- a/sources/api/migration/migration-helpers/src/common_migrations.rs
+++ b/sources/api/migration/migration-helpers/src/common_migrations.rs
@@ -1,4 +1,4 @@
-use crate::{error, Metadata, Migration, MigrationData, Result};
+use crate::{error, Migration, MigrationData, Result};
 use serde::Serialize;
 use snafu::{OptionExt, ResultExt};
 use std::collections::HashMap;
@@ -632,17 +632,14 @@ impl ReplaceTemplateMigration {
         incoming_template: &str,
         input: &mut MigrationData,
     ) -> Result<()> {
-        if let Some(template) = &self.get_setting_template(&input) {
+        if let Some(template) = &self.get_setting_template(input) {
             if template == outgoing_template {
                 println!(
                     "Changing template of '{}' from '{}' to '{}'",
                     self.setting, outgoing_template, incoming_template
                 );
                 // Update the setting's template
-                let metadata = input
-                    .metadata
-                    .entry(self.setting.to_string())
-                    .or_insert(Metadata::new());
+                let metadata = input.metadata.entry(self.setting.to_string()).or_default();
                 metadata.insert(
                     "template".to_string(),
                     serde_json::Value::String(incoming_template.to_string()),
@@ -703,6 +700,7 @@ impl Migration for ReplaceTemplateMigration {
             self.update_template_and_data(
                 // Clone the input string; we need to give the function mutable access to
                 // the structure that contains the string, so we can't pass a reference into the structure.
+                #[allow(clippy::unnecessary_to_owned)]
                 &data.to_owned(),
                 self.old_template,
                 self.new_template,
@@ -728,6 +726,7 @@ impl Migration for ReplaceTemplateMigration {
             self.update_template_and_data(
                 // Clone the input string; we need to give the function mutable access to
                 // the structure that contains the string, so we can't pass a reference into the structure.
+                #[allow(clippy::unnecessary_to_owned)]
                 &data.to_owned(),
                 self.new_template,
                 self.old_template,
@@ -815,7 +814,7 @@ mod test_add_metadata {
         assert_eq!(
             result.metadata,
             hashmap! {
-                "hi".into() => HashMap::new().into(),
+                "hi".into() => HashMap::new(),
             }
         );
     }

--- a/sources/api/migration/migration-helpers/src/datastore_helper.rs
+++ b/sources/api/migration/migration-helpers/src/datastore_helper.rs
@@ -106,7 +106,7 @@ pub(crate) fn set_output_data<D: DataStore>(
             key_type: KeyType::Data,
             key: data_key_name,
         })?;
-        for (metadata_key_name, raw_value) in meta_map.into_iter() {
+        for (metadata_key_name, raw_value) in meta_map.iter() {
             let metadata_key =
                 Key::new(KeyType::Meta, metadata_key_name).context(error::InvalidKeySnafu {
                     key_type: KeyType::Meta,

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -13,11 +13,15 @@ pub enum Error {
     #[snafu(display("Unable to get {:?} data for migration: {}", committed, source))]
     GetData {
         committed: datastore::Committed,
-        source: datastore::Error,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
     },
 
     #[snafu(display("Unable to get metadata for migration: {}", source))]
-    GetMetadata { source: datastore::Error },
+    GetMetadata {
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
 
     #[snafu(display("Unable to deserialize to Value from '{}': {}", input, source))]
     Deserialize {
@@ -34,12 +38,16 @@ pub enum Error {
     },
 
     #[snafu(display("Unable to write to data store: {}", source))]
-    DataStoreWrite { source: datastore::Error },
+    DataStoreWrite {
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
 
     #[snafu(display("Unable to remove key '{}' from data store: {}", key, source))]
     DataStoreRemove {
         key: String,
-        source: datastore::Error,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
     },
 
     #[snafu(display("Migrated data failed validation: {}", msg))]
@@ -57,11 +65,15 @@ pub enum Error {
     InvalidKey {
         key_type: datastore::KeyType,
         key: String,
-        source: datastore::Error,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
     },
 
     #[snafu(display("Unable to list transactions in data store: {}", source))]
-    ListTransactions { source: datastore::Error },
+    ListTransactions {
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
 
     #[snafu(display("Unable to build handlebar template registry: {}", source))]
     BuildTemplateRegistry { source: schnauzer::error::Error },
@@ -69,7 +81,8 @@ pub enum Error {
     #[snafu(display("Unable to render template string '{}': {}", template, source))]
     RenderTemplate {
         template: String,
-        source: handlebars::RenderError,
+        #[snafu(source(from(handlebars::RenderError, Box::new)))]
+        source: Box<handlebars::RenderError>,
     },
 
     #[snafu(display("'{}' is set to non-string value", setting))]

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
@@ -10,7 +10,7 @@ fn run() -> Result<()> {
         migrate(AddMetadataMigration(&[SettingMetadata {
             metadata: &["affected-services"],
             setting: "settings.autoscaling",
-        }]));
+        }]))?;
     };
 
     Ok(())

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
@@ -12,7 +12,7 @@ fn run() -> Result<()> {
             "settings.autoscaling",
             "services.autoscaling-warm-pool",
             "configuration-files.warm-pool-wait-toml",
-        ]));
+        ]))?;
     };
 
     Ok(())

--- a/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/src/main.rs
@@ -3,9 +3,9 @@
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use std::process;
 
-const SETTING: &'static str = "configuration-files.kubelet-server-key.path";
-const OLD_VALUE: &'static str = "/etc/kubernetes/pki/kubelet-server.key";
-const NEW_VALUE: &'static str = "/etc/kubernetes/pki/private/kubelet-server.key";
+const SETTING: &str = "configuration-files.kubelet-server-key.path";
+const OLD_VALUE: &str = "/etc/kubernetes/pki/kubelet-server.key";
+const NEW_VALUE: &str = "/etc/kubernetes/pki/private/kubelet-server.key";
 
 /// We moved the render output location for the kubelet PKI private key to be in a restricted
 /// subdirectory. We need to update this output path in the stored configuration so updated nodes

--- a/sources/api/migration/migrator/src/args.rs
+++ b/sources/api/migration/migrator/src/args.rs
@@ -138,7 +138,7 @@ impl Args {
         Self {
             datastore_path: datastore_path
                 .unwrap_or_else(|| usage_msg("--datastore-path must be specified")),
-            log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+            log_level: log_level.unwrap_or(LevelFilter::Info),
             migration_directory: migration_directory
                 .unwrap_or_else(|| usage_msg("--migration-directory must be specified")),
             migrate_to_version: migrate_to_version.unwrap_or_else(|| {

--- a/sources/api/migration/migrator/src/direction.rs
+++ b/sources/api/migration/migrator/src/direction.rs
@@ -26,7 +26,7 @@ impl Direction {
     /// Determines the migration direction, given the outgoing ("from') and incoming ("to")
     /// versions.
     pub(crate) fn from_versions(from: &Version, to: &Version) -> Option<Self> {
-        match from.cmp(&to) {
+        match from.cmp(to) {
             Ordering::Less => Some(Direction::Forward),
             Ordering::Greater => Some(Direction::Backward),
             Ordering::Equal => None,

--- a/sources/api/migration/migrator/src/error.rs
+++ b/sources/api/migration/migrator/src/error.rs
@@ -73,13 +73,15 @@ pub(crate) enum Error {
     #[snafu(display("Invalid target name '{}': {}", target, source))]
     TargetName {
         target: String,
-        source: tough::error::Error,
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
     },
 
     #[snafu(display("Error loading migration '{}': {}", migration, source))]
     LoadMigration {
         migration: String,
-        source: tough::error::Error,
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
     },
 
     #[snafu(display("Failed to decode LZ4-compressed migration {}: {}", migration, source))]
@@ -89,7 +91,10 @@ pub(crate) enum Error {
     },
 
     #[snafu(display("Error loading manifest: {}", source))]
-    ManifestLoad { source: tough::error::Error },
+    ManifestLoad {
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
+    },
 
     #[snafu(display("Manifest not found in repository"))]
     ManifestNotFound,
@@ -112,7 +117,10 @@ pub(crate) enum Error {
     ReadMigrationEntry { source: io::Error },
 
     #[snafu(display("Failed to load TUF repo: {}", source))]
-    RepoLoad { source: tough::error::Error },
+    RepoLoad {
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
+    },
 
     #[snafu(display("Failed reading metadata of '{}': {}", path.display(), source))]
     PathMetadata { path: PathBuf, source: io::Error },

--- a/sources/api/migration/migrator/src/error.rs
+++ b/sources/api/migration/migrator/src/error.rs
@@ -55,7 +55,7 @@ pub(crate) enum Error {
                     output.status.code()
                         .map(|i| i.to_string()).unwrap_or_else(|| "signal".to_string()),
                     std::str::from_utf8(&output.stderr)
-                        .unwrap_or_else(|_e| "<invalid UTF-8>")))]
+                        .unwrap_or("<invalid UTF-8>")))]
     MigrationFailure { output: Output },
 
     #[snafu(display("Failed to create symlink for new version at {}: {}", path.display(), source))]

--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -104,7 +104,7 @@ pub(crate) fn run(args: &Args) -> Result<()> {
             path: &args.datastore_path,
         })?;
 
-    let current_version = get_current_version(&datastore_dir)?;
+    let current_version = get_current_version(datastore_dir)?;
     let direction = Direction::from_versions(&current_version, &args.migrate_to_version)
         .unwrap_or_else(|| {
             info!(
@@ -176,7 +176,7 @@ pub(crate) fn run(args: &Args) -> Result<()> {
             &args.datastore_path,
             &args.migrate_to_version,
         )?;
-        flip_to_new_version(&args.migrate_to_version, &copy_path)?;
+        flip_to_new_version(&args.migrate_to_version, copy_path)?;
     }
     Ok(())
 }
@@ -277,7 +277,7 @@ where
         ]);
 
         // Create a new output location for this migration.
-        target_datastore = new_datastore_location(&source_datastore, &new_version)?;
+        target_datastore = new_datastore_location(source_datastore, new_version)?;
 
         command.args(&[
             "--target-datastore".to_string(),
@@ -328,7 +328,7 @@ fn delete_intermediate_datastore(path: &PathBuf) {
     // Even if we fail to remove an intermediate data store, we don't want to fail the upgrade -
     // just let someone know for later cleanup.
     trace!("Removing intermediate data store at {}", path.display());
-    if let Err(e) = fs::remove_dir_all(&path) {
+    if let Err(e) = fs::remove_dir_all(path) {
         error!(
             "Failed to remove intermediate data store at '{}': {}",
             path.display(),
@@ -424,7 +424,7 @@ where
     // Create a symlink from the patch version to the new data store.  We create it at a temporary
     // path so we can atomically swap it into the real path with a rename call.
     // This will point at, for example, /path/to/datastore/v1.5.2_0123456789abcdef
-    symlink(&to_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
+    symlink(to_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
     // Atomically swap the link into place, so that the patch version link points to the new data
     // store copy.
     fs::rename(&temp_link, &patch_version_link).context(error::LinkSwapSnafu {
@@ -441,7 +441,7 @@ where
 
     // Create a symlink from the minor version to the new patch version.
     // This will point at, for example, /path/to/datastore/v1.5.2
-    symlink(&patch_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
+    symlink(patch_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
     // Atomically swap the link into place, so that the minor version link points to the new patch
     // version.
     fs::rename(&temp_link, &minor_version_link).context(error::LinkSwapSnafu {
@@ -458,7 +458,7 @@ where
 
     // Create a symlink from the major version to the new minor version.
     // This will point at, for example, /path/to/datastore/v1.5
-    symlink(&minor_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
+    symlink(minor_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
     // Atomically swap the link into place, so that the major version link points to the new minor
     // version.
     fs::rename(&temp_link, &major_version_link).context(error::LinkSwapSnafu {
@@ -475,7 +475,7 @@ where
 
     // Create a symlink from 'current' to the new major version.
     // This will point at, for example, /path/to/datastore/v1
-    symlink(&major_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
+    symlink(major_target, &temp_link).context(error::LinkCreateSnafu { path: &temp_link })?;
     // Atomically swap the link into place, so that 'current' points to the new major version.
     fs::rename(&temp_link, &current_version_link).context(error::LinkSwapSnafu {
         link: &current_version_link,

--- a/sources/api/netdog/src/cli/generate_hostname.rs
+++ b/sources/api/netdog/src/cli/generate_hostname.rs
@@ -70,10 +70,13 @@ fn retry_strategy() -> impl Iterator<Item = Duration> {
 }
 
 mod platform {
-    use snafu::{ResultExt, Snafu};
-    use tokio::time::Duration;
+    use snafu::Snafu;
 
-    const IMDS_RETRY_TIMEOUT: Duration = Duration::from_secs(3);
+    #[cfg(variant_platform = "aws")]
+    use snafu::ResultExt;
+
+    #[cfg(variant_platform = "aws")]
+    const IMDS_RETRY_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(3);
 
     /// Query IMDS on AWS platforms to determine hostname.
     #[cfg(variant_platform = "aws")]

--- a/sources/api/pluto/src/api.rs
+++ b/sources/api/pluto/src/api.rs
@@ -20,7 +20,8 @@ mod inner {
     pub(crate) enum Error {
         #[snafu(display("Error calling Bottlerocket API: {}", source))]
         ApiClient {
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
             uri: String,
         },
 

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -278,15 +278,13 @@ async fn get_node_ip(client: &mut ImdsClient) -> Result<String> {
             .context(error::ImdsNoneSnafu {
                 what: "node ipv4 address",
             }),
-        IpAddr::V6(_) => {
-            return client
-                .fetch_primary_ipv6_address()
-                .await
-                .context(error::ImdsRequestSnafu)?
-                .context(error::ImdsNoneSnafu {
-                    what: "ipv6s associated with primary network interface",
-                });
-        }
+        IpAddr::V6(_) => client
+            .fetch_primary_ipv6_address()
+            .await
+            .context(error::ImdsRequestSnafu)?
+            .context(error::ImdsNoneSnafu {
+                what: "ipv6s associated with primary network interface",
+            }),
     }
 }
 

--- a/sources/api/prairiedog/src/bootconfig.rs
+++ b/sources/api/prairiedog/src/bootconfig.rs
@@ -190,7 +190,7 @@ fn parse_boot_config_values(input: &str) -> Result<Vec<BootConfigValue>> {
             expect_delimiter = false;
         }
     }
-    ensure!(quote == None, error::UnbalancedQuotesSnafu { input });
+    ensure!(quote.is_none(), error::UnbalancedQuotesSnafu { input });
     // Push last element
     let last_ele = if &input[start_index..] == "," {
         // If it's just a comma, assume it's an empty value at the end

--- a/sources/api/prairiedog/src/main.rs
+++ b/sources/api/prairiedog/src/main.rs
@@ -158,7 +158,7 @@ fn capture_dump() -> Result<()> {
     // --dump-dmesg generates a dump with only dmesg logs
     command(
         MAKEDUMPFILE_PATH,
-        &[
+        [
             "--dump-dmesg",
             "--message-level",
             "4",
@@ -172,7 +172,7 @@ fn capture_dump() -> Result<()> {
     // zlib compression
     command(
         MAKEDUMPFILE_PATH,
-        &[
+        [
             "-c",
             "--message-level",
             "4",
@@ -272,7 +272,7 @@ fn load_crash_kernel() -> Result<()> {
     // a specific systemd service instead of the default target.
     command(
         KEXEC_PATH,
-        &[
+        [
             "-ps",
             "--reuse-cmdline",
             "--append",
@@ -291,7 +291,7 @@ where
 {
     if is_reboot_required(socket_path).await? {
         info!("Boot settings changed and require a reboot to take effect. Initiating reboot...");
-        command("/usr/bin/systemctl", &["reboot"])?;
+        command("/usr/bin/systemctl", ["reboot"])?;
         // The "systemctl reboot" process will not block until the host does
         // reboot, but return as soon as the request either failed or the job
         // to start the systemd reboot.target and its dependencies have been

--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -355,7 +355,7 @@ pub fn base64_decode(
     trace!("Base64 string from template: {}", base64_str);
 
     // Base64 decode the &str
-    let decoded_bytes = base64::decode(&base64_str).context(error::Base64DecodeSnafu {
+    let decoded_bytes = base64::decode(base64_str).context(error::Base64DecodeSnafu {
         template: template_name.to_owned(),
     })?;
 

--- a/sources/api/schnauzer/src/lib.rs
+++ b/sources/api/schnauzer/src/lib.rs
@@ -27,7 +27,8 @@ pub mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Error {} when {}ing to {}: {}", code, method, uri, response_body))]

--- a/sources/api/schnauzer/src/main.rs
+++ b/sources/api/schnauzer/src/main.rs
@@ -34,7 +34,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Error {} when {}ing to '{}': {}", code, method, uri, response_body))]
@@ -79,7 +80,8 @@ mod error {
         RenderTemplate {
             setting_name: String,
             template: String,
-            source: handlebars::RenderError,
+            #[snafu(source(from(handlebars::RenderError, Box::new)))]
+            source: Box<handlebars::RenderError>,
         },
     }
 }

--- a/sources/api/settings-committer/src/main.rs
+++ b/sources/api/settings-committer/src/main.rs
@@ -35,7 +35,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]

--- a/sources/api/settings-committer/src/main.rs
+++ b/sources/api/settings-committer/src/main.rs
@@ -13,7 +13,6 @@ The `--transaction` argument can be used to specify another transaction.
 #[macro_use]
 extern crate log;
 
-use constants;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::ResultExt;
 use std::str::FromStr;
@@ -193,7 +192,7 @@ fn parse_args(args: env::Args) -> Args {
 
     Args {
         transaction: transaction.unwrap_or_else(|| constants::LAUNCH_TRANSACTION.to_string()),
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }

--- a/sources/api/shibaken/src/warmpool/autoscaling_warm_pool.rs
+++ b/sources/api/shibaken/src/warmpool/autoscaling_warm_pool.rs
@@ -4,7 +4,7 @@ use crate::warmpool::error::{self, Result};
 use argh::FromArgs;
 use imdsclient::ImdsClient;
 use serde::Deserialize;
-use snafu::{OptionExt, ResultExt};
+use snafu::ResultExt;
 use std::fs;
 use std::path::Path;
 use tokio::time::{sleep, Duration};

--- a/sources/api/static-pods/src/static_pods.rs
+++ b/sources/api/static-pods/src/static_pods.rs
@@ -56,7 +56,7 @@ where
     let manifest = manifest.as_ref();
 
     let target_dir = Path::new(STATIC_POD_DIR);
-    fs::create_dir_all(&target_dir).context(error::MkdirSnafu { dir: &target_dir })?;
+    fs::create_dir_all(target_dir).context(error::MkdirSnafu { dir: &target_dir })?;
 
     // Create a temporary directory adjacent to the static pods directory. This directory will be
     // automatically cleaned-up as soon as it goes out of scope.
@@ -222,7 +222,7 @@ fn parse_args(args: env::Args) -> Result<Args> {
     }
 
     Ok(Args {
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.into()),
     })
 }
@@ -230,7 +230,7 @@ fn parse_args(args: env::Args) -> Result<Args> {
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
 // https://github.com/shepmaster/snafu/issues/110
-pub(crate) async fn main() -> () {
+pub(crate) async fn main() {
     if let Err(e) = run().await {
         match e {
             error::Error::Usage { .. } => {

--- a/sources/api/storewolf/build.rs
+++ b/sources/api/storewolf/build.rs
@@ -65,7 +65,7 @@ fn generate_defaults_toml() -> Result<()> {
     let data = toml::to_string(&defaults).context(error::TomlSerializeSnafu)?;
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set; are you not using cargo?");
     let path = Path::new(&out_dir).join("defaults.toml");
-    fs::write(&path, &data).context(error::FileSnafu { op: "write", path })?;
+    fs::write(&path, data).context(error::FileSnafu { op: "write", path })?;
 
     Ok(())
 }

--- a/sources/api/storewolf/merge-toml/src/lib.rs
+++ b/sources/api/storewolf/merge-toml/src/lib.rs
@@ -16,7 +16,7 @@ pub fn merge_values<'a>(merge_into: &'a mut Value, merge_from: &'a Value) -> Res
     // If the types of left and right don't match, we have inconsistent models, and shouldn't try
     // to merge them.
     ensure!(
-        merge_into.same_type(&merge_from),
+        merge_into.same_type(merge_from),
         error::DataTypeMismatchSnafu
     );
 

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -26,8 +26,6 @@ use datastore::serialization::{to_pairs, to_pairs_with_prefix};
 use datastore::{self, DataStore, FilesystemDataStore, ScalarError};
 use model::modeled_types::SingleLineString;
 
-use constants;
-
 mod error {
     use std::io;
     use std::path::PathBuf;
@@ -170,11 +168,10 @@ fn parse_metadata_toml(md_toml_val: toml::Value) -> Result<Vec<model::Metadata>>
 
                 // Make sure that the path contains more than 1 item, i.e. ["settings", "motd"]
                 ensure!(
-                    path.len() >= 1,
+                    !path.is_empty(),
                     error::InternalSnafu {
-                        msg: format!(
-                            "Cannot create empty metadata data key - is root not a Table?"
-                        )
+                        msg: "Cannot create empty metadata data key - is root not a Table?"
+                            .to_string()
                     }
                 );
                 let data_key = path.join(".");
@@ -447,7 +444,7 @@ fn parse_args(args: env::Args) -> Args {
 
     Args {
         data_store_base_path: data_store_base_path.unwrap_or_else(|| usage()),
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         version,
     }
 }

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -61,10 +61,16 @@ mod error {
         DefaultsMetadataUnexpectedFormat {},
 
         #[snafu(display("Error querying datastore for populated keys: {}", source))]
-        QueryData { source: datastore::Error },
+        QueryData {
+            #[snafu(source(from(datastore::Error, Box::new)))]
+            source: Box<datastore::Error>,
+        },
 
         #[snafu(display("Error querying datastore for populated metadata: {}", source))]
-        QueryMetadata { source: datastore::Error },
+        QueryMetadata {
+            #[snafu(source(from(datastore::Error, Box::new)))]
+            source: Box<datastore::Error>,
+        },
 
         #[snafu(display("Error serializing {}: {} ", given, source))]
         Serialization {
@@ -76,17 +82,24 @@ mod error {
         SerializeScalar { given: String, source: ScalarError },
 
         #[snafu(display("Unable to write keys to the datastore: {}", source))]
-        WriteKeys { source: datastore::Error },
+        WriteKeys {
+            #[snafu(source(from(datastore::Error, Box::new)))]
+            source: Box<datastore::Error>,
+        },
 
         #[snafu(display("Unable to create {:?} key '{}': {}", key_type, key, source))]
         InvalidKey {
             key_type: KeyType,
             key: String,
-            source: datastore::Error,
+            #[snafu(source(from(datastore::Error, Box::new)))]
+            source: Box<datastore::Error>,
         },
 
         #[snafu(display("Unable to write metadata to the datastore: {}", source))]
-        WriteMetadata { source: datastore::Error },
+        WriteMetadata {
+            #[snafu(source(from(datastore::Error, Box::new)))]
+            source: Box<datastore::Error>,
+        },
 
         #[snafu(display("Logger setup error: {}", source))]
         Logger { source: log::SetLoggerError },

--- a/sources/api/sundog/src/main.rs
+++ b/sources/api/sundog/src/main.rs
@@ -77,7 +77,8 @@ mod error {
         APIRequest {
             method: String,
             uri: String,
-            source: apiclient::Error,
+            #[snafu(source(from(apiclient::Error, Box::new)))]
+            source: Box<apiclient::Error>,
         },
 
         #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]
@@ -146,7 +147,8 @@ mod error {
         InvalidKey {
             key_type: KeyType,
             key: String,
-            source: datastore::Error,
+            #[snafu(source(from(datastore::Error, Box::new)))]
+            source: Box<datastore::Error>,
         },
 
         #[snafu(display("Logger setup error: {}", source))]

--- a/sources/api/sundog/src/main.rs
+++ b/sources/api/sundog/src/main.rs
@@ -523,7 +523,7 @@ fn parse_args(args: env::Args) -> Args {
     }
 
     Args {
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }

--- a/sources/api/thar-be-settings/src/error.rs
+++ b/sources/api/thar-be-settings/src/error.rs
@@ -42,14 +42,16 @@ pub enum Error {
     #[snafu(display("Configuration file '{}' failed to render: {}", template, source))]
     TemplateRender {
         template: String,
-        source: handlebars::RenderError,
+        #[snafu(source(from(handlebars::RenderError, Box::new)))]
+        source: Box<handlebars::RenderError>,
     },
 
     #[snafu(display("Error sending {} to {}: {}", method, uri, source))]
     APIRequest {
         method: String,
         uri: String,
-        source: apiclient::Error,
+        #[snafu(source(from(apiclient::Error, Box::new)))]
+        source: Box<apiclient::Error>,
     },
 
     #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]

--- a/sources/api/thar-be-settings/src/main.rs
+++ b/sources/api/thar-be-settings/src/main.rs
@@ -116,7 +116,7 @@ fn parse_args(args: env::Args) -> Args {
     Args {
         daemon,
         mode,
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }

--- a/sources/api/thar-be-updates/src/error.rs
+++ b/sources/api/thar-be-updates/src/error.rs
@@ -58,7 +58,8 @@ pub enum Error {
     APIRequest {
         method: String,
         uri: String,
-        source: apiclient::Error,
+        #[snafu(source(from(apiclient::Error, Box::new)))]
+        source: Box<apiclient::Error>,
     },
 
     #[snafu(display("Error {} when sending {} to {}: {}", code, method, uri, response_body))]

--- a/sources/api/thar-be-updates/src/main.rs
+++ b/sources/api/thar-be-updates/src/main.rs
@@ -16,7 +16,6 @@ thar-be-updates uses a lockfile to control read/write access to the disks and th
 
 */
 
-use constants;
 use fs2::FileExt;
 use log::{debug, warn};
 use nix::unistd::{fork, ForkResult};
@@ -112,7 +111,7 @@ fn parse_args(args: std::env::Args) -> Args {
 
     Args {
         subcommand: subcommand.unwrap_or_else(|| usage()),
-        log_level: log_level.unwrap_or_else(|| LevelFilter::Info),
+        log_level: log_level.unwrap_or(LevelFilter::Info),
         socket_path: socket_path.unwrap_or_else(|| constants::API_SOCKET.to_string()),
     }
 }
@@ -185,7 +184,7 @@ fn refresh(status: &mut UpdateStatus, socket_path: &str) -> Result<bool> {
     fork_and_return!({
         debug!("Spawning 'updog whats'");
         let output = Command::new("updog")
-            .args(&["whats", "--all", "--json"])
+            .args(["whats", "--all", "--json"])
             .output()
             .context(error::UpdogSnafu)?;
         status.set_recent_command_info(UpdateCommand::Refresh, &output);

--- a/sources/api/thar-be-updates/src/status.rs
+++ b/sources/api/thar-be-updates/src/status.rs
@@ -100,11 +100,9 @@ pub fn get_update_status(_lockfile: &File) -> Result<UpdateStatus> {
     let status_file = File::open(UPDATE_STATUS_FILE).context(error::NoStatusFileSnafu {
         path: UPDATE_STATUS_FILE,
     })?;
-    Ok(
-        serde_json::from_reader(status_file).context(error::StatusParseSnafu {
-            path: UPDATE_STATUS_FILE,
-        })?,
-    )
+    serde_json::from_reader(status_file).context(error::StatusParseSnafu {
+        path: UPDATE_STATUS_FILE,
+    })
 }
 
 /// Retrieves settings from the API.
@@ -150,14 +148,14 @@ impl UpdateStatus {
 
     pub fn chosen_update(&self) -> Option<&UpdateImage> {
         match &self.chosen_update {
-            Some(update) => Some(&update),
+            Some(update) => Some(update),
             None => None,
         }
     }
 
     pub fn staging_partition(&self) -> Option<&StagedImage> {
         match &self.staging_partition {
-            Some(partition_info) => Some(&partition_info),
+            Some(partition_info) => Some(partition_info),
             None => None,
         }
     }
@@ -279,7 +277,7 @@ impl UpdateStatus {
             setting: "/settings/updates/version-lock",
         })?;
 
-        if String::from(locked_version.to_owned()) == "latest" {
+        if locked_version == "latest" {
             // Set chosen_update to the latest version available
             if let Some(latest_update) = UpdateStatus::get_latest_update(updates)? {
                 self.chosen_update = Some(UpdateImage {

--- a/sources/cfsignal/src/cloudformation.rs
+++ b/sources/cfsignal/src/cloudformation.rs
@@ -33,7 +33,7 @@ pub async fn signal_resource(
         .logical_resource_id(logical_resource_id)
         .status(
             aws_sdk_cloudformation::model::ResourceSignalStatus::from_str(&status)
-                .context(error::ParseStatusSnafu)?,
+                .expect("infallible"),
         )
         .unique_id(instance_id)
         .send()

--- a/sources/cfsignal/src/error.rs
+++ b/sources/cfsignal/src/error.rs
@@ -39,7 +39,4 @@ pub enum Error {
             aws_sdk_cloudformation::error::SignalResourceError,
         >,
     },
-
-    #[snafu(display("Failed to parse status: {}", source))]
-    ParseStatus { source: core::convert::Infallible },
 }

--- a/sources/generate-readme/src/lib.rs
+++ b/sources/generate-readme/src/lib.rs
@@ -86,7 +86,7 @@ where
 
     // Make sure the end of the file has a newline
     if content.chars().last().unwrap_or_default() != '\n' {
-        content = content + "\n";
+        content += "\n";
     }
 
     let mut readme = File::create("README.md").context(error::ReadmeCreateSnafu)?;

--- a/sources/ghostdog/src/main.rs
+++ b/sources/ghostdog/src/main.rs
@@ -76,7 +76,7 @@ where
 }
 
 /// Print the device type in the environment key format udev expects.
-fn emit_device_type(device_type: &str) -> () {
+fn emit_device_type(device_type: &str) {
     println!("BOTTLEROCKET_DEVICE_TYPE={}", device_type);
 }
 

--- a/sources/logdog/build.rs
+++ b/sources/logdog/build.rs
@@ -37,7 +37,7 @@ fn symlink_variant() {
     // create the symlink from conf/current/logdog.conf to the variant-specific file
     let target = format!("../{}", variant_filename);
     let link = "conf/current/logdog.conf";
-    symlink_force(&target, &link).unwrap_or_else(|e| {
+    symlink_force(&target, link).unwrap_or_else(|e| {
         eprintln!(
             "Failed to create symlink at '{}' pointing to '{}' - we need this to \
             support different logdog commands for variants.  Error: {}",

--- a/sources/logdog/src/error.rs
+++ b/sources/logdog/src/error.rs
@@ -13,7 +13,8 @@ use snafu::{Backtrace, Snafu};
 pub(crate) enum Error {
     #[snafu(display("Error calling Bottlerocket API '{}': {}", uri, source))]
     ApiClient {
-        source: apiclient::Error,
+        #[snafu(source(from(apiclient::Error, Box::new)))]
+        source: Box<apiclient::Error>,
         uri: String,
     },
 

--- a/sources/logdog/src/error.rs
+++ b/sources/logdog/src/error.rs
@@ -9,6 +9,7 @@ use snafu::{Backtrace, Snafu};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum Error {
     #[snafu(display("Error calling Bottlerocket API '{}': {}", uri, source))]
     ApiClient {

--- a/sources/models/model-derive/src/lib.rs
+++ b/sources/models/model-derive/src/lib.rs
@@ -100,11 +100,8 @@ impl From<ParsedArgs> for ModelHelper {
 impl VisitMut for ModelHelper {
     // Visit struct definitions.
     fn visit_item_struct_mut(&mut self, node: &mut ItemStruct) {
-        match node.vis {
-            // If unset, make pub.
-            Visibility::Inherited => node.vis = parse_quote!(pub),
-            // Leave alone anything the user set.
-            _ => {}
+        if let Visibility::Inherited = node.vis {
+            node.vis = parse_quote!(pub)
         }
 
         // Add our serde attribute, if the user hasn't set one
@@ -142,11 +139,8 @@ impl VisitMut for ModelHelper {
 
     // Visit field definitions in structs.
     fn visit_field_mut(&mut self, node: &mut Field) {
-        match node.vis {
-            // If unset, make pub.
-            Visibility::Inherited => node.vis = parse_quote!(pub),
-            // Leave alone anything the user set.
-            _ => {}
+        if let Visibility::Inherited = node.vis {
+            node.vis = parse_quote!(pub)
         }
 
         // Add our serde attribute, if the user hasn't set one
@@ -177,5 +171,5 @@ fn is_attr_set(attr_name: &'static str, attrs: &[Attribute]) -> bool {
             }
         }
     }
-    return false;
+    false
 }

--- a/sources/shimpei/src/main.rs
+++ b/sources/shimpei/src/main.rs
@@ -9,7 +9,6 @@
 #[macro_use]
 extern crate log;
 
-use nix;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{OptionExt, ResultExt};
 use std::env;

--- a/sources/updater/block-party/src/lib.rs
+++ b/sources/updater/block-party/src/lib.rs
@@ -145,7 +145,7 @@ impl BlockDevice {
     /// Creates a `BlockDevice` from a special block device node.
     pub fn from_device_node<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
-        let metadata = fs::metadata(&path).context(error::PathMetadataSnafu { path })?;
+        let metadata = fs::metadata(path).context(error::PathMetadataSnafu { path })?;
         let major = metadata.st_rdev() >> 8;
         let minor = metadata.st_rdev() & 0xff;
         Self::from_major_minor(major, minor)

--- a/sources/updater/signpost/src/error.rs
+++ b/sources/updater/signpost/src/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     ))]
     ActiveNotInSet {
         active_partition: PathBuf,
-        sets: [PartitionSet; 2],
+        sets: Vec<PartitionSet>,
     },
 
     #[snafu(display("Failed to get block device from path {}: {}", device.display(), source))]

--- a/sources/updater/signpost/src/main.rs
+++ b/sources/updater/signpost/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
 
     if let Err(err) = State::load().and_then(|mut state| {
         match command {
-            Command::Status => println!("{}", state),
+            Command::Status => println!("{state}"),
             Command::ClearInactive => {
                 state.clear_inactive();
                 state.write()?;
@@ -69,7 +69,7 @@ fn main() {
         }
         Ok(())
     }) {
-        eprintln!("{}", err);
+        eprintln!("{err}");
         std::process::exit(1)
     }
 }

--- a/sources/updater/update_metadata/src/de.rs
+++ b/sources/updater/update_metadata/src/de.rs
@@ -55,6 +55,7 @@ where
 }
 
 /// Converts the tuple keys to a `Version` before insertion and catches duplicates
+#[allow(clippy::type_complexity)]
 pub(crate) fn deserialize_migration<'de, D>(
     deserializer: D,
 ) -> Result<BTreeMap<(Version, Version), Vec<String>>, D::Error>
@@ -67,7 +68,7 @@ where
         let r = Regex::new(r"\((?P<from_ver>[^ ,]+),[ ]*(?P<to_ver>[^ ,]+)\)");
 
         if let Ok(regex) = r {
-            if let Some(captures) = regex.captures(&key) {
+            if let Some(captures) = regex.captures(key) {
                 if let (Some(from), Some(to)) = (captures.name("from_ver"), captures.name("to_ver"))
                 {
                     return Ok((from.as_str(), to.as_str()));
@@ -91,7 +92,7 @@ where
             );
         } else {
             return error::BadDataVersionsFromToSnafu {
-                key: format!("{}, {}", from, to),
+                key: format!("{from}, {to}"),
             }
             .fail();
         }

--- a/sources/updater/update_metadata/src/error.rs
+++ b/sources/updater/update_metadata/src/error.rs
@@ -104,8 +104,8 @@ pub enum Error {
     MigrationInvalidTarget {
         backtrace: Backtrace,
         name: String,
-        to: Version,
-        version: Version,
+        to: Box<Version>,
+        version: Box<Version>,
     },
 
     #[snafu(display(
@@ -116,8 +116,8 @@ pub enum Error {
     #[snafu(display("Unable to get mutable reference to ({},{}) migrations", from, to))]
     MigrationMutable {
         backtrace: Backtrace,
-        from: Version,
-        to: Version,
+        from: Box<Version>,
+        to: Box<Version>,
     },
 
     #[snafu(display(
@@ -127,8 +127,8 @@ pub enum Error {
     ))]
     MissingMigration {
         backtrace: Backtrace,
-        current: Version,
-        target: Version,
+        current: Box<Version>,
+        target: Box<Version>,
     },
 
     #[snafu(display("Failed to serialize update information: {}", source))]

--- a/sources/updater/updog/src/bin/updata.rs
+++ b/sources/updater/updog/src/bin/updata.rs
@@ -165,7 +165,7 @@ impl WaveArgs {
         let waves: UpdateWaves =
             toml::from_str(&wave_str).context(error::ConfigParseSnafu { path: &wave_file })?;
 
-        let start_at = self.start_at.unwrap_or(Utc::now());
+        let start_at = self.start_at.unwrap_or_else(Utc::now);
         let num_matching = manifest.set_waves(
             self.variant,
             self.arch,
@@ -304,7 +304,7 @@ mod tests {
         let path = "tests/data/single_wave.json";
         let mut manifest: Manifest = serde_json::from_reader(File::open(path).unwrap()).unwrap();
         let wave_path = "tests/data/default_waves.toml";
-        let waves: UpdateWaves = toml::from_str(&fs::read_to_string(&wave_path).unwrap()).unwrap();
+        let waves: UpdateWaves = toml::from_str(&fs::read_to_string(wave_path).unwrap()).unwrap();
         let variant = manifest.updates[0].variant.clone();
         let arch = manifest.updates[0].arch.clone();
         let image_version = manifest.updates[0].version.clone();
@@ -313,7 +313,7 @@ mod tests {
             .set_waves(variant, arch, image_version, Utc::now(), &waves)
             .is_ok());
 
-        assert!(manifest.updates[0].waves.len() == 4)
+        assert!(manifest.updates[0].waves.len() == 4);
     }
 
     #[test]
@@ -323,7 +323,7 @@ mod tests {
         let temp_manifest = NamedTempFile::new().context(error::TmpFileCreateSnafu)?;
 
         // Create a new blank manifest
-        update_metadata::write_file(&temp_manifest.path(), &Manifest::default()).unwrap();
+        update_metadata::write_file(temp_manifest.path(), &Manifest::default()).unwrap();
 
         // Copy the migration data to the new manifest
         MigrationArgs {
@@ -334,8 +334,8 @@ mod tests {
         .unwrap();
 
         // Make sure the manifest has the correct releases
-        let manifest: Manifest = update_metadata::load_file(&temp_manifest.path()).unwrap();
-        let release_data = fs::read_to_string(&release_path).unwrap();
+        let manifest: Manifest = update_metadata::load_file(temp_manifest.path()).unwrap();
+        let release_data = fs::read_to_string(release_path).unwrap();
         let release: Release = toml::from_str(&release_data).unwrap();
         assert_eq!(manifest.migrations, release.migrations);
         Ok(())
@@ -350,8 +350,8 @@ mod tests {
         // Write example data to temp manifest so we dont' overwrite the file
         // when we call MigrationsArgs.set() below
         let temp_manifest = NamedTempFile::new().context(error::TmpFileCreateSnafu)?;
-        let example_data = fs::read_to_string(&example_manifest).unwrap();
-        fs::write(&temp_manifest, &example_data).unwrap();
+        let example_data = fs::read_to_string(example_manifest).unwrap();
+        fs::write(&temp_manifest, example_data).unwrap();
 
         // Copy the migration data to the existing manifest
         MigrationArgs {
@@ -364,7 +364,7 @@ mod tests {
         // Make sure the manifest has the correct releases
         let manifest: Manifest =
             update_metadata::load_file(Path::new(&temp_manifest.path())).unwrap();
-        let release_data = fs::read_to_string(&release_path).unwrap();
+        let release_data = fs::read_to_string(release_path).unwrap();
         let release: Release = toml::from_str(&release_data).unwrap();
         assert_eq!(manifest.migrations, release.migrations);
         Ok(())

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -69,12 +69,14 @@ pub(crate) enum Error {
     #[snafu(display("Invalid target name '{}': {}", target, source))]
     TargetName {
         target: String,
-        source: tough::error::Error,
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
     },
 
     #[snafu(display("Manifest load error: {}", source))]
     ManifestLoad {
-        source: tough::error::Error,
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
         backtrace: Backtrace,
     },
 
@@ -89,7 +91,8 @@ pub(crate) enum Error {
 
     #[snafu(display("Metadata error: {}", source))]
     Metadata {
-        source: tough::error::Error,
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
         backtrace: Backtrace,
     },
 
@@ -195,7 +198,10 @@ pub(crate) enum Error {
     },
 
     #[snafu(display("Failed to store manifest and migrations: {}", source))]
-    RepoCacheMigrations { source: tough::error::Error },
+    RepoCacheMigrations {
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
+    },
 
     #[snafu(display("Unable to parse '{}' as a URL: {}", url, source))]
     UrlParse {

--- a/sources/updater/updog/src/transport.rs
+++ b/sources/updater/updog/src/transport.rs
@@ -31,7 +31,7 @@ impl QueryParams {
         url
     }
 
-    pub(crate) fn add<S1, S2>(&self, key: S1, val: S2) -> ()
+    pub(crate) fn add<S1, S2>(&self, key: S1, val: S2)
     where
         S1: Into<String>,
         S2: Into<String>,
@@ -49,7 +49,7 @@ impl QueryParams {
             }
             Ok(lock_result) => lock_result,
         };
-        params.push((key.into(), val.into()))
+        params.push((key.into(), val.into()));
     }
 }
 


### PR DESCRIPTION
**Issue number:**

Fixes #1776 (finally)

**Description of changes:**
Fix all clippy warnings for the `sources` tree, and add coverage to the CI lint checks.


**Testing done:**
`cargo make check-lints` passes for three platforms:
* `aws-k8s-1.24`
* `vmware-k8s-1.24`
* `metal-k8s-1.24`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
