### PR TITLE
TESTING.md: Fixes missing trailing backslash on `ami` commands

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -205,7 +205,7 @@ cargo make \
 cargo make \
   -e BUILDSYS_VARIANT="aws-k8s-1.21" \
   -e BUILDSYS_ARCH="x86_64" \
-  -e PUBLISH_REGIONS="us-west-2"
+  -e PUBLISH_REGIONS="us-west-2" \
   ami
 
 cargo make \
@@ -234,7 +234,7 @@ cargo make \
 cargo make \
   -e BUILDSYS_VARIANT="aws-ecs-1" \
   -e BUILDSYS_ARCH="x86_64" \
-  -e PUBLISH_REGIONS="us-west-2"
+  -e PUBLISH_REGIONS="us-west-2" \
   ami
 
 cargo make \


### PR DESCRIPTION
**Issue number:**

Closes: N/a - found this while I was reading through `TESTING.md`

**Description of changes:**

Adds missing backslashes to the `ami` commands.

**Testing done:**

Able to copy and paste commands now without problem!

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
