### PR TITLE
Makefile: use SDK for Rust formatting

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -470,7 +470,6 @@ if ! docker run --rm \
    -e CARGO_HOME="/tmp/.cargo" \
    -v "${CARGO_HOME}":/tmp/.cargo \
    -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
-   -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
    -e VARIANT \
    "${BUILDSYS_SDK_IMAGE}" \
    cargo clippy \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -401,16 +401,29 @@ for m in ${GO_MODULES}; do
 done
 
 # For rust first-party source code
-if ! cargo fmt \
-  --manifest-path ${BUILDSYS_SOURCES_DIR}/Cargo.toml \
+if ! docker run --rm \
+   -u $(id -u):$(id -g) \
+   -e CARGO_HOME="/tmp/.cargo" \
+   -v "${CARGO_HOME}":/tmp/.cargo \
+   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
+   "${BUILDSYS_SDK_IMAGE}" \
+   cargo fmt \
+  --manifest-path /tmp/sources/Cargo.toml \
   --message-format short \
   --all \
   -- --check; then
   rc=1
 fi
 
-if ! cargo fmt \
-  --manifest-path ${BUILDSYS_TOOLS_DIR}/Cargo.toml \
+if ! docker run --rm \
+   -u $(id -u):$(id -g) \
+   -e CARGO_HOME="/tmp/.cargo" \
+   -v "${CARGO_HOME}":/tmp/.cargo \
+   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
+   -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
+   "${BUILDSYS_SDK_IMAGE}" \
+   cargo fmt \
+  --manifest-path /tmp/tools/Cargo.toml \
   --message-format short \
   --all \
   -- --check; then


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2846

**Description of changes:**

Changed the `rustfmt` used in the `check-fmt` target for Rust formatting to the one included in the BUILDSYS_SDK to avoid conflicting lints between local builds and GitHub actions.

Testing done:

Ran cargo make check-fmt locally.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
