### PR TITLE
testsys: Add support for `sonobuoy-image`

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -253,6 +253,8 @@ pub struct GenericVariantConfig {
     pub secrets: BTreeMap<String, SecretName>,
     /// The role that should be assumed for this particular variant
     pub agent_role: Option<String>,
+    /// The location of the sonobuoy testing image
+    pub sonobuoy_image: Option<String>,
     /// The custom images used for conformance testing
     pub conformance_image: Option<String>,
     /// The custom registry used for conformance testing
@@ -300,6 +302,7 @@ impl GenericVariantConfig {
             instance_type: self.instance_type.or(other.instance_type),
             secrets,
             agent_role: self.agent_role.or(other.agent_role),
+            sonobuoy_image: self.sonobuoy_image.or(other.sonobuoy_image),
             conformance_image: self.conformance_image.or(other.conformance_image),
             conformance_registry: self.conformance_registry.or(other.conformance_registry),
             control_plane_endpoint: self.control_plane_endpoint.or(other.control_plane_endpoint),

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -131,6 +131,11 @@ struct CliConfig {
     #[clap(long, env = "TESTSYS_TARGET_CLUSTER_NAME")]
     target_cluster_name: Option<String>,
 
+    /// The sonobuoy image that should be used for conformance testing. It may be omitted to use the default
+    /// sonobuoy image.
+    #[clap(long, env = "TESTSYS_SONOBUOY_IMAGE")]
+    sonobuoy_image: Option<String>,
+
     /// The image that should be used for conformance testing. It may be omitted to use the default
     /// testing image.
     #[clap(long, env = "TESTSYS_CONFORMANCE_IMAGE")]
@@ -179,6 +184,7 @@ impl From<CliConfig> for GenericVariantConfig {
             instance_type: val.instance_type,
             secrets: val.secret.into_iter().collect(),
             agent_role: val.assume_role,
+            sonobuoy_image: val.sonobuoy_image,
             conformance_image: val.conformance_image,
             conformance_registry: val.conformance_registry,
             control_plane_endpoint: val.control_plane_endpoint,

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -68,6 +68,7 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
                 .to_owned()
                 .map(e2e_repo_config_base64),
         )
+        .sonobuoy_image(test_input.crd_input.config.sonobuoy_image.to_owned())
         .kube_conformance_image(test_input.crd_input.config.conformance_image.to_owned())
         .assume_role(test_input.crd_input.config.agent_role.to_owned())
         .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #N/A

**Description of changes:**

Support the use of custom sonobuoy images for testing in clusters that don't have access to the default sonobuoy image.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
