### PR TITLE
build: ensure empty build/rpms directory is included in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 /.git
 /.gomodcache
 /build/*
+!/build/rpms/
+/build/rpms/*
 !/build/rpms/*.rpm
 /build/rpms/*-debuginfo-*.rpm
 /build/rpms/*-debugsource-*.rpm


### PR DESCRIPTION
**Issue number:**

Closes #2783 

**Description of changes:**

Whether intentionally or not, Docker 23 subtly changed the handling of negated patterns in `.dockerignore` files. In our case,

    /build/*
    !/build/rpms/*.rpm

will not include `build/rpms` in the build context with Docker 23 if the `build/rpms` is empty. This breaks the build since the directory is expected to exist in any case.

Add a couple extra patterns that amount to the desired behavior, whether run with Docker 23 or prior versions.


**Testing done:** Ran builds with Docker 20 and 23, with RPMs from prior builds in `build/rpms` after running `cargo make clean` to remove them. All builds succeeded.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
