### PR TITLE
tools: Update coldsnap to 0.5

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "coldsnap"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe7c5bb30e67fee6c251ce9be3e066a05f60ce572282dd3cb4b9affa6084e11"
+checksum = "7cb5b7cce3f0df950d0ed759a9cd31c5c8c54ec783e501187fa60b7b866ea183"
 dependencies = [
  "argh",
  "async-trait",

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -20,7 +20,7 @@ aws-types = "0.54"
 buildsys = { path = "../buildsys", version = "0.1" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 clap = "3"
-coldsnap = { version = "0.4", default-features = false, features = ["aws-sdk-rust-rustls"] }
+coldsnap = { version = "0.5", default-features = false, features = ["aws-sdk-rust-rustls"] }
 duct = "0.13"
 futures = "0.3"
 governor = "0.5"


### PR DESCRIPTION
**Description of changes:**

`coldsnap` v0.4.3 was yanked and republished as v0.5.0, so we're bumping it again.


**Testing done:**

`cargo make && cargo make ami`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
