### PR TITLE
kubernetes 1-26: updated to v1.26.2

### DIFF
--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.26"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/3/artifacts/kubernetes/v1.26.1/kubernetes-src.tar.gz"
-sha512 = "06762a6e032b6940af7e07986cc85520067c559af558a90bcf2bc1c86157b888d9577c9d363bcfbe75e9bdf3176ab3479024fb961b2219e02e78cbc2c8f76fea"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/5/artifacts/kubernetes/v1.26.2/kubernetes-src.tar.gz"
+sha512 = "da2a9b636c25f9501aa55623a321fcc5840b7509e8e611482e213f3dbb32cf4f8219008f4e90fdf9180a0446cbc8e29a679753c2a9cdaf8a3cb8fc7238b074fa"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.26.1
+%global gover 1.26.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/5/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
(cherry picked from commit 2e84784de56a5c0f7c52c45e81a940ddfa909ddb)

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Updates Kubernetes 1.26 to the EKS-D 1.26.2 package.

**Testing done:**

See #2929 for testing details.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
