### PR TITLE
vmware: Disable UDP offload for primary interface

### DIFF
--- a/packages/os/disable-udp-offload.service
+++ b/packages/os/disable-udp-offload.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Disables UDP offload
+After=network-online.target
+# Block manual interactions with this service
+RefuseManualStart=true
+RefuseManualStop=true
+# This unit disables UDP offload for the default primary interface (eth0) in
+# VMware.  This avoids an issue with the VXLAN / Geneve tunnels used by Cilium,
+# which affects the vmxnet3 driver in recent kernels.
+ConditionVirtualization=vmware
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ethtool -K eth0 tx-udp_tnl-segmentation off
+ExecStart=/usr/sbin/ethtool -K eth0 tx-udp_tnl-csum-segmentation off
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -46,6 +46,7 @@ Source117: cfsignal.service
 Source118: generate-network-config.service
 Source119: reboot-if-required.service
 Source120: warm-pool-wait.service
+Source121: disable-udp-offload.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -442,6 +443,10 @@ install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-storage.rules
 install -p -m 0644 %{S:301} %{buildroot}%{_cross_udevrulesdir}/81-ebs-volumes.rules
 
+%if %{with vmware_platform}
+install -p -m 0644 %{S:121} %{buildroot}%{_cross_unitdir}
+%endif
+
 %cross_scan_attribution --clarify %{_builddir}/sources/clarify.toml \
     cargo --offline --locked %{_builddir}/sources/Cargo.toml
 
@@ -465,6 +470,10 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_udevrulesdir}/81-ebs-volumes.ru
 %{_cross_bindir}/netdog
 %{_cross_tmpfilesdir}/netdog.conf
 %{_cross_unitdir}/generate-network-config.service
+%if %{with vmware_platform}
+%{_cross_unitdir}/disable-udp-offload.service
+%endif
+
 
 %files -n %{_cross_os}corndog
 %{_cross_bindir}/corndog


### PR DESCRIPTION
**Issue number:**
N/A
Depends on #2829 

**Description of changes:**
We've had reports of Bottlerocket in VMware having networking issues that we've traced back to the combination of our 5.10 kernel and the `vmxnet3` driver.  This driver enables UDP offload which has caused conflicts with NSX-T in certain environments.

This PR adds a systemd unit to VMware variants only.  The systemd unit disables UDP offload via `ethtool` commands for the default primary interface in VMware: `eth0`.

The unit _does_ reference `eth0`.  Given that `eth0` is the default primary interface in VMware, and changing it isn't trivial (especially with EKS-A), this felt pretty safe and should cover the 98% use case.

If a user does opt to do their own networking shenanigans, and runs into an issue where UDP offload is a problem, they are able to use a bootstrap container to run this same set of commands for their preferred interface.


**Testing done:**
* Build an `aws-k8s-1.24` image and ensure the unit does not exist and is not run
```
bash-5.1# systemctl --type=service | grep -i disable-udp
bash-5.1#
```
* Build a `vmware-k8s-1.24` image and ensure the unit runs and the settings are applied for the interface. 
```
bash-5.1# systemctl --type=service | grep -i disable-udp
  disable-udp-offload.service            loaded active     exited          Disables UDP offload

bash-5.1# ethtool -k eth0        
Features for eth0:
...
tx-udp_tnl-segmentation: off
tx-udp_tnl-csum-segmentation: off
...
```

Without the systemd unit - the settings show as "on":
```
bash-5.1# ethtool -k eth0 | grep -i tx-udp
tx-udp_tnl-segmentation: on
tx-udp_tnl-csum-segmentation: on
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
