### PR TITLE
imdsclient: return a single hostname from `fetch_hostname`

### DIFF
--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -237,10 +237,14 @@ impl ImdsClient {
         Ok(Some(public_keys))
     }
 
-    /// Gets the hostname from instance metadata.
+    /// Gets the hostname from instance metadata. The`metadata/local-hostname` IMDS target may
+    /// potentially return multiple space-delimited hostnames; choose the first one.
     pub async fn fetch_hostname(&mut self) -> Result<Option<String>> {
         let hostname_target = "meta-data/local-hostname";
-        self.fetch_string(&hostname_target).await
+        Ok(self
+            .fetch_string(&hostname_target)
+            .await?
+            .and_then(|h| h.split_whitespace().next().map(String::from)))
     }
 
     /// Helper to fetch bytes from IMDS using the pinned schema version.


### PR DESCRIPTION
**Issue number:**

Related to #3031 

**Description of changes:**


The `fetch_hostname` method queries the `metadata/local-hostname` IMDS target, which has the potential to return multiple space-delimited hostnames.  This changes the method to return only the first hostname in the list.


**Testing done:**
Build and booted an `aws-k8s-1.24` node into a VPC setup with a DHCP option set with multiple domain names.

Confirmed IMDS returns multiple hostnames from the `meta-data/local-hostname` endpoint:
```
[ec2-user@admin]$ curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-hostname
ip-192-168-23-243.us-west-2.compute.internal fdjskl.com abcdefg.com
```

Confirmed my node has the proper hostname set in `/proc/sys/kernel/hostname` and in `settings.network.hostname`
```
bash-5.1# cat /proc/sys/kernel/hostname 
ip-192-168-23-243.us-west-2.compute.internal
bash-5.1# apiclient get settings.network.hostname
{
  "settings": {
    "network": {
      "hostname": "ip-192-168-23-243.us-west-2.compute.internal"
    }
  }
}
```

Confirm the node properly joins the cluster and has the expected name:
```
$ kubectl get nodes
NAME                                           STATUS   ROLES    AGE   VERSION
ip-192-168-23-243.us-west-2.compute.internal   Ready    <none>   18m   v1.24.12-eks-76dc719
```

Also turned on RBN in my subnet and launched another instance to validate we see the same correct behavior:
```
[ec2-user@admin]$ curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-hostname
i-009d9789c65c9a4a4.us-west-2.compute.internal fdjskl.com abcdefg.com

[ec2-user@admin]$ cat /proc/sys/kernel/hostname 
i-009d9789c65c9a4a4.us-west-2.compute.internal

[ec2-user@admin]$ apiclient get settings.network.hostname
{
  "settings": {
    "network": {
      "hostname": "i-009d9789c65c9a4a4.us-west-2.compute.internal"
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
