### PR TITLE
kernel: Update to 5.10.178 and 5.15.108

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/7ca24767b6ccf9edb988e7415593fb1fef1691b323a0a5f41077742adecc881f/kernel-5.10.177-158.645.amzn2.src.rpm"
-sha512 = "036798180a75bb7c7872306845a2b15118c7183472f77823c6398774c1abc692489a5bb1e0f07fb10ad036ea68dee769a51e4ad4181afdddd0c267e1233c8bdf"
+url = "https://cdn.amazonlinux.com/blobstore/13be720c0258208a986213f02d549940509f5125eac626729bc5dd3612bef2f8/kernel-5.10.178-162.673.amzn2.src.rpm"
+sha512 = "d1785ac9f88afbe2ee36bc4a16319c076048b89eb4488fdec884a785d1f68ad981b9499c54fa289329d5db228400175aa7cf05d4e0c7d9a75a68a18532a31957"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.177
+Version: 5.10.178
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/7ca24767b6ccf9edb988e7415593fb1fef1691b323a0a5f41077742adecc881f/kernel-5.10.177-158.645.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/13be720c0258208a986213f02d549940509f5125eac626729bc5dd3612bef2f8/kernel-5.10.178-162.673.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/a05414b6b80f2113b47d97b12e0a706c05597c2dd2100da31341333605de9209/kernel-5.15.106-64.140.amzn2.src.rpm"
-sha512 = "0a5a0319bd4c019a31d8139f4b5468ca0abc989f1846f4a7ae90c05e90be29119d33d43dc64cd39ddbcd0bf6b445aaa7379d0ca6392c146afa34c64f6dbb156f"
+url = "https://cdn.amazonlinux.com/blobstore/e8de7cc956678c88e06d181df5b0dde1c39fdc2fce4a47b5b466585f1e164a35/kernel-5.15.108-65.141.amzn2.src.rpm"
+sha512 = "3c5eaa6bea14f8f06a8999f05c2fe92b4b623ec4c445c0136903977a5cee02e46119585fa7afd20685156735bd6512e5400628868c759016027673c4ebb5cceb"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.106
+Version: 5.15.108
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/a05414b6b80f2113b47d97b12e0a706c05597c2dd2100da31341333605de9209/kernel-5.15.106-64.140.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/e8de7cc956678c88e06d181df5b0dde1c39fdc2fce4a47b5b466585f1e164a35/kernel-5.15.108-65.141.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** -

**Description of changes:**

Update kernels to latest AL kernels available in the repositories.


**Testing done:**

Kconfig changes:

```
config-aarch64-aws-k8s-1.23-diff:         0 removed,   2 added,   1 changed
config-aarch64-aws-k8s-1.26-diff:         0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   2 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.23-diff:        0 removed,   2 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:        0 removed,   0 added,   0 changed
```

The added config options on 5.10 are `AS_IS_GNU` and `AS_VERSION` which have been added upstream through [83f55e6f298e9e79](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.10.179&id=83f55e6f298e9e79a38b92d771179090ff0ac771) to enable checking for against a minimum assembler version when building certain kernel features.

The changed option on 5.10 on aarch64 is `ARM_CMN n -> y` is for supporting the full set of PMUs on graviton3 C7g.metal instances.

Testing on a cluster with one node each, passing a sonobuoy quick test:

```
NAME                                              STATUS   ROLES    AGE   VERSION                INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-47-89.eu-central-1.compute.internal    Ready    <none>   14h   v1.23.17-eks-712c388   192.168.47.89    35.158.121.177   Bottlerocket OS 1.14.0 (aws-k8s-1.23)   5.10.178         containerd://1.6.20+bottlerocket
ip-192-168-79-135.eu-central-1.compute.internal   Ready    <none>   14h   v1.26.2-eks-b106822    192.168.79.135   <none>           Bottlerocket OS 1.14.0 (aws-k8s-1.26)   5.15.108         containerd://1.6.20+bottlerocket
```
```
$ sonobuoy run --mode=quick --wait
[...]
10:36:57             e2e                                            global   complete   passed   Passed:  1, Failed:  0
10:36:57    systemd-logs    ip-192-168-47-89.eu-central-1.compute.internal   complete   passed                         
10:36:57    systemd-logs   ip-192-168-79-135.eu-central-1.compute.internal   complete   passed
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
