### PR TITLE
kubelet: K8s 1.26 use v1alpha1 credential provider

### DIFF
--- a/packages/kubernetes-1.26/credential-provider-config-yaml
+++ b/packages/kubernetes-1.26/credential-provider-config-yaml
@@ -10,7 +10,7 @@ providers:
       - "{{this}}"
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
 {{#if (or (eq @key "ecr-credential-provider") this.environment)}}
     env:
 {{#if this.environment}}


### PR DESCRIPTION
**Issue number:**

Closes #3069 

**Description of changes:**

In Kubernetes 1.26, the image credential provider graduated to API version v1. Due to a [bug in the ecr-credential-provider](https://github.com/kubernetes/cloud-provider-aws/issues/596) though, the provider apiVersion needs to still be v1alpha1. Using the v1 version causes an error from the provider.

**Testing done:**

Before:

```
/usr/libexec/kubernetes/kubelet/plugins/ecr-credential-provider <<< '{"apiVersion": "credentialprovider.kubelet.k8s.io/v1", "kind": "CredentialProviderRe>
E0502 16:52:22.809788    6287 main.go:161] Error running credential provider plugin: group version credentialprovider.kubelet.k8s.io/v1 is not supported
```

After:

```
/usr/libexec/kubernetes/kubelet/plugins/ecr-credential-provider <<< '{"apiVersion": "credentialprovider.kubelet.k8s.io/v1", "kind": "CredentialProviderRe>
[expected credential output]
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
