### PR TITLE
testsys: Support ecs workload testing

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -373,6 +373,7 @@ pub struct TestsysImages {
     pub ecs_test_agent_image: Option<String>,
     pub migration_test_agent_image: Option<String>,
     pub k8s_workload_agent_image: Option<String>,
+    pub ecs_workload_agent_image: Option<String>,
     pub controller_image: Option<String>,
     pub testsys_agent_pull_secret: Option<String>,
 }
@@ -405,6 +406,7 @@ impl TestsysImages {
             ecs_test_agent_image: Some(format!("{}/ecs-test-agent:{tag}", registry)),
             migration_test_agent_image: Some(format!("{}/migration-test-agent:{tag}", registry)),
             k8s_workload_agent_image: Some(format!("{}/k8s-workload-agent:{tag}", registry)),
+            ecs_workload_agent_image: Some(format!("{}/ecs-workload-agent:{tag}", registry)),
             controller_image: Some(format!("{}/controller:{tag}", registry)),
             testsys_agent_pull_secret: None,
         }
@@ -440,6 +442,9 @@ impl TestsysImages {
             k8s_workload_agent_image: self
                 .k8s_workload_agent_image
                 .or(other.k8s_workload_agent_image),
+            ecs_workload_agent_image: self
+                .ecs_workload_agent_image
+                .or(other.ecs_workload_agent_image),
             controller_image: self.controller_image.or(other.controller_image),
             testsys_agent_pull_secret: self
                 .testsys_agent_pull_secret

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -559,6 +559,13 @@ pub(crate) struct TestsysImages {
     )]
     pub(crate) k8s_workload: Option<String>,
 
+    /// ECS workload agent URI. If not provided the latest released test agent will be used.
+    #[clap(
+        long = "ecs-workload-agent-image",
+        env = "TESTSYS_ECS_WORKLOAD_AGENT_IMAGE"
+    )]
+    pub(crate) ecs_workload: Option<String>,
+
     /// TestSys controller URI. If not provided the latest released controller will be used.
     #[clap(long = "controller-image", env = "TESTSYS_CONTROLLER_IMAGE")]
     pub(crate) controller_uri: Option<String>,
@@ -584,6 +591,7 @@ impl From<TestsysImages> for testsys_config::TestsysImages {
             ecs_test_agent_image: val.ecs_test,
             migration_test_agent_image: val.migration_test,
             k8s_workload_agent_image: val.k8s_workload,
+            ecs_workload_agent_image: val.ecs_workload,
             controller_image: val.controller_uri,
             testsys_agent_pull_secret: val.secret,
         }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes N/A

**Description of changes:**

The pr enables workload testing on the `aws-ecs` variants. This works the same way as k8s workloads and uses the ecs workload agent instead of the k8s workload agent.

**Testing done:**

Used cargo make test on `aws-ecs-1` with `workload` test type and verified that the correct agent was used and that testing completed as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
