### PR TITLE
Add support for ECS exec

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "amazon-ssm-agent"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+
+[lib]
+path = "pkg.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.815.0/amazon-ssm-agent-3.2.815.0.tar.gz"
+sha512 = "724b659f7141dc9c797288f109b35c2a516f08f843d472da0d44f1a04c5fbce30fd8df0cde95be355ca2a710b146c89e1ee3bb5905c297a90b3aaccf78d9da8b"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -1,0 +1,50 @@
+# Don't generate debug packages because we are compiling without CGO,
+# and the `gc` compiler doesn't append the  the ".note.gnu.build-id" section
+# https://fedoraproject.org/wiki/PackagingDrafts/Go#Build_ID
+%global debug_package %{nil}
+
+%global goproject github.com/aws
+%global gorepo amazon-ssm-agent
+%global goimport %{goproject}/%{gorepo}
+
+Name: %{_cross_os}amazon-ssm-agent
+Version: 3.2.815.0
+Release: 1%{?dist}
+Summary: An agent to enable remote management of EC2 instances
+License: Apache-2.0
+URL: https://github.com/aws/amazon-ssm-agent
+Source0: %{gorepo}-%{version}.tar.gz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -n %{gorepo}-%{version}
+
+%build
+%set_cross_go_flags
+
+# Set CGO_ENABLED=0 to statically link binaries that will be bind-mounted by the ECS agent
+CGO_ENABLED=0 go build ${GOFLAGS} -installsuffix cgo -a -ldflags "-s" -o amazon-ssm-agent \
+  ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
+CGO_ENABLED=0 go build ${GOFLAGS} -installsuffix cgo -a -ldflags "-s" -o ssm-agent-worker \
+  ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
+CGO_ENABLED=0 go build ${GOFLAGS} -installsuffix cgo -a -ldflags "-s" -o ssm-session-worker \
+  ./agent/framework/processor/executer/outofproc/sessionworker/main.go
+
+%install
+# Install the SSM agent under 'libexecdir', since it is meant to be used by other programs
+install -d %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
+for b in amazon-ssm-agent ssm-agent-worker ssm-session-worker; do
+  install -D -p -m 0755 ${b} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
+done
+
+%cross_scan_attribution go-vendor vendor
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%dir %{_cross_libexecdir}/amazon-ssm-agent
+%{_cross_libexecdir}/amazon-ssm-agent

--- a/packages/amazon-ssm-agent/build.rs
+++ b/packages/amazon-ssm-agent/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/packages/amazon-ssm-agent/pkg.rs
+++ b/packages/amazon-ssm-agent/pkg.rs
@@ -1,0 +1,1 @@
+// not used

--- a/packages/ecs-agent/0006-execcmd-change-execcmd-directories-for-Bottlerocket.patch
+++ b/packages/ecs-agent/0006-execcmd-change-execcmd-directories-for-Bottlerocket.patch
@@ -1,0 +1,67 @@
+From c9f3e2e695fa0c426c7c9196354c5ac7f138845a Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Wed, 3 May 2023 18:23:40 +0000
+Subject: [PATCH] execcmd: change execcmd directories for Bottlerocket
+
+The ECS agent performs checks on directories that, in normal
+circumstances, are mounted on the ECS agent container.  Since the ECS
+agent runs as a service in Bottlerocket, the paths to the directories
+are different.
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ agent/app/agent_capability_unix.go              | 2 +-
+ agent/engine/execcmd/manager_init_task_linux.go | 4 ++--
+ agent/engine/execcmd/manager_linux.go           | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/agent/app/agent_capability_unix.go b/agent/app/agent_capability_unix.go
+index 51b4393..76492c7 100644
+--- a/agent/app/agent_capability_unix.go
++++ b/agent/app/agent_capability_unix.go
+@@ -37,7 +37,7 @@ const (
+ 	SSE41                 = "sse4_1"
+ 	SSE42                 = "sse4_2"
+ 	CpuInfoPath           = "/proc/cpuinfo"
+-	capabilityDepsRootDir = "/managed-agents"
++	capabilityDepsRootDir = "/usr/libexec/amazon-ecs-agent/managed-agents"
+ )
+ 
+ var (
+diff --git a/agent/engine/execcmd/manager_init_task_linux.go b/agent/engine/execcmd/manager_init_task_linux.go
+index 05af158..6117e55 100644
+--- a/agent/engine/execcmd/manager_init_task_linux.go
++++ b/agent/engine/execcmd/manager_init_task_linux.go
+@@ -24,7 +24,7 @@ import (
+ )
+ 
+ const (
+-	ecsAgentExecDepsDir = "/managed-agents/execute-command"
++	ecsAgentExecDepsDir = "/usr/libexec/amazon-ecs-agent/managed-agents/execute-command"
+ 
+ 	// ecsAgentDepsBinDir is the directory where ECS Agent will read versions of SSM agent
+ 	ecsAgentDepsBinDir   = ecsAgentExecDepsDir + "/bin"
+@@ -40,7 +40,7 @@ const (
+ 	ContainerLogDir    = "/var/log/amazon/ssm"
+ 	ECSAgentExecLogDir = "/log/exec"
+ 
+-	HostCertFile            = "/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem"
++	HostCertFile            = "/usr/libexec/amazon-ecs-agent/managed-agents/execute-command/certs/tls-ca-bundle.pem"
+ 	ContainerCertFileSuffix = "certs/amazon-ssm-agent.crt"
+ 
+ 	ContainerConfigFileSuffix = "configuration/" + containerConfigFileName
+diff --git a/agent/engine/execcmd/manager_linux.go b/agent/engine/execcmd/manager_linux.go
+index 706d5da..6322816 100644
+--- a/agent/engine/execcmd/manager_linux.go
++++ b/agent/engine/execcmd/manager_linux.go
+@@ -16,6 +16,6 @@
+ package execcmd
+ 
+ const (
+-	hostExecDepsDir = "/var/lib/ecs/deps/execute-command"
++	hostExecDepsDir = "/usr/libexec/amazon-ecs-agent/managed-agents/execute-command"
+ 	HostBinDir      = hostExecDepsDir + "/bin"
+ )
+-- 
+2.39.2
+

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -41,3 +41,4 @@ glibc = { path = "../glibc" }
 # docker-engine = { path = "../docker-engine" }
 # `iptables` is only needed at runtime, and is pulled in by `release`.
 # iptables = { path = "../iptables" }
+amazon-ssm-agent = { path = "../amazon-ssm-agent" }

--- a/packages/ecs-agent/ecs-tmpfiles.conf
+++ b/packages/ecs-agent/ecs-tmpfiles.conf
@@ -1,2 +1,5 @@
 d /var/lib/ecs/data 0700 root root
 d /var/log/ecs 0755 root root
+d /var/log/ecs/exec 0755 root root -
+R /var/ecs/managed-agents - - - -
+d /var/ecs/managed-agents/execute-command/config 0750 root root -

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -10,6 +10,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "amazon-ssm-agent"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "aws-dev"
 version = "0.1.0"
 dependencies = [
@@ -343,6 +350,7 @@ dependencies = [
 name = "ecs-agent"
 version = "0.1.0"
 dependencies = [
+ "amazon-ssm-agent",
  "glibc",
 ]
 


### PR DESCRIPTION
**Issue number:**

Closes #1649 

**Description of changes:**
This includes the changes required to support ECS exec in Bottlerocket.

Under the hood, the ECS agent runs the Amazon SSM agent in each container configured to use EXEC. The ECS agent bind-mounts the statically-linked SSM agent's binaries (`amazon-ssm-agent`, `ssm-agent-worker`, `ssm-session-worker`) onto each container and uses docker to execute them within the container's namespaces.

In the ECS Optimized AMIs, the ECS agent looks at the path `/managed-agents` for the dependencies needed to use ECS exec. This directory is a bind-mount to `/var/lib/ecs/deps/`. The ECS agent checks that the `bin`, `config` and `certs` directories exist to mark the instances as “capable” to run ECS exec. The ECS agent requires the SSM binaries to be in a versioned directory within `bin`, and a CA bundle named `tls-ca-bundle.pem` to be available in `certs`. The agent uses `config` to store configurations created at runtime for each ECS exec session, so it needs to be writable by agent.

In this PR, a patch for the ECS agent updates the path used to check for dependencies from `/managed-agents` to `/usr/libexec/amazon-ecs-agent/managed-agents`. This is because in Bottlerocket the ECS agent runs as a system service instead of a docker container, and `/usr/libexec` is used to store binaries that are used by other programs.

The `config` directory for the SSM sessions is a symbolic link to `/var/ecs/managed-agents/execute-command/config` to allow the ECS agent generate the required configurations at runtime. This directory is created via `tmpfiles.d`. The `certs` directory contains a symbolic link to the CA Bundle of the host. The `bin` directory is a symbolic link to the directory that contains the versioned SSM binaries.

**Testing done:**
- SSM exec tests in the ECS conformance test suite pass.
- I validated the ECS exec sessions don't interfere with the SSM agent in the control host container
- I validated I can exec into a task

```bash
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c76b9874",
    "pretty_name": "Bottlerocket OS 1.14.0 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.14.0"
  }
}

#...

~ ❯ aws ecs execute-command --cluster bottlerocket \
    --task <task-arn> --container fedora \
    --interactive --command "cat /etc/os-release" | rg PRETTY_NAME
PRETTY_NAME="Fedora Linux 35 (Container Image)"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
