### PR TITLE
bootstrap-containers: extend bootstrap-containers capabilities

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -660,9 +660,12 @@ func withBootstrap() oci.SpecOpts {
 		withRootFsShared(),
 		oci.WithSelinuxLabel("system_u:system_r:control_t:s0-s0:c0.c1023"),
 		// Bootstrap containers don't require all capabilities. We only add
-		// `CAP_SYS_ADMIN` for mounting filesystems, and `CAP_NET_ADMIN` for
-		// managing iptables rules.
-		oci.WithAddedCapabilities([]string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN"}),
+		// - CAP_SYS_ADMIN: for mounting filesystems
+		// - CAP_NET_ADMIN: for managing iptables rules
+		// - CAP_SYS_CHROOT: to execute binaries from the root filesystem
+		// - CAP_SYS_MODULE: to load kernel modules from the root filesystem
+		// managing iptables rules, `CAP_SYS_CH`
+		oci.WithAddedCapabilities([]string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN", "CAP_SYS_CHROOT", "CAP_SYS_MODULE"}),
 		// `WithDefaultProfile` creates the proper seccomp profile based on the
 		// container's capabilities.
 		seccomp.WithDefaultProfile(),


### PR DESCRIPTION


**Issue number:**

Closes #2652

**Description of changes:**

This adds `CAP_SYS_MODULE` and `CAP_CHROOT` to bootstrap containers

**Testing done:**

- I created a container image with this definition:

```Dockerfile
FROM fedora
ENTRYPOINT ["chroot", "/.bottlerocket/rootfs", "modprobe", "vfio_pci"]
```

I confirmed the kernel module was loaded:

```bash
bash-5.1# lsmod | grep vfio
vfio_pci               77824  0
vfio_virqfd            16384  1 vfio_pci
vfio_iommu_type1       36864  0
vfio                   45056  2 vfio_iommu_type1,vfio_pci
irqbypass              16384  1 vfio_pci

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
