### PR TITLE
testsys: Add support for node provisioning with Karpenter

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3236,6 +3236,7 @@ dependencies = [
 name = "testsys-config"
 version = "0.1.0"
 dependencies = [
+ "bottlerocket-types",
  "bottlerocket-variant",
  "handlebars",
  "home",
@@ -3243,6 +3244,7 @@ dependencies = [
  "log",
  "maplit",
  "serde",
+ "serde_plain",
  "serde_yaml 0.8.26",
  "snafu",
  "testsys-model",

--- a/tools/testsys-config/Cargo.toml
+++ b/tools/testsys-config/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.7", tag = "v0.0.7"}
 bottlerocket-variant = { version = "0.1", path = "../../sources/bottlerocket-variant" }
 handlebars = "4"
 home = "0.5"
@@ -15,6 +16,7 @@ log = "0.4"
 maplit="1"
 testsys-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.7", tag = "v0.0.7"}
 serde = { version = "1", features = ["derive"]  }
+serde_plain = "1"
 serde_yaml = "0.8"
 snafu = "0.7"
 toml = "0.5"

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -1,3 +1,4 @@
+use bottlerocket_types::agent_config::KarpenterDeviceMapping;
 use bottlerocket_variant::Variant;
 pub use error::Error;
 use handlebars::Handlebars;
@@ -11,6 +12,7 @@ use std::path::Path;
 use testsys_model::constants::TESTSYS_VERSION;
 use testsys_model::{DestructionPolicy, SecretName};
 pub type Result<T> = std::result::Result<T, error::Error>;
+use serde_plain::derive_fromstr_from_deserialize;
 
 /// Configuration needed to run tests
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -248,6 +250,11 @@ pub struct GenericVariantConfig {
     pub cluster_names: Vec<String>,
     /// The instance type that instances should be launched with
     pub instance_type: Option<String>,
+    /// Specify how Bottlerocket instances should be launched (ec2, karpenter)
+    pub resource_agent_type: Option<ResourceAgentType>,
+    /// Launch instances with the following Block Device Mapping
+    #[serde(default)]
+    pub block_device_mapping: Vec<KarpenterDeviceMapping>,
     /// The secrets needed by the agents
     #[serde(default)]
     pub secrets: BTreeMap<String, SecretName>,
@@ -295,9 +302,17 @@ impl GenericVariantConfig {
             self.workloads
         };
 
+        let block_device_mapping = if self.block_device_mapping.is_empty() {
+            other.block_device_mapping
+        } else {
+            self.block_device_mapping
+        };
+
         Self {
             cluster_names,
             instance_type: self.instance_type.or(other.instance_type),
+            resource_agent_type: self.resource_agent_type.or(other.resource_agent_type),
+            block_device_mapping,
             secrets,
             agent_role: self.agent_role.or(other.agent_role),
             conformance_image: self.conformance_image.or(other.conformance_image),
@@ -311,6 +326,21 @@ impl GenericVariantConfig {
         }
     }
 }
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum ResourceAgentType {
+    Karpenter,
+    Ec2,
+}
+
+impl Default for ResourceAgentType {
+    fn default() -> Self {
+        Self::Ec2
+    }
+}
+
+derive_fromstr_from_deserialize!(ResourceAgentType);
 
 /// The configuration for a specific config level (<PLATFORM>-<FLAVOR>). This may or may not be arch
 /// specific depending on it's location in `GenericConfig`.
@@ -368,6 +398,7 @@ pub struct TestsysImages {
     pub vsphere_k8s_cluster_resource_agent_image: Option<String>,
     pub metal_k8s_cluster_resource_agent_image: Option<String>,
     pub ec2_resource_agent_image: Option<String>,
+    pub ec2_karpenter_resource_agent_image: Option<String>,
     pub vsphere_vm_resource_agent_image: Option<String>,
     pub sonobuoy_test_agent_image: Option<String>,
     pub ecs_test_agent_image: Option<String>,
@@ -397,6 +428,10 @@ impl TestsysImages {
                 registry
             )),
             ec2_resource_agent_image: Some(format!("{}/ec2-resource-agent:{tag}", registry)),
+            ec2_karpenter_resource_agent_image: Some(format!(
+                "{}/ec2-karpenter-resource-agent:{tag}",
+                registry
+            )),
             vsphere_vm_resource_agent_image: Some(format!(
                 "{}/vsphere-vm-resource-agent:{tag}",
                 registry
@@ -430,6 +465,9 @@ impl TestsysImages {
             ec2_resource_agent_image: self
                 .ec2_resource_agent_image
                 .or(other.ec2_resource_agent_image),
+            ec2_karpenter_resource_agent_image: self
+                .ec2_karpenter_resource_agent_image
+                .or(other.ec2_karpenter_resource_agent_image),
             sonobuoy_test_agent_image: self
                 .sonobuoy_test_agent_image
                 .or(other.sonobuoy_test_agent_image),

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -19,7 +19,7 @@ use snafu::{OptionExt, ResultExt};
 use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::str::FromStr;
-use testsys_config::{GenericVariantConfig, TestConfig};
+use testsys_config::{GenericVariantConfig, ResourceAgentType, TestConfig};
 use testsys_model::test_manager::TestManager;
 use testsys_model::SecretName;
 
@@ -157,6 +157,10 @@ struct CliConfig {
     #[clap(long, env = "TESTSYS_USERDATA")]
     pub userdata: Option<String>,
 
+    /// Specify the method that should be used to launch instances
+    #[clap(long, env = "TESTSYS_RESOURCE_AGENT")]
+    pub resource_agent_type: Option<ResourceAgentType>,
+
     /// A set of workloads that should be run for a workload test (--workload my-workload=<WORKLOAD-IMAGE>)
     #[clap(long = "workload", parse(try_from_str = parse_workloads), number_of_values = 1)]
     pub workloads: Vec<(String, String)>,
@@ -177,6 +181,8 @@ impl From<CliConfig> for GenericVariantConfig {
         GenericVariantConfig {
             cluster_names: val.target_cluster_name.into_iter().collect(),
             instance_type: val.instance_type,
+            resource_agent_type: val.resource_agent_type,
+            block_device_mapping: Default::default(),
             secrets: val.secret.into_iter().collect(),
             agent_role: val.assume_role,
             conformance_image: val.conformance_image,
@@ -527,6 +533,13 @@ pub(crate) struct TestsysImages {
     )]
     pub(crate) ec2_resource: Option<String>,
 
+    /// EC2 Karpenter resource agent URI. If not provided the latest released resource agent will be used.
+    #[clap(
+        long = "ec2-resource-agent-image",
+        env = "TESTSYS_EC2_KARPENTER_RESOURCE_AGENT_IMAGE"
+    )]
+    pub(crate) ec2_karpenter_resource: Option<String>,
+
     /// vSphere VM resource agent URI. If not provided the latest released resource agent will be used.
     #[clap(
         long = "vsphere-vm-resource-agent-image",
@@ -579,6 +592,7 @@ impl From<TestsysImages> for testsys_config::TestsysImages {
             vsphere_k8s_cluster_resource_agent_image: val.vsphere_k8s_cluster_resource,
             metal_k8s_cluster_resource_agent_image: val.metal_k8s_cluster_resource,
             ec2_resource_agent_image: val.ec2_resource,
+            ec2_karpenter_resource_agent_image: val.ec2_karpenter_resource,
             vsphere_vm_resource_agent_image: val.vsphere_vm_resource,
             sonobuoy_test_agent_image: val.sonobuoy_test,
             ecs_test_agent_image: val.ecs_test,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #N/A

**Description of changes:**

Enables the use of the agent created in https://github.com/bottlerocket-os/bottlerocket-test-system/pull/803/

**Note**: You can provision nodes with karpenter by specifying `karpenter-block-device-mappings` in `Test.toml`.
To follow the generic mapping, use the following configuration:

```toml
[aws-k8s.configuration.karpenter]
test-type = "quick"
karpenter-device-mapping = [
    {name = "/dev/xvda", volumeType = "gp3", volumeSize = 4, deleteOnTermination = true},
    {name = "/dev/xvdb", volumeType = "gp3", volumeSize = 20, deleteOnTermination = true},
]
```

This configuration creates a new test type for all `aws-k8s` variants called `karpenter` (the string following `.configuration` in the table heading).


Before launching nodes with karpenter you will need to add the karpenter role to your cluster's `aws-auth` config map.

```bash
# Change to your clusters name
CLUSTER_NAME=my-cluster
ACCOUNT_ID=your-account-id
REGION=us-west-2
eksctl create iamidentity mapping \
  -r ${REGION} \
  --cluster ${CLUSTER_NAME} \
  --arn arn:aws:iam::${ACCOUNT_ID}:role/KarpenterInstanceNodeRole \
  --username system:node:{{EC2PrivateDNSName}} \
  --group system:bootstrappers \
  --group system:nodes
```

You can run the test by calling,

```bash
cargo make -e TESTSYS_TEST=karpenter test
```

**Testing done:**

Verified that `cargo make test` still works as expected when `sonobuoy-image` is and is not provided.

Tested using the above instructions and verified that the instances we created and the test ran successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
