### PR TITLE
sources: Remove unnecessary time 0.1.x dependency

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.17",
+ "time",
  "url",
 ]
 
@@ -398,7 +398,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -501,7 +501,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.17",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -665,7 +665,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
- "time 0.3.17",
+ "time",
  "tracing",
 ]
 
@@ -768,7 +768,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -1032,12 +1032,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1640,7 +1637,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2295,7 +2292,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.42.0",
 ]
 
@@ -3356,7 +3353,7 @@ checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -3640,17 +3637,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -4111,12 +4097,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -4372,7 +4352,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -28,7 +28,7 @@ url = "2.1.1"
 generate-readme = { version = "0.1", path = "../../../generate-readme" }
 
 [dev-dependencies]
-chrono = "0.4.11"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 storewolf = { path = "../../storewolf", version = "0.1.0" }
 tempfile = "3.1.0"
 

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["README.md"]
 apiclient = { path = "../apiclient", version = "0.1.0" }
 constants = { path = "../../constants", version = "0.1.0" }
 bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
-chrono = { version = "0.4.11", features = [ "serde" ] }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
 fs2 = "0.4.3"
 http = "0.2.1"
 log = "0.4.8"

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -66,8 +66,6 @@ skip-tree = [
     { name = "sha-1", version = "=0.9.8" },
     # structopt is using an older clap and heck
     { name = "structopt", version = "=0.3.26" },
-    # older version used by chrono
-    { name = "time", version = "=0.1.45" },
     # windows-sys is not a direct dependency. mio and schannel
     # are using different versions of windows-sys. we skip the
     # dependency tree because windows-sys has many sub-crates

--- a/sources/parse-datetime/Cargo.toml
+++ b/sources/parse-datetime/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-chrono = "0.4.11"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 
 [build-dependencies]

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-chrono = { version = "0.4.9", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
 parse-datetime = { path = "../../parse-datetime", version = "0.1.0" }
 regex = "1.1"
 semver = { version = "1.0", features = ["serde"] }

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["README.md"]
 
 [dependencies]
 bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1.0" }
-chrono = "0.4.9"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 log = "0.4"
 lz4 = "1.23.1"
 rand = "0.8"


### PR DESCRIPTION
**Description of changes:**

This commit builds `chrono` only with the features that we need to avoid pulling in an additional (and older) `time` dependency.

Inspired by https://github.com/awslabs/tough/pull/506.

**Testing done:**

Built `aws-k8s-1.24` and did an upgrade/downgrade test.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
