### PR TITLE
[1.13.x] Change CredentialProviderConfig API version to v1beta1

### DIFF
--- a/packages/kubernetes-1.25/credential-provider-config-yaml
+++ b/packages/kubernetes-1.25/credential-provider-config-yaml
@@ -1,4 +1,4 @@
-apiVersion: kubelet.config.k8s.io/v1
+apiVersion: kubelet.config.k8s.io/v1beta1
 kind: CredentialProviderConfig
 providers:
 {{#if settings.kubernetes.credential-providers}}
@@ -10,7 +10,7 @@ providers:
       - "{{this}}"
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
 {{#if (eq @key "ecr-credential-provider")}}
     env:
       - name: HOME

--- a/packages/kubernetes-1.26/credential-provider-config-yaml
+++ b/packages/kubernetes-1.26/credential-provider-config-yaml
@@ -10,7 +10,7 @@ providers:
       - "{{this}}"
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
 {{#if (eq @key "ecr-credential-provider")}}
     env:
       - name: HOME


### PR DESCRIPTION
(cherry picked from commit cec0561073015daf56422b81bc7939c62b218f22)

**Issue number:**

Closes #2905

**Description of changes:**

API version was set to `v1` for Kubernetes 1.25, but that version is not available until Kubernetes 1.26. This fixes the version specifier to v1beta1 to match the correct version for this release.

**Testing done:**

See #2906 for testing details.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
