### PR TITLE
hardening: Enable setting templated file permissions

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -204,4 +204,5 @@ version = "1.14.0"
 "(1.13.5, 1.14.0)" = [
     "migrate_v1.14.0_kubernetes-gc-percent-type-change.lz4",
     "migrate_v1.14.0_kubelet-config-settings.lz4",
+    "migrate_v1.14.0_k8s-services-mode.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2234,6 +2234,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-services-mode"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
 name = "kubelet-config-settings"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "api/migration/migrations/v1.13.4/add-hostname-override-metadata",
     "api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change",
     "api/migration/migrations/v1.14.0/kubelet-config-settings",
+    "api/migration/migrations/v1.14.0/k8s-services-mode",
 
     "bottlerocket-release",
 

--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -737,6 +737,7 @@ mod test {
             hashmap!("foo".to_string() => ConfigurationFile {
                 path: "file".try_into().unwrap(),
                 template_path: "template".try_into().unwrap(),
+                mode: None,
             })
         );
 

--- a/sources/api/migration/migrations/v1.14.0/k8s-services-mode/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/k8s-services-mode/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "k8s-services-mode"
+version = "0.1.0"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+serde_json = "1.0"

--- a/sources/api/migration/migrations/v1.14.0/k8s-services-mode/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/k8s-services-mode/src/main.rs
@@ -1,0 +1,23 @@
+use migration_helpers::{common_migrations::AddSettingsMigration, migrate, Result};
+use std::process;
+
+/// Mode settings were added for a handful of the templated kubelet configuration files.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "configuration-files.kubelet-config.mode",
+        "configuration-files.kubelet-kubeconfig.mode",
+        "configuration-files.kubelet-bootstrap-kubeconfig.mode",
+        "configuration-files.kubelet-exec-start-conf.mode",
+        "configuration-files.credential-provider-config-yaml.mode",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -162,8 +162,7 @@ impl RenderedConfigFile {
         let mut binding = OpenOptions::new();
         let options = binding.write(true).create(true).mode(DEFAULT_FILE_MODE);
 
-        // See if this file has a config setting for a specific mode, but don't error if we are
-        // not able to honor that request.
+        // See if this file has a config setting for a specific mode
         if let Some(mode) = &self.mode {
             let mode_int =
                 u32::from_str_radix(mode.as_str(), 8).context(error::TemplateModeSnafu {

--- a/sources/api/thar-be-settings/src/error.rs
+++ b/sources/api/thar-be-settings/src/error.rs
@@ -1,3 +1,4 @@
+use core::num;
 use http::StatusCode;
 use snafu::Snafu;
 use std::io;
@@ -25,6 +26,13 @@ pub enum Error {
         path: PathBuf,
         pathtype: &'static str,
         source: io::Error,
+    },
+
+    #[snafu(display("Failed to set template {} to mode {}: {}", path.display(), mode, source))]
+    TemplateMode {
+        path: PathBuf,
+        mode: String,
+        source: num::ParseIntError,
     },
 
     #[snafu(display("Failed to run restart command - '{}': {}", command, source))]

--- a/sources/models/shared-defaults/kubernetes-services.toml
+++ b/sources/models/shared-defaults/kubernetes-services.toml
@@ -22,18 +22,22 @@ template-path = "/usr/share/templates/kubelet-env"
 [configuration-files.kubelet-config]
 path = "/etc/kubernetes/kubelet/config"
 template-path = "/usr/share/templates/kubelet-config"
+mode = "0600"
 
 [configuration-files.kubelet-kubeconfig]
 path = "/etc/kubernetes/kubelet/kubeconfig"
 template-path = "/usr/share/templates/kubelet-kubeconfig"
+mode = "0600"
 
 [configuration-files.kubelet-bootstrap-kubeconfig]
 path = "/etc/kubernetes/kubelet/bootstrap-kubeconfig"
 template-path = "/usr/share/templates/kubelet-bootstrap-kubeconfig"
+mode = "0600"
 
 [configuration-files.kubernetes-ca-crt]
 path = "/etc/kubernetes/pki/ca.crt"
 template-path = "/usr/share/templates/kubernetes-ca-crt"
+mode = "0600"
 
 [configuration-files.kubelet-server-crt]
 path = "/etc/kubernetes/pki/kubelet-server.crt"
@@ -46,10 +50,12 @@ template-path = "/usr/share/templates/kubelet-server-key"
 [configuration-files.kubelet-exec-start-conf]
 path = "/etc/systemd/system/kubelet.service.d/exec-start.conf"
 template-path = "/usr/share/templates/kubelet-exec-start-conf"
+mode = "0600"
 
 [configuration-files.credential-provider-config-yaml]
 path = "/etc/kubernetes/kubelet/credential-provider-config.yaml"
 template-path = "/usr/share/templates/credential-provider-config-yaml"
+mode = "0600"
 
 [services.static-pods]
 configuration-files = []

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -454,6 +454,8 @@ pub type ConfigurationFiles = HashMap<String, ConfigurationFile>;
 struct ConfigurationFile {
     path: SingleLineString,
     template_path: SingleLineString,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<String>,
 }
 
 ///// Metadata


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds the ability to specify the permission mode of files created from a template. This enables the ability to have file-by-file control for sensitive files to enforce more restrictive permissions.

Note that Bottlerocket is not a multiuser system and this is just extra precaution to change the permissions on these files. It does happen from time to time that security tools meant for more general purpose Linux distributions are run against Bottlerocket and report issues based on the default file permissions, so this is partly a cosmetic change to prevent these tools from report false errors.

**Testing done:**

Built and deployed EKS cluster. Verified that the file permissions on the modified template files were set to the correct permissions and that the system operated as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
