### PR TITLE
Remove kernel updates from 1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
-# v1.13.2 (2023-04-03)
+# v1.13.2 (2023-04-04)
 
 ## OS Changes
 
-* Update kernel-5.10 to 5.10.173 and kernel-5.15 to 5.15.102 ([#2948])
 * Update `runc` to version 1.1.5 ([#2946])
 
 ## Orchestrator Changes
@@ -12,7 +11,6 @@
 * Update to Kubernetes v1.26.2 ([#2929])
 * Update `aws-iam-authenticator` package to v0.6.8 ([#2965])
 
-[#2948]: https://github.com/bottlerocket-os/bottlerocket/pull/2948
 [#2946]: https://github.com/bottlerocket-os/bottlerocket/pull/2946
 [#2929]: https://github.com/bottlerocket-os/bottlerocket/pull/2929
 [#2965]: https://github.com/bottlerocket-os/bottlerocket/pull/2965


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Kernel updates had issues that are being investigated. In the meantime, this removes the kernel updates from being part of the 1.13.2 release.

**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
