### PR TITLE
Fix `sources/models` README from generated content

### DIFF
--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -27,47 +27,47 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-k8s-1.22/mod.rs)
 * [Default settings](src/aws-k8s-1.22/defaults.d/)
 
-#### aws-k8s-1.22-nvidia: Kubernetes 1.22 NVIDIA
+### aws-k8s-1.22-nvidia: Kubernetes 1.22 NVIDIA
 
 * [Model](src/aws-k8s-1.22-nvidia/mod.rs)
 * [Default settings](src/aws-k8s-1.22-nvidia/defaults.d/)
 
 ### aws-k8s-1.23: Kubernetes 1.23
 
-* [Model](src/aws-k8s-1.23/mod.rs)
-* [Default settings](src/aws-k8s-1.23/defaults.d/)
+* [Model](src/aws-k8s-1.26/mod.rs)
+* [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-#### aws-k8s-1.23-nvidia: Kubernetes 1.23 NVIDIA
+### aws-k8s-1.23-nvidia: Kubernetes 1.23 NVIDIA
 
-* [Model](src/aws-k8s-1.23-nvidia/mod.rs)
-* [Default settings](src/aws-k8s-1.23-nvidia/defaults.d/)
+* [Model](src/aws-k8s-1.26-nvidia/mod.rs)
+* [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
 
 ### aws-k8s-1.24: Kubernetes 1.24
 
-* [Model](src/aws-k8s-1.24/mod.rs)
-* [Default settings](src/aws-k8s-1.24/defaults.d/)
+* [Model](src/aws-k8s-1.26/mod.rs)
+* [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-#### aws-k8s-1.24-nvidia: Kubernetes 1.24 NVIDIA
+### aws-k8s-1.24-nvidia: Kubernetes 1.24 NVIDIA
 
-* [Model](src/aws-k8s-1.24-nvidia/mod.rs)
-* [Default settings](src/aws-k8s-1.24-nvidia/defaults.d/)
+* [Model](src/aws-k8s-1.26-nvidia/mod.rs)
+* [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
 
 ### aws-k8s-1.25: Kubernetes 1.25
 
-* [Model](src/aws-k8s-1.25/mod.rs)
-* [Default settings](src/aws-k8s-1.25/defaults.d/)
+* [Model](src/aws-k8s-1.26/mod.rs)
+* [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-#### aws-k8s-1.25-nvidia: Kubernetes 1.25 NVIDIA
+### aws-k8s-1.25-nvidia: Kubernetes 1.25 NVIDIA
 
-* [Model](src/aws-k8s-1.25-nvidia/mod.rs)
-* [Default settings](src/aws-k8s-1.25-nvidia/defaults.d/)
+* [Model](src/aws-k8s-1.26-nvidia/mod.rs)
+* [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
 
 ### aws-k8s-1.26: Kubernetes 1.26
 
 * [Model](src/aws-k8s-1.26/mod.rs)
 * [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-#### aws-k8s-1.26-nvidia: Kubernetes 1.26 NVIDIA
+### aws-k8s-1.26-nvidia: Kubernetes 1.26 NVIDIA
 
 * [Model](src/aws-k8s-1.26-nvidia/mod.rs)
 * [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
@@ -94,18 +94,18 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 
 ### vmware-k8s-1.23: VMware Kubernetes 1.23
 
-* [Model](src/vmware-k8s-1.23/mod.rs)
-* [Default settings](src/vmware-k8s-1.23/defaults.d/)
+* [Model](src/vmware-k8s-1.26/mod.rs)
+* [Default settings](src/vmware-k8s-1.26/defaults.d/)
 
 ### vmware-k8s-1.24: VMware Kubernetes 1.24
 
-* [Model](src/vmware-k8s-1.24/mod.rs)
-* [Default settings](src/vmware-k8s-1.24/defaults.d/)
+* [Model](src/vmware-k8s-1.26/mod.rs)
+* [Default settings](src/vmware-k8s-1.26/defaults.d/)
 
 ### vmware-k8s-1.25: VMware Kubernetes 1.25
 
-* [Model](src/vmware-k8s-1.25/mod.rs)
-* [Default settings](src/vmware-k8s-1.25/defaults.d/)
+* [Model](src/vmware-k8s-1.26/mod.rs)
+* [Default settings](src/vmware-k8s-1.26/defaults.d/)
 
 ### vmware-k8s-1.26: VMware Kubernetes 1.26
 
@@ -124,18 +124,18 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 
 ### metal-k8s-1.23: Metal Kubernetes 1.23
 
-* [Model](src/metal-k8s-1.23/mod.rs)
-* [Default settings](src/metal-k8s-1.23/defaults.d/)
+* [Model](src/metal-k8s-1.26/mod.rs)
+* [Default settings](src/metal-k8s-1.26/defaults.d/)
 
 ### metal-k8s-1.24: Metal Kubernetes 1.24
 
-* [Model](src/metal-k8s-1.24/mod.rs)
-* [Default settings](src/metal-k8s-1.24/defaults.d/)
+* [Model](src/metal-k8s-1.26/mod.rs)
+* [Default settings](src/metal-k8s-1.26/defaults.d/)
 
 ### metal-k8s-1.25: Metal Kubernetes 1.25
 
-* [Model](src/metal-k8s-1.25/mod.rs)
-* [Default settings](src/metal-k8s-1.25/defaults.d/)
+* [Model](src/metal-k8s-1.26/mod.rs)
+* [Default settings](src/metal-k8s-1.26/defaults.d/)
 
 ### metal-k8s-1.26: Metal Kubernetes 1.26
 

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -24,47 +24,47 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-k8s-1.22/mod.rs)
 * [Default settings](src/aws-k8s-1.22/defaults.d/)
 
-### aws-k8s-1.22-nvidia: Kubernetes 1.22 NVIDIA
+## aws-k8s-1.22-nvidia: Kubernetes 1.22 NVIDIA
 
 * [Model](src/aws-k8s-1.22-nvidia/mod.rs)
 * [Default settings](src/aws-k8s-1.22-nvidia/defaults.d/)
 
 ## aws-k8s-1.23: Kubernetes 1.23
 
-* [Model](src/aws-k8s-1.23/mod.rs)
-* [Default settings](src/aws-k8s-1.23/defaults.d/)
+* [Model](src/aws-k8s-1.26/mod.rs)
+* [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-### aws-k8s-1.23-nvidia: Kubernetes 1.23 NVIDIA
+## aws-k8s-1.23-nvidia: Kubernetes 1.23 NVIDIA
 
-* [Model](src/aws-k8s-1.23-nvidia/mod.rs)
-* [Default settings](src/aws-k8s-1.23-nvidia/defaults.d/)
+* [Model](src/aws-k8s-1.26-nvidia/mod.rs)
+* [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
 
 ## aws-k8s-1.24: Kubernetes 1.24
 
-* [Model](src/aws-k8s-1.24/mod.rs)
-* [Default settings](src/aws-k8s-1.24/defaults.d/)
+* [Model](src/aws-k8s-1.26/mod.rs)
+* [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-### aws-k8s-1.24-nvidia: Kubernetes 1.24 NVIDIA
+## aws-k8s-1.24-nvidia: Kubernetes 1.24 NVIDIA
 
-* [Model](src/aws-k8s-1.24-nvidia/mod.rs)
-* [Default settings](src/aws-k8s-1.24-nvidia/defaults.d/)
+* [Model](src/aws-k8s-1.26-nvidia/mod.rs)
+* [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
 
 ## aws-k8s-1.25: Kubernetes 1.25
 
-* [Model](src/aws-k8s-1.25/mod.rs)
-* [Default settings](src/aws-k8s-1.25/defaults.d/)
+* [Model](src/aws-k8s-1.26/mod.rs)
+* [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-### aws-k8s-1.25-nvidia: Kubernetes 1.25 NVIDIA
+## aws-k8s-1.25-nvidia: Kubernetes 1.25 NVIDIA
 
-* [Model](src/aws-k8s-1.25-nvidia/mod.rs)
-* [Default settings](src/aws-k8s-1.25-nvidia/defaults.d/)
+* [Model](src/aws-k8s-1.26-nvidia/mod.rs)
+* [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
 
 ## aws-k8s-1.26: Kubernetes 1.26
 
 * [Model](src/aws-k8s-1.26/mod.rs)
 * [Default settings](src/aws-k8s-1.26/defaults.d/)
 
-### aws-k8s-1.26-nvidia: Kubernetes 1.26 NVIDIA
+## aws-k8s-1.26-nvidia: Kubernetes 1.26 NVIDIA
 
 * [Model](src/aws-k8s-1.26-nvidia/mod.rs)
 * [Default settings](src/aws-k8s-1.26-nvidia/defaults.d/)
@@ -91,18 +91,23 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 
 ## vmware-k8s-1.23: VMware Kubernetes 1.23
 
-* [Model](src/vmware-k8s-1.23/mod.rs)
-* [Default settings](src/vmware-k8s-1.23/defaults.d/)
+* [Model](src/vmware-k8s-1.26/mod.rs)
+* [Default settings](src/vmware-k8s-1.26/defaults.d/)
 
 ## vmware-k8s-1.24: VMware Kubernetes 1.24
 
-* [Model](src/vmware-k8s-1.24/mod.rs)
-* [Default settings](src/vmware-k8s-1.24/defaults.d/)
+* [Model](src/vmware-k8s-1.26/mod.rs)
+* [Default settings](src/vmware-k8s-1.26/defaults.d/)
 
 ## vmware-k8s-1.25: VMware Kubernetes 1.25
 
-* [Model](src/vmware-k8s-1.25/mod.rs)
-* [Default settings](src/vmware-k8s-1.25/defaults.d/)
+* [Model](src/vmware-k8s-1.26/mod.rs)
+* [Default settings](src/vmware-k8s-1.26/defaults.d/)
+
+## vmware-k8s-1.26: VMware Kubernetes 1.26
+
+* [Model](src/vmware-k8s-1.26/mod.rs)
+* [Default settings](src/vmware-k8s-1.26/defaults.d/)
 
 ## metal-dev: Metal development build
 
@@ -116,18 +121,23 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 
 ## metal-k8s-1.23: Metal Kubernetes 1.23
 
-* [Model](src/metal-k8s-1.23/mod.rs)
-* [Default settings](src/metal-k8s-1.23/defaults.d/)
+* [Model](src/metal-k8s-1.26/mod.rs)
+* [Default settings](src/metal-k8s-1.26/defaults.d/)
 
 ## metal-k8s-1.24: Metal Kubernetes 1.24
 
-* [Model](src/metal-k8s-1.24/mod.rs)
-* [Default settings](src/metal-k8s-1.24/defaults.d/)
+* [Model](src/metal-k8s-1.26/mod.rs)
+* [Default settings](src/metal-k8s-1.26/defaults.d/)
 
 ## metal-k8s-1.25: Metal Kubernetes 1.25
 
-* [Model](src/metal-k8s-1.25/mod.rs)
-* [Default settings](src/metal-k8s-1.25/defaults.d/)
+* [Model](src/metal-k8s-1.26/mod.rs)
+* [Default settings](src/metal-k8s-1.26/defaults.d/)
+
+## metal-k8s-1.26: Metal Kubernetes 1.26
+
+* [Model](src/metal-k8s-1.26/mod.rs)
+* [Default settings](src/metal-k8s-1.26/defaults.d/)
 
 # This directory
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

New k8s-1.26 variants were recently added, but the README.md file was modified directly with the updated variants. This would normally be fine, but like many README.md files in the repo, this file is generated based on code comments in another file. This would result in the file showing modified whenever doing a local build.

This updates the code comments so the generated README has all necessary variant information.

This also cleans up some changes in title level that have been copy/pasted to a few different variants. Title levels are now the same for all variants.

There is also a problem that GitHub does not work with hyperlinks to symlinks. So as we update new variants, we point the old variant to the new variant if the model does not change. This causes the majority of the hyperlinks in the README on GitHub to go to 404 error pages.

This updates the link references to go to the "real" file in the repo so all hyperlinks lead to a valid destination that shows the model being used for that variant.

**Testing done:**

- Performed a local build and made sure the `README.md` file did not show it had been modified by the build.
- Checked each link reference to make sure it points to the correct file that is actually used for that variant.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
