### PR TITLE
kernel: Update to v5.10.176 and v5.15.104

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/bfdedd54405ee75070fa9b53342399680e3145e362f41deb1276de2082625061/kernel-5.10.173-154.642.amzn2.src.rpm"
-sha512 = "b98f97a00dfbec2ba6681faa326782bbe02c8a57758890076f71bb07a149d6dee3dba1237c07fb195c6a65956bee572f0d8757898375f437244eec7e69938e0b"
+url = "https://cdn.amazonlinux.com/blobstore/c945e51a5ad81a6fd3ec405e57ad4ccd8ea44c8e26b1165771768e3da28fc382/kernel-5.10.176-157.645.amzn2.src.rpm"
+sha512 = "57bb9eb168ad6051c7a8e938edb5f70ef9a1234a5e32f31a96dcb6dec8e3a48e3b4ba41f00fd5ea2934c89bb28c37c5553dc34e96345c354b563707ae52ae59d"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.173
+Version: 5.10.176
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/bfdedd54405ee75070fa9b53342399680e3145e362f41deb1276de2082625061/kernel-5.10.173-154.642.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/c945e51a5ad81a6fd3ec405e57ad4ccd8ea44c8e26b1165771768e3da28fc382/kernel-5.10.176-157.645.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/567d93a3639fa16d002a80a970223b8dc134fc4d1214125b379750ee689a76ea/kernel-5.15.102-61.139.amzn2.src.rpm"
-sha512 = "6df4d568ef60cd631a7764d33f771cae6be576cbbf0400e86eafdad0a86ddeb65c96dc2ad40698573277fa8afe1076cdc9e45c9776f6f7f782a273f0e416fc88"
+url = "https://cdn.amazonlinux.com/blobstore/0e9e64310ac3393b8630cc3e40ae23a8ae04cdf1e7c76f578f18bf94dcd72771/kernel-5.15.104-63.140.amzn2.src.rpm"
+sha512 = "6f80bbec90263a331fd93bc429b0050833229bc437d9e860f56e711a2689c20fa17828434675c0fa40fa4dc5ed7e75e68699640bb77d02a60caf460184cd908a"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.102
+Version: 5.15.104
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/567d93a3639fa16d002a80a970223b8dc134fc4d1214125b379750ee689a76ea/kernel-5.15.102-61.139.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/0e9e64310ac3393b8630cc3e40ae23a8ae04cdf1e7c76f578f18bf94dcd72771/kernel-5.15.104-63.140.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** -

**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

```
config-aarch64-aws-k8s-1.23-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:         0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   1 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          0 removed,   1 added,   0 changed
config-x86_64-metal-k8s-1.23-diff:        0 removed,   1 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:        0 removed,   1 added,   0 changed
```

The one new option in the x86_64 variants is `MLX_PLATFORM`. The dependencies for that one were changed and it now becomes visible in our config, however it is set to disabled, so no functional change. The upstream commit was backported into [v5.10.175](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=93367126f68cd66359bbc81c3e9f6fda93701099) and 
[v5.15.103](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=dafde107220266ffd3dcbd33978132bcabc0d987).


Doing some simple smoke testing, starting a cluster and running an al2 pod on it:

* 5.10.176:
```
NAME                                              STATUS   ROLES    AGE   VERSION                INTERNAL-IP      EXTERNAL-IP    OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-90-128.eu-central-1.compute.internal   Ready    <none>   43m   v1.23.16-eks-ac99dab   192.168.90.128   3.64.228.134   Bottlerocket OS 1.14.0 (aws-k8s-1.23)   5.10.176         containerd://1.6.19+bottlerocket
```
```
NAME   READY   STATUS    RESTARTS   AGE
test   1/1     Running   0          2m30s
```
* 5.15.104:
```
NAME                                            STATUS   ROLES    AGE   VERSION               INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-0-20.eu-central-1.compute.internal   Ready    <none>   69s   v1.25.6-eks-232056e   192.168.0.20   3.77.41.236   Bottlerocket OS 1.14.0 (aws-k8s-1.25)   5.15.104         containerd://1.6.19+bottlerocket
```
```
NAME   READY   STATUS    RESTARTS   AGE
test   1/1     Running   0          7s
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
