### PR TITLE
testsys: Fix incorrect migration starting image for VMware testing

### DIFF
--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -36,7 +36,7 @@ impl CrdCreator for VmwareK8sCreator {
     /// Use standard naming conventions to predict the starting OVA.
     async fn starting_image_id(&self, crd_input: &CrdInput) -> Result<String> {
         Ok(format!(
-            "bottlerocket-{}-{}-{}",
+            "bottlerocket-{}-{}-{}.ova",
             crd_input.variant,
             crd_input.arch,
             crd_input
@@ -190,7 +190,7 @@ impl CrdCreator for VmwareK8sCreator {
 
         let suffix: String = repeat_with(fastrand::lowercase).take(4).collect();
         let vsphere_vm_crd = VSphereVmConfig::builder()
-            .ova_name(self.image_id(bottlerocket_input.crd_input)?)
+            .ova_name(bottlerocket_input.image_id)
             .tuf_repo(bottlerocket_input.crd_input.tuf_repo_config().context(
                 error::InvalidSnafu {
                     what: "TUF repo information is required for Bottlerocket vSphere VM creation.",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

The original `starting_image_id` used for migration testing on VMware variants was the new image version instead of an existing bottlerocket version.

**Testing done:**

`cargo make -e BUILDSYS_VARIANT="vmware-k8s-1.22" -e TESTSYS_TEST="migration" test`
Thanks @jpmcb 

```bash
 NAME                                                TYPE                    STATE                   PASSED                   SKIPPED                   FAILED                  LAST UPDATE                             BUILD ID
 x86-64-vmware-k8s-122-1-initial                     Test                    pass                    1                        6443                      0                        2023-02-14T17:59:17Z                   3623d422-dirty
 x86-64-vmware-k8s-122-2-migrate                     Test                    pass                    2                        0                         0                        2023-02-14T18:00:14Z                   3623d422-dirty
 x86-64-vmware-k8s-122-3-migrated                    Test                    pass                    1                        6443                      0                        2023-02-14T18:01:02Z                   3623d422-dirty
 x86-64-vmware-k8s-122-4-migrate                     Test                    pass                    2                        0                         0                        2023-02-14T18:01:44Z                   3623d422-dirty
 x86-64-vmware-k8s-122-5-final                       Test                    pass                    1                        6443                      0                        2023-02-14T18:02:33Z                   3623d422-dirty
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
