### PR TITLE
Change CredentialProviderConfig API version to v1beta1

### DIFF
--- a/packages/kubernetes-1.25/credential-provider-config-yaml
+++ b/packages/kubernetes-1.25/credential-provider-config-yaml
@@ -1,4 +1,4 @@
-apiVersion: kubelet.config.k8s.io/v1
+apiVersion: kubelet.config.k8s.io/v1beta1
 kind: CredentialProviderConfig
 providers:
 {{#if settings.kubernetes.credential-providers}}
@@ -10,7 +10,7 @@ providers:
       - "{{this}}"
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
 {{#if (eq @key "ecr-credential-provider")}}
     env:
       - name: HOME

--- a/packages/kubernetes-1.26/credential-provider-config-yaml
+++ b/packages/kubernetes-1.26/credential-provider-config-yaml
@@ -10,7 +10,7 @@ providers:
       - "{{this}}"
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
 {{#if (eq @key "ecr-credential-provider")}}
     env:
       - name: HOME


### PR DESCRIPTION
**Issue number:**

Closes #2905

**Description of changes:**

API version was set to `v1` for Kubernetes 1.25, but that version is not available until Kubernetes 1.26. This fixes the version specifier to v1beta1 to match the correct version for this release.

**Testing done:**

Visual verification, and confirmed API version for 1.25 with https://kubernetes.io/docs/reference/config-api/kubelet-credentialprovider.v1beta1/

Deployed node with changes. Configured credential provider with:

```txt
# apiclient apply << EOF
> [settings.kubernetes.credential-providers.ecr-credential-provider]
> enabled = true
> # (optional - defaults to "12h")
> cache-duration = "30m"
> image-patterns = [
>   # One or more URL paths to match an image prefix. Supports globbing of subdomains.
>   "*.dkr.ecr.us-east-2.amazonaws.com"
> ]
> EOF
```

Verified settings:

```yaml
# cat /etc/kubernetes/kubelet/credential-provider-config.yaml
apiVersion: kubelet.config.k8s.io/v1beta1
kind: CredentialProviderConfig
providers:
  - name: ecr-credential-provider
    matchImages:
      - "*.dkr.ecr.us-east-2.amazonaws.com"
    defaultCacheDuration: "12h"
    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
    env:
      - name: HOME
        value: /root
```

Rebooted with `apiclient reboot` and waited for node to come back up.

Verified kubelet was happy:

```txt
# systemctl status kubelet
● kubelet.service - Kubelet
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d
             └─dockershim-symlink.conf
             /etc/systemd/system/kubelet.service.d
             └─exec-start.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d
             └─load-ipvs-modules.conf, make-kubelet-dirs.conf, prestart-pull-pause-ctr.conf
     Active: active (running) since Fri 2023-03-17 21:48:28 UTC; 1min 0s ago
```

Deployed pod referencing test image in ECR private repo. Verified able to pull image:

```
Successfully pulled image "861807767978.dkr.ecr.us-east-2.amazonaws.com/controller:demo"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
