### PR TITLE
models: change pause container imageref to Public ECR pause image for vmware-k8s

### DIFF
--- a/sources/api/migration/migrations/v1.13.0/k8s-registry/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.0/k8s-registry/src/main.rs
@@ -3,14 +3,13 @@ use migration_helpers::{migrate, Result};
 use std::process;
 
 const OLD_K8S_PAUSE_IMAGE: &str = "k8s.gcr.io/pause:3.2";
-const NEW_K8S_PAUSE_IMAGE: &str = "registry.k8s.io/pause:3.2";
+const NEW_K8S_PAUSE_IMAGE: &str = "public.ecr.aws/eks-distro/kubernetes/pause:3.3";
 
-// The `k8s.gcr.io registry`, as of April 2023 will be frozen and
+// The `k8s.gcr.io` registry, as of April 2023 will be frozen and
 // images will no longer be pushed to that registry.
-// Instead, Kubernetes consumers are expected to use `registry.k8s.io`
 // For further details: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/
 //
-// In this migration, we move image references from k8s.gcr.io to registry.k8s.io
+// In this migration, we move pause container image references from `k8s.gcr.io` to `public.ecr.aws/eks-distro/kubernetes/`
 fn run() -> Result<()> {
     migrate(ReplaceStringMigration {
         setting: "settings.kubernetes.pod-infra-container-image",

--- a/sources/models/shared-defaults/kubernetes-vmware.toml
+++ b/sources/models/shared-defaults/kubernetes-vmware.toml
@@ -2,7 +2,7 @@
 cluster-domain = "cluster.local"
 standalone-mode = false
 authentication-mode = "tls"
-pod-infra-container-image = "registry.k8s.io/pause:3.2"
+pod-infra-container-image = "public.ecr.aws/eks-distro/kubernetes/pause:3.3"
 server-tls-bootstrap = false
 cloud-provider = "external"
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**

Changes the default pause container image to the one hosted by EKS-D in Public ECR.

Modifies the existing 'k8s-registry' migration to migrate 'k8s.gcr.io' to 'public.ecr.aws/eks-distro/kubernetes/'.


**Testing done:**

Migration testing comes back fine:
```
bash-5.1# apiclient get settings.kubernetes.pod-infra-container-image
{
  "settings": {
    "kubernetes": {
      "pod-infra-container-image": "k8s.gcr.io/pause:3.2"
    }
  }
}
bash-5.1# apiclient get os                                           
{
  "os": {
    "arch": "x86_64",
    "build_id": "6ef1139f",
    "pretty_name": "Bottlerocket OS 1.12.0 (vmware-k8s-1.24)",
    "variant_id": "vmware-k8s-1.24",
    "version_id": "1.12.0"
  }
}


bash-5.1# updog update -r -n --ignore-waves
Starting update to 1.13.0
Cannot schedule shutdown without logind support, proceeding with immediate shutdown.
Update applied: vmware-k8s-1.24 1.13.0
bash-5.1# Connection to 198.19.131.127 closed by remote host.
Connection to 198.19.131.127 closed.

$ ssh -i eks-a-id_rsa ec2-user@198.19.131.127
          Welcome to Bottlerocket's admin container!
    ╱╲
   ╱┄┄╲   This container provides access to the Bottlerocket host
   │▗▖│   filesystems (see /.bottlerocket/rootfs) and contains common
  ╱│  │╲  tools for inspection and troubleshooting.  It is based on
  │╰╮╭╯│  Amazon Linux 2, and most things are in the same places you
    ╹╹    would find them on an AL2 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[ec2-user@admin]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "17c0241a",
    "pretty_name": "Bottlerocket OS 1.13.0 (vmware-k8s-1.24)",
    "variant_id": "vmware-k8s-1.24",
    "version_id": "1.13.0"
  }
}
[ec2-user@admin]$ apiclient get settings.kubernetes.pod-infra-container-image
{
  "settings": {
    "kubernetes": {
      "pod-infra-container-image": "public.ecr.aws/eks-distro/kubernetes/pause:3.3"
    }
  }
}

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
