### PR TITLE
testsys: Add support for metal-k8s testing

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3244,6 +3244,7 @@ dependencies = [
  "testsys-model",
  "tokio",
  "unescape",
+ "url",
 ]
 
 [[package]]

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -261,6 +261,12 @@ pub struct GenericVariantConfig {
     pub control_plane_endpoint: Option<String>,
     /// The path to userdata that should be used for Bottlerocket launch
     pub userdata: Option<String>,
+    /// The directory containing Bottlerocket images. For metal, this is the directory containing
+    /// gzipped images.
+    pub os_image_dir: Option<String>,
+    /// The hardware that should be used for provisioning Bottlerocket. For metal, this is the
+    /// hardware csv that is passed to EKS Anywhere.
+    pub hardware_csv: Option<String>,
     /// The workload tests that should be run
     #[serde(default)]
     pub workloads: BTreeMap<String, String>,
@@ -298,6 +304,8 @@ impl GenericVariantConfig {
             conformance_registry: self.conformance_registry.or(other.conformance_registry),
             control_plane_endpoint: self.control_plane_endpoint.or(other.control_plane_endpoint),
             userdata: self.userdata.or(other.userdata),
+            os_image_dir: self.os_image_dir.or(other.os_image_dir),
+            hardware_csv: self.hardware_csv.or(other.hardware_csv),
             workloads,
             dev: self.dev.merge(other.dev),
         }
@@ -358,6 +366,7 @@ pub struct TestsysImages {
     pub eks_resource_agent_image: Option<String>,
     pub ecs_resource_agent_image: Option<String>,
     pub vsphere_k8s_cluster_resource_agent_image: Option<String>,
+    pub metal_k8s_cluster_resource_agent_image: Option<String>,
     pub ec2_resource_agent_image: Option<String>,
     pub vsphere_vm_resource_agent_image: Option<String>,
     pub sonobuoy_test_agent_image: Option<String>,
@@ -381,6 +390,10 @@ impl TestsysImages {
             ecs_resource_agent_image: Some(format!("{}/ecs-resource-agent:{tag}", registry)),
             vsphere_k8s_cluster_resource_agent_image: Some(format!(
                 "{}/vsphere-k8s-cluster-resource-agent:{tag}",
+                registry
+            )),
+            metal_k8s_cluster_resource_agent_image: Some(format!(
+                "{}/metal-k8s-cluster-resource-agent:{tag}",
                 registry
             )),
             ec2_resource_agent_image: Some(format!("{}/ec2-resource-agent:{tag}", registry)),
@@ -408,6 +421,9 @@ impl TestsysImages {
             vsphere_k8s_cluster_resource_agent_image: self
                 .vsphere_k8s_cluster_resource_agent_image
                 .or(other.vsphere_k8s_cluster_resource_agent_image),
+            metal_k8s_cluster_resource_agent_image: self
+                .metal_k8s_cluster_resource_agent_image
+                .or(other.metal_k8s_cluster_resource_agent_image),
             vsphere_vm_resource_agent_image: self
                 .vsphere_vm_resource_agent_image
                 .or(other.vsphere_vm_resource_agent_image),

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -31,3 +31,4 @@ term_size = "0.3"
 testsys-config = { path = "../testsys-config/", version = "0.1" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 unescape = "0.1"
+url = "2"

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -22,7 +22,7 @@ pub(crate) struct AwsEcsCreator {
 #[async_trait::async_trait]
 impl CrdCreator for AwsEcsCreator {
     /// Determine the AMI from `amis.json`.
-    fn image_id(&self, _: &CrdInput) -> Result<String> {
+    async fn image_id(&self, _: &CrdInput) -> Result<String> {
         ami(&self.ami_input, &self.region)
     }
 

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -26,7 +26,7 @@ pub(crate) struct AwsK8sCreator {
 #[async_trait::async_trait]
 impl CrdCreator for AwsK8sCreator {
     /// Determine the AMI from `amis.json`.
-    fn image_id(&self, _: &CrdInput) -> Result<String> {
+    async fn image_id(&self, _: &CrdInput) -> Result<String> {
         ami(&self.ami_input, &self.region)
     }
 

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -102,6 +102,12 @@ pub enum Error {
     #[snafu(display("{} is not supported.", what))]
     Unsupported { what: String },
 
+    #[snafu(display("Unable to parse url from '{}': {}", url, source))]
+    UrlParse {
+        url: String,
+        source: url::ParseError,
+    },
+
     #[snafu(display("Unable to create `Variant` from `{}`: {}", variant, source))]
     Variant {
         variant: String,

--- a/tools/testsys/src/main.rs
+++ b/tools/testsys/src/main.rs
@@ -21,6 +21,7 @@ mod delete;
 mod error;
 mod install;
 mod logs;
+mod metal_k8s;
 mod migration;
 mod restart_test;
 mod run;
@@ -70,8 +71,8 @@ impl TestsysArgs {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    Install(Install),
-    // We need to box run because it requires significantly more arguments than the other commands.
+    // We need to box some commands because they require significantly more arguments than the other commands.
+    Install(Box<Install>),
     Run(Box<Run>),
     Delete(Delete),
     Status(Status),

--- a/tools/testsys/src/metal_k8s.rs
+++ b/tools/testsys/src/metal_k8s.rs
@@ -1,0 +1,253 @@
+use crate::crds::{
+    BottlerocketInput, ClusterInput, CrdCreator, CrdInput, CreateCrdOutput, MigrationInput,
+    TestInput,
+};
+use crate::error::{self, Result};
+use crate::migration::migration_crd;
+use crate::sonobuoy::{sonobuoy_crd, workload_crd};
+use bottlerocket_types::agent_config::MetalK8sClusterConfig;
+use maplit::btreemap;
+use serde::Deserialize;
+use snafu::{OptionExt, ResultExt};
+use std::collections::BTreeMap;
+use testsys_model::{Crd, DestructionPolicy};
+use url::Url;
+
+/// A `CrdCreator` responsible for creating crd related to `metal-k8s` variants.
+pub(crate) struct MetalK8sCreator {
+    pub(crate) region: String,
+    pub(crate) encoded_mgmt_cluster_kubeconfig: String,
+    pub(crate) image_name: String,
+}
+
+#[async_trait::async_trait]
+impl CrdCreator for MetalK8sCreator {
+    /// Use the provided image name with the `os_image_dir` from `Test.toml` for the image id.
+    async fn image_id(&self, crd_input: &CrdInput) -> Result<String> {
+        image_url(
+            crd_input
+                .config
+                .os_image_dir
+                .as_ref()
+                .context(error::InvalidSnafu {
+                    what: "An os image directory is required for metal testing",
+                })?,
+            &self.image_name,
+        )
+    }
+
+    /// Use standard naming conventions to predict the starting image name.
+    async fn starting_image_id(&self, crd_input: &CrdInput) -> Result<String> {
+        let filename = format!(
+            "bottlerocket-{}-{}-{}.img.gz",
+            crd_input.variant,
+            crd_input.arch,
+            crd_input
+                .starting_version
+                .as_ref()
+                .context(error::InvalidSnafu {
+                    what: "The starting version must be provided for migration testing"
+                })?
+        );
+        image_url(crd_input.config.os_image_dir.as_ref().context(error::InvalidSnafu {
+            what: "An os image directory is required for metal testing if a starting image id not used",
+        })?, &filename)
+    }
+
+    /// Creates a metal K8s cluster CRD with the `cluster_name` in `cluster_input`.
+    async fn cluster_crd<'a>(&self, cluster_input: ClusterInput<'a>) -> Result<CreateCrdOutput> {
+        let (cluster_name, control_plane_endpoint_ip, k8s_version) = cluster_data(
+            cluster_input
+                .cluster_config
+                .as_ref()
+                .context(error::InvalidSnafu {
+                    what: "A cluster config is required for Bare Metal cluster provisioning.",
+                })?,
+        )?;
+
+        let labels = cluster_input.crd_input.labels(btreemap! {
+            "testsys/type".to_string() => "cluster".to_string(),
+            "testsys/cluster".to_string() => cluster_name.clone(),
+            "testsys/controlPlaneEndpoint".to_string() => control_plane_endpoint_ip,
+            "testsys/k8sVersion".to_string() => k8s_version
+        });
+
+        // Check if the cluster already has a CRD
+        if let Some(cluster_crd) = cluster_input
+            .crd_input
+            .existing_crds(
+                &labels,
+                &[
+                    "testsys/cluster",
+                    "testsys/type",
+                    "testsys/controlPlaneEndpoint",
+                    "testsys/k8sVersion",
+                ],
+            )
+            .await?
+            .pop()
+        {
+            return Ok(CreateCrdOutput::ExistingCrd(cluster_crd));
+        }
+
+        // Check if an existing cluster is using this endpoint
+        let existing_clusters = cluster_input
+            .crd_input
+            .existing_crds(&labels, &["testsys/type", "testsys/controlPlaneEndpoint"])
+            .await?;
+
+        let metal_k8s_crd = MetalK8sClusterConfig::builder()
+            .set_labels(Some(labels))
+            .mgmt_cluster_kubeconfig_base64(&self.encoded_mgmt_cluster_kubeconfig)
+            .hardware_csv_base64(base64::encode(
+                cluster_input
+                    .hardware_csv
+                    .as_ref()
+                    .context(error::InvalidSnafu {
+                        what: "A hardware CSV is required for Bare Metal testing",
+                    })?,
+            ))
+            .cluster_config_base64(base64::encode(
+                cluster_input
+                    .cluster_config
+                    .as_ref()
+                    .context(error::InvalidSnafu {
+                        what: "A cluster config is required for Bare Metal testing",
+                    })?,
+            ))
+            .set_conflicts_with(Some(existing_clusters))
+            .destruction_policy(
+                cluster_input
+                    .crd_input
+                    .config
+                    .dev
+                    .cluster_destruction_policy
+                    .to_owned()
+                    .unwrap_or(DestructionPolicy::OnTestSuccess),
+            )
+            .image(
+                cluster_input
+                    .crd_input
+                    .images
+                    .metal_k8s_cluster_resource_agent_image
+                    .as_ref()
+                    .expect(
+                        "The default metal K8s cluster resource provider image URI is missing.",
+                    ),
+            )
+            .set_image_pull_secret(
+                cluster_input
+                    .crd_input
+                    .images
+                    .testsys_agent_pull_secret
+                    .to_owned(),
+            )
+            .privileged(true)
+            .build(cluster_name)
+            .context(error::BuildSnafu {
+                what: "metal K8s cluster CRD",
+            })?;
+
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Resource(
+            metal_k8s_crd,
+        ))))
+    }
+
+    /// Machines are provisioned during cluster creation, so there is nothing to do here.
+    async fn bottlerocket_crd<'a>(
+        &self,
+        _bottlerocket_input: BottlerocketInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::None)
+    }
+
+    async fn migration_crd<'a>(
+        &self,
+        migration_input: MigrationInput<'a>,
+    ) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(migration_crd(
+            migration_input,
+            Some("us-west-2".to_string()),
+            "instanceIds",
+        )?))))
+    }
+
+    async fn test_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(sonobuoy_crd(
+            test_input,
+        )?))))
+    }
+
+    async fn workload_crd<'a>(&self, test_input: TestInput<'a>) -> Result<CreateCrdOutput> {
+        Ok(CreateCrdOutput::NewCrd(Box::new(Crd::Test(workload_crd(
+            test_input,
+        )?))))
+    }
+
+    fn additional_fields(&self, _test_type: &str) -> BTreeMap<String, String> {
+        btreemap! {"region".to_string() => self.region.clone()}
+    }
+}
+
+/// Determine the (cluster name, control plane endpoint ip, K8s version) from an EKS Anywhere cluster manifest
+fn cluster_data(config: &str) -> Result<(String, String, String)> {
+    let cluster_manifest = serde_yaml::Deserializer::from_str(config)
+        .map(|config| {
+            serde_yaml::Value::deserialize(config).context(error::SerdeYamlSnafu {
+                what: "Unable to deserialize cluster config",
+            })
+        })
+        // Make sure all of the configs were deserializable
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        // Find the `Cluster` config
+        .find(|config| {
+            config.get("kind") == Some(&serde_yaml::Value::String("Cluster".to_string()))
+        });
+    let cluster_name = cluster_manifest
+        .as_ref()
+        // Get the name from the metadata field in the `Cluster` config
+        .and_then(|config| config.get("metadata"))
+        .and_then(|config| config.get("name"))
+        .and_then(|name| name.as_str())
+        .context(error::MissingSnafu {
+            item: "name",
+            what: "EKS Anywhere config metadata",
+        })?
+        .to_string();
+
+    let control_plane_endpoint_ip = cluster_manifest
+        .as_ref()
+        // Get the name from the metadata field in the `Cluster` config
+        .and_then(|config| config.get("spec"))
+        .and_then(|config| config.get("controlPlaneConfiguration"))
+        .and_then(|config| config.get("endpoint"))
+        .and_then(|config| config.get("host"))
+        .and_then(|name| name.as_str())
+        .context(error::MissingSnafu {
+            item: "control plane endpoint",
+            what: "EKS Anywhere config metadata",
+        })?
+        .to_string();
+
+    let k8s_version = cluster_manifest
+        .as_ref()
+        // Get the name from the metadata field in the `Cluster` config
+        .and_then(|config| config.get("spec"))
+        .and_then(|config| config.get("kubernetesVersion"))
+        .and_then(|name| name.as_str())
+        .context(error::MissingSnafu {
+            item: "control plane endpoint",
+            what: "EKS Anywhere config metadata",
+        })?
+        .to_string();
+
+    Ok((cluster_name, control_plane_endpoint_ip, k8s_version))
+}
+
+fn image_url(image_dir: &str, filename: &str) -> Result<String> {
+    let image_url = Url::parse(image_dir)
+        .and_then(|base_url| base_url.join(filename))
+        .context(error::UrlParseSnafu { url: image_dir })?;
+    Ok(image_url.to_string())
+}

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -14,11 +14,8 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
     let cluster_resource_name = test_input
         .cluster_crd_name
         .as_ref()
-        .expect("A cluster name is required for migrations");
-    let bottlerocket_resource_name = test_input
-        .bottlerocket_crd_name
-        .as_ref()
-        .expect("A cluster name is required for migrations");
+        .expect("A cluster name is required for sonobuoy testing");
+    let bottlerocket_resource_name = test_input.bottlerocket_crd_name;
     let sonobuoy_mode = match test_input.test_type {
         KnownTestType::Conformance => SonobuoyMode::CertifiedConformance,
         KnownTestType::Quick | KnownTestType::Migration | KnownTestType::Workload => {
@@ -33,7 +30,7 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
     });
 
     SonobuoyConfig::builder()
-        .resources(bottlerocket_resource_name)
+        .set_resources(Some(bottlerocket_resource_name.iter().cloned().collect()))
         .resources(cluster_resource_name)
         .set_depends_on(Some(test_input.prev_tests))
         .set_retries(Some(5))

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -29,7 +29,7 @@ pub(crate) struct VmwareK8sCreator {
 #[async_trait::async_trait]
 impl CrdCreator for VmwareK8sCreator {
     /// Use the provided OVA name for the image id.
-    fn image_id(&self, _: &CrdInput) -> Result<String> {
+    async fn image_id(&self, _: &CrdInput) -> Result<String> {
         Ok(self.ova_name.to_string())
     }
 
@@ -104,7 +104,7 @@ impl CrdCreator for VmwareK8sCreator {
             .control_plane_endpoint_ip(control_plane_endpoint)
             .creation_policy(CreationPolicy::IfNotExists)
             .version(cluster_version)
-            .ova_name(self.image_id(cluster_input.crd_input)?)
+            .ova_name(self.image_id(cluster_input.crd_input).await?)
             .tuf_repo(
                 cluster_input
                     .crd_input


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2152 

**Description of changes:**

Adds support for testing metal k8s variants with testsys. There are several requirements for testing with metal that will be described in `TESTING.md`.

**Testing done:**

Ran `cargo make -e BUILDSYS_VARIANT="aws-k8s-1.24" test` with sample files and made sure the crd was properly created.

```sh
cargo make -e BUILDSYS_VARIANT="metal-k8s-1.24"
# Convert lz4 to gzip and push
cargo make -e BUILDSYS_VARIANT="metal-k8s-1.24" -e TESTSYS_MGMT_CLUSTER_KUBECONFIG=tests/metal-mgmt.kubeconfig test
```

Test passed after the cluster finished provisioning.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
