### PR TITLE
revert change to noatsecure rules in SELinux policy

### DIFF
--- a/packages/selinux-policy/processes.cil
+++ b/packages/selinux-policy/processes.cil
@@ -15,7 +15,7 @@
 
 ; Permission group for relaxing security constraints on processes.
 (classmapping processes relax (
-  process (execheap execmem execstack noatsecure)))
+  process (execheap execmem execstack)))
 (classmapping processes relax (
   memprotect (mmap_zero)))
 
@@ -23,6 +23,6 @@
 (classmapping processes interact (
   process (not (
     dyntransition transition setcurrent setexec
-    setfscreate setkeycreate setsockcreate 
+    setfscreate setkeycreate setsockcreate
     getsched getsession getpgid getcap getattr getrlimit
-    execheap execmem execstack noatsecure))))
+    execheap execmem execstack))))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -26,12 +26,6 @@
 ; Unprivileged components cannot interact with privileged processes.
 (neverallow unprivileged_s privileged_s (processes (interact)))
 
-
-; Host subjects are denied the `noatsecure` permission to ensure that
-; the environment is sanitized during all domain transitions. Suppress
-; this audit message since otherwise it adds a lot of noise
-(dontaudit all_s all_s (process (noatsecure)))
-
 ; PID 1 starts as "kernel_t" and becomes "init_t".
 (typetransition kernel_t init_exec_t process init_t)
 (allow kernel_t init_t (processes (transform)))


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
This reverts commit c55908923359554d4ff0bfa2477a21c734de2bee.

The net effect of the previous change was to set the AT_SECURE bit on execution for all domain transitions for host programs, but not on executions within containers.

However, `runc` is a host program that needs to transition into the container domains. Applying AT_SECURE in these cases means that any environment variables expected to be set for the container's entry point will be ignored if that program uses `secure_getenv` rather than `getenv` to access its environment.

The impact is uncertain and depends on how the entry point program is written and whether it uses `secure_getenv`. In any case, the change has a larger blast radius than intended; `runc` must be allowed to use "noatsecure" transitions to maximize compatibility.


**Testing done:**
Before the revert, verified that [`AT_SECURE`](https://github.com/bminor/glibc/blob/359a0b9dbcd46475f443a33e0062a14b252e327d/elf/elf.h#L1217) was set in the auxiliary vector of a container's entry point program:
```
[root@admin]# od -t d8 /proc/6426/auxv 
...
0000360                   23                    1
...
```

On a host with the revert, confirmed that `AT_SECURE` was cleared in the auxiliary vector:
```
[root@admin]# od -t d8 /proc/8664/auxv
...
0000360                   23                    0
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
