### PR TITLE
Enable firelens capability in aws-ecs-1 variant

### DIFF
--- a/packages/ecs-agent/0002-bottlerocket-remove-unsupported-capabilities.patch
+++ b/packages/ecs-agent/0002-bottlerocket-remove-unsupported-capabilities.patch
@@ -1,17 +1,18 @@
-From 331c76247d4c4c0f8fb968e21db85e28b991b716 Mon Sep 17 00:00:00 2001
-From: "Sean P. Kelly" <seankell@amazon.com>
-Date: Wed, 1 Dec 2021 19:19:52 +0000
-Subject: [PATCH 2/5] bottlerocket: remove unsupported capabilities
+From effeecb19f10b639608bf3b5a5b09d1dbd19abf9 Mon Sep 17 00:00:00 2001
+From: Sean McGinnis <stmcg@amazon.com>
+Date: Tue, 21 Feb 2023 19:06:43 +0000
+Subject: [PATCH] Create capabilities diff
 
+Signed-off-by: Sean McGinnis <stmcg@amazon.com>
 ---
- agent/app/agent_capability.go | 20 ++++++++++----------
- 1 file changed, 10 insertions(+), 10 deletions(-)
+ agent/app/agent_capability.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/agent/app/agent_capability.go b/agent/app/agent_capability.go
-index 5febc49..48cf468 100644
+index 601879cd..d965f8af 100644
 --- a/agent/app/agent_capability.go
 +++ b/agent/app/agent_capability.go
-@@ -233,36 +233,36 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
+@@ -238,10 +238,10 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
  	capabilities = agent.appendPIDAndIPCNamespaceSharingCapabilities(capabilities)
  
  	// ecs agent version 1.26.0 supports aws-appmesh cni plugin
@@ -23,29 +24,8 @@ index 5febc49..48cf468 100644
 +	// capabilities = agent.appendTaskEIACapabilities(capabilities)
  
  	// support aws router capabilities for fluentd
--	capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
-+	// capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
- 
- 	// support aws router capabilities for fluentbit
--	capabilities = agent.appendFirelensFluentbitCapabilities(capabilities)
-+	// capabilities = agent.appendFirelensFluentbitCapabilities(capabilities)
- 
- 	// support aws router capabilities for log driver router
--	capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
-+	// capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
- 
- 	// support aws router capabilities for log driver router config
--	capabilities = agent.appendFirelensLoggingDriverConfigCapabilities(capabilities)
-+	// capabilities = agent.appendFirelensLoggingDriverConfigCapabilities(capabilities)
- 
- 	// support efs on ecs capabilities
- 	capabilities = agent.appendEFSCapabilities(capabilities)
- 
- 	// support external firelens config
--	capabilities = agent.appendFirelensConfigCapabilities(capabilities)
-+	// capabilities = agent.appendFirelensConfigCapabilities(capabilities)
- 
- 	// support GMSA capabilities
+ 	capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
+@@ -265,9 +265,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
  	capabilities = agent.appendGMSACapabilities(capabilities)
  
  	// support efs auth on ecs capabilities
@@ -53,11 +33,11 @@ index 5febc49..48cf468 100644
 -		capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
 -	}
 +	// for _, cap := range agent.cfg.VolumePluginCapabilities {
-+	//	capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
++	// 	capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
 +	// }
  
  	// support fsxWindowsFileServer on ecs capabilities
  	capabilities = agent.appendFSxWindowsFileServerCapabilities(capabilities)
 -- 
-2.32.0
+2.34.1
 


### PR DESCRIPTION
**Issue number:**

Closes #1079

**Description of changes:**

Report FireLens capabilities in the `amazon-ecs-agent`. This enables using [FireLens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html) in ECS with a Bottlerocket container instance.

**Testing done:**

Deployed task definition with `log_router` and workload container using the [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-logs.html) example configuration. Verified log group was created in CloudWatch Logs and that it contained expected output. Checked Bottlerocket instance journal logs and verified no unusual errors there.

Huge thanks to @arnaldo2792 for running through various testing scenarios:

- [x] FireLens with FluentD
- [x] FireLens with fluent-bit
- [x] Each with extra config loaded from S3
- [x] Each with "bridge mode"
- [x] Each with "AWS VPC mode"

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
