### PR TITLE
packages: Add ethtool to release

### DIFF
--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ethtool"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://kernel.org/pub/software/network/ethtool/"
+
+[[package.metadata.build-package.external-files]]
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.2.tar.xz"
+sha512 = "ff1f14c7876163bef93ca48e22a3429f09b4bcb3e1d101ef297d9f226e3fc2d3c3f19faf5b85f54cb558479e4a408ef5356a2d12e7ba132cc4cadaf92effccaf"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libmnl = { path = "../libmnl" }

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethtool"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/ethtool/build.rs
+++ b/packages/ethtool/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,0 +1,29 @@
+Name: %{_cross_os}ethtool
+Version: 6.2
+Release: 1%{?dist}
+Summary: Settings tool for Ethernet NICs
+License: GPL-2.0-only AND GPL-2.0-or-later
+URL: https://www.kernel.org/pub/software/network/ethtool/
+Source0: https://www.kernel.org/pub/software/network/ethtool/ethtool-%{version}.tar.xz
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libmnl-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -n ethtool-%{version}
+
+%build
+%cross_configure
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING LICENSE
+%{_cross_attribution_file}
+%{_cross_sbindir}/ethtool
+%exclude %{_cross_datadir}/bash-completion
+%exclude %{_cross_mandir}

--- a/packages/ethtool/pkg.rs
+++ b/packages/ethtool/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -23,6 +23,7 @@ containerd = { path = "../containerd" }
 coreutils = { path = "../coreutils" }
 dbus-broker = { path = "../dbus-broker" }
 e2fsprogs = { path = "../e2fsprogs" }
+ethtool = { path = "../ethtool" }
 filesystem = { path = "../filesystem" }
 findutils = { path = "../findutils" }
 glibc = { path = "../glibc" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -82,6 +82,7 @@ Requires: %{_cross_os}containerd
 Requires: %{_cross_os}coreutils
 Requires: %{_cross_os}dbus-broker
 Requires: %{_cross_os}e2fsprogs
+Requires: %{_cross_os}ethtool
 Requires: %{_cross_os}libgcc
 Requires: %{_cross_os}libstd-rust
 Requires: %{_cross_os}filesystem

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -353,6 +353,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethtool"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libmnl",
+]
+
+[[package]]
 name = "filesystem"
 version = "0.1.0"
 
@@ -952,6 +960,7 @@ dependencies = [
  "coreutils",
  "dbus-broker",
  "e2fsprogs",
+ "ethtool",
  "filesystem",
  "findutils",
  "glibc",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # 2794

**Description of changes:**
This adds ethtool to all variants.

**Testing done:**
Validated it works on a k8s variant in AWS:
```bash
[root@admin]# sudo sheltie
bash-5.1# ethtool eth0
Settings for eth0:
        Current message level: 0x000000f3 (243)
                               drv probe ifdown ifup rx_err tx_err
        Link detected: yes
bash-5.1# ethtool --version
ethtool version 6.2
```
Tested the use case from https://github.com/bottlerocket-os/bottlerocket/issues/2794
``` bash 
bash-5.1# ethtool -S eth0
NIC statistics:
     tx_timeout: 0
     suspend: 0
     resume: 0
     wd_expired: 0
     interface_up: 1
     interface_down: 0
     admin_q_pause: 0
     reset_fail: 0
     bw_in_allowance_exceeded: 17
     bw_out_allowance_exceeded: 0
     pps_allowance_exceeded: 0
     conntrack_allowance_exceeded: 0
     linklocal_allowance_exceeded: 0
     conntrack_allowance_available: 76950
     queue_0_tx_cnt: 11387
     queue_0_tx_bytes: 1587195
     queue_0_tx_queue_stop: 0
     queue_0_tx_queue_wakeup: 0
     queue_0_tx_dma_mapping_err: 0
     queue_0_tx_linearize: 0
     queue_0_tx_linearize_failed: 0
     queue_0_tx_napi_comp: 17282
     queue_0_tx_tx_poll: 17593
     queue_0_tx_doorbells: 11222
     queue_0_tx_prepare_ctx_err: 0
     queue_0_tx_bad_req_id: 0
     queue_0_tx_llq_buffer_copy: 2029
     queue_0_tx_missed_tx: 0
     queue_0_tx_unmask_interrupt: 17282
     queue_0_tx_xsk_need_wakeup_set: 0
     queue_0_tx_xsk_wakeup_request: 0
     queue_0_rx_cnt: 124148
     queue_0_rx_bytes: 225658754
     queue_0_rx_rx_copybreak_pkt: 5130
     queue_0_rx_csum_good: 120904
     queue_0_rx_refil_partial: 0
     queue_0_rx_csum_bad: 0
     queue_0_rx_page_alloc_fail: 0
     queue_0_rx_skb_alloc_fail: 0
     queue_0_rx_dma_mapping_err: 0
     queue_0_rx_bad_desc_num: 0
     queue_0_rx_bad_req_id: 0
     queue_0_rx_empty_rx_ring: 0
     queue_0_rx_csum_unchecked: 3221
     queue_0_rx_xdp_aborted: 0
     queue_0_rx_xdp_drop: 0
     queue_0_rx_xdp_pass: 0
     queue_0_rx_xdp_tx: 0
     queue_0_rx_xdp_invalid: 0
     queue_0_rx_xdp_redirect: 0
     queue_0_rx_lpc_warm_up: 0
     queue_0_rx_lpc_full: 0
     queue_0_rx_lpc_wrong_numa: 0
     queue_0_rx_xsk_need_wakeup_set: 0
     queue_0_rx_zc_queue_pkt_copy: 0
     ena_admin_q_aborted_cmd: 0
     ena_admin_q_submitted_cmd: 21
     ena_admin_q_completed_cmd: 21
     ena_admin_q_out_of_space: 0
     ena_admin_q_no_completion: 0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
