### PR TITLE
Upgrade to Kubernetes v1.25.6

### DIFF
--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.25"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/2/artifacts/kubernetes/v1.25.5/kubernetes-src.tar.gz"
-sha512 = "d6b238dd8cf957006959d5c16ee1e2943c087d269c30c4e936c9af41d3568b4b696200bc416a3b0d9f212f5fe4c9a5a9428b7337adc2be9b89a0914e618abf94"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/5/artifacts/kubernetes/v1.25.6/kubernetes-src.tar.gz"
+sha512 = "2d526c6f98593b8eed4a63f975a3e5cf138525861385a9973d6a1bb09f6fb3101b184b3aadbf088eaac2749656264ea1dc28954ed2fc84d4363afcb49899455c"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.25.5
+%global gover 1.25.6
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/2/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/5/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2781

**Description of changes:**
* Update to latest release of EKS-D 1.25 (v1.25-eks-5), which upgrades Kubernetes from 1.25.5 to 1.25.6 and includes updates to patches

**Testing done:**
* Conformance


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
