### PR TITLE
logdog: output precise timestamps in journalctl

### DIFF
--- a/sources/logdog/conf/logdog.common.conf
+++ b/sources/logdog/conf/logdog.common.conf
@@ -7,7 +7,7 @@ exec iptables-filter iptables -nvL -t filter
 exec iptables-nat iptables -nvL -t nat
 exec journalctl-boots journalctl --list-boots --no-pager
 exec journalctl.errors journalctl -p err -a --no-pager
-exec journalctl.log journalctl -a --no-pager
+exec journalctl.log journalctl -o short-precise -a --no-pager
 exec systemd-analyze-blame systemd-analyze blame --no-pager
 exec systemd-analyze-critical-chain systemd-analyze critical-chain --no-pager preconfigured.target configured.target multi-user.target
 exec systemd-analyze-plot.svg systemd-analyze plot


### PR DESCRIPTION
**Issue number:**
This is being done in service of #2878

**Description of changes:**
This adds microsecond precision to journalctl log messages, which by default only have second precision.

```
--short

    is the default and generates an output that is mostly identical
    to the formatting of classic syslog files, showing one line per
    journal entry.

...

--short-precise
    is very similar, but shows classic syslog timestamps with full
    microsecond precision.
```


**Testing done:**
Tested running logdog on a build of the `aws-k8s-1.23` variant. Sample output:

```
Mar 14 10:12:31.545053 localhost kernel: x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT  
Mar 14 10:12:31.545065 localhost kernel: last_pfn = 0xbffe6 max_arch_pfn = 0x400000000
Mar 14 10:12:31.545076 localhost kernel: check: Scanning 1 areas for low memory corruption
Mar 14 10:12:31.545088 localhost kernel: Using GB pages for direct mapping
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
