### PR TITLE
Update rust edition to 2021

### DIFF
--- a/packages/acpid/Cargo.toml
+++ b/packages/acpid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acpid"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-iam-authenticator"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-signing-helper"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/bash/Cargo.toml
+++ b/packages/bash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bash"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/binutils/Cargo.toml
+++ b/packages/binutils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "binutils"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ca-certificates"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/chrony/Cargo.toml
+++ b/packages/chrony/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chrony"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cni-plugins"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cni"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/conntrack-tools/Cargo.toml
+++ b/packages/conntrack-tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conntrack-tools"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "containerd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/coreutils/Cargo.toml
+++ b/packages/coreutils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coreutils"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dbus-broker"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-cli"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-engine"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/docker-init/Cargo.toml
+++ b/packages/docker-init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-init"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/docker-proxy/Cargo.toml
+++ b/packages/docker-proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docker-proxy"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "e2fsprogs"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/ecr-credential-provider/Cargo.toml
+++ b/packages/ecr-credential-provider/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ecr-credential-provider"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ecs-agent"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/ecs-gpu-init/Cargo.toml
+++ b/packages/ecs-gpu-init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ecs-gpu-init"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/filesystem/Cargo.toml
+++ b/packages/filesystem/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "filesystem"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/findutils/Cargo.toml
+++ b/packages/findutils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "findutils"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/glibc/Cargo.toml
+++ b/packages/glibc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "glibc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/grep/Cargo.toml
+++ b/packages/grep/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grep"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/grub/Cargo.toml
+++ b/packages/grub/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grub"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/host-ctr/Cargo.toml
+++ b/packages/host-ctr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "host-ctr"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/hotdog/Cargo.toml
+++ b/packages/hotdog/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hotdog"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/iproute/Cargo.toml
+++ b/packages/iproute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iproute"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/iptables/Cargo.toml
+++ b/packages/iptables/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iptables"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/iputils/Cargo.toml
+++ b/packages/iputils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iputils"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kernel-5_10"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kernel-5_15"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kexec-tools/Cargo.toml
+++ b/packages/kexec-tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kexec-tools"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kmod-5_10-nvidia"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kmod-5_15-nvidia"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kmod"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kubernetes-1.22/Cargo.toml
+++ b/packages/kubernetes-1.22/Cargo.toml
@@ -3,7 +3,7 @@
 # directory and spec file, so we override it below.
 name = "kubernetes-1_22"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -3,7 +3,7 @@
 # directory and spec file, so we override it below.
 name = "kubernetes-1_23"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -3,7 +3,7 @@
 # directory and spec file, so we override it below.
 name = "kubernetes-1_24"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -3,7 +3,7 @@
 # directory and spec file, so we override it below.
 name = "kubernetes-1_25"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libacl/Cargo.toml
+++ b/packages/libacl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libacl"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libattr/Cargo.toml
+++ b/packages/libattr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libattr"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libaudit"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libbzip2/Cargo.toml
+++ b/packages/libbzip2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libbzip2"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcap"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libdbus/Cargo.toml
+++ b/packages/libdbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libdbus"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libelf/Cargo.toml
+++ b/packages/libelf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libelf"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libexpat"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libffi/Cargo.toml
+++ b/packages/libffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libffi"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libgcc/Cargo.toml
+++ b/packages/libgcc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libgcc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libglib"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libiw/Cargo.toml
+++ b/packages/libiw/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libiw"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/liblzma/Cargo.toml
+++ b/packages/liblzma/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "liblzma"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libmnl/Cargo.toml
+++ b/packages/libmnl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libmnl"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libncurses/Cargo.toml
+++ b/packages/libncurses/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libncurses"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnetfilter_conntrack/Cargo.toml
+++ b/packages/libnetfilter_conntrack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnetfilter_conntrack"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnetfilter_cthelper/Cargo.toml
+++ b/packages/libnetfilter_cthelper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnetfilter_cthelper"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnetfilter_cttimeout/Cargo.toml
+++ b/packages/libnetfilter_cttimeout/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnetfilter_cttimeout"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnetfilter_queue/Cargo.toml
+++ b/packages/libnetfilter_queue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnetfilter_queue"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnfnetlink/Cargo.toml
+++ b/packages/libnfnetlink/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnfnetlink"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnftnl/Cargo.toml
+++ b/packages/libnftnl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnftnl"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnl/Cargo.toml
+++ b/packages/libnl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnl"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnvidia-container"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libpcap/Cargo.toml
+++ b/packages/libpcap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libpcap"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libpcre/Cargo.toml
+++ b/packages/libpcre/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libpcre"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libseccomp/Cargo.toml
+++ b/packages/libseccomp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libseccomp"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libselinux/Cargo.toml
+++ b/packages/libselinux/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libselinux"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libsemanage/Cargo.toml
+++ b/packages/libsemanage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsemanage"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libsepol/Cargo.toml
+++ b/packages/libsepol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsepol"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libstd-rust/Cargo.toml
+++ b/packages/libstd-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libstd-rust"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libtirpc/Cargo.toml
+++ b/packages/libtirpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libtirpc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libxcrypt"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libz/Cargo.toml
+++ b/packages/libz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libz"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/libzstd/Cargo.toml
+++ b/packages/libzstd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzstd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/log4j2-hotpatch/Cargo.toml
+++ b/packages/log4j2-hotpatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "log4j2-hotpatch"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/login/Cargo.toml
+++ b/packages/login/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "login"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "makedumpfile"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/microcode/Cargo.toml
+++ b/packages/microcode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "microcode"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nvidia-container-toolkit"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nvidia-k8s-device-plugin"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/oci-add-hooks/Cargo.toml
+++ b/packages/oci-add-hooks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oci-add-hooks"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "open-vm-tools"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "os"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/policycoreutils/Cargo.toml
+++ b/packages/policycoreutils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "policycoreutils"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/procps/Cargo.toml
+++ b/packages/procps/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "procps"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/readline/Cargo.toml
+++ b/packages/readline/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "readline"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "release"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "runc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/selinux-policy/Cargo.toml
+++ b/packages/selinux-policy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "selinux-policy"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "strace"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "systemd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/tcpdump/Cargo.toml
+++ b/packages/tcpdump/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tcpdump"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "util-linux"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/wicked/Cargo.toml
+++ b/packages/wicked/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wicked"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -3,7 +3,7 @@ name = "apiclient"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -3,7 +3,7 @@ name = "apiserver"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/apiserver/src/server/exec/child.rs
+++ b/sources/api/apiserver/src/server/exec/child.rs
@@ -142,6 +142,9 @@ impl ChildHandles {
         // process too, or it'd stick around forever.  Perform the rest of initialization in a
         // closure so that we can kill the child easily on any error, returning the original value.
         (move || {
+            // Starting with Rust 2021, need to explicitly capture the while child variable
+            let _ = &child;
+
             // Now that the process is spawned, if we created a PTY, close its slave fd in the
             // parent process, or reads of the master side will block.
             if let Some(close_fd) = child_fds.close_fd {

--- a/sources/api/bootstrap-containers/Cargo.toml
+++ b/sources/api/bootstrap-containers/Cargo.toml
@@ -3,7 +3,7 @@ name = "bootstrap-containers"
 version = "0.1.0"
 authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/bork/Cargo.toml
+++ b/sources/api/bork/Cargo.toml
@@ -3,7 +3,7 @@ name = "bork"
 version = "0.1.0"
 authors = ["Samuel Mendoza-Jonas <samjonas@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -3,7 +3,7 @@ name = "certdog"
 version = "0.1.0"
 authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -3,7 +3,7 @@ name = "corndog"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/datastore/Cargo.toml
+++ b/sources/api/datastore/Cargo.toml
@@ -3,7 +3,7 @@ name = "datastore"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/early-boot-config/Cargo.toml
+++ b/sources/api/early-boot-config/Cargo.toml
@@ -3,7 +3,7 @@ name = "early-boot-config"
 version = "0.1.0"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Samuel Karp <skarp@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 publish = false
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -3,7 +3,7 @@ name = "host-containers"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>", "Zac Mrowicki <mrowicki@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -3,7 +3,7 @@ name = "migration-helpers"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/Cargo.toml
@@ -3,7 +3,7 @@ name = "add-k8s-autoscaling-warm-pool-setting-metadata"
 version = "0.1.0"
 authors = ["Tianhao Geng <tianhg@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/Cargo.toml
@@ -3,7 +3,7 @@ name = "add-k8s-autoscaling-warm-pool-setting"
 version = "0.1.0"
 authors = ["Tianhao Geng <tianhg@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/Cargo.toml
@@ -3,7 +3,7 @@ name = "aws-admin-container-v0-9-4"
 version = "0.1.0"
 authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/Cargo.toml
@@ -3,7 +3,7 @@ name = "aws-control-container-v0-7-0"
 version = "0.1.0"
 authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/Cargo.toml
@@ -3,7 +3,7 @@ name = "k8s-private-pki-path"
 version = "0.1.0"
 authors = ["Sean McGinnis <stmcg@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.12.0/oci-defaults-setting-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/oci-defaults-setting-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oci-defaults-setting-metadata"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Mahdi Chaker <mmchaker@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 publish = false

--- a/sources/api/migration/migrations/v1.12.0/oci-defaults-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/oci-defaults-setting/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oci-defaults-setting"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Mahdi Chaker <mmchaker@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 publish = false

--- a/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/Cargo.toml
@@ -3,7 +3,7 @@ name = "public-admin-container-v0-9-4"
 version = "0.1.0"
 authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/Cargo.toml
@@ -3,7 +3,7 @@ name = "public-control-container-v0-7-0"
 version = "0.1.0"
 authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrations/v1.13.0/k8s-registry/Cargo.toml
+++ b/sources/api/migration/migrations/v1.13.0/k8s-registry/Cargo.toml
@@ -3,7 +3,7 @@ name = "k8s-registry"
 version = "0.1.0"
 authors = ["John McBride <jpmmcb@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -3,7 +3,7 @@ name = "migrator"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -3,7 +3,7 @@ name = "netdog"
 version = "0.1.0"
 authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -3,7 +3,7 @@ name = "pluto"
 version = "0.1.0"
 authors = ["Michael Patraw <patraw@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/prairiedog/Cargo.toml
+++ b/sources/api/prairiedog/Cargo.toml
@@ -3,7 +3,7 @@ name = "prairiedog"
 version = "0.1.0"
 authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -3,7 +3,7 @@ name = "schnauzer"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -3,7 +3,7 @@ name = "settings-committer"
 version = "0.1.0"
 authors = ["Michael Patraw <patraw@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -3,7 +3,7 @@ name = "shibaken"
 version = "0.1.0"
 authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/static-pods/Cargo.toml
+++ b/sources/api/static-pods/Cargo.toml
@@ -3,7 +3,7 @@ name = "static-pods"
 version = "0.1.0"
 authors = ["Erikson Tung <etung@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -3,7 +3,7 @@ name = "storewolf"
 version = "0.1.0"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/storewolf/merge-toml/Cargo.toml
+++ b/sources/api/storewolf/merge-toml/Cargo.toml
@@ -3,7 +3,7 @@ name = "merge-toml"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -3,7 +3,7 @@ name = "sundog"
 version = "0.1.0"
 authors = ["mrowicki <mrowicki@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -3,7 +3,7 @@ name = "thar-be-settings"
 version = "0.1.0"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -3,7 +3,7 @@ name = "thar-be-updates"
 version = "0.1.0"
 authors = ["Erikson Tung <etung@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/bottlerocket-release/Cargo.toml
+++ b/sources/bottlerocket-release/Cargo.toml
@@ -3,7 +3,7 @@ name = "bottlerocket-release"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/bottlerocket-variant/Cargo.toml
+++ b/sources/bottlerocket-variant/Cargo.toml
@@ -3,7 +3,7 @@ name = "bottlerocket-variant"
 version = "0.1.0"
 authors = ["Matt Briggs <brigmatt@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/cfsignal/Cargo.toml
+++ b/sources/cfsignal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfsignal"
 version = "0.1.0"
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/constants/Cargo.toml
+++ b/sources/constants/Cargo.toml
@@ -3,7 +3,7 @@ name = "constants"
 version = "0.1.0"
 authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/driverdog/Cargo.toml
+++ b/sources/driverdog/Cargo.toml
@@ -3,7 +3,7 @@ name = "driverdog"
 version = "0.1.0"
 authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/generate-readme/Cargo.toml
+++ b/sources/generate-readme/Cargo.toml
@@ -3,7 +3,7 @@ name = "generate-readme"
 version = "0.1.0"
 authors = ["Matt Briggs <brigmatt@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -3,7 +3,7 @@ name = "ghostdog"
 version = "0.1.0"
 authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/imdsclient/Cargo.toml
+++ b/sources/imdsclient/Cargo.toml
@@ -3,7 +3,7 @@ name = "imdsclient"
 version = "0.1.0"
 authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -3,7 +3,7 @@ name = "logdog"
 version = "0.1.0"
 authors = ["Matt Briggs <brigmatt@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -3,7 +3,7 @@ name = "metricdog"
 version = "0.1.0"
 authors = ["Matt Briggs <brigmatt@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -3,7 +3,7 @@ name = "models"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/models/model-derive/Cargo.toml
+++ b/sources/models/model-derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "model-derive"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/models/scalar-derive/Cargo.toml
+++ b/sources/models/scalar-derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "scalar-derive"
 version = "0.1.0"
 authors = ["Matt Briggs <brigmatt@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/models/scalar/Cargo.toml
+++ b/sources/models/scalar/Cargo.toml
@@ -3,7 +3,7 @@ name = "scalar"
 version = "0.1.0"
 authors = ["Matt Briggs <brigmatt@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/sources/parse-datetime/Cargo.toml
+++ b/sources/parse-datetime/Cargo.toml
@@ -3,7 +3,7 @@ name = "parse-datetime"
 version = "0.1.0"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/retry-read/Cargo.toml
+++ b/sources/retry-read/Cargo.toml
@@ -3,7 +3,7 @@ name = "retry-read"
 version = "0.1.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/shimpei/Cargo.toml
+++ b/sources/shimpei/Cargo.toml
@@ -3,7 +3,7 @@ name = "shimpei"
 version = "0.1.0"
 authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/updater/block-party/Cargo.toml
+++ b/sources/updater/block-party/Cargo.toml
@@ -3,7 +3,7 @@ name = "block-party"
 version = "0.1.0"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/updater/signpost/Cargo.toml
+++ b/sources/updater/signpost/Cargo.toml
@@ -3,7 +3,7 @@ name = "signpost"
 version = "0.1.0"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -3,7 +3,7 @@ name = "update_metadata"
 version = "0.1.0"
 authors = ["Samuel Mendoza-Jonas <samjonas@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -3,7 +3,7 @@ name = "updog"
 version = "0.1.0"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/tools/buildsys/Cargo.toml
+++ b/tools/buildsys/Cargo.toml
@@ -3,7 +3,7 @@ name = "buildsys"
 version = "0.1.0"
 authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/tools/infrasys/Cargo.toml
+++ b/tools/infrasys/Cargo.toml
@@ -3,7 +3,7 @@ name = "infrasys"
 version = "0.1.0"
 license = "Apache-2.0 OR MIT"
 authors = ["Aashna Sheth <shetaash@amazon.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/tools/pubsys-config/Cargo.toml
+++ b/tools/pubsys-config/Cargo.toml
@@ -3,7 +3,7 @@ name = "pubsys-config"
 version = "0.1.0"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>", "Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/tools/pubsys-setup/Cargo.toml
+++ b/tools/pubsys-setup/Cargo.toml
@@ -3,7 +3,7 @@ name = "pubsys-setup"
 version = "0.1.0"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>", "Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -3,7 +3,7 @@ name = "pubsys"
 version = "0.1.0"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>", "Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-dev"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-ecs-1-nvidia"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-ecs-1"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/variants/aws-k8s-1.22-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.22-nvidia/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_22-nvidia"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-k8s-1.22/Cargo.toml
+++ b/variants/aws-k8s-1.22/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_22"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-k8s-1.23-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.23-nvidia/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_23-nvidia"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-k8s-1.23/Cargo.toml
+++ b/variants/aws-k8s-1.23/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_23"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.24-nvidia/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_24-nvidia"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-k8s-1.24/Cargo.toml
+++ b/variants/aws-k8s-1.24/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_24"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-k8s-1.25-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.25-nvidia/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_25-nvidia"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/aws-k8s-1.25/Cargo.toml
+++ b/variants/aws-k8s-1.25/Cargo.toml
@@ -3,7 +3,7 @@
 # don't use this crate name anywhere.
 name = "aws-k8s-1_25"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "metal-dev"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/metal-k8s-1.22/Cargo.toml
+++ b/variants/metal-k8s-1.22/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "metal-k8s-1_22"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/metal-k8s-1.23/Cargo.toml
+++ b/variants/metal-k8s-1.23/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "metal-k8s-1_23"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/metal-k8s-1.24/Cargo.toml
+++ b/variants/metal-k8s-1.24/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "metal-k8s-1_24"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/metal-k8s-1.25/Cargo.toml
+++ b/variants/metal-k8s-1.25/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "metal-k8s-1_25"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vmware-dev"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/vmware-k8s-1.22/Cargo.toml
+++ b/variants/vmware-k8s-1.22/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "vmware-k8s-1_22"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/vmware-k8s-1.23/Cargo.toml
+++ b/variants/vmware-k8s-1.23/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "vmware-k8s-1_23"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/vmware-k8s-1.24/Cargo.toml
+++ b/variants/vmware-k8s-1.24/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "vmware-k8s-1_24"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.

--- a/variants/vmware-k8s-1.25/Cargo.toml
+++ b/variants/vmware-k8s-1.25/Cargo.toml
@@ -3,7 +3,7 @@
 # we don't use this crate name anywhere.
 name = "vmware-k8s-1_25"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 # Don't rebuild crate just because of changes to README.


### PR DESCRIPTION
**Issue number:**

Closes #1789

**Description of changes:**

The 2021 edition of Rust has been available in the Bottlerocket SDK since late 2021. Most crates in the project still set their edition to 2018 though.

This updates the declared edition to 2021. This brings various [default language improvements](https://doc.rust-lang.org/edition-guide/rust-2021/index.html).

**Testing done:**

Ran `cargo make check` to run linters and unit tests.
Build `aws-k8s-1.24` variant and deployed new cluster. Verified cluster initializes successfully and deployed a pod to cluster to verify operation.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
