### PR TITLE
Testsys 0.0.6

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.19",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -444,7 +444,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2",
- "time 0.3.19",
+ "time",
  "tracing",
 ]
 
@@ -600,7 +600,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]
@@ -681,16 +681,16 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-types"
-version = "0.0.5"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.5#d8a03928552d8bb2c1eec94271d76dcb4e47dcb4"
+version = "0.0.6"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.6#a69b7006887249f89238b428a9acb6a0050dd384"
 dependencies = [
  "builder-derive",
  "configuration-derive",
- "model",
  "serde",
  "serde_json",
  "serde_plain",
  "serde_yaml",
+ "testsys-model",
 ]
 
 [[package]]
@@ -713,8 +713,8 @@ dependencies = [
 
 [[package]]
 name = "builder-derive"
-version = "0.0.5"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.5#d8a03928552d8bb2c1eec94271d76dcb4e47dcb4"
+version = "0.0.6"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.6#a69b7006887249f89238b428a9acb6a0050dd384"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -748,6 +748,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "byteorder"
@@ -805,12 +811,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -906,8 +909,8 @@ dependencies = [
 
 [[package]]
 name = "configuration-derive"
-version = "0.0.5"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.5#d8a03928552d8bb2c1eec94271d76dcb4e47dcb4"
+version = "0.0.6"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.6#a69b7006887249f89238b428a9acb6a0050dd384"
 dependencies = [
  "quote",
  "syn",
@@ -1671,19 +1674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,12 +1815,13 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
+checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
  "treediff",
 ]
 
@@ -1847,11 +1838,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
+checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bytes",
  "chrono",
  "serde",
@@ -1861,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.75.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
+checksum = "53ee2ba94546e32a5aef943e5831c6ac25592ff8dcfa8b2a06e0aaea90c69188"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1873,11 +1864,11 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.75.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
+checksum = "7c9ca1f597bd48ed26f45f601bf2fa3aaa0933b8d1652d883b8444519b72af4a"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bytes",
  "chrono",
  "dirs-next",
@@ -1888,7 +1879,6 @@ dependencies = [
  "hyper",
  "hyper-openssl",
  "hyper-timeout",
- "hyper-tls",
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
@@ -1902,7 +1892,6 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "tokio-native-tls",
  "tokio-tungstenite",
  "tokio-util",
  "tower",
@@ -1912,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.75.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
+checksum = "61f2c6d1a2d1584859499eb05a41c5a44713818041621fa7515cfdbdf4769ea7"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1930,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.75.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98459d53b2841237392cd6959956185b2df15c19d32c3b275ed6ca7b7ee1adae"
+checksum = "3e1dfe288fd87029f87c5713ddf585a4221e1b5be8f8c7c02ba28f5211f2a6d7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2066,55 +2055,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "model"
-version = "0.0.5"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.5#d8a03928552d8bb2c1eec94271d76dcb4e47dcb4"
-dependencies = [
- "async-recursion",
- "async-trait",
- "base64 0.20.0",
- "bytes",
- "chrono",
- "futures",
- "http",
- "json-patch",
- "k8s-openapi",
- "kube",
- "lazy_static",
- "log",
- "maplit",
- "regex",
- "schemars",
- "serde",
- "serde_json",
- "serde_plain",
- "serde_yaml",
- "snafu",
- "tabled",
- "tokio",
- "tokio-util",
- "topological-sort",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2298,10 +2238,12 @@ checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "papergrid"
-version = "0.3.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63709d10e2c2ec58f7bd91d8258d27ce80de090064b0ddf3a4bf38b907b61b8a"
+checksum = "1526bb6aa9f10ec339fb10360f22c57edf81d5678d0278e93bc12a47ffbe4b01"
 dependencies = [
+ "bytecount",
+ "fnv",
  "unicode-width",
 ]
 
@@ -3039,17 +2981,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,7 +3044,7 @@ checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]
@@ -3231,20 +3162,23 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.6.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15827061abcf689257b1841c8e2732b1dfcc3ef825b24ce6c606e1e9e1a7bde"
+checksum = "56c3ee73732ffceaea7b8f6b719ce3bb17f253fa27461ffeaf568ebd0cdb4b85"
 dependencies = [
  "papergrid",
  "tabled_derive",
+ "unicode-width",
 ]
 
 [[package]]
 name = "tabled_derive"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278ea3921cee8c5a69e0542998a089f7a14fa43c9c4e4f9951295da89bd0c943"
+checksum = "beca1b4eaceb4f2755df858b88d9b9315b7ccfd1ffd0d7a48a52602301f01a57"
 dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -3297,10 +3231,8 @@ dependencies = [
  "fastrand",
  "futures",
  "handlebars",
- "kube-client",
  "log",
  "maplit",
- "model",
  "pubsys-config",
  "serde",
  "serde_json",
@@ -3309,6 +3241,7 @@ dependencies = [
  "snafu",
  "term_size",
  "testsys-config",
+ "testsys-model",
  "tokio",
  "unescape",
 ]
@@ -3323,12 +3256,43 @@ dependencies = [
  "lazy_static",
  "log",
  "maplit",
- "model",
  "serde",
  "serde_yaml",
  "snafu",
+ "testsys-model",
  "toml",
  "url",
+]
+
+[[package]]
+name = "testsys-model"
+version = "0.0.6"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.6#a69b7006887249f89238b428a9acb6a0050dd384"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "base64 0.20.0",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "json-patch",
+ "k8s-openapi",
+ "kube",
+ "lazy_static",
+ "log",
+ "maplit",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "serde_yaml",
+ "snafu",
+ "tabled",
+ "tokio",
+ "tokio-util",
+ "topological-sort",
 ]
 
 [[package]]
@@ -3364,16 +3328,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3472,16 +3426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-openssl"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,9 +3461,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
@@ -3697,9 +3641,9 @@ dependencies = [
 
 [[package]]
 name = "treediff"
-version = "3.0.2"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
 dependencies = [
  "serde_json",
 ]
@@ -3712,9 +3656,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -3723,7 +3667,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -64,8 +64,6 @@ skip = [
     { name = "base64", version = "=0.13.1" },
     # governor uses an old version of wasi
     { name = "wasi", version = "=0.10.2" },
-    # testsys uses an old version of time
-    { name = "time", version = "=0.1.43" },
 ]
 
 skip-tree = [

--- a/tools/testsys-config/Cargo.toml
+++ b/tools/testsys-config/Cargo.toml
@@ -13,7 +13,7 @@ home = "0.5"
 lazy_static = "1"
 log = "0.4"
 maplit="1"
-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.5", tag = "v0.0.5"}
+testsys-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.6", tag = "v0.0.6"}
 serde = { version = "1", features = ["derive"]  }
 serde_yaml = "0.8"
 snafu = "0.7"

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -3,13 +3,13 @@ pub use error::Error;
 use handlebars::Handlebars;
 use log::{debug, trace, warn};
 use maplit::btreemap;
-use model::constants::TESTSYS_VERSION;
-use model::{DestructionPolicy, SecretName};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
+use testsys_model::constants::TESTSYS_VERSION;
+use testsys_model::{DestructionPolicy, SecretName};
 pub type Result<T> = std::result::Result<T, error::Error>;
 
 /// Configuration needed to run tests

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -11,16 +11,15 @@ async-trait = "0.1"
 aws-config = "0.54.1"
 aws-sdk-ec2 = "0.24"
 base64 = "0.20"
-bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.5", tag = "v0.0.5"}
+bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.6", tag = "v0.0.6"}
 bottlerocket-variant = { version = "0.1", path = "../../sources/bottlerocket-variant" }
 clap = { version = "3", features = ["derive", "env"] }
 env_logger = "0.10"
 futures = "0.3"
 handlebars = "4"
-kube-client = { version = "0.75"}
 log = "0.4"
 maplit = "1"
-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.5", tag = "v0.0.5"}
+testsys-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.6", tag = "v0.0.6"}
 pubsys-config = { path = "../pubsys-config/", version = "0.1.0" }
 fastrand = "1"
 serde = { version = "1", features = ["derive"] }

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -8,9 +8,9 @@ use crate::migration::migration_crd;
 use bottlerocket_types::agent_config::{ClusterType, EcsClusterConfig, EcsTestConfig};
 use log::debug;
 use maplit::btreemap;
-use model::{Crd, DestructionPolicy};
 use snafu::{OptionExt, ResultExt};
 use std::collections::BTreeMap;
+use testsys_model::{Crd, DestructionPolicy};
 
 /// A `CrdCreator` responsible for creating crd related to `aws-ecs` variants.
 pub(crate) struct AwsEcsCreator {

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -10,11 +10,11 @@ use bottlerocket_types::agent_config::{
     ClusterType, CreationPolicy, EksClusterConfig, EksctlConfig, K8sVersion,
 };
 use maplit::btreemap;
-use model::{Crd, DestructionPolicy};
 use serde_yaml::Value;
 use snafu::{OptionExt, ResultExt};
 use std::collections::BTreeMap;
 use std::str::FromStr;
+use testsys_model::{Crd, DestructionPolicy};
 
 /// A `CrdCreator` responsible for creating crd related to `aws-k8s` variants.
 pub(crate) struct AwsK8sCreator {

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -4,12 +4,12 @@ use aws_sdk_ec2::model::{Filter, Image};
 use aws_sdk_ec2::Region;
 use bottlerocket_types::agent_config::{ClusterType, CustomUserData, Ec2Config};
 use maplit::btreemap;
-use model::{DestructionPolicy, Resource};
 use serde::Deserialize;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::fs::File;
 use std::iter::repeat_with;
+use testsys_model::{DestructionPolicy, Resource};
 
 /// Get the AMI for the given `region` from the `ami_input` file.
 pub(crate) fn ami(ami_input: &str, region: &str) -> Result<String> {

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -5,9 +5,6 @@ use bottlerocket_variant::Variant;
 use handlebars::Handlebars;
 use log::{debug, info, warn};
 use maplit::btreemap;
-use model::constants::{API_VERSION, NAMESPACE};
-use model::test_manager::{SelectionParams, TestManager};
-use model::Crd;
 use pubsys_config::RepoConfig;
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt};
@@ -15,6 +12,9 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use testsys_config::{rendered_cluster_name, GenericVariantConfig, TestsysImages};
+use testsys_model::constants::{API_VERSION, NAMESPACE};
+use testsys_model::test_manager::{SelectionParams, TestManager};
+use testsys_model::Crd;
 
 /// A type that is used for the creation of all CRDs.
 pub struct CrdInput<'a> {

--- a/tools/testsys/src/delete.rs
+++ b/tools/testsys/src/delete.rs
@@ -2,7 +2,7 @@ use crate::error::Result;
 use clap::Parser;
 use futures::TryStreamExt;
 use log::info;
-use model::test_manager::{CrdState, CrdType, DeleteEvent, SelectionParams, TestManager};
+use testsys_model::test_manager::{CrdState, CrdType, DeleteEvent, SelectionParams, TestManager};
 
 /// Delete all tests and resources from a testsys cluster.
 #[derive(Debug, Parser)]

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -50,7 +50,10 @@ pub enum Error {
     },
 
     #[snafu(display("Unable to create map from {}: {}", what, source))]
-    IntoMap { what: String, source: model::Error },
+    IntoMap {
+        what: String,
+        source: testsys_model::Error,
+    },
 
     #[snafu(display("{}", what))]
     Invalid { what: String },
@@ -64,9 +67,6 @@ pub enum Error {
     #[snafu(display("Unable to parse K8s version '{}'", version))]
     K8sVersion { version: String },
 
-    #[snafu(display("{}", source))]
-    KubeClient { source: kube_client::error::Error },
-
     #[snafu(display("{} was missing from {}", item, what))]
     Missing { item: String, what: String },
 
@@ -76,7 +76,7 @@ pub enum Error {
     #[snafu(display("Unable to create secret name for '{}': {}", secret_name, source))]
     SecretName {
         secret_name: String,
-        source: model::Error,
+        source: testsys_model::Error,
     },
 
     #[snafu(display("{}: {}", what, source))]
@@ -92,7 +92,9 @@ pub enum Error {
     },
 
     #[snafu(context(false), display("{}", source))]
-    TestManager { source: model::test_manager::Error },
+    TestManager {
+        source: testsys_model::test_manager::Error,
+    },
 
     #[snafu(context(false), display("{}", source))]
     TestsysConfig { source: testsys_config::Error },

--- a/tools/testsys/src/install.rs
+++ b/tools/testsys/src/install.rs
@@ -2,9 +2,9 @@ use crate::error::Result;
 use crate::run::TestsysImages;
 use clap::Parser;
 use log::{info, trace};
-use model::test_manager::{ImageConfig, TestManager};
 use std::path::PathBuf;
 use testsys_config::TestConfig;
+use testsys_model::test_manager::{ImageConfig, TestManager};
 
 /// The install subcommand is responsible for putting all of the necessary components for testsys in
 /// a k8s cluster.

--- a/tools/testsys/src/logs.rs
+++ b/tools/testsys/src/logs.rs
@@ -1,8 +1,8 @@
 use crate::error::{self, Result};
 use clap::Parser;
 use futures::TryStreamExt;
-use model::test_manager::{ResourceState, TestManager};
-use snafu::{OptionExt, ResultExt};
+use snafu::OptionExt;
+use testsys_model::test_manager::{ResourceState, TestManager};
 use unescape::unescape;
 
 /// Stream the logs of an object from a testsys cluster.
@@ -30,13 +30,13 @@ impl Logs {
         match (self.test, self.resource, self.resource_state) {
             (Some(test), None, None) => {
                 let mut logs = client.test_logs(test, self.follow).await?;
-                while let Some(line) = logs.try_next().await.context(error::KubeClientSnafu)? {
+                while let Some(line) = logs.try_next().await? {
                     println!("{}", unescape(&String::from_utf8_lossy(&line)).context(error::InvalidSnafu{what: "Unable to unescape log string"})?);
                 }
             }
             (None, Some(resource), Some(state)) => {
                 let mut logs = client.resource_logs(resource, state, self.follow).await?;
-                while let Some(line) = logs.try_next().await.context(error::KubeClientSnafu)? {
+                while let Some(line) = logs.try_next().await? {
                     println!("{}", unescape(&String::from_utf8_lossy(&line)).context(error::InvalidSnafu{what: "Unable to unescape log string"})?);
                 }
             }

--- a/tools/testsys/src/main.rs
+++ b/tools/testsys/src/main.rs
@@ -5,12 +5,12 @@ use error::Result;
 use install::Install;
 use log::{debug, error, LevelFilter};
 use logs::Logs;
-use model::test_manager::TestManager;
 use restart_test::RestartTest;
 use run::Run;
 use secret::Add;
 use status::Status;
 use std::path::PathBuf;
+use testsys_model::test_manager::TestManager;
 use uninstall::Uninstall;
 
 mod aws_ecs;

--- a/tools/testsys/src/migration.rs
+++ b/tools/testsys/src/migration.rs
@@ -2,8 +2,8 @@ use crate::crds::{MigrationDirection, MigrationInput};
 use crate::error::{self, Result};
 use bottlerocket_types::agent_config::MigrationConfig;
 use maplit::btreemap;
-use model::Test;
 use snafu::{OptionExt, ResultExt};
+use testsys_model::Test;
 
 /// Create a CRD for migrating Bottlerocket instances using SSM commands.
 /// `aws_region_override` allows the region that's normally derived from the cluster resource CRD to be overridden

--- a/tools/testsys/src/restart_test.rs
+++ b/tools/testsys/src/restart_test.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use clap::Parser;
-use model::test_manager::TestManager;
+use testsys_model::test_manager::TestManager;
 
 /// Restart a test. This will delete the test object from the testsys cluster and replace it with
 /// a new, identical test object with a clean state.

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -7,8 +7,6 @@ use crate::vmware_k8s::VmwareK8sCreator;
 use bottlerocket_variant::Variant;
 use clap::Parser;
 use log::{debug, info};
-use model::test_manager::TestManager;
-use model::SecretName;
 use pubsys_config::vmware::{
     Datacenter, DatacenterBuilder, DatacenterCreds, DatacenterCredsBuilder, DatacenterCredsConfig,
     VMWARE_CREDS_PATH,
@@ -21,6 +19,8 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::str::FromStr;
 use testsys_config::{GenericVariantConfig, TestConfig};
+use testsys_model::test_manager::TestManager;
+use testsys_model::SecretName;
 
 /// Run a set of tests for a given arch and variant
 #[derive(Debug, Parser)]

--- a/tools/testsys/src/secret.rs
+++ b/tools/testsys/src/secret.rs
@@ -1,8 +1,8 @@
 use crate::error::{self, Result};
 use clap::Parser;
-use model::test_manager::TestManager;
-use model::SecretName;
 use snafu::OptionExt;
+use testsys_model::test_manager::TestManager;
+use testsys_model::SecretName;
 
 /// Add a testsys object to the testsys cluster.
 #[derive(Debug, Parser)]

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -5,9 +5,9 @@ use bottlerocket_types::agent_config::{
     SonobuoyConfig, SonobuoyMode, WorkloadConfig, WorkloadTest,
 };
 use maplit::btreemap;
-use model::Test;
 use snafu::ResultExt;
 use std::fmt::Display;
+use testsys_model::Test;
 
 /// Create a Sonobuoy CRD for K8s conformance and quick testing.
 pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
@@ -110,6 +110,7 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
         .map(|(name, image)| WorkloadTest {
             name: name.to_string(),
             image: image.to_string(),
+            ..Default::default()
         })
         .collect();
     if plugins.is_empty() {
@@ -142,7 +143,7 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
         )
         .keep_running(true)
         .kubeconfig_base64_template(cluster_resource_name, "encodedKubeconfig")
-        .plugins(plugins)
+        .tests(plugins)
         .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))
         .set_labels(Some(labels))
         .build(format!(

--- a/tools/testsys/src/status.rs
+++ b/tools/testsys/src/status.rs
@@ -1,10 +1,12 @@
 use crate::error::{self, Result};
 use clap::Parser;
 use log::{debug, info};
-use model::test_manager::{CrdState, CrdType, SelectionParams, StatusProgress, TestManager};
 use serde::Deserialize;
 use serde_plain::derive_fromstr_from_deserialize;
 use snafu::ResultExt;
+use testsys_model::test_manager::{
+    CrdState, CrdType, SelectionParams, StatusProgress, TestManager,
+};
 
 /// Check the status of testsys objects.
 #[derive(Debug, Parser)]

--- a/tools/testsys/src/uninstall.rs
+++ b/tools/testsys/src/uninstall.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use clap::Parser;
 use log::{info, trace};
-use model::test_manager::TestManager;
+use testsys_model::test_manager::TestManager;
 
 /// The uninstall subcommand is responsible for removing all of the components for testsys in
 /// a k8s cluster. This is completed by removing the `testsys-bottlerocket-aws` namespace.

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -10,12 +10,12 @@ use bottlerocket_types::agent_config::{
     VSphereVmConfig,
 };
 use maplit::btreemap;
-use model::{Crd, DestructionPolicy, SecretName};
 use pubsys_config::vmware::Datacenter;
 use snafu::{OptionExt, ResultExt};
 use std::collections::BTreeMap;
 use std::iter::repeat_with;
 use std::str::FromStr;
+use testsys_model::{Crd, DestructionPolicy, SecretName};
 
 /// A `CrdCreator` responsible for creating crd related to `vmware-k8s` variants.
 pub(crate) struct VmwareK8sCreator {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Updates the testsys cli to use TestSys v0.0.6 - https://github.com/bottlerocket-os/bottlerocket-test-system/releases/tag/v0.0.6 

**Testing done:**

Ran `cargo make test` with `aws-ecs-1` and verified that testing completed successfully. All agents were tested as part of the TestSys v0.0.6 release.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
