### PR TITLE
SECURITY_FEATURES: remove inaccurate wording

### DIFF
--- a/SECURITY_FEATURES.md
+++ b/SECURITY_FEATURES.md
@@ -143,8 +143,6 @@ There is no way to disable it.
 
 SELinux is a Linux Security Module (LSM) that provides a mechanism for mandatory access control (MAC).
 Processes that run as root with full capabilities are still subject to the mandatory policy restrictions.
-Host containers with the `superpowered = true` flag set are an exception, and will run in the permissive `super_t` domain.
-Permissive means that actions that are not allowed by policy will be logged but not blocked.
 
 The policy in Bottlerocket has the following objectives:
 1) Prevent most components from directly modifying the API settings.


### PR DESCRIPTION
**Issue number:**

Closes #2703

**Description of changes:**

Even though `super_t` is highly privileged, it isn't marked as permissive.


**Testing done:**
N / A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
