### PR TITLE
testsys: Fix incorrect env for `TESTSYS_TESTS_DIR`

### DIFF
--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -45,7 +45,7 @@ pub(crate) struct Run {
     test_config_path: PathBuf,
 
     /// The path to the `tests` directory
-    #[clap(long, env = "TESTSYS_FOLDER", parse(from_os_str))]
+    #[clap(long, env = "TESTSYS_TESTS_DIR", parse(from_os_str))]
     tests_directory: PathBuf,
 
     /// The path to the EKS-A management cluster kubeconfig for vSphere K8s cluster creation


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #N/A

**Description of changes:**

This changes the name of the `tests_directory` environment variable to be the same as the one set in `Makefile.toml` as part of #2737.

**Testing done:**

`cargo make test`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
