### PR TITLE
migrator: info logging

### DIFF
--- a/packages/os/migrator.service
+++ b/packages/os/migrator.service
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/migrator \
   --metadata-directory /var/cache/bottlerocket-metadata \
   --migrate-to-version-from-os-release
 RemainAfterExit=true
+StandardOutput=journal+console
 StandardError=journal+console
 
 [Install]

--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -210,7 +210,7 @@ where
         }
     );
 
-    info!(
+    debug!(
         "New data store is being built at work location {}",
         to.display()
     );
@@ -284,7 +284,8 @@ where
             target_datastore.display().to_string(),
         ]);
 
-        info!("Running migration command: {:?}", command);
+        info!("Running migration '{}'", migration.raw());
+        debug!("Migration command: {:?}", command);
 
         let output = command.output().context(error::StartMigrationSnafu)?;
 
@@ -415,7 +416,7 @@ where
 
     // =^..^=   =^..^=   =^..^=   =^..^=
 
-    info!(
+    debug!(
         "Flipping {} to point to {}",
         patch_version_link.display(),
         to_target.to_string_lossy(),
@@ -433,7 +434,7 @@ where
 
     // =^..^=   =^..^=   =^..^=   =^..^=
 
-    info!(
+    debug!(
         "Flipping {} to point to {}",
         minor_version_link.display(),
         patch_target.to_string_lossy(),
@@ -450,7 +451,7 @@ where
 
     // =^..^=   =^..^=   =^..^=   =^..^=
 
-    info!(
+    debug!(
         "Flipping {} to point to {}",
         major_version_link.display(),
         minor_target.to_string_lossy(),
@@ -467,7 +468,7 @@ where
 
     // =^..^=   =^..^=   =^..^=   =^..^=
 
-    info!(
+    debug!(
         "Flipping {} to point to {}",
         current_version_link.display(),
         major_target.to_string_lossy(),


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

It would be really helpful to know, at least, what migrations ran before a problem occurred.

```
    migrator: info logging

    Before this change, none of migrators logs would make it to the journal.
    This made it very hard to understand what was happening when things
    went wrong because a problem may have been caused by a previous,
    seemingly happy-path iteration of the migration loop.

    Now we output a few important info lines to the journal as a record of
    what migrator did.
```

**Testing done:**

Before: `no logs from migrator`

After:

```text
         Starting wicked managed network interfaces...
[    2.324212] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_k8s-private-pki-path.lz4'
[    2.436743] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_add-k8s-autoscaling-warm-pool-setting.lz4'
[    2.454130] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_add-k8s-autoscaling-warm-pool-setting-metadata.lz4'
[    2.473640] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_oci-defaults-setting.lz4'
[    2.490995] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_oci-defaults-setting-metadata.lz4'
[    2.516293] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_aws-admin-container-v0-9-4.lz4'
[    2.536707] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_public-admin-container-v0-9-4.lz4'
[    2.563077] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_aws-control-container-v0-7-0.lz4'
[    2.581471] migrator[1461]: 00:21:28 [INFO] Running migration 'migrate_v1.12.0_public-control-container-v0-7-0.lz4'
[  OK  ] Finished Bottlerocket data store migrator.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
