### PR TITLE
Remove extraneous parameter property from OpenAPI spec

### DIFF
--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -339,7 +339,6 @@ paths:
           style: form
           explode: false
           required: false
-      parameters:
         - in: query
           name: prefix
           description: "Specific key prefix to query. This parameter will be ignored if 'names' is also supplied"


### PR DESCRIPTION
**Issue number:**

Closes #2981

**Description of changes:**

The `configuration-files` endpoint has two query parameters. These should be listed as two items under the single `parameters` property, but it looks like there was a copy/paste error that added a second `parameters` property. This causes parsing errors for the API spec.

**Testing done:**

Pasted output into OpenAPI editor and verified it was able to be validated against the schema.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
