### PR TITLE
kernel: Update to latest upstream versions

### DIFF
--- a/packages/kernel-5.10/1001-Makefile-add-prepare-target-for-external-modules.patch
+++ b/packages/kernel-5.10/1001-Makefile-add-prepare-target-for-external-modules.patch
@@ -26,10 +26,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 9 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index 1d4a50ebe3b7..b9347d1e69e2 100644
+index aba2651d0..6f0cb64df 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1719,6 +1719,15 @@ else # KBUILD_EXTMOD
+@@ -1706,6 +1706,15 @@ else # KBUILD_EXTMOD
  KBUILD_BUILTIN :=
  KBUILD_MODULES := 1
  
@@ -43,8 +43,8 @@ index 1d4a50ebe3b7..b9347d1e69e2 100644
 +prepare: modules_prepare
 +
  build-dirs := $(KBUILD_EXTMOD)
- PHONY += modules
- modules: $(MODORDER)
+ $(MODORDER): descend
+ 	@:
 -- 
-2.21.3
+2.39.1
 

--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/600467e36826436cd8d518e9a7e4d66ea820bbb8561b4973bcda9b7516a44056/kernel-5.10.157-139.675.amzn2.src.rpm"
-sha512 = "59c0a0aa88ab891c0ae5b8777871c28005fd5d1700d7be88e688fb54226e8a6f163e0f67a86861aacf9801bc13c34dbe0a4292b8d82b778c6f07343623214b2a"
+url = "https://cdn.amazonlinux.com/blobstore/f4682a5336292f734ea4abbbad28a4d460ebad6578e4fbfd26de479f9ff8f84d/kernel-5.10.165-143.735.amzn2.src.rpm"
+sha512 = "f5c0f3c2082f54fa052ecf4c8ed7752698f29765014456214e78d9af181c36926a26b2adb3a8644987cf99afe6eddcb335c758e06fce801953da2d7aa90c1133"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.157
+Version: 5.10.165
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/600467e36826436cd8d518e9a7e4d66ea820bbb8561b4973bcda9b7516a44056/kernel-5.10.157-139.675.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/f4682a5336292f734ea4abbbad28a4d460ebad6578e4fbfd26de479f9ff8f84d/kernel-5.10.165-143.735.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/e281307f83b2add956c002192425c943cdac6a4a2c2b201594dc8590ef68b26e/kernel-5.15.79-51.138.amzn2.src.rpm"
-sha512 = "4ab89281ede2773f29e76f8c7fe50cb3b1a5b8819d8760dea2191ee6230ab32c7795485c36b302220560b18fe421edea1f55b0c4f266b39293d459b7b35e7676"
+url = "https://cdn.amazonlinux.com/blobstore/c6618e1460b8ace4707e17615e7bcb6c9654796d739014a1d7f6d6e2a70d8bfe/kernel-5.15.90-54.138.amzn2.src.rpm"
+sha512 = "225dea26f9e740a36c9df7d333688a9759761a080ca1586b2e515eec0f084919d1898ac5bfca4dfa067e56c49a86ca86ba7233d7117a13f85a6cf49df464d7f0"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.79
+Version: 5.15.90
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/e281307f83b2add956c002192425c943cdac6a4a2c2b201594dc8590ef68b26e/kernel-5.15.79-51.138.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/c6618e1460b8ace4707e17615e7bcb6c9654796d739014a1d7f6d6e2a70d8bfe/kernel-5.15.90-54.138.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2765

**Description of changes:**

Update kernels to latest AL kernels available in the repositories. A minor contextual change was needed for one of our downstream patches in 5.10.

**Testing done:**

```
config-aarch64-5.10-aws-k8s-1.23-diff:    0 removed,   0 added,   0 changed
config-aarch64-5.15-aws-dev-diff:         0 removed,   1 added,   0 changed
config-aarch64-5.15-metal-dev-diff:       0 removed,   1 added,   0 changed
config-x86_64-5.10-aws-k8s-1.23-diff:     0 removed,   0 added,   0 changed
config-x86_64-5.10-metal-k8s-1.23-diff:   0 removed,   0 added,   0 changed
config-x86_64-5.15-aws-dev-diff:          0 removed,   1 added,   0 changed
config-x86_64-5.15-metal-dev-diff:        0 removed,   1 added,   0 changed
```
Full config diff report can be found in [this gist](https://gist.github.com/foersleo/27cc9b9688dbfe82f3adca2a176abc11)

The one additional config options is due to an upstream inclusion of a new option through [e2e33f213dea tcp: configurable source port perturb table size](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=e2e33f213dea) introduced in v5.15.81. It is set to upstream default and in that setting does not introduce any functional change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
