### PR TITLE
aws-iam-authenticator: Upgrade to v0.6.8

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.2/aws-iam-authenticator-0.6.2.tar.gz"
-sha512 = "4789fe7c11d4d1b94da5f35844a0da8e62da743bef3fc13f668c542f3dbc83584ef29abbcebc6f4651aad8ecbd9195d6bfc13476c7dd4a1d34ed11822652fc5e"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.8/aws-iam-authenticator-0.6.8.tar.gz"
+sha512 = "6e9f43852cdd3fb7d47ea70df5d108a0e235245b6db1a4f6406efffc329f5c940bf284c216e4bf20e83ff691b078652cee3fbae4c7c3da658ea3eef2ecab92b5"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.6.2
+%global gover 0.6.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Issue number:**

N/a

**Description of changes:**

```
Fixes building on the tip of `develop` when using GOPROXY="direct".
v0.6.2 of aws-iam-authenticator has a Go code dependency on kubernetes
1.22. There are privated GitHub repositories that can not be pulled down
through the "direct" method.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

Example of the broken build using `GOPROXY="direct"`:
```
❯ GOPROXY=direct cargo make -e PACKAGE=aws-iam-authenticator -e BUILDSYS_VARIANT=aws-k8s-1.22 build-package
...

   Compiling aws-iam-authenticator v0.1.0 (/home/ubuntu/workspace/bottlerocket-os/bottlerocket/packages/aws-iam-authenticator)
error: failed to run custom build command for `aws-iam-authenticator v0.1.0 (/home/ubuntu/workspace/bottlerocket-os/bottlerocket/packages/aws-iam-authenticator)`
 
Caused by:
  process didn't exit successfully: `/home/ubuntu/workspace/bottlerocket-os/bottlerocket/variants/target/x86_64/debug/build/aws-iam-authenticator-d52bf5b23e1e1e35/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=Cargo.toml
  cargo:rerun-if-changed=bundled-aws-iam-authenticator-0.6.2.tar.gz
  program: /home/ubuntu/workspace/bottlerocket-os/bottlerocket/tools/docker-go
  direct
 
 
  sum.golang.org
  /usr/src/module/aws-iam-authenticator-0.6.2 /usr/src/module
  go: k8s.io/kubernetes@v1.22.0 requires
        github.com/storageos/go-api@v2.2.0+incompatible: reading github.com/storageos/go-api/go.mod at revision v2.2.0: git ls-remote -q origin in /tmp/go/pkg/mod/cache/vcs/f4474392d641b836e8296e236f2861d83ba42188d7ff117e30acb6b06774a32d: exit status 128:
        fatal: could not read Username for 'https://github.com': terminal prompts disabled
  Confirm the import path was entered correctly.
  If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
  go: downloading k8s.io/apimachinery v0.23.0-alpha.0
  go: downloading k8s.io/client-go v0.22.0
  go: downloading k8s.io/kubernetes v1.22.0
  go: downloading github.com/aws/aws-sdk-go v1.44.107
  go: downloading k8s.io/api v0.22.0
  go: downloading github.com/onsi/ginkgo v1.14.0
  go: downloading github.com/onsi/gomega v1.10.1
  go: downloading github.com/fsnotify/fsnotify v1.4.9
  go: downloading github.com/sirupsen/logrus v1.8.1
  go: downloading k8s.io/component-base v0.22.0
  go: downloading github.com/gofrs/flock v0.7.0
  go: downloading github.com/prometheus/client_golang v1.11.0
  go: downloading golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
  go: downloading sigs.k8s.io/yaml v1.2.0
  go: downloading github.com/spf13/cobra v1.1.3
  go: downloading github.com/spf13/viper v1.7.0
  go: downloading k8s.io/sample-controller v0.22.0
  go: downloading github.com/manifoldco/promptui v0.9.0
  go: k8s.io/kubernetes@v1.22.0 requires
        github.com/storageos/go-api@v2.2.0+incompatible: reading github.com/storageos/go-api/go.mod at revision v2.2.0: git ls-remote -q origin in /tmp/go/pkg/mod/cache/vcs/f4474392d641b836e8296e236f2861d83ba42188d7ff117e30acb6b06774a32d: exit status 128:
        fatal: could not read Username for 'https://github.com': terminal prompts disabled
  Confirm the import path was entered correctly.
  If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
  /usr/src/module
  tar: aws-iam-authenticator-0.6.2//vendor: Cannot stat: No such file or directory
  tar: Exiting with failure status due to previous errors
 
 
  --- stderr
  GoMod: Failed to execute docker-go script. 'args: --module-path /home/ubuntu/workspace/bottlerocket-os/bottlerocket/packages/aws-iam-authenticator --sdk-image public.ecr.aws/bottlerocket/bottlerocket-sdk-x86_64:v0.30.2 --go-mod-cache /home/ubuntu/workspace/bottlerocket-os/bottlerocket/.gomodcache --command ./docker-go-script.sh'
[cargo-make] ERROR - Error while executing command, exit code: 101
[cargo-make] WARN - Build Failed.
```

And a quick and dirty way to reproduce with the broken GitHub repo:
```
❯ mkdir test-mod
❯ cd test-mod
❯ go mod init example.com
go: creating new go.mod: module example.com
❯ GOPROXY=direct go get github.com/storageos/go-api
go: module github.com/storageos/go-api: git ls-remote -q origin in /home/ubuntu/go/pkg/mod/cache/vcs/f4474392d641b836e8296e236f2861d83ba42188d7ff117e30acb6b06774a32d: exit status 128:
        remote: Repository `storageos/go-api' is disabled.
        remote: Please ask the owner to check their account.
        fatal: unable to access 'https://github.com/storageos/go-api/': The requested URL returned error: 403
```

**Testing done:**

_Coming soon_. Able to build locally now.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
