### PR TITLE
kernel-5.15: disable IMA and SafeSetID LSM

### DIFF
--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -79,6 +79,9 @@ CONFIG_SECURITY_LOCKDOWN_LSM=y
 # kernel command line, it can be enforced.
 CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=y
 
+# disable integrity measurement architecture
+# CONFIG_IMA is not set
+
 # enable /proc/config.gz
 CONFIG_IKCONFIG=y
 CONFIG_IKCONFIG_PROC=y

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -82,6 +82,9 @@ CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=y
 # disable integrity measurement architecture
 # CONFIG_IMA is not set
 
+# Disable SafeSetID LSM
+# CONFIG_SECURITY_SAFESETID is not set
+
 # enable /proc/config.gz
 CONFIG_IKCONFIG=y
 CONFIG_IKCONFIG_PROC=y


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/2708 https://github.com/bottlerocket-os/bottlerocket/issues/2707

**Description of changes:**

As a fallout of the latest kernel updates we inherited some additional hardening features. Evaluating both of these features (IMA, SafeSetID LSM) we identified them as not applicable in a meaningful way in Bottlerocket. Hence, disable them to keep our kernel as lean as possible.

**Testing done:**

With disabling IMA we also remove a bunch of IMA sub-configurations that are not reachable anymore. We do not remove any unwanted options:

```
config-aarch64-5.15-aws-dev-diff:        18 removed,   0 added,   2 changed
config-aarch64-5.15-metal-dev-diff:      18 removed,   0 added,   2 changed
config-x86_64-5.15-aws-dev-diff:         16 removed,   0 added,   2 changed
config-x86_64-5.15-metal-dev-diff:       16 removed,   0 added,   2 changed
```

A full config diff for all versions can be found in [this gist](https://gist.github.com/foersleo/73779ba95dc128d00a8dafd199b7b4e1).

Running the a test build locally in qemu worked as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
