### PR TITLE
Makefile: adds tasks to purge go and rust cached code

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1394,6 +1394,36 @@ rm -rf ${BUILDSYS_STATE_DIR}
 '''
 ]
 
+# Deletes cached code used for Bottlerocket builds
+[tasks.purge-cache]
+dependencies = [
+  "purge-go-vendor",
+  "purge-cargo",
+]
+
+# This task will delete vendored Go code, primarily, the Go module cache.
+# The Go module cache is intentionally readonly and does not have writable
+# subdirectories or files. So, we first need to perform the `chmod` in order to
+# have permissions to delete it.
+# See for more context: https://github.com/golang/go/issues/27455
+[tasks.purge-go-vendor]
+script_runner = "bash"
+script = [
+    '''
+    chmod -R 755 ${GO_MOD_CACHE}
+    rm -rf ${GO_MOD_CACHE}
+    '''
+]
+
+# This task will remove all the cached Rust code found in the cargo home dir
+[tasks.purge-cargo]
+script_runner = "bash"
+script = [
+    '''
+    rm -rf ${CARGO_HOME}
+    '''
+]
+
 [tasks.test-tools]
 dependencies = ["setup", "fetch-sources"]
 script = [


### PR DESCRIPTION
**Issue number:**

N/a - related to issues attempting to purge the `.gomodcache` directory
that gets populated during build. The `GOMODCACHE` directory is _intentionally_
made readonly: https://github.com/golang/go/issues/27455

So, after our docker build environment has vendored and cached the go code,
the only way to purge it before this change was `sudo rm -rf .gomodcache`

**Description of changes:**

2 new tasks:
- `purge-go-vendor` which `chmod` on the `.gomodcache` directory in order to `rm` it
- `purge-cargo` which will `rm` the projects cached rust code in `.cargo`

**Testing done:**

Able to run `cargo make purge-cache` and `cargo make -e BUILDSYS_VARIANT=aws-k8s-1.25`
sequentially without error.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
