### PR TITLE
Default to cgroup v2 for dev and k8s-1.26 variants

### DIFF
--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -9,6 +9,7 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
+unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 kernel-parameters = [

--- a/variants/aws-k8s-1.26-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.26-nvidia/Cargo.toml
@@ -14,6 +14,7 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
+unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.26/Cargo.toml
+++ b/variants/aws-k8s-1.26/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
+unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -12,6 +12,7 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
+unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/metal-k8s-1.26/Cargo.toml
+++ b/variants/metal-k8s-1.26/Cargo.toml
@@ -15,6 +15,7 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
+unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -12,6 +12,7 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
+unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"

--- a/variants/vmware-k8s-1.26/Cargo.toml
+++ b/variants/vmware-k8s-1.26/Cargo.toml
@@ -14,6 +14,7 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
+unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"


### PR DESCRIPTION
**Issue number:**

Closes #2843

**Description of changes:** Make the `*-dev` and `*-k8s-1.26` variants use cgroup v2 by default.


**Testing done:**

* Confirmed defaults on boot and fallback instructions (user data/`apiclient`) work as expected via inspection of `/sys/fs/cgroup` on the host.
* Basic functional testing done with the `aws-k8s-1.24` variant for availability of a working EKS cluster.
* **Would appreciate help with running the conformance tests on the `*-k8s-1.26` variants!**


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
