### PR TITLE
Add pigz for parallel decompression by containerd

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -74,7 +74,7 @@ Our sample package has the following manifest.
 [package]
 name = "libwoof"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 build = "build.rs"
 

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -22,3 +22,4 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 runc = { path = "../runc" }
+pigz = { path = "../pigz" }

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -38,6 +38,7 @@ Source1000: clarify.toml
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}runc
+Requires: %{_cross_os}pigz
 
 %description
 %{summary}.

--- a/packages/pigz/Cargo.toml
+++ b/packages/pigz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pigz"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://zlib.net/pigz/pigz-2.7.tar.gz"
+sha512 = "9f9f61de4a0307fc057dc4e31a98bd8d706d9e709ecde0be02a871534fddf6a1fe1321158aa72708603aaaece43f83d2423b127f7689b6219b23aea4f989e8f5"
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+libz = { path = "../libz" }
+
+# RPM Requires
+[dependencies]
+# None

--- a/packages/pigz/build.rs
+++ b/packages/pigz/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/pigz/pigz.spec
+++ b/packages/pigz/pigz.spec
@@ -1,0 +1,35 @@
+Name: %{_cross_os}pigz
+Version: 2.7
+Release: 1%{?dist}
+Summary: pigz is a parallel implementation of gzip which utilizes multiple cores
+License: Zlib AND Apache-2.0
+URL: http://www.zlib.net/pigz
+Source0: https://zlib.net/pigz/pigz-%{version}.tar.gz
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libz-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n pigz-%{version} -p1
+
+%global set_env \
+%set_cross_build_flags \\\
+export CC=%{_cross_target}-gcc \\\
+%{nil}
+
+%build
+%set_env
+%make_build CC="${CC}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 unpigz %{buildroot}%{_cross_bindir}
+
+%files
+%license README zopfli/COPYING
+%{_cross_bindir}/unpigz
+%{_cross_attribution_file}
+
+%changelog

--- a/packages/pigz/pkg.rs
+++ b/packages/pigz/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -268,6 +268,7 @@ name = "containerd"
 version = "0.1.0"
 dependencies = [
  "glibc",
+ "pigz",
  "runc",
 ]
 
@@ -918,6 +919,14 @@ name = "os"
 version = "0.1.0"
 dependencies = [
  "glibc",
+]
+
+[[package]]
+name = "pigz"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libz",
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2886

**Description of changes:**

Let containerd use pigz (or more precisely, `unpigz`).
pigz doesn't have a LICENSE file (https://github.com/madler/pigz/issues/89) and I decided to use `README`...

If there is no pigz, and the log level of containerd is set to debug, the following log will be output at the time of pull.
```
Mar 14 09:30:08 10.0.2.15 containerd[1175]: time="2023-03-14T09:30:08.609765577Z" level=debug msg="unpigz not found, falling back to go gzip" error="exec: \"unpigz\": executable file not found in $PATH"
```
I have confirmed that with this change that log disappears (i.e. containerd uses unpigz).

Here is a quick benchmark.

machine spec:
Google Compute Engine c3-highcpu-22 Ubuntu 22.04.2 (enable nested virtualization)

Command to execute:
```bash
ctr image pull docker.io/library/mysql:8.0.32
```

without pigz(commit b1ac8ef6922e776ee410b6e3020ec8133c51a959)
```
6.139457575s
7.236172524s
7.730825494s
```

with pigz(this commit)
```
5.842488681s
6.319545383s
5.777997267s
```

**Testing done:** yes

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
