### PR TITLE
update nvidia-container-toolkit to 1.13.1

### DIFF
--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.13.0/nvidia-container-toolkit-1.13.0.tar.gz"
-sha512 = "d0b3b087b1771146986eb909af040e3fb14c55810bcb83b2e51ad2f8a5f8679efacd534b361251f096525a66cbabc09c384eb680ee810ee7f2da7919fd0e2d9f"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.13.1/nvidia-container-toolkit-1.13.1.tar.gz"
+sha512 = "e0d9dbb06e2b8ef075a881f4414bfb4b1ab9f571d148a202fbf7c2a7b59447f199028d5d176196703dadcb04040a74a229f09062da24e615faa4c051d614e206"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.13.0
+%global gover 1.13.1
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** N/A
**Description of changes:**
packages: update nvidia-container-toolkit to 1.13.1(The version of nvidia-container-toolkit should match with
libnvidia-container)

**Testing done:**
- [x] k8s pods can access the GPUs
- [x] ECS tasks can access the GPU


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
