### PR TITLE
kernel: Switch SCSI_VIRTIO driver to built-in

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket-metal
+++ b/packages/kernel-5.10/config-bottlerocket-metal
@@ -103,3 +103,6 @@ CONFIG_MEGARAID_SAS=y
 
 # Microsemi PQI controllers
 CONFIG_SCSI_SMARTPQI=y
+
+# Support for virtio scsi boot devices for other cloud providers
+CONFIG_SCSI_VIRTIO=y

--- a/packages/kernel-5.15/config-bottlerocket-metal
+++ b/packages/kernel-5.15/config-bottlerocket-metal
@@ -123,3 +123,6 @@ CONFIG_MEGARAID_SAS=y
 
 # Microsemi PQI controllers
 CONFIG_SCSI_SMARTPQI=y
+
+# Support for virtio scsi boot devices for other cloud providers
+CONFIG_SCSI_VIRTIO=y


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3045 

**Description of changes:**

Enable usage of the Bottlerocket metal variant on other virtualization stacks where the boot device is provided through the scsis virtio driver.

**Testing done:**

I have built both metal kernels and as expected the only config changes we see in the resulting configs is the changed `CONFIG_SCSI_VIRTIO`:

```
config-x86_64-metal-k8s-1.23-diff:	  0 removed,   0 added,   1 changed
config-x86_64-metal-k8s-1.26-diff:	  0 removed,   0 added,   1 changed
```

```
==> 3045_scsi_virtio/config-x86_64-metal-k8s-1.23-diff <==
 SCSI_VIRTIO m -> y

==> 3045_scsi_virtio/config-x86_64-metal-k8s-1.26-diff <==
 SCSI_VIRTIO m -> y
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
