### PR TITLE
aws.profile: Add note to avoid default profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,8 @@ They can be overridden for testing purposes in [the same way as other settings](
   ```
 
   **Note**: If `settings.aws.profile` is not set, the setting will fallback to the "default" profile.
+  In general it is recommended not to include a `[profile default]` section in the `aws.config` contents though.
+  This may have unintended side effects for other AWS services running on the node (e.g. `aws-iam-authenticator`).
 
   **Note:** The `config`, `credentials`, and `profile` are optional and do not need to be set when using an Instance Profile when running on an AWS instance.
 


### PR DESCRIPTION
**Issue number:**

Related: #2989

**Description of changes:**

Recent versions of `aws-iam-authenticator`, and perhaps other AWS components, not pick up the default credential settings when `settings.aws.profile` is set to `default`. To help avoid this situation, this adds a note to the settings documentation to avoid using `default` for AWS credentials.

**Testing done:**

👀 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
