### PR TITLE
netdog: Add missing versions to bond-related net config

### DIFF
--- a/sources/api/netdog/src/net_config/devices/bonding.rs
+++ b/sources/api/netdog/src/net_config/devices/bonding.rs
@@ -19,11 +19,11 @@ pub(crate) struct NetBondV1 {
     #[serde(rename = "route")]
     pub(crate) routes: Option<Vec<RouteV1>>,
     kind: String,
-    pub(crate) mode: BondMode,
+    pub(crate) mode: BondModeV1,
     #[serde(rename = "min-links")]
     pub(crate) min_links: Option<usize>,
     #[serde(rename = "monitoring")]
-    pub(crate) monitoring_config: BondMonitoringConfig,
+    pub(crate) monitoring_config: BondMonitoringConfigV1,
     pub(crate) interfaces: Vec<InterfaceName>,
 }
 
@@ -69,8 +69,8 @@ impl Validate for NetBondV1 {
         }
         // Validate monitoring configuration
         match &self.monitoring_config {
-            BondMonitoringConfig::MiiMon(config) => config.validate()?,
-            BondMonitoringConfig::ArpMon(config) => config.validate()?,
+            BondMonitoringConfigV1::MiiMon(config) => config.validate()?,
+            BondMonitoringConfigV1::ArpMon(config) => config.validate()?,
         }
 
         Ok(())
@@ -80,20 +80,20 @@ impl Validate for NetBondV1 {
 // Currently only mode 1 (active-backup) is supported but eventually 0-6 could be added
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub(crate) enum BondMode {
+pub(crate) enum BondModeV1 {
     ActiveBackup,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
-pub(crate) enum BondMonitoringConfig {
-    MiiMon(MiiMonitoringConfig),
-    ArpMon(ArpMonitoringConfig),
+pub(crate) enum BondMonitoringConfigV1 {
+    MiiMon(MiiMonitoringConfigV1),
+    ArpMon(ArpMonitoringConfigV1),
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct MiiMonitoringConfig {
+pub(crate) struct MiiMonitoringConfigV1 {
     #[serde(rename = "miimon-frequency-ms")]
     pub(crate) frequency: u32,
     #[serde(rename = "miimon-updelay-ms")]
@@ -102,7 +102,7 @@ pub(crate) struct MiiMonitoringConfig {
     pub(crate) downdelay: u32,
 }
 
-impl Validate for MiiMonitoringConfig {
+impl Validate for MiiMonitoringConfigV1 {
     fn validate(&self) -> Result<()> {
         ensure!(
             self.frequency > 0,
@@ -124,16 +124,16 @@ impl Validate for MiiMonitoringConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct ArpMonitoringConfig {
+pub(crate) struct ArpMonitoringConfigV1 {
     #[serde(rename = "arpmon-interval-ms")]
     pub(crate) interval: u32,
     #[serde(rename = "arpmon-validate")]
-    pub(crate) validate: ArpValidate,
+    pub(crate) validate: ArpValidateV1,
     #[serde(rename = "arpmon-targets")]
     pub(crate) targets: Vec<IpAddr>,
 }
 
-impl Validate for ArpMonitoringConfig {
+impl Validate for ArpMonitoringConfigV1 {
     fn validate(&self) -> Result<()> {
         ensure!(
             self.interval > 0,
@@ -155,7 +155,7 @@ impl Validate for ArpMonitoringConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub(crate) enum ArpValidate {
+pub(crate) enum ArpValidateV1 {
     Active,
     All,
     Backup,

--- a/sources/api/netdog/src/wicked/bonding.rs
+++ b/sources/api/netdog/src/wicked/bonding.rs
@@ -1,6 +1,6 @@
 use crate::interface_id::InterfaceName;
 use crate::net_config::devices::bonding::{
-    ArpMonitoringConfig, ArpValidate, BondMode, MiiMonitoringConfig,
+    ArpMonitoringConfigV1, ArpValidateV1, BondModeV1, MiiMonitoringConfigV1,
 };
 
 use serde::Serialize;
@@ -60,16 +60,16 @@ pub(crate) enum WickedBondMode {
     PrimaryBackup,
 }
 
-impl From<BondMode> for WickedBondMode {
-    fn from(mode: BondMode) -> Self {
+impl From<BondModeV1> for WickedBondMode {
+    fn from(mode: BondModeV1) -> Self {
         match mode {
-            BondMode::ActiveBackup => WickedBondMode::PrimaryBackup,
+            BondModeV1::ActiveBackup => WickedBondMode::PrimaryBackup,
         }
     }
 }
 
-impl From<MiiMonitoringConfig> for WickedMiiMonitoringConfig {
-    fn from(config: MiiMonitoringConfig) -> Self {
+impl From<MiiMonitoringConfigV1> for WickedMiiMonitoringConfig {
+    fn from(config: MiiMonitoringConfigV1) -> Self {
         WickedMiiMonitoringConfig {
             frequency: config.frequency,
             updelay: config.updelay,
@@ -79,8 +79,8 @@ impl From<MiiMonitoringConfig> for WickedMiiMonitoringConfig {
     }
 }
 
-impl From<ArpMonitoringConfig> for WickedArpMonitoringConfig {
-    fn from(config: ArpMonitoringConfig) -> Self {
+impl From<ArpMonitoringConfigV1> for WickedArpMonitoringConfig {
+    fn from(config: ArpMonitoringConfigV1) -> Self {
         let mut t_vec = Vec::new();
         for t in config.targets {
             t_vec.push(ArpTarget(t))
@@ -143,13 +143,13 @@ pub(crate) enum WickedArpValidate {
     None,
 }
 
-impl From<ArpValidate> for WickedArpValidate {
-    fn from(validate: ArpValidate) -> Self {
+impl From<ArpValidateV1> for WickedArpValidate {
+    fn from(validate: ArpValidateV1) -> Self {
         match validate {
-            ArpValidate::Active => WickedArpValidate::Active,
-            ArpValidate::All => WickedArpValidate::All,
-            ArpValidate::Backup => WickedArpValidate::Backup,
-            ArpValidate::None => WickedArpValidate::None,
+            ArpValidateV1::Active => WickedArpValidate::Active,
+            ArpValidateV1::All => WickedArpValidate::All,
+            ArpValidateV1::Backup => WickedArpValidate::Backup,
+            ArpValidateV1::None => WickedArpValidate::None,
         }
     }
 }

--- a/sources/api/netdog/src/wicked/mod.rs
+++ b/sources/api/netdog/src/wicked/mod.rs
@@ -9,7 +9,7 @@ mod static_address;
 mod vlan;
 
 use crate::interface_id::{InterfaceId, InterfaceName, MacAddress};
-use crate::net_config::devices::bonding::{BondMonitoringConfig, NetBondV1};
+use crate::net_config::devices::bonding::{BondMonitoringConfigV1, NetBondV1};
 use crate::net_config::devices::interface::NetInterfaceV2;
 use crate::net_config::devices::vlan::NetVlanV1;
 use crate::net_config::devices::NetworkDeviceV1;
@@ -234,10 +234,10 @@ where
         wicked_bond.min_links = config.min_links;
 
         match &config.monitoring_config {
-            BondMonitoringConfig::MiiMon(config) => {
+            BondMonitoringConfigV1::MiiMon(config) => {
                 wicked_bond.mii_monitoring = Some(WickedMiiMonitoringConfig::from(config.clone()))
             }
-            BondMonitoringConfig::ArpMon(config) => {
+            BondMonitoringConfigV1::ArpMon(config) => {
                 wicked_bond.arp_monitoring = Some(WickedArpMonitoringConfig::from(config.clone()))
             }
         }


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
```
    netdog: Add missing versions to bond-related net config
    
    Somehow these two structs ended up being unversioned in the midst of all
    of our versioned structs.  This commit adds a 'V1' to these structs to
    stay in line with the rest of the config versioning and also cover for
    the case they do change in the future.
```

**Testing done:**
All unit tests still pass, indicating the serialized form of these structs hasn't changed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
