### PR TITLE
testsys: Provide advanced config control

### DIFF
--- a/tools/testsys/Test.toml.example
+++ b/tools/testsys/Test.toml.example
@@ -78,6 +78,9 @@ eks-resource-agent-image = "public.ecr.aws/bottlerocket-test-system/eks_resource
 # Note: values passed by command line argument will take precedence over those passed by environment
 # variable, and both take precedence over values set by `Test.toml`.
 
+# Additional fields are configurable with the `dev` table.
+# See `DeveloperConfig` for individual fields.
+
 # Example Configurations
 
 # Configuration for all variants with the `aws` platform.

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -39,6 +39,7 @@ impl CrdCreator for AwsEcsCreator {
             })?)
            , &crd_input.arch,
            & self.region,
+           crd_input.config.dev.image_account_id.as_deref(),
         )
         .await
     }
@@ -73,7 +74,15 @@ impl CrdCreator for AwsEcsCreator {
             .cluster_name(cluster_input.cluster_name)
             .region(Some(self.region.to_owned()))
             .assume_role(cluster_input.crd_input.config.agent_role.clone())
-            .destruction_policy(DestructionPolicy::OnTestSuccess)
+            .destruction_policy(
+                cluster_input
+                    .crd_input
+                    .config
+                    .dev
+                    .cluster_destruction_policy
+                    .to_owned()
+                    .unwrap_or(DestructionPolicy::OnTestSuccess),
+            )
             .image(
                 cluster_input
                     .crd_input
@@ -160,7 +169,14 @@ impl CrdCreator for AwsEcsCreator {
                     .testsys_agent_pull_secret
                     .to_owned(),
             )
-            .keep_running(true)
+            .keep_running(
+                test_input
+                    .crd_input
+                    .config
+                    .dev
+                    .keep_tests_running
+                    .unwrap_or(false),
+            )
             .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))
             .set_labels(Some(labels))
             .build(format!(

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -43,6 +43,7 @@ impl CrdCreator for AwsK8sCreator {
             })?)
            , &crd_input.arch,
            & self.region,
+           crd_input.config.dev.image_account_id.as_deref(),
         )
         .await
     }
@@ -123,7 +124,15 @@ impl CrdCreator for AwsK8sCreator {
             )
             .set_labels(Some(labels))
             .set_secrets(Some(cluster_input.crd_input.config.secrets.clone()))
-            .destruction_policy(DestructionPolicy::Never)
+            .destruction_policy(
+                cluster_input
+                    .crd_input
+                    .config
+                    .dev
+                    .cluster_destruction_policy
+                    .to_owned()
+                    .unwrap_or(DestructionPolicy::Never),
+            )
             .build(cluster_name)
             .context(error::BuildSnafu {
                 what: "EKS cluster CRD",

--- a/tools/testsys/src/migration.rs
+++ b/tools/testsys/src/migration.rs
@@ -80,7 +80,14 @@ pub(crate) fn migration_crd(
                 .testsys_agent_pull_secret
                 .to_owned(),
         )
-        .keep_running(true)
+        .keep_running(
+            migration_input
+                .crd_input
+                .config
+                .dev
+                .keep_tests_running
+                .unwrap_or(false),
+        )
         .set_secrets(Some(migration_input.crd_input.config.secrets.to_owned()))
         .set_labels(Some(labels))
         .build(format!(

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -164,6 +164,7 @@ impl From<CliConfig> for GenericVariantConfig {
             conformance_registry: val.conformance_registry,
             control_plane_endpoint: val.control_plane_endpoint,
             userdata: val.userdata,
+            dev: Default::default(),
         }
     }
 }

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -48,7 +48,14 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
                 .testsys_agent_pull_secret
                 .to_owned(),
         )
-        .keep_running(true)
+        .keep_running(
+            test_input
+                .crd_input
+                .config
+                .dev
+                .keep_tests_running
+                .unwrap_or(false),
+        )
         .kubeconfig_base64_template(cluster_resource_name, "encodedKubeconfig")
         .plugin("e2e")
         .mode(sonobuoy_mode)

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -121,7 +121,15 @@ impl CrdCreator for VmwareK8sCreator {
             .vcenter_workload_folder(&self.datacenter.folder)
             .mgmt_cluster_kubeconfig_base64(&self.encoded_mgmt_cluster_kubeconfig)
             .set_conflicts_with(Some(existing_clusters))
-            .destruction_policy(DestructionPolicy::OnTestSuccess)
+            .destruction_policy(
+                cluster_input
+                    .crd_input
+                    .config
+                    .dev
+                    .cluster_destruction_policy
+                    .to_owned()
+                    .unwrap_or(DestructionPolicy::OnTestSuccess),
+            )
             .image(
                 cluster_input
                     .crd_input
@@ -208,7 +216,15 @@ impl CrdCreator for VmwareK8sCreator {
             .assume_role(bottlerocket_input.crd_input.config.agent_role.clone())
             .set_labels(Some(labels))
             .set_conflicts_with(Some(existing_clusters))
-            .destruction_policy(DestructionPolicy::OnTestSuccess)
+            .destruction_policy(
+                bottlerocket_input
+                    .crd_input
+                    .config
+                    .dev
+                    .bottlerocket_destruction_policy
+                    .to_owned()
+                    .unwrap_or(DestructionPolicy::OnTestSuccess),
+            )
             .image(
                 bottlerocket_input
                     .crd_input


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

When developing TestSys, the simplicity of `cargo make test` calls can make it difficult to force certain behavior to occur. It is also possible that the default values are not the best for a user. This pr introduces `DeveloperConfig` for additional control.

`DeveloperConfig` is intended to contain advanced configuration values that most users shouldn't need to care about. There is currently a 1:1 mapping for `GenericVariantConfig : Command Line Env Variables` that I'd like to preserve which is why I created a new type.

Currently there are 4 configuration values:
* `cluster-destruction-policy` allows users to control the destruction policy of cluster crds. The defaults currently used were carefully selected to improve the ux, but some users may want to alter this behavior
* `bottlerocket-destruction-policy` allows users to control the destruction policy of Bottlerocket crds.
* `keep-tests-running` is used to set the `keep_running` field on tests. With `keep_running: true`, the test's pods are kept in a running state until the test is deleted, as a result, the default behavior has been set to `false`, but can be enabled if a user wishes to.
* `image-account-id` is used to set an alternate account as the one starting AMIs are stored in. This is useful for storing AMIs in a separate account from the one testing is occurring in. Without `image-account-id`, a user needs to find the ami id from the account and set `TESTSYS_STARTING_IMAGE_ID`. With this new variable, all manual steps are removed.

**Testing done:**

Tested each new value and verified that the expected values were added to the CRDs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
