### PR TITLE
kubelet: Enable setting cpuManagerPolicyOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,18 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.container-log-max-files`: The maximum number of container log files that can be present for a container.
 * `settings.kubernetes.container-log-max-size`: The maximum size of container log file before it is rotated.
 * `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`. If you want to allow pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node, you can set this setting to `static`. You should reboot if you change this setting after startup - try `apiclient reboot`.
+* `settings.kubernetes.cpu-manager-policy-options`: Policy options to apply when `cpu-manager-policy` is set to `static`. Currently `full-pcpus-only` is the only option.
+
+  For example:
+
+  ```toml
+  [settings.kubernetes]
+  cpu-manager-policy = "static"
+  cpu-manager-policy-options = [
+    "full-pcpus-only"
+  ]
+  ```
+
 * `settings.kubernetes.cpu-manager-reconcile-period`: Specifies the CPU manager reconcile period, which controls how often updated CPU assignments are written to cgroupfs. The value is a duration like `30s` for 30 seconds or `1h5m` for 1 hour and 5 minutes.
 * `settings.kubernetes.credential-providers`: Contains a collection of Kubelet image credential provider settings.
   Each name under `credential-providers` is the name of the plugin to configure.

--- a/Release.toml
+++ b/Release.toml
@@ -201,5 +201,6 @@ version = "1.14.0"
     "migrate_v1.13.4_add-hostname-override-metadata.lz4",
 ]
 "(1.13.4, 1.14.0)" = [
-    "migrate_v1.14.0_kubernetes-gc-percent-type-change.lz4"
+    "migrate_v1.14.0_kubernetes-gc-percent-type-change.lz4",
+    "migrate_v1.14.0_kubernetes-config-settings.lz4",
 ]

--- a/packages/kubernetes-1.22/kubelet-config
+++ b/packages/kubernetes-1.22/kubelet-config
@@ -80,6 +80,12 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{/if}}
+{{#if settings.kubernetes.cpu-manager-policy-options}}
+cpuManagerPolicyOptions:
+{{#each settings.kubernetes.cpu-manager-policy-options}}
+    {{this}}: "true"
+{{/each}}
+{{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{/if}}

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -80,6 +80,12 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{/if}}
+{{#if settings.kubernetes.cpu-manager-policy-options}}
+cpuManagerPolicyOptions:
+{{#each settings.kubernetes.cpu-manager-policy-options}}
+    {{this}}: "true"
+{{/each}}
+{{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{/if}}

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -80,6 +80,12 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{/if}}
+{{#if settings.kubernetes.cpu-manager-policy-options}}
+cpuManagerPolicyOptions:
+{{#each settings.kubernetes.cpu-manager-policy-options}}
+    {{this}}: "true"
+{{/each}}
+{{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{/if}}

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -80,6 +80,12 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{/if}}
+{{#if settings.kubernetes.cpu-manager-policy-options}}
+cpuManagerPolicyOptions:
+{{#each settings.kubernetes.cpu-manager-policy-options}}
+    {{this}}: "true"
+{{/each}}
+{{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{/if}}

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -80,6 +80,12 @@ cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
 {{#if settings.kubernetes.cpu-manager-reconcile-period}}
 cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{/if}}
+{{#if settings.kubernetes.cpu-manager-policy-options}}
+cpuManagerPolicyOptions:
+{{#each settings.kubernetes.cpu-manager-policy-options}}
+    {{this}}: "true"
+{{/each}}
+{{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}
 topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2234,6 +2234,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-config-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-gc-percent-type-change"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "api/migration/migrations/v1.13.4/add-hostname-override",
     "api/migration/migrations/v1.13.4/add-hostname-override-metadata",
     "api/migration/migrations/v1.14.0/kubernetes-gc-percent-type-change",
+    "api/migration/migrations/v1.14.0/kubelet-config-settings",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-config-settings"
+version = "0.1.0"
+authors = ["Sean McGinnis <stmcg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/kubelet-config-settings/src/main.rs
@@ -1,0 +1,19 @@
+use migration_helpers::{common_migrations::AddSettingsMigration, migrate, Result};
+use std::process;
+
+/// Additional `settings.kubernetes` options for this release.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.cpu-manager-policy-options",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -172,6 +172,7 @@ mod variant;
 // The "de" module contains custom deserialization trait implementation for models.
 mod de;
 
+use modeled_types::KubernetesCPUManagerPolicyOption;
 pub use variant::*;
 
 // Types used to communicate between client and server for 'apiclient exec'.
@@ -243,6 +244,7 @@ struct KubernetesSettings {
     container_log_max_files: i32,
     cpu_manager_policy: CpuManagerPolicy,
     cpu_manager_reconcile_period: KubernetesDurationValue,
+    cpu_manager_policy_options: Vec<KubernetesCPUManagerPolicyOption>,
     topology_manager_scope: TopologyManagerScope,
     topology_manager_policy: TopologyManagerPolicy,
     pod_pids_limit: i64,

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use regex::Regex;
+use scalar_derive::Scalar;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 // Just need serde's Error in scope to get its trait methods
 use super::error;
@@ -1327,4 +1328,33 @@ pub struct CredentialProvider {
     image_patterns: Vec<SingleLineString>,
     cache_duration: Option<KubernetesDurationValue>,
     environment: Option<EnvVarMap>,
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// KubernetesCPUManagerPolicyOption values are the possible option names for the cpuManagerPolicyOptions.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Scalar)]
+pub enum KubernetesCPUManagerPolicyOption {
+    #[serde(rename = "full-pcpus-only")]
+    FullPCPUsOnly,
+}
+
+#[cfg(test)]
+mod test_kubernetes_cpu_manager_policy_option {
+    use super::KubernetesCPUManagerPolicyOption;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_cpu_manager_policy_option() {
+        for ok in &["full-pcpus-only"] {
+            KubernetesCPUManagerPolicyOption::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_cpu_manager_policy_option() {
+        for err in &["fullPCPUSOnly", "", "align-by-socket"] {
+            KubernetesCPUManagerPolicyOption::try_from(*err).unwrap_err();
+        }
+    }
 }


### PR DESCRIPTION
**Issue number:**

Closes #2342

**Description of changes:**

This adds a new `settings.kubernetes.cpu-manager-policy-options` setting to allow configuring the kubelet cpuManagerPolicyOptions. When the CPU manager policy is set to "static", these options allow affecting the behavior of CPU allocation for pods.

The only supported policy option at this point is [`full-pcpus-only` as it is the only one that is not hidden by an alpha feature gate](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options). More options can be supported later as they leave alpha.

This change could have been included with #2930, but that PR is already getting quite large. So at this point it will probably be better dealing with merge conflicts than inflating that further. If one or the other doesn't make it in time for the next release they can also be divided up and updated to have the correct migration for their ultimate release version.

**Testing done:**

Deployed built image and applied these settings:

```toml
[settings.kubernetes]
cpu-manager-policy = "static"
cpu-manager-policy-options = [
  "full-pcpus-only"
]
```

Verified the `/etc/kubernetes/kubelet/config` file rendered as expected:

```yaml
cpuManagerPolicy: static
cpuManagerPolicyOptions:
  full-pcpus-only: "true"
```

Checked `systemctl status kubelet` and made sure the service was healthy and reviewed logs to make sure `kubelet` was able to start up and recognize the new configuration.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
