### PR TITLE
systemd: Add patch to split networkd tmpfiles into a separate file

### DIFF
--- a/packages/systemd/9012-tmpfiles-Split-networkd-entries-into-a-separate-file.patch
+++ b/packages/systemd/9012-tmpfiles-Split-networkd-entries-into-a-separate-file.patch
@@ -1,0 +1,67 @@
+From abdd268ab3c16c606a1578e5d40d5847a1d99523 Mon Sep 17 00:00:00 2001
+From: Daan De Meyer <daan.j.demeyer@gmail.com>
+Date: Wed, 27 Apr 2022 10:25:22 +0100
+Subject: [PATCH] tmpfiles: Split networkd entries into a separate file
+
+Many distributions ship systemd-networkd as a separate file so we
+need to be able to ship the tmpfiles networkd entries as part of
+that separate networkd package. Let's split the networkd entries
+into a separate file to make that possible.
+---
+ tmpfiles.d/meson.build          |  1 +
+ tmpfiles.d/systemd-network.conf | 13 +++++++++++++
+ tmpfiles.d/systemd.conf.in      |  6 ------
+ 3 files changed, 14 insertions(+), 6 deletions(-)
+ create mode 100644 tmpfiles.d/systemd-network.conf
+
+diff --git a/tmpfiles.d/meson.build b/tmpfiles.d/meson.build
+index b8d3919025..7c2604cfe1 100644
+--- a/tmpfiles.d/meson.build
++++ b/tmpfiles.d/meson.build
+@@ -13,6 +13,7 @@ files = [['README',               ''],
+          ['systemd-pstore.conf',  'ENABLE_PSTORE'],
+          ['tmp.conf',             ''],
+          ['x11.conf',             ''],
++         ['systemd-network.conf', 'ENABLE_NETWORKD'],
+         ]
+ 
+ foreach pair : files
+diff --git a/tmpfiles.d/systemd-network.conf b/tmpfiles.d/systemd-network.conf
+new file mode 100644
+index 0000000000..b30bc914a5
+--- /dev/null
++++ b/tmpfiles.d/systemd-network.conf
+@@ -0,0 +1,13 @@
++#  This file is part of systemd.
++#
++#  systemd is free software; you can redistribute it and/or modify it
++#  under the terms of the GNU Lesser General Public License as published by
++#  the Free Software Foundation; either version 2.1 of the License, or
++#  (at your option) any later version.
++
++# See tmpfiles.d(5) for details
++
++d /run/systemd/netif 0755 systemd-network systemd-network -
++d /run/systemd/netif/links 0755 systemd-network systemd-network -
++d /run/systemd/netif/leases 0755 systemd-network systemd-network -
++d /run/systemd/netif/lldp 0755 systemd-network systemd-network -
+diff --git a/tmpfiles.d/systemd.conf.in b/tmpfiles.d/systemd.conf.in
+index 9b2357cd31..e23e102782 100644
+--- a/tmpfiles.d/systemd.conf.in
++++ b/tmpfiles.d/systemd.conf.in
+@@ -18,12 +18,6 @@ d /run/systemd/sessions 0755 root root -
+ d /run/systemd/users 0755 root root -
+ d /run/systemd/machines 0755 root root -
+ d /run/systemd/shutdown 0755 root root -
+-{% if ENABLE_NETWORKD %}
+-d /run/systemd/netif 0755 systemd-network systemd-network -
+-d /run/systemd/netif/links 0755 systemd-network systemd-network -
+-d /run/systemd/netif/leases 0755 systemd-network systemd-network -
+-d /run/systemd/netif/lldp 0755 systemd-network systemd-network -
+-{% endif %}
+ 
+ d /run/log 0755 root root -
+ 
+-- 
+2.38.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -52,6 +52,10 @@ Patch9010: 9010-sysusers-set-root-shell-to-sbin-nologin.patch
 # Local patch to keep modprobe units running to avoid repeated log entries.
 Patch9011: 9011-units-keep-modprobe-service-units-running.patch
 
+# Local patch to split the systemd-networkd tmpfiles into a separate file which
+# allows us to exclude them when not using networkd.
+Patch9012: 9012-tmpfiles-Split-networkd-entries-into-a-separate-file.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson
@@ -327,6 +331,7 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_libdir}/sysusers.d/*
 %{_cross_libdir}/systemd/*
 %{_cross_libdir}/udev/*
+%exclude %{_cross_libdir}/tmpfiles.d/systemd-network.conf
 %exclude %{_cross_libdir}/sysusers.d/systemd-network.conf
 %exclude %{_cross_libdir}/systemd/systemd-networkd
 %exclude %{_cross_libdir}/systemd/systemd-networkd-wait-online
@@ -421,5 +426,6 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_libdir}/sysusers.d/systemd-network.conf
 %{_cross_datadir}/dbus-1/system-services/org.freedesktop.network1.service
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
+%{_cross_libdir}/tmpfiles.d/systemd-network.conf
 
 %changelog


### PR DESCRIPTION
**Issue number:**
Related to #2741 and #2449 

**Description of changes:**
It appears I missed some files when I made the `networkd` subpackage in `systemd`.  These tmpfiles should only be included if the `networkd` subpackage is included.  [An upstream patch](https://github.com/systemd/systemd-stable/commit/eb1446f8f155e2253c9cc7068b29dcdbb6d68aa6) moves these entries into a separate file for situations such as this, so we include that patch.

The offending journal entries that tipped us off to this mistake looked like:
```
Feb 24 18:36:39 localhost systemd-tmpfiles[1562]: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/tmpfiles.d
/systemd.conf:18: Failed to resolve user 'systemd-network': No such process
```
```
    systemd: Add patch to split networkd tmpfiles into a separate file
    
    This commit adds an upstream patch that moves systemd-networkd tmpfiles
    entries into a separate file.  This makes it simpler to include/exclude
    these tmpfiles depending on the inclusion of the networkd subpackage.
    
    The systemd.spec has been updated to exclude this new file, while the
    networkd subpackage explicitly includes it
```

**Testing done:**
* Build and boot an `aws-k8s-1.24` variant and ensure no messages referring to `systemd-network`'s tmpfiles show up in the journal.
```
bash-5.1# journalctl | grep -i systemd-network                                                                                                   
bash-5.1# journalctl | grep -i networkd       
bash-5.1#
```
* Build and boot an `aws-dev` variant with the `systemd-networkd` image-feature enabled (and add a dependency on `console-getty.service` in `preconfigured.target` since I knew early boot services will fail).  Observe the `systemd-networkd` tmpfiles being created properly and no other networkd-related issues in the journal:
```
bash-5.1# ls -lah /run/systemd/netif/
total 4.0K
drwxr-xr-x.  5 systemd-network systemd-network 120 Feb 24 21:32 .
drwxr-xr-x. 20 root            root            540 Feb 24 21:32 ..
drwxr-xr-x.  2 systemd-network systemd-network  40 Feb 24 21:32 leases
drwxr-xr-x.  2 systemd-network systemd-network  80 Feb 24 21:32 links
drwxr-xr-x.  2 systemd-network systemd-network  40 Feb 24 21:32 lldp
-rw-r--r--.  1 systemd-network systemd-network 135 Feb 24 21:32 state

bash-5.1# journalctl | grep -i systemd-network
Feb 24 21:32:34 localhost systemd-sysusers[315]: Creating group 'systemd-network' with GID 981.
Feb 24 21:32:34 localhost systemd-sysusers[315]: Creating user 'systemd-network' (systemd Network Management) with UID 981 and GID 981.
Feb 24 21:32:35 localhost systemd-tmpfiles[894]: Reading config file "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/tmpfiles.d/systemd-network.conf"…
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
