### PR TITLE
kubelet.service: change the restart policy to always

### DIFF
--- a/packages/kubernetes-1.21/kubelet.service
+++ b/packages/kubernetes-1.21/kubelet.service
@@ -14,7 +14,7 @@ ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 
-Restart=on-failure
+Restart=always
 RestartForceExitStatus=SIGPIPE
 RestartSec=5
 Delegate=yes

--- a/packages/kubernetes-1.22/kubelet.service
+++ b/packages/kubernetes-1.22/kubelet.service
@@ -14,7 +14,7 @@ ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 
-Restart=on-failure
+Restart=always
 RestartForceExitStatus=SIGPIPE
 RestartSec=5
 Delegate=yes

--- a/packages/kubernetes-1.23/kubelet.service
+++ b/packages/kubernetes-1.23/kubelet.service
@@ -14,7 +14,7 @@ ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 
-Restart=on-failure
+Restart=always
 RestartForceExitStatus=SIGPIPE
 RestartSec=5
 Delegate=yes

--- a/packages/kubernetes-1.24/kubelet.service
+++ b/packages/kubernetes-1.24/kubelet.service
@@ -14,7 +14,7 @@ ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 
-Restart=on-failure
+Restart=always
 RestartForceExitStatus=SIGPIPE
 RestartSec=5
 Delegate=yes

--- a/packages/kubernetes-1.25/kubelet.service
+++ b/packages/kubernetes-1.25/kubelet.service
@@ -14,7 +14,7 @@ ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 
-Restart=on-failure
+Restart=always
 RestartForceExitStatus=SIGPIPE
 RestartSec=5
 Delegate=yes


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2512

**Description of changes:**
```
kubelet.service: change the restart policy to always
```
currently we only specify kubelet to be restarted when it on failure. However, the situation resources starvation evicts kubelet isn't recognized as failure, so kubelet won't be restarted on this situation. Therefore, setting kubelet restart policy to `always` can solve this issue.

**Testing done:**
- [x] created resource starvation issue to evict kubelet (exit code = 0)
        - launch small instance  and add heavy computable pods to the cluster
- [x] verify if kubelet has been restarted

been


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
