### PR TITLE
tools/diff-kernel-config: enhance functionality and output formats

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -32,8 +32,9 @@ Compare kernel configurations before and after a series of commits.
 
     -a, --after         new Git revision to compare from
     -b, --before        baseline Git revision to compare against
-    -k, --kernel        kernel versions to compare configs for, may be given
-                        multiple times (optional, defaults to all kernels)
+    -v, --variant       variant to pick kernel from to compare configs for, may
+                        be given multiple times (optional, defaults to this list:
+                        'aws-k8s-1.23', 'metal-k8s-1.23', 'aws-dev', 'metal-dev')
     -o, --output-dir    path to the output directory; must not exist yet
     -h, --help          show this help text
 
@@ -66,6 +67,7 @@ usage_error() {
 #
 
 kernel_versions=()
+variants=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -73,8 +75,8 @@ while [[ $# -gt 0 ]]; do
             shift; gitrev_after_arg=$1 ;;
         -b|--before)
             shift; gitrev_before_arg=$1 ;;
-        -k|--kernel)
-            shift; kernel_versions+=( "$1" ) ;;
+        -v|--variant)
+            shift; variants+=( "$1" ) ;;
         -o|--output-dir)
             shift; output_dir=$1 ;;
         -h|--help)
@@ -85,18 +87,14 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-if [[ ${#kernel_versions[@]} -eq 0 ]]; then
-    kernel_versions=( 5.10 5.15 )
-else
-    for kver in "${kernel_versions[@]}"; do
-        case ${kver} in
-            5.10) continue ;;
-            5.15) continue ;;
-            *)    bail "Unknown kernel version '${kver}'" ;;
-        esac
-    done
+if [[ ${#variants[@]} -eq 0 ]]; then
+    variants=( aws-k8s-1.23 metal-k8s-1.23 aws-dev metal-dev )
 fi
-readonly kernel_versions
+
+for var in "${variants[@]}"; do
+    [[ -d variants/${var} ]] || bail "Unknown variant '${var}'"
+done
+readonly variants
 
 [[ -n ${output_dir} ]] || usage_error 'require -o|--output-dir'
 [[ -e ${output_dir} ]] && bail "Output directory '${output_dir}' exists already, not touching it"
@@ -147,80 +145,72 @@ for state in before after; do
     gitrev_var=gitrev_${state}
     git checkout --quiet "${!gitrev_var}" || bail "Cannot check out '${!gitrev_var}'."
 
-    for arch in aarch64 x86_64; do
+    for variant in "${variants[@]}"; do
 
-        for kver in "${kernel_versions[@]}"; do
+        arches=()
+        IFS=" " read -r -a arches <<< "$(grep "supported-arches" "variants/${variant}/Cargo.toml" | cut -d ' ' -f 3 | tr -d '"[]')"
+        if [[ ${#arches[@]} -eq 0 ]]; then
+            arches=( aarch64 x86_64 )
+        fi
 
-            variants=()
-            case ${kver} in
-                5.10)
-                    variants+=( 'aws-k8s-1.23' )
-                    if [[ ${arch} = x86_64 ]]; then
-                        variants+=( 'metal-k8s-1.23' )
-                    fi
-                    ;;
-                5.15)
-                    variants+=( 'aws-dev' 'metal-dev' )
-                    ;;
-                *)
-                    bail "No known variants build kernel ${kver}."
-                    ;;
+        kver=$(grep "packages/kernel" "variants/${variant}/Cargo.toml" | cut -d ' ' -f 1 | cut -d '-' -f 2 | tr '_' '.')
+
+        kernel_versions+=( "${kver}" )
+
+        for arch in "${arches[@]}"; do
+
+            debug_id="state=${state} arch=${arch} variant=${variant} kernel=${kver}"
+
+            IFS=- read -ra variant_parts <<<"${variant}"
+            variant_platform="${variant_parts[0]}"
+            variant_runtime="${variant_parts[1]}"
+            variant_family="${variant_platform}-${variant_runtime}"
+
+            #
+            # Run build
+            #
+
+            cargo make \
+                    -e BUILDSYS_ARCH="${arch}" \
+                    -e BUILDSYS_VARIANT="${variant}" \
+                    -e BUILDSYS_VARIANT_PLATFORM="${variant_platform}" \
+                    -e BUILDSYS_VARIANT_RUNTIME="${variant_runtime}" \
+                    -e BUILDSYS_VARIANT_FAMILY="${variant_family}" \
+                    -e PACKAGE="kernel-${kver/./_}" \
+                    build-package \
+                || bail "Build failed for ${debug_id}"
+
+            #
+            # Find kernel RPM
+            #
+
+            shopt -s nullglob
+            kernel_rpms=(
+                ./build/rpms/bottlerocket-"${arch}"-*kernel-"${kver}"-"${kver}".*.rpm
+            )
+            shopt -u nullglob
+
+            case ${#kernel_rpms[@]} in
+                0) bail "No kernel RPM found for ${debug_id}" ;;
+                1) kernel_rpm=${kernel_rpms[0]} ;;
+                *) bail "More than one kernel RPM found for ${debug_id}" ;;
             esac
 
-            for variant in "${variants[@]}"; do
+            kver_full=$(echo "${kernel_rpm}" | cut -d '-' -f 5)
+            #
+            # Extract kernel config
+            #
 
-                debug_id="state=${state} arch=${arch} variant=${variant}"
-
-                IFS=- read -ra variant_parts <<<"${variant}"
-                variant_platform="${variant_parts[0]}"
-                variant_runtime="${variant_parts[1]}"
-                variant_family="${variant_platform}-${variant_runtime}"
-
-                #
-                # Run build
-                #
-
-                cargo make \
-                        -e BUILDSYS_ARCH="${arch}" \
-                        -e BUILDSYS_VARIANT="${variant}" \
-                        -e BUILDSYS_VARIANT_PLATFORM="${variant_platform}" \
-                        -e BUILDSYS_VARIANT_RUNTIME="${variant_runtime}" \
-                        -e BUILDSYS_VARIANT_FAMILY="${variant_family}" \
-                        -e PACKAGE="kernel-${kver/./_}" \
-                        build-package \
-                    || bail "Build failed for ${debug_id}"
-
-                #
-                # Find kernel RPM
-                #
-
-                shopt -s nullglob
-                kernel_rpms=(
-                    ./build/rpms/bottlerocket-"${arch}"-*kernel-"${kver}"-"${kver}".*.rpm
-                )
-                shopt -u nullglob
-
-                case ${#kernel_rpms[@]} in
-                    0) bail "No kernel RPM found for ${debug_id}" ;;
-                    1) kernel_rpm=${kernel_rpms[0]} ;;
-                    *) bail "More than one kernel RPM found for ${debug_id}" ;;
-                esac
+            config_path=${output_dir}/config-${arch}-${variant}-${state}
+            rpm2cpio "${kernel_rpm}" \
+                | cpio --quiet --extract --to-stdout ./boot/config >"${config_path}"
+            [[ -s "${config_path}" ]] || bail "Failed to extract config for ${debug_id}"
 
 
-                #
-                # Extract kernel config
-                #
+            echo "config-${arch}-${variant}-${state} -> ${kver_full}" >> "${output_dir}"/kver_mapping
+        done #arch
 
-                config_path=${output_dir}/config-${arch}-${kver}-${variant}-${state}
-                rpm2cpio "${kernel_rpm}" \
-                    | cpio --quiet --extract --to-stdout ./boot/config >"${config_path}"
-                [[ -s "${config_path}" ]] || bail "Failed to extract config for ${debug_id}"
-
-            done  # variant
-
-        done  # kver
-
-    done  # arch
+    done #variant
 
 done  # state
 

--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -256,3 +256,24 @@ echo
 # Generate combined report of changes
 head -v -n 999999 "${output_dir}"/*-diff >"${output_dir}"/diff-report
 echo "A full report has been placed in '${output_dir}/diff-report'"
+
+# Generate combined report in tabular form (csv)
+echo "config change" > "${output_dir}"/diff-table
+cat "${output_dir}"/*-diff | sort | uniq >> "${output_dir}"/diff-table
+
+for config_diff in "${output_dir}"/config-*-diff; do
+    variant_name=$(echo "${config_diff}" | sed -e "s%^${output_dir}/config-%%" -e "s%-diff$%%")
+    kver_before=$(grep "${variant_name}-before" "${output_dir}/kver_mapping" | cut -d ' ' -f 3)
+    kver_after=$(grep "${variant_name}-after" "${output_dir}/kver_mapping" | cut -d ' ' -f 3)
+    col_name="${variant_name} (${kver_before} -> ${kver_after})"
+
+    sed -i "s/$/,/" "${output_dir}"/diff-table
+    sed -i "/^config change/ s/$/${col_name}/" "${output_dir}"/diff-table
+
+    mapfile -t diff_lines < "${config_diff}"
+
+    for line in "${diff_lines[@]}"; do
+        sed -i "/^${line}/ s/$/x/" "${output_dir}"/diff-table
+    done
+done
+echo "A tabular report in csv-format has been placed in '${output_dir}/diff-table'"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** - 

**Description of changes:**

Make the `diff-config-tool` a bit more useful by:

* shifting its perspective on config changes from a kernel version anchored view to a variant anchored view. This has the advantage that we do not need to hard-code a translation of variants for specific kernel versions. In addition this comes in handy when doing major kernel version updates. In those cases we will usually change the kernel used in `-dev` variants, allowing for easy comparison of configs between major kernel versions.
* adding a more structured output format for config changes. Presenting changes in tabular form makes comparison between multiple variants easier to see which config changes are shared between variants and architectures and which are distinct to specific configurations.

_Review hint: The diff for the first patch of the series seems bigger than the interesting parts are. This is an unfortunate side effect of changing indentation on some loop nesting._

**Testing done:**

I am using the new tooling for the major kernel update to kernel 6.1. It helps a lot to get the reports without extra manual steps for major kernel updates and getting the tabular data provides a good starting point for working through the massive amount of config changes in a structured way.

The summary for an example invocation looking at dev variants looks familiar:
```
./tools/diff-kernel-config -a HEAD -b develop -v aws-dev -v metal-dev -v vmware-dev -o config-diff-test
[...]
config-aarch64-aws-dev-diff:     92 removed, 226 added,   2 changed
config-aarch64-metal-dev-diff:   92 removed, 227 added,   2 changed
config-x86_64-aws-dev-diff:      81 removed, 231 added,   3 changed
config-x86_64-metal-dev-diff:    81 removed, 233 added,   3 changed
config-x86_64-vmware-dev-diff:   97 removed, 229 added,   4 changed
```

Excerpt from the newly created `diff_table` can be seen on [gist](https://gist.github.com/foersleo/c27315baaada31945e0d4f7eca9ae50a).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
