### PR TITLE
set a user agent header in the requests sent by buildsys

### DIFF
--- a/tools/buildsys/src/cache/error.rs
+++ b/tools/buildsys/src/cache/error.rs
@@ -6,6 +6,12 @@ use std::path::PathBuf;
 #[snafu(visibility(pub(super)))]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Error {
+    #[snafu(display("Missing environment variable '{}'", var))]
+    Environment {
+        var: String,
+        source: std::env::VarError,
+    },
+
     #[snafu(display("Bad file name '{}'", path.display()))]
     ExternalFileName { path: PathBuf },
 


### PR DESCRIPTION
Issue number:
 Resolves [2903](https://github.com/bottlerocket-os/bottlerocket/issues/2903) 

Description of changes:
```
 Buildsys (via reqwest) does not seem to set a user agent by default, and this causes netfilter.org to 
 respond 403 Forbidden and the build to fail if the package is unavailable in the look-aside cache. 
 By this change we will add USER_AGENT as a header in HTTP request. 
```
Testing done:
All unit tests passes.

Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.