### PR TITLE
Remove outdated rust_2018_idioms enforcement

### DIFF
--- a/sources/api/apiclient/src/lib.rs
+++ b/sources/api/apiclient/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 //! The apiclient library provides high-level methods to interact with the Bottlerocket API.  See
 //! the documentation for submodules [`apply`], [`exec`], [`get`], [`reboot`], [`set`], and
 //! [`update`] for high-level helpers.

--- a/sources/api/apiserver/src/bin/apiserver.rs
+++ b/sources/api/apiserver/src/bin/apiserver.rs
@@ -1,7 +1,5 @@
 //! This is the primary binary for the Bottlerocket API server.
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/apiserver/src/lib.rs
+++ b/sources/api/apiserver/src/lib.rs
@@ -69,7 +69,6 @@ You can start the API server from the `apiserver` directory with a command like:
 Then, from another shell, you can query or modify data.
 See `../../apiclient/README.md` for client examples.
 */
-#![deny(rust_2018_idioms)]
 
 #[macro_use]
 extern crate log;

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -70,8 +70,6 @@ journalctl -u bootstrap-containers@bear.service
 ```
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/bork/src/main.rs
+++ b/sources/api/bork/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use rand::{thread_rng, Rng};
 
 fn main() {

--- a/sources/api/certdog/src/main.rs
+++ b/sources/api/certdog/src/main.rs
@@ -4,8 +4,6 @@
   in the API.
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/corndog/src/main.rs
+++ b/sources/api/corndog/src/main.rs
@@ -5,8 +5,6 @@ It sets kernel-related settings, for example:
 * lockdown mode, based on the value of `settings.kernel.lockdown`
 */
 
-#![deny(rust_2018_idioms)]
-
 use log::{debug, error, info, trace, warn};
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::ResultExt;

--- a/sources/api/early-boot-config/src/main.rs
+++ b/sources/api/early-boot-config/src/main.rs
@@ -10,8 +10,6 @@ Currently, Amazon EC2 is supported through the IMDSv1 HTTP API.  Data will be ta
 /etc/early-boot-config instead, if available, for testing purposes.
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -11,8 +11,6 @@ It queries the API for their settings, then configures the system by:
 * ensuring the host container's systemd service is enabled/started or disabled/stopped
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/migration/migration-helpers/src/lib.rs
+++ b/sources/api/migration/migration-helpers/src/lib.rs
@@ -9,8 +9,6 @@
 // locked, and also because migration authors are given an interface for ordering via migration
 // name, and running in parallel would violate that.
 
-#![deny(rust_2018_idioms)]
-
 mod args;
 pub mod common_migrations;
 mod datastore_helper;

--- a/sources/api/migration/migrations/archived/v0.3.2/migrate-admin-container-v0-5-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v0.3.2/migrate-admin-container-v0-5-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v0.4.1/add-version-lock-ignore-waves/src/main.rs
+++ b/sources/api/migration/migrations/archived/v0.4.1/add-version-lock-ignore-waves/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v0.4.1/pivot-repo-2020-07-07/src/main.rs
+++ b/sources/api/migration/migrations/archived/v0.4.1/pivot-repo-2020-07-07/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v0.5.0/add-cluster-domain/src/main.rs
+++ b/sources/api/migration/migrations/archived/v0.5.0/add-cluster-domain/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v0.5.0/migrate-admin-container-v0-5-2/src/main.rs
+++ b/sources/api/migration/migrations/archived/v0.5.0/migrate-admin-container-v0-5-2/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v0.5.0/migrate-control-container-v0-4-1/src/main.rs
+++ b/sources/api/migration/migrations/archived/v0.5.0/migrate-control-container-v0-4-1/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.0/ecr-helper-admin/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.0/ecr-helper-admin/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.0/ecr-helper-control/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.0/ecr-helper-control/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.2/add-enable-spot-instance-draining/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.2/add-enable-spot-instance-draining/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.3/add-sysctl/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.3/add-sysctl/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.5/add-lockdown/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.5/add-lockdown/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.5/add-network-settings/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.5/add-network-settings/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.5/add-proxy-restart/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.5/add-proxy-restart/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.5/add-proxy-services/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.5/add-proxy-services/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.5/add-user-data/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.5/add-user-data/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use std::process;
 

--- a/sources/api/migration/migrations/archived/v1.0.5/sysctl-subcommand/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.5/sysctl-subcommand/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.6/add-shibaken/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.6/add-shibaken/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.6/add-static-pods/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.6/add-static-pods/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.6/admin-container-v0-6-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.6/admin-container-v0-6-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.6/control-container-v0-4-2/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.6/control-container-v0-4-2/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.6/kubelet-standalone-tls-services/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.6/kubelet-standalone-tls-services/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.6/kubelet-standalone-tls-settings/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.6/kubelet-standalone-tls-settings/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.6/metricdog-init/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.6/metricdog-init/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.8/add-bootstrap-containers/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.8/add-bootstrap-containers/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.8/admin-container-v0-7-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.8/admin-container-v0-7-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.8/control-container-v0-5-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.8/control-container-v0-5-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.8/kubelet-eviction-hard/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.8/kubelet-eviction-hard/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.8/kubelet-unsafe-sysctl-kube-reserved/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.8/kubelet-unsafe-sysctl-kube-reserved/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.0.8/proxy-affect-host-containers/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.0.8/proxy-affect-host-containers/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{
     MetadataListReplacement, ReplaceMetadataListsMigration,
 };

--- a/sources/api/migration/migrations/archived/v1.1.0/kubelet-cloud-provider/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.0/kubelet-cloud-provider/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.0/kubelet-event-qps-event-burst/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.0/kubelet-event-qps-event-burst/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.0/kubelet-kube-api-qps-kube-api-burst/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.0/kubelet-kube-api-qps-kube-api-burst/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.0/kubelet-registry-qps-registry-burst/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.0/kubelet-registry-qps-registry-burst/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.0/kubelet-server-tls-bootstrap/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.0/kubelet-server-tls-bootstrap/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.0/schnauzer-paws/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.0/schnauzer-paws/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use std::process;
 

--- a/sources/api/migration/migrations/archived/v1.1.0/shared-containerd-configs/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.0/shared-containerd-configs/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use lazy_static::lazy_static;
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.2/admin-container-v0-7-1/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.2/admin-container-v0-7-1/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.2/control-container-v0-5-1/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.2/control-container-v0-5-1/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.2/kubelet-container-log/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.2/kubelet-container-log/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.2/kubelet-system-reserved/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.2/kubelet-system-reserved/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.1.3/kubelet-cpu-manager-state/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.3/kubelet-cpu-manager-state/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{error, migrate, Migration, MigrationData, Result};
 use snafu::ResultExt;
 use std::fs;

--- a/sources/api/migration/migrations/archived/v1.1.3/kubelet-cpu-manager/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.1.3/kubelet-cpu-manager/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/aws-admin-container-v0-9-2/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/aws-admin-container-v0-9-2/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/aws-control-container-v0-6-3/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/aws-control-container-v0-6-3/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/dns-settings-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/dns-settings-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/dns-settings/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/dns-settings/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/kubelet-log-level/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/kubelet-log-level/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/public-admin-container-v0-9-2/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/public-admin-container-v0-9-2/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/public-control-container-v0-6-3/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/public-control-container-v0-6-3/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.0/reboot-to-reconcile-setting/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.0/reboot-to-reconcile-setting/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.1/container-runtime-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.1/container-runtime-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.10.1/container-runtime/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.10.1/container-runtime/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/aws-admin-container-v0-9-3/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/aws-admin-container-v0-9-3/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/aws-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/aws-config-settings/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/aws-control-container-v0-6-4/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/aws-control-container-v0-6-4/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/aws-creds-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/aws-creds-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/aws-creds/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/aws-creds/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddPrefixesMigration, AddSettingsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/credential-providers/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/credential-providers/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/ecs-additional-configurations/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/ecs-additional-configurations/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/kubelet-new-config-files/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/kubelet-new-config-files/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/kubelet-tls-config/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/kubelet-tls-config/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/kubelet-tls-files/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/kubelet-tls-files/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/public-admin-container-v0-9-3/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/public-admin-container-v0-9-3/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.11.0/public-control-container-v0-6-4/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.11.0/public-control-container-v0-6-4/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.2.0/add-custom-certificates/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.2.0/add-custom-certificates/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.2.0/admin-container-v0-7-2/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.2.0/admin-container-v0-7-2/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.2.0/container-registry-config-restarts/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.2.0/container-registry-config-restarts/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.2.0/container-registry-mirrors/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.2.0/container-registry-mirrors/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.2.0/hostname-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.2.0/hostname-setting-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.2.0/hostname-setting/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.2.0/hostname-setting/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.2.0/kubelet-topology-manager/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.2.0/kubelet-topology-manager/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.3.0/control-container-v0-5-2/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.3.0/control-container-v0-5-2/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.3.0/etc-hosts-service/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.3.0/etc-hosts-service/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.3.0/hostname-affects-etc-hosts/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.3.0/hostname-affects-etc-hosts/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{
     MetadataListReplacement, ReplaceMetadataListsMigration,
 };

--- a/sources/api/migration/migrations/archived/v1.4.0/registry-mirror-representation/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.4.0/registry-mirror-representation/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use serde_json::{Map, Value};
 use std::collections::HashMap;

--- a/sources/api/migration/migrations/archived/v1.4.2/admin-container-v0-7-3/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.4.2/admin-container-v0-7-3/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.4.2/control-container-v0-5-3/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.4.2/control-container-v0-5-3/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.5.0/oci-hooks-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.5.0/oci-hooks-setting-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.5.0/oci-hooks-setting/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.5.0/oci-hooks-setting/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.5.1/control-container-v0-5-4/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.5.1/control-container-v0-5-4/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.5.3/vmware-host-containers/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.5.3/vmware-host-containers/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use std::process;
 

--- a/sources/api/migration/migrations/archived/v1.6.0/aws-admin-container-v0-7-4/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.0/aws-admin-container-v0-7-4/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.6.0/aws-control-container-v0-5-5/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.0/aws-control-container-v0-5-5/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.6.0/node-taints-representation/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.0/node-taints-representation/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{error, migrate, Migration, MigrationData, Result};
 use serde_json::Value;
 use snafu::OptionExt;

--- a/sources/api/migration/migrations/archived/v1.6.0/public-admin-container-v0-7-4/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.0/public-admin-container-v0-7-4/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.6.0/public-control-container-v0-5-5/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.0/public-control-container-v0-5-5/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.6.2/add-cfsignal/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.2/add-cfsignal/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.6.2/container-registry-credentials-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.2/container-registry-credentials-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.6.2/container-registry-credentials/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.6.2/container-registry-credentials/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.7.0/aws-admin-container-v0-8-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.7.0/aws-admin-container-v0-8-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.7.0/aws-control-container-v0-6-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.7.0/aws-control-container-v0-6-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.7.0/public-admin-container-v0-8-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.7.0/public-admin-container-v0-8-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.7.0/public-control-container-v0-6-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.7.0/public-control-container-v0-6-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/add-autoscaling/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/add-autoscaling/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/add-pull-behavior/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/add-pull-behavior/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/aws-admin-container-v0-9-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/aws-admin-container-v0-9-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/aws-control-container-v0-6-1/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/aws-control-container-v0-6-1/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/boot-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/boot-setting-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/boot-setting/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/boot-setting/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/cluster-dns-ip-list/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/cluster-dns-ip-list/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use std::process;
 

--- a/sources/api/migration/migrations/archived/v1.8.0/etc-hosts-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/etc-hosts-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/etc-hosts/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/etc-hosts/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/kubelet-pod-pids-limit/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/kubelet-pod-pids-limit/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/kubelet-provider-id/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/kubelet-provider-id/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/pki-affected-services/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/pki-affected-services/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{
     MetadataListReplacement, ReplaceMetadataListsMigration,
 };

--- a/sources/api/migration/migrations/archived/v1.8.0/public-admin-container-v0-9-0/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/public-admin-container-v0-9-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.8.0/public-control-container-v0-6-1/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.8.0/public-control-container-v0-6-1/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.9.0/image-gc-thresholds/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/image-gc-thresholds/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddSettingsMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.9.0/kernel-modules-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/kernel-modules-setting-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.9.0/kernel-modules-setting/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/kernel-modules-setting/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::AddPrefixesMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.9.0/kubelet-no-daemon-reload/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/kubelet-no-daemon-reload/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.9.0/ntp-affected-services/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/ntp-affected-services/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{
     MetadataListReplacement, ReplaceMetadataListsMigration,
 };

--- a/sources/api/migration/migrations/archived/v1.9.0/shibaken-admin-userdata-semantics/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/shibaken-admin-userdata-semantics/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{MetadataReplacement, ReplaceMetadataMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.9.0/shibaken-send-metrics/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/shibaken-send-metrics/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/archived/v1.9.0/updates-targets-base-url/src/main.rs
+++ b/sources/api/migration/migrations/archived/v1.9.0/updates-targets-base-url/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddMetadataMigration, NoOpMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceTemplateMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::{migrate, Migration, MigrationData, Result};
 use std::process;
 

--- a/sources/api/migration/migrations/v1.12.0/oci-defaults-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/oci-defaults-setting-metadata/src/main.rs
@@ -1,4 +1,3 @@
-#![deny(rust_2018_idioms)]
 use migration_helpers::common_migrations::{AddMetadataMigration, NoOpMigration, SettingMetadata};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/oci-defaults-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/oci-defaults-setting/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrations/v1.13.0/k8s-registry/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.0/k8s-registry/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use migration_helpers::common_migrations::ReplaceStringMigration;
 use migration_helpers::{migrate, Result};
 use std::process;

--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -18,8 +18,6 @@
 //! To understand motivation and more about the overall process, look at the migration system
 //! documentation, one level up.
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -26,8 +26,6 @@ supplementing any missing settings with DNS settings from the primary interface'
 is meant to be used as a restart command for DNS API settings.
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate serde_plain;
 

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 /*!
 # Introduction
 

--- a/sources/api/prairiedog/src/main.rs
+++ b/sources/api/prairiedog/src/main.rs
@@ -10,8 +10,6 @@ It does the following:
 
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/schnauzer/src/main.rs
+++ b/sources/api/schnauzer/src/main.rs
@@ -13,8 +13,6 @@ If the returned value is "baz", our generated value will be "foo-baz".
 (The name "schnauzer" comes from the fact that Schnauzers are search and rescue dogs (similar to this search and replace task) and because they have mustaches.)
 */
 
-#![deny(rust_2018_idioms)]
-
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::string::String;

--- a/sources/api/settings-committer/src/main.rs
+++ b/sources/api/settings-committer/src/main.rs
@@ -8,8 +8,6 @@ By default, it commits the 'bottlerocket-launch' transaction, which is used to o
 
 The `--transaction` argument can be used to specify another transaction.
 */
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -13,8 +13,6 @@ shibaken can:
 (The name "shibaken" comes from the fact that Shiba are small, but agile, hunting dogs.)
 */
 
-#![deny(rust_2018_idioms)]
-
 use argh::FromArgs;
 use simplelog::{ColorChoice, Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
 use snafu::ResultExt;

--- a/sources/api/static-pods/src/main.rs
+++ b/sources/api/static-pods/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 #[cfg(variant_runtime = "k8s")]
 mod static_pods;
 #[cfg(variant_runtime = "k8s")]

--- a/sources/api/storewolf/src/lib.rs
+++ b/sources/api/storewolf/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use bottlerocket_release::BottlerocketRelease;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -6,8 +6,6 @@ storewolf creates the filesystem datastore used by the API system.
 It creates the datastore at a provided path and populates any default settings, as given in the
 TOML files of the current variant's `defaults.d` directory, unless the datastore already exists.
 */
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/sundog/src/main.rs
+++ b/sources/api/sundog/src/main.rs
@@ -7,8 +7,6 @@ It requests settings generators from the API and runs them.
 The output is collected and sent to a known Bottlerocket API server endpoint.
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/api/thar-be-settings/src/lib.rs
+++ b/sources/api/thar-be-settings/src/lib.rs
@@ -14,8 +14,6 @@ Service data from the API includes any commands needed to restart services affec
 In the standalone ("all keys") mode, it queries the API for all services and configuration files, then renders and rewrites all configuration files and restarts all services.
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/cfsignal/src/main.rs
+++ b/sources/cfsignal/src/main.rs
@@ -1,4 +1,4 @@
-#![deny(rust_2018_idioms, unused_imports)]
+#![deny(unused_imports)]
 
 /*!
 ## Introduction
@@ -16,8 +16,6 @@ Configuration is read from a TOML file, which is generated from Bottlerocket set
 * `stack_name`: Name of the CFN stack to signal.
 * `logical_resource_id`: The logical ID of the AutoScalingGroup resource that you want to signal.
 */
-
-#![deny(rust_2018_idioms)]
 
 mod cloudformation;
 mod config;

--- a/sources/driverdog/src/main.rs
+++ b/sources/driverdog/src/main.rs
@@ -7,8 +7,6 @@ driverdog is a tool to link kernel modules at runtime. It uses a toml configurat
 `kernel-modules`: hash with the kernel modules to be linked, each kernel module in the map should include the files used to link it
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -17,8 +17,6 @@ will create an IMDSv2 session _(if one does not already exist)_ and send a reque
 The result is returned as a `String` _(ex. m5.large)_.
 */
 
-#![deny(rust_2018_idioms)]
-
 use std::sync::RwLock;
 
 use http::StatusCode;

--- a/sources/logdog/src/main.rs
+++ b/sources/logdog/src/main.rs
@@ -22,8 +22,6 @@ based on the value of the `VARIANT` environment variable at build time.
 
 */
 
-#![deny(rust_2018_idioms)]
-
 mod create_tarball;
 mod error;
 mod log_request;

--- a/sources/metricdog/src/main.rs
+++ b/sources/metricdog/src/main.rs
@@ -1,4 +1,4 @@
-#![deny(rust_2018_idioms, unused_imports)]
+#![deny(unused_imports)]
 
 /*!
 # Introduction
@@ -56,8 +56,6 @@ version_lock = "latest"
 ignore_waves = false
 ```
 */
-
-#![deny(rust_2018_idioms)]
 
 mod args;
 mod config;

--- a/sources/shimpei/src/main.rs
+++ b/sources/shimpei/src/main.rs
@@ -4,8 +4,6 @@
   parameters that can't be provided by containerd.
 */
 
-#![deny(rust_2018_idioms)]
-
 #[macro_use]
 extern crate log;
 

--- a/sources/updater/block-party/src/lib.rs
+++ b/sources/updater/block-party/src/lib.rs
@@ -6,7 +6,7 @@
 //! * Getting a numbered partition on a disk
 //! * Getting the devices that are combined as a block device, e.g. a dm-verity device
 
-#![deny(missing_docs, rust_2018_idioms)]
+#![deny(missing_docs)]
 
 use snafu::{ensure, OptionExt, ResultExt};
 use std::ffi::OsString;

--- a/sources/updater/signpost/src/main.rs
+++ b/sources/updater/signpost/src/main.rs
@@ -1,4 +1,3 @@
-#![deny(rust_2018_idioms)]
 #![warn(clippy::pedantic)]
 
 use serde::Deserialize;

--- a/sources/updater/updog/src/bin/updata.rs
+++ b/sources/updater/updog/src/bin/updata.rs
@@ -1,4 +1,3 @@
-#![deny(rust_2018_idioms)]
 #![warn(clippy::pedantic)]
 
 #[path = "../error.rs"]

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -1,4 +1,3 @@
-#![deny(rust_2018_idioms)]
 #![warn(clippy::pedantic)]
 
 mod error;

--- a/tools/pubsys-setup/src/main.rs
+++ b/tools/pubsys-setup/src/main.rs
@@ -4,8 +4,6 @@ the repos you use to update them.  Specifically, it can create a new key and rol
 existing role.
 */
 
-#![deny(rust_2018_idioms)]
-
 use log::{debug, info, trace, warn};
 use pubsys_config::InfraConfig;
 use sha2::{Digest, Sha512};

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -21,8 +21,6 @@ Configuration comes from:
 * Policy files for repo metadata expiration and update wave timing
 */
 
-#![deny(rust_2018_idioms)]
-
 mod aws;
 mod repo;
 mod vmware;


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The `#![deny(rust_2018_idioms)]` tag was used to help [move from Rust 2015 style code to 2018](https://doc.rust-lang.org/rustc/lints/groups.html). We've already moved beyond that and clippy flags much more than that. Since these are now useless, this cleans up all instances in the code where we were using this tag.

**Testing done:**

Ran `cargo make check` to run lints and unit tests.
Created an `aws-k8s-1.24` image, deployed cluster, and verified everything came up fine and able to deploy a test workload.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
