### PR TITLE
Makefile: point to cargo cache when running check-clippy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
           key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
-      - run: rustup default 1.66.1 && rustup component add rustfmt && rustup component add clippy
+      - run: rustup component add rustfmt
       - run: cargo install --version 0.36.0 cargo-make
       - run: cargo install --version 0.6.2 cargo-sweep
       - run: |

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -45,7 +45,6 @@ jobs:
             tools/.crates2.json
             tools/target
           key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
-      - run: rustup default 1.66.1
       - run: cargo install --locked --version 0.36.0 cargo-make
       - run: cargo install --locked --version 0.8.3 --no-default-features --features ci-autoclean cargo-cache
       - run: cargo install --locked --version 0.6.2 cargo-sweep

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -440,7 +440,10 @@ export VARIANT="${BUILDSYS_VARIANT}"
 
 # For rust first-party source code
 if ! docker run --rm \
-   -v "$(pwd)":/tmp \
+   -e CARGO_HOME="/tmp/.cargo" \
+   -v "${CARGO_HOME}":/tmp/.cargo \
+   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
+   -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
    "${BUILDSYS_SDK_IMAGE}" \
    cargo clippy \
   --manifest-path /tmp/tools/Cargo.toml \
@@ -449,7 +452,10 @@ if ! docker run --rm \
 fi
 
 if ! docker run --rm \
-   -v "$(pwd)":/tmp \
+   -e CARGO_HOME="/tmp/.cargo" \
+   -v "${CARGO_HOME}":/tmp/.cargo \
+   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
+   -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
    -e VARIANT \
    "${BUILDSYS_SDK_IMAGE}" \
    cargo clippy \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Mounted only relevant directories to docker container (`sources`, `tools`, and `.cargo`) instead of the whole working directory. Set the `CARGO_HOME` directory in the docker container to `/tmp/.cargo` so it would find the registry cache and not have to download, compile, and check each crate every time `check-clippy` is invoked.

Removed pinned Rust version since we use `clippy` from the SDK.

**Testing done:**

Ran `cargo make check-clippy` twice: first time had to download and compile several crates, second time finished immediately.

```
ubuntu:~/dev/bottlerocket$ cargo make check-clippy
[cargo-make] INFO - cargo make 0.36.0
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: check-clippy
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: check-clippy
   Compiling ring v0.16.20
   Compiling bottlerocket-variant v0.1.0 (/tmp/sources/bottlerocket-variant)
   Compiling rustls v0.20.8
    Checking testsys-config v0.1.0 (/tmp/tools/testsys-config)
    Checking webpki v0.22.0
    Checking sct v0.7.0
    Checking webpki-roots v0.22.6
    Checking tokio-rustls v0.23.4
    Checking hyper-rustls v0.23.2
    Checking aws-smithy-client v0.54.1
    Checking reqwest v0.11.13
    Checking tough v0.13.0
    Checking buildsys v0.1.0 (/tmp/tools/buildsys)
    Checking pubsys-setup v0.1.0 (/tmp/tools/pubsys-setup)
    Checking aws-types v0.54.1
    Checking aws-endpoint v0.54.1
    Checking aws-http v0.54.1
    Checking aws-sig-auth v0.54.1
    Checking aws-sdk-sso v0.24.0
    Checking aws-sdk-sts v0.24.0
    Checking aws-sdk-ec2 v0.24.0
    Checking aws-sdk-ssm v0.24.0
    Checking aws-sdk-kms v0.24.0
    Checking aws-sdk-ebs v0.24.0
    Checking aws-sdk-cloudformation v0.24.0
    Checking aws-sdk-s3 v0.24.0
    Checking aws-config v0.54.1
    Checking tough-kms v0.5.0
    Checking infrasys v0.1.0 (/tmp/tools/infrasys)
    Checking tough-ssm v0.8.0
    Checking coldsnap v0.4.3
    Checking testsys v0.1.0 (/tmp/tools/testsys)
    Checking pubsys v0.1.0 (/tmp/tools/pubsys)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 01s
   Compiling ring v0.16.20
   Compiling bottlerocket-variant v0.1.0 (/tmp/sources/bottlerocket-variant)
   Compiling apiclient v0.1.0 (/tmp/sources/api/apiclient)
   Compiling imdsclient v0.1.0 (/tmp/sources/imdsclient)
   Compiling rustls v0.20.8
   Compiling apiserver v0.1.0 (/tmp/sources/api/apiserver)
   Compiling thar-be-settings v0.1.0 (/tmp/sources/api/thar-be-settings)
   Compiling shibaken v0.1.0 (/tmp/sources/api/shibaken)
   Compiling metricdog v0.1.0 (/tmp/sources/metricdog)
   Compiling corndog v0.1.0 (/tmp/sources/api/corndog)
   Compiling host-containers v0.1.0 (/tmp/sources/api/host-containers)
   Compiling driverdog v0.1.0 (/tmp/sources/driverdog)
   Compiling shimpei v0.1.0 (/tmp/sources/shimpei)
   Compiling sundog v0.1.0 (/tmp/sources/api/sundog)
   Compiling cfsignal v0.1.0 (/tmp/sources/cfsignal)
   Compiling prairiedog v0.1.0 (/tmp/sources/api/prairiedog)
   Compiling settings-committer v0.1.0 (/tmp/sources/api/settings-committer)
   Compiling certdog v0.1.0 (/tmp/sources/api/certdog)
   Compiling models v0.1.0 (/tmp/sources/models)
   Compiling netdog v0.1.0 (/tmp/sources/api/netdog)
   Compiling add-k8s-autoscaling-warm-pool-setting-metadata v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting-metadata)
   Compiling oci-defaults-setting-metadata v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/oci-defaults-setting-metadata)
   Compiling oci-defaults-setting v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/oci-defaults-setting)
   Compiling add-k8s-autoscaling-warm-pool-setting v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/add-k8s-autoscaling-warm-pool-setting)
   Compiling static-pods v0.1.0 (/tmp/sources/api/static-pods)
   Compiling early-boot-config v0.1.0 (/tmp/sources/api/early-boot-config)
   Compiling ecs-settings-applier v0.1.0 (/tmp/sources/api/ecs-settings-applier)
   Compiling pluto v0.1.0 (/tmp/sources/api/pluto)
   Compiling logdog v0.1.0 (/tmp/sources/logdog)
    Checking sct v0.7.0
    Checking webpki v0.22.0
    Checking sct v0.6.1
    Checking webpki v0.21.4
    Checking aws-sigv4 v0.48.0
    Checking ct-logs v0.8.0
    Checking rustls v0.19.1
    Checking rustls-native-certs v0.5.0
    Checking tokio-rustls v0.22.0
    Checking hyper-rustls v0.22.1
    Checking aws-smithy-client v0.48.0
    Checking hyper-proxy v0.9.1
    Checking tokio-rustls v0.23.4
    Checking hyper-rustls v0.23.2
    Checking reqwest v0.11.13
    Checking aws-types v0.48.0
    Checking aws-endpoint v0.48.0
    Checking aws-http v0.48.0
    Checking aws-sig-auth v0.48.0
   Compiling storewolf v0.1.0 (/tmp/sources/api/storewolf)
    Checking aws-sdk-sso v0.18.0
    Checking aws-sdk-sts v0.18.0
    Checking aws-sdk-cloudformation v0.18.0
    Checking aws-sdk-eks v0.18.0
    Checking tough v0.13.0
    Checking schnauzer v0.1.0 (/tmp/sources/api/schnauzer)
    Checking thar-be-updates v0.1.0 (/tmp/sources/api/thar-be-updates)
    Checking bootstrap-containers v0.1.0 (/tmp/sources/api/bootstrap-containers)
    Checking aws-config v0.48.0
    Checking migration-helpers v0.1.0 (/tmp/sources/api/migration/migration-helpers)
    Checking k8s-private-pki-path v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/k8s-private-pki-path)
    Checking public-admin-container-v0-9-4 v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/public-admin-container-v0-9-4)
    Checking aws-admin-container-v0-9-4 v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/aws-admin-container-v0-9-4)
    Checking public-control-container-v0-7-0 v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/public-control-container-v0-7-0)
    Checking k8s-registry v0.1.0 (/tmp/sources/api/migration/migrations/v1.13.0/k8s-registry)
    Checking aws-control-container-v0-7-0 v0.1.0 (/tmp/sources/api/migration/migrations/v1.12.0/aws-control-container-v0-7-0)
    Checking updog v0.1.0 (/tmp/sources/updater/updog)
    Checking migrator v0.1.0 (/tmp/sources/api/migration/migrator)
    Finished dev [unoptimized + debuginfo] target(s) in 10.44s
[cargo-make] INFO - Build Done in 76.84 seconds.
ubuntu:~/dev/bottlerocket$ cargo make check-clippy
[cargo-make] INFO - cargo make 0.36.0
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: check-clippy
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: check-clippy
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
[cargo-make] INFO - Build Done in 2.27 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
