### PR TITLE
packages: add keyutils

### DIFF
--- a/packages/keyutils/Cargo.toml
+++ b/packages/keyutils/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "keyutils"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[package.metadata.build-package]
+releases-url = "https://people.redhat.com/~dhowells/keyutils/"
+
+[[package.metadata.build-package.external-files]]
+url = "https://people.redhat.com/~dhowells/keyutils/keyutils-1.6.1.tar.bz2"
+sha512 = "ea6e20b2594234c7f51581eef2b8fd19c109fa9eacaaef8dfbb4f237bd1d6fdf071ec23b4ff334cb22a46461d09d17cf499987fd1f00e66f27506888876961e1"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/keyutils/build.rs
+++ b/packages/keyutils/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/keyutils/keyutils-tmpfiles.conf
+++ b/packages/keyutils/keyutils-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/request-key.conf - - - -

--- a/packages/keyutils/keyutils.spec
+++ b/packages/keyutils/keyutils.spec
@@ -1,0 +1,78 @@
+Name: %{_cross_os}keyutils
+Version: 1.6.1
+Release: 1%{?dist}
+Summary: Linux key management utilities
+License: GPL-2.0-or-later AND GPL-2.1-or-later
+Url: http://people.redhat.com/~dhowells/keyutils/
+Source0: http://people.redhat.com/~dhowells/keyutils/keyutils-%{version}.tar.bz2
+Source1: keyutils-tmpfiles.conf
+Source2: request-key.conf
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Development package for building Linux key management utilities
+
+%description devel
+%{summary}.
+
+%prep
+%setup -n keyutils-%{version} -q
+
+%global keyutilsmake \
+%set_cross_build_flags \\\
+export CC=%{_cross_target}-gcc ; \
+%make_build \\\
+  NO_ARLIB=1 \\\
+  ETCDIR=%{_cross_sysconfdir} \\\
+  LIBDIR=%{_cross_libdir} \\\
+  USRLIBDIR=%{_cross_libdir} \\\
+  BINDIR=%{_cross_bindir} \\\
+  SBINDIR=%{_cross_sbindir} \\\
+  MANDIR=%{_cross_mandir} \\\
+  INCLUDEDIR=%{_cross_includedir} \\\
+  SHAREDIR=%{_cross_datadir}/keyutils \\\
+  RELEASE=.%{release} \\\
+  NO_GLIBC_KEYERR=1 \\\
+  CC="${CC}" \\\
+  CFLAGS="${CFLAGS}" \\\
+  LDFLAGS="${LDFLAGS}" \\\
+  DESTDIR=%{buildroot} \\\
+%{nil}
+
+
+%build
+%keyutilsmake
+
+%install
+%keyutilsmake install
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
+
+install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/keyutils.conf
+install -p -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/request-key.conf
+
+%files
+%{_cross_attribution_file}
+%license LICENCE.GPL LICENCE.LGPL
+%{_cross_tmpfilesdir}/keyutils.conf
+%{_cross_bindir}/keyctl
+%{_cross_sbindir}/key.dns_resolver
+%{_cross_sbindir}/request-key
+%{_cross_datadir}/keyutils
+%{_cross_libdir}/libkeyutils.so.*
+%{_cross_factorydir}%{_cross_sysconfdir}/request-key.conf
+
+%exclude %{_cross_mandir}
+%exclude %{_cross_sysconfdir}/request-key.conf
+
+%files devel
+%{_cross_libdir}/libkeyutils.so
+%{_cross_includedir}/keyutils.h
+%{_cross_libdir}/pkgconfig/libkeyutils.pc
+
+%changelog

--- a/packages/keyutils/pkg.rs
+++ b/packages/keyutils/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/keyutils/request-key.conf
+++ b/packages/keyutils/request-key.conf
@@ -1,0 +1,2 @@
+create  dns_resolver *		*               /sbin/key.dns_resolver %k
+negate	*	*		*		/bin/keyctl negate %k 30 %S

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -34,6 +34,7 @@ hotdog = { path = "../hotdog" }
 iproute = { path = "../iproute" }
 iptables = { path = "../iptables" }
 kexec-tools = { path = "../../packages/kexec-tools" }
+keyutils = { path = "../keyutils" }
 libaudit = { path = "../libaudit" }
 libgcc = { path = "../libgcc" }
 libstd-rust = { path = "../libstd-rust" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -98,6 +98,7 @@ Requires: %{_cross_os}hotdog
 Requires: %{_cross_os}iproute
 Requires: %{_cross_os}iptables
 Requires: %{_cross_os}kexec-tools
+Requires: %{_cross_os}keyutils
 Requires: %{_cross_os}makedumpfile
 Requires: %{_cross_os}os
 Requires: %{_cross_os}policycoreutils

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -455,6 +455,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyutils"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "kmod"
 version = "0.1.0"
 dependencies = [
@@ -980,6 +987,7 @@ dependencies = [
  "iproute",
  "iptables",
  "kexec-tools",
+ "keyutils",
  "libaudit",
  "libgcc",
  "libstd-rust",


### PR DESCRIPTION
**Issue number:**
n/a

**Description of changes:**
```
keyutils is a mechanism used by the kernel to reach into userspace. Typically this is used to
fetch security keys, but it is also a mechanism that the kernel uses to resolve domain names.
```

This change is required when mounting some distributed filesystems. The Linux kernel needs the ability to resolve domain names. To do this, it uses an "upcall" procedure to interact with dns resolution in userspace. That "upcall" procedure uses the Linux userspace keyring system -- specifically `/sbin/request-key`.

Of note:
I've removed keyring configuration options from `/etc/request-key.conf` other than the DNS resolver. Our userspace utilities don't need them, and we haven't otherwise fielded requests about the missing utilities for the kernel.


**Testing done:**
* [x] Launched an instance and noted that the contents of `/etc/request-key.conf` are correct
* [x] Noted the presence of keyutils shared libraries in /usr/lib64
* [x] Tested mounting an CIFS/AD filesystem
* [x] Test new config which only includes `dns_resolver`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
