### PR TITLE
Fix kernel packaging link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1177,7 +1177,7 @@ RPM itself is not in the image - it's just a common and convenient package defin
 
 We currently package the following major third-party components:
 
-* Linux kernel ([background](https://en.wikipedia.org/wiki/Linux), [packaging](packages/kernel-5.4/))
+* Linux kernel ([background](https://en.wikipedia.org/wiki/Linux), [5.10 packaging](packages/kernel-5.10/), [5.15 packaging](packages/kernel-5.15/))
 * glibc ([background](https://www.gnu.org/software/libc/), [packaging](packages/glibc/))
 * Buildroot as build toolchain ([background](https://buildroot.org/), via the [SDK](https://github.com/bottlerocket-os/bottlerocket-sdk))
 * GRUB, with patches for partition flip updates ([background](https://www.gnu.org/software/grub/), [packaging](packages/grub/))


### PR DESCRIPTION
**Issue number:**

Closes #2909

**Description of changes:**

There was an old link to a 5.4 kernel package in the README. This updates it to point to the 5.10 and 5.15 kernel packages.

**Testing done:**

Read the README.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
