### PR TITLE
rpm2img: stripe root filesystem

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -126,6 +126,11 @@ VERITY_HASH_ALGORITHM=sha256
 VERITY_DATA_BLOCK_SIZE=4096
 VERITY_HASH_BLOCK_SIZE=4096
 
+# Bottlerocket has been experimentally shown to boot faster on EBS volumes when striping the root filesystem into 4MiB stripes.
+# We use 4kb ext4 blocks. The stride and stripe should both be $STRIPE_SIZE / $EXT4_BLOCK_SIZE
+ROOT_STRIDE=1024
+ROOT_STRIPE_WIDTH=1024
+
 case "${PARTITION_PLAN}" in
   split)
     truncate -s "${OS_IMAGE_SIZE_GIB}G" "${OS_IMAGE}"
@@ -279,7 +284,8 @@ mkdir -p "${ROOT_MOUNT}/lost+found"
 ROOT_LABELS=$(setfiles -n -d -F -m -r "${ROOT_MOUNT}" \
     "${SELINUX_FILE_CONTEXTS}" "${ROOT_MOUNT}" \
     | awk -v root="${ROOT_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_set", $1, "security.selinux", $4}')
-mkfs.ext4 -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" "${partsize[ROOT-A]}M"
+mkfs.ext4 -E "lazy_itable_init=0,stride=${ROOT_STRIDE},stripe_width=${ROOT_STRIPE_WIDTH}" \
+  -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" "${partsize[ROOT-A]}M"
 echo "${ROOT_LABELS}" | debugfs -w -f - "${ROOT_IMAGE}"
 resize2fs -M "${ROOT_IMAGE}"
 dd if="${ROOT_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[ROOT-A]}"


### PR DESCRIPTION
**Description of changes:**
```
Aligning the root filesystem along 4M boundaries provides a subtle but
measureable performance improvement in Bottlerocket's boot process.
```

I had this idea while looking at our filesystem settings and reading the manpages for ext4, then found [this article](https://utcc.utoronto.ca/~cks/space/blog/linux/Ext4AndRAIDStripes) on the web, suggesting others have had this idea to improve SSD performance as well. I used [this article](https://thelastmaimou.wordpress.com/2013/05/04/magic-soup-ext4-with-ssd-stripes-and-strides/) for some guidance on how to select the `stride` and `stripe_width`.

The other change here is to disable `lazy_itable_init`. Enabled by default, this performs inode table initialization at boot in the background, speeding up calls to `mkfs.ext4`. Instead, we're opting to slow down our filesystem creation for added safety and speed at boot.

Some useful `manpages` snippets:


> stride=stride-size
Configure  the  filesystem  for a RAID array with stride-size filesystem blocks. This is the number of blocks read or written to disk before moving to the next disk, which is sometimes referred to as the chunk size.  This mostly affects placement of filesystem metadata like bitmaps at mke2fs time to avoid placing them on a single disk, which can hurt performance.  It may also be used by the block allocator.
>
> stripe_width=stripe-width
> Configure the filesystem for a RAID array with stripe-width filesystem blocks per stripe. This is typically stride-size * N, where N is the number of data-bearing disks in the RAID (e.g. for RAID 5  there  is  one  parity disk, so N will be the number of disks in the array minus 1).  This allows the block allocator to prevent read-modify-write of the parity in a RAID stripe if possible when the data is written.
>
> lazy_itable_init[= <0 to disable, 1 to enable>]
> If  enabled  and  the  uninit_bg  feature  is  enabled,  the inode table will not be fully initialized by mke2fs.  This speeds up filesystem initialization noticeably, but it requires the kernel to finish initializing the filesystem in the background when the filesystem is first mounted.  If the option value is omitted, it defaults to 1 to enable lazy inode table zeroing.


**Testing done:**
 Experimentally, this results in a performance improvement to Bottlerocket ([Welch's t-test](https://en.wikipedia.org/wiki/Welch%27s_t-test) with p value < 0.00000).

I also tested using a 512kb stripe size based on some suggestion of a 512kb stripe size in [the EBS direct documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-accessing-snapshot.html) but experimentation did not conclusively indicate an improvement.

<details>
<summary>(click me)
</summary>

![speedtest-diskmagic](https://user-images.githubusercontent.com/990370/223679639-5fc64828-407f-4165-bc3d-7ecb26d99bd3.png)
</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
