### PR TITLE
Makefile: changed Rust lint clippy to the one included in SDK

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -439,14 +439,21 @@ rc=0
 export VARIANT="${BUILDSYS_VARIANT}"
 
 # For rust first-party source code
-if ! cargo clippy \
-  --manifest-path ${BUILDSYS_TOOLS_DIR}/Cargo.toml \
+if ! docker run --rm \
+   -v "$(pwd)":/tmp \
+   "${BUILDSYS_SDK_IMAGE}" \
+   cargo clippy \
+  --manifest-path /tmp/tools/Cargo.toml \
   --locked -- -D warnings --no-deps; then
   rc=1
 fi
 
-if ! cargo clippy \
-  --manifest-path ${BUILDSYS_SOURCES_DIR}/Cargo.toml \
+if ! docker run --rm \
+   -v "$(pwd)":/tmp \
+   -e VARIANT \
+   "${BUILDSYS_SDK_IMAGE}" \
+   cargo clippy \
+  --manifest-path /tmp/sources/Cargo.toml \
   --locked -- -D warnings --no-deps; then
   rc=1
 fi

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -644,20 +644,23 @@ mod error {
         #[snafu(display("Failed to add new target '{}' to repo: {}", path.display(), source))]
         AddTarget {
             path: PathBuf,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Failed to build target metadata from path '{}': {}", path.display(), source))]
         BuildTarget {
             path: PathBuf,
-            source: tough::schema::Error,
+            #[snafu(source(from(tough::schema::Error, Box::new)))]
+            source: Box<tough::schema::Error>,
         },
 
         #[snafu(display("Failed to copy target '{}' to '{}': {}", target.display(), path.display(), source))]
         CopyTarget {
             target: PathBuf,
             path: PathBuf,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Error reading config: {}", source))]
@@ -667,7 +670,10 @@ mod error {
         CreateDir { path: PathBuf, source: io::Error },
 
         #[snafu(display("Failed to create repo editor from given repo: {}", source))]
-        EditorFromRepo { source: tough::error::Error },
+        EditorFromRepo {
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
+        },
 
         #[snafu(display("Failed to read '{}': {}", path.display(), source))]
         File { path: PathBuf, source: io::Error },
@@ -685,7 +691,8 @@ mod error {
         LinkTarget {
             target: PathBuf,
             path: PathBuf,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Failed to write Manifest to '{}': {}", path.display(), source))]
@@ -701,7 +708,10 @@ mod error {
         MissingRepoUrls { repo: String },
 
         #[snafu(display("Failed to create new repo editor: {}", source))]
-        NewEditor { source: tough::error::Error },
+        NewEditor {
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
+        },
 
         #[snafu(display("Repo does not have a manifest.json: {}", metadata_url))]
         NoManifest { metadata_url: Url },
@@ -718,7 +728,8 @@ mod error {
         #[snafu(display("Failed to read target '{}' from repo: {}", target, source))]
         ReadTarget {
             target: String,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Failed to create async runtime: {}", source))]
@@ -727,7 +738,8 @@ mod error {
         #[snafu(display("Failed to parse target name from string '{}': {}", target, source))]
         ParseTargetName {
             target: String,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Repo exists at '{}' - remove it and try again", path.display()))]
@@ -743,31 +755,38 @@ mod error {
         ))]
         RepoLoad {
             metadata_base_url: Url,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Requested repository does not exist: '{}'", url))]
         RepoNotFound { url: Url },
 
         #[snafu(display("Failed to sign repository: {}", source))]
-        RepoSign { source: tough::error::Error },
+        RepoSign {
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
+        },
 
         #[snafu(display("Failed to write repository to {}: {}", path.display(), source))]
         RepoWrite {
             path: PathBuf,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Failed to set targets expiration to {}: {}", expiration, source))]
         SetTargetsExpiration {
             expiration: DateTime<Utc>,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Failed to set targets version to {}: {}", version, source))]
         SetTargetsVersion {
             version: u64,
-            source: tough::error::Error,
+            #[snafu(source(from(tough::error::Error, Box::new)))]
+            source: Box<tough::error::Error>,
         },
 
         #[snafu(display("Failed to set waves from '{}': {}", wave_policy_path.display(), source))]

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -454,7 +454,10 @@ mod error {
             context(false),
             display("Failed to create template for cluster name: {}", source)
         )]
-        TemplateError { source: handlebars::TemplateError },
+        TemplateError {
+            #[snafu(source(from(handlebars::TemplateError, Box::new)))]
+            source: Box<handlebars::TemplateError>,
+        },
 
         #[snafu(
             context(false),

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -44,7 +44,10 @@ pub enum Error {
         context(false),
         display("Unable create template from yaml: {}", source)
     )]
-    HandlebarsTemplate { source: handlebars::TemplateError },
+    HandlebarsTemplate {
+        #[snafu(source(from(handlebars::TemplateError, Box::new)))]
+        source: Box<handlebars::TemplateError>,
+    },
 
     #[snafu(display("Unable to create map from {}: {}", what, source))]
     IntoMap { what: String, source: model::Error },


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2704 

**Description of changes:**

Changed the `clippy` used in the `check-clippy` target for Rust linting to the one included in the `BUILDSYS_SDK` to avoid conflicting lints between local builds and GitHub actions. Blocked until https://github.com/bottlerocket-os/bottlerocket-sdk/pull/89 is merged and included in an SDK update.

**Testing done:**

Ran `cargo make check-clippy` with a local `cargo` install which resulted in a few warnings/errors. Ran it again with the SDK version of `clippy` which finished with no problems and exit code 0.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
