### PR TITLE
rpm2img,release: conditionally create data fs based on part layout

### DIFF
--- a/packages/os/has-boot-ever-succeeded.service
+++ b/packages/os/has-boot-ever-succeeded.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Checks and marks if boot has ever succeeded before
 DefaultDependencies=no
-Before=label-data-alternative.service label-data-preferred.service
+Before=label-data-a.service label-data-b.service
 RequiresMountsFor=/etc
 
 [Service]

--- a/packages/release/local.mount
+++ b/packages/release/local.mount
@@ -3,6 +3,8 @@ Description=Local Directory (/local)
 DefaultDependencies=no
 Conflicts=umount.target
 Before=local-fs.target umount.target
+After=prepare-local-fs.service
+Requires=prepare-local-fs.service
 
 [Mount]
 What=/dev/disk/by-partlabel/BOTTLEROCKET-DATA

--- a/packages/release/prepare-local-fs.service
+++ b/packages/release/prepare-local-fs.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Prepare Local Filesystem (/local)
+DefaultDependencies=no
+Wants=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dDATA.device
+After=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dDATA.device
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+
+# Create the filesystem on the partition, if it doesn't exist.
+ExecStart=/usr/lib/systemd/systemd-makefs ext4 /dev/disk/by-partlabel/BOTTLEROCKET-DATA
+
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -59,6 +59,7 @@ Source1045: mask-local-opt.service
 Source1046: mask-local-var.service
 Source1047: label-data-b.service
 Source1048: label-data-a.service
+Source1049: prepare-local-fs.service
 
 # Services for kdump support
 Source1060: capture-kernel-dump.service
@@ -141,7 +142,8 @@ install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} %{S:1006} %{S:1007} \
   %{S:1008} %{S:1009} %{S:1010} %{S:1011} %{S:1012} %{S:1013} %{S:1015} \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} %{S:1045} %{S:1046} \
-  %{S:1047} %{S:1048} %{S:1060} %{S:1061} %{S:1062} %{S:1080} %{S:1014} \
+  %{S:1047} %{S:1048} %{S:1049} %{S:1060} %{S:1061} %{S:1062} %{S:1080} \
+  %{S:1014} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d
@@ -224,6 +226,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/root-.aws.mount
 %{_cross_unitdir}/label-data-b.service
 %{_cross_unitdir}/label-data-a.service
+%{_cross_unitdir}/prepare-local-fs.service
 %dir %{_cross_unitdir}/systemd-tmpfiles-setup.service.d
 %{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
 %dir %{_cross_templatedir}

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -109,8 +109,7 @@ ROOT_IMAGE="$(mktemp)"
 DATA_IMAGE="$(mktemp)"
 EFI_IMAGE="$(mktemp)"
 PRIVATE_IMAGE="$(mktemp)"
-BOTTLEROCKET_DATA_A="$(mktemp)"
-BOTTLEROCKET_DATA_B="$(mktemp)"
+BOTTLEROCKET_DATA="$(mktemp)"
 
 ROOT_MOUNT="$(mktemp -d)"
 BOOT_MOUNT="$(mktemp -d)"
@@ -402,25 +401,33 @@ dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRI
 UNLABELED=$(find "${DATA_MOUNT}" \
     | awk -v root="${DATA_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_rm", $1, "security.selinux"}')
 
-for side in A B ; do
-  if [ "${side}" == "B" ] && [ "${PARTITION_PLAN}" == "unified" ] ; then
-    continue
-  fi
-  dev="BOTTLEROCKET_DATA_${side}"
-  dev="${!dev}"
-  mkfs.ext4 -d "${DATA_MOUNT}" "${dev}" "${partsize["DATA-${side}"]}M"
-  echo "${UNLABELED}" | debugfs -w -f - "${dev}"
-done
+mkfs_data() {
+  local target size offset
+  target="${1:?}"
+  size="${2:?}"
+  offset="${3:?}"
+  mkfs.ext4 -m 0 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" "${size}"
+  echo "${UNLABELED}" | debugfs -w -f - "${BOTTLEROCKET_DATA}"
+  dd if="${BOTTLEROCKET_DATA}" of="${target}" conv=notrunc bs=1M seek="${offset}"
+}
 
+# Decide which data filesystem to create at build time based on layout.
+#
+# The DATA-A partition will always exist, but for the "split" layout, it will be
+# too small to provide the desired filesystem parameters (inode count, etc) when
+# it is grown later on. Hence this filesystem is only created for "unified".
+#
+# The DATA-B partition does not exist on the "unified" layout, which anticipates
+# a single storage device. Hence this filesystem is only created for "split".
+#
+# If the other partition is available at runtime, the filesystem will be created
+# during first boot instead, providing flexibility at the cost of a minor delay.
 case "${PARTITION_PLAN}" in
-  split)
-    # Only create data partition B on data image in "split" image layout configurations
-    dd if="${BOTTLEROCKET_DATA_B}" of="${DATA_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA-B]}"
-
-    dd if="${BOTTLEROCKET_DATA_A}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA-A]}"
-    ;;
   unified)
-    dd if="${BOTTLEROCKET_DATA_A}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[DATA-A]}"
+    mkfs_data "${OS_IMAGE}" "${partsize["DATA-A"]}M" "${partoff["DATA-A"]}"
+    ;;
+  split)
+    mkfs_data "${DATA_IMAGE}" "${partsize["DATA-B"]}M" "${partoff["DATA-B"]}"
     ;;
 esac
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
    rpm2img,release: conditionally create data fs based on part layout
    
    DATA-A partition in the "split" layout is too small to create an
    initial filesystem with desirable filesystem parameters. So we defer the
    filesystem creation to later at runtime with 'prepare-local-fs' after
    the partition gets resized to fill the disk/volume. This only needs to
    happen when DATA-B on the separate disk/volume is unavailable and we
    have additional space on the root disk/volume for DATA-A to grow.
    
    For "unified" layout, DATA-B does not exist since we only anticipate the
    root disk/volume and no other storage device. Therefore we can skip
    creating a filesystem for DATA-B.

```
```
    os: fix dependency ordering in 'has-boot-ever-succeeded'
    
    Fixes typos for the units in Before=
```


**Testing done:**
### Normal storage device configuration for "split" layouts (2 GB root, 20 GB data)
Host comes up fine. `prepare-local-fs` doesn't run because the data part filesystem already exists:
```
bash-5.1# systemctl status label-data-a label-data-b prepare-local-fs local.mount repart-local
● label-data-a.service - Label data partition A
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-a.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:15:49 UTC; 3min 41s ago
   Main PID: 850 (code=killed, signal=ABRT)

Mar 10 21:15:48 localhost systemd[1]: Starting Label data partition A...
Mar 10 21:15:49 localhost systemd-repart[850]: Assertion 'amount <= total' failed at src/partition/repart.c:533, function charge_size(). Aborting.
Mar 10 21:15:49 localhost systemd[1]: Finished Label data partition A.

● label-data-b.service - Label data partition B
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-b.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:15:49 UTC; 3min 41s ago
   Main PID: 861 (code=exited, status=0/SUCCESS)

Mar 10 21:15:48 localhost systemd[1]: Starting Label data partition B...
Mar 10 21:15:49 localhost systemd-repart[861]: Applying changes.
Mar 10 21:15:49 localhost systemd-repart[861]: Storage does not support discard, not discarding gap at beginning of disk.
Mar 10 21:15:49 localhost systemd-repart[861]: Growing existing partition 0.
Mar 10 21:15:49 localhost systemd-repart[861]: Setting partition label of existing partition 0.
Mar 10 21:15:49 localhost systemd-repart[861]: Writing new partition table.
Mar 10 21:15:49 localhost systemd-repart[861]: Telling kernel to reread partition table.
Mar 10 21:15:49 localhost systemd-repart[861]: All done.
Mar 10 21:15:49 localhost systemd[1]: Finished Label data partition B.

● prepare-local-fs.service - Prepare Local Filesystem (/local)
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/prepare-local-fs.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:15:49 UTC; 3min 41s ago
   Main PID: 882 (code=exited, status=0/SUCCESS)

Mar 10 21:15:49 localhost systemd[1]: Starting Prepare Local Filesystem (/local)...
Mar 10 21:15:49 localhost systemd-makefs[882]: '/dev/disk/by-partlabel/BOTTLEROCKET-DATA' is not empty (contains file system of type ext4), exiting.
Mar 10 21:15:49 localhost systemd[1]: Finished Prepare Local Filesystem (/local).

● local.mount - Local Directory (/local)
     Loaded: loaded (/proc/self/mountinfo; enabled; vendor preset: enabled)
     Active: active (mounted) since Fri 2023-03-10 21:15:49 UTC; 3min 41s ago
      Until: Fri 2023-03-10 21:15:49 UTC; 3min 41s ago
      Where: /local
       What: /dev/nvme1n1p1
      Tasks: 0 (limit: 9265)
     Memory: 28.0K
     CGroup: /system.slice/local.mount

Mar 10 21:15:49 localhost systemd[1]: Mounting Local Directory (/local)...
Mar 10 21:15:49 localhost systemd[1]: Mounted Local Directory (/local).

● repart-local.service - Resize Data Partition
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/repart-local.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:15:49 UTC; 3min 41s ago
   Main PID: 890 (code=exited, status=0/SUCCESS)

Mar 10 21:15:49 localhost systemd[1]: Starting Resize Data Partition...
Mar 10 21:15:49 localhost systemd-repart[887]: No changes.
Mar 10 21:15:49 localhost systemd-growfs[890]: Successfully resized "/local" to 19.9G bytes.
Mar 10 21:15:49 localhost systemd[1]: Finished Resize Data Partition.
```
Data part filesystem parameters look normal:
```
bash-5.1# tune2fs -l /dev/nvme1n1p1                                                   
tune2fs 1.47.0 (5-Feb-2023)                                                           
Filesystem volume name:   <none>
Last mounted on:          /var                                                        
Filesystem UUID:          519a6a21-1dff-4641-96a9-a98b0760331b                                                                                                              
Filesystem magic number:  0xEF53                                                      
Filesystem revision #:    1 (dynamic)                                                 
Filesystem features:      has_journal ext_attr resize_inode dir_index filetype needs_recovery extent 64bit flex_bg sparse_super large_file huge_file dir_nlink extra_isize metadata_csum                                                                          
Filesystem flags:         unsigned_directory_hash                                                                                                                           
Default mount options:    user_xattr acl                                              
Filesystem state:         clean
Errors behavior:          Continue      
Filesystem OS type:       Linux                                                       
Inode count:              1308160                                                     
Block count:              5242368                                                     
Reserved block count:     0
Overhead clusters:        87595
Free blocks:              5154767
Free inodes:              1308149
First block:              0           
Block size:               4096
Fragment size:            4096                                                        
Group descriptor size:    64                                                          
Reserved GDT blocks:      125
Blocks per group:         32768                                                       
Fragments per group:      32768                                                                                                                                             
Inodes per group:         8176                                                        
Inode blocks per group:   511                                                         
Flex block group size:    16
Filesystem created:       Fri Mar 10 21:14:05 2023                     
Last mount time:          Fri Mar 10 21:15:49 2023        
Last write time:          Fri Mar 10 21:15:49 2023                                                                                                                          
Mount count:              1                                                           
Maximum mount count:      -1            
Last checked:             Fri Mar 10 21:14:05 2023
Check interval:           0 (<none>)    
Lifetime writes:          533 kB                                                      
Reserved blocks uid:      0 (user root)                                               
Reserved blocks gid:      0 (group root)
First inode:              11
Inode size:               256    
Required extra isize:     32               
Desired extra isize:      32        
Journal inode:            8
Default directory hash:   half_md4
Directory Hash Seed:      0b70b56f-1125-4bd4-b2dc-8c8c90d44993
Journal backup:           inode blocks
Checksum type:            crc32c
Checksum:                 0x5cc11926

```

### Single 22 GB root EBS volume with "split" partition layout (data partition missing)
Host comes up fine. `label-data-a` runs and resizes/labels the data partition on the root volume as expected. `prepare-local-fs` creates the filesystem successfully:
```
bash-5.1# systemctl status label-data-a label-data-b prepare-local-fs local.mout repart-local
Unit local.mout.service could not be found.
● label-data-a.service - Label data partition A
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-a.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:17:52 UTC; 2min 44s ago
   Main PID: 821 (code=exited, status=0/SUCCESS)

Mar 10 21:17:52 localhost systemd[1]: Starting Label data partition A...
Mar 10 21:17:52 localhost systemd-repart[821]: Applying changes.
Mar 10 21:17:52 localhost systemd-repart[821]: Storage does not support discard, not discarding gap at beginning of disk.
Mar 10 21:17:52 localhost systemd-repart[821]: Growing existing partition 12.
Mar 10 21:17:52 localhost systemd-repart[821]: Setting partition label of existing partition 12.
Mar 10 21:17:52 localhost systemd-repart[821]: Writing new partition table.
Mar 10 21:17:52 localhost systemd-repart[821]: Telling kernel to reread partition table.
Mar 10 21:17:52 localhost systemd-repart[821]: All done.
Mar 10 21:17:52 localhost systemd[1]: Finished Label data partition A.

○ label-data-b.service - Label data partition B
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-b.service; enabled; vendor preset: enabled)
     Active: inactive (dead)
  Condition: start condition failed at Fri 2023-03-10 21:19:22 UTC; 1min 14s ago
             └─ ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA was not met

Mar 10 21:19:22 ip-192-168-15-70.us-west-2.compute.internal systemd[1]: Label data partition B was skipped because of a failed condition check (ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA).

● prepare-local-fs.service - Prepare Local Filesystem (/local)
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/prepare-local-fs.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:17:52 UTC; 2min 43s ago
   Main PID: 851 (code=exited, status=0/SUCCESS)

Mar 10 21:17:52 localhost systemd[1]: Starting Prepare Local Filesystem (/local)...
Mar 10 21:17:52 localhost systemd-makefs[851]: /dev/disk/by-partlabel/BOTTLEROCKET-DATA successfully formatted as ext4 (label "BOTTLEROCKET-DAT", uuid 51562f76-61e1-4b6a-8907-b36cba11362e)
Mar 10 21:17:52 localhost systemd[1]: Finished Prepare Local Filesystem (/local).

● repart-local.service - Resize Data Partition
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/repart-local.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:17:53 UTC; 2min 43s ago
   Main PID: 894 (code=exited, status=0/SUCCESS)

Mar 10 21:17:53 localhost systemd[1]: Starting Resize Data Partition...
Mar 10 21:17:53 localhost systemd-repart[875]: No changes.
Mar 10 21:17:53 localhost systemd-growfs[894]: Successfully resized "/local" to 20.0G bytes.
Mar 10 21:17:53 localhost systemd[1]: Finished Resize Data Partition.
```
Filesystem parameters look normal and is mostly the same as `DATA-B`:
```
bash-5.1# tune2fs -l /dev/nvme0n1p13
tune2fs 1.47.0 (5-Feb-2023)
Filesystem volume name:   BOTTLEROCKET-DAT
Last mounted on:          /var
Filesystem UUID:          51562f76-61e1-4b6a-8907-b36cba11362e
Filesystem magic number:  0xEF53
Filesystem revision #:    1 (dynamic)
Filesystem features:      has_journal ext_attr resize_inode dir_index orphan_file filetype needs_recovery extent 64bit flex_bg metadata_csum_seed sparse_super large_file huge_file dir_nlink extra_isize metadata_csum orphan_present
Filesystem flags:         signed_directory_hash 
Default mount options:    user_xattr acl
Filesystem state:         clean
Errors behavior:          Continue
Filesystem OS type:       Linux
Inode count:              1313280
Block count:              5242880
Reserved block count:     0
Overhead clusters:        126476
Free blocks:              5115886
Free inodes:              1313268
First block:              0
Block size:               4096
Fragment size:            4096
Group descriptor size:    64
Reserved GDT blocks:      1024
Blocks per group:         32768
Fragments per group:      32768
Inodes per group:         8208
Inode blocks per group:   513
Flex block group size:    16
Filesystem created:       Fri Mar 10 21:17:52 2023
Last mount time:          Fri Mar 10 21:17:53 2023
Last write time:          Fri Mar 10 21:17:53 2023
Mount count:              1
Maximum mount count:      -1
Last checked:             Fri Mar 10 21:17:52 2023
Check interval:           0 (<none>)
Lifetime writes:          6210 kB
Reserved blocks uid:      0 (user root)
Reserved blocks gid:      0 (group root)
First inode:              11
Inode size:               256
Required extra isize:     32
Desired extra isize:      32
Journal inode:            8
Default directory hash:   half_md4
Directory Hash Seed:      210a295e-3161-4d7a-9329-d988f82e80a4
Journal backup:           inode blocks
Checksum type:            crc32c
Checksum:                 0x76e08afd
Checksum seed:            0x2a877858
Orphan file inode:        12
```

### "Unified" image layout
Host comes up fine. `label-data-a` runs and resizes/labels the data partition on the root volume as expected. `prepare-local-fs` creates the filesystem successfully:
```
bash-5.1# systemctl status label-data-a label-data-b prepare-local-fs local.mount repart-local
● label-data-a.service - Label data partition A
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-a.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:22:29 UTC; 3min 22s ago
   Main PID: 797 (code=exited, status=0/SUCCESS)

Mar 10 21:22:29 localhost systemd[1]: Starting Label data partition A...
Mar 10 21:22:29 localhost systemd-repart[797]: Applying changes.
Mar 10 21:22:29 localhost systemd-repart[797]: Storage does not support discard, not discarding gap at beginning of disk.
Mar 10 21:22:29 localhost systemd-repart[797]: Growing existing partition 12.
Mar 10 21:22:29 localhost systemd-repart[797]: Setting partition label of existing partition 12.
Mar 10 21:22:29 localhost systemd-repart[797]: Writing new partition table.
Mar 10 21:22:29 localhost systemd-repart[797]: Telling kernel to reread partition table.
Mar 10 21:22:29 localhost systemd-repart[797]: All done.
Mar 10 21:22:29 localhost systemd[1]: Finished Label data partition A.

○ label-data-b.service - Label data partition B
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/label-data-b.service; enabled; vendor preset: enabled)
     Active: inactive (dead)
  Condition: start condition failed at Fri 2023-03-10 21:23:58 UTC; 1min 53s ago
             └─ ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA was not met

Mar 10 21:23:58 ip-192-168-29-170.us-west-2.compute.internal systemd[1]: Label data partition B was skipped because of a failed condition check (ConditionPathIsSymbolicLink=!/dev/disk/by-partlabel/BOTTLEROCKET-DATA).

● prepare-local-fs.service - Prepare Local Filesystem (/local)
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/prepare-local-fs.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:22:29 UTC; 3min 22s ago
   Main PID: 850 (code=exited, status=0/SUCCESS)

Mar 10 21:22:29 localhost systemd[1]: Starting Prepare Local Filesystem (/local)...
Mar 10 21:22:29 localhost systemd-makefs[850]: '/dev/disk/by-partlabel/BOTTLEROCKET-DATA' is not empty (contains file system of type ext4), exiting.
Mar 10 21:22:29 localhost systemd[1]: Finished Prepare Local Filesystem (/local).

● local.mount - Local Directory (/local)
     Loaded: loaded (/proc/self/mountinfo; enabled; vendor preset: enabled)
     Active: active (mounted) since Fri 2023-03-10 21:22:29 UTC; 3min 22s ago
      Until: Fri 2023-03-10 21:22:29 UTC; 3min 22s ago
      Where: /local
       What: /dev/nvme0n1p13
      Tasks: 0 (limit: 9265)
     Memory: 28.0K
     CGroup: /system.slice/local.mount

Mar 10 21:22:29 localhost systemd[1]: Mounting Local Directory (/local)...
Mar 10 21:22:29 localhost systemd[1]: Mounted Local Directory (/local).

● repart-local.service - Resize Data Partition
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/repart-local.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2023-03-10 21:22:29 UTC; 3min 22s ago
   Main PID: 886 (code=exited, status=0/SUCCESS)

Mar 10 21:22:29 localhost systemd[1]: Starting Resize Data Partition...
Mar 10 21:22:29 localhost systemd-repart[867]: No changes.
Mar 10 21:22:29 localhost systemd[1]: Finished Resize Data Partition.

```
Filesystem parameters  look normal:
```
bash-5.1# tune2fs -l /dev/nvme0n1p13
tune2fs 1.47.0 (5-Feb-2023)
Filesystem volume name:   <none>
Last mounted on:          /var
Filesystem UUID:          c6a2a24e-be4a-421a-a6ed-1b6a68ca1492
Filesystem magic number:  0xEF53
Filesystem revision #:    1 (dynamic)
Filesystem features:      has_journal ext_attr resize_inode dir_index filetype needs_recovery extent 64bit flex_bg sparse_super large_file huge_file dir_nlink extra_isize metadata_csum
Filesystem flags:         unsigned_directory_hash 
Default mount options:    user_xattr acl
Filesystem state:         clean
Errors behavior:          Continue
Filesystem OS type:       Linux
Inode count:              1310720
Block count:              5242880
Reserved block count:     0
Overhead clusters:        91851
Free blocks:              5151023
Free inodes:              1310709
First block:              0
Block size:               4096
Fragment size:            4096
Group descriptor size:    64
Reserved GDT blocks:      125
Blocks per group:         32768
Fragments per group:      32768
Inodes per group:         8192
Inode blocks per group:   512
Flex block group size:    16
Filesystem created:       Fri Mar 10 21:18:43 2023
Last mount time:          Fri Mar 10 21:22:29 2023
Last write time:          Fri Mar 10 21:22:29 2023
Mount count:              1
Maximum mount count:      -1
Last checked:             Fri Mar 10 21:18:43 2023
Check interval:           0 (<none>)
Lifetime writes:          533 kB
Reserved blocks uid:      0 (user root)
Reserved blocks gid:      0 (group root)
First inode:              11
Inode size:               256
Required extra isize:     32
Desired extra isize:      32
Journal inode:            8
Default directory hash:   half_md4
Directory Hash Seed:      f2a7253f-ae75-4cb6-994a-9f8cfd55ecd1
Journal backup:           inode blocks
Checksum type:            crc32c
Checksum:                 0x8b4541be

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
