### PR TITLE
ecs-nvidia: Upgrades Go dependencies

### DIFF
--- a/sources/ecs-gpu-init/go.mod
+++ b/sources/ecs-gpu-init/go.mod
@@ -2,4 +2,4 @@ module ecs-gpu-init
 
 go 1.19
 
-require github.com/NVIDIA/go-nvml v0.12.0-0
+require github.com/NVIDIA/go-nvml v0.12.0-1

--- a/sources/ecs-gpu-init/go.sum
+++ b/sources/ecs-gpu-init/go.sum
@@ -1,4 +1,2 @@
-github.com/NVIDIA/go-nvml v0.11.6-0 h1:tugQzmaX84Y/6+03wZ/MAgcpfSKDkvkAWeuxFNLHmxY=
-github.com/NVIDIA/go-nvml v0.11.6-0/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=
-github.com/NVIDIA/go-nvml v0.12.0-0 h1:eHYNHbzAsMgWYshf6dEmTY66/GCXnORJFnzm3TNH4mc=
-github.com/NVIDIA/go-nvml v0.12.0-0/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=
+github.com/NVIDIA/go-nvml v0.12.0-1 h1:6mdjtlFo+17dWL7VFPfuRMtf0061TF4DKls9pkSw6uM=
+github.com/NVIDIA/go-nvml v0.12.0-1/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=


### PR DESCRIPTION
**Issue number:**

N/a

**Description of changes:**

This upgrades the github.com/NVIDIA/go-nvml library used for ECS nvidia instances. This change from v0.12.0-0 to v0.12.0-1 contains 2 changes: https://github.com/NVIDIA/go-nvml/compare/v0.12.0-0...v0.12.0-1

Looks like this change also cleans up a dependency on one of the older versions of the driver

**Testing done:**

Launched an ecs nvidia instance and:

```
bash-5.1# cat /var/lib/ecs/gpu/nvidia-gpu-info.json
{"DriverVersion":"470.161.03","GPUIDs":["GPU-abc-123"]}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
