### PR TITLE
pubsys: changed validate-ssm input to single file

### DIFF
--- a/tools/pubsys/src/aws/validate_ssm/results.rs
+++ b/tools/pubsys/src/aws/validate_ssm/results.rs
@@ -69,10 +69,6 @@ pub struct SsmValidationResult {
     #[serde(serialize_with = "serialize_region")]
     pub(crate) region: Region,
 
-    /// The ID of the AMI the parameter is associated with
-    #[tabled(display_with = "display_option")]
-    pub(crate) ami_id: Option<String>,
-
     /// The validation status of the parameter
     pub(crate) status: SsmValidationResultStatus,
 }
@@ -97,7 +93,6 @@ impl SsmValidationResult {
         expected_value: Option<String>,
         actual_value: Option<String>,
         region: Region,
-        ami_id: Option<String>,
     ) -> SsmValidationResult {
         // Determine the validation status based on equality, presence, and absence of expected and
         // actual parameter values
@@ -114,7 +109,6 @@ impl SsmValidationResult {
             expected_value,
             actual_value,
             region,
-            ami_id,
             status,
         }
     }
@@ -264,7 +258,7 @@ mod test {
             (Region::new("us-west-2"), Ok(HashSet::from([]))),
             (Region::new("us-east-1"), Ok(HashSet::from([]))),
         ]));
-        let results_filtered = results.get_results_for_status(&vec![
+        let results_filtered = results.get_results_for_status(&[
             SsmValidationResultStatus::Correct,
             SsmValidationResultStatus::Incorrect,
             SsmValidationResultStatus::Missing,
@@ -286,28 +280,24 @@ mod test {
                         Some("test3-parameter-value".to_string()),
                         None,
                         Region::new("us-west-2"),
-                        Some("test3-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-west-2"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        None,
                     ),
                 ])),
             ),
@@ -319,34 +309,30 @@ mod test {
                         Some("test3-parameter-value".to_string()),
                         None,
                         Region::new("us-east-1"),
-                        Some("test3-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-east-1"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        None,
                     ),
                 ])),
             ),
         ]));
         let results_filtered =
-            results.get_results_for_status(&vec![SsmValidationResultStatus::Correct]);
+            results.get_results_for_status(&[SsmValidationResultStatus::Correct]);
 
         assert_eq!(
             results_filtered,
@@ -356,14 +342,12 @@ mod test {
                     Some("test1-parameter-value".to_string()),
                     Some("test1-parameter-value".to_string()),
                     Region::new("us-west-2"),
-                    Some("test1-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test1-parameter-name".to_string(),
                     Some("test1-parameter-value".to_string()),
                     Some("test1-parameter-value".to_string()),
                     Region::new("us-east-1"),
-                    Some("test1-image-id".to_string()),
                 )
             ])
         );
@@ -381,28 +365,24 @@ mod test {
                         Some("test3-parameter-value".to_string()),
                         None,
                         Region::new("us-west-2"),
-                        Some("test3-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-west-2"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        None,
                     ),
                 ])),
             ),
@@ -414,33 +394,29 @@ mod test {
                         Some("test3-parameter-value".to_string()),
                         None,
                         Region::new("us-east-1"),
-                        Some("test3-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-east-1"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        None,
                     ),
                 ])),
             ),
         ]));
-        let results_filtered = results.get_results_for_status(&vec![
+        let results_filtered = results.get_results_for_status(&[
             SsmValidationResultStatus::Correct,
             SsmValidationResultStatus::Incorrect,
         ]);
@@ -453,28 +429,24 @@ mod test {
                     Some("test1-parameter-value".to_string()),
                     Some("test1-parameter-value".to_string()),
                     Region::new("us-west-2"),
-                    Some("test1-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test1-parameter-name".to_string(),
                     Some("test1-parameter-value".to_string()),
                     Some("test1-parameter-value".to_string()),
                     Region::new("us-east-1"),
-                    Some("test1-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Some("test2-parameter-value-wrong".to_string()),
                     Region::new("us-west-2"),
-                    Some("test2-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Some("test2-parameter-value-wrong".to_string()),
                     Region::new("us-east-1"),
-                    Some("test2-image-id".to_string()),
                 )
             ])
         );
@@ -492,28 +464,24 @@ mod test {
                         Some("test3-parameter-value".to_string()),
                         None,
                         Region::new("us-west-2"),
-                        Some("test3-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-west-2"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        None,
                     ),
                 ])),
             ),
@@ -525,33 +493,29 @@ mod test {
                         Some("test3-parameter-value".to_string()),
                         None,
                         Region::new("us-east-1"),
-                        Some("test3-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-east-1"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        None,
                     ),
                 ])),
             ),
         ]));
-        let results_filtered = results.get_results_for_status(&vec![
+        let results_filtered = results.get_results_for_status(&[
             SsmValidationResultStatus::Correct,
             SsmValidationResultStatus::Incorrect,
             SsmValidationResultStatus::Missing,
@@ -566,56 +530,48 @@ mod test {
                     Some("test1-parameter-value".to_string()),
                     Some("test1-parameter-value".to_string()),
                     Region::new("us-west-2"),
-                    Some("test1-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test1-parameter-name".to_string(),
                     Some("test1-parameter-value".to_string()),
                     Some("test1-parameter-value".to_string()),
                     Region::new("us-east-1"),
-                    Some("test1-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Some("test2-parameter-value-wrong".to_string()),
                     Region::new("us-west-2"),
-                    Some("test2-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Some("test2-parameter-value-wrong".to_string()),
                     Region::new("us-east-1"),
-                    Some("test2-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test3-parameter-name".to_string(),
                     Some("test3-parameter-value".to_string()),
                     None,
                     Region::new("us-west-2"),
-                    Some("test3-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test4-parameter-name".to_string(),
                     None,
                     Some("test4-parameter-value".to_string()),
                     Region::new("us-west-2"),
-                    None,
                 ),
                 &SsmValidationResult::new(
                     "test3-parameter-name".to_string(),
                     Some("test3-parameter-value".to_string()),
                     None,
                     Region::new("us-east-1"),
-                    Some("test3-image-id".to_string()),
                 ),
                 &SsmValidationResult::new(
                     "test4-parameter-name".to_string(),
                     None,
                     Some("test4-parameter-value".to_string()),
                     Region::new("us-east-1"),
-                    None,
                 )
             ])
         );
@@ -633,21 +589,18 @@ mod test {
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-west-2"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-west-2"),
-                        None,
                     ),
                 ])),
             ),
@@ -659,27 +612,24 @@ mod test {
                         Some("test1-parameter-value".to_string()),
                         Some("test1-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        Some("test1-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Some("test2-parameter-value-wrong".to_string()),
                         Region::new("us-east-1"),
-                        Some("test2-image-id".to_string()),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Some("test4-parameter-value".to_string()),
                         Region::new("us-east-1"),
-                        None,
                     ),
                 ])),
             ),
         ]));
         let results_filtered =
-            results.get_results_for_status(&vec![SsmValidationResultStatus::Missing]);
+            results.get_results_for_status(&[SsmValidationResultStatus::Missing]);
 
         assert_eq!(results_filtered, HashSet::new());
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Addressed @bcressey's comments on https://github.com/bottlerocket-os/bottlerocket/pull/2987. Instead of the `validate-ssm` subcommand taking a config file as input, it now only takes the path to a single file containing SSM parameters to validate. The file is set up like this:
```
{
  "<region-name>": {
    "<parameter-name>": "<parameter-value>",
    ...
  },
  ...
}
```

Added a bool flag `check-unexpected`, which tracks unexpected parameters in a region if set to true (a parameter is unexpected if fetched from SSM while not in the file holding expected parameters). If this flag is not present, unexpected parameters are not tracked and only the ones in the input file are validated.

**Testing done:**

- Ran the command with a JSON file containing all 1.12.0 parameters as input and no `--check-unexpected` flag. Result:
```
+----------------+---------+-----------+---------+------------+------------+
| String         | correct | incorrect | missing | unexpected | accessible |
+----------------+---------+-----------+---------+------------+------------+
| ap-southeast-1 | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-central-1   | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-west-2      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-northeast-1 | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| sa-east-1      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-west-1      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-northeast-2 | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| ca-central-1   | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-north-1     | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-east-1      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-west-3      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-northeast-3 | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-south-1     | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-west-2      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-west-1      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-southeast-2 | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-east-2      | 96      | 0         | 0       | 0          | true       |
+----------------+---------+-----------+---------+------------+------------+
```

- With the `--check-unexpected` flag:
```
+----------------+---------+-----------+---------+------------+------------+
| String         | correct | incorrect | missing | unexpected | accessible |
+----------------+---------+-----------+---------+------------+------------+
| ap-northeast-1 | 96      | 0         | 0       | 2472       | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-west-1      | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-east-2      | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-central-1   | 96      | 0         | 0       | 2472       | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-south-1     | 96      | 0         | 0       | 2462       | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-southeast-2 | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-west-3      | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-northeast-2 | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-northeast-3 | 96      | 0         | 0       | 2060       | true       |
+----------------+---------+-----------+---------+------------+------------+
| ap-southeast-1 | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-west-2      | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-west-1      | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| eu-north-1     | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-east-1      | 96      | 0         | 0       | 2472       | true       |
+----------------+---------+-----------+---------+------------+------------+
| sa-east-1      | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
| us-west-2      | 96      | 0         | 0       | 2472       | true       |
+----------------+---------+-----------+---------+------------+------------+
| ca-central-1   | 96      | 0         | 0       | 2452       | true       |
+----------------+---------+-----------+---------+------------+------------+
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
