### PR TITLE
Update Kubernetes version 1.22 source given patch changes in EKS-D

### DIFF
--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.22"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/16/artifacts/kubernetes/v1.22.17/kubernetes-src.tar.gz"
-sha512 = "8ff23be77ded11377e0fc0b1ceb6b3bf7ef253e12d59afe9370c81c6cf480cfe0fde0a11a7f23c60f986652c847e3dca06b274ecc01d3f07fbf7330b54927f46"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-22/releases/19/artifacts/kubernetes/v1.22.17/kubernetes-src.tar.gz"
+sha512 = "8a71caf9c490022fe3865bae21b49c56046598004dba524c12cf9ff7954585fb9f97c903539fd491229c0200437462aad46e388c34dd66d22dfa7461a47dfac4"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.22/kubernetes-1.22.spec
+++ b/packages/kubernetes-1.22/kubernetes-1.22.spec
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/13/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-22/releases/19/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
The [latest release of EKS-D 1.22](https://github.com/aws/eks-distro/releases/tag/v1-22-eks-19) has [updated the patches applied to v1.22](https://github.com/aws/eks-distro/pull/1716/files#diff-8b9f6e0a09a3b65a5c16ff03a88de3bae6c296718150040436b0c98d1b25816b), leading to changes in the Kubernetes source without a patch version change.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
