### PR TITLE
docs: Update Bottlerocket version in provisioning

### DIFF
--- a/PROVISIONING-METAL.md
+++ b/PROVISIONING-METAL.md
@@ -37,7 +37,7 @@ To install `tuftool` you'll need to install Rust (via [rustup](https://rustup.rs
 
 ```shell
 ARCH="x86_64"
-VERSION="v1.9.0"
+VERSION="v1.12.0"
 VARIANT="metal-k8s-1.23"
 IMAGE="bottlerocket-${VARIANT}-${ARCH}-${VERSION}.img.lz4"
 OUTDIR="${VARIANT}-${VERSION}"


### PR DESCRIPTION
PROVISIONING-METAL doc refernces 1.9 which is well aged. This commit simply updates us to 1.12 for easy copy and paste.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
None

**Description of changes:**
Simply updating the version in the docs.


**Testing done:**
Tested via hands-on metal provisioning

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
