### PR TITLE
Update SDK to v0.30.2

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # SDK name used for building
 BUILDSYS_SDK_NAME="bottlerocket"
 # SDK version used for building
-BUILDSYS_SDK_VERSION="v0.30.1"
+BUILDSYS_SDK_VERSION="v0.30.2"
 # Site for fetching the SDK
 BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 


### PR DESCRIPTION
**Issue number:**

N/a - related to permission errors we're seeing in our GitHub actions. Needed to add the `builder` user in latest SDK release.
See: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/102

**Description of changes:**

Upgrades SDK to v0.30.2

**Testing done:**

_In flight ..._

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
