### PR TITLE
kubernetes-1.26: fix cloud provider condition

### DIFF
--- a/packages/kubernetes-1.26/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.26/kubelet-exec-start-conf
@@ -2,7 +2,7 @@
 ExecStart=
 ExecStart=/usr/bin/kubelet \
 {{#unless settings.kubernetes.standalone-mode}}
-{{#if (eq settings.kubernetes.cloud-provider "")}}
+{{#if (eq settings.kubernetes.cloud-provider "\"\"")}}
     --cloud-provider "" \
 {{else}}
     --cloud-provider "external" \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Fri Mar 10 10:09:08 2023 +0000

    kubernetes-1.26: fix cloud provider condition

    Bottlerocket settings model for cloud_provider converts the empty string to
    "\"\"", so we should improve the if condition to eq to it.
```


**Testing done:**

- [x] - `aws-*` conformance test
- [x] - `metal-*` conformance test
- [x] - `vmware-*` conformance test

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
