### PR TITLE
Cherry-pick: aws-iam-authenticator: Upgrade to v0.6.8

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.2/aws-iam-authenticator-0.6.2.tar.gz"
-sha512 = "4789fe7c11d4d1b94da5f35844a0da8e62da743bef3fc13f668c542f3dbc83584ef29abbcebc6f4651aad8ecbd9195d6bfc13476c7dd4a1d34ed11822652fc5e"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.8/aws-iam-authenticator-0.6.8.tar.gz"
+sha512 = "6e9f43852cdd3fb7d47ea70df5d108a0e235245b6db1a4f6406efffc329f5c940bf284c216e4bf20e83ff691b078652cee3fbae4c7c3da658ea3eef2ecab92b5"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.6.2
+%global gover 0.6.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
```
Fixes building on the tip of `develop` when using GOPROXY="direct".
v0.6.2 of aws-iam-authenticator has a Go code dependency on kubernetes 1.22.
There are privated GitHub repositories that can not be pulled down through the "direct" method.

Signed-off-by: John McBride <jpmmcb@amazon.com>
(cherry picked from commit 64c93d243d5b33fefd99808049656ee649c59947)
```

**Issue number:**

N/a - related to #2956 

**Description of changes:**

Upgrades the aws-iam-athenticator package to v0.6.8

**Testing done:**

N/a - see #2956

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
