### PR TITLE
ecs-gpu-init: upgrades Nvidia Go library

### DIFF
--- a/sources/ecs-gpu-init/go.mod
+++ b/sources/ecs-gpu-init/go.mod
@@ -2,4 +2,4 @@ module ecs-gpu-init
 
 go 1.19
 
-require github.com/NVIDIA/go-nvml v0.11.6-0
+require github.com/NVIDIA/go-nvml v0.12.0-0

--- a/sources/ecs-gpu-init/go.sum
+++ b/sources/ecs-gpu-init/go.sum
@@ -1,2 +1,4 @@
 github.com/NVIDIA/go-nvml v0.11.6-0 h1:tugQzmaX84Y/6+03wZ/MAgcpfSKDkvkAWeuxFNLHmxY=
 github.com/NVIDIA/go-nvml v0.11.6-0/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=
+github.com/NVIDIA/go-nvml v0.12.0-0 h1:eHYNHbzAsMgWYshf6dEmTY66/GCXnORJFnzm3TNH4mc=
+github.com/NVIDIA/go-nvml v0.12.0-0/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=


### PR DESCRIPTION
**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket/issues/2761

**Description of changes:**

Upgrades the Nvidia Go library to the latest tag

**Testing done:**

Built a custom aws-ecs-1-nvidia AMI and deployed it to a p2.xlarge machine (1 GPU)

```
ash-5.1# cat /var/lib/ecs/gpu/nvidia-gpu-info.json
{"DriverVersion":"470.161.03","GPUIDs":["<GPU-ID>"]}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
