### PR TITLE
[migration] Add missing "mode" setting for kubernetes-ca-crt

### DIFF
--- a/sources/api/migration/migrations/v1.14.0/k8s-services-mode/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/k8s-services-mode/src/main.rs
@@ -9,6 +9,7 @@ fn run() -> Result<()> {
         "configuration-files.kubelet-bootstrap-kubeconfig.mode",
         "configuration-files.kubelet-exec-start-conf.mode",
         "configuration-files.credential-provider-config-yaml.mode",
+        "configuration-files.kubernetes-ca-crt.mode",
     ]))
 }
 


### PR DESCRIPTION
**Issue number:**
Related to #2921 

**Description of changes:**
```
This change adds the missing line to the migration to add the "mode" 
setting for `configuration-files.kubernetes-ca-crt`.
```

**Testing done:**
Build a `aws-k8s-1.24` 1.13.5 AMI (from 1.13.5 tag), built a repo including a (fictional) 1.14.0 image and associated new migrations.

* Booted into 1.13.5, checked for upgrade, and ensure that the `mode` file doesn't exist. Started upgrade.
```
bash-5.1# cat /etc/os-release                                                                                                                  
...                                                                                          
VARIANT_ID=aws-k8s-1.24                                                                                                                        
VERSION_ID=1.13.5                                                                                                                              
BUILD_ID=33225cc9                                                                                                                              
...
                                                                    
bash-5.1# ls /var/lib/bottlerocket/datastore/current/live/configuration-files/kubernetes-ca-crt/                                               
path  template-path              
                                                                                                              
bash-5.1# updog check-update -a --json                                                                                                         
[                                                                                                                                              
  {                                                                                                                                            
    "variant": "aws-k8s-1.24",                                                                                                                 
    "arch": "x86_64",                                                                                                                          
    "version": "1.14.0",                                                                                                                       
    "max_version": "1.14.0",
...
  }
]
bash-5.1# updog update -i 1.14.0 -r -n
```

* Ensure 1.14.0 came up correctly, ran the migration and the `mode` file exists and has the right value
```
bash-5.1# cat /etc/os-release 
...
VARIANT_ID=aws-k8s-1.24
VERSION_ID=1.14.0
BUILD_ID=dd2e6c6c
...

bash-5.1# ls /var/lib/bottlerocket/datastore/current/live/configuration-files/kubernetes-ca-crt/
mode  path  template-path
bash-5.1# cat /var/lib/bottlerocket/datastore/current/live/configuration-files/kubernetes-ca-crt/mode 
"0600"


bash-5.1# journalctl | grep -i migration
...
May 05 19:02:41 localhost migrator[2640]: 19:02:41 [INFO] Running migration 'migrate_v1.14.0_kubernetes-gc-percent-type-change.lz4'
May 05 19:02:41 localhost migrator[2640]: 19:02:41 [INFO] Running migration 'migrate_v1.14.0_kubelet-config-settings.lz4'
May 05 19:02:41 localhost migrator[2640]: 19:02:41 [INFO] Running migration 'migrate_v1.14.0_kubelet-prefix-config-settings.lz4'
May 05 19:02:41 localhost migrator[2640]: 19:02:41 [INFO] Running migration 'migrate_v1.14.0_k8s-services-mode.lz4'
...

bash-5.1# signpost rollback-to-inactive
bash-5.1# reboot
```
* Downgrade back to 1.13.5 and make sure the `mode` file disapears
```
bash-5.1# cat /etc/os-release 
...
VARIANT_ID=aws-k8s-1.24
VERSION_ID=1.13.5
BUILD_ID=33225cc9
...

bash-5.1# ls /var/lib/bottlerocket/datastore/current/live/configuration-files/kubernetes-ca-crt/
path  template-path
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
