### PR TITLE
buildsys, systemd: add unified-cgroup-hierarchy image feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ ARG VARIANT_FLAVOR
 ARG REPO
 ARG GRUB_SET_PRIVATE_VAR
 ARG SYSTEMD_NETWORKD
+ARG UNIFIED_CGROUP_HIERARCHY
 ENV SYSTEMD_NETWORKD=${SYSTEMD_NETWORKD}
 ENV VARIANT=${VARIANT}
 WORKDIR /home/builder
@@ -102,6 +103,7 @@ RUN rpmdev-setuptree \
    && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> .bconds \
    && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> .bconds \
    && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> .bconds \
+   && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> .bconds \
    && cat .bconds ${PACKAGE}.spec >> rpmbuild/SPECS/${PACKAGE}.spec \
    && find . -maxdepth 1 -not -path '*/\.*' -type f -exec mv {} rpmbuild/SOURCES/ \; \
    && echo ${NOCACHE}

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -10,6 +10,7 @@ path = "pkg.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/systemd/systemd-stable/releases"
+package-features = ["unified-cgroup-hierarchy"]
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/systemd/systemd-stable/archive/v250.9/systemd-stable-250.9.tar.gz"

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -176,7 +176,11 @@ CONFIGURE_OPTS=(
  -Dpkgconfigdatadir='%{_cross_pkgconfigdir}'
  -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
 
+ %if %{with unified_cgroup_hierarchy}
+ -Ddefault-hierarchy=unified
+ %else
  -Ddefault-hierarchy=hybrid
+ %endif
 
  -Dadm-group=false
  -Dwheel-group=false

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -204,6 +204,16 @@ flag is meant primarily for development, and will be removed when development ha
 [package.metadata.build-variant.image-features]
 systemd-networkd = true
 ```
+
+`unified-cgroup-hierarchy` makes systemd set up a unified cgroup hierarchy on
+boot, i.e. the host will use cgroup v2 by default. This feature flag allows
+old variants to continue booting with cgroup v1 and new variants to move to
+cgroup v2, while users will still be able to override the default via command
+line arguments set in the boot configuration.
+```
+[package.metadata.build-variant.image-features]
+unified-cgroup-hierarchy = true
+```
 */
 
 mod error;
@@ -494,6 +504,7 @@ impl SupportedArch {
 pub enum ImageFeature {
     GrubSetPrivateVar,
     SystemdNetworkd,
+    UnifiedCgroupHierarchy,
 }
 
 impl TryFrom<String> for ImageFeature {
@@ -502,6 +513,7 @@ impl TryFrom<String> for ImageFeature {
         match s.as_str() {
             "grub-set-private-var" => Ok(ImageFeature::GrubSetPrivateVar),
             "systemd-networkd" => Ok(ImageFeature::SystemdNetworkd),
+            "unified-cgroup-hierarchy" => Ok(ImageFeature::UnifiedCgroupHierarchy),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -512,6 +524,7 @@ impl fmt::Display for ImageFeature {
         match self {
             ImageFeature::GrubSetPrivateVar => write!(f, "GRUB_SET_PRIVATE_VAR"),
             ImageFeature::SystemdNetworkd => write!(f, "SYSTEMD_NETWORKD"),
+            ImageFeature::UnifiedCgroupHierarchy => write!(f, "UNIFIED_CGROUP_HIERARCHY"),
         }
     }
 }


### PR DESCRIPTION
**Issue number:**

#2843 

**Description of changes:**

Add a new image feature toggle `unified-cgroup-hierarchy`. The image feature allows variants to select either cgroup v1 or cgroup v2 (the "unified cgroup hierarchy") as the default for systemd to set up during host boot.

The image feature changes how systemd is configured at build time. This results in slightly differing builds of systemd depending on variants' selected image features. Users can still override the default choice via a command line argument (`systemd.unified_cgroup_hierarchy=[01]`) supplied via the user data and boot config mechanisms.

Alternatively, the default cgroup version to use could be selected by baking a command line argument into the image. However, this would present a liability since GRUB and its configuration are not being updated during image updates, and some hosts would be stuck with it forever. Whether a user could override this setting via their own command line arguments would come down to parsing logic handles duplicate settings and seems brittle, especially when trying to provide guarantees "forever".


**Testing done:**

* [x] Modified `variants/metal-dev/Cargo.toml` to carry `unified-cgroup-hierarchy = true` in the `package.metadata.build-variant.image-features]` section
* [x] Built the `metal-dev` variant
* [x] Confirmed the image booted with a cgroup v2 hierarchy by checking `mount | grep cgroup` output and only finding a single `cgroup2` mount
* [x] Rebuilt the `metal-dev` variant to confirm the systemd build is cached if the image feature flag doesn't change
* [x] Built the (unchanged) `aws-dev` variant to confirm systemd and dependent packages get rebuilt if the image feature flag changes

**Reviewer notes:**

This does not yet make any variant actually default to cgroup v2, but only provides the means to do so. This is still pending version 0.10.0 of the admin container getting deployed, which carries changes to make it work on cgroup v2 hosts.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
