### PR TITLE
update to SDK v0.30.1

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK name used for building
 BUILDSYS_SDK_NAME="bottlerocket"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.30.0"
+BUILDSYS_SDK_VERSION="v0.30.1"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 


### PR DESCRIPTION
**Description of changes:**

Update SDK to v0.30.1. Includes fixes from https://github.com/bottlerocket-os/bottlerocket-sdk/pull/100.

**Testing done:**

Builds succeed.

Smoke tests passed for `aws-k8s-1.24.x86_64` and `aws-ecs-1.aarch64`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
