### PR TITLE
Fix aws.profile rendering in cred-provider template

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -189,3 +189,6 @@ version = "1.13.0"
     "migrate_v1.13.0_aws-control-container-v0-7-1.lz4",
     "migrate_v1.13.0_public-control-container-v0-7-1.lz4",
 ]
+"(1.13.0, 1.13.1)" = [
+    "migrate_v1.13.1_aws-profile-cred-provider.lz4",
+]

--- a/packages/kubernetes-1.22/credential-provider-config-yaml
+++ b/packages/kubernetes-1.22/credential-provider-config-yaml
@@ -15,9 +15,9 @@ providers:
     env:
       - name: HOME
         value: /root
-{{#if settings.aws.profile}}
+{{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{settings.aws.profile}}
+        value: {{@root.settings.aws.profile}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.23/credential-provider-config-yaml
+++ b/packages/kubernetes-1.23/credential-provider-config-yaml
@@ -15,9 +15,9 @@ providers:
     env:
       - name: HOME
         value: /root
-{{#if settings.aws.profile}}
+{{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{settings.aws.profile}}
+        value: {{@root.settings.aws.profile}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.24/credential-provider-config-yaml
+++ b/packages/kubernetes-1.24/credential-provider-config-yaml
@@ -15,9 +15,9 @@ providers:
     env:
       - name: HOME
         value: /root
-{{#if settings.aws.profile}}
+{{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{settings.aws.profile}}
+        value: {{@root.settings.aws.profile}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.25/credential-provider-config-yaml
+++ b/packages/kubernetes-1.25/credential-provider-config-yaml
@@ -15,9 +15,9 @@ providers:
     env:
       - name: HOME
         value: /root
-{{#if settings.aws.profile}}
+{{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{settings.aws.profile}}
+        value: {{@root.settings.aws.profile}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.26/credential-provider-config-yaml
+++ b/packages/kubernetes-1.26/credential-provider-config-yaml
@@ -15,9 +15,9 @@ providers:
     env:
       - name: HOME
         value: /root
-{{#if settings.aws.profile}}
+{{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{settings.aws.profile}}
+        value: {{@root.settings.aws.profile}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -562,6 +562,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-profile-cred-provider"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-sdk-cloudformation"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "api/migration/migrations/v1.13.0/public-admin-container-v0-10-0",
     "api/migration/migrations/v1.13.0/aws-control-container-v0-7-1",
     "api/migration/migrations/v1.13.0/public-control-container-v0-7-1",
+    "api/migration/migrations/v1.13.1/aws-profile-cred-provider",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.13.1/aws-profile-cred-provider/Cargo.toml
+++ b/sources/api/migration/migrations/v1.13.1/aws-profile-cred-provider/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-profile-cred-provider"
+version = "0.1.0"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.13.1/aws-profile-cred-provider/src/main.rs
+++ b/sources/api/migration/migrations/v1.13.1/aws-profile-cred-provider/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added `affected-services` metadata for `aws.profile`
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.aws.profile",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/kubernetes-services.toml
+++ b/sources/models/shared-defaults/kubernetes-services.toml
@@ -57,3 +57,6 @@ restart-commands = ["/usr/bin/static-pods"]
 
 [metadata.settings.kubernetes.static-pods]
 affected-services = ["static-pods"]
+
+[metadata.settings.aws.profile]
+affected-services = ["kubernetes"]


### PR DESCRIPTION
**Issue number:**

Closes #2885

**Description of changes:**

The ecr-credential-provider can use a profile for determining which credential settings to use out of `~/.aws`. This wasn't getting rendered in the configuration template because it was inside an `{{#each}}` block that would change the handlebars context so it would look for settings values relative to the setting being iterated.

This fixes that by explicitly referencing the `aws.profile` setting from the root, ignoring iteration context.

Another issue was that setting `aws.profile` after setting the credential provider settings would not trigger re-rendering of the credential provider configuration file. This adds an "affected-services" value for the setting to tell it to restart kubelet, which triggers the rendering of the template.

A migration was needed because of this affected-services metadata change.

**Testing done:**

Set credential provider data:

```
# apiclient apply << EOF
> [settings.kubernetes.credential-providers.ecr-credential-provider]
> enabled = true
> # (optional - defaults to "12h")
> cache-duration = "30m"
> image-patterns = [
>   # One or more URL paths to match an image prefix. Supports globbing of subdomains.
>   "*.dkr.ecr.us-east-2.amazonaws.com",
>   "*.dkr.ecr.us-west-2.amazonaws.com"
> ]
> EOF
```

Verified the config file rendered with the default `aws.profile` value:

```yaml
# cat /etc/kubernetes/kubelet/credential-provider-config.yaml
apiVersion: kubelet.config.k8s.io/v1beta1
kind: CredentialProviderConfig
providers:
  - name: ecr-credential-provider
    matchImages:
      - "*.dkr.ecr.us-east-2.amazonaws.com"
      - "*.dkr.ecr.us-west-2.amazonaws.com"
    defaultCacheDuration: "30m"
    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
    env:
      - name: HOME
        value: /root
      - name: AWS_PROFILE
        value: default
```

Updated the profile setting:

```
# apiclient set -j '{"aws": { "profile": "foo"}}'
```

Verified the config file was re-rendered with the correct information:

```yaml
# cat /etc/kubernetes/kubelet/credential-provider-config.yaml
apiVersion: kubelet.config.k8s.io/v1beta1
kind: CredentialProviderConfig
providers:
  - name: ecr-credential-provider
    matchImages:
      - "*.dkr.ecr.us-east-2.amazonaws.com"
      - "*.dkr.ecr.us-west-2.amazonaws.com"
    defaultCacheDuration: "30m"
    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
    env:
      - name: HOME
        value: /root
      - name: AWS_PROFILE
        value: foo
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
