### PR TITLE
pubsys: write SSM parameters and AMI permissions to output files

### DIFF
--- a/tools/pubsys/src/aws/ami/launch_permissions.rs
+++ b/tools/pubsys/src/aws/ami/launch_permissions.rs
@@ -1,0 +1,98 @@
+use aws_sdk_ec2::{model::LaunchPermission, Client as Ec2Client};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+/// Returns the launch permissions for the given AMI
+pub(crate) async fn get_launch_permissions(
+    ec2_client: &Ec2Client,
+    region: &str,
+    ami_id: &str,
+) -> Result<Vec<LaunchPermissionDef>> {
+    let ec2_response = ec2_client
+        .describe_image_attribute()
+        .image_id(ami_id)
+        .attribute(aws_sdk_ec2::model::ImageAttributeName::LaunchPermission)
+        .send()
+        .await
+        .context(error::DescribeImageAttributeSnafu {
+            ami_id,
+            region: region.to_string(),
+        })?;
+
+    let mut launch_permissions = vec![];
+
+    let responses: Vec<LaunchPermission> =
+        ec2_response.launch_permissions().unwrap_or(&[]).to_vec();
+    for permission in responses {
+        launch_permissions.push(LaunchPermissionDef::try_from(permission)?)
+    }
+    Ok(launch_permissions)
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LaunchPermissionDef {
+    /// The name of the group
+    Group(String),
+
+    /// The Amazon Web Services account ID
+    UserId(String),
+
+    /// The ARN of an organization
+    OrganizationArn(String),
+
+    /// The ARN of an organizational unit
+    OrganizationalUnitArn(String),
+}
+
+impl TryFrom<LaunchPermission> for LaunchPermissionDef {
+    type Error = crate::aws::ami::launch_permissions::Error;
+
+    fn try_from(launch_permission: LaunchPermission) -> std::result::Result<Self, Self::Error> {
+        let LaunchPermission {
+            group,
+            user_id,
+            organization_arn,
+            organizational_unit_arn,
+            ..
+        } = launch_permission.clone();
+        match (group, user_id, organization_arn, organizational_unit_arn) {
+            (Some(group), None, None, None) => {
+                Ok(LaunchPermissionDef::Group(group.as_str().to_string()))
+            }
+            (None, Some(user_id), None, None) => Ok(LaunchPermissionDef::UserId(user_id)),
+            (None, None, Some(organization_arn), None) => {
+                Ok(LaunchPermissionDef::OrganizationArn(organization_arn))
+            }
+            (None, None, None, Some(organizational_unit_arn)) => Ok(
+                LaunchPermissionDef::OrganizationalUnitArn(organizational_unit_arn),
+            ),
+            _ => Err(Error::InvalidLaunchPermission { launch_permission }),
+        }
+    }
+}
+
+mod error {
+    use aws_sdk_ec2::error::DescribeImageAttributeError;
+    use aws_sdk_ec2::model::LaunchPermission;
+    use aws_sdk_ec2::types::SdkError;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub(crate) enum Error {
+        #[snafu(display("Error describing AMI {} in {}: {}", ami_id, region, source))]
+        DescribeImageAttribute {
+            ami_id: String,
+            region: String,
+            #[snafu(source(from(SdkError<DescribeImageAttributeError>, Box::new)))]
+            source: Box<SdkError<DescribeImageAttributeError>>,
+        },
+
+        #[snafu(display("Invalid launch permission: {:?}", launch_permission))]
+        InvalidLaunchPermission { launch_permission: LaunchPermission },
+    }
+}
+pub(crate) use error::Error;
+
+type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/ssm/template.rs
+++ b/tools/pubsys/src/aws/ssm/template.rs
@@ -177,6 +177,58 @@ fn join_name(ssm_prefix: &str, name_suffix: &str) -> String {
     }
 }
 
+type RegionName = String;
+type SsmParameterName = String;
+type SsmParameterValue = String;
+
+/// Struct containing a HashMap of RegionName, mapped to a HashMap
+/// of SsmParameterName, SsmParameterValue pairs
+#[derive(Deserialize, PartialEq, Serialize)]
+pub(crate) struct RenderedParametersMap {
+    pub(crate) rendered_parameters:
+        HashMap<RegionName, HashMap<SsmParameterName, SsmParameterValue>>,
+}
+
+impl From<&Vec<RenderedParameter>> for RenderedParametersMap {
+    fn from(parameters: &Vec<RenderedParameter>) -> Self {
+        let mut parameter_map: HashMap<RegionName, HashMap<SsmParameterName, SsmParameterValue>> =
+            HashMap::new();
+        for parameter in parameters.iter() {
+            parameter_map
+                .entry(parameter.ssm_key.region.to_string())
+                .or_insert(HashMap::new())
+                .insert(
+                    parameter.ssm_key.name.to_owned(),
+                    parameter.value.to_owned(),
+                );
+        }
+        RenderedParametersMap {
+            rendered_parameters: parameter_map,
+        }
+    }
+}
+
+impl From<HashMap<Region, HashMap<SsmKey, String>>> for RenderedParametersMap {
+    fn from(parameters: HashMap<Region, HashMap<SsmKey, String>>) -> Self {
+        let mut parameter_map: HashMap<RegionName, HashMap<SsmParameterName, SsmParameterValue>> =
+            HashMap::new();
+        parameters
+            .into_iter()
+            .for_each(|(region, region_parameters)| {
+                parameter_map.insert(
+                    region.to_string(),
+                    region_parameters
+                        .into_iter()
+                        .map(|(ssm_key, ssm_value)| (ssm_key.name, ssm_value))
+                        .collect::<HashMap<SsmParameterName, SsmParameterValue>>(),
+                );
+            });
+        RenderedParametersMap {
+            rendered_parameters: parameter_map,
+        }
+    }
+}
+
 mod error {
     use snafu::Snafu;
     use std::io;
@@ -216,3 +268,148 @@ mod error {
 }
 pub(crate) use error::Error;
 type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use super::{RenderedParameter, RenderedParametersMap};
+    use crate::aws::{ami::Image, ssm::SsmKey};
+    use aws_sdk_ssm::Region;
+
+    // These tests assert that the RenderedParametersMap can be created correctly.
+    #[test]
+    fn rendered_parameters_map_from_vec() {
+        let rendered_parameters = vec![
+            RenderedParameter {
+                ami: Image {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image-name".to_string(),
+                    public: Some(true),
+                    launch_permissions: Some(vec![]),
+                },
+                ssm_key: SsmKey {
+                    region: Region::new("us-west-2"),
+                    name: "test1-parameter-name".to_string(),
+                },
+                value: "test1-parameter-value".to_string(),
+            },
+            RenderedParameter {
+                ami: Image {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image-name".to_string(),
+                    public: Some(true),
+                    launch_permissions: Some(vec![]),
+                },
+                ssm_key: SsmKey {
+                    region: Region::new("us-west-2"),
+                    name: "test2-parameter-name".to_string(),
+                },
+                value: "test2-parameter-value".to_string(),
+            },
+            RenderedParameter {
+                ami: Image {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image-name".to_string(),
+                    public: Some(true),
+                    launch_permissions: Some(vec![]),
+                },
+                ssm_key: SsmKey {
+                    region: Region::new("us-east-1"),
+                    name: "test3-parameter-name".to_string(),
+                },
+                value: "test3-parameter-value".to_string(),
+            },
+        ];
+        let map = &RenderedParametersMap::from(&rendered_parameters).rendered_parameters;
+        let expected_map = &HashMap::from([
+            (
+                "us-east-1".to_string(),
+                HashMap::from([(
+                    "test3-parameter-name".to_string(),
+                    "test3-parameter-value".to_string(),
+                )]),
+            ),
+            (
+                "us-west-2".to_string(),
+                HashMap::from([
+                    (
+                        "test1-parameter-name".to_string(),
+                        "test1-parameter-value".to_string(),
+                    ),
+                    (
+                        "test2-parameter-name".to_string(),
+                        "test2-parameter-value".to_string(),
+                    ),
+                ]),
+            ),
+        ]);
+        assert_eq!(map, expected_map);
+    }
+
+    #[test]
+    fn rendered_parameters_map_from_empty_vec() {
+        let rendered_parameters = vec![];
+        let map = &RenderedParametersMap::from(&rendered_parameters).rendered_parameters;
+        let expected_map = &HashMap::new();
+        assert_eq!(map, expected_map);
+    }
+
+    #[test]
+    fn rendered_parameters_map_from_map() {
+        let existing_parameters = HashMap::from([
+            (
+                Region::new("us-west-2"),
+                HashMap::from([
+                    (
+                        SsmKey::new(Region::new("us-west-2"), "test1-parameter-name".to_string()),
+                        "test1-parameter-value".to_string(),
+                    ),
+                    (
+                        SsmKey::new(Region::new("us-west-2"), "test2-parameter-name".to_string()),
+                        "test2-parameter-value".to_string(),
+                    ),
+                ]),
+            ),
+            (
+                Region::new("us-east-1"),
+                HashMap::from([(
+                    SsmKey::new(Region::new("us-east-1"), "test3-parameter-name".to_string()),
+                    "test3-parameter-value".to_string(),
+                )]),
+            ),
+        ]);
+        let map = &RenderedParametersMap::from(existing_parameters).rendered_parameters;
+        let expected_map = &HashMap::from([
+            (
+                "us-east-1".to_string(),
+                HashMap::from([(
+                    "test3-parameter-name".to_string(),
+                    "test3-parameter-value".to_string(),
+                )]),
+            ),
+            (
+                "us-west-2".to_string(),
+                HashMap::from([
+                    (
+                        "test1-parameter-name".to_string(),
+                        "test1-parameter-value".to_string(),
+                    ),
+                    (
+                        "test2-parameter-name".to_string(),
+                        "test2-parameter-value".to_string(),
+                    ),
+                ]),
+            ),
+        ]);
+        assert_eq!(map, expected_map);
+    }
+
+    #[test]
+    fn rendered_parameters_map_from_empty_map() {
+        let existing_parameters = HashMap::new();
+        let map = &RenderedParametersMap::from(existing_parameters).rendered_parameters;
+        let expected_map = &HashMap::new();
+        assert_eq!(map, expected_map);
+    }
+}

--- a/tools/pubsys/src/aws/validate_ssm/mod.rs
+++ b/tools/pubsys/src/aws/validate_ssm/mod.rs
@@ -64,8 +64,7 @@ pub async fn validate(
 
     // Parse the file holding expected parameters
     info!("Parsing expected parameters file");
-    let expected_parameters =
-        parse_expected_parameters(&validate_ssm_args.expected_parameters_path).await?;
+    let expected_parameters = parse_parameters(&validate_ssm_args.expected_parameters_path).await?;
 
     info!("Parsed expected parameters file");
 
@@ -180,7 +179,7 @@ type ParameterValue = String;
 /// Parse the file holding expected parameters. Return a HashMap of Region mapped to a HashMap
 /// of the parameters in that region, with each parameter being a mapping of `SsmKey` to its
 /// value as `String`.
-pub(crate) async fn parse_expected_parameters(
+pub(crate) async fn parse_parameters(
     expected_parameters_file: &PathBuf,
 ) -> Result<HashMap<Region, HashMap<SsmKey, String>>> {
     // Parse the JSON file as a HashMap of region_name, mapped to a HashMap of parameter_name and
@@ -232,7 +231,7 @@ pub(crate) async fn run(args: &Args, validate_ssm_args: &ValidateSsmArgs) -> Res
     Ok(())
 }
 
-mod error {
+pub(crate) mod error {
     use crate::aws::ssm::ssm;
     use snafu::Snafu;
     use std::path::PathBuf;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Modified the `pubsys ssm` and `pubsys promote-ssm` commands to allow the parameters to be written to a file. Modified the `pubsys ami` and `pubsys publish-ami` commands to have them write AMI launch permissions and publicity info to the output file.

- `pubsys ssm` has one new argument: `ssm_parameter_output`. If set, the rendered parameters will be written to the file at this path with the following structure:
```
{
  "<region-name>": {
    "<parameter-name>": "<parameter-value>",
    ...
  }
}
```

- `pubsys promote-ssm` has one new argument: `ssm_parameter_output`. The newly promoted parameters will be combined with the parameters already present in the file and written to it.

- `pubsys ami` now writes `public` and `launch_permissions` to the output file along with `id` and `name`. The `public` field is set to `false` by default when registering the AMI, but if the AMI ID has already been registered before, then the field is set to the publicity of that AMI. The `launch_permissions` field gets an empty vec by default, but if the AMI is already registered, then the launch permissions for that AMI are retrieved and stored in that field.

- `pubsys publish-ami` updates the `public` and `launch_permissions` fields in the input file if anything has changed after the publishing has finished.

**Testing done:**

- Unit tests
- Ran `cargo make`, `cargo make ami`, `cargo make ssm` with the new argument, and got a file like this:
```
{
  "us-west-2": {
    "/msterckx/aws-k8s-1.24/x86_64/1.14.0-f782c96d-dirty/image_id": "ami-012345678",
    "/msterckx/aws-k8s-1.24/x86_64/1.14.0-f782c96d-dirty/image_version": "1.14.0-f782c96d-dirty"
  }
}
```
The AMI file looked like this:
```
{
    "us-west-2": {
        "id": "ami-012345678",
        "name": "bottlerocket-aws-k8s-1.24-x86_64-v1.14.0-f782c96d-dirty",
        "public": false,
        "launch_permissions": [ ]
    }
}
```

- Ran `cargo make promote-ssm` with the above file as input and `keep_original_parameters` false, and got a file like this:
```
{
  "us-west-2": {
    "/msterckx/aws-k8s-1.24/x86_64/1.14.0/image_version": "1.14.0-f782c96d-dirty",
    "/msterckx/aws-k8s-1.24/x86_64/1.14.0/image_id": "ami-012345678",
    "/msterckx/aws-k8s-1.24/x86_64/1.14.0-f782c96d-dirty/image_id": "ami-012345678",
    "/msterckx/aws-k8s-1.24/x86_64/1.14.0-f782c96d-dirty/image_version": "1.14.0-f782c96d-dirty"
  }
}
```

- Ran `cargo make ami-public` and the `amis.json` file looked like this afterwards:
```
{
  "us-west-2": {
    "id": "ami-012345678",
    "name": "bottlerocket-aws-k8s-1.24-x86_64-v1.14.0-f782c96d-dirty",
    "public": true,
    "launch_permissions": [
      {
        "group": "all",
        "user_id": null,
        "organization_arn": null,
        "organizational_unit_arn": null
      }
    ]
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
