### PR TITLE
iptables: fix check for rule existence in ip6tables v1.8.9

### DIFF
--- a/packages/iptables/1002-ip6tables-Fix-checking-existence-of-rule.patch
+++ b/packages/iptables/1002-ip6tables-Fix-checking-existence-of-rule.patch
@@ -1,0 +1,31 @@
+From ba75342ff3e01605258810eb7f5683d8e326ffd8 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Mon, 3 Apr 2023 22:20:23 +0200
+Subject: [PATCH] ip6tables: Fix checking existence of rule
+
+Pass the proper entry size when creating a match mask for checking the
+existence of a rule. Failing to do so causes wrong results.
+
+Reported-by: Jonathan Caicedo <jonathan@jcaicedo.com>
+Fixes: eb2546a846776 ("xshared: Share make_delete_mask() between ip{,6}tables")
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ iptables/ip6tables.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iptables/ip6tables.c b/iptables/ip6tables.c
+index 345af451..9afc32c1 100644
+--- a/iptables/ip6tables.c
++++ b/iptables/ip6tables.c
+@@ -331,7 +331,7 @@ check_entry(const xt_chainlabel chain, struct ip6t_entry *fw,
+ 	int ret = 1;
+ 	unsigned char *mask;
+ 
+-	mask = make_delete_mask(matches, target, sizeof(fw));
++	mask = make_delete_mask(matches, target, sizeof(*fw));
+ 	for (i = 0; i < nsaddrs; i++) {
+ 		fw->ipv6.src = saddrs[i];
+ 		fw->ipv6.smsk = smasks[i];
+-- 
+2.25.1
+

--- a/packages/iptables/iptables.spec
+++ b/packages/iptables/iptables.spec
@@ -17,6 +17,7 @@ Requires: %{_cross_os}libnftnl
 Requires: %{_cross_os}libnetfilter_conntrack
 
 Patch1001: 1001-extensions-NAT-Fix-for-Werror-format-security.patch
+Patch1002: 1002-ip6tables-Fix-checking-existence-of-rule.patch
 
 %description
 %{summary}.


### PR DESCRIPTION
**Issue number:**

Closes #2975 

**Description of changes:**

iptables v1.8.9 breaks the rule existence check in `ip6tables`. Fix this downstream until the issue has been patched in the upstream project.

I proposed this patch upstream: https://marc.info/?l=netfilter-devel&m=168055689214144

**Testing done:**

* [x] Locally: Reproducer from [upstream bug report](https://bugzilla.netfilter.org/show_bug.cgi?id=1667) shows expected behavior and reports the missing rule
* [x] Locally: Valgrind doesn't report any out-of-bounds reads anymore
* [x] Bottlerocket: `aws-k8s-1.24` on x86_64 builds and can launch pods
* [x] Bottlerocket: pod can have multiple host ports forwarded to it with IPv4 (confirmed via `iptables -t nat -L` on the host)
* [x] Bottlerocket: pod can have multiple host ports forwarded to it with IPv6 (on an IPv6 cluster; details see below)

Pod spec:

```
apiVersion: v1
kind: Pod
metadata:
  name: test-poly-host-ports
spec:
  restartPolicy: OnFailure
  containers:
    - name: test
      image: amazonlinux:2023
      command: ["sleep", "3600"]
      ports:
        - containerPort: 80
          hostPort: 10080
        - containerPort: 81
          hostPort: 10081
```

On the host (admin container --> `sudo sheltie`):

```
bash-5.1# ip6tables -t nat -L -n
[...]
Chain CNI-DN-b4a7dc28d99c75afb1337 (1 references)
target     prot opt source               destination         
CNI-HOSTPORT-SETMARK  6    --  2a05:d014:a18:a000:8e24::2  ::/0                 tcp dpt:10080
DNAT       6    --  ::/0                 ::/0                 tcp dpt:10080 to:[2a05:d014:a18:a000:8e24::2]:80
CNI-HOSTPORT-SETMARK  6    --  2a05:d014:a18:a000:8e24::2  ::/0                 tcp dpt:10081
DNAT       6    --  ::/0                 ::/0                 tcp dpt:10081 to:[2a05:d014:a18:a000:8e24::2]:81

Chain CNI-HOSTPORT-DNAT (2 references)
target     prot opt source               destination         
CNI-DN-b4a7dc28d99c75afb1337  6    --  ::/0                 ::/0                 /* dnat name: "aws-cni" id: "77c07952c638f66094ba7b92262990f5e9c4e680a038d91a81f1162d4beef863" */ multiport dports 10080,10081
[...]
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
