### PR TITLE
testsys: Add support for k8s workloads

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -381,6 +381,26 @@ cargo make -e TESTSYS_TEST=migration test
 
 To see the state of the tests as they run use `cargo make watch-test`.
 
+### Testing Workloads
+
+Workload tests are tests designed to run as an orchestrated container.
+A workload test is defined in `Test.toml` with a map named `workloads`.
+
+```toml
+[aws-nvidia]
+workloads = { <WORKLOAD-NAME> = "<WORKLOAD-IMAGE-URI>" }
+```
+
+To run the workload test set `TESTSYS_TEST=workload` in the `cargo make test` call.
+
+```shell
+cargo make -e TESTSYS_TEST=workload test
+```
+
+To see the state of the tests as they run use `cargo make watch-test`.
+
+For more information can be found in the [TestSys workload documentation](https://github.com/bottlerocket-os/bottlerocket-test-system/tree/develop/bottlerocket/tests/workload).
+
 ### Custom Test Types
 
 Custom tests can be run with TestSys by calling `cargo make -e TESTSYS_TEST=<CUSTOM-TEST-NAME> test -f <PATH-TO-TEMPLATED-YAML>`.

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -261,6 +261,9 @@ pub struct GenericVariantConfig {
     pub control_plane_endpoint: Option<String>,
     /// The path to userdata that should be used for Bottlerocket launch
     pub userdata: Option<String>,
+    /// The workload tests that should be run
+    #[serde(default)]
+    pub workloads: BTreeMap<String, String>,
     #[serde(default)]
     pub dev: DeveloperConfig,
 }
@@ -280,6 +283,12 @@ impl GenericVariantConfig {
             self.secrets
         };
 
+        let workloads = if self.workloads.is_empty() {
+            other.workloads
+        } else {
+            self.workloads
+        };
+
         Self {
             cluster_names,
             instance_type: self.instance_type.or(other.instance_type),
@@ -289,6 +298,7 @@ impl GenericVariantConfig {
             conformance_registry: self.conformance_registry.or(other.conformance_registry),
             control_plane_endpoint: self.control_plane_endpoint.or(other.control_plane_endpoint),
             userdata: self.userdata.or(other.userdata),
+            workloads,
             dev: self.dev.merge(other.dev),
         }
     }
@@ -353,6 +363,7 @@ pub struct TestsysImages {
     pub sonobuoy_test_agent_image: Option<String>,
     pub ecs_test_agent_image: Option<String>,
     pub migration_test_agent_image: Option<String>,
+    pub k8s_workload_agent_image: Option<String>,
     pub controller_image: Option<String>,
     pub testsys_agent_pull_secret: Option<String>,
 }
@@ -380,6 +391,7 @@ impl TestsysImages {
             sonobuoy_test_agent_image: Some(format!("{}/sonobuoy-test-agent:{tag}", registry)),
             ecs_test_agent_image: Some(format!("{}/ecs-test-agent:{tag}", registry)),
             migration_test_agent_image: Some(format!("{}/migration-test-agent:{tag}", registry)),
+            k8s_workload_agent_image: Some(format!("{}/k8s-workload-agent:{tag}", registry)),
             controller_image: Some(format!("{}/controller:{tag}", registry)),
             testsys_agent_pull_secret: None,
         }
@@ -409,6 +421,9 @@ impl TestsysImages {
             migration_test_agent_image: self
                 .migration_test_agent_image
                 .or(other.migration_test_agent_image),
+            k8s_workload_agent_image: self
+                .k8s_workload_agent_image
+                .or(other.k8s_workload_agent_image),
             controller_image: self.controller_image.or(other.controller_image),
             testsys_agent_pull_secret: self
                 .testsys_agent_pull_secret

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -193,6 +193,12 @@ impl CrdCreator for AwsEcsCreator {
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(test_crd))))
     }
 
+    async fn workload_crd<'a>(&self, _test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        Err(error::Error::Invalid {
+            what: "Workload testing is not supported for non-k8s variants".to_string(),
+        })
+    }
+
     fn additional_fields(&self, _test_type: &str) -> BTreeMap<String, String> {
         btreemap! {"region".to_string() => self.region.clone()}
     }

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -5,7 +5,7 @@ use crate::crds::{
 };
 use crate::error::{self, Result};
 use crate::migration::migration_crd;
-use crate::sonobuoy::sonobuoy_crd;
+use crate::sonobuoy::{sonobuoy_crd, workload_crd};
 use bottlerocket_types::agent_config::{
     ClusterType, CreationPolicy, EksClusterConfig, EksctlConfig, K8sVersion,
 };
@@ -165,6 +165,12 @@ impl CrdCreator for AwsK8sCreator {
 
     async fn test_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(sonobuoy_crd(
+            test_input,
+        )?))))
+    }
+
+    async fn workload_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(workload_crd(
             test_input,
         )?))))
     }

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -4,7 +4,7 @@ use crate::crds::{
 };
 use crate::error::{self, Result};
 use crate::migration::migration_crd;
-use crate::sonobuoy::sonobuoy_crd;
+use crate::sonobuoy::{sonobuoy_crd, workload_crd};
 use bottlerocket_types::agent_config::{
     CreationPolicy, CustomUserData, K8sVersion, VSphereK8sClusterConfig, VSphereK8sClusterInfo,
     VSphereVmConfig,
@@ -275,6 +275,12 @@ impl CrdCreator for VmwareK8sCreator {
 
     async fn test_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
         Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(sonobuoy_crd(
+            test_input,
+        )?))))
+    }
+
+    async fn workload_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(workload_crd(
             test_input,
         )?))))
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2515 

**Description of changes:**

Enables workload testing with TestSys.
_Note:_ The workload agent must be used with a custom build workload agent image from https://github.com/bottlerocket-os/bottlerocket-test-system/tree/d2f62a070a1642ce8c073e282434d7c189f2ad6e

**Testing done:**

Ran `cargo make -e TESTSYS_TEST=workload test`

In `Test.toml`
```sh
[aws]
workloads = { smoke-test = "<URI-TO-SMOKE-TEST-IMAGE>" }
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
