### PR TITLE
Add support for cgroup v2 to NVIDIA variants

### DIFF
--- a/packages/libnvidia-container/0005-makefile-avoid-ldconfig-when-cross-compiling.patch
+++ b/packages/libnvidia-container/0005-makefile-avoid-ldconfig-when-cross-compiling.patch
@@ -1,26 +1,34 @@
-From 0fbe931ffee3b95a7940fc749a6ee6c4ce894665 Mon Sep 17 00:00:00 2001
+From 5bdaf17b05b7cb9620681cbd594ec050237e2403 Mon Sep 17 00:00:00 2001
 From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 Date: Tue, 18 Jan 2022 23:57:24 +0000
 Subject: [PATCH] makefile: avoid ldconfig when cross-compiling
 
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+
+Also create necessary symlinks for `libnvidia-container-go.so` if the
+package is compiled `WITH_NVCGO=yes`.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
 ---
- Makefile | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ Makefile | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 60429d3..075dc9b 100644
+index 60429d3..7d4c19b 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -269,7 +269,7 @@ ifeq ($(WITH_NVCGO), yes)
+@@ -269,7 +269,10 @@ ifeq ($(WITH_NVCGO), yes)
  	$(INSTALL) -m 755 $(DEPS_DIR)$(libdir)/$(LIBGO_SHARED) $(DESTDIR)$(libdir)
  	$(LN) -sf $(LIBGO_SONAME) $(DESTDIR)$(libdir)/$(LIBGO_SYMLINK)
  endif
 -	$(LDCONFIG) -n $(DESTDIR)$(libdir)
 +	$(LN) -sf $(LIB_SHARED) $(DESTDIR)$(libdir)/$(LIB_SONAME)
++ifeq ($(WITH_NVCGO), yes)
++	$(LN) -sf $(LIBGO_SHARED) $(DESTDIR)$(libdir)/$(LIBGO_SONAME)
++endif
  	# Install configuration files
  	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
  	# Install binary files
 -- 
-2.37.1
+2.39.0
 

--- a/packages/libnvidia-container/libnvidia-container-sysctl.conf
+++ b/packages/libnvidia-container/libnvidia-container-sysctl.conf
@@ -1,0 +1,5 @@
+# Only apply eBPF JIT hardening to programs loaded by unprivileged users. JIT
+# hardening prevents existing programs from being read. libnvidia-container-go
+# needs a read/modify/write cycle of device eBPF programs attached to a cgroup
+# to allowlist GPUs on a cgroup v2 host.
+net.core.bpf_jit_harden = 1

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -10,6 +10,7 @@ License: Apache-2.0
 URL: https://github.com/NVIDIA/libnvidia-container
 Source0: https://github.com/NVIDIA/libnvidia-container/archive/v%{version}/libnvidia-container-%{version}.tar.gz
 Source1: https://github.com/NVIDIA/nvidia-modprobe/archive/%{nvidia_modprobe_version}/nvidia-modprobe-%{nvidia_modprobe_version}.tar.gz
+Source2: libnvidia-container-sysctl.conf
 
 # First party patches from 1 to 1000
 Patch0001: 0001-use-shared-libtirpc.patch
@@ -67,6 +68,8 @@ export DESTDIR=%{buildroot} \\\
 %install
 %set_env
 %make_install
+install -d %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:2} %{buildroot}%{_cross_sysctldir}/90-libnvidia-container.conf
 
 %files
 %license NOTICE LICENSE
@@ -76,6 +79,7 @@ export DESTDIR=%{buildroot} \\\
 %{_cross_libdir}/libnvidia-container-go.so
 %{_cross_libdir}/libnvidia-container-go.so.*
 %{_cross_bindir}/nvidia-container-cli
+%{_cross_sysctldir}/90-libnvidia-container.conf
 %exclude %{_cross_docdir}
 
 %files devel

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -48,13 +48,14 @@ touch deps/src/nvidia-modprobe-%{nvidia_modprobe_version}/.download_stamp
 
 %global set_env \
 %set_cross_build_flags \\\
+%set_cross_go_flags \\\
 export CC=%{_cross_target}-gcc \\\
 export LD=%{_cross_target}-ld \\\
 export CFLAGS="${CFLAGS} -I%{_cross_includedir}/tirpc" \\\
 export WITH_LIBELF=yes \\\
 export WITH_SECCOMP=yes \\\
 export WITH_TIRPC=yes \\\
-export WITH_NVCGO=no \\\
+export WITH_NVCGO=yes \\\
 export prefix=%{_cross_prefix} \\\
 export DESTDIR=%{buildroot} \\\
 %{nil}
@@ -72,6 +73,8 @@ export DESTDIR=%{buildroot} \\\
 %{_cross_attribution_file}
 %{_cross_libdir}/libnvidia-container.so
 %{_cross_libdir}/libnvidia-container.so.*
+%{_cross_libdir}/libnvidia-container-go.so
+%{_cross_libdir}/libnvidia-container-go.so.*
 %{_cross_bindir}/nvidia-container-cli
 %exclude %{_cross_docdir}
 


### PR DESCRIPTION
**Issue number:**

Closes #2504

**Description of changes:**

Make the NVIDIA variants of Bottlerocket work on hosts with cgroup v2 enabled ("unified cgroup hierarchy"). For this
* build `libnvidia-container` with its Go library that can handle both cgroup v1 and cgroup v2 (`libnvidia-container-go`, also `nvcgo`)
* fix up a previous downstream patch to also create symlinks for the new Go library (which wasn't around when the patch was introduced, and wasn't yet needed when the library became available with a dependency update)
* disable eBPF JIT hardening for privileged users on NVIDIA variants, see the commit for an explanation why and #2504 for debugging notes


**Testing done:**

* [x] Build an `aws-k8s-1.24-nvidia` AMI to be used in a Kubernetes cluster with a g3.16xlarge EC2 instance (x86_64, 4x Tesla M60 GPUs)
* [x] Create a pod with 4 GPUs assigned (manifest see below)
* [x] Run `kubectl exec test -- nvidia-smi` to verify the container is running, verify all 4 GPUs show up and report data
* [x] Enable cgroup v2 on the host (needs a reboot): `apiclient set -j '{"settings": {"boot": {"init": {"systemd.unified_cgroup_hierarchy": ["1"]}}}}'` followed by `apiclient reboot`
* [x] Wait for reboot
* [x] Run `kubectl exec test -- nvidia-smi` to verify the container is running, and verify all 4 GPUs show up and report data


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.