### PR TITLE
build: fix inference of BUILDSYS_VARIANT-dependent environment variables

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -677,7 +677,7 @@ fi
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
 
 # Parse the variant into its components and set additional variables.
-eval $(bottlerocket-variant)
+eval "$(bottlerocket-variant)"
 export BUILDSYS_VARIANT_PLATFORM="${BUILDSYS_VARIANT_PLATFORM:?}"
 export BUILDSYS_VARIANT_RUNTIME="${BUILDSYS_VARIANT_RUNTIME:?}"
 export BUILDSYS_VARIANT_FAMILY="${BUILDSYS_VARIANT_FAMILY:?}"
@@ -702,7 +702,7 @@ script = [
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
 
 # Parse the variant into its components and set additional variables.
-eval $(bottlerocket-variant)
+eval "$(bottlerocket-variant)"
 export BUILDSYS_VARIANT_PLATFORM="${BUILDSYS_VARIANT_PLATFORM:?}"
 export BUILDSYS_VARIANT_RUNTIME="${BUILDSYS_VARIANT_RUNTIME:?}"
 export BUILDSYS_VARIANT_FAMILY="${BUILDSYS_VARIANT_FAMILY:?}"


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:**

This fixes `cargo make build-package` for all variants. Please see the commit message for a detailed explanation of how and why.

The commit message turned into a little treatise, because while we all know to eat our vegetables and quote our expansions lest bad things happen, I found some nuances of this very case to be unusual and decided to share the joy. Incidentally, this also makes it the longest commit message in the repository by far ([source](https://gist.github.com/markusboehme/66f4d6a0a1ce7dbd5cdab5688f6d5f57)). My apologies to the now runner-ups who undoubtedly had a bigger impact on the project.

**Testing done:**

All of these succeed now:

* `cargo make`
* `cargo make` again (confirmed no rebuild happened)
* `cargo make -e BUILDSYS_VARIANT=aws-ecs-1`
* `cargo make -e BUILDSYS_VARIANT=aws-ecs-1 -e PACKAGE=kernel-5_10 build-package`
* `cargo make -e BUILDSYS_VARIANT=aws-k8s-1.26 -e PACKAGE=kernel-5_15 build-package` (this failed before!)
* `cargo make -e BUILDSYS_VARIANT=vmware-dev -e PACKAGE=kernel-5_15 build-package` (triggers a rebuild because the platform changed; this failed before!)

The previously observed failure looked like this:

```
[cargo-make] INFO - Running Task: build-package
/tmp/fsio_39LBCFVOZo.sh: line 14: BUILDSYS_VARIANT_PLATFORM: parameter null or not set
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
