### PR TITLE
Storewolf: adds feature to create inventory file symlink

### DIFF
--- a/packages/os/storewolf.service
+++ b/packages/os/storewolf.service
@@ -9,7 +9,9 @@ RefuseManualStop=true
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/storewolf --data-store-base-path /var/lib/bottlerocket/datastore
+ExecStart=/usr/bin/storewolf \
+  --data-store-base-path /var/lib/bottlerocket/datastore \
+  --inventory-file-symlink-path /var/lib/bottlerocket/inventory/application.json
 RemainAfterExit=true
 StandardError=journal+console
 


### PR DESCRIPTION
**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket/issues/2967

**Description of changes:**

Feature for `storewolf` to create a symlink at a given path and destination:

```bash
/usr/bin/storewolf \
    --data-store-base-path /var/lib/bottlerocket/datastore \
    --inventory-file-symlink-path /var/lib/bottlerocket/inventory/application.json
```

will then create the a symlink to the default file location `/usr/share/bottlerocket/application-inventory.json`. Users may also specify the source location of the inventory file via the optional `--inventory-file-path` flag.

**Testing done:**

Built bottlerocket, launched instance and see symlink created correctly:
```
bash-5.1# ls -la /var/lib/bottlerocket/inventory/
total 8
drwxr-xr-x. 2 root root 4096 Apr 19 16:37 .
drwxr-xr-x. 5 root root 4096 Apr 19 16:37 ..
lrwxrwxrwx. 1 root root   50 Apr 19 16:37 application.json -> /usr/share/bottlerocket/application-inventory.json
```

Contents looks good:
```
bash-5.1# cat /var/lib/bottlerocket/inventory/application.json | head
{
  "Content": [
    {
      "Name": "acpid",
      "Publisher": "Bottlerocket",
      "Version": "1.14.0",
      "Release": "1ecaea34-dirty",
      "InstalledTime": "2023-04-19T16:35:20Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
```

And bootlogs look good:
```
bash-5.1# journalctl | grep "storewolf"
Apr 19 16:37:54 localhost storewolf[1537]: 16:37:54 [INFO] Storewolf started
Apr 19 16:37:54 localhost storewolf[1537]: 16:37:54 [INFO] Deleting pending transactions
Apr 19 16:37:54 localhost storewolf[1537]: 16:37:54 [INFO] Populating datastore at: /var/lib/bottlerocket/datastore
Apr 19 16:37:54 localhost storewolf[1537]: 16:37:54 [INFO] Creating datastore at: /var/lib/bottlerocket/datastore/current/live
Apr 19 16:37:54 localhost storewolf[1537]: 16:37:54 [INFO] Datastore populated
Apr 19 16:37:54 localhost storewolf[1537]: 16:37:54 [INFO] Creating inventory file symlink at: /var/lib/bottlerocket/inventory/application.json
Apr 19 16:37:54 localhost storewolf[1537]: 16:37:54 [INFO] Inventory symlink created
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
