### PR TITLE
selinux-policy: add rules to limit noatsecure access

### DIFF
--- a/packages/selinux-policy/processes.cil
+++ b/packages/selinux-policy/processes.cil
@@ -15,7 +15,7 @@
 
 ; Permission group for relaxing security constraints on processes.
 (classmapping processes relax (
-  process (execheap execmem execstack)))
+  process (execheap execmem execstack noatsecure)))
 (classmapping processes relax (
   memprotect (mmap_zero)))
 
@@ -23,6 +23,6 @@
 (classmapping processes interact (
   process (not (
     dyntransition transition setcurrent setexec
-    setfscreate setkeycreate setsockcreate
+    setfscreate setkeycreate setsockcreate 
     getsched getsession getpgid getcap getattr getrlimit
-    execheap execmem execstack))))
+    execheap execmem execstack noatsecure))))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -26,6 +26,12 @@
 ; Unprivileged components cannot interact with privileged processes.
 (neverallow unprivileged_s privileged_s (processes (interact)))
 
+
+; Host subjects are denied the `noatsecure` permission to ensure that
+; the environment is sanitized during all domain transitions. Suppress
+; this audit message since otherwise it adds a lot of noise
+(dontaudit all_s all_s (process (noatsecure)))
+
 ; PID 1 starts as "kernel_t" and becomes "init_t".
 (typetransition kernel_t init_exec_t process init_t)
 (allow kernel_t init_t (processes (transform)))


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

This updates the `relax` and `interact` class mappings to prevent processes from disabling the secure mode environment cleansing provided with the `AT_SECURE` flag while calling `execve(2)`. Allowing `noatsecure` to processes could open a small window for exploits, so it is better to forbid system processes from attempting to use the permission. It should be safe to add the new rule since SELinux doesn't allow access by default and all access must be explicitly granted.

**Testing done:**

- [X] Build aws-ecs-1 and confirmed the system is running
- [X] Build aws-k8s-1.2X and confirmed the system is running
- [X] Test containerized workloads can run without `AT_SECURE`
- [X] Test containerized workloads get the `AT_SECURE` flag set when executed as `setuid`
- [X] Validate AVC denials weren't logged

**Testing details:**

One of the scenarios where the ELF binary loader of the kernel will set the `AT_SECURE` flag is when the process is executing as `setuid` / `setgid`. In my test, I created a binary that queries the `AT_SECURE` flag with `getauxval`, and prints out the value.

I have two different setups:
- Run the binary with the `setgid` bit set to force the `AT_SECURE` flag:

```
❯ kubectl exec at-secure-4v7tg -c at-secure -- sh -c "at_secure"
Value 1⏎
```
- Run the binary without the `setgid` bit set, to validate the updated rules don't force the flag in containers' processes:

```
❯ kubectl exec at-secure-4v7tg -c no-at-secure -- sh -c "at_secure"
Value 0⏎
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
