### PR TITLE
logdog: include systemd-analyze plot

### DIFF
--- a/sources/logdog/conf/logdog.common.conf
+++ b/sources/logdog/conf/logdog.common.conf
@@ -10,6 +10,7 @@ exec journalctl.errors journalctl -p err -a --no-pager
 exec journalctl.log journalctl -a --no-pager
 exec systemd-analyze-blame systemd-analyze blame --no-pager
 exec systemd-analyze-critical-chain systemd-analyze critical-chain --no-pager preconfigured.target configured.target multi-user.target
+exec systemd-analyze-plot.svg systemd-analyze plot
 # file copy does not work for this, use cat command instead
 exec proc-mounts cat /proc/mounts
 exec signpost signpost status


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
This appends `systemd-analyze plot` to the output of logdog. systemd-analyze critical-chain is good, but plot adds some nice additional information which is helpful for understanding what happened at boot.

<details>
  <summary>(click me) They look like this</summary>
  
![systemd-analyze-plot](https://user-images.githubusercontent.com/990370/224432514-dc7ba279-7f9a-4bff-85a2-a3b9ac926318.svg)

</details>


**Testing done:**
I launched an instance and from the admin container ran:

```
sudo sheltie
logdog
```

Then from the admin container unpacked the contents of `/.bottlerocket/support/bottlerocket-logs.tar.gz` and noted that an SVG file was present at `systemd-analyze-plot.svg`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
