### PR TITLE
Release.toml: fix reference to kubelet-config-settings migration

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -202,5 +202,5 @@ version = "1.14.0"
 ]
 "(1.13.4, 1.14.0)" = [
     "migrate_v1.14.0_kubernetes-gc-percent-type-change.lz4",
-    "migrate_v1.14.0_kubernetes-config-settings.lz4",
+    "migrate_v1.14.0_kubelet-config-settings.lz4",
 ]


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** Fix a typo in Release.toml for the recent kubelet settings PR introducing CPU manager policy options.


**Testing done:** Manual migration and rollback testing.

On 1.13.0:
```
[ec2-user@admin]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f7a2e3cc-dirty",
    "pretty_name": "Bottlerocket OS 1.13.0 (aws-k8s-1.23)",
    "variant_id": "aws-k8s-1.23",
    "version_id": "1.13.0"
  }
}
[ec2-user@admin]$ apiclient get settings.kubernetes.cpu-manager
{}
```

After migration to 1.14.0:

```
[ec2-user@admin]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "abfb51be-dirty",
    "pretty_name": "Bottlerocket OS 1.14.0 (aws-k8s-1.23)",
    "variant_id": "aws-k8s-1.23",
    "version_id": "1.14.0"
  }
}
[ec2-user@admin]$ apiclient apply                                                 
[settings.kubernetes]
cpu-manager-policy = "static"
cpu-manager-policy-options = ["full-pcpus-only"]
[ec2-user@admin]$ apiclient get settings.kubernetes.cpu-manager                   
{
  "settings": {
    "kubernetes": {
      "cpu-manager-policy": "static",
      "cpu-manager-policy-options": [
        "full-pcpus-only"
      ]
    }
  }
}
```

After rollback to 1.13.0:
```
[ec2-user@admin]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f7a2e3cc-dirty",
    "pretty_name": "Bottlerocket OS 1.13.0 (aws-k8s-1.23)",
    "variant_id": "aws-k8s-1.23",
    "version_id": "1.13.0"
  }
}
[ec2-user@admin]$ apiclient get settings.kubernetes.cpu-manager
{
  "settings": {
    "kubernetes": {
      "cpu-manager-policy": "static"
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
