### PR TITLE
pubsys: added ami validation

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -2485,6 +2485,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_plain",
  "simplelog",
  "snafu",
  "structopt",

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_plain = "1"
 simplelog = "0.12"
 snafu = "0.7"
 structopt = { version = "0.3", default-features = false }

--- a/tools/pubsys/src/aws/mod.rs
+++ b/tools/pubsys/src/aws/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod ami;
 pub(crate) mod promote_ssm;
 pub(crate) mod publish_ami;
 pub(crate) mod ssm;
+pub(crate) mod validate_ami;
 pub(crate) mod validate_ssm;
 
 /// Builds a Region from the given region name.

--- a/tools/pubsys/src/aws/validate_ami/ami.rs
+++ b/tools/pubsys/src/aws/validate_ami/ami.rs
@@ -1,0 +1,224 @@
+//! The ami module owns the describing of images in EC2.
+
+use aws_sdk_ec2::model::Image;
+use aws_sdk_ec2::{Client as Ec2Client, Region};
+use futures::future::{join, ready};
+use futures::stream::{FuturesUnordered, StreamExt};
+use log::{info, trace};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::collections::HashMap;
+
+use crate::aws::ami::launch_permissions::{get_launch_permissions, LaunchPermissionDef};
+
+/// Wrapper structure for the `ImageDef` struct, used during deserialization
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(crate) enum ImageData {
+    Image(ImageDef),
+    ImageList(Vec<ImageDef>),
+}
+
+impl ImageData {
+    pub(crate) fn images(&self) -> Vec<ImageDef> {
+        match self {
+            ImageData::Image(image) => vec![image.to_owned()],
+            ImageData::ImageList(images) => images.to_owned(),
+        }
+    }
+}
+
+/// Structure of the EC2 image fields that should be validated
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone)]
+pub(crate) struct ImageDef {
+    /// The ID of the EC2 image
+    pub(crate) id: String,
+
+    /// The name of the EC2 image
+    pub(crate) name: String,
+
+    /// Whether or not the EC2 image is public
+    #[serde(default)]
+    pub(crate) public: bool,
+
+    /// The launch permissions for the EC2 image.
+    pub(crate) launch_permissions: Option<Vec<LaunchPermissionDef>>,
+
+    /// Whether or not the EC2 image supports Elastic Network Adapter
+    #[serde(default = "default_ena_support")]
+    pub(crate) ena_support: bool,
+
+    /// The level of the EC2 image's Single Root I/O Virtualization support
+    #[serde(default = "default_sriov_net_support")]
+    pub(crate) sriov_net_support: String,
+}
+
+fn default_ena_support() -> bool {
+    true
+}
+
+fn default_sriov_net_support() -> String {
+    "simple".to_string()
+}
+
+impl From<(Image, Option<Vec<LaunchPermissionDef>>)> for ImageDef {
+    fn from(args: (Image, Option<Vec<LaunchPermissionDef>>)) -> Self {
+        Self {
+            id: args.0.image_id().unwrap_or_default().to_string(),
+            name: args.0.name().unwrap_or_default().to_string(),
+            public: args.0.public().unwrap_or_default(),
+            launch_permissions: args.1,
+            ena_support: args.0.ena_support().unwrap_or_default(),
+            sriov_net_support: args.0.sriov_net_support().unwrap_or_default().to_string(),
+        }
+    }
+}
+
+/// Fetches all images whose IDs are keys in `expected_images`. The map `expected_image_public` is
+/// used to determine if the launch permissions for the image should be fetched (only if the image is not
+/// public). The return value is a HashMap of Region to a Result, which is `Ok` if the request for
+/// that region was successful and `Err` if not. The Result contains a HashMap of `image_id` to
+/// `ImageDef`.
+pub(crate) async fn describe_images<'a>(
+    clients: &'a HashMap<Region, Ec2Client>,
+    expected_images: &HashMap<Region, Vec<ImageDef>>,
+) -> HashMap<&'a Region, Result<HashMap<String, ImageDef>>> {
+    // Build requests for images; we have to request with a regional client so we split them by
+    // region
+    let mut requests = Vec::with_capacity(clients.len());
+    clients.iter().for_each(|(region, ec2_client)| {
+        trace!("Requesting images in {}", region);
+        let get_future = describe_images_in_region(
+            region,
+            ec2_client,
+            expected_images
+                .get(region)
+                .map(|i| i.to_owned())
+                .unwrap_or_default()
+                .into_iter()
+                .map(|i| (i.id.clone(), i))
+                .collect::<HashMap<String, ImageDef>>(),
+        );
+
+        requests.push(join(ready(region), get_future));
+    });
+
+    // Send requests in parallel and wait for responses, collecting results into a list.
+    requests
+        .into_iter()
+        .collect::<FuturesUnordered<_>>()
+        .collect()
+        .await
+}
+
+/// Fetches the images whose IDs are keys in `expected_images`
+pub(crate) async fn describe_images_in_region(
+    region: &Region,
+    client: &Ec2Client,
+    expected_images: HashMap<String, ImageDef>,
+) -> Result<HashMap<String, ImageDef>> {
+    info!("Retrieving images in {}", region.to_string());
+    let mut images = HashMap::new();
+
+    // Send the request
+    let mut get_future = client
+        .describe_images()
+        .include_deprecated(true)
+        .set_image_ids(Some(Vec::from_iter(
+            expected_images.keys().map(|k| k.to_owned()),
+        )))
+        .into_paginator()
+        .send();
+
+    // Iterate over the retrieved images
+    while let Some(page) = get_future.next().await {
+        let retrieved_images = page
+            .context(error::DescribeImagesSnafu {
+                region: region.to_string(),
+            })?
+            .images()
+            .unwrap_or_default()
+            .to_owned();
+        for image in retrieved_images {
+            // Insert a new key-value pair into the map, with the key containing image ID
+            // and the value containing the ImageDef object created from the image
+            let image_id = image
+                .image_id()
+                .ok_or(error::Error::MissingField {
+                    missing: "image_id".to_string(),
+                })?
+                .to_string();
+            let expected_public = expected_images
+                .get(&image_id)
+                .ok_or(error::Error::MissingExpectedPublic {
+                    missing: image_id.clone(),
+                })?
+                .public;
+            // If the image is not expected to be public, retrieve the launch permissions
+            trace!(
+                "Retrieving launch permissions for {} in {}",
+                image_id,
+                region.as_ref()
+            );
+            let launch_permissions = if !expected_public {
+                Some(
+                    get_launch_permissions(client, region.as_ref(), &image_id)
+                        .await
+                        .context(error::GetLaunchPermissionsSnafu {
+                            region: region.as_ref(),
+                            image_id: image_id.clone(),
+                        })?,
+                )
+            } else {
+                None
+            };
+            let image_def = ImageDef::from((image.to_owned(), launch_permissions));
+            images.insert(image_id, image_def);
+        }
+    }
+
+    info!("Images in {} have been retrieved", region.to_string());
+    Ok(images)
+}
+
+pub(crate) mod error {
+    use aws_sdk_ec2::error::DescribeImagesError;
+    use aws_sdk_ssm::types::SdkError;
+    use aws_smithy_types::error::display::DisplayErrorContext;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    #[allow(clippy::large_enum_variant)]
+    pub(crate) enum Error {
+        #[snafu(display(
+            "Failed to describe images in {}: {}",
+            region,
+            DisplayErrorContext(source)
+        ))]
+        DescribeImages {
+            region: String,
+            source: SdkError<DescribeImagesError>,
+        },
+
+        #[snafu(display(
+            "Failed to retrieve launch permissions for image {} in region {}: {}",
+            image_id,
+            region,
+            source
+        ))]
+        GetLaunchPermissions {
+            region: String,
+            image_id: String,
+            source: crate::aws::ami::launch_permissions::Error,
+        },
+
+        #[snafu(display("Missing field in image: {}", missing))]
+        MissingField { missing: String },
+
+        #[snafu(display("Missing image ID in expected image publicity map: {}", missing))]
+        MissingExpectedPublic { missing: String },
+    }
+}
+
+pub(crate) type Result<T> = std::result::Result<T, error::Error>;

--- a/tools/pubsys/src/aws/validate_ami/mod.rs
+++ b/tools/pubsys/src/aws/validate_ami/mod.rs
@@ -1,0 +1,851 @@
+//! The validate_ami module owns the 'validate-ami' subcommand and controls the process of validating
+//! EC2 images
+
+pub(crate) mod ami;
+pub(crate) mod results;
+
+use self::ami::{ImageData, ImageDef};
+use self::results::{AmiValidationResult, AmiValidationResultStatus, AmiValidationResults};
+use crate::aws::client::build_client_config;
+use crate::aws::validate_ami::ami::describe_images;
+use crate::Args;
+use aws_sdk_ec2::{Client as AmiClient, Region};
+use log::{error, info, trace};
+use pubsys_config::InfraConfig;
+use snafu::ResultExt;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::path::PathBuf;
+use structopt::{clap, StructOpt};
+
+/// Validates EC2 images by calling `describe-images` on all images in the file given by
+/// `expected-amis-path` and ensuring that the returned `public`, `ena-support`,
+/// `sriov-net-support`, and `launch-permissions` fields have the expected values.
+#[derive(Debug, StructOpt)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
+pub(crate) struct ValidateAmiArgs {
+    /// File holding the expected amis
+    #[structopt(long, parse(from_os_str))]
+    expected_amis_path: PathBuf,
+
+    /// Optional path where the validation results should be written
+    #[structopt(long, parse(from_os_str))]
+    write_results_path: Option<PathBuf>,
+
+    #[structopt(long, requires = "write-results-path")]
+    /// Optional filter to only write validation results with these statuses to the above path
+    /// The available statuses are: `Correct`, `Incorrect`, `Missing`.
+    write_results_filter: Option<Vec<AmiValidationResultStatus>>,
+
+    #[structopt(long)]
+    /// If this argument is given, print the validation results summary as a JSON object instead
+    /// of a plaintext table
+    json: bool,
+}
+
+/// Performs EC2 image validation and returns the `AmiValidationResults` object
+pub(crate) async fn validate(
+    args: &Args,
+    validate_ami_args: &ValidateAmiArgs,
+) -> Result<AmiValidationResults> {
+    info!("Parsing Infra.toml file");
+
+    // If a lock file exists, use that, otherwise use Infra.toml
+    let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
+        .context(error::ConfigSnafu)?;
+
+    trace!("Parsed infra config: {:#?}", infra_config);
+
+    let aws = infra_config.aws.unwrap_or_default();
+
+    // Parse the expected ami file
+    info!("Parsing expected ami file");
+    let expected_images = parse_expected_amis(&validate_ami_args.expected_amis_path).await?;
+
+    info!("Parsed expected ami file");
+
+    // Create a `HashMap` of `AmiClient`s, one for each region where validation should happen
+    let base_region = &Region::new(
+        aws.regions
+            .get(0)
+            .ok_or(error::Error::EmptyInfraRegions {
+                path: args.infra_config_path.clone(),
+            })?
+            .clone(),
+    );
+    let mut ami_clients = HashMap::with_capacity(expected_images.len());
+
+    for region in expected_images.keys() {
+        let client_config = build_client_config(region, base_region, &aws).await;
+        let ami_client = AmiClient::new(&client_config);
+        ami_clients.insert(region.clone(), ami_client);
+    }
+
+    // Retrieve the EC2 images using the `AmiClient`s
+    info!("Retrieving EC2 images");
+    let images = describe_images(&ami_clients, &expected_images)
+        .await
+        .into_iter()
+        .map(|(region, result)| {
+            (
+                region,
+                result.map_err(|e| {
+                    error!(
+                        "Failed to retrieve images in region {}: {}",
+                        region.to_string(),
+                        e
+                    );
+                    error::Error::UnreachableRegion {
+                        region: region.to_string(),
+                    }
+                }),
+            )
+        })
+        .collect::<HashMap<&Region, Result<_>>>();
+
+    // Validate the retrieved EC2 images per region
+    info!("Validating EC2 images");
+    let results: HashMap<Region, HashSet<AmiValidationResult>> = images
+        .into_iter()
+        .map(|(region, region_result)| {
+            (
+                region.clone(),
+                validate_images_in_region(
+                    &expected_images
+                        .get(region)
+                        .map(|e| e.to_owned())
+                        .unwrap_or_default(),
+                    &region_result,
+                    region,
+                ),
+            )
+        })
+        .collect();
+
+    let validation_results = AmiValidationResults::from_result_map(results);
+
+    // If a path was given, write the results
+    if let Some(write_results_path) = &validate_ami_args.write_results_path {
+        // Filter the results by given status, and if no statuses were given, get all results
+        info!("Writing results to file");
+        let results = if let Some(filter) = &validate_ami_args.write_results_filter {
+            validation_results.get_results_for_status(filter)
+        } else {
+            validation_results.get_all_results()
+        };
+
+        // Write the results as JSON
+        serde_json::to_writer_pretty(
+            &File::create(write_results_path).context(error::WriteValidationResultsSnafu {
+                path: write_results_path,
+            })?,
+            &results,
+        )
+        .context(error::SerializeValidationResultsSnafu)?;
+    }
+
+    Ok(validation_results)
+}
+
+/// Validates EC2 images in a single region, based on a `Vec<ImageDef>` of expected images
+/// and a `HashMap<AmiId, ImageDef>` of actual retrieved images. Returns a
+/// `HashSet<AmiValidationResult>` containing the result objects.
+pub(crate) fn validate_images_in_region(
+    expected_images: &[ImageDef],
+    actual_images: &Result<HashMap<AmiId, ImageDef>>,
+    region: &Region,
+) -> HashSet<AmiValidationResult> {
+    match actual_images {
+        Ok(actual_images) => expected_images
+            .iter()
+            .map(|image| {
+                let new_image = if image.public {
+                    ImageDef {
+                        launch_permissions: None,
+                        ..image.clone()
+                    }
+                } else {
+                    image.clone()
+                };
+                AmiValidationResult::new(
+                    image.id.clone(),
+                    new_image,
+                    Ok(actual_images.get(&image.id).map(|v| v.to_owned())),
+                    region.clone(),
+                )
+            })
+            .collect(),
+        Err(_) => expected_images
+            .iter()
+            .map(|image| {
+                AmiValidationResult::new(
+                    image.id.clone(),
+                    image.clone(),
+                    Err(error::Error::UnreachableRegion {
+                        region: region.to_string(),
+                    }),
+                    region.clone(),
+                )
+            })
+            .collect(),
+    }
+}
+
+type RegionName = String;
+type AmiId = String;
+
+/// Parse the file holding image values. Return a `HashMap` of `Region` mapped to a vec of `ImageDef`s
+/// for that region.
+pub(crate) async fn parse_expected_amis(
+    expected_amis_path: &PathBuf,
+) -> Result<HashMap<Region, Vec<ImageDef>>> {
+    // Parse the JSON file as a `HashMap` of region_name, mapped to an `ImageData` struct
+    let expected_amis: HashMap<RegionName, ImageData> = serde_json::from_reader(
+        &File::open(expected_amis_path.clone()).context(error::ReadExpectedImagesFileSnafu {
+            path: expected_amis_path,
+        })?,
+    )
+    .context(error::ParseExpectedImagesFileSnafu)?;
+
+    // Extract the `Vec<ImageDef>` from the `ImageData` structs
+    let vectored_images = expected_amis
+        .into_iter()
+        .map(|(region, value)| (Region::new(region), value.images()))
+        .collect::<HashMap<Region, Vec<ImageDef>>>();
+
+    Ok(vectored_images)
+}
+
+/// Common entrypoint from main()
+pub(crate) async fn run(args: &Args, validate_ami_args: &ValidateAmiArgs) -> Result<()> {
+    let results = validate(args, validate_ami_args).await?;
+
+    if validate_ami_args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&results.get_json_summary())
+                .context(error::SerializeResultsSummarySnafu)?
+        )
+    } else {
+        println!("{}", results);
+    }
+    Ok(())
+}
+
+mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub(crate) enum Error {
+        #[snafu(display("Error reading config: {}", source))]
+        Config { source: pubsys_config::Error },
+
+        #[snafu(display("Empty regions array in Infra.toml at path {}", path.display()))]
+        EmptyInfraRegions { path: PathBuf },
+
+        #[snafu(display("Failed to parse image file: {}", source))]
+        ParseExpectedImagesFile { source: serde_json::Error },
+
+        #[snafu(display("Failed to read image file: {:?}", path))]
+        ReadExpectedImagesFile {
+            source: std::io::Error,
+            path: PathBuf,
+        },
+
+        #[snafu(display("Failed to serialize validation results to json: {}", source))]
+        SerializeValidationResults { source: serde_json::Error },
+
+        #[snafu(display("Failed to retrieve images from region {}", region))]
+        UnreachableRegion { region: String },
+
+        #[snafu(display("Failed to write validation results to {:?}: {}", path, source))]
+        WriteValidationResults {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to serialize results summary to JSON: {}", source))]
+        SerializeResultsSummary { source: serde_json::Error },
+    }
+}
+
+pub(crate) use error::Error;
+
+type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod test {
+    use super::ami::ImageDef;
+    use super::validate_images_in_region;
+    use crate::aws::{
+        ami::launch_permissions::LaunchPermissionDef,
+        validate_ami::results::{AmiValidationResult, AmiValidationResultStatus},
+    };
+    use aws_sdk_ec2::Region;
+    use std::collections::{HashMap, HashSet};
+
+    // These tests assert that the images can be validated correctly.
+
+    // Tests validation of images where the expected value is equal to the actual value
+    #[test]
+    fn validate_images_all_correct() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef {
+                id: "test1-image-id".to_string(),
+                name: "test1-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test2-image-id".to_string(),
+                name: "test2-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test3-image-id".to_string(),
+                name: "test3-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+        ];
+        let actual_parameters: HashMap<String, ImageDef> = HashMap::from([
+            (
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+            (
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+            (
+                "test3-image-id".to_string(),
+                ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+        ]);
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            &expected_parameters,
+            &Ok(actual_parameters),
+            &Region::new("us-west-2"),
+        );
+
+        for result in &results {
+            assert_eq!(result.status, AmiValidationResultStatus::Correct);
+        }
+        assert_eq!(results, expected_results);
+    }
+
+    // Tests validation of images where the expected value is different from the actual value
+    #[test]
+    fn validate_images_all_incorrect() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef {
+                id: "test1-image-id".to_string(),
+                name: "test1-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test2-image-id".to_string(),
+                name: "test2-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test3-image-id".to_string(),
+                name: "test3-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+        ];
+        let actual_parameters: HashMap<String, ImageDef> = HashMap::from([
+            (
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: false,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+            (
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: false,
+                    launch_permissions: Some(vec![LaunchPermissionDef::Group("all".to_string())]),
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+            (
+                "test3-image-id".to_string(),
+                ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "not simple".to_string(),
+                },
+            ),
+        ]);
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "not simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: false,
+                    launch_permissions: Some(vec![LaunchPermissionDef::Group("all".to_string())]),
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: false,
+                    sriov_net_support: "simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            &expected_parameters,
+            &Ok(actual_parameters),
+            &Region::new("us-west-2"),
+        );
+        for result in &results {
+            assert_eq!(result.status, AmiValidationResultStatus::Incorrect);
+        }
+        assert_eq!(results, expected_results);
+    }
+
+    // Tests validation of images where the actual value is missing
+    #[test]
+    fn validate_images_all_missing() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef {
+                id: "test1-image-id".to_string(),
+                name: "test1-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test2-image-id".to_string(),
+                name: "test2-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test3-image-id".to_string(),
+                name: "test3-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+        ];
+        let actual_parameters = HashMap::new();
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(None),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(None),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(None),
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            &expected_parameters,
+            &Ok(actual_parameters),
+            &Region::new("us-west-2"),
+        );
+        for result in &results {
+            assert_eq!(result.status, AmiValidationResultStatus::Missing);
+        }
+        assert_eq!(results, expected_results);
+    }
+
+    // Tests validation of parameters where each reachable status (Correct, Incorrect, Missing) happens once
+    #[test]
+    fn validate_images_mixed() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef {
+                id: "test1-image-id".to_string(),
+                name: "test1-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test2-image-id".to_string(),
+                name: "test2-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test3-image-id".to_string(),
+                name: "test3-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+        ];
+        let actual_parameters: HashMap<String, ImageDef> = HashMap::from([
+            (
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+            (
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: false,
+                    launch_permissions: Some(vec![LaunchPermissionDef::Group("all".to_string())]),
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+            ),
+        ]);
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(Some(ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: false,
+                    launch_permissions: Some(vec![LaunchPermissionDef::Group("all".to_string())]),
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                })),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Ok(None),
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            &expected_parameters,
+            &Ok(actual_parameters),
+            &Region::new("us-west-2"),
+        );
+
+        assert_eq!(results, expected_results);
+    }
+
+    // Tests validation of parameters where the region is unreachable
+    #[test]
+    fn validate_images_unreachable() {
+        let expected_parameters: Vec<ImageDef> = vec![
+            ImageDef {
+                id: "test1-image-id".to_string(),
+                name: "test1-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test2-image-id".to_string(),
+                name: "test2-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+            ImageDef {
+                id: "test3-image-id".to_string(),
+                name: "test3-image".to_string(),
+                public: true,
+                launch_permissions: None,
+                ena_support: true,
+                sriov_net_support: "simple".to_string(),
+            },
+        ];
+        let expected_results = HashSet::from_iter(vec![
+            AmiValidationResult::new(
+                "test1-image-id".to_string(),
+                ImageDef {
+                    id: "test1-image-id".to_string(),
+                    name: "test1-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Err(crate::aws::validate_ami::Error::UnreachableRegion {
+                    region: "us-west-2".to_string(),
+                }),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test2-image-id".to_string(),
+                ImageDef {
+                    id: "test2-image-id".to_string(),
+                    name: "test2-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Err(crate::aws::validate_ami::Error::UnreachableRegion {
+                    region: "us-west-2".to_string(),
+                }),
+                Region::new("us-west-2"),
+            ),
+            AmiValidationResult::new(
+                "test3-image-id".to_string(),
+                ImageDef {
+                    id: "test3-image-id".to_string(),
+                    name: "test3-image".to_string(),
+                    public: true,
+                    launch_permissions: None,
+                    ena_support: true,
+                    sriov_net_support: "simple".to_string(),
+                },
+                Err(crate::aws::validate_ami::Error::UnreachableRegion {
+                    region: "us-west-2".to_string(),
+                }),
+                Region::new("us-west-2"),
+            ),
+        ]);
+        let results = validate_images_in_region(
+            &expected_parameters,
+            &Err(crate::aws::validate_ami::Error::UnreachableRegion {
+                region: "us-west-2".to_string(),
+            }),
+            &Region::new("us-west-2"),
+        );
+
+        assert_eq!(results, expected_results);
+    }
+}

--- a/tools/pubsys/src/aws/validate_ami/results.rs
+++ b/tools/pubsys/src/aws/validate_ami/results.rs
@@ -1,0 +1,1034 @@
+//! The results module owns the reporting of EC2 image validation results.
+
+use super::ami::ImageDef;
+use super::Result;
+use aws_sdk_ec2::Region;
+use serde::{Deserialize, Serialize};
+use serde_plain::{derive_display_from_serialize, derive_fromstr_from_deserialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Display};
+use tabled::{Table, Tabled};
+
+/// Represent the possible status of an EC2 image validation
+#[derive(Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub(crate) enum AmiValidationResultStatus {
+    /// The image was found and its monitored fields have the expected values
+    Correct,
+
+    /// The image was found but some of the monitored fields do not have the expected values
+    Incorrect,
+
+    /// The image was expected but not included in the actual images
+    Missing,
+
+    /// The region containing the image was not reachable
+    Unreachable,
+}
+
+derive_display_from_serialize!(AmiValidationResultStatus);
+derive_fromstr_from_deserialize!(AmiValidationResultStatus);
+
+/// Represents a single EC2 image validation result
+#[derive(Debug, Eq, Hash, PartialEq, Serialize)]
+pub(crate) struct AmiValidationResult {
+    /// The ID of the image
+    pub(crate) id: String,
+
+    /// `ImageDef` containing expected values for the image
+    pub(crate) expected_image_def: ImageDef,
+
+    /// `ImageDef` containing actual values for the image
+    pub(crate) actual_image_def: Option<ImageDef>,
+
+    /// The region the image resides in
+    #[serde(serialize_with = "serialize_region")]
+    pub(crate) region: Region,
+
+    /// The validation status of the image
+    pub(crate) status: AmiValidationResultStatus,
+}
+
+fn serialize_region<S>(region: &Region, serializer: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(region.to_string().as_str())
+}
+
+impl AmiValidationResult {
+    pub(crate) fn new(
+        id: String,
+        expected_image_def: ImageDef,
+        actual_image_def: Result<Option<ImageDef>>,
+        region: Region,
+    ) -> Self {
+        // Determine the validation status based on equality, presence, and absence of expected and
+        // actual image values
+        let status = match (&expected_image_def, &actual_image_def) {
+            (expected_image_def, Ok(Some(actual_image_def)))
+                if actual_image_def == expected_image_def =>
+            {
+                AmiValidationResultStatus::Correct
+            }
+            (_, Ok(Some(_))) => AmiValidationResultStatus::Incorrect,
+            (_, Ok(None)) => AmiValidationResultStatus::Missing,
+            (_, Err(_)) => AmiValidationResultStatus::Unreachable,
+        };
+        AmiValidationResult {
+            id,
+            expected_image_def,
+            actual_image_def: actual_image_def.unwrap_or_default(),
+            region,
+            status,
+        }
+    }
+}
+
+#[derive(Tabled, Serialize)]
+struct AmiValidationRegionSummary {
+    correct: u64,
+    incorrect: u64,
+    missing: u64,
+    unreachable: u64,
+}
+
+impl From<&HashSet<AmiValidationResult>> for AmiValidationRegionSummary {
+    fn from(results: &HashSet<AmiValidationResult>) -> Self {
+        let mut region_validation = AmiValidationRegionSummary {
+            correct: 0,
+            incorrect: 0,
+            missing: 0,
+            unreachable: 0,
+        };
+        for validation_result in results {
+            match validation_result.status {
+                AmiValidationResultStatus::Correct => region_validation.correct += 1,
+                AmiValidationResultStatus::Incorrect => region_validation.incorrect += 1,
+                AmiValidationResultStatus::Missing => region_validation.missing += 1,
+                AmiValidationResultStatus::Unreachable => region_validation.missing += 1,
+            }
+        }
+        region_validation
+    }
+}
+
+/// Represents all EC2 image validation results
+#[derive(Debug)]
+pub(crate) struct AmiValidationResults {
+    pub(crate) results: HashMap<Region, HashSet<AmiValidationResult>>,
+}
+
+impl Default for AmiValidationResults {
+    fn default() -> Self {
+        Self::from_result_map(HashMap::new())
+    }
+}
+
+impl Display for AmiValidationResults {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Create a summary for each region, counting the number of parameters per status
+        let region_validations: HashMap<Region, AmiValidationRegionSummary> =
+            self.get_results_summary();
+
+        // Represent the `HashMap` of summaries as a `Table`
+        let table = Table::new(
+            region_validations
+                .iter()
+                .map(|(region, results)| (region.to_string(), results))
+                .collect::<Vec<(String, &AmiValidationRegionSummary)>>(),
+        )
+        .to_string();
+        write!(f, "{}", table)
+    }
+}
+
+impl AmiValidationResults {
+    pub(crate) fn from_result_map(results: HashMap<Region, HashSet<AmiValidationResult>>) -> Self {
+        AmiValidationResults { results }
+    }
+
+    /// Returns a `HashSet` containing all validation results whose status is present in `requested_status`
+    pub(crate) fn get_results_for_status(
+        &self,
+        requested_status: &[AmiValidationResultStatus],
+    ) -> HashSet<&AmiValidationResult> {
+        let mut results = HashSet::new();
+        for region_results in self.results.values() {
+            results.extend(
+                region_results
+                    .iter()
+                    .filter(|result| requested_status.contains(&result.status))
+                    .collect::<HashSet<&AmiValidationResult>>(),
+            )
+        }
+        results
+    }
+
+    /// Returns a `HashSet` containing all validation results
+    pub(crate) fn get_all_results(&self) -> HashSet<&AmiValidationResult> {
+        let mut results = HashSet::new();
+        for region_results in self.results.values() {
+            results.extend(region_results)
+        }
+        results
+    }
+
+    fn get_results_summary(&self) -> HashMap<Region, AmiValidationRegionSummary> {
+        self.results
+            .iter()
+            .map(|(region, region_result)| {
+                (
+                    region.clone(),
+                    AmiValidationRegionSummary::from(region_result),
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn get_json_summary(&self) -> serde_json::Value {
+        serde_json::json!(self
+            .get_results_summary()
+            .into_iter()
+            .map(|(region, results)| (region.to_string(), results))
+            .collect::<HashMap<String, AmiValidationRegionSummary>>())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{AmiValidationResult, AmiValidationResultStatus, AmiValidationResults};
+    use crate::aws::validate_ami::ami::ImageDef;
+    use aws_sdk_ssm::Region;
+    use std::collections::{HashMap, HashSet};
+
+    // These tests assert that the `get_results_for_status` function returns the correct values.
+
+    // Tests empty `AmiValidationResults`
+    #[test]
+    fn get_results_for_status_empty() {
+        let results = AmiValidationResults::from_result_map(HashMap::from([
+            (Region::new("us-west-2"), HashSet::from([])),
+            (Region::new("us-east-1"), HashSet::from([])),
+        ]));
+        let results_filtered = results.get_results_for_status(&vec![
+            AmiValidationResultStatus::Correct,
+            AmiValidationResultStatus::Incorrect,
+            AmiValidationResultStatus::Missing,
+        ]);
+
+        assert_eq!(results_filtered, HashSet::new());
+    }
+
+    // Tests the `Correct` status
+    #[test]
+    fn get_results_for_status_correct() {
+        let results = AmiValidationResults::from_result_map(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                ]),
+            ),
+            (
+                Region::new("us-east-1"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                ]),
+            ),
+        ]));
+        let results_filtered =
+            results.get_results_for_status(&vec![AmiValidationResultStatus::Correct]);
+
+        assert_eq!(
+            results_filtered,
+            HashSet::from([
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-east-1"),
+                )
+            ])
+        );
+    }
+
+    // Tests a filter containing the `Correct` and `Incorrect` statuses
+    #[test]
+    fn get_results_for_status_correct_incorrect() {
+        let results = AmiValidationResults::from_result_map(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(None),
+                        Region::new("us-west-2"),
+                    ),
+                ]),
+            ),
+            (
+                Region::new("us-east-1"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(None),
+                        Region::new("us-east-1"),
+                    ),
+                ]),
+            ),
+        ]));
+        let results_filtered = results.get_results_for_status(&vec![
+            AmiValidationResultStatus::Correct,
+            AmiValidationResultStatus::Incorrect,
+        ]);
+
+        assert_eq!(
+            results_filtered,
+            HashSet::from([
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-east-1"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-east-1"),
+                )
+            ])
+        );
+    }
+
+    // Tests a filter containing all statuses
+    #[test]
+    fn get_results_for_status_all() {
+        let results = AmiValidationResults::from_result_map(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(None),
+                        Region::new("us-west-2"),
+                    ),
+                ]),
+            ),
+            (
+                Region::new("us-east-1"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(None),
+                        Region::new("us-east-1"),
+                    ),
+                ]),
+            ),
+            (
+                Region::new("us-east-2"),
+                HashSet::from([AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Err(crate::aws::validate_ami::error::Error::UnreachableRegion {
+                        region: "us-east-2".to_string(),
+                    }),
+                    Region::new("us-east-2"),
+                )]),
+            ),
+        ]));
+        let results_filtered = results.get_results_for_status(&vec![
+            AmiValidationResultStatus::Correct,
+            AmiValidationResultStatus::Incorrect,
+            AmiValidationResultStatus::Missing,
+            AmiValidationResultStatus::Unreachable,
+        ]);
+
+        assert_eq!(
+            results_filtered,
+            HashSet::from([
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-east-1"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test1-image-id".to_string(),
+                    ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(Some(ImageDef {
+                        id: "test1-image-id".to_string(),
+                        name: "test1-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: false,
+                        sriov_net_support: "simple".to_string(),
+                    })),
+                    Region::new("us-east-1"),
+                ),
+                &AmiValidationResult::new(
+                    "test2-image-id".to_string(),
+                    ImageDef {
+                        id: "test2-image-id".to_string(),
+                        name: "test2-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(None),
+                    Region::new("us-west-2"),
+                ),
+                &AmiValidationResult::new(
+                    "test2-image-id".to_string(),
+                    ImageDef {
+                        id: "test2-image-id".to_string(),
+                        name: "test2-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Ok(None),
+                    Region::new("us-east-1"),
+                ),
+                &AmiValidationResult::new(
+                    "test3-image-id".to_string(),
+                    ImageDef {
+                        id: "test3-image-id".to_string(),
+                        name: "test3-image".to_string(),
+                        public: true,
+                        launch_permissions: None,
+                        ena_support: true,
+                        sriov_net_support: "simple".to_string(),
+                    },
+                    Err(crate::aws::validate_ami::error::Error::UnreachableRegion {
+                        region: "us-east-2".to_string(),
+                    }),
+                    Region::new("us-east-2"),
+                ),
+            ])
+        );
+    }
+
+    // Tests the `Missing` filter when none of the AmiValidationResults have this status
+    #[test]
+    fn get_results_for_status_missing_none() {
+        let results = AmiValidationResults::from_result_map(HashMap::from([
+            (
+                Region::new("us-west-2"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        })),
+                        Region::new("us-west-2"),
+                    ),
+                ]),
+            ),
+            (
+                Region::new("us-east-1"),
+                HashSet::from([
+                    AmiValidationResult::new(
+                        "test3-image-id".to_string(),
+                        ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test3-image-id".to_string(),
+                            name: "test3-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test1-image-id".to_string(),
+                        ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test1-image-id".to_string(),
+                            name: "test1-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: false,
+                            sriov_net_support: "simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                    AmiValidationResult::new(
+                        "test2-image-id".to_string(),
+                        ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "simple".to_string(),
+                        },
+                        Ok(Some(ImageDef {
+                            id: "test2-image-id".to_string(),
+                            name: "test2-image".to_string(),
+                            public: true,
+                            launch_permissions: None,
+                            ena_support: true,
+                            sriov_net_support: "not simple".to_string(),
+                        })),
+                        Region::new("us-east-1"),
+                    ),
+                ]),
+            ),
+        ]));
+        let results_filtered =
+            results.get_results_for_status(&vec![AmiValidationResultStatus::Missing]);
+
+        assert_eq!(results_filtered, HashSet::new());
+    }
+}

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -123,6 +123,14 @@ fn run() -> Result<()> {
                     .context(error::ValidateSsmSnafu)
             })
         }
+        SubCommand::ValidateAmi(ref validate_ami_args) => {
+            let rt = Runtime::new().context(error::RuntimeSnafu)?;
+            rt.block_on(async {
+                aws::validate_ami::run(&args, validate_ami_args)
+                    .await
+                    .context(error::ValidateAmiSnafu)
+            })
+        }
         SubCommand::UploadOva(ref upload_args) => {
             vmware::upload_ova::run(&args, upload_args).context(error::UploadOvaSnafu)
         }
@@ -161,6 +169,7 @@ enum SubCommand {
 
     Ami(aws::ami::AmiArgs),
     PublishAmi(aws::publish_ami::PublishArgs),
+    ValidateAmi(aws::validate_ami::ValidateAmiArgs),
 
     Ssm(aws::ssm::SsmArgs),
     PromoteSsm(aws::promote_ssm::PromoteArgs),
@@ -238,6 +247,11 @@ mod error {
         #[snafu(display("Failed to validate SSM parameters: {}", source))]
         ValidateSsm {
             source: crate::aws::validate_ssm::Error,
+        },
+
+        #[snafu(display("Failed to validate EC2 images: {}", source))]
+        ValidateAmi {
+            source: crate::aws::validate_ami::Error,
         },
     }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Added a `validate-ami` subcommand to the `pubsys` tool. This command has the following signature:
```
pubsys-validate-ami 0.1.0
Validates EC2 images

USAGE:
    pubsys --infra-config-path <infra-config-path> validate-ami [FLAGS] [OPTIONS] --expected-amis-path <expected-amis-path>

FLAGS:
        --json       If this argument is given, print the validation results summary as a JSON object instead of a
                     plaintext table
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --expected-amis-path <expected-amis-path>           File holding the expected amis
        --write-results-path <write-results-path>           Optional path where the validation results should be written
        --write-results-filter <write-results-filter>...
            Optional filter to only write validation results with these statuses to the above path The available
            statuses are: `Correct`, `Incorrect`, `Missing`
        --log-level <log-level>
            How much detail to log; from least to most: ERROR, WARN, INFO, DEBUG, TRACE [default: INFO]
```

The function takes a path to a file containing an image object per region. An example file looks like this:
```
{
  "us-west-2": {
    "id": "ami-012345678",
    "name": "bottlerocket-aws-k8s-1.24-x86_64-v1.14.0-abcdef-dirty",
    "public": true,
    "launch_permissions": [
      {
        "group": "all"
      }
    ]
  }
}
```

The function will call the `describe-images` function on each image in the file to ensure that the retrieved id, name, and publicity match the expected values. If `public` is false, then the specific launch_permissions are retrieved using `describe-image-attribute` and included in the comparison. Aside from publicity and launch_permissions, the function will check that `sriov_net_support` is `simple` and `ena_support` is `true`.

The result of the function looks like this:
```
+-----------+---------+-----------+---------+------------+
| String    | correct | incorrect | missing | unreachable |
+-----------+---------+-----------+---------+------------+
| us-west-2 | 0       | 0         | 1       | 0          |
+-----------+---------+-----------+---------+------------+
```
- `correct` indicates that all retrieved values match the expected values
- `incorrect` indicates that at least one value does not match the expected value
- `missing` indicates that the specific image failed to be retrieved
- `unreachable` indicates that the images in this region could not be retrieved because the region could not be reached

`--write-results-path` and `--write-results-filter` allow the user to write the results of the ami validation to a JSON file. The filter determines which statuses will be written to this file. The file looks like this:

```
[
  {
    "id": "ami-012345678",
    "expected_image_def": {
      "id": "ami-012345678",
      "name": "bottlerocket-aws-k8s-1.24-x86_64-v1.14.0-abcdef-dirty",
      "public": true,
      "launch_permissions": null,
      "ena_support": true,
      "sriov_net_support": "simple"
    },
    "actual_image_def": null,
    "region": "us-west-2",
    "status": "Missing"
  }
]
```

Modified the SSM validation results to represent the new `Unreachable` status as well.

**Testing done:**

- Unit tests
- Ran the program on an unregistered ami (results seen above) and on registered public ones, which showed as `correct`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
