### PR TITLE
Removes k8s.gcr.io in favor of registry.k8s.io

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -182,4 +182,6 @@ version = "1.13.0"
     "migrate_v1.12.0_aws-control-container-v0-7-0.lz4",
     "migrate_v1.12.0_public-control-container-v0-7-0.lz4",
 ]
-"(1.12.0, 1.13.0)" = []
+"(1.12.0, 1.13.0)" = [
+    "migrate_v1.13.0_k8s-registry.lz4"
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2072,6 +2072,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-registry"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "api/migration/migrations/v1.12.0/public-admin-container-v0-9-4",
     "api/migration/migrations/v1.12.0/aws-control-container-v0-7-0",
     "api/migration/migrations/v1.12.0/public-control-container-v0-7-0",
+    "api/migration/migrations/v1.13.0/k8s-registry",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.13.0/k8s-registry/Cargo.toml
+++ b/sources/api/migration/migrations/v1.13.0/k8s-registry/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "k8s-registry"
+version = "0.1.0"
+authors = ["John McBride <jpmmcb@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.13.0/k8s-registry/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.0/k8s-registry/src/main.rs
@@ -1,0 +1,32 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_K8S_PAUSE_IMAGE: &str = "k8s.gcr.io/pause:3.2";
+const NEW_K8S_PAUSE_IMAGE: &str = "registry.k8s.io/pause:3.2";
+
+// The `k8s.gcr.io registry`, as of April 2023 will be frozen and
+// images will no longer be pushed to that registry.
+// Instead, Kubernetes consumers are expected to use `registry.k8s.io`
+// For further details: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/
+//
+// In this migration, we move image references from k8s.gcr.io to registry.k8s.io
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.kubernetes.pod-infra-container-image",
+        old_val: OLD_K8S_PAUSE_IMAGE,
+        new_val: NEW_K8S_PAUSE_IMAGE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/kubernetes-vmware.toml
+++ b/sources/models/shared-defaults/kubernetes-vmware.toml
@@ -2,7 +2,7 @@
 cluster-domain = "cluster.local"
 standalone-mode = false
 authentication-mode = "tls"
-pod-infra-container-image = "k8s.gcr.io/pause:3.2"
+pod-infra-container-image = "registry.k8s.io/pause:3.2"
 server-tls-bootstrap = false
 cloud-provider = "external"
 


### PR DESCRIPTION
**Issue number:**

N/a - `k8s.gcr.io` is being deprecated in favor of `registry.k8s.io`.
See: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/

**Description of changes:**

Replaces registry for pause image. Image is present:

```
❯ crane ls registry.k8s.io/pause
0.8.0
1.0
2.0
3.0
3.1
3.2
3.3
3.4.1
3.5
3.6
3.7
3.8
3.9
go
latest
sha256-7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097.sig
sha256-9001185023633d17a2f98ff69b6ff2615b8ea02a825adffa40422f51dfdcde9d.sig
test
test2
```

**Testing done:**

What testing should we do here since this only affects defaults for vmware k8s?

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
