### PR TITLE
packages: update runc

### DIFF
--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,9 +12,9 @@ path = "pkg.rs"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.5/runc.tar.xz"
-path = "runc-v1.1.5.tar.xz"
-sha512 = "7b10c0d6739e7fe3c718b3219bdb2437ae3ed8d1995b88136b9a0e8b4e909adbe8b6af6634a751b507bf793d0d5e924f5c85525d8fd46c3daf72c664dc25ab04"
+url = "https://github.com/opencontainers/runc/releases/download/v1.1.6/runc.tar.xz"
+path = "runc-v1.1.6.tar.xz"
+sha512 = "a5b799cb5a69f7251f81e5887a9269fb8fc6573b8a7d1b2e2436a0955feea982a34cf0bc62017534fdbc75e37fa70db4a06bdaecc6e67140fb094d06642a8440"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -1,8 +1,8 @@
 %global goproject github.com/opencontainers
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
-%global commit f19387a6bec4944c770f7668ab51c4348d9c2f38
-%global gover 1.1.5
+%global commit 0f48801a0e21e3f0bc4e74643ead2a502df4818d
+%global gover 1.1.6
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION
Updates `runc` to v1.1.6

**Description of changes:**
```
    packages: update runc

    Updates runc to v1.1.6
```

**Testing done:**

Built and launched an `aws-k8s-1.24` image and ensured they came up connected to the cluster:
```
$ kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-24-146.us-west-2.compute.internal   Ready    <none>   8m17s   v1.24.12-eks-76dc719   192.168.24.146   35.87.71.87     Bottlerocket OS 1.14.0 (aws-k8s-1.24)   5.15.102         containerd://1.6.19+bottlerocket
ip-192-168-88-71.us-west-2.compute.internal    Ready    <none>   8m17s   v1.24.12-eks-76dc719   192.168.88.71    54.212.206.90   Bottlerocket OS 1.14.0 (aws-k8s-1.24)   5.15.102         containerd://1.6.19+bottlerocket
```

Built and launched an `aws-ecs-1` image and ensured it is launching containers as well:
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "bd18a998",
    "pretty_name": "Bottlerocket OS 1.14.0 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.14.0"
  }
}
[ssm-user@control]$ curl localhost:49153
<html>
    <body style="background-color:rgb(49, 214, 220);"><center>
    <head>
        <title>Hello world</title>
    </head>
    <body>
        <h1>Hello from NGINX!
        </h1>
    </body>

</html>
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
