### PR TITLE
[1.13.x] Enable stable branch checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   pull_request:
-    branches: [develop]
+    branches: [1.13.x]
     # Here we list file types that don't affect the build and don't need to use
     # up our Actions runners.
     paths-ignore:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -3,7 +3,7 @@
 name: CacheDepsAndTools
 on:
   push:
-    branches: [develop]
+    branches: [1.13.x]
     paths:
       - '.github/**'
       - 'sources/Cargo.lock'

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,7 +1,7 @@
 name: golangci-lint
 on:
   pull_request:
-    branches: [develop]
+    branches: [1.13.x]
     # Only run this workflow if Go files or this workflow have been modified
     paths:
       - '**.go'


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates the branch designation for the GitHub Actions so they run for any PRs proposed to the 1.13.x branch.

**Testing done:**

Will validate by seeing checks run on PRs proposed to the 1.13.x branch.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
