### PR TITLE
netdog: add primary-interface argument

### DIFF
--- a/sources/api/netdog/src/cli/mod.rs
+++ b/sources/api/netdog/src/cli/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod generate_hostname;
 pub(crate) mod generate_net_config;
 pub(crate) mod node_ip;
+#[cfg(net_backend = "systemd-networkd")]
+pub(crate) mod primary_interface;
 pub(crate) mod set_hostname;
 pub(crate) mod write_resolv_conf;
 
@@ -19,6 +21,8 @@ use crate::{
 pub(crate) use generate_hostname::GenerateHostnameArgs;
 pub(crate) use generate_net_config::GenerateNetConfigArgs;
 pub(crate) use node_ip::NodeIpArgs;
+#[cfg(net_backend = "systemd-networkd")]
+pub(crate) use primary_interface::PrimaryInterfaceArgs;
 use serde::{Deserialize, Serialize};
 pub(crate) use set_hostname::SetHostnameArgs;
 use snafu::{ensure, OptionExt, ResultExt};

--- a/sources/api/netdog/src/cli/primary_interface.rs
+++ b/sources/api/netdog/src/cli/primary_interface.rs
@@ -1,0 +1,13 @@
+use super::{primary_interface_name, print_json, Result};
+use argh::FromArgs;
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "primary-interface")]
+/// Return the current IP address
+pub(crate) struct PrimaryInterfaceArgs {}
+
+/// Return the current IP address as JSON (intended for use as a settings generator)
+pub(crate) fn run() -> Result<()> {
+    let primary_interface = primary_interface_name()?;
+    print_json(primary_interface)
+}

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -82,6 +82,8 @@ enum SubCommand {
     WriteResolvConf(cli::WriteResolvConfArgs),
     #[cfg(net_backend = "systemd-networkd")]
     WritePrimaryInterfaceStatus(cli::WritePrimaryInterfaceStatusArgs),
+    #[cfg(net_backend = "systemd-networkd")]
+    PrimaryInterface(cli::PrimaryInterfaceArgs),
 }
 
 async fn run() -> cli::Result<()> {
@@ -98,6 +100,8 @@ async fn run() -> cli::Result<()> {
         SubCommand::WriteResolvConf(_) => cli::write_resolv_conf::run()?,
         #[cfg(net_backend = "systemd-networkd")]
         SubCommand::WritePrimaryInterfaceStatus(_) => cli::write_primary_interface_status::run()?,
+        #[cfg(net_backend = "systemd-networkd")]
+        SubCommand::PrimaryInterface(_) => cli::primary_interface::run()?,
     }
     Ok(())
 }


### PR DESCRIPTION


**Issue number:** #2449 has a sub task for D-Bus listener, this is part 2 of this change.

Closes #

**Description of changes:**
This command provides a way to get the machine's primary interface without reading the files directly which provides a CLI API to access this value. This will be used in yet to be implemented logic to watch this interface for changes on D-Bus.


**Testing done:**
cargo build, fmt, clippy, and test to ensure everything passes. This command isn't in play unless systemd-networkd is configured. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
