### PR TITLE
Update docker run `--security-opt` command format

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -441,7 +441,7 @@ rc=0
 if ! docker run --rm \
   --network=none \
   --user "$(id -u):$(id -g)" \
-  --security-opt label:disable \
+  --security-opt="label=disable" \
   -v "${BUILDSYS_TOOLS_DIR}":/tmp/tools \
   "${BUILDSYS_SDK_IMAGE}" \
   bash -c \
@@ -592,7 +592,7 @@ fi
 docker run --rm \
    --network=none \
    --user "$(id -u):$(id -g)" \
-   --security-opt label:disable \
+   --security-opt="label=disable" \
    -v "${BOOT_CONFIG_INPUT}":/tmp/bootconfig-input \
    -v "${boot_config}":/tmp/bootconfig.data \
    "${BUILDSYS_SDK_IMAGE}" \
@@ -613,7 +613,7 @@ script = [
 docker run --rm \
    --network=none \
    --user "$(id -u):$(id -g)" \
-   --security-opt label:disable \
+   --security-opt="label=disable" \
    -v "${BOOT_CONFIG}":/tmp/bootconfig.data \
    "${BUILDSYS_SDK_IMAGE}" \
    bootconfig -l /tmp/bootconfig.data
@@ -692,7 +692,7 @@ set +e
 docker run --rm \
   --network=none \
   --user "$(id -u):$(id -g)" \
-  --security-opt label:disable \
+  --security-opt="label=disable" \
   -e CARGO_HOME="/tmp/.cargo" \
   -v "${CARGO_HOME}":/tmp/.cargo \
   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
@@ -730,7 +730,7 @@ set +e
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \
-  --security-opt label:disable \
+  --security-opt="label=disable" \
   -e CARGO_HOME="/tmp/.cargo" \
   -v "${CARGO_HOME}":/tmp/.cargo \
   -v "${BUILDSYS_ROOT_DIR}/licenses:/tmp/licenses" \

--- a/PROVISIONING-METAL.md
+++ b/PROVISIONING-METAL.md
@@ -307,7 +307,7 @@ touch $(pwd)/bootconfig.data
 docker run --rm \
    --network=none \
    --user "$(id -u):$(id -g)" \
-   --security-opt label:disable \
+   --security-opt label=disable \
    -v $(pwd)/bootconfig-input:/tmp/bootconfig-input \
    -v $(pwd)/bootconfig.data:/tmp/bootconfig.data \
    "${SDK_IMAGE}" \
@@ -327,7 +327,7 @@ SDK_IMAGE="public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:${SDK_VERSION}"
 docker run --rm \
    --network=none \
    --user "$(id -u):$(id -g)" \
-   --security-opt label:disable \
+   --security-opt label=disable \
    -v $(pwd)/bootconfig.data:/tmp/bootconfig.data \
    "${SDK_IMAGE}" \
    bootconfig -l /tmp/bootconfig.data

--- a/tools/docker-go
+++ b/tools/docker-go
@@ -82,7 +82,7 @@ docker run --rm \
   "${go_env[@]}" \
   "${proxy_env[@]}" \
   --user "$(id -u):$(id -g)" \
-  --security-opt label:disable \
+  --security-opt="label=disable" \
   ${DOCKER_RUN_ARGS} \
   -v "${GO_MOD_CACHE}":/tmp/go/pkg/mod \
   -v "${GO_MODULE_PATH}":/usr/src/module \


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

During our build process we have several places where we use the Bottlerocket SDK to perform the build. In these `docker run` commands we pass `--security-opt label:disable` to avoid labeling a large number of files.

It appears this syntax may have changed since we started using it, and the [correct syntax is now `label=disable`](https://docs.docker.com/engine/reference/run/#security-configuration). Based on reports in the Docker repo, the way we had it of `label:disable` [may not actually work](https://github.com/docker/for-linux/issues/1000).

While there are other issues to be addressed, the older format generates an error when trying to build with finch, while the newer format - [though not recognized](https://github.com/runfinch/finch/issues/192) - only generates a warning message.

**Testing done:**

Performed full build, made sure everything completed and no errors.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
