### PR TITLE
migrations, migration-helpers: add `NoOpMigration`

### DIFF
--- a/sources/api/migration/migration-helpers/src/common_migrations.rs
+++ b/sources/api/migration/migration-helpers/src/common_migrations.rs
@@ -1368,3 +1368,25 @@ mod test_replace_metadata {
         );
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// When we add conditional migrations that can only run for specific variants, we need to run this
+/// migration helper for cases where the migration does NOT apply so migrator will still create a valid
+/// intermediary datastore that the host can transition to.
+#[derive(Debug)]
+pub struct NoOpMigration;
+
+impl Migration for NoOpMigration {
+    /// No work to do on forward migrations, copy the same datastore
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("NoOpMigration has no work to do on upgrade.",);
+        Ok(input)
+    }
+
+    /// No work to do on backward migrations, copy the same datastore
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("NoOpMigration has no work to do on downgrade.",);
+        Ok(input)
+    }
+}

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(rust_2018_idioms)]
 
-use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::common_migrations::{AddMetadataMigration, NoOpMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;
 
@@ -11,7 +11,9 @@ fn run() -> Result<()> {
             metadata: &["affected-services"],
             setting: "settings.autoscaling",
         }]))?;
-    };
+    } else {
+        migrate(NoOpMigration)?;
+    }
 
     Ok(())
 }

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(rust_2018_idioms)]
 
-use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
 use migration_helpers::{migrate, Result};
 use std::process;
 
@@ -13,7 +13,9 @@ fn run() -> Result<()> {
             "services.autoscaling-warm-pool",
             "configuration-files.warm-pool-wait-toml",
         ]))?;
-    };
+    } else {
+        migrate(NoOpMigration)?;
+    }
 
     Ok(())
 }

--- a/sources/api/migration/migrations/v1.12.0/oci-defaults-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/oci-defaults-setting-metadata/src/main.rs
@@ -1,5 +1,5 @@
 #![deny(rust_2018_idioms)]
-use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::common_migrations::{AddMetadataMigration, NoOpMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;
 
@@ -12,7 +12,9 @@ fn run() -> Result<()> {
             metadata: &["affected-services"],
             setting: "settings.oci-defaults",
         }]))?
-    };
+    } else {
+        migrate(NoOpMigration)?;
+    }
 
     Ok(())
 }

--- a/sources/api/migration/migrations/v1.12.0/oci-defaults-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/oci-defaults-setting/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(rust_2018_idioms)]
 
-use migration_helpers::common_migrations;
+use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
 use migration_helpers::{migrate, Result};
 use std::process;
 
@@ -10,11 +10,13 @@ use std::process;
 /// `settings.oci-defaults.resource-limits`
 fn run() -> Result<()> {
     if cfg!(variant_runtime = "k8s") {
-        migrate(common_migrations::AddPrefixesMigration(vec![
+        migrate(AddPrefixesMigration(vec![
             "settings.oci-defaults",
             "services.oci-defaults",
             "configuration-files.oci-defaults",
         ]))?
+    } else {
+        migrate(NoOpMigration)?;
     }
 
     Ok(())


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**

```
    migrations: call 'NoOpMigration' for when no data migration necessary
    
    Conditional migrations need to call migrate regardless of whether data
    is being migrated or not in order to generate a valid datastore for
    migrator to transition between during host updates.

```
```

    migration-helpers: add new helper 'NoOpMigration'
    
    This adds a new migration helper for cases where we don't want to
    migrate any data but just copy the datastore as is during the migration.
    
    This is useful for conditional migration where we selectively choose
    what data to migrate depending on the variant.
```

**Testing done:**
### aws-ecs-1:

Starting from v1.11.1, upgrade to v1.12.0 with these changes:
```bash
bash-5.1# updog check-update -a --json
[
  {
    "variant": "aws-ecs-1",
    "arch": "aarch64",
    "version": "1.12.0",
    "max_version": "1.12.0",
    "waves": {
      "0": "2023-01-25T01:01:14.825756980Z",
      "20": "2023-01-25T04:01:14.825756980Z",
      "102": "2023-01-26T00:01:14.825756980Z",
      "307": "2023-01-27T00:01:14.825756980Z",
      "819": "2023-01-29T00:01:14.825756980Z",
      "1228": "2023-01-30T00:01:14.825756980Z",
      "1843": "2023-01-31T00:01:14.825756980Z"
    },
    "images": {
      "boot": "bottlerocket-aws-ecs-1-aarch64-1.12.0-769c48a5-boot.ext4.lz4",
      "root": "bottlerocket-aws-ecs-1-aarch64-1.12.0-769c48a5-root.ext4.lz4",
      "hash": "bottlerocket-aws-ecs-1-aarch64-1.12.0-769c48a5-root.verity.lz4"
    }
  }
]
bash-5.1# updog update -r -n          
Starting update to 1.12.0
Cannot schedule shutdown without logind support, proceeding with immediate shutdown.
...
```
After reboot into v1.12.0, everything comes up fine:
```bash
[root@admin]# sudo sheltie                                                                                                                 
bash-5.1# cat /etc/os-release 
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.12.0 (aws-ecs-1)"
PRETTY_NAME="Bottlerocket OS 1.12.0 (aws-ecs-1)"
VARIANT_ID=aws-ecs-1
VERSION_ID=1.12.0
BUILD_ID=769c48a5
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
```

Downgrading back:
```
bash-5.1# signpost rollback-to-inactive
bash-5.1# reboot
```
```
[root@admin]# apiclient get os                                                                                                             
{
  "os": {
    "arch": "aarch64",
    "build_id": "104f8e0f",
    "pretty_name": "Bottlerocket OS 1.11.1 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.11.1"
  }
}
[root@admin]# 
```

### Same thing for `aws-k8s-1.24`:
From 1.11.1 to v1.12.0:
```bash
bash-5.1# updog whats -a --json
[
  {
    "variant": "aws-k8s-1.24",
    "arch": "aarch64",
    "version": "1.12.0",
    "max_version": "1.12.0",
    "waves": {
      "0": "2023-01-25T01:14:05.801419830Z",
      "20": "2023-01-25T04:14:05.801419830Z",
      "102": "2023-01-26T00:14:05.801419830Z",
      "307": "2023-01-27T00:14:05.801419830Z",
      "819": "2023-01-29T00:14:05.801419830Z",
      "1228": "2023-01-30T00:14:05.801419830Z",
      "1843": "2023-01-31T00:14:05.801419830Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.24-aarch64-1.12.0-769c48a5-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.24-aarch64-1.12.0-769c48a5-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.24-aarch64-1.12.0-769c48a5-root.verity.lz4"
    }
  }
]
bash-5.1# updog update -r -n
Starting update to 1.12.0
Cannot schedule shutdown without logind support, proceeding with immediate shutdown.
Update applied: aws-k8s-1.24 1.12.0
...
```

Comes up fine:
```bash
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "769c48a5",
    "pretty_name": "Bottlerocket OS 1.12.0 (aws-k8s-1.24)",
    "variant_id": "aws-k8s-1.24",
    "version_id": "1.12.0"
  }
}
```

Downgrade and comes up fine:
```bash
[root@admin]# sudo sheltie                                                                                                           
bash-5.1# signpost rollback-to-inactive
bash-5.1# reboot
....

[root@admin]# apiclient get /os
{
  "arch": "aarch64",
  "build_id": "104f8e0f",
  "pretty_name": "Bottlerocket OS 1.11.1 (aws-k8s-1.24)",
  "variant_id": "aws-k8s-1.24",
  "version_id": "1.11.1"
}

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
