### PR TITLE
Revert docker proxy and ecr credential provider

### DIFF
--- a/packages/docker-proxy/Cargo.toml
+++ b/packages/docker-proxy/Cargo.toml
@@ -12,8 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/docker/libnetwork/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/libnetwork/archive/f7cdd0e7adbf0818e384178093aa67e38ffdb112/libnetwork-f7cdd0e7adbf0818e384178093aa67e38ffdb112.tar.gz"
-sha512 = "45e2acdd3cd059e6b1cc670b30e3d68b274e04b7c056ba031e0476c605b9264827defc280b20e09a339afcf853a83aae93e2fb28931df8b13dcd151a6a4da74c"
+url = "https://github.com/moby/libnetwork/archive/0dde5c895075df6e3630e76f750a447cf63f4789/libnetwork-0dde5c895075df6e3630e76f750a447cf63f4789.tar.gz"
+sha512 = "d73e2091c9aeefce501f5900d6c0c108d89e7970f1e091f7db4e05123536357311e65aa8210493f2386aaf4d68aac2ddf66c2c600054b87438d2f2ddd7e39584"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-proxy/docker-proxy.spec
+++ b/packages/docker-proxy/docker-proxy.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 # Use the libnetwork commit listed in this file for the docker version we ship:
 # https://github.com/moby/moby/blob/DOCKER-VERSION-HERE/vendor.conf
-%global commit f7cdd0e7adbf0818e384178093aa67e38ffdb112
+%global commit 0dde5c895075df6e3630e76f750a447cf63f4789
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/ecr-credential-provider/Cargo.toml
+++ b/packages/ecr-credential-provider/Cargo.toml
@@ -12,9 +12,8 @@ path = "pkg.rs"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.27.0/cloud-provider-aws-1.27.0.tar.gz"
-sha512 = "2803871801d222e58f46fe106067c6a05c3c4792774bd653f8be2f52b536f7b6510a5209636793f11aedcb2d46fa23157b0297a02912a76f3c70284027a10b60"
-
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.25.3/cloud-provider-aws-1.25.3.tar.gz"
+sha512 = "d727c01ea98608b0b51edc2bfe892218b55eee7148e358e18387f3f4a52ad765f8d0ee372884e36f95f1303c13dbeba81926f7560c325a8d3c258da11cdfc24b"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider/ecr-credential-provider.spec
+++ b/packages/ecr-credential-provider/ecr-credential-provider.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.0
+%global gover 1.25.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
packages: revert docker proxy to 0dde5c895075df6e3630e76f750a447cf63f4789
packages: revert ecr-credential-provider to 1.25.3
```

**Testing done:**
In progress 
- [x] aws-k8s-1.24
- [x] aws-k8s-1.24-nvidia

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
