### PR TITLE
tools/diff-kernel-config: optimize bail-out time on failure

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -140,7 +140,7 @@ on_exit "git checkout --quiet '${gitrev_original}'"
 
 mkdir -p "${output_dir}" || bail "Failed to create output directory '${output_dir}'"
 
-for state in before after; do
+for state in after before; do
 
     gitrev_var=gitrev_${state}
     git checkout --quiet "${!gitrev_var}" || bail "Cannot check out '${!gitrev_var}'."


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** -

**Description of changes:**

We usually use the diff-kernel-config tool to find differences in kernel configuration for changes to our kernels (updates, features, config changes). The script builds kernels at two diffrent development stages, extracts the resulting kernel config and compares. Usually we can expect the 'before' state to be stable and being the state currently in the repo, while the 'after' state will have changes.

The state at 'before' is more unlikely to fail builds than the 'after' state. So build the 'after' state first so we do waste less time re-doing builds in case of build failures on 'after' state.


**Testing done:** -


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
