### PR TITLE
GitHub actions: Use `GOPROXY=direct` during builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,14 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # When Go packages are built, buildsys will vendor in dependent Go code for
+  # that package and bundle it up in a tarball. This env variable is consumed
+  # and used to configure Go to directly download code from its upstream source.
+  # This is a useful early signal during GitHub actions to see if there are
+  # upstream Go code problems.
+  GOPROXY: direct
+
 jobs:
   build:
     runs-on:


### PR DESCRIPTION
**Issue number:**

N/a

**Description of changes:**

Forces Go during builds to vendor code from direct upstream sources.
This is a useful and early signal to the team around problems with upstream
code repos.

Also note: this may make the builds for GitHub runners slightly longer.
The upstream Go proxy server has a CDN / cacheing / etc. which makes it
rather efficient. However, when Go gets code "directly", it's falling back
to using git to clone repositories (which can be slow for large codebases).
This seems like an acceptable tradeoff since we have very few Go code
packages and we get an early signal on problematic upstream repos.

**Testing done:**

N/a - check run in PR.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
