### PR TITLE
Additional kubelet configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,34 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.kube-api-qps`: The QPS to use while talking with kubernetes apiserver.
 * `settings.kubernetes.log-level`: Adjust the logging verbosity of the `kubelet` process.
   The default log level is 2, with higher numbers enabling more verbose logging.
+* `settings.kubernetes.memory-manager-policy`: The memory management policy to use: `None` (default) or `Static`.
+  Note, when using the `Static` policy you should also set `settings.kubernetes.memory-manager-reserved-memory` values.
+* `settings.kubernetes.memory-manager-reserved-memory`: Used to set the total amount of reserved memory for a node.
+  These settings are used to configure memory manager policy when `settings.kubernetes.memory-manager-policy` is set to `Static`.
+
+  `memory-manager-reserved-memory` is set per NUMA node. For example:
+
+  ```toml
+  [settings.kubernetes]
+  "memory-manager-policy" = "Static"
+
+  [settings.kubernetes.memory-manager-reserved-memory.0]
+  # Reserve a single 1GiB huge page along with 674MiB of memory
+  "enabled" = true
+  "memory" = "674Mi"
+  "hugepages-1Gi" = "1Gi"
+
+  [settings.kubernetes.memory-manager-reserved-memory.1]
+  # Reserve 1,074 2MiB huge pages
+  "enabled" = true
+  "hugepages-2Mi" = "2148Mi"
+  ```
+
+  **Warning:** `memory-manager-reserved-memory` settings are an advanced configuration and requires a clear understanding of what you are setting.
+  Misconfiguration of reserved memory settings may cause the Kubernetes `kubelet` process to fail.
+  It can be very difficult to recover from configuration errors.
+  Use the memory reservation information from `kubectl describe node` and make sure you understand the Kubernetes documentation related to the [memory manager](https://kubernetes.io/docs/tasks/administer-cluster/memory-manager/) and how to [reserve compute resources for system daemons](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/).
+
 * `settings.kubernetes.pod-pids-limit`: The maximum number of processes per pod.
 * `settings.kubernetes.provider-id`: This sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node.
 * `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.

--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ If you downgrade from v1.14.0 to an earlier version, and you have these values s
 * `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.
 * `settings.kubernetes.registry-qps`: The registry pull QPS.
 * `settings.kubernetes.server-tls-bootstrap`: Enables or disables server certificate bootstrap. When enabled, the kubelet will request a certificate from the certificates.k8s.io API. This requires an approver to approve the certificate signing requests (CSR). Defaults to `true`.
+* `settings.kubernetes.shutdown-grace-period`: Delay the node should wait for pod termination before shutdown. Default is `0s`.
+* `settings.kubernetes.shutdown-grace-period-for-critical-pods`: The portion of the shutdown delay that should be dedicated to critical pod shutdown. Default is `0s`.
 * `settings.kubernetes.standalone-mode`: Whether to run the kubelet in standalone mode, without connecting to an API server. Defaults to `false`.
 * `settings.kubernetes.system-reserved`: Resources reserved for system components.
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.cluster-domain`: The DNS domain for this cluster, allowing all Kubernetes-run containers to search this domain before the host's search domains. Defaults to `cluster.local`.
 * `settings.kubernetes.container-log-max-files`: The maximum number of container log files that can be present for a container.
 * `settings.kubernetes.container-log-max-size`: The maximum size of container log file before it is rotated.
+* `settings.kubernetes.cpu-cfs-quota-enforced`: Whether CPU CFS quotas are enforced. Defaults to `true`.
 * `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`. If you want to allow pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node, you can set this setting to `static`. You should reboot if you change this setting after startup - try `apiclient reboot`.
 * `settings.kubernetes.cpu-manager-policy-options`: Policy options to apply when `cpu-manager-policy` is set to `static`. Currently `full-pcpus-only` is the only option.
 

--- a/README.md
+++ b/README.md
@@ -477,37 +477,50 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.event-burst`: The maximum size of a burst of event creations.
 * `settings.kubernetes.event-qps`: The maximum event creations per second.
 * `settings.kubernetes.eviction-hard`: The signals and thresholds that trigger pod eviction.
+* `settings.kubernetes.eviction-max-pod-grace-period`: Maximum grace period, in seconds, to wait for pod termination before soft eviction. Default is `0`.
+* `settings.kubernetes.eviction-soft`: The signals and thresholds that trigger pod eviction with a provided grace period.
+* `settings.kubernetes.eviction-soft-grace-period`: Delay for each signal to wait for pod termination before eviction.
+
   Remember to quote signals (since they all contain ".") and to quote all values.
 
-  Example user data for setting up eviction hard:
+  Example user data for setting up eviction values:
 
   ```toml
   [settings.kubernetes.eviction-hard]
   "memory.available" = "15%"
+
+  [settings.kubernetes.eviction-soft]
+  "memory.available" = "12%"
+
+  [settings.kubernetes.eviction-soft-grace-period]
+  "memory.available" = "30s"
+
+  [settings.kubernetes]
+  "eviction-max-pod-grace-period" = 40
   ```
 
 * `settings.kubernetes.image-gc-high-threshold-percent`: The percent of disk usage after which image garbage collection is always run, expressed as an integer from 0-100 inclusive.
 * `settings.kubernetes.image-gc-low-threshold-percent`: The percent of disk usage before which image garbage collection is never run, expressed as an integer from 0-100 inclusive.
 
-Since v1.14.0 `image-gc-high-threshold-percent` and `image-gc-low-threshold-percent` can be represented as numbers.
-For example:
+  Since v1.14.0 `image-gc-high-threshold-percent` and `image-gc-low-threshold-percent` can be represented as numbers.
+  For example:
 
-```toml
-[settings.kubernetes]
-image-gc-high-threshold-percent = 85
-image-gc-low-threshold-percent = 80
-```
+  ```toml
+  [settings.kubernetes]
+  image-gc-high-threshold-percent = 85
+  image-gc-low-threshold-percent = 80
+  ```
 
-For backward compatibility, both string and numeric representations are accepted since v1.14.0.
-Prior to v1.14.0 these needed to be represented as strings, for example:
+  For backward compatibility, both string and numeric representations are accepted since v1.14.0.
+  Prior to v1.14.0 these needed to be represented as strings, for example:
 
-```toml
-[settings.kubernetes]
-image-gc-high-threshold-percent = "85"
-image-gc-low-threshold-percent = "80"
-```
+  ```toml
+  [settings.kubernetes]
+  image-gc-high-threshold-percent = "85"
+  image-gc-low-threshold-percent = "80"
+  ```
 
-If you downgrade from v1.14.0 to an earlier version, and you have these values set as numbers, they will be converted to strings on downgrade.
+  If you downgrade from v1.14.0 to an earlier version, and you have these values set as numbers, they will be converted to strings on downgrade.
 
 * `settings.kubernetes.kube-api-burst`: The burst to allow while talking with kubernetes.
 * `settings.kubernetes.kube-api-qps`: The QPS to use while talking with kubernetes apiserver.

--- a/Release.toml
+++ b/Release.toml
@@ -204,5 +204,6 @@ version = "1.14.0"
 "(1.13.5, 1.14.0)" = [
     "migrate_v1.14.0_kubernetes-gc-percent-type-change.lz4",
     "migrate_v1.14.0_kubelet-config-settings.lz4",
+    "migrate_v1.14.0_kubelet-prefix-config-settings.lz4",
     "migrate_v1.14.0_k8s-services-mode.lz4",
 ]

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -134,3 +134,9 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.shutdown-grace-period}}
+shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+{{/if}}

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -76,6 +76,7 @@ systemReserved:
   {{/each}}
 systemReservedCgroup: "/system"
 {{/if}}
+cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -41,6 +41,21 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{/each}}
 {{/if}}
+{{#if settings.kubernetes.eviction-soft}}
+evictionSoft:
+  {{#each settings.kubernetes.eviction-soft}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft-grace-period}}
+evictionSoftGracePeriod:
+  {{#each settings.kubernetes.eviction-soft-grace-period}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-max-pod-grace-period}}
+evictionMaxPodGracePeriod: {{settings.kubernetes.eviction-max-pod-grace-period}}
+{{/if}}
 {{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{/if}}

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -155,3 +155,26 @@ shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 {{/if}}
+{{#if settings.kubernetes.memory-manager-reserved-memory}}
+{{#if (any_enabled settings.kubernetes.memory-manager-reserved-memory)}}
+{{#if settings.kubernetes.memory-manager-policy}}
+memoryManagerPolicy: {{settings.kubernetes.memory-manager-policy}}
+{{/if}}
+reservedMemory:
+{{#each settings.kubernetes.memory-manager-reserved-memory}}
+{{#if this.enabled}}
+  - numaNode: {{@key}}
+    limits:
+{{#if this.memory}}
+      memory: {{this.memory}}
+{{/if}}
+{{#if this.hugepages-1Gi}}
+      hugepages-1Gi: {{this.hugepages-1Gi}}
+{{/if}}
+{{#if this.hugepages-2Mi}}
+      hugepages-2Mi: {{this.hugepages-2Mi}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -136,3 +136,9 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.shutdown-grace-period}}
+shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+{{/if}}

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -76,6 +76,7 @@ systemReserved:
   {{/each}}
 systemReservedCgroup: "/system"
 {{/if}}
+cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -41,6 +41,21 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{/each}}
 {{/if}}
+{{#if settings.kubernetes.eviction-soft}}
+evictionSoft:
+  {{#each settings.kubernetes.eviction-soft}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft-grace-period}}
+evictionSoftGracePeriod:
+  {{#each settings.kubernetes.eviction-soft-grace-period}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-max-pod-grace-period}}
+evictionMaxPodGracePeriod: {{settings.kubernetes.eviction-max-pod-grace-period}}
+{{/if}}
 {{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{/if}}

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -157,3 +157,26 @@ shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 {{/if}}
+{{#if settings.kubernetes.memory-manager-reserved-memory}}
+{{#if (any_enabled settings.kubernetes.memory-manager-reserved-memory)}}
+{{#if settings.kubernetes.memory-manager-policy}}
+memoryManagerPolicy: {{settings.kubernetes.memory-manager-policy}}
+{{/if}}
+reservedMemory:
+{{#each settings.kubernetes.memory-manager-reserved-memory}}
+{{#if this.enabled}}
+  - numaNode: {{@key}}
+    limits:
+{{#if this.memory}}
+      memory: {{this.memory}}
+{{/if}}
+{{#if this.hugepages-1Gi}}
+      hugepages-1Gi: {{this.hugepages-1Gi}}
+{{/if}}
+{{#if this.hugepages-2Mi}}
+      hugepages-2Mi: {{this.hugepages-2Mi}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -135,3 +135,9 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.shutdown-grace-period}}
+shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+{{/if}}

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -76,6 +76,7 @@ systemReserved:
   {{/each}}
 systemReservedCgroup: "/system"
 {{/if}}
+cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -41,6 +41,21 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{/each}}
 {{/if}}
+{{#if settings.kubernetes.eviction-soft}}
+evictionSoft:
+  {{#each settings.kubernetes.eviction-soft}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft-grace-period}}
+evictionSoftGracePeriod:
+  {{#each settings.kubernetes.eviction-soft-grace-period}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-max-pod-grace-period}}
+evictionMaxPodGracePeriod: {{settings.kubernetes.eviction-max-pod-grace-period}}
+{{/if}}
 {{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{/if}}

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -156,3 +156,26 @@ shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 {{/if}}
+{{#if settings.kubernetes.memory-manager-reserved-memory}}
+{{#if (any_enabled settings.kubernetes.memory-manager-reserved-memory)}}
+{{#if settings.kubernetes.memory-manager-policy}}
+memoryManagerPolicy: {{settings.kubernetes.memory-manager-policy}}
+{{/if}}
+reservedMemory:
+{{#each settings.kubernetes.memory-manager-reserved-memory}}
+{{#if this.enabled}}
+  - numaNode: {{@key}}
+    limits:
+{{#if this.memory}}
+      memory: {{this.memory}}
+{{/if}}
+{{#if this.hugepages-1Gi}}
+      hugepages-1Gi: {{this.hugepages-1Gi}}
+{{/if}}
+{{#if this.hugepages-2Mi}}
+      hugepages-2Mi: {{this.hugepages-2Mi}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -135,3 +135,9 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.shutdown-grace-period}}
+shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+{{/if}}

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -76,6 +76,7 @@ systemReserved:
   {{/each}}
 systemReservedCgroup: "/system"
 {{/if}}
+cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -41,6 +41,21 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{/each}}
 {{/if}}
+{{#if settings.kubernetes.eviction-soft}}
+evictionSoft:
+  {{#each settings.kubernetes.eviction-soft}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft-grace-period}}
+evictionSoftGracePeriod:
+  {{#each settings.kubernetes.eviction-soft-grace-period}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-max-pod-grace-period}}
+evictionMaxPodGracePeriod: {{settings.kubernetes.eviction-max-pod-grace-period}}
+{{/if}}
 {{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{/if}}

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -156,3 +156,26 @@ shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 {{/if}}
+{{#if settings.kubernetes.memory-manager-reserved-memory}}
+{{#if (any_enabled settings.kubernetes.memory-manager-reserved-memory)}}
+{{#if settings.kubernetes.memory-manager-policy}}
+memoryManagerPolicy: {{settings.kubernetes.memory-manager-policy}}
+{{/if}}
+reservedMemory:
+{{#each settings.kubernetes.memory-manager-reserved-memory}}
+{{#if this.enabled}}
+  - numaNode: {{@key}}
+    limits:
+{{#if this.memory}}
+      memory: {{this.memory}}
+{{/if}}
+{{#if this.hugepages-1Gi}}
+      hugepages-1Gi: {{this.hugepages-1Gi}}
+{{/if}}
+{{#if this.hugepages-2Mi}}
+      hugepages-2Mi: {{this.hugepages-2Mi}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -135,3 +135,9 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.shutdown-grace-period}}
+shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+{{/if}}

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -76,6 +76,7 @@ systemReserved:
   {{/each}}
 systemReservedCgroup: "/system"
 {{/if}}
+cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -41,6 +41,21 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{/each}}
 {{/if}}
+{{#if settings.kubernetes.eviction-soft}}
+evictionSoft:
+  {{#each settings.kubernetes.eviction-soft}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft-grace-period}}
+evictionSoftGracePeriod:
+  {{#each settings.kubernetes.eviction-soft-grace-period}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-max-pod-grace-period}}
+evictionMaxPodGracePeriod: {{settings.kubernetes.eviction-max-pod-grace-period}}
+{{/if}}
 {{#if settings.kubernetes.allowed-unsafe-sysctls}}
 allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
 {{/if}}

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -156,3 +156,26 @@ shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
 {{/if}}
+{{#if settings.kubernetes.memory-manager-reserved-memory}}
+{{#if (any_enabled settings.kubernetes.memory-manager-reserved-memory)}}
+{{#if settings.kubernetes.memory-manager-policy}}
+memoryManagerPolicy: {{settings.kubernetes.memory-manager-policy}}
+{{/if}}
+reservedMemory:
+{{#each settings.kubernetes.memory-manager-reserved-memory}}
+{{#if this.enabled}}
+  - numaNode: {{@key}}
+    limits:
+{{#if this.memory}}
+      memory: {{this.memory}}
+{{/if}}
+{{#if this.hugepages-1Gi}}
+      hugepages-1Gi: {{this.hugepages-1Gi}}
+{{/if}}
+{{#if this.hugepages-2Mi}}
+      hugepages-2Mi: {{this.hugepages-2Mi}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2249,6 +2249,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-prefix-config-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-gc-percent-type-change"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "api/migration/migrations/v1.13.4/add-hostname-override-metadata",
     "api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change",
     "api/migration/migrations/v1.14.0/kubelet-config-settings",
+    "api/migration/migrations/v1.14.0/kubelet-prefix-config-settings",
     "api/migration/migrations/v1.14.0/k8s-services-mode",
 
     "bottlerocket-release",

--- a/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
@@ -8,6 +8,9 @@ fn run() -> Result<()> {
         "settings.kubernetes.cpu-cfs-quota-enforced",
         "settings.kubernetes.shutdown-grace-period",
         "settings.kubernetes.shutdown-grace-period-for-critical-pods",
+        "settings.kubernetes.eviction-soft",
+        "settings.kubernetes.eviction-soft-grace-period",
+        "settings.kubernetes.eviction-max-pod-grace-period",
     ]))
 }
 

--- a/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
@@ -5,6 +5,7 @@ use std::process;
 fn run() -> Result<()> {
     migrate(AddSettingsMigration(&[
         "settings.kubernetes.cpu-manager-policy-options",
+        "settings.kubernetes.cpu-cfs-quota-enforced",
     ]))
 }
 

--- a/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
@@ -6,6 +6,8 @@ fn run() -> Result<()> {
     migrate(AddSettingsMigration(&[
         "settings.kubernetes.cpu-manager-policy-options",
         "settings.kubernetes.cpu-cfs-quota-enforced",
+        "settings.kubernetes.shutdown-grace-period",
+        "settings.kubernetes.shutdown-grace-period-for-critical-pods",
     ]))
 }
 

--- a/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
@@ -11,6 +11,7 @@ fn run() -> Result<()> {
         "settings.kubernetes.eviction-soft",
         "settings.kubernetes.eviction-soft-grace-period",
         "settings.kubernetes.eviction-max-pod-grace-period",
+        "settings.kubernetes.memory-manager-policy",
     ]))
 }
 

--- a/sources/api/migration/migrations/v1.14.0/kubelet-prefix-config-settings/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-prefix-config-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-prefix-config-settings"
+version = "0.1.0"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.0/kubelet-prefix-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-prefix-config-settings/src/main.rs
@@ -1,0 +1,19 @@
+use migration_helpers::{common_migrations::AddPrefixesMigration, migrate, Result};
+use std::process;
+
+/// Additional `settings.kubernetes` options for this release.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.memory-manager-reserved-memory",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -242,6 +242,7 @@ struct KubernetesSettings {
     kube_api_burst: i32,
     container_log_max_size: KubernetesQuantityValue,
     container_log_max_files: i32,
+    cpu_cfs_quota_enforced: bool,
     cpu_manager_policy: CpuManagerPolicy,
     cpu_manager_reconcile_period: KubernetesDurationValue,
     cpu_manager_policy_options: Vec<KubernetesCPUManagerPolicyOption>,

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -256,6 +256,8 @@ struct KubernetesSettings {
     credential_providers: HashMap<Identifier, CredentialProvider>,
     server_certificate: ValidBase64,
     server_key: ValidBase64,
+    shutdown_grace_period: KubernetesDurationValue,
+    shutdown_grace_period_for_critical_pods: KubernetesDurationValue,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -174,6 +174,8 @@ mod de;
 
 use modeled_types::KubernetesCPUManagerPolicyOption;
 use modeled_types::KubernetesEvictionKey;
+use modeled_types::KubernetesMemoryManagerPolicy;
+use modeled_types::KubernetesMemoryReservation;
 use modeled_types::NonNegativeInteger;
 pub use variant::*;
 
@@ -263,6 +265,8 @@ struct KubernetesSettings {
     server_key: ValidBase64,
     shutdown_grace_period: KubernetesDurationValue,
     shutdown_grace_period_for_critical_pods: KubernetesDurationValue,
+    memory_manager_reserved_memory: HashMap<Identifier, KubernetesMemoryReservation>,
+    memory_manager_policy: KubernetesMemoryManagerPolicy,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -173,6 +173,7 @@ mod variant;
 mod de;
 
 use modeled_types::KubernetesCPUManagerPolicyOption;
+use modeled_types::KubernetesEvictionKey;
 pub use variant::*;
 
 // Types used to communicate between client and server for 'apiclient exec'.
@@ -193,11 +194,11 @@ use crate::modeled_types::{
     DNSDomain, ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
     ECSDurationValue, EtcHostsEntries, FriendlyVersion, Identifier, IntegerPercent, KmodKey,
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesCloudProvider,
-    KubernetesClusterDnsIp, KubernetesClusterName, KubernetesDurationValue,
-    KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue, KubernetesQuantityValue,
-    KubernetesReservedResourceKey, KubernetesTaintValue, KubernetesThresholdValue, Lockdown,
-    OciDefaultsCapability, OciDefaultsResourceLimitType, PemCertificateString, SingleLineString,
-    SysctlKey, TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
+    KubernetesClusterDnsIp, KubernetesClusterName, KubernetesDurationValue, KubernetesLabelKey,
+    KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
+    KubernetesTaintValue, KubernetesThresholdValue, Lockdown, OciDefaultsCapability,
+    OciDefaultsResourceLimitType, PemCertificateString, SingleLineString, SysctlKey,
+    TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
 };
 
 // Kubernetes static pod manifest settings
@@ -228,7 +229,10 @@ struct KubernetesSettings {
     authentication_mode: KubernetesAuthenticationMode,
     bootstrap_token: KubernetesBootstrapToken,
     standalone_mode: bool,
-    eviction_hard: HashMap<KubernetesEvictionHardKey, KubernetesThresholdValue>,
+    eviction_hard: HashMap<KubernetesEvictionKey, KubernetesThresholdValue>,
+    eviction_soft: HashMap<KubernetesEvictionKey, KubernetesThresholdValue>,
+    eviction_soft_grace_period: HashMap<KubernetesEvictionKey, KubernetesDurationValue>,
+    eviction_max_pod_grace_period: i32,
     kube_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
     system_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
     allowed_unsafe_sysctls: Vec<SingleLineString>,

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -174,6 +174,7 @@ mod de;
 
 use modeled_types::KubernetesCPUManagerPolicyOption;
 use modeled_types::KubernetesEvictionKey;
+use modeled_types::NonNegativeInteger;
 pub use variant::*;
 
 // Types used to communicate between client and server for 'apiclient exec'.
@@ -232,7 +233,7 @@ struct KubernetesSettings {
     eviction_hard: HashMap<KubernetesEvictionKey, KubernetesThresholdValue>,
     eviction_soft: HashMap<KubernetesEvictionKey, KubernetesThresholdValue>,
     eviction_soft_grace_period: HashMap<KubernetesEvictionKey, KubernetesDurationValue>,
-    eviction_max_pod_grace_period: i32,
+    eviction_max_pod_grace_period: NonNegativeInteger,
     kube_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
     system_reserved: HashMap<KubernetesReservedResourceKey, KubernetesQuantityValue>,
     allowed_unsafe_sysctls: Vec<SingleLineString>,

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -778,7 +778,9 @@ pub struct CpuManagerPolicy {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum ValidCpuManagerPolicy {
+    #[serde(alias = "Static")]
     Static,
+    #[serde(alias = "None")]
     None,
 }
 
@@ -802,7 +804,7 @@ mod test_cpu_manager_policy {
 
     #[test]
     fn good_cpu_manager_policy() {
-        for ok in &["static", "none"] {
+        for ok in &["Static", "static", "None", "none"] {
             CpuManagerPolicy::try_from(*ok).unwrap();
         }
     }

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -464,17 +464,12 @@ mod test_kubernetes_bootstrap_token {
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
-/// KubernetesEvictionHardKey represents a string that contains a valid Kubernetes eviction hard key.
+/// KubernetesEvictionKey represents a string that contains a valid Kubernetes eviction key.
 /// https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct KubernetesEvictionHardKey {
-    inner: String,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Scalar)]
 #[serde(rename_all = "lowercase")]
-enum EvictionSignal {
+pub enum KubernetesEvictionKey {
     #[serde(rename = "memory.available")]
     MemoryAvailable,
     #[serde(rename = "nodefs.available")]
@@ -489,27 +484,13 @@ enum EvictionSignal {
     PidAvailable,
 }
 
-impl TryFrom<&str> for KubernetesEvictionHardKey {
-    type Error = error::Error;
-
-    fn try_from(input: &str) -> Result<Self, Self::Error> {
-        serde_plain::from_str::<EvictionSignal>(input).context(error::InvalidPlainValueSnafu {
-            field: "Eviction Hard key",
-        })?;
-        Ok(KubernetesEvictionHardKey {
-            inner: input.to_string(),
-        })
-    }
-}
-string_impls_for!(KubernetesEvictionHardKey, "KubernetesEvictionHardKey");
-
 #[cfg(test)]
-mod test_kubernetes_eviction_hard_key {
-    use super::KubernetesEvictionHardKey;
+mod test_kubernetes_eviction_key {
+    use super::KubernetesEvictionKey;
     use std::convert::TryFrom;
 
     #[test]
-    fn good_eviction_hard_key() {
+    fn good_eviction_key() {
         for ok in &[
             "memory.available",
             "nodefs.available",
@@ -518,14 +499,14 @@ mod test_kubernetes_eviction_hard_key {
             "imagefs.inodesFree",
             "pid.available",
         ] {
-            KubernetesEvictionHardKey::try_from(*ok).unwrap();
+            KubernetesEvictionKey::try_from(*ok).unwrap();
         }
     }
 
     #[test]
-    fn bad_eviction_hard_key() {
+    fn bad_eviction_key() {
         for err in &["", "storage.available", ".bad", "bad.", &"a".repeat(64)] {
-            KubernetesEvictionHardKey::try_from(*err).unwrap_err();
+            KubernetesEvictionKey::try_from(*err).unwrap_err();
         }
     }
 }

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -1339,3 +1339,75 @@ mod test_kubernetes_cpu_manager_policy_option {
         }
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// KubernetesMemoryReservationKey represents a string that contains a valid Kubernetes memory
+/// resource reservation key.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Scalar)]
+pub enum KubernetesMemoryReservationKey {
+    #[serde(rename = "memory")]
+    Memory,
+    #[serde(rename = "hugepages-2Mi")]
+    HugePages2Mi,
+    #[serde(rename = "hugepages-1Gi")]
+    HugePages1Gi,
+}
+
+#[cfg(test)]
+mod test_memory_reservation_key {
+    use super::KubernetesMemoryReservationKey;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_memory_reservation_key() {
+        for ok in &["memory", "hugepages-2Mi", "hugepages-1Gi"] {
+            KubernetesMemoryReservationKey::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_memory_reservation_key() {
+        for err in &["", "cpu", "hugepages-1Mi", "HugePages_1Gi", &"a".repeat(64)] {
+            KubernetesMemoryReservationKey::try_from(*err).unwrap_err();
+        }
+    }
+}
+
+/// KubernetesMemoryReservation enables setting kubelet reserved memory values.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KubernetesMemoryReservation {
+    enabled: bool,
+    #[serde(flatten)]
+    limits: HashMap<KubernetesMemoryReservationKey, KubernetesQuantityValue>,
+}
+
+/// KubernetesMemoryManagerPolicy represents the valid options for the memory manager policy.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Scalar)]
+pub enum KubernetesMemoryManagerPolicy {
+    #[serde(alias = "static")]
+    Static,
+    #[serde(alias = "none")]
+    None,
+}
+
+#[cfg(test)]
+mod test_kubernetes_memory_manager_policy {
+    use super::KubernetesMemoryManagerPolicy;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_policy_key() {
+        for ok in &["Static", "static", "None", "none"] {
+            KubernetesMemoryManagerPolicy::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_policy_key() {
+        for err in &["", "dynamic", &"a".repeat(64)] {
+            KubernetesMemoryManagerPolicy::try_from(*err).unwrap_err();
+        }
+    }
+}


### PR DESCRIPTION
### Issue number:

Closes: #2877 
Closes: #1792 
Closes: #1445
Closes: #2977

### Description of changes:

This adds new settings that can be used for soft eviction, graceful shutdown, CPU quota enforcement, and memory manager policy.

The new settings are:

**Soft eviction**

- `settings.kubernetes.eviction-soft`
- `settings.kubernetes.eviction-soft-grace-period`
- `settings.kubernetes.eviction-max-pod-grace-period`

`eviction-soft` is the same as the existing `eviction-hard` but allows a grace period before pods are evicted. The `eviction-soft-grace-period` allows setting this grace period for each of the support eviction keys. `eviction-max-grace-period` is used to set an overall maximum for the eviction grace period.

**Graceful shutdown**

- `settings.kubernetes.shutdown-grace-period`
- `settings.kubernetes.shutdown-grace-period-for-critical-pods`

These allow setting a grace period to wait on node shut down to allow pods to exit. Of that grace period, a portion can be dedicated to making sure critical pods are shut down.

**CPU quota enforcement**

- `settings.kubernetes.cpu-cfs-quota-enforced`

This sets a flag telling kubelet whether or not to enforce quota for containers that specify CPU limits. The default behavior is to enforce these quotas.

For additional reference on the kubelet setting values, see [the node eviction documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/) and the [`KubeletConfiguration` docs](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration).

**Memory manager**

- `settings.kubernetes.memory-manager-policy`
- `settings.kubernetes.memory-manager-reserved-memory`

Allows configuring kubelet settings for the [memory manager](https://kubernetes.io/docs/tasks/administer-cluster/memory-manager/).

### Testing done:

Built and deployed a cluster. Configured these settings with:

```sh
apiclient apply << EOF
[settings.kubernetes.eviction-hard]
"memory.available" = "15%"

[settings.kubernetes.eviction-soft]
"memory.available" = "12%"

[settings.kubernetes.eviction-soft-grace-period]
"memory.available" = "30s"

[settings.kubernetes]
cpu-cfs-quota-enforced = false
shutdown-grace-period = "30s"
shutdown-grace-period-for-critical-pods = "10s"
eviction-max-pod-grace-period = 40
memory-manager-policy = "Static"

[settings.kubernetes.memory-manager-reserved-memory.0]
enabled = true
memory = "674Mi"
EOF
```

Verified values were accepted. The performed:

```sh
cat /etc/kubernetes/kubelet/config
```

Verified the config file had the expected configuration keys and values. Then ran:

```sh
systemctl status kubelet
journalctl -u kubelet
```

And made sure there were no errors or issues with service operation.

### Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
