### PR TITLE
pubsys: fix AWS SDK API calls and surface service error codes

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -358,7 +358,11 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             }
             Err(e) => {
                 saw_error = true;
-                error!("Copy to {} failed: {}", region, e);
+                error!(
+                    "Copy to {} failed: {}",
+                    region,
+                    e.into_service_error().code().unwrap_or("unknown")
+                );
             }
         }
     }

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -399,12 +399,14 @@ pub(crate) async fn modify_regional_snapshots(
             }
             Err(e) => {
                 error_count += 1;
-                error!(
-                    "Failed to modify permissions in {} for snapshots [{}]: {}",
-                    region.as_ref(),
-                    snapshot_ids.join(", "),
-                    e
-                );
+                if let Error::ModifyImageAttribute { source: err, .. } = e {
+                    error!(
+                        "Failed to modify permissions in {} for snapshots [{}]: {:?}",
+                        region.as_ref(),
+                        snapshot_ids.join(", "),
+                        err.into_service_error().code().unwrap_or("unknown"),
+                    );
+                }
             }
         }
     }
@@ -483,7 +485,9 @@ pub(crate) async fn modify_regional_images(
                 error_count += 1;
                 error!(
                     "Modifying permissions of {} in {} failed: {}",
-                    image_id, region, e
+                    image_id,
+                    region,
+                    e.into_service_error().code().unwrap_or("unknown"),
                 );
             }
         }

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -331,8 +331,12 @@ pub(crate) async fn modify_snapshots(
         let response_future = ec2_client
             .modify_snapshot_attribute()
             .set_attribute(Some(SnapshotAttributeName::CreateVolumePermission))
-            .set_user_ids(Some(modify_opts.user_ids.clone()))
-            .set_group_names(Some(modify_opts.group_names.clone()))
+            .set_user_ids(
+                (!modify_opts.user_ids.is_empty()).then_some(modify_opts.user_ids.clone()),
+            )
+            .set_group_names(
+                (!modify_opts.group_names.is_empty()).then_some(modify_opts.group_names.clone()),
+            )
             .set_operation_type(Some(operation.clone()))
             .set_snapshot_id(Some(snapshot_id.clone()))
             .send();
@@ -435,10 +439,18 @@ pub(crate) async fn modify_image(
         .set_attribute(Some(
             ImageAttributeName::LaunchPermission.as_ref().to_string(),
         ))
-        .set_user_ids(Some(modify_opts.user_ids.clone()))
-        .set_user_groups(Some(modify_opts.group_names.clone()))
-        .set_organization_arns(Some(modify_opts.organization_arns.clone()))
-        .set_organizational_unit_arns(Some(modify_opts.organizational_unit_arns.clone()))
+        .set_user_ids((!modify_opts.user_ids.is_empty()).then_some(modify_opts.user_ids.clone()))
+        .set_user_groups(
+            (!modify_opts.group_names.is_empty()).then_some(modify_opts.group_names.clone()),
+        )
+        .set_organization_arns(
+            (!modify_opts.organization_arns.is_empty())
+                .then_some(modify_opts.organization_arns.clone()),
+        )
+        .set_organizational_unit_arns(
+            (!modify_opts.organizational_unit_arns.is_empty())
+                .then_some(modify_opts.organizational_unit_arns.clone()),
+        )
         .set_operation_type(Some(operation.clone()))
         .set_image_id(Some(image_id.to_string()))
         .send()

--- a/tools/pubsys/src/aws/ssm/ssm.rs
+++ b/tools/pubsys/src/aws/ssm/ssm.rs
@@ -43,7 +43,7 @@ where
             let len = names_chunk.len();
             let get_future = ssm_client
                 .get_parameters()
-                .set_names(Some(names_chunk.to_vec()))
+                .set_names((!names_chunk.is_empty()).then_some(names_chunk.to_vec().clone()))
                 .send();
 
             // Store the region so we can include it in errors and the output map


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

```
    pubsys: fix put-parameter taking a empty list
    
    Ensure we pass None if the list of names we're passing is empty.
```
```
    pubsys: fix AWS SDK API calls
    
    The EC2 API call for modify-snapshot-attribute and
    modify-image-attribute errors on empty vecs. This passes 'None' for the
    list parameters if the list is empty.
```
```

    pubsys: surface AWS API service error code in error log
    
    This surfaces the actual AWS API service error code in the error log message.

```

**Testing done:**
@jpculp ran the tests:
- [x]  Ran pubsys directly to revoke user ids
- [x] Ran pubsys directly to grant user ids
- [x] Published ami with cargo make -e BUILDSYS_ARCH=x86_64 -e BUILDSYS_VARIANT=aws-k8s-1.24 ami
- [x] Granted permissions to ami with cargo make -e BUILDSYS_ARCH=x86_64 -e BUILDSYS_VARIANT=aws-k8s-1.24 -e GRANT_TO_USERS=<> grant-ami


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
