### PR TITLE
host-ctr: PID namespace tracking via bind-mounted manifest file

### DIFF
--- a/packages/os/host-containers-tmpfiles.conf
+++ b/packages/os/host-containers-tmpfiles.conf
@@ -1,3 +1,4 @@
 d /etc/host-containers 0750 root root -
+d /etc/host-ctr-namespaces 0750 root root -
 d /local/host-containers 0700 root root -
 T /local/host-containers - - - - security.selinux=system_u:object_r:secret_t:s0

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -840,6 +840,12 @@ func withPrivilegedMounts() oci.SpecOpts {
 			Source:      "/mnt",
 			Type:        "bind",
 		},
+		{
+			Options:     []string{"rbind", "ro"},
+			Destination: "/.bottlerocket/host-ctr-namespaces",
+			Source:      "/etc/host-ctr-namespaces",
+			Type:        "bind",
+		},
 	})
 }
 

--- a/sources/host-ctr/go.mod
+++ b/sources/host-ctr/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.176
 	github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20221221205310-1903c4ed45d1
 	github.com/containerd/containerd v1.6.15
+	github.com/gofrs/flock v0.8.1
 	github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1

--- a/sources/host-ctr/go.sum
+++ b/sources/host-ctr/go.sum
@@ -437,6 +437,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=

--- a/sources/host-ctr/pidnamespaces/pid_namespaces.go
+++ b/sources/host-ctr/pidnamespaces/pid_namespaces.go
@@ -1,0 +1,166 @@
+package pidnamespaces
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	lockfile     string = "/run/lock/host-ctr-pid-ns.lock"
+	manifestPath string = "/etc/host-ctr-namespaces/pid-namespaces.json"
+)
+
+// HostCtrPidNs represents the list of PID namespaces
+type HostCtrPidNs struct {
+	PidNamespaces []int64 `json:"pid-namespaces,omitempty"`
+}
+
+// GetTaskPidNs returns the PID NS associated with the container task PID or error on failure
+func GetTaskPidNs(pid uint32) (int64, error) {
+	pidNsFile, err := os.Open(fmt.Sprintf("/proc/%d/ns/pid", pid))
+	if err != nil {
+		return -1, fmt.Errorf("failed to open %d PID namespace file", pid)
+	}
+	pidNsFd := int(pidNsFile.Fd())
+
+	// Get file descriptor that refers to a parent namespace, ioctl() request '_IO(NSIO, 0x2)'
+	parentPidNsFd, err := unix.IoctlRetInt(pidNsFd, unix.NS_GET_PARENT)
+	if parentPidNsFd == -1 && err == unix.EPERM {
+		// If we can't access the parent PID namespace, this means the current container task is sharing the root PID
+		// namespace. We don't want to track the root PID namespace in the manifest, so we return -1.
+		return -1, err
+	} else if err != nil {
+		return -1, errors.Wrap(err, fmt.Sprintf("ioctl failed to 'NS_GET_PARENTNS' for '%s'", pidNsFile.Name()))
+	}
+
+	// The PID namespace is represented by the inode number of the task's PID namespace file
+	var sb unix.Stat_t
+	if err := unix.Fstat(pidNsFd, &sb); err != nil {
+		return -1, errors.Wrap(err, "failed to stat task PID namespace fd")
+	}
+
+	return int64(sb.Ino), nil
+}
+
+// AddPidNsToManifest takes a given PID's namespace and adds it to the internal manifest
+func AddPidNsToManifest(pidNs int64) (err error) {
+	fileLock := flock.New(lockfile)
+	lockCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ok, err := fileLock.TryLockContext(lockCtx, 500*time.Millisecond)
+	if err != nil && !ok {
+		return errors.Wrap(err, "acquiring lock for writing to PID NS manifest failed with error")
+	}
+	defer func() {
+		if err = fileLock.Unlock(); err != nil {
+			err = errors.Wrap(err, "failed to release lock for writing to PID NS manifest")
+		}
+	}()
+
+	// Add task PID NS to manifest
+	hostCtrPidNs, err := readManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+	for _, ele := range hostCtrPidNs.PidNamespaces {
+		// If it already exists in the manifest list for whatever reason, we can just return without doing anything.
+		if ele == pidNs {
+			return nil
+		}
+	}
+	hostCtrPidNs.PidNamespaces = append(hostCtrPidNs.PidNamespaces, pidNs)
+	if err = writeManifest(&hostCtrPidNs, manifestPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemovePidNsFromManifest takes a PID's namespace and removes it from the internal manifest
+func RemovePidNsFromManifest(pidNs int64) (err error) {
+	fileLock := flock.New(lockfile)
+	lockCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ok, err := fileLock.TryLockContext(lockCtx, 500*time.Millisecond)
+	if err != nil && !ok {
+		return errors.Wrap(err, "acquiring lock for writing to PID NS manifest failed with error")
+	}
+	defer func() {
+		if err = fileLock.Unlock(); err != nil {
+			err = errors.Wrap(err, "failed to release lock for writing to PID NS manifest")
+		}
+	}()
+
+	// Remove task PID NS from manifest
+	hostCtrPidNs, err := readManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	for i, ele := range hostCtrPidNs.PidNamespaces {
+		// Remove PID NS from list
+		if ele == pidNs {
+			hostCtrPidNs.PidNamespaces = append(hostCtrPidNs.PidNamespaces[:i], hostCtrPidNs.PidNamespaces[i+1:]...)
+		}
+	}
+	if err = writeManifest(&hostCtrPidNs, manifestPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readManifest(manifestPath string) (HostCtrPidNs, error) {
+	manifest, err := os.OpenFile(manifestPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return HostCtrPidNs{}, errors.Wrap(err, "failed to open PID NS manifest file")
+	}
+	defer manifest.Close()
+
+	manifestStat, err := manifest.Stat()
+	if err != nil {
+		return HostCtrPidNs{}, errors.Wrap(err, "failed to stat PID NS manifest file")
+	}
+	raw := make([]byte, manifestStat.Size())
+	if _, err = manifest.Read(raw); err != nil {
+		return HostCtrPidNs{}, errors.Wrap(err, "failed to read PID NS manifest file")
+	}
+	hostCtrPidNsList := HostCtrPidNs{}
+	if len(raw) != 0 {
+		err = json.Unmarshal(raw, &hostCtrPidNsList)
+		if err != nil {
+			return HostCtrPidNs{}, errors.Wrap(err, "failed to unmarshal PID NS manifest")
+		}
+	}
+	return hostCtrPidNsList, nil
+}
+
+// writeManifest writes the list of host-container PID NS to the open manifest file
+func writeManifest(hostCtrPidNsList *HostCtrPidNs, manifestPath string) error {
+	newData, err := json.Marshal(*hostCtrPidNsList)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal PID NS list to JSON")
+	}
+	tempFile, err := os.CreateTemp(filepath.Dir(manifestPath), "temp-pidns-*.json")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temporary PID NS file")
+	}
+	defer tempFile.Close()
+
+	if _, err = tempFile.Write(newData); err != nil {
+		return errors.Wrap(err, "failed to write to temporary PID NS file")
+	}
+
+	// Persist the temporary PID NS file to the PID NS manifest path to ensure atomicity
+	if err = os.Rename(tempFile.Name(), manifestPath); err != nil {
+		return errors.Wrap(err, "failed to persist temporary PID NS file to manifest path")
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Resolves https://github.com/bottlerocket-os/bottlerocket/issues/2796

**Description of changes:**

```
    host-ctr: add host containers information bind mount
    
    Superpowered host-containers now has a bind mount containing all
    host-container information (e.g. PID namespaces).

```
```

    host-ctr: container task PID NS tracking
    
    Create a manifest file that stores the PID namespace of all
    non-superpowered host-containers.

```

I was debating whether to have `host-ctr` sync the PID namespace "manifest" with the all of `host-containerd` daemon's container tasks every time it's invoked or just have `host-ctr` only update the "manifest" for the container task it's responsible for. I eventually settled for the latter since for me it was simpler to reason about in terms of concurrency and it adheres to the model of how `host-ctr` works so far, e.g. the `host-ctr` process for the `admin` container only deals with the `admin` container and does not interfere or gather information about other containers.

I don't feel too strongly about this, so if people want to have `host-ctr` sync for every container running in `host-containerd` then I can change it pretty easily.

**Testing done:**
From a fresh host's admin container, the control container is running.
You can check the list of host-containers PID namespaces via `/.bottlerocket/host-containers/info/pid-namespaces.json` in a superpowered host-container (e.g. admin):
```
[root@admin]# cat /.bottlerocket/host-containers/info/pid-namespaces.json                                                                        
{
  "pid-namespaces": [
    4026532532
  ]
[root@admin]# lsns | grep 4026532532                                                                                                             
4026532532 pid         6  1591 root /usr/bin/amazon-ssm-agent
                                                                 
```
After enabling a nginx host-container, I see the manifest gets populated with the nginx PID namespace inode number:
```
[root@admin]# apiclient set --json '{"host-containers": {"nginx":{"enabled":true, "source":"docker.io/library/nginx:latest"}}}' 
[root@admin]# cat /.bottlerocket/host-containers/info/pid-namespaces.json                                                       
{
  "pid-namespaces": [
    4026532532,
    4026532677
  ]
}
[root@admin]# lsns | grep 4026532677                                                                                            
4026532677 pid         3  7038 root nginx: master process nginx -g daemon off;
```
Then I disabled the nginx host container and observed the manifest gets updated accordingly:
```
[root@admin]# apiclient set --json '{"host-containers": {"nginx":{"enabled":false, "source":"docker.io/library/nginx:latest"}}}'
[root@admin]# cat /.bottlerocket/host-containers/info/pid-namespaces.json                                                       
{
  "pid-namespaces": [
    4026532532
  ]
}
```

Now I try the nginx again, but this time making it super-powered:
```
[root@admin]# apiclient set --json '{"host-containers": {"nginx":{"enabled":true, "superpowered":true, "source":"docker.io/library/nginx:latest"}}}'
[root@admin]# cat /.bottlerocket/host-containers/info/pid-namespaces.json                                                                           
{
  "pid-namespaces": [
    4026532532
  ]
}
```
It's PID NS is not tracked since it's shared with the root PID namespace. This is expected.
Nginx is confirmed running:
```
[root@admin]# curl localhost:80
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```
Cleaning it up:
```
[root@admin]# apiclient set --json '{"host-containers": {"nginx":{"enabled":false, "superpowered":true, "source":"docker.io/library/nginx:latest"}}}'
[root@admin]# curl localhost:80                                                                                                                      
curl: (7) Failed to connect to localhost port 80 after 0 ms: Connection refused
[root@admin]# cat /.bottlerocket/host-containers/info/pid-namespaces.json                                                                            
{
  "pid-namespaces": [
    4026532532
  ]
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
