### PR TITLE
Enable environment variables for Kubernetes credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,11 @@ The following settings are optional and allow you to further configure your clus
     "*.dkr.ecr.us-east-2.amazonaws.com",
     "*.dkr.ecr.us-west-2.amazonaws.com"
   ]
+
+  [settings.kubernetes.credential-providers.ecr-credential-provider.environment]
+  # The following are not used with ecr-credential-provider, but are provided for illustration
+  "KEY" = "abc123xyz"
+  "GOMAXPROCS" = "2"
   ```
 
   **Note:** `ecr-credential-provider` is currently the only supported provider.

--- a/packages/kubernetes-1.22/credential-provider-config-yaml
+++ b/packages/kubernetes-1.22/credential-provider-config-yaml
@@ -11,13 +11,21 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
-{{#if (eq @key "ecr-credential-provider")}}
+{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
     env:
+{{#if this.environment}}
+{{#each this.environment}}
+      - name: {{@key}}
+        value: '{{this}}'
+{{/each}}
+{{/if}}
+{{#if (eq @key "ecr-credential-provider")}}
       - name: HOME
-        value: /root
+        value: '/root'
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{@root.settings.aws.profile}}
+        value: '{{@root.settings.aws.profile}}'
+{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.23/credential-provider-config-yaml
+++ b/packages/kubernetes-1.23/credential-provider-config-yaml
@@ -11,13 +11,21 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
-{{#if (eq @key "ecr-credential-provider")}}
+{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
     env:
+{{#if this.environment}}
+{{#each this.environment}}
+      - name: {{@key}}
+        value: '{{this}}'
+{{/each}}
+{{/if}}
+{{#if (eq @key "ecr-credential-provider")}}
       - name: HOME
-        value: /root
+        value: '/root'
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{@root.settings.aws.profile}}
+        value: '{{@root.settings.aws.profile}}'
+{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.24/credential-provider-config-yaml
+++ b/packages/kubernetes-1.24/credential-provider-config-yaml
@@ -11,13 +11,21 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
-{{#if (eq @key "ecr-credential-provider")}}
+{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
     env:
+{{#if this.environment}}
+{{#each this.environment}}
+      - name: {{@key}}
+        value: '{{this}}'
+{{/each}}
+{{/if}}
+{{#if (eq @key "ecr-credential-provider")}}
       - name: HOME
-        value: /root
+        value: '/root'
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{@root.settings.aws.profile}}
+        value: '{{@root.settings.aws.profile}}'
+{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.25/credential-provider-config-yaml
+++ b/packages/kubernetes-1.25/credential-provider-config-yaml
@@ -11,13 +11,21 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
-{{#if (eq @key "ecr-credential-provider")}}
+{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
     env:
+{{#if this.environment}}
+{{#each this.environment}}
+      - name: {{@key}}
+        value: '{{this}}'
+{{/each}}
+{{/if}}
+{{#if (eq @key "ecr-credential-provider")}}
       - name: HOME
-        value: /root
+        value: '/root'
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{@root.settings.aws.profile}}
+        value: '{{@root.settings.aws.profile}}'
+{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.26/credential-provider-config-yaml
+++ b/packages/kubernetes-1.26/credential-provider-config-yaml
@@ -11,13 +11,21 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
-{{#if (eq @key "ecr-credential-provider")}}
+{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
     env:
+{{#if this.environment}}
+{{#each this.environment}}
+      - name: {{@key}}
+        value: '{{this}}'
+{{/each}}
+{{/if}}
+{{#if (eq @key "ecr-credential-provider")}}
       - name: HOME
-        value: /root
+        value: '/root'
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
-        value: {{@root.settings.aws.profile}}
+        value: '{{@root.settings.aws.profile}}'
+{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -7,6 +7,7 @@ use serde::de::Error as _;
 use serde_json::Value;
 use snafu::{ensure, ResultExt};
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -1315,12 +1316,15 @@ mod test_cluster_dns_ip {
     }
 }
 
+type EnvVarMap = HashMap<SingleLineString, SingleLineString>;
+
 /// CredentialProvider contains the settings for a credential provider for use
 /// in CredentialProviderConfig.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct CredentialProvider {
     enabled: bool,
     image_patterns: Vec<SingleLineString>,
     cache_duration: Option<KubernetesDurationValue>,
+    environment: Option<EnvVarMap>,
 }


### PR DESCRIPTION
**Issue number:**

Closes #2602 

**Description of changes:**

This adds the capability to provide environment variables that can be passed through to the Kubernetes credential provider configuration.

This makes it possible to provide user data settings like:

```toml
[settings.kubernetes.credential-providers.my-provider.env-variables]
"GOMAXPROCS" = "2"
```

and have that show up in the credential provider configuration file as:

```yaml
providers:
  - name: my-provider
    matchImages:
      - "*.dkr.ecr.us-east-2.amazonaws.com"
    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
    env:
      - name: GOMAXPROCS
        value: 2
```

**Testing done:**

Deployed node and verified launched successfully.

Ran:

```sh
apiclient apply <<EOL
  [settings.kubernetes.credential-providers.ecr-credential-provider]
  enabled = true
  # (optional - defaults to "12h")
  cache-duration = "30m"
  image-patterns = [
    # One or more URL paths to match an image prefix. Supports globbing of subdomains.
    "*.dkr.ecr.us-east-2.amazonaws.com",
    "*.dkr.ecr.us-west-2.amazonaws.com"
  ]
EOL
```

Checked `kubelet` status and cat'd `/etc/kubernetes/kubelet/credential-provider-config.yaml to make sure it reflected normal (pre-this change) configuration.

Ran:

```sh
apiclient apply <<EOL
  [settings.kubernetes.credential-providers.ecr-credential-provider.env-variables]
  # The following are not used with ecr-credential-provider, but are provided for illustration
  "KEY" = "abc123xyz"
  "GOMAXPROCS" = "2"
EOL
```

Checked `kubelet` status and cat'd `/etc/kubernetes/kubelet/credential-provider-config.yaml to see that it now contained the expected `env:` entries.

On new clean nodes, tried specifying all settings at once, and only current settings with adding environment variables later to make sure there was proper handling for template generation in all cases.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
