### PR TITLE
pluto: update usage

### DIFF
--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -334,7 +334,7 @@ async fn get_private_dns_name(client: &mut ImdsClient) -> Result<String> {
 fn usage() -> ! {
     let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
     eprintln!(
-        r"Usage: {} [max-pods | cluster-dns-ip | node-ip]",
+        r"Usage: {} [max-pods | cluster-dns-ip | node-ip | provider-id | private-dns-name]",
         program_name
     );
     process::exit(1);


### PR DESCRIPTION
**Description of changes:**

I noticed that the usage wasn't updated with the last few PRs and decided I would do a quick PR to add them. This doesn't affect any functionality but might be handy if a user is trying to run `pluto` manually while debugging.

Adds the new subcommands that were recently added to the usage.

**Testing done:**

Quick build of `cargo make` passed for `aws-k8s1.26` and tried it out:
```bash
bash-5.1# pluto
Usage: pluto [max-pods | cluster-dns-ip | node-ip | provider-id | private-dns-name]
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
