### PR TITLE
release: ensure 'prepare-boot' runs after 'mark-successful-boot'

### DIFF
--- a/packages/release/prepare-boot.service
+++ b/packages/release/prepare-boot.service
@@ -2,6 +2,8 @@
 Description=Prepare Boot Directory (/boot)
 RefuseManualStart=true
 RefuseManualStop=true
+After=mark-successful-boot.service
+Requires=mark-successful-boot.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

```
    release: ensure 'prepare-boot' runs after 'mark-successful-boot'
    
    To prevent prairiedog from reading the GPT table while signpost is still
    writing to it during 'mark-successful-boot', we enforce strict ordering
    between the two services to ensure 'prepare-boot' runs after
    'mark-successful-boot' is fully active/finished.
```

**Testing done:**
Verified that `prepare-boot.service` runs after `mark-successful-boot.service`
```
....
         Starting Call signpost to mark the …r all required targets are met....
         Starting Bottlerocket data store migrator...
[  OK  ] Started ACPI event daemon.
[  OK  ] Mounted Kernel Development Sources (Read-Only).
         Mounting Kernel Development Sources (Read-Write)...
[  OK  ] Mounted Kernel Development Sources (Read-Write).
[  OK  ] Finished Call signpost to mark the …ter all required targets are met..
         Starting Prepare Boot Directory (/boot)...
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
