### PR TITLE
samples: Change default to IMDSv2

### DIFF
--- a/sample-eksctl-ssh.yaml
+++ b/sample-eksctl-ssh.yaml
@@ -12,6 +12,7 @@ nodeGroups:
     instanceType: m5.large
     desiredCapacity: 4
     amiFamily: Bottlerocket
+    disableIMDSv1: true
     iam:
        attachPolicyARNs:
           - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy

--- a/sample-eksctl.yaml
+++ b/sample-eksctl.yaml
@@ -12,6 +12,7 @@ nodeGroups:
     instanceType: m5.large
     desiredCapacity: 4
     amiFamily: Bottlerocket
+    disableIMDSv1: true
     iam:
        attachPolicyARNs:
           - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy


### PR DESCRIPTION
**Description of changes:**
Add in the option to use IMDSv2 by default in the samples.


**Testing done:**

I deleted and recreated a node group with the setting and the metadata is set by default:
```
$ aws ec2 describe-instances --region us-west-2 --instance-id i-01234567890abcd --query "Reservations[0].Instances[0].MetadataOptions"
{
    "State": "applied",
    "HttpTokens": "required",
    ...
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
