### PR TITLE
Label `BOTTLEROCKET-DATA` at runtime

### DIFF
--- a/packages/os/has-boot-ever-succeeded.service
+++ b/packages/os/has-boot-ever-succeeded.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Checks and marks if boot has ever succeeded before
+DefaultDependencies=no
+Before=label-data-alternative.service label-data-preferred.service
+RequiresMountsFor=/etc
+
+[Service]
+Type=oneshot
+# Check if boot has ever succeeded before
+ExecStart=/bin/signpost has-boot-ever-succeeded
+RemainAfterExit=true
+# If boot has succeeded before, the marker file will be non-zero-sized
+StandardOutput=file:/etc/has-boot-ever-succeeded
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -47,6 +47,7 @@ Source118: generate-network-config.service
 Source119: reboot-if-required.service
 Source120: warm-pool-wait.service
 Source121: disable-udp-offload.service
+Source122: has-boot-ever-succeeded.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -411,7 +412,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:100} %{S:101} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
-  %{S:113} %{S:114} %{S:118} %{S:119} \
+  %{S:113} %{S:114} %{S:118} %{S:119} %{S:122} \
   %{buildroot}%{_cross_unitdir}
 
 %if %{with nvidia_flavor}
@@ -526,6 +527,7 @@ install -p -m 0644 %{S:121} %{buildroot}%{_cross_unitdir}
 %files -n %{_cross_os}signpost
 %{_cross_bindir}/signpost
 %{_cross_unitdir}/mark-successful-boot.service
+%{_cross_unitdir}/has-boot-ever-succeeded.service
 
 %files -n %{_cross_os}updog
 %{_cross_bindir}/updog

--- a/packages/release/label-data-a.service
+++ b/packages/release/label-data-a.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 # Only run this if a partition labeled 'BOTTLEROCKET-DATA' does not exist already.
 ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA
+# Only run if this boot has never succeeded before
+ConditionFileNotEmpty=!/etc/has-boot-ever-succeeded
 # This is the partition GUID for the DATA-A partition.
 Wants=dev-disk-by\x2dpartuuid-5b94e8df\x2d28b8\x2d485c\x2d9d19\x2d362263b5944c.device
 After=dev-disk-by\x2dpartuuid-5b94e8df\x2d28b8\x2d485c\x2d9d19\x2d362263b5944c.device

--- a/packages/release/label-data-a.service
+++ b/packages/release/label-data-a.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Label data partition A
+DefaultDependencies=no
+Conflicts=shutdown.target
+# Only run this if a partition labeled 'BOTTLEROCKET-DATA' does not exist already.
+ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA
+# This is the partition GUID for the DATA-A partition.
+Wants=dev-disk-by\x2dpartuuid-5b94e8df\x2d28b8\x2d485c\x2d9d19\x2d362263b5944c.device
+After=dev-disk-by\x2dpartuuid-5b94e8df\x2d28b8\x2d485c\x2d9d19\x2d362263b5944c.device
+
+[Service]
+Type=oneshot
+
+# Label the partition as 'BOTTLEROCKET-DATA' and resize the partition, whether or not it resides on the same disk as /.
+ExecStart=-/usr/bin/systemd-repart --dry-run=no /dev/disk/by-partuuid/5b94e8df-28b8-485c-9d19-362263b5944c
+
+RemainAfterExit=true
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/release/label-data-b.service
+++ b/packages/release/label-data-b.service
@@ -4,7 +4,9 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 # Only run this if a partition labeled 'BOTTLEROCKET-DATA' does not exist already.
 ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA
-# This is the partition GUID for the fallback data partition.
+# Only run if this boot has never succeeded before
+ConditionFileNotEmpty=!/etc/has-boot-ever-succeeded
+# This is the partition GUID for DATA-B data partition.
 Wants=dev-disk-by\x2dpartuuid-69040874\x2d417d\x2d4e26\x2da764\x2d7885f22007ea.device
 After=dev-disk-by\x2dpartuuid-69040874\x2d417d\x2d4e26\x2da764\x2d7885f22007ea.device
 

--- a/packages/release/label-data-b.service
+++ b/packages/release/label-data-b.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Label data partition B
+DefaultDependencies=no
+Conflicts=shutdown.target
+# Only run this if a partition labeled 'BOTTLEROCKET-DATA' does not exist already.
+ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA
+# This is the partition GUID for the fallback data partition.
+Wants=dev-disk-by\x2dpartuuid-69040874\x2d417d\x2d4e26\x2da764\x2d7885f22007ea.device
+After=dev-disk-by\x2dpartuuid-69040874\x2d417d\x2d4e26\x2da764\x2d7885f22007ea.device
+
+[Service]
+Type=oneshot
+
+# Label the partition as 'BOTTLEROCKET-DATA' and resize the partition, whether or not it resides on the same disk as /.
+ExecStart=-/usr/bin/systemd-repart --dry-run=no /dev/disk/by-partuuid/69040874-417d-4e26-a764-7885f22007ea
+
+RemainAfterExit=true
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/release/release-repart-local.conf
+++ b/packages/release/release-repart-local.conf
@@ -1,4 +1,7 @@
 [Partition]
+# We want to label this partition 'BOTTLEROCKET-DATA'
+Label=BOTTLEROCKET-DATA
+
 # This is the partition type UUID for BOTTLEROCKET-DATA, which will be resized
 # to fill the remaining sectors on the disk where it resides.
 Type=626f7474-6c65-6474-6861-726d61726b73

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -57,6 +57,8 @@ Source1043: repart-local.service
 Source1044: mask-local-mnt.service
 Source1045: mask-local-opt.service
 Source1046: mask-local-var.service
+Source1047: label-data-b.service
+Source1048: label-data-a.service
 
 # Services for kdump support
 Source1060: capture-kernel-dump.service
@@ -114,7 +116,7 @@ Requires: %{_cross_os}util-linux
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -p -m 0644 %{S:11} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 
-install -d %{buildroot}%{_cross_libdir}/repart.d
+install -d %{buildroot}%{_cross_libdir}/repart.d/
 install -p -m 0644 %{S:96} %{buildroot}%{_cross_libdir}/repart.d/80-local.conf
 
 install -d %{buildroot}%{_cross_sysctldir}
@@ -139,7 +141,7 @@ install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} %{S:1006} %{S:1007} \
   %{S:1008} %{S:1009} %{S:1010} %{S:1011} %{S:1012} %{S:1013} %{S:1015} \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} %{S:1045} %{S:1046} \
-  %{S:1060} %{S:1061} %{S:1062} %{S:1080} %{S:1014} \
+  %{S:1047} %{S:1048} %{S:1060} %{S:1061} %{S:1062} %{S:1080} %{S:1014} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d
@@ -220,6 +222,8 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/mask-local-opt.service
 %{_cross_unitdir}/mask-local-var.service
 %{_cross_unitdir}/root-.aws.mount
+%{_cross_unitdir}/label-data-b.service
+%{_cross_unitdir}/label-data-a.service
 %dir %{_cross_unitdir}/systemd-tmpfiles-setup.service.d
 %{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
 %dir %{_cross_templatedir}

--- a/packages/release/repart-local.service
+++ b/packages/release/repart-local.service
@@ -13,7 +13,7 @@ RequiresMountsFor=/local
 Type=oneshot
 
 # Resize the partition, whether or not it resides on the same disk as /.
-ExecStart=/usr/bin/systemd-repart --dry-run=no /dev/disk/by-partlabel/BOTTLEROCKET-DATA
+ExecStart=-/usr/bin/systemd-repart --dry-run=no /dev/disk/by-partlabel/BOTTLEROCKET-DATA
 
 # Grow the filesystem to fill the partition. Doing this in another unit could
 # introduce a race if the underlying block device is not ready after resizing.

--- a/sources/updater/signpost/README.md
+++ b/sources/updater/signpost/README.md
@@ -9,9 +9,12 @@ USAGE:
 SUBCOMMANDS:
     status                  Show partition sets and priority status
     mark-successful-boot    Mark the active partitions as successfully booted
-    clear-inactive          Clears inactive priority information to prepare writing images disk
-    upgrade-to-inactive     Sets the inactive partitions as new upgrade partitions
+    clear-inactive          Clears inactive priority information to prepare writing images to disk
+    mark-inactive-valid     Marks the inactive partition as having a valid image
+    upgrade-to-inactive     Sets the inactive partitions as new upgrade partitions if marked valid
+    cancel-upgrade          Reverse upgrade-to-inactive
     rollback-to-inactive    Deprioritizes the inactive partitions
+    has-boot-ever-succeeded Checks whether boot has ever succeeded
     rewrite-table           Rewrite the partition table with no changes to disk (used for testing this code)
 ```
 
@@ -25,13 +28,14 @@ The Bottlerocket OS disk has two partition sets, each containing three partition
 
 The Bottlerocket boot partition uses the same GPT partition attribute flags as Chrome OS, which are used by GRUB to select the partition from which to read a `grub.cfg`:
 
-| Bits  | Content                       |
-|-------|-------------------------------|
-| 63-57 | Unused                        |
-| 56    | Successful boot flag          |
-| 55-52 | Tries remaining               |
-| 51-48 | Priority                      |
-| 47-0  | Reserved by GPT specification |
+| Bits  | Content                         |
+|-------|---------------------------------|
+| 63-56 | Unused                          |
+| 57    | Have successfully booted before |
+| 56    | Successful boot flag            |
+| 55-52 | Tries remaining                 |
+| 51-48 | Priority                        |
+| 47-0  | Reserved by GPT specification   |
 
 The boot partition GRUB selects contains a grub.cfg which references the root and hash partitions by offset, thus selecting all three partitions of a set.
 

--- a/sources/updater/signpost/src/gptprio.rs
+++ b/sources/updater/signpost/src/gptprio.rs
@@ -34,6 +34,14 @@ impl GptPrio {
     pub(crate) fn will_boot(self) -> bool {
         (self.priority() > 0 && self.tries_left() > 0) || self.successful()
     }
+
+    pub(crate) fn boot_has_succeeded(&mut self) {
+        self.0.set_bit(57, true);
+    }
+
+    pub(crate) fn has_boot_succeeded(&self) -> bool {
+        self.0.get_bit(57)
+    }
 }
 
 impl From<u64> for GptPrio {
@@ -78,5 +86,10 @@ mod tests {
         prio.set_successful(false);
         assert_eq!(prio.0, 0x5400555555555555);
         assert_eq!(prio.will_boot(), false);
+
+        prio = GptPrio(0x0000000000000000);
+        assert_eq!(prio.has_boot_succeeded(), false);
+        prio.boot_has_succeeded();
+        assert_eq!(prio.has_boot_succeeded(), true);
     }
 }

--- a/sources/updater/signpost/src/main.rs
+++ b/sources/updater/signpost/src/main.rs
@@ -13,6 +13,7 @@ enum Command {
     UpgradeToInactive,
     CancelUpgrade,
     RollbackToInactive,
+    HasBootEverSucceeded,
     RewriteTable,
 }
 
@@ -29,6 +30,7 @@ SUBCOMMANDS:
     upgrade-to-inactive     Sets the inactive partitions as new upgrade partitions if marked valid
     cancel-upgrade          Reverse upgrade-to-inactive
     rollback-to-inactive    Deprioritizes the inactive partitions
+    has-boot-ever-succeeded Checks whether boot has ever succeeded
     rewrite-table           Rewrite the partition table with no changes to disk (used for testing this code)");
     std::process::exit(1)
 }
@@ -63,6 +65,11 @@ fn main() {
             Command::RollbackToInactive => {
                 state.rollback_to_inactive()?;
                 state.write()?;
+            }
+            Command::HasBootEverSucceeded => {
+                if state.has_boot_succeeded() {
+                    println!("true");
+                }
             }
             Command::RewriteTable => state.write()?,
         }

--- a/tools/partyplanner
+++ b/tools/partyplanner
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034  # Variables are used externally by rpm2img
 
 ###############################################################################
-# Section 1: partition type GUIDs
+# Section 1: partition type GUIDs and partition GUIDs
 
 # Define partition type GUIDs for all OS-managed partitions. This is required
 # for the boot partition, where we set gptprio bits in the GUID-specific use
@@ -40,6 +40,11 @@ EFI_SYSTEM_TYPECODE="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
 # for an alternate bank.
 EFI_BACKUP_TYPECODE="B39CE39C-0A00-B4AB-2D11-F18F8237A21C"
 
+# Define partition GUIDs for the data partitions. We use the GUID for determining
+# which data partition to label and use at boot.
+BOTTLEROCKET_DATA_A_PARTGUID="5b94e8df-28b8-485c-9d19-362263b5944c"
+BOTTLEROCKET_DATA_B_PARTGUID="69040874-417d-4e26-a764-7885f22007ea"
+
 ###############################################################################
 # Section 2: fixed size partitions and reservations
 
@@ -61,6 +66,9 @@ OVERHEAD_MIB="$((GPT_MIB * 2 + BIOS_MIB))"
 # under 2MB, so this will suffice for now. It would be possible to increase the
 # EFI partition size by taking space from the "reserved" area below.
 EFI_MIB="5" # one per bank
+
+# Allocate 1 MiB for the initial data partition A.
+DATA_A_MIB="1" # one per disk
 
 ###############################################################################
 # Section 3: variable sized partitions
@@ -102,7 +110,8 @@ PRIVATE_SCALE_FACTOR="24"
 #          | Hash partition B         5 MiB* |          500 MiB
 #          | Reserved partition B    10 MiB* |
 #          +---------------------------------+
-#          | Private partition       18 MiB* | (image size * 24 as MiB) - prelude
+#          | Private partition       17 MiB* | (image size * 24 as MiB) - prelude - DATA-A size
+#          | Data partition A         1 MiB  | Data partition A
 # Postlude | GPT footer               1 MiB  | GPT is fixed, private partition grows.
 #          +---------------------------------+
 
@@ -139,6 +148,8 @@ set_partition_sizes() {
 
   # Private space scales per GiB, minus the BIOS and GPT partition overhead.
   private_mib=$((os_image_gib * PRIVATE_SCALE_FACTOR - OVERHEAD_MIB))
+  # We need 1 MiB of space for data partition A.
+  private_mib=$((private_mib - DATA_A_MIB))
 
   # Skip the GPT label at start of disk.
   local offset
@@ -176,16 +187,21 @@ set_partition_sizes() {
 
   case "${partition_plan}" in
     split)
+      # For data partition A that lives on the OS image
+      pp_offset["DATA-A"]="${offset}"
+      pp_size["DATA-A"]="${DATA_A_MIB}"
+      ((offset += DATA_A_MIB))
+
       # For a split data image, the first and last MiB are reserved for the GPT
-      # labels, and the rest is for the "data" partition.
-      pp_size["DATA"]="$((data_image_gib * 1024 - GPT_MIB * 2))"
-      pp_offset["DATA"]="1"
+      # labels, and the rest is for data partition B.
+      pp_size["DATA-B"]="$((data_image_gib * 1024 - GPT_MIB * 2))"
+      pp_offset["DATA-B"]="1"
       ;;
     unified)
       # For a unified image, we've already accounted for the GPT label space in
-      # the earlier calculations, so all the space is for the "data" partition.
-      pp_size["DATA"]="$((data_image_gib * 1024))"
-      pp_offset["DATA"]="${offset}"
+      # the earlier calculations, so all the space is for the data partition.
+      pp_size["DATA-A"]="$((data_image_gib * 1024))"
+      pp_offset["DATA-A"]="${offset}"
       ((offset += data_image_gib * 1024))
       ;;
     *)
@@ -200,9 +216,12 @@ set_partition_labels() {
   local -n pp_label
   pp_label="${1:?}"
   pp_label["BIOS"]="BIOS-BOOT"
-  pp_label["DATA"]="BOTTLEROCKET-DATA"
   pp_label["EFI-A"]="EFI-SYSTEM"
   pp_label["EFI-B"]="EFI-BACKUP"
+  # Empty label for the data partitions. We're labeling the data partition
+  # during boot.
+  pp_label["DATA-A"]=""
+  pp_label["DATA-B"]=""
   pp_label["PRIVATE"]="BOTTLEROCKET-PRIVATE"
   for part in BOOT ROOT HASH RESERVED ; do
     for bank in A B ; do
@@ -216,7 +235,8 @@ set_partition_types() {
   local -n pp_type
   pp_type="${1:?}"
   pp_type["BIOS"]="${BIOS_BOOT_TYPECODE}"
-  pp_type["DATA"]="${BOTTLEROCKET_DATA_TYPECODE}"
+  pp_type["DATA-A"]="${BOTTLEROCKET_DATA_TYPECODE}"
+  pp_type["DATA-B"]="${BOTTLEROCKET_DATA_TYPECODE}"
   pp_type["EFI-A"]="${EFI_SYSTEM_TYPECODE}"
   pp_type["EFI-B"]="${EFI_BACKUP_TYPECODE}"
   pp_type["PRIVATE"]="${BOTTLEROCKET_PRIVATE_TYPECODE}"
@@ -227,5 +247,18 @@ set_partition_types() {
       typecode="${!typecode}"
       pp_type["${part}-${bank}"]="${typecode}"
     done
+  done
+}
+
+# Populate the caller's table with GPT partition UUIDs for DATA-A and
+# DATA-B partitions.
+set_partition_uuids() {
+  local -n pp_uuid
+  pp_uuid="${1:?}"
+  local uuid
+  for bank in A B ; do
+    uuid="BOTTLEROCKET_DATA_${bank}_PARTGUID"
+    uuid="${!uuid}"
+    pp_uuid["DATA-${bank}"]="${uuid}"
   done
 }

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -109,7 +109,8 @@ ROOT_IMAGE="$(mktemp)"
 DATA_IMAGE="$(mktemp)"
 EFI_IMAGE="$(mktemp)"
 PRIVATE_IMAGE="$(mktemp)"
-BOTTLEROCKET_DATA="$(mktemp)"
+BOTTLEROCKET_DATA_A="$(mktemp)"
+BOTTLEROCKET_DATA_B="$(mktemp)"
 
 ROOT_MOUNT="$(mktemp -d)"
 BOOT_MOUNT="$(mktemp -d)"
@@ -136,22 +137,23 @@ case "${PARTITION_PLAN}" in
     ;;
 esac
 
-declare -A partlabel parttype partsize partoff
+declare -A partlabel parttype partguid partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" "${PARTITION_PLAN}" \
   partsize partoff
 set_partition_labels partlabel
 set_partition_types parttype
+set_partition_uuids partguid
 
 declare -a partargs
 for part in \
   BIOS \
   EFI-A BOOT-A ROOT-A HASH-A RESERVED-A \
   EFI-B BOOT-B ROOT-B HASH-B RESERVED-B \
-  PRIVATE DATA ;
+  PRIVATE DATA-A DATA-B ;
 do
-  # We only append the data partition if we're using the unified layout.
-  if [ "${part}" == "DATA" ] && [ "${PARTITION_PLAN}" != "unified" ] ; then
+  # We create the DATA-B partition separately if we're using the split layout
+  if [ "${part}" == "DATA-B" ] ; then
     continue
   fi
 
@@ -166,6 +168,7 @@ do
   partargs+=(-n "0:${part_start}M:${part_end}")
   partargs+=(-c "0:${partlabel[${part}]}")
   partargs+=(-t "0:${parttype[${part}]}")
+  partargs+=(-u "0:${partguid[${part}]:-R}")
 
   # Boot partition attributes:
   #  48 = gptprio priority bit
@@ -180,13 +183,14 @@ sgdisk --clear "${partargs[@]}" --sort --print "${OS_IMAGE}"
 
 # Partition the separate data disk, if we're using the split layout.
 if [ "${PARTITION_PLAN}" == "split" ] ; then
-  data_start="${partoff[DATA]}"
-  data_end=$((data_start + partsize[DATA]))
+  data_start="${partoff[DATA-B]}"
+  data_end=$((data_start + partsize[DATA-B]))
   data_end=$((data_end * 2048 - 1))
   sgdisk --clear \
     -n "0:${data_start}M:${data_end}" \
-    -c "0:${partlabel[DATA]}" \
-    -t "0:${parttype[DATA]}" \
+    -c "0:${partlabel[DATA-B]}" \
+    -t "0:${parttype[DATA-B]}" \
+    -u "0:${partguid[DATA-B]}" \
     --sort --print "${DATA_IMAGE}"
 fi
 
@@ -383,7 +387,7 @@ cp /host/tools/bootconfig/empty-bootconfig.data "${PRIVATE_MOUNT}/bootconfig.dat
 mkfs.ext4 -b 4096 -i 4096 -I 256 -d "${PRIVATE_MOUNT}" "${PRIVATE_IMAGE}" "${partsize[PRIVATE]}M"
 dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
 
-# BOTTLEROCKET-DATA
+# BOTTLEROCKET-DATA-A and BOTTLEROCKET-DATA-B
 
 # If we build on a host with SELinux enabled, we could end up with labels that
 # do not match our policy. Since we allow replacing the data volume at runtime,
@@ -391,14 +395,26 @@ dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRI
 # remove them all.
 UNLABELED=$(find "${DATA_MOUNT}" \
     | awk -v root="${DATA_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_rm", $1, "security.selinux"}')
-mkfs.ext4 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" "${partsize[DATA]}M"
-echo "${UNLABELED}" | debugfs -w -f - "${BOTTLEROCKET_DATA}"
+
+for side in A B ; do
+  if [ "${side}" == "B" ] && [ "${PARTITION_PLAN}" == "unified" ] ; then
+    continue
+  fi
+  dev="BOTTLEROCKET_DATA_${side}"
+  dev="${!dev}"
+  mkfs.ext4 -d "${DATA_MOUNT}" "${dev}" "${partsize["DATA-${side}"]}M"
+  echo "${UNLABELED}" | debugfs -w -f - "${dev}"
+done
+
 case "${PARTITION_PLAN}" in
   split)
-    dd if="${BOTTLEROCKET_DATA}" of="${DATA_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA]}"
+    # Only create data partition B on data image in "split" image layout configurations
+    dd if="${BOTTLEROCKET_DATA_B}" of="${DATA_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA-B]}"
+
+    dd if="${BOTTLEROCKET_DATA_A}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA-A]}"
     ;;
   unified)
-    dd if="${BOTTLEROCKET_DATA}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA]}"
+    dd if="${BOTTLEROCKET_DATA_A}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA-A]}"
     ;;
 esac
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket/issues/2822

**Description of changes:**
```

    release,os: ensure data partition label/resize services only run once
    
    This adds additional safeguards to prevent a different data partition
    from being labeled and resized if the host has ever booted successfully
    in the past with an original data partition.

```
```
    signpost: mark if boot has succeeded before, add subcommand for checking
    
    'mark-successful-boot' now also updates BOTTLEROCKET_PRIVATE's GPT table
    attribute to indicate whether boot has ever succeeded before.
    
    Add a new 'has-boot-ever-succeeded' subcommand for checking if boot has
    ever succeeded before
```


```
    release, rpm2img, partyplanner: label BOTTLEROCKET-DATA during firstboot
    
    Changes partitioning to always keep a data partition on the os image.
    We grow and label data partition at runtime. We will still create a
    separate data partiion on the second volume/disk for "split" partition
    layouts.
    
    We add two new services that run as part of 'local-fs.target' and
    before 'local.mount' and 'repart-local.service':
      * 'label-data-a.service'
      * 'label-data-b.service'
    
    'label-data-a' and 'label-data-b' will "compete" and both try to
    label 'BOTTLEROCKET-DATA' first with the partition they're each waiting
    for.
    
    'label-data-a' waits for the data partition that resides on the OS disk
    image. Once that device is ready, we call 'systemd-repart' to relabel it
    as 'BOTTLEROCKET-DATA' and grow it as much as possible.
    
    'label-data-b' calls 'systemd-repart' to label the data partition on
    the data image as 'BOTTLEROCKET-DATA' and grow the partition to fill the
    remainder of the disk.
    
    All of this lets the host to boot if data partition on the data image
    doesn't exist and the root filesystem disk has leftover extra space to
    accommodate a reasonably-sized back-up data partition.

```

**Testing done:**

#### Instance with the `aws-k8s-1.24` AMI as is without modification.
<details>

The host comes up as expected and system logs doesn't show any abnormalities:
```
...
         Starting Rule-based Manager for Device Events and Files...
[  OK  ] Started Rule-based Manager for Device Events and Files.
[  OK  ] Found device Amazon Elastic Block Store 1.
[  OK  ] Found device Amazon Elastic Block Store 13.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-PRIVATE.
         Starting Label alternative data partition...
         Starting Label preferred data partition...
[  OK  ] Finished Label alternative data partition.
[  OK  ] Finished Label preferred data partition.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-DATA.
         Mounting Containerd Configuration Directory (/etc/containerd)...
         Mounting Host containers Configurat…irectory (/etc/host-containers)...
         Mounting Kubernetes PKI private dir…y (/etc/kubernetes/pki/private)...
         Mounting Local Directory (/local)...
         Mounting AWS configuration directory (/root/.aws)...
[  OK  ] Mounted Containerd Configuration Directory (/etc/containerd).
[  OK  ] Mounted Host containers Configurati… Directory (/etc/host-containers).
[  OK  ] Mounted Kubernetes PKI private dire…ory (/etc/kubernetes/pki/private).
[  OK  ] Mounted AWS configuration directory (/root/.aws).
[  OK  ] Mounted Local Directory (/local).

...
```

The status `label-data-preferred`, `label-data-alternative`, `repart-local` shows the data partition gets labelled and the local fs gets created and grows successfully.
```bash
bash-5.1# systemctl status label-data-preferred label-data-alternative repart-local
● label-data-preferred.service - Label preferred data partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-preferred.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-02-17 23:16:16 UTC; 2h 26min ago
   Main PID: 881 (code=exited, status=0/SUCCESS)

Feb 17 23:16:16 localhost systemd[1]: Starting Label preferred data partition...
Feb 17 23:16:16 localhost systemd-repart[881]: Applying changes.
Feb 17 23:16:16 localhost systemd-repart[881]: Storage does not support discard, not discarding gap at beginning of disk.
Feb 17 23:16:16 localhost systemd-repart[881]: Growing existing partition 0.
Feb 17 23:16:16 localhost systemd-repart[881]: Setting partition label of existing partition 0.
Feb 17 23:16:16 localhost systemd-repart[881]: Writing new partition table.
Feb 17 23:16:16 localhost systemd-repart[881]: Telling kernel to reread partition table.
Feb 17 23:16:16 localhost systemd-repart[881]: All done.
Feb 17 23:16:16 localhost systemd[1]: Finished Label preferred data partition.

● label-data-alternative.service - Label alternative data partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-alternative.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-02-17 23:16:16 UTC; 2h 26min ago
   Main PID: 880 (code=killed, signal=ABRT)

Feb 17 23:16:16 localhost systemd[1]: Starting Label alternative data partition...
Feb 17 23:16:16 localhost systemd-repart[880]: Assertion 'amount <= total' failed at src/partition/repart.c:533, function charge_size(). Aborting.
Feb 17 23:16:16 localhost systemd[1]: Finished Label alternative data partition.

● repart-local.service - Resize Data Partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/repart-local.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-02-17 23:16:17 UTC; 2h 26min ago
   Main PID: 927 (code=exited, status=0/SUCCESS)

Feb 17 23:16:17 localhost systemd[1]: Starting Resize Data Partition...
Feb 17 23:16:17 localhost systemd-growfs[927]: Successfully resized "/local" to 19.9G bytes.
Feb 17 23:16:17 localhost systemd[1]: Finished Resize Data Partition.

```


`blkid` shows the expected new partition UUIDs for the data partitions
```bash
bash-5.1# blkid | sort
/dev/dm-0: UUID="1c118fe4-f172-4dda-8e90-e07c76b787f8" BLOCK_SIZE="4096" TYPE="ext4"
/dev/loop0: TYPE="squashfs"
/dev/loop1: TYPE="squashfs"
/dev/nvme0n1p10: PARTLABEL="BOTTLEROCKET-HASH-B" PARTUUID="07fd37a6-0c06-4728-bd2d-0131b65c7000"
/dev/nvme0n1p11: PARTLABEL="BOTTLEROCKET-RESERVED-B" PARTUUID="cdc6aab5-5549-410d-b716-4d90c8a93372"
/dev/nvme0n1p12: UUID="ee5e711f-4217-4a46-884d-b069fa502260" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-PRIVATE" PARTUUID="b0cbafc7-ff84-4361-93bc-1029d1efee63"
/dev/nvme0n1p13: UUID="892c66e2-bf1e-42e4-b358-554e2c55860a" BLOCK_SIZE="1024" TYPE="ext4" PARTUUID="69040874-417d-4e26-a764-7885f22007ea"
/dev/nvme0n1p1: PARTLABEL="BIOS-BOOT" PARTUUID="0da51cfe-8a04-43c2-a8c2-917c9c7370f8"
/dev/nvme0n1p2: SEC_TYPE="msdos" UUID="A3C3-D6E8" BLOCK_SIZE="512" TYPE="vfat" PARTLABEL="EFI-SYSTEM" PARTUUID="d3472a38-c8a0-4f27-80d9-d2f924ce9021"
/dev/nvme0n1p3: UUID="6aaf9639-5654-4e61-9abd-4228b8aacb4f" BLOCK_SIZE="1024" TYPE="ext4" PARTLABEL="BOTTLEROCKET-BOOT-A" PARTUUID="d062f4d5-a027-47b1-8528-e73d2f2032da"
/dev/nvme0n1p4: UUID="1c118fe4-f172-4dda-8e90-e07c76b787f8" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-ROOT-A" PARTUUID="b7cc8d9a-c075-4ce4-bcc2-aefab130e286"
/dev/nvme0n1p5: UUID="bc552628-baa0-4201-bfad-84d0abf3f32e" TYPE="DM_verity_hash" PARTLABEL="BOTTLEROCKET-HASH-A" PARTUUID="ded71c16-6020-4fcb-8130-adb4b01df3a6"
/dev/nvme0n1p6: PARTLABEL="BOTTLEROCKET-RESERVED-A" PARTUUID="413c75b9-6ecc-4577-a4a3-971a7ba93d4f"
/dev/nvme0n1p7: PARTLABEL="EFI-BACKUP" PARTUUID="cc18beca-3432-41bf-bf11-e26c1e6b674a"
/dev/nvme0n1p8: PARTLABEL="BOTTLEROCKET-BOOT-B" PARTUUID="e8789cf6-e927-4014-aa05-ef1d2340b432"
/dev/nvme0n1p9: PARTLABEL="BOTTLEROCKET-ROOT-B" PARTUUID="3e86e59f-4716-4b8a-affe-ad74be4563e7"
/dev/nvme1n1p1: UUID="b04e749b-cb13-49e9-a532-457de5cec304" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-DATA" PARTUUID="5b94e8df-28b8-485c-9d19-362263b5944c"

```

`lsblk` looks normal
```bash
bash-5.1# lsblk                                                                                                 
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0          7:0    0 11.8M  1 loop /var/lib/kernel-devel/.overlay/lower
loop1          7:1    0  304K  1 loop /aarch64-bottlerocket-linux-gnu/sys-root/usr/share/licenses
nvme0n1      259:0    0    2G  0 disk 
|-nvme0n1p1  259:3    0    4M  0 part 
|-nvme0n1p2  259:4    0    5M  0 part 
|-nvme0n1p3  259:5    0   40M  0 part /boot
|-nvme0n1p4  259:6    0  920M  0 part 
|-nvme0n1p5  259:7    0   10M  0 part 
|-nvme0n1p6  259:8    0   25M  0 part 
|-nvme0n1p7  259:9    0    5M  0 part 
|-nvme0n1p8  259:10   0   40M  0 part 
|-nvme0n1p9  259:11   0  920M  0 part 
|-nvme0n1p10 259:12   0   10M  0 part 
|-nvme0n1p11 259:13   0   25M  0 part 
|-nvme0n1p12 259:14   0   41M  0 part /var/lib/bottlerocket
`-nvme0n1p13 259:15   0    1M  0 part 
nvme1n1      259:1    0   20G  0 disk 
`-nvme1n1p1  259:16   0   20G  0 part /opt
                                      /var
                                      /mnt
                                      /local

```

Upon reboot, `label-data-*` oneshot service units do not run since a partition labelled  `BOTTLEROCKET-DATA` already exists:
```bash
bash-5.1# systemctl status label-data-pref label-data-alt
○ label-data-pref.service
     Loaded: masked (Reason: Unit label-data-pref.service is masked.)
     Active: inactive (dead)
  Condition: start condition failed at Wed 2023-02-15 23:10:42 UTC; 3min 11s ago

Feb 15 23:10:42 localhost systemd[1]: Label preferred data partition was skipped because of a failed condition check (ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA).

○ label-data-alt.service
     Loaded: masked (Reason: Unit label-data-alt.service is masked.)
     Active: inactive (dead)
  Condition: start condition failed at Wed 2023-02-15 23:10:42 UTC; 3min 11s ago

Feb 15 23:10:42 localhost systemd[1]: Label alternative data partition was skipped because of a failed condition check (ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA).
```

</details>

#### Instance with the `aws-k8s-1.24` AMI but with the default 20 GB data EBS volume removed. The single root EBS volume size increased from 2GB to 12GB

<details>

The host boots and comes up even though it's missing the data EBS volume:
```
        Starting Apply Kernel Variables...
[  OK  ] Finished Apply Kernel Variables.
[  OK  ] Found device Amazon Elastic Block Store 13.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-PRIVATE.
         Starting Label alternative data partition...
[  OK  ] Finished Label alternative data partition.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-DATA.
         Mounting Local Directory (/local)...
[  OK  ] Mounted Local Directory (/local).

```
e (dead)
```

The status `label-data-preferred`, `label-data-alternative`, `repart-local` shows the data partition gets labelled and the local fs gets created and grows successfully:
```bash
bash-5.1# systemctl status label-data-preferred label-data-alternative repart-local
○ label-data-preferred.service - Label preferred data partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-preferred.service; enabled; vendor preset: enabled)
     Active: inactive (dead)
  Condition: start condition failed at Fri 2023-02-17 23:36:18 UTC; 2h 12min ago
             └─ ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA was not met

Feb 17 23:36:18 ip-192-168-7-234.us-west-2.compute.internal systemd[1]: Label preferred data partition was skipped because of a failed condition check (ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA).

● label-data-alternative.service - Label alternative data partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-alternative.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-02-17 23:34:49 UTC; 2h 13min ago
   Main PID: 800 (code=exited, status=0/SUCCESS)

Feb 17 23:34:49 localhost systemd[1]: Starting Label alternative data partition...
Feb 17 23:34:49 localhost systemd-repart[800]: Applying changes.
Feb 17 23:34:49 localhost systemd-repart[800]: Storage does not support discard, not discarding gap at beginning of disk.
Feb 17 23:34:49 localhost systemd-repart[800]: Growing existing partition 12.
Feb 17 23:34:49 localhost systemd-repart[800]: Setting partition label of existing partition 12.
Feb 17 23:34:49 localhost systemd-repart[800]: Writing new partition table.
Feb 17 23:34:49 localhost systemd-repart[800]: Telling kernel to reread partition table.
Feb 17 23:34:49 localhost systemd-repart[800]: All done.
Feb 17 23:34:49 localhost systemd[1]: Finished Label alternative data partition.

● repart-local.service - Resize Data Partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/repart-local.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-02-17 23:34:50 UTC; 2h 13min ago
   Main PID: 838 (code=exited, status=0/SUCCESS)

Feb 17 23:34:49 localhost systemd[1]: Starting Resize Data Partition...
Feb 17 23:34:49 localhost systemd-repart[822]: Can't fit requested partitions into available free space (1004.0K), refusing.
Feb 17 23:34:49 localhost systemd-repart[822]: Automatically determined minimal disk image size as 12.0G, current image size is 12.0G.
Feb 17 23:34:50 localhost systemd-growfs[838]: Successfully resized "/local" to 10.0G bytes.
Feb 17 23:34:50 localhost systemd[1]: Finished Resize Data Partition.
```


`blkid` shows the expected static partition UUIDs and no second NVMe disk
```bash
bash-5.1# blkid | sort                                                                                                                                                                         
/dev/dm-0: UUID="3ced6171-f404-4d16-9fbb-03dcc8cc9a7e" BLOCK_SIZE="4096" TYPE="ext4"
/dev/loop0: TYPE="squashfs"
/dev/loop1: TYPE="squashfs"
/dev/nvme0n1p10: PARTLABEL="BOTTLEROCKET-HASH-B" PARTUUID="a84cc2e6-9cf5-4f7d-aa12-329528bb3134"
/dev/nvme0n1p11: PARTLABEL="BOTTLEROCKET-RESERVED-B" PARTUUID="0cb8a41e-704f-4a21-aa56-a671913a8d61"
/dev/nvme0n1p12: UUID="c28859e5-dd8b-4fa5-90ac-de60b963ecc5" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-PRIVATE" PARTUUID="f27b75bc-0441-47f0-84ec-09e298f95bb5"
/dev/nvme0n1p13: UUID="ab366348-471b-4fa2-91cf-26e0ab4ba5f2" BLOCK_SIZE="1024" TYPE="ext4" PARTLABEL="BOTTLEROCKET-DATA" PARTUUID="69040874-417d-4e26-a764-7885f22007ea"
/dev/nvme0n1p1: PARTLABEL="BIOS-BOOT" PARTUUID="03f45119-fffa-45f8-bcfd-77541c732a37"
/dev/nvme0n1p2: SEC_TYPE="msdos" UUID="E651-2BEE" BLOCK_SIZE="512" TYPE="vfat" PARTLABEL="EFI-SYSTEM" PARTUUID="1219a1cf-cd0e-4e4b-9122-b62ed1e797a3"
/dev/nvme0n1p3: UUID="6b841fe7-b045-446c-a1c4-d672648aaea9" BLOCK_SIZE="1024" TYPE="ext4" PARTLABEL="BOTTLEROCKET-BOOT-A" PARTUUID="3ef63431-77ba-4472-94af-7af42c150473"
/dev/nvme0n1p4: UUID="3ced6171-f404-4d16-9fbb-03dcc8cc9a7e" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-ROOT-A" PARTUUID="f6ccee74-df82-438a-a0c9-96d8523d6e17"
/dev/nvme0n1p5: UUID="c7e7f22f-5d4e-498e-888b-4df0ce03c29e" TYPE="DM_verity_hash" PARTLABEL="BOTTLEROCKET-HASH-A" PARTUUID="6f414b51-b546-444f-82c6-315da3fadb2b"
/dev/nvme0n1p6: PARTLABEL="BOTTLEROCKET-RESERVED-A" PARTUUID="95d3fc19-e86d-4ed8-9de0-bb2ddc8311c8"
/dev/nvme0n1p7: PARTLABEL="EFI-BACKUP" PARTUUID="fb81ad6e-ea24-4304-b028-f45bb17ad4a1"
/dev/nvme0n1p8: PARTLABEL="BOTTLEROCKET-BOOT-B" PARTUUID="9717564c-47bb-421d-ac5f-ff2d0643e68b"
/dev/nvme0n1p9: PARTLABEL="BOTTLEROCKET-ROOT-B" PARTUUID="807bc9c8-8e0e-4578-a440-b0363cd8def9"

```

`lsblk` looks normal.
```bash
bash-5.1# lsblk                                                                                                                                    
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0          7:0    0 11.8M  1 loop /var/lib/kernel-devel/.overlay/lower
loop1          7:1    0  304K  1 loop /aarch64-bottlerocket-linux-gnu/sys-root/usr/share/licenses
nvme0n1      259:0    0   12G  0 disk 
|-nvme0n1p1  259:1    0    4M  0 part 
|-nvme0n1p2  259:2    0    5M  0 part 
|-nvme0n1p3  259:3    0   40M  0 part /boot
|-nvme0n1p4  259:4    0  920M  0 part 
|-nvme0n1p5  259:5    0   10M  0 part 
|-nvme0n1p6  259:6    0   25M  0 part 
|-nvme0n1p7  259:7    0    5M  0 part 
|-nvme0n1p8  259:8    0   40M  0 part 
|-nvme0n1p9  259:9    0  920M  0 part 
|-nvme0n1p10 259:10   0   10M  0 part 
|-nvme0n1p11 259:11   0   25M  0 part 
|-nvme0n1p12 259:12   0   41M  0 part /var/lib/bottlerocket
`-nvme0n1p13 259:13   0   10G  0 part /opt
                                      /var
                                      /mnt
                                      /local
```


</details>

#### AMI with "unified" image layout

<details>

The host comes up as fine. There is no change to the image layout from before this change.
```
         Starting Label preferred data partition...
[  OK  ] Finished Label preferred data partition.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-DATA.
         Mounting Containerd Configuration Directory (/etc/containerd)...
         Mounting Host containers Configurat…irectory (/etc/host-containers)...
         Mounting Kubernetes PKI private dir…y (/etc/kubernetes/pki/private)...
         Mounting Local Directory (/local)...
         Mounting AWS configuration directory (/root/.aws)...
[  OK  ] Mounted Containerd Configuration Directory (/etc/containerd).
[  OK  ] Mounted Host containers Configurati… Directory (/etc/host-containers).
[  OK  ] Mounted Kubernetes PKI private dire…ory (/etc/kubernetes/pki/private).
[  OK  ] Mounted Local Directory (/local).
```

The status `label-data-preferred`, `label-data-alternative`, `repart-local` shows the data partition gets labelled and the local fs gets created and grows successfully:
```bash
bash-5.1# systemctl status label-data-preferred label-data-alternative repart-local
● label-data-preferred.service - Label preferred data partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-preferred.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-02-17 23:58:23 UTC; 1h 53min ago
   Main PID: 867 (code=exited, status=0/SUCCESS)

Feb 17 23:58:23 localhost systemd[1]: Starting Label preferred data partition...
Feb 17 23:58:23 localhost systemd-repart[867]: Applying changes.
Feb 17 23:58:23 localhost systemd-repart[867]: Storage does not support discard, not discarding gap at beginning of disk.
Feb 17 23:58:23 localhost systemd-repart[867]: Growing existing partition 12.
Feb 17 23:58:23 localhost systemd-repart[867]: Setting partition label of existing partition 12.
Feb 17 23:58:23 localhost systemd-repart[867]: Writing new partition table.
Feb 17 23:58:23 localhost systemd-repart[867]: Telling kernel to reread partition table.
Feb 17 23:58:23 localhost systemd-repart[867]: All done.
Feb 17 23:58:23 localhost systemd[1]: Finished Label preferred data partition.

○ label-data-alternative.service - Label alternative data partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-alternative.service; enabled; vendor preset: enabled)
     Active: inactive (dead)
  Condition: start condition failed at Fri 2023-02-17 23:59:53 UTC; 1h 52min ago
             └─ ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA was not met

Feb 17 23:59:53 ip-192-168-9-148.us-west-2.compute.internal systemd[1]: Label alternative data partition was skipped because of a failed condition check (ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA).

● repart-local.service - Resize Data Partition
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/repart-local.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-02-17 23:58:24 UTC; 1h 53min ago
   Main PID: 895 (code=exited, status=0/SUCCESS)

Feb 17 23:58:24 localhost systemd[1]: Starting Resize Data Partition...
Feb 17 23:58:24 localhost systemd-repart[894]: No changes.
Feb 17 23:58:24 localhost systemd-growfs[895]: Successfully resized "/local" to 20.0G bytes.
Feb 17 23:58:24 localhost systemd[1]: Finished Resize Data Partition.
                                                                                                                                                      
```

`blkid` looks fine:
```bash
bash-5.1# blkid | sort                                                                                                                                                                                                     
/dev/dm-0: UUID="5d667680-3724-4e5b-93ae-cda44de314fc" BLOCK_SIZE="4096" TYPE="ext4"
/dev/loop0: TYPE="squashfs"
/dev/loop1: TYPE="squashfs"
/dev/nvme0n1p10: PARTLABEL="BOTTLEROCKET-HASH-B" PARTUUID="bace40c4-18a6-4947-8a77-5cb4a35f4484"
/dev/nvme0n1p11: PARTLABEL="BOTTLEROCKET-RESERVED-B" PARTUUID="7b0a6af4-b095-4e43-beba-c37f6696dcf7"
/dev/nvme0n1p12: UUID="9ddce00a-e071-401d-b708-5e4b587e6348" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-PRIVATE" PARTUUID="125f6bfe-f71d-4eb7-9039-3b4a597798ae"
/dev/nvme0n1p13: UUID="003d02e2-8057-4043-80fb-211108ca2b77" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-DATA" PARTUUID="5b94e8df-28b8-485c-9d19-362263b5944c"
/dev/nvme0n1p1: PARTLABEL="BIOS-BOOT" PARTUUID="d7f2098b-2a3b-413f-b0d9-5a170869e27d"
/dev/nvme0n1p2: SEC_TYPE="msdos" UUID="2704-81C7" BLOCK_SIZE="512" TYPE="vfat" PARTLABEL="EFI-SYSTEM" PARTUUID="cee0268b-5831-4767-b66c-0ddea2ff8b89"
/dev/nvme0n1p3: UUID="94c61991-db56-4ddf-8057-50819aa67265" BLOCK_SIZE="1024" TYPE="ext4" PARTLABEL="BOTTLEROCKET-BOOT-A" PARTUUID="e07310d9-43b0-4b25-a952-66923626a822"
/dev/nvme0n1p4: UUID="5d667680-3724-4e5b-93ae-cda44de314fc" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="BOTTLEROCKET-ROOT-A" PARTUUID="d5d8c9bd-4c1a-4c5e-97b3-27430955dd4d"
/dev/nvme0n1p5: UUID="575019b8-e62e-4d74-a184-1445ccf9d10c" TYPE="DM_verity_hash" PARTLABEL="BOTTLEROCKET-HASH-A" PARTUUID="d9694ab9-1cd8-4b09-8cac-25187709881c"
/dev/nvme0n1p6: PARTLABEL="BOTTLEROCKET-RESERVED-A" PARTUUID="f0339459-57d7-4f7f-9d5b-ab02810c46ce"
/dev/nvme0n1p7: PARTLABEL="EFI-BACKUP" PARTUUID="71ffac70-d957-475c-8b73-c5e01fcdff31"
/dev/nvme0n1p8: PARTLABEL="BOTTLEROCKET-BOOT-B" PARTUUID="330e3c82-75d6-4fed-a18b-8d010077d731"
/dev/nvme0n1p9: PARTLABEL="BOTTLEROCKET-ROOT-B" PARTUUID="c1ff364e-ff0a-415f-b05b-bbcf4ff719ca"
```

`lsblk` looks normal
```bash
bash-5.1# lsblk                                                                                                                           
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0          7:0    0 11.8M  1 loop /var/lib/kernel-devel/.overlay/lower
loop1          7:1    0  304K  1 loop /aarch64-bottlerocket-linux-gnu/sys-root/usr/share/licenses
nvme0n1      259:0    0   22G  0 disk 
|-nvme0n1p1  259:1    0    4M  0 part 
|-nvme0n1p2  259:2    0    5M  0 part 
|-nvme0n1p3  259:3    0   40M  0 part /boot
|-nvme0n1p4  259:4    0  920M  0 part 
|-nvme0n1p5  259:5    0   10M  0 part 
|-nvme0n1p6  259:6    0   25M  0 part 
|-nvme0n1p7  259:7    0    5M  0 part 
|-nvme0n1p8  259:8    0   40M  0 part 
|-nvme0n1p9  259:9    0  920M  0 part 
|-nvme0n1p10 259:10   0   10M  0 part 
|-nvme0n1p11 259:11   0   25M  0 part 
|-nvme0n1p12 259:12   0   42M  0 part /var/lib/bottlerocket
`-nvme0n1p13 259:13   0   20G  0 part /var
                                      /opt
                                      /mnt
                                      /local

```

</details>

#### Single EBS volume with default 2 GB size and no additional space

<details>

The host fails boot as expected during `label-data-alt` since there is not enough space to label and grow the alternative data partition.
```
[  OK  ] Finished Apply Kernel Variables.
[  OK  ] Found device Amazon Elastic Block Store 13.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-PRIVATE.
         Starting Label alternative data partition...
[  OK  ] Finished Label alternative data partition.
[*     ] (1 of 2) A start job is running for…/BOTTLEROCKET-DATA (3s / 1min 30s)
^M[**    ] (1 of 2) A start job is running for…/BOTTLEROCKET-DATA (4s / 1min 30s)
^M[***   ] (1 of 2) A start job is running for…/BOTTLEROCKET-DATA (4s / 1min 30s)
...
^M[***   ] (1 of 2) A start job is running for…EROCKET-DATA (1min 29s / 1min 30s)
^M[ ***  ] (2 of 2) A start job is running for…362263b5944c (1min 30s / 1min 30s)
^M[ TIME ] Timed out waiting for device /dev/disk/by-partlabel/BOTTLEROCKET-DATA.
[DEPEND] Dependency failed for Local Directory (/local).
...
[DEPEND] Dependency failed for Resize Data Partition.
[ TIME ] Timed out waiting for device /dev/d…4e8df-28b8-485c-9d19-362263b5944c.

```

</details>

#### Testing at scale

Launched 1000 instances with "split" layout AMI with both EBS attached. All hosts come up and join the cluster
```
$ kubectl get nodes -o wide --no-headers | wc
   1000   13000  215000
```

Launched 1500 instance with split image AMI with a single 12 GB EBS volume. All hosts comes up and joins the cluster.




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
