### PR TITLE
Update host container images for v1.13.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -183,5 +183,7 @@ version = "1.13.0"
     "migrate_v1.12.0_public-control-container-v0-7-0.lz4",
 ]
 "(1.12.0, 1.13.0)" = [
-    "migrate_v1.13.0_k8s-registry.lz4"
+    "migrate_v1.13.0_k8s-registry.lz4",
+    "migrate_v1.13.0_aws-admin-container-v0-10-0.lz4",
+    "migrate_v1.13.0_public-admin-container-v0-10-0.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -186,4 +186,6 @@ version = "1.13.0"
     "migrate_v1.13.0_k8s-registry.lz4",
     "migrate_v1.13.0_aws-admin-container-v0-10-0.lz4",
     "migrate_v1.13.0_public-admin-container-v0-10-0.lz4",
+    "migrate_v1.13.0_aws-control-container-v0-7-1.lz4",
+    "migrate_v1.13.0_public-control-container-v0-7-1.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -474,6 +474,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-admin-container-v0-10-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-admin-container-v0-9-4"
 version = "0.1.0"
 dependencies = [
@@ -2820,6 +2827,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "public-admin-container-v0-10-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -523,6 +523,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-endpoint"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,6 +2852,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-1"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -36,6 +36,8 @@ members = [
     "api/migration/migrations/v1.12.0/aws-control-container-v0-7-0",
     "api/migration/migrations/v1.12.0/public-control-container-v0-7-0",
     "api/migration/migrations/v1.13.0/k8s-registry",
+    "api/migration/migrations/v1.13.0/aws-admin-container-v0-10-0",
+    "api/migration/migrations/v1.13.0/public-admin-container-v0-10-0",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -38,6 +38,8 @@ members = [
     "api/migration/migrations/v1.13.0/k8s-registry",
     "api/migration/migrations/v1.13.0/aws-admin-container-v0-10-0",
     "api/migration/migrations/v1.13.0/public-admin-container-v0-10-0",
+    "api/migration/migrations/v1.13.0/aws-control-container-v0-7-1",
+    "api/migration/migrations/v1.13.0/public-control-container-v0-7-1",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.13.0/aws-admin-container-v0-10-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.13.0/aws-admin-container-v0-10-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-10-0"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.13.0/aws-admin-container-v0-10-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.0/aws-admin-container-v0-10-0/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.4";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.0";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.13.0/aws-control-container-v0-7-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.13.0/aws-control-container-v0-7-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-1"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.13.0/aws-control-container-v0-7-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.0/aws-control-container-v0-7-1/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.0";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.1";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.13.0/public-admin-container-v0-10-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.13.0/public-admin-container-v0-10-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-10-0"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.13.0/public-admin-container-v0-10-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.0/public-admin-container-v0-10-0/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.0";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.13.0/public-control-container-v0-7-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.13.0/public-control-container-v0-7-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-1"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.13.0/public-control-container-v0-7-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.0/public-control-container-v0-7-1/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.1";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.9.4"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.0"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.0"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.1"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.0"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.1"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.0"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Issue number:**

Closes #2764 

**Description of changes:**

Update the official admin and control container images to v0.10.0 and v0.7.1, respectively. Provide migrations for nodes running with the default container images.


**Testing done:**

* [x] aws-k8s-1.24 image with the changes boots with admin container v0.10.0 and control container v0.7.1 configured; both containers run when enabled
* [x] aws-k8s-1.24 image of the Bottlerocket v1.12.0 release migrates its admin and control container image sources to the new versions; both containers run when enabled:

Before update:

```
[ec2-user@admin]$ apiclient get settings.host-containers.{admin,control}.source
{
  "settings": {
    "host-containers": {
      "admin": {
        "source": "328549459982.dkr.ecr.eu-central-1.amazonaws.com/bottlerocket-admin:v0.9.4"
      },
      "control": {
        "source": "328549459982.dkr.ecr.eu-central-1.amazonaws.com/bottlerocket-control:v0.7.0"
      }
    }
  }
}
```

After update:

```
[ec2-user@admin]$ apiclient get settings.host-containers.{admin,control}.source
{
  "settings": {
    "host-containers": {
      "admin": {
        "source": "328549459982.dkr.ecr.eu-central-1.amazonaws.com/bottlerocket-admin:v0.10.0"
      },
      "control": {
        "source": "328549459982.dkr.ecr.eu-central-1.amazonaws.com/bottlerocket-control:v0.7.1"
      }
    }
  }
}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
