### PR TITLE
check-clippy: Fix user permissions

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -440,6 +440,7 @@ export VARIANT="${BUILDSYS_VARIANT}"
 
 # For rust first-party source code
 if ! docker run --rm \
+   -u $(id -u):$(id -g) \
    -e CARGO_HOME="/tmp/.cargo" \
    -v "${CARGO_HOME}":/tmp/.cargo \
    -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
@@ -452,6 +453,7 @@ if ! docker run --rm \
 fi
 
 if ! docker run --rm \
+   -u $(id -u):$(id -g) \
    -e CARGO_HOME="/tmp/.cargo" \
    -v "${CARGO_HOME}":/tmp/.cargo \
    -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

When running the `check-clippy` task, by default cargo clippy is run from the SDK. When this container runs, it is under the `builder` user context. This causes a problem when trying to access the locally mounted path to the .cargo_lock file. This local file is owned by the current local user, with only read permissions for Other.

```txt
-rw-r--r--   1 stmcg stmcg      0 Mar 17 14:48 .cargo-lock
```

This in turn causes a failure in the clippy execution.

```txt
[cargo-make] INFO - Running Task: check-clippy
error: failed to open: /tmp/tools/target/debug/.cargo-lock

Caused by:
  Permission denied (os error 13)
error: failed to open: /tmp/sources/target/debug/.cargo-lock

Caused by:
  Permission denied (os error 13)
Found lint warnings. First-party source code is checked with clippy.
```

This change updates our check-clippy task to call `docker run` with the uid:gid of the current user so there are no permission conflicts.

**Testing done:**

Ran without the change and observed failure behavior.
Applied changes to `docker run` command to use uid:gid.
Ran task again and verified `clippy` check is able to run and complete successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
