### PR TITLE
pubsys: added EC2 image validation

### DIFF
--- a/tools/pubsys/src/aws/mod.rs
+++ b/tools/pubsys/src/aws/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod ami;
 pub(crate) mod promote_ssm;
 pub(crate) mod publish_ami;
 pub(crate) mod ssm;
+pub(crate) mod validate_ami;
 pub(crate) mod validate_ssm;
 
 /// Builds a Region from the given region name.

--- a/tools/pubsys/src/aws/validate_ami/ami.rs
+++ b/tools/pubsys/src/aws/validate_ami/ami.rs
@@ -1,0 +1,148 @@
+//! The ami module owns the describing of images in EC2.
+
+use aws_sdk_ec2::model::Image;
+use aws_sdk_ec2::{Client as Ec2Client, Region};
+use futures::future::{join, ready};
+use futures::stream::{FuturesUnordered, StreamExt};
+use log::{info, trace};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::collections::HashMap;
+
+/// Structure of the EC2 image fields that should be validated
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct ImageDef {
+    /// The id of the EC2 image
+    pub(crate) image_id: String,
+
+    /// Whether or not the EC2 image is public
+    pub(crate) public: bool,
+
+    /// Whether or not the EC2 image supports Elastic Network Adapter
+    pub(crate) ena_support: bool,
+
+    /// The level of the EC2 image's Single Root I/O Virtualization support
+    pub(crate) sriov_net_support: String,
+}
+
+impl From<Image> for ImageDef {
+    fn from(image: Image) -> Self {
+        Self {
+            image_id: image.image_id().unwrap_or_default().to_string(),
+            public: image.public().unwrap_or_default(),
+            ena_support: image.ena_support().unwrap_or_default(),
+            sriov_net_support: image.sriov_net_support().unwrap_or_default().to_string(),
+        }
+    }
+}
+
+impl ImageDef {
+    // Creates a new ImageDef with a given image_id and expected values for public, ena_support,
+    // and sriov_net_support
+    pub(crate) fn expected(image_id: String) -> Self {
+        Self {
+            image_id,
+            public: true,
+            ena_support: true,
+            sriov_net_support: "simple".to_string(),
+        }
+    }
+}
+
+pub(crate) async fn describe_images<'a>(
+    clients: &'a HashMap<Region, Ec2Client>,
+    image_ids: &HashMap<Region, Vec<String>>,
+) -> HashMap<&'a Region, Result<HashMap<String, ImageDef>>> {
+    // Build requests for images; we have to request with a regional client so we split them by
+    // region
+    let mut requests = Vec::with_capacity(clients.len());
+    for region in clients.keys() {
+        trace!("Requesting images in {}", region);
+        let ec2_client: &Ec2Client = &clients[region];
+        let get_future = describe_images_in_region(
+            region,
+            ec2_client,
+            image_ids
+                .get(region)
+                .map(|i| i.to_owned())
+                .unwrap_or(vec![]),
+        );
+
+        requests.push(join(ready(region), get_future));
+    }
+
+    // Send requests in parallel and wait for responses, collecting results into a list.
+    requests
+        .into_iter()
+        .collect::<FuturesUnordered<_>>()
+        .collect()
+        .await
+}
+
+/// Fetches all images in a single region
+pub(crate) async fn describe_images_in_region(
+    region: &Region,
+    client: &Ec2Client,
+    image_ids: Vec<String>,
+) -> Result<HashMap<String, ImageDef>> {
+    info!("Retrieving images in {}", region.to_string());
+    let mut images = HashMap::new();
+
+    // Send the request
+    let mut get_future = client
+        .describe_images()
+        .include_deprecated(true)
+        .set_image_ids(Some(image_ids))
+        .into_paginator()
+        .send();
+
+    // Iterate over the retrieved images
+    while let Some(page) = get_future.next().await {
+        let retrieved_images = page
+            .context(error::DescribeImagesSnafu {
+                region: region.to_string(),
+            })?
+            .images()
+            .unwrap_or_default()
+            .to_owned();
+        for image in retrieved_images {
+            // Insert a new key-value pair into the map, with the key containing image id
+            // and the value containing the ImageDef object created from the image
+            images.insert(
+                image
+                    .image_id()
+                    .ok_or(error::Error::MissingField {
+                        missing: "image_id".to_string(),
+                    })?
+                    .to_string(),
+                ImageDef::from(image.to_owned()),
+            );
+        }
+    }
+
+    info!("Images in {} have been retrieved", region.to_string());
+    Ok(images)
+}
+
+pub(crate) mod error {
+    use aws_sdk_ec2::error::DescribeImagesError;
+    use aws_sdk_ssm::types::SdkError;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    #[allow(clippy::large_enum_variant)]
+    pub enum Error {
+        #[snafu(display("Failed to describe images in {}: {}", region, source))]
+        DescribeImages {
+            region: String,
+            source: SdkError<DescribeImagesError>,
+        },
+
+        #[snafu(display("Missing field in image: {}", missing))]
+        MissingField { missing: String },
+    }
+}
+
+pub(crate) type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/validate_ami/mod.rs
+++ b/tools/pubsys/src/aws/validate_ami/mod.rs
@@ -1,0 +1,550 @@
+//! The validate_ami module owns the 'validate-ami' subcommand and controls the process of validating
+//! EC2 images
+
+pub(crate) mod ami;
+pub(crate) mod results;
+
+use self::ami::ImageDef;
+use self::results::{AmiValidationResult, AmiValidationResultStatus, AmiValidationResults};
+use crate::aws::client::build_client_config;
+use crate::aws::validate_ami::ami::describe_images;
+use crate::Args;
+use aws_sdk_ec2::{Client as AmiClient, Region};
+use log::{info, trace};
+use pubsys_config::InfraConfig;
+use serde::Deserialize;
+use snafu::ResultExt;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::path::PathBuf;
+use structopt::{clap, StructOpt};
+
+/// Validates EC2 images
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct ValidateAmiArgs {
+    /// File holding the validation configuration
+    #[structopt(long, parse(from_os_str))]
+    validation_config_path: PathBuf,
+
+    /// Optional path where the validation results should be written
+    #[structopt(long, parse(from_os_str))]
+    write_results_path: Option<PathBuf>,
+
+    #[structopt(long, requires = "write-results-path")]
+    /// Optional filter to only write validation results with these statuses to the above path
+    /// The available statuses are: `Correct`, `Incorrect`, `Missing`
+    write_results_filter: Option<Vec<AmiValidationResultStatus>>,
+
+    #[structopt(long)]
+    /// If this argument is given, print the validation results summary as a JSON object instead
+    /// of a plaintext table
+    json: bool,
+}
+
+/// Structure of the validation configuration file
+#[derive(Debug, Deserialize)]
+pub(crate) struct ValidationConfig {
+    /// Vec of paths to JSON files containing expected metadata (image ids and SSM parameters)
+    /// Paths can be absolute or relative to the pwd of the caller
+    expected_metadata_lists: Vec<PathBuf>,
+
+    /// Vec of regions where the parameters should be validated
+    validation_regions: Vec<String>,
+}
+
+/// Performs EC2 image validation and returns the `AmiValidationResults` object
+pub(crate) async fn validate(
+    args: &Args,
+    validate_ami_args: &ValidateAmiArgs,
+) -> Result<AmiValidationResults> {
+    info!("Parsing Infra.toml file");
+
+    // If a lock file exists, use that, otherwise use Infra.toml
+    let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
+        .context(error::ConfigSnafu)?;
+
+    let aws = infra_config.aws.clone().unwrap_or_default();
+
+    trace!("Parsed infra config: {:#?}", infra_config);
+
+    // Read the validation config file and parse it into the `ValidationConfig` struct
+    let validation_config_file = File::open(&validate_ami_args.validation_config_path).context(
+        error::ReadValidationConfigSnafu {
+            path: validate_ami_args.validation_config_path.clone(),
+        },
+    )?;
+    let validation_config: ValidationConfig = serde_json::from_reader(validation_config_file)
+        .context(error::ParseValidationConfigSnafu)?;
+
+    // Parse the image lists found in the validation config
+    info!("Parsing expected image lists");
+    let expected_images = parse_image_lists(
+        validation_config.expected_metadata_lists,
+        &validation_config.validation_regions,
+    )
+    .await?;
+
+    info!("Parsed expected image lists");
+
+    // Create a Vec of Regions based on the region names in the validation config
+    let validation_regions: Vec<Region> = validation_config
+        .validation_regions
+        .iter()
+        .map(|s| Region::new(s.clone()))
+        .collect();
+
+    // Create a HashMap of AmiClients, one for each region where validation should happen
+    let base_region = &validation_regions[0];
+    let mut ami_clients = HashMap::with_capacity(validation_regions.len());
+
+    for region in &validation_regions {
+        let client_config = build_client_config(region, base_region, &aws).await;
+        let ami_client = AmiClient::new(&client_config);
+        ami_clients.insert(region.clone(), ami_client);
+    }
+
+    // Retrieve the EC2 images using the AmiClients
+    info!("Retrieving EC2 images");
+    let images = describe_images(
+        &ami_clients,
+        &expected_images
+            .iter()
+            .map(|(region, images)| {
+                (
+                    region.clone(),
+                    images
+                        .iter()
+                        .map(|i| i.image_id.clone())
+                        .collect::<Vec<String>>(),
+                )
+            })
+            .collect::<HashMap<Region, Vec<String>>>(),
+    )
+    .await;
+
+    // Validate the retrieved EC2 images per region
+    info!("Validating EC2 images");
+    let results: HashMap<Region, ami::Result<HashSet<AmiValidationResult>>> = images
+        .into_iter()
+        .map(|(region, region_result)| {
+            (
+                region.clone(),
+                region_result.map(|result| {
+                    validate_images_in_region(
+                        expected_images
+                            .get(region)
+                            .map(|e| e.to_owned())
+                            .unwrap_or(vec![]),
+                        result,
+                        region,
+                    )
+                }),
+            )
+        })
+        .collect::<HashMap<Region, ami::Result<HashSet<AmiValidationResult>>>>();
+
+    let validation_results = AmiValidationResults::new(results);
+
+    // If a path was given to write the results to, write the results
+    if let Some(write_results_path) = &validate_ami_args.write_results_path {
+        // Filter the results by given status, and if no statuses were given, get all results
+        info!("Writing results to file");
+        let filtered_results = validation_results.get_results_for_status(
+            validate_ami_args
+                .write_results_filter
+                .as_ref()
+                .unwrap_or(&vec![
+                    AmiValidationResultStatus::Correct,
+                    AmiValidationResultStatus::Incorrect,
+                    AmiValidationResultStatus::Missing,
+                ]),
+        );
+
+        // Write the results as JSON
+        serde_json::to_writer_pretty(
+            &File::create(write_results_path).context(error::WriteValidationResultsSnafu {
+                path: write_results_path,
+            })?,
+            &filtered_results,
+        )
+        .context(error::SerializeValidationResultsSnafu)?;
+    }
+
+    Ok(validation_results)
+}
+
+/// Validates EC2 images in a single region, based on a Vec (ImageDef) of expected images
+/// and a HashMap (AmiId, ImageDef) of actual retrieved images. Returns a HashSet of
+/// AmiValidationResult objects.
+pub(crate) fn validate_images_in_region(
+    expected_images: Vec<ImageDef>,
+    actual_images: HashMap<AmiId, ImageDef>,
+    region: &Region,
+) -> HashSet<AmiValidationResult> {
+    let mut results = HashSet::new();
+
+    // Validate all expected images, creating an AmiValidationResult object
+    for image in expected_images {
+        results.insert(AmiValidationResult::new(
+            image.image_id.clone(),
+            image.clone(),
+            actual_images.get(&image.image_id).map(|v| v.to_owned()),
+            region.clone(),
+        ));
+    }
+
+    results
+}
+
+type RegionName = String;
+type AmiId = String;
+
+/// Parse the lists of images whose paths are in `image_lists`. Only parse the images
+/// in the regions present in `validation_regions`. Return a HashMap of Region mapped to a Vec
+/// of the ImageDefs in that region.
+pub(crate) async fn parse_image_lists(
+    image_lists: Vec<PathBuf>,
+    validation_regions: &[RegionName],
+) -> Result<HashMap<Region, Vec<ImageDef>>> {
+    let mut image_map: HashMap<Region, Vec<ImageDef>> = HashMap::new();
+    for image_list_path in image_lists {
+        // Parse the JSON list as a HashMap of region_name, mapped to a Vec of ImageDefs
+        let image_list: HashMap<RegionName, HashMap<AmiId, serde_json::Value>> =
+            serde_json::from_reader(&File::open(image_list_path.clone()).context(
+                error::ReadExpectedImageListSnafu {
+                    path: image_list_path,
+                },
+            )?)
+            .context(error::ParseExpectedImageListSnafu)?;
+
+        image_list
+            .into_iter()
+            .filter(|(region_name, _)| validation_regions.contains(region_name))
+            .map(|(region_name, images)| {
+                (
+                    Region::new(region_name),
+                    images
+                        .keys()
+                        .map(|i| ImageDef::expected(i.to_owned()))
+                        .collect::<Vec<ImageDef>>(),
+                )
+            })
+            .for_each(|(region, images)| image_map.entry(region).or_insert(vec![]).extend(images));
+    }
+    Ok(image_map)
+}
+
+/// Common entrypoint from main()
+pub(crate) async fn run(args: &Args, validate_ami_args: &ValidateAmiArgs) -> Result<()> {
+    let results = validate(args, validate_ami_args).await?;
+
+    if validate_ami_args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&results.get_json_summary())
+                .context(error::SerializeResultsSummarySnafu)?
+        )
+    } else {
+        println!("{}", results);
+    }
+    Ok(())
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub(crate) enum Error {
+        #[snafu(display("Error reading config: {}", source))]
+        Config { source: pubsys_config::Error },
+
+        #[snafu(display("Error reading validation config at path {:?}: {}", path, source))]
+        ReadValidationConfig {
+            source: std::io::Error,
+            path: PathBuf,
+        },
+
+        #[snafu(display("Error parsing validation config: {}", source))]
+        ParseValidationConfig { source: serde_json::Error },
+
+        #[snafu(display("Missing field in validation config: {}", missing))]
+        MissingField { missing: String },
+
+        #[snafu(display("Infra.toml is missing {}", missing))]
+        MissingConfig { missing: String },
+
+        #[snafu(display("Failed to parse image list: {}", source))]
+        ParseExpectedImageList { source: serde_json::Error },
+
+        #[snafu(display("Failed to read image list: {:?}", path))]
+        ReadExpectedImageList {
+            source: std::io::Error,
+            path: PathBuf,
+        },
+
+        #[snafu(display("Invalid validation status filter: {}", filter))]
+        InvalidStatusFilter { filter: String },
+
+        #[snafu(display("Failed to serialize validation results to json: {}", source))]
+        SerializeValidationResults { source: serde_json::Error },
+
+        #[snafu(display("Failed to write validation results to {:?}: {}", path, source))]
+        WriteValidationResults {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to serialize results summary to JSON: {}", source))]
+        SerializeResultsSummary { source: serde_json::Error },
+    }
+}
+
+pub(crate) use error::Error;
+type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod test {
+    use super::ami::ImageDef;
+    use super::validate_images_in_region;
+    use crate::aws::validate_ami::results::{AmiValidationResult, AmiValidationResultStatus};
+    use aws_sdk_ec2::Region;
+    use std::collections::{HashMap, HashSet};
+
+    // These tests assert that the images can be validated correctly.
+
+    // Tests validation of images where the expected value is equal to the actual value
+    #[test]
+    fn validate_images_all_correct() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef::expected("test1-image-id".to_string()),
+            ImageDef::expected("test2-image-id".to_string()),
+            ImageDef::expected("test3-image-id".to_string()),
+        ];
+        let actual_parameters: HashMap<String, ImageDef> = HashMap::from([
+            (
+                "test1-image-id".to_string(),
+                ImageDef::expected("test1-image-id".to_string()),
+            ),
+            (
+                "test2-image-id".to_string(),
+                ImageDef::expected("test2-image-id".to_string()),
+            ),
+            (
+                "test3-image-id".to_string(),
+                ImageDef::expected("test3-image-id".to_string()),
+            ),
+        ]);
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef::expected("test3-image-id".to_string()),
+                Some(ImageDef::expected("test3-image-id".to_string())),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef::expected("test2-image-id".to_string()),
+                Some(ImageDef::expected("test2-image-id".to_string())),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef::expected("test1-image-id".to_string()),
+                Some(ImageDef::expected("test1-image-id".to_string())),
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            expected_parameters,
+            actual_parameters,
+            &Region::new("us-west-2"),
+        );
+        for result in &results {
+            assert_eq!(result.status, AmiValidationResultStatus::Correct);
+        }
+        assert_eq!(results, expected_results);
+    }
+
+    // Tests validation of images where the expected value is different from the actual value
+    #[test]
+    fn validate_images_all_incorrect() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef::expected("test1-image-id".to_string()),
+            ImageDef::expected("test2-image-id".to_string()),
+            ImageDef::expected("test3-image-id".to_string()),
+        ];
+        let actual_parameters: HashMap<String, ImageDef> = HashMap::from([
+            (
+                "test1-image-id".to_string(),
+                ImageDef {
+                    image_id: "test1-image-id".to_string(),
+                    public: true,
+                    ena_support: false,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+            (
+                "test2-image-id".to_string(),
+                ImageDef {
+                    image_id: "test2-image-id".to_string(),
+                    public: false,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+            (
+                "test3-image-id".to_string(),
+                ImageDef {
+                    image_id: "test3-image-id".to_string(),
+                    public: true,
+                    ena_support: true,
+                    sriov_net_support: "not simple".to_string(),
+                },
+            ),
+        ]);
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef::expected("test3-image-id".to_string()),
+                Some(ImageDef {
+                    image_id: "test3-image-id".to_string(),
+                    public: true,
+                    ena_support: true,
+                    sriov_net_support: "not simple".to_string(),
+                }),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef::expected("test2-image-id".to_string()),
+                Some(ImageDef {
+                    image_id: "test2-image-id".to_string(),
+                    public: false,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                }),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef::expected("test1-image-id".to_string()),
+                Some(ImageDef {
+                    image_id: "test1-image-id".to_string(),
+                    public: true,
+                    ena_support: false,
+                    sriov_net_support: "simple".to_string(),
+                }),
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            expected_parameters,
+            actual_parameters,
+            &Region::new("us-west-2"),
+        );
+        for result in &results {
+            assert_eq!(result.status, AmiValidationResultStatus::Incorrect);
+        }
+        assert_eq!(results, expected_results);
+    }
+
+    // Tests validation of images where the actual value is missing
+    #[test]
+    fn validate_images_all_missing() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef::expected("test1-image-id".to_string()),
+            ImageDef::expected("test2-image-id".to_string()),
+            ImageDef::expected("test3-image-id".to_string()),
+        ];
+        let actual_parameters = HashMap::new();
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef::expected("test3-image-id".to_string()),
+                None,
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef::expected("test2-image-id".to_string()),
+                None,
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef::expected("test1-image-id".to_string()),
+                None,
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            expected_parameters,
+            actual_parameters,
+            &Region::new("us-west-2"),
+        );
+        for result in &results {
+            assert_eq!(result.status, AmiValidationResultStatus::Missing);
+        }
+        assert_eq!(results, expected_results);
+    }
+
+    // Tests validation of parameters where each status (Correct, Incorrect, Missing) happens once
+    #[test]
+    fn validate_images_mixed() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef::expected("test1-image-id".to_string()),
+            ImageDef::expected("test2-image-id".to_string()),
+            ImageDef::expected("test3-image-id".to_string()),
+        ];
+        let actual_parameters: HashMap<String, ImageDef> = HashMap::from([
+            (
+                "test1-image-id".to_string(),
+                ImageDef::expected("test1-image-id".to_string()),
+            ),
+            (
+                "test2-image-id".to_string(),
+                ImageDef {
+                    image_id: "test2-image-id".to_string(),
+                    public: false,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+        ]);
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef::expected("test1-image-id".to_string()),
+                Some(ImageDef::expected("test1-image-id".to_string())),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef::expected("test2-image-id".to_string()),
+                Some(ImageDef {
+                    image_id: "test2-image-id".to_string(),
+                    public: false,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                }),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef::expected("test3-image-id".to_string()),
+                None,
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            expected_parameters,
+            actual_parameters,
+            &Region::new("us-west-2"),
+        );
+
+        assert_eq!(results, expected_results);
+    }
+}

--- a/tools/pubsys/src/aws/validate_ami/results.rs
+++ b/tools/pubsys/src/aws/validate_ami/results.rs
@@ -1,0 +1,716 @@
+//! The results module owns the reporting of EC2 image validation results.
+
+use super::ami::{ImageDef, Result};
+use aws_sdk_ec2::Region;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use tabled::{Table, Tabled};
+
+/// Represent the possible status of an EC2 image validation
+#[derive(Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub(crate) enum AmiValidationResultStatus {
+    /// The AMI was found and its monitored fields have the expected values
+    Correct,
+
+    /// The AMI was found but some of the monitored fields do not have the expected values
+    Incorrect,
+
+    /// The image was expected but not included in the actual images
+    Missing,
+}
+
+impl Display for AmiValidationResultStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AmiValidationResultStatus::Correct => write!(f, "Correct"),
+            AmiValidationResultStatus::Incorrect => write!(f, "Incorrect"),
+            AmiValidationResultStatus::Missing => write!(f, "Missing"),
+        }
+    }
+}
+
+impl FromStr for AmiValidationResultStatus {
+    type Err = super::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "Correct" => Ok(Self::Correct),
+            "Incorrect" => Ok(Self::Incorrect),
+            "Missing" => Ok(Self::Missing),
+            filter => Err(Self::Err::InvalidStatusFilter {
+                filter: filter.to_string(),
+            }),
+        }
+    }
+}
+
+/// Represents a single EC2 image validation result
+#[derive(Debug, Eq, Hash, PartialEq, Serialize)]
+pub(crate) struct AmiValidationResult {
+    /// The id of the image
+    pub(crate) image_id: String,
+
+    /// ImageDef containing expected values for the image
+    pub(crate) expected_image_def: ImageDef,
+
+    /// ImageDef containing actual values for the image
+    pub(crate) actual_image_def: Option<ImageDef>,
+
+    /// The region the image resides in
+    #[serde(serialize_with = "serialize_region")]
+    pub(crate) region: Region,
+
+    /// The validation status of the image
+    pub(crate) status: AmiValidationResultStatus,
+}
+
+fn serialize_region<S>(region: &Region, serializer: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(region.to_string().as_str())
+}
+
+impl AmiValidationResult {
+    pub(crate) fn new(
+        image_id: String,
+        expected_image_def: ImageDef,
+        actual_image_def: Option<ImageDef>,
+        region: Region,
+    ) -> Self {
+        // Determine the validation status based on equality, presence, and absence of expected and
+        // actual image values
+        let status = match (&expected_image_def, &actual_image_def) {
+            (expected_image_def, Some(actual_image_def))
+                if actual_image_def == expected_image_def =>
+            {
+                AmiValidationResultStatus::Correct
+            }
+            (_, Some(_)) => AmiValidationResultStatus::Incorrect,
+            (_, None) => AmiValidationResultStatus::Missing,
+        };
+        AmiValidationResult {
+            image_id,
+            expected_image_def,
+            actual_image_def,
+            region,
+            status,
+        }
+    }
+}
+
+#[derive(Tabled, Serialize)]
+struct AmiValidationRegionSummary {
+    correct: i32,
+    incorrect: i32,
+    missing: i32,
+    accessible: bool,
+}
+
+impl From<&HashSet<AmiValidationResult>> for AmiValidationRegionSummary {
+    fn from(results: &HashSet<AmiValidationResult>) -> Self {
+        let mut region_validation = AmiValidationRegionSummary {
+            correct: 0,
+            incorrect: 0,
+            missing: 0,
+            accessible: true,
+        };
+        for validation_result in results {
+            match validation_result.status {
+                AmiValidationResultStatus::Correct => region_validation.correct += 1,
+                AmiValidationResultStatus::Incorrect => region_validation.incorrect += 1,
+                AmiValidationResultStatus::Missing => region_validation.missing += 1,
+            }
+        }
+        region_validation
+    }
+}
+
+impl AmiValidationRegionSummary {
+    fn no_valid_results() -> Self {
+        // When the images in a region couldn't be retrieved, use `-1` to indicate this in the output table
+        // and set `accessible` to `false`
+        AmiValidationRegionSummary {
+            correct: -1,
+            incorrect: -1,
+            missing: -1,
+            accessible: false,
+        }
+    }
+}
+
+/// Represents all EC2 image validation results
+#[derive(Debug)]
+pub(crate) struct AmiValidationResults {
+    pub(crate) results: HashMap<Region, Result<HashSet<AmiValidationResult>>>,
+}
+
+impl Default for AmiValidationResults {
+    fn default() -> Self {
+        Self::new(HashMap::new())
+    }
+}
+
+impl Display for AmiValidationResults {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Create a summary for each region, counting the number of parameters per status
+        let region_validations: HashMap<Region, AmiValidationRegionSummary> =
+            self.get_results_summary();
+
+        // Represent the HashMap of summaries as a `Table`
+        let table = Table::new(
+            region_validations
+                .iter()
+                .map(|(region, results)| (region.to_string(), results))
+                .collect::<Vec<(String, &AmiValidationRegionSummary)>>(),
+        )
+        .to_string();
+        write!(f, "{}", table)
+    }
+}
+
+impl AmiValidationResults {
+    pub(crate) fn new(results: HashMap<Region, Result<HashSet<AmiValidationResult>>>) -> Self {
+        AmiValidationResults { results }
+    }
+
+    /// Returns a HashSet containing all validation results whose status is present in `requested_status`
+    pub(crate) fn get_results_for_status(
+        &self,
+        requested_status: &[AmiValidationResultStatus],
+    ) -> HashSet<&AmiValidationResult> {
+        let mut results = HashSet::new();
+        for region_results in self.results.values().flatten() {
+            results.extend(
+                region_results
+                    .iter()
+                    .filter(|result| requested_status.contains(&result.status))
+                    .collect::<HashSet<&AmiValidationResult>>(),
+            )
+        }
+        results
+    }
+
+    fn get_results_summary(&self) -> HashMap<Region, AmiValidationRegionSummary> {
+        self.results
+            .iter()
+            .map(|(region, region_result)| {
+                region_result
+                    .as_ref()
+                    .map(|region_validation| {
+                        (
+                            region.clone(),
+                            AmiValidationRegionSummary::from(region_validation),
+                        )
+                    })
+                    .unwrap_or((
+                        region.clone(),
+                        AmiValidationRegionSummary::no_valid_results(),
+                    ))
+            })
+            .collect()
+    }
+
+    pub(crate) fn get_json_summary(&self) -> serde_json::Value {
+        serde_json::json!(self
+            .get_results_summary()
+            .into_iter()
+            .map(|(region, results)| (region.to_string(), results))
+            .collect::<HashMap<String, AmiValidationRegionSummary>>())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{AmiValidationResult, AmiValidationResultStatus, AmiValidationResults};
+    use crate::aws::validate_ami::ami::ImageDef;
+    use aws_sdk_ssm::Region;
+    use std::collections::{HashMap, HashSet};
+
+    // These tests assert that the `get_results_for_status` function returns the correct values.
+
+    // Tests empty AmiValidationResults
+    #[test]
+    fn get_results_for_status_empty() {
+        let results = AmiValidationResults::new(HashMap::from([
+            (Region::new("us-west-2"), Ok(HashSet::from([]))),
+            (Region::new("us-east-1"), Ok(HashSet::from([]))),
+        ]));
+        let results_filtered = results.get_results_for_status(&vec![
+            AmiValidationResultStatus::Correct,
+            AmiValidationResultStatus::Incorrect,
+            AmiValidationResultStatus::Missing,
+        ]);
+
+        assert_eq!(results_filtered, HashSet::new());
+    }
+
+    // Tests the `Correct` status
+    #[test]
+    fn get_results_for_status_correct() {
+        let results = AmiValidationResults::new(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test2-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                ])),
+            ),
+            (
+                Region::new("us-east-1"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test2-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                ])),
+            ),
+        ]));
+        let results_filtered =
+            results.get_results_for_status(&vec![AmiValidationResultStatus::Correct]);
+
+        assert_eq!(
+            results_filtered,
+            HashSet::from([
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef::expected("test1-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test1-image-id".to_string(),
+                        public: true,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef::expected("test3-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test3-image-id".to_string(),
+                        public: true,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-east-1"),
+                )
+            ])
+        );
+    }
+
+    // Tests a filter containing the `Correct` and `Incorrect` statuses
+    #[test]
+    fn get_results_for_status_correct_incorrect() {
+        let results = AmiValidationResults::new(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        None,
+                        Region::new("us-west-2"),
+                    ),
+                ])),
+            ),
+            (
+                Region::new("us-east-1"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        None,
+                        Region::new("us-east-1"),
+                    ),
+                ])),
+            ),
+        ]));
+        let results_filtered = results.get_results_for_status(&vec![
+            AmiValidationResultStatus::Correct,
+            AmiValidationResultStatus::Incorrect,
+        ]);
+
+        assert_eq!(
+            results_filtered,
+            HashSet::from([
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef::expected("test1-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test1-image-id".to_string(),
+                        public: true,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef::expected("test3-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test3-image-id".to_string(),
+                        public: true,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-east-1"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef::expected("test3-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test3-image-id".to_string(),
+                        public: true,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef::expected("test1-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test1-image-id".to_string(),
+                        public: true,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-east-1"),
+                )
+            ])
+        );
+    }
+
+    // Tests a filter containing all statuses
+    #[test]
+    fn get_results_for_status_all() {
+        let results = AmiValidationResults::new(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        None,
+                        Region::new("us-west-2"),
+                    ),
+                ])),
+            ),
+            (
+                Region::new("us-east-1"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        None,
+                        Region::new("us-east-1"),
+                    ),
+                ])),
+            ),
+        ]));
+        let results_filtered = results.get_results_for_status(&vec![
+            AmiValidationResultStatus::Correct,
+            AmiValidationResultStatus::Incorrect,
+            AmiValidationResultStatus::Missing,
+        ]);
+
+        assert_eq!(
+            results_filtered,
+            HashSet::from([
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef::expected("test1-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test1-image-id".to_string(),
+                        public: true,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef::expected("test3-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test3-image-id".to_string(),
+                        public: true,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-east-1"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef::expected("test3-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test3-image-id".to_string(),
+                        public: true,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef::expected("test1-image-id".to_string()),
+                    Some(ImageDef {
+                        image_id: "test1-image-id".to_string(),
+                        public: true,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    }),
+                    Region::new("us-east-1"),
+                ),
+                &AmiValidationResult::new(
+                    "test2-image-id".to_string(),
+                    ImageDef::expected("test2-image-id".to_string()),
+                    None,
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test2-image-id".to_string(),
+                    ImageDef::expected("test2-image-id".to_string()),
+                    None,
+                    Region::new("us-east-1"),
+                ),
+            ])
+        );
+    }
+
+    // Tests the `Missing` filter when none of the AmiValidationResults have this status
+    #[test]
+    fn get_results_for_status_missing_none() {
+        let results = AmiValidationResults::new(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test2-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        }),
+                        Region::new("us-west-2"),
+                    ),
+                ])),
+            ),
+            (
+                Region::new("us-east-1"),
+                Ok(HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef::expected("test3-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test3-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef::expected("test1-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test1-image-id".to_string(),
+                            public: true,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef::expected("test2-image-id".to_string()),
+                        Some(ImageDef {
+                            image_id: "test2-image-id".to_string(),
+                            public: true,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        }),
+                        Region::new("us-east-1"),
+                    ),
+                ])),
+            ),
+        ]));
+        let results_filtered =
+            results.get_results_for_status(&vec![AmiValidationResultStatus::Missing]);
+
+        assert_eq!(results_filtered, HashSet::new());
+    }
+}

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -123,6 +123,14 @@ fn run() -> Result<()> {
                     .context(error::ValidateSsmSnafu)
             })
         }
+        SubCommand::ValidateAmi(ref validate_ami_args) => {
+            let rt = Runtime::new().context(error::RuntimeSnafu)?;
+            rt.block_on(async {
+                aws::validate_ami::run(&args, validate_ami_args)
+                    .await
+                    .context(error::ValidateAmiSnafu)
+            })
+        }
         SubCommand::UploadOva(ref upload_args) => {
             vmware::upload_ova::run(&args, upload_args).context(error::UploadOvaSnafu)
         }
@@ -161,6 +169,7 @@ enum SubCommand {
 
     Ami(aws::ami::AmiArgs),
     PublishAmi(aws::publish_ami::PublishArgs),
+    ValidateAmi(aws::validate_ami::ValidateAmiArgs),
 
     Ssm(aws::ssm::SsmArgs),
     PromoteSsm(aws::promote_ssm::PromoteArgs),
@@ -238,6 +247,11 @@ mod error {
         #[snafu(display("Failed to validate SSM parameters: {}", source))]
         ValidateSsm {
             source: crate::aws::validate_ssm::Error,
+        },
+
+        #[snafu(display("Failed to validate EC2 images: {}", source))]
+        ValidateAmi {
+            source: crate::aws::validate_ami::Error,
         },
     }
 


### PR DESCRIPTION
Added a `validate-ami` subcommand to pubsys to validate EC2 images, given a config file with regions and paths to files containing image ids.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Added a validate_ami mod to the pubsys crate. This mod adds a subcommand validate-ami with the following signature:
```
pubsys-validate-ami 0.1.0
Validates EC2 images

USAGE:
    pubsys --infra-config-path <infra-config-path> validate-ami [FLAGS] [OPTIONS] --validation-config-path <validation-config-path>

FLAGS:
        --json       If this argument is given, print the validation results summary as a JSON object instead of a
                     plaintext table
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --validation-config-path <validation-config-path>    File holding the validation configuration
        --write-results-path <write-results-path>
            Optional path where the validation results should be written

        --write-results-filter <write-results-filter>...
            Optional filter to only write validation results with these statuses to the above path The available
            statuses are: `Correct`, `Incorrect`, `Missing`
        --log-level <log-level>
            How much detail to log; from least to most: ERROR, WARN, INFO, DEBUG, TRACE [default: INFO]
```
- validation-config-path is the path to the file containing the validation configuration. This file should look like this:
```
{
    "validation_regions": [ "us-west-2", "us-east-1" ],
    "expected_metadata_lists": [ "./canary/ami/ami_lists/1.11.0.json", "./canary/ami/ami_lists/1.11.1.json", "./canary/ami/ami_lists/1.12.0.json", "./canary/ami/ami_lists/latest.json" ]
}
```
Each expected_metadata_list should have the following structure:
```
{
  "us-west-2": {
    "ami-12345678": {
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/arm64/1.12.0-6ef1139f/image_id": "ami-12345678",
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/arm64/1.12.0-6ef1139f/image_version": "1.12.0-abcdefgh",
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/arm64/1.12.0/image_id": "ami-12345678",
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/arm64/1.12.0/image_version": "1.12.0-abcdefgh"
    },
    "ami-082d59d8979d777a6": {
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/x86_64/1.12.0-6ef1139f/image_id": "ami-87654321",
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/x86_64/1.12.0-6ef1139f/image_version": "1.12.0-hgfedcba",
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/x86_64/1.12.0/image_id": "ami-87654321",
      "/aws/service/bottlerocket/aws-ecs-1-nvidia/x86_64/1.12.0/image_version": "1.12.0-hgfedcba"
    },`
    ...
  },
  "us-east-1": {
    ...
  }
}
```
The parameters inside the image-id objects are irrelevant, but this same file structure is used for SSM validation (https://github.com/bottlerocket-os/bottlerocket/pull/2969) so this allows both validations to use the same input files.
- write-results-path is the path to the file where the validation results will be written. The file will look like this:
```
[
  {
    "image_id": "ami-0f4c91eb881453540",
    "expected_value": {
      "ImageId": "ami-0f4c91eb881453540",
      "Public": true,
      "EnaSupport": true,
      "SriovNetSupport": "simple"
    },
    "actual_value": {
      "ImageId": "ami-0f4c91eb881453540",
      "Public": true,
      "EnaSupport": true,
      "SriovNetSupport": "simple"
    },
    "region": "us-east-1",
    "status": "Correct"
  },
  ...
]
```
- write-results-filter is a vec of potential statuses, which limits the validation results written to the above file. If the vec contains Correct and Incorrect, then only the validation results with those statuses will be written to the file and Missing validation results will not.

The command outputs a tabled summary of the validation results. This table will look like this (unless the `--json` flag is passed, in which case a JSON object will be printed):
```
+----------------+---------+-----------+---------+------------+
| String         | correct | incorrect | missing | accessible |
+----------------+---------+-----------+---------+------------+
| ap-northeast-3 | 448     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| eu-west-2      | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| ap-northeast-1 | 558     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| eu-west-1      | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| ca-central-1   | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| ap-southeast-1 | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| ap-south-1     | 553     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| us-east-1      | 558     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| sa-east-1      | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| us-east-2      | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| us-west-1      | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| eu-west-3      | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| ap-southeast-2 | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| eu-north-1     | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| us-west-2      | 558     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| eu-central-1   | 558     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
| ap-northeast-2 | 548     | 0         | 0       | true       |
+----------------+---------+-----------+---------+------------+
```
The meaning of the different columns is this:

- correct: the expected validated values of the images are equal to the values of the retrieved image
- incorrect: the expected value of the parameter is different from the retrieved value
- missing: the parameter was expected in that region but not retrieved
- accessible: SSM parameters were successfully retrieved from that region. If an invalid region was given, this would say false and all other columns in that row would show -1

The validation will check the following 3 fields with their expected values:
- `Public`: true
- `EnaSupport`: true
- `SriovNetSupport`: `simple`

**Testing done:**

- Unit tests
- Compiled a list of Bottlerocket image ids for each version in each validation region based on the public SSM parameters and used this as input for the command. Results are shown in the table above (each image validated correctly).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
