### PR TITLE
release: revert "ensure data partition can be grown to 20 GiB"

### DIFF
--- a/packages/release/release-repart-local.conf
+++ b/packages/release/release-repart-local.conf
@@ -13,7 +13,3 @@ Type=626f7474-6c65-6474-6861-726d61726b73
 # sectors left, or 1031680 bytes. The repart tool expects a multiple of 4096,
 # which is (1031680 - (1031680 % 4096)), or 1028096 bytes.
 PaddingMinBytes=1028096
-
-# The data partition should grow to at least 20 GiB - 2 MiB (for GPT
-# header/footer).
-SizeMinBytes=21472739328


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
    release: revert "ensure data partition can be grown to 20 GiB"
                                                                 
    This reverts commit 1a6bf19a7c0924e679ea850451ead0eb5a8eb3f6. 
     
    This change is incompatible with our NVIDIA variant disk layout. We also
    do not have enough confidence that 20 GiB, or any value, is safe to
    enforce as theminimum partition size for the data partition.

```

**Testing done:**

Behavior is now as before the change in `1a6bf19a7c0924e679ea850451ead0eb5a8eb3f6`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
