### PR TITLE
allow k8s gc percent thresholds to be set as numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,8 +468,29 @@ The following settings are optional and allow you to further configure your clus
   "memory.available" = "15%"
   ```
 
-* `settings.kubernetes.image-gc-high-threshold-percent`: The percent of disk usage after which image garbage collection is always run.
-* `settings.kubernetes.image-gc-low-threshold-percent`: The percent of disk usage before which image garbage collection is never run.
+* `settings.kubernetes.image-gc-high-threshold-percent`: The percent of disk usage after which image garbage collection is always run, expressed as an integer from 0-100 inclusive.
+* `settings.kubernetes.image-gc-low-threshold-percent`: The percent of disk usage before which image garbage collection is never run, expressed as an integer from 0-100 inclusive.
+
+Since v1.14.0 `image-gc-high-threshold-percent` and `image-gc-low-threshold-percent` can be represented as numbers.
+For example:
+
+```toml
+[settings.kubernetes]
+image-gc-high-threshold-percent = 85
+image-gc-low-threshold-percent = 80
+```
+
+For backward compatibility, both string and numeric representations are accepted since v1.14.0.
+Prior to v1.14.0 these needed to be represented as strings, for example:
+
+```toml
+[settings.kubernetes]
+image-gc-high-threshold-percent = "85"
+image-gc-low-threshold-percent = "80"
+```
+
+If you downgrade from v1.14.0 to an earlier version, and you have these values set as numbers, they will be converted to strings on downgrade.
+
 * `settings.kubernetes.kube-api-burst`: The burst to allow while talking with kubernetes.
 * `settings.kubernetes.kube-api-qps`: The QPS to use while talking with kubernetes apiserver.
 * `settings.kubernetes.log-level`: Adjust the logging verbosity of the `kubelet` process.

--- a/Release.toml
+++ b/Release.toml
@@ -192,4 +192,6 @@ version = "1.14.0"
 "(1.13.0, 1.13.1)" = [
     "migrate_v1.13.1_aws-profile-cred-provider.lz4",
 ]
-"(1.13.1, 1.14.0)" = []
+"(1.13.1, 1.14.0)" = [
+    "migrate_v1.14.0_kubernetes-gc-percent-type-change.lz4"
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2119,6 +2119,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-gc-percent-type-change"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "api/migration/migrations/v1.13.0/aws-control-container-v0-7-1",
     "api/migration/migrations/v1.13.0/public-control-container-v0-7-1",
     "api/migration/migrations/v1.13.1/aws-profile-cred-provider",
+    "api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kubernetes-gc-percent-type-change"
+version = "0.1.0"
+authors = ["Matt Briggs <brigmatt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+serde_json = "1"

--- a/sources/api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change/src/main.rs
@@ -1,0 +1,54 @@
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use serde_json::Value;
+use std::process;
+
+const GC_HIGH_SETTING: &str = "settings.kubernetes.image-gc-high-threshold-percent";
+const GC_LOW_SETTING: &str = "settings.kubernetes.image-gc-low-threshold-percent";
+
+/// We changed these settings so that they can be specified as numbers. Previously they could only
+/// be specified as strings, which was confusing since they are numeric. On upgrade we don't need
+/// to do anything because a valid string representation will still be accepted. On downgrade, we
+/// need to check if the values are represented as numbers, and if so, convert them to strings.
+pub struct ChangeK8sGcPercentType;
+
+fn convert_to_string(value: &mut Value) {
+    let s = if let Value::Number(n) = value {
+        n.to_string()
+    } else {
+        return;
+    };
+    *value = Value::String(s);
+}
+
+impl Migration for ChangeK8sGcPercentType {
+    /// On upgrade there is nothing to do (see above).
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        Ok(input)
+    }
+
+    /// On downgrade, if the value is a number, we need to convert it to a string (see above).
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(v) = input.data.get_mut(GC_HIGH_SETTING) {
+            convert_to_string(v);
+        }
+        if let Some(v) = input.data.get_mut(GC_LOW_SETTING) {
+            convert_to_string(v);
+        }
+        Ok(input)
+    }
+}
+
+/// We made changes to `image-gc-low-threshold-percent` and `image-gc-high-threshold-percent`.
+fn run() -> Result<()> {
+    migrate(ChangeK8sGcPercentType)
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -21,6 +21,7 @@ scalar = { path = "scalar", version = "0.1" }
 scalar-derive = { path = "scalar-derive", version = "0.1" }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_plain = "1"
 snafu = "0.7"
 toml = "0.5"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -190,14 +190,13 @@ use crate::de::{deserialize_mirrors, deserialize_node_taints};
 use crate::modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, CredentialProvider,
     DNSDomain, ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
-    ECSDurationValue, EtcHostsEntries, FriendlyVersion, Identifier, ImageGCHighThresholdPercent,
-    ImageGCLowThresholdPercent, KmodKey, KubernetesAuthenticationMode, KubernetesBootstrapToken,
-    KubernetesCloudProvider, KubernetesClusterDnsIp, KubernetesClusterName,
-    KubernetesDurationValue, KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue,
-    KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
-    KubernetesThresholdValue, Lockdown, OciDefaultsCapability, OciDefaultsResourceLimitType,
-    PemCertificateString, SingleLineString, SysctlKey, TopologyManagerPolicy, TopologyManagerScope,
-    Url, ValidBase64, ValidLinuxHostname,
+    ECSDurationValue, EtcHostsEntries, FriendlyVersion, Identifier, IntegerPercent, KmodKey,
+    KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesCloudProvider,
+    KubernetesClusterDnsIp, KubernetesClusterName, KubernetesDurationValue,
+    KubernetesEvictionHardKey, KubernetesLabelKey, KubernetesLabelValue, KubernetesQuantityValue,
+    KubernetesReservedResourceKey, KubernetesTaintValue, KubernetesThresholdValue, Lockdown,
+    OciDefaultsCapability, OciDefaultsResourceLimitType, PemCertificateString, SingleLineString,
+    SysctlKey, TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
 };
 
 // Kubernetes static pod manifest settings
@@ -247,8 +246,8 @@ struct KubernetesSettings {
     topology_manager_scope: TopologyManagerScope,
     topology_manager_policy: TopologyManagerPolicy,
     pod_pids_limit: i64,
-    image_gc_high_threshold_percent: ImageGCHighThresholdPercent,
-    image_gc_low_threshold_percent: ImageGCLowThresholdPercent,
+    image_gc_high_threshold_percent: IntegerPercent,
+    image_gc_low_threshold_percent: IntegerPercent,
     provider_id: Url,
     log_level: u8,
     credential_providers: HashMap<Identifier, CredentialProvider>,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2883
Related to, but not comprehensive for #2324

**Description of changes:**

Make this intuitive userdata work:

```toml
[settings.kubernetes]
image-gc-high-threshold-percent = 85
image-gc-low-threshold-percent = 80
```

Prior to this change, the values had to be quoted as strings.

This change is backward compatible so that users relying on these being strings will not be broken by the change.

**Testing done:**

- [x] Booted with `settings.kubernetes.image-gc-high-threshold-percent = 85` and `settings.kubernetes.image-gc-low-threshold-percent = 80`
  - [x] Checked datastore
  - [x] Checked config files
  - [x] Ran a pod
- [x] Changed value `settings.kubernetes.image-gc-high-threshold-percent = "83"` with the API
  - [x] Checked datastore - it is still stored as a number (turns out `apiclient set` only sets scalar strings, so I also used apiclient to change the setting with JSON, and when I did I was able to convert it to a string)
  - [x] Checked config files - they look the same, but with the new value
- [x] Downgraded to v1.13.0
  - [x] Checked datastore - both values are now strings
  - [x] Checked config files - values look the same
  - [x] Ran a pod
- [x] Upgraded back up to v1.14.0
  - [x] Checked datastore - both values are still strings
  - [x] Checked config files - values look good
  - [x] Ran a pod
- [x] Booted a v1.13.0 AMI with `settings.kubernetes.image-gc-high-threshold-percent = "87"` and `settings.kubernetes.image-gc-low-threshold-percent = "79"`
  - [x] Checked datastore - these are strings
  - [x] Checked config file - correct
- [x] Upgraded to v1.14.0
  - [x] Checked datastore - these are still strings
  - [x] Checked config file, looks the same
  - [x] Ran a pod
- [x] Downgraded to v1.13.0
  - [x] Checked datastore - these are strings
  - [x] Checked config file - correct
  - [x] Ran a pod

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
