### PR TITLE
packages: Update cni and cni-plugin packages

### DIFF
--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/containernetworking/plugins/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/plugins/archive/v0.9.1/plugins-0.9.1.tar.gz"
-sha512 = "24e8fcedbff2ae7a83aa96085b546b164de6a0884d593e3b5386e9d2de3c4d9a215db9e9405332020cc45c371709a32b600e263e4f8dee62c51adafdc0180f24"
+url = "https://github.com/containernetworking/plugins/archive/v1.2.0/plugins-1.2.0.tar.gz"
+sha512 = "fb6fb4f46ac1610b3721f5f3a6ddfb096cbf2e5d5b792306edca5351a3944d2f802170d83e5adec01420395bf64fc8a174ede61ac9b93b5ac6b938a4b48651e6"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 %global gorepo plugins
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.9.1
+%global gover 1.2.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -45,8 +45,8 @@ install -p -m 0755 bin/* %{buildroot}%{_cross_libexecdir}/cni/bin
 %{_cross_libexecdir}/cni/bin/bandwidth
 %{_cross_libexecdir}/cni/bin/bridge
 %{_cross_libexecdir}/cni/bin/dhcp
+%{_cross_libexecdir}/cni/bin/dummy
 %{_cross_libexecdir}/cni/bin/firewall
-%{_cross_libexecdir}/cni/bin/flannel
 %{_cross_libexecdir}/cni/bin/host-device
 %{_cross_libexecdir}/cni/bin/host-local
 %{_cross_libexecdir}/cni/bin/ipvlan

--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -12,8 +12,9 @@ path = "pkg.rs"
 releases-url = "https://github.com/containernetworking/cni/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/cni/archive/v0.8.1/cni-0.8.1.tar.gz"
-sha512 = "b869e76806c6e259743715831ddf5754a56e79fa7f25435e54e3f0648700e473e5778630e592f5c5d181058e74c7542aeac5c4f3d8cd26b83f7758bb186f43e9"
+url = "https://github.com/containernetworking/cni/archive/v1.1.2/cni-1.1.2.tar.gz"
+sha512 = "dc4795fb03b8dc9d116692e0dd0feb1b57a481ed7414c8dc376a892725b0b3d9dd8b04b2be09073b95c8c9eec2c0165d0353f6be643647f4c4de0114b9dd5930"
+bundle-modules = [ "go" ]
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -2,7 +2,7 @@
 %global gorepo cni
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.8.1
+%global gover 1.1.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -14,6 +14,7 @@ Summary: Plugins for container networking
 License: Apache-2.0
 URL: https://%{goimport}
 Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
+Source1: bundled-%{gorepo}-%{gover}.tar.gz
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}iptables
@@ -22,20 +23,24 @@ Requires: %{_cross_os}iptables
 %{summary}.
 
 %prep
-%autosetup -Sgit -n %{gorepo}-%{gover} -p1
-%cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
+%setup -n %{gorepo}-%{gover} -q
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build
-%cross_go_configure %{goimport}
+%set_cross_go_flags
+
 go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o "bin/cnitool" %{goimport}/cnitool
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin
 install -p -m 0755 bin/cnitool %{buildroot}%{_cross_libexecdir}/cni/bin
 
+%cross_scan_attribution go-vendor vendor
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
 %{_cross_libexecdir}/cni/bin/cnitool
 
 %changelog


### PR DESCRIPTION
**Issue number:**

Closes: #1745

**Description of changes:**

This updates the `cni` and `cni-plugin` packages in Bottlerocket.

Most of the time, the CNI plugins that are used are actually pulled down via EKS. There are some CNIs, and perhaps metal and vmware variants, where they need to use the locally installed CNI binaries. This gets those local binaries up to date with the binaries that end up getting pulled from EKS.

The `flannel` CNI plugin was deprecated and has since been removed. The `dummy` plugin has been introduced and can be used when chained with other CNIs for local routing.

**Testing done:**

Testing in progress:

- [x] Build and test `aws-k8s-1.24` for basic functionality
- [x] Deploy `aws-k8s-*` variant and verify a more complex CNI like Cilium is functional

```
$ cilium connectivity test
........

✅ All 32 tests (228 actions) successful, 0 tests skipped, 1 scenarios skipped.
```

```
$ kubectl get pods -n kube-system
NAME                              READY   STATUS    RESTARTS   AGE
cilium-jr94q                      1/1     Running   0          30m
cilium-operator-fc8765957-j4xfb   1/1     Running   0          35m
cilium-operator-fc8765957-xnj2x   1/1     Running   0          35m
cilium-qdjqp                      1/1     Running   0          30m
coredns-5c5677bc78-cvwmh          1/1     Running   0          43m
coredns-5c5677bc78-l9zfh          1/1     Running   0          43m
kube-proxy-cbhn2                  1/1     Running   0          30m
kube-proxy-n8qgr                  1/1     Running   0          30m
```

```
$ cilium status
    /¯¯\
 /¯¯\__/¯¯\    Cilium:          OK
 \__/¯¯\__/    Operator:        OK
 /¯¯\__/¯¯\    Hubble Relay:    disabled
 \__/¯¯\__/    ClusterMesh:     disabled
    \__/

Deployment        cilium-operator    Desired: 2, Ready: 2/2, Available: 2/2
DaemonSet         cilium             Desired: 2, Ready: 2/2, Available: 2/2
Containers:       cilium             Running: 2
                  cilium-operator    Running: 2
Cluster Pods:     6/6 managed by Cilium
Image versions    cilium             quay.io/cilium/cilium:v1.13.0@sha256:6544a3441b086a2e09005d3e21d1a4afb216fae19c5a60b35793c8a9438f8f68: 2
                  cilium-operator    quay.io/cilium/operator-aws:v1.13.0@sha256:3cc9ff5bcc57f536427e7059abc916831b368654dfddcbad8a412731984a95e4: 2
```

- [x] `vmware-k8s-1.24` with cilium

```
$ kubectl --kubeconfig br-eksa-124-eks-a-cluster.kubeconfig get all -A
NAMESPACE                           NAME                                                                 READY   STATUS    RESTARTS        AGE
capi-kubeadm-bootstrap-system       pod/capi-kubeadm-bootstrap-controller-manager-6b5b855b54-d72ll       1/1     Running   0               3m49s
capi-kubeadm-control-plane-system   pod/capi-kubeadm-control-plane-controller-manager-79cc69f86c-hcmzd   1/1     Running   0               3m32s
capi-system                         pod/capi-controller-manager-7f84fc79cc-ppzt7                         1/1     Running   0               3m53s
capv-system                         pod/capv-controller-manager-df774d599-qxcvn                          1/1     Running   0               3m27s
cert-manager                        pod/cert-manager-76c4fc967-7wmxv                                     1/1     Running   0               4m9s
cert-manager                        pod/cert-manager-cainjector-5bbdf98444-rgmj4                         1/1     Running   0               4m9s
cert-manager                        pod/cert-manager-webhook-5b966777df-24tqf                            1/1     Running   0               4m9s
eksa-packages                       pod/eks-anywhere-packages-99446dc64-wndjn                            1/1     Running   0               85s
eksa-system                         pod/eksa-controller-manager-6b969b586b-s8qgz                         1/1     Running   0               116s
etcdadm-bootstrap-provider-system   pod/etcdadm-bootstrap-provider-controller-manager-bf77c4666-n9czg    1/1     Running   0               3m39s
etcdadm-controller-system           pod/etcdadm-controller-controller-manager-6dbb4b78-4xfmt             1/1     Running   0               3m36s
kube-system                         pod/cilium-ck4b4                                                     1/1     Running   0               4m53s
kube-system                         pod/cilium-nxcl4                                                     1/1     Running   0               5m45s
kube-system                         pod/cilium-operator-6c8bfc95dd-5x448                                 1/1     Running   0               5m45s
kube-system                         pod/cilium-operator-6c8bfc95dd-blwkr                                 1/1     Running   0               5m45s
kube-system                         pod/cilium-rnvzd                                                     1/1     Running   0               5m2s
kube-system                         pod/cilium-w7ndl                                                     1/1     Running   0               4m50s
kube-system                         pod/coredns-745b844d56-68lzl                                         1/1     Running   0               5m54s
kube-system                         pod/coredns-745b844d56-rc4xj                                         1/1     Running   0               5m54s
kube-system                         pod/kube-apiserver-198.19.131.134                                    1/1     Running   0               6m10s
kube-system                         pod/kube-apiserver-198.19.16.112                                     1/1     Running   0               4m43s
kube-system                         pod/kube-controller-manager-198.19.131.134                           1/1     Running   0               6m10s
kube-system                         pod/kube-controller-manager-198.19.16.112                            1/1     Running   0               4m43s
kube-system                         pod/kube-proxy-24kx2                                                 1/1     Running   0               4m50s
kube-system                         pod/kube-proxy-hwdcp                                                 1/1     Running   0               4m53s
kube-system                         pod/kube-proxy-ppwzx                                                 1/1     Running   0               5m54s
kube-system                         pod/kube-proxy-q64mk                                                 1/1     Running   0               5m2s
kube-system                         pod/kube-scheduler-198.19.131.134                                    1/1     Running   0               6m10s
kube-system                         pod/kube-scheduler-198.19.16.112                                     1/1     Running   0               4m42s
kube-system                         pod/kube-vip-198.19.131.134                                          1/1     Running   0               6m10s
kube-system                         pod/kube-vip-198.19.16.112                                           1/1     Running   0               4m42s
kube-system                         pod/vsphere-cloud-controller-manager-2cgxx                           1/1     Running   1 (4m14s ago)   4m50s
kube-system                         pod/vsphere-cloud-controller-manager-dq8xc                           1/1     Running   1 (4m17s ago)   4m53s
kube-system                         pod/vsphere-cloud-controller-manager-pwbjc                           1/1     Running   0               5m49s
kube-system                         pod/vsphere-cloud-controller-manager-sqjf9                           1/1     Running   1 (4m25s ago)   5m2s
kube-system                         pod/vsphere-csi-controller-7446c59556-87hj4                          5/5     Running   0               5m49s
kube-system                         pod/vsphere-csi-node-7hdfv                                           3/3     Running   0               5m2s
kube-system                         pod/vsphere-csi-node-7z8dv                                           3/3     Running   0               4m53s
kube-system                         pod/vsphere-csi-node-9vv8q                                           3/3     Running   0               4m50s
kube-system                         pod/vsphere-csi-node-c2bhx                                           3/3     Running   0               5m50s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
