### PR TITLE
start-local-vm: add "--product-name" argument to support BUILDSYS_NAME

### DIFF
--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -5,6 +5,7 @@ shopt -s nullglob
 
 arch=${BUILDSYS_ARCH}
 variant=${BUILDSYS_VARIANT}
+product_name=${BUILDSYS_NAME:-bottlerocket}
 host_port_forwards=tcp::2222-:22
 vm_mem=4G
 vm_cpus=4
@@ -41,6 +42,10 @@ Options:
                         BUILDSYS_ARCH environment variable is set)
     --variant           Bottlerocket variant to run (may be omitted if the
                         BUILDSYS_VARIANT environment variable is set)
+    --product-name
+                        product name used for file and directory naming used when
+                        building with the "-e BUILDSYS_NAME" option; may be omitted if the
+                        BUILDSYS_NAME environment variable is set. Otherwise default is bottlerocket if not defined or empty
     --host-port-forwards
                         list of host ports to forward to the VM; HOST_PORT_FWDS
                         must be a valid QEMU port forwarding specifier (default
@@ -92,6 +97,8 @@ parse_args() {
                 shift; arch=$1 ;;
             --variant)
                 shift; variant=$1 ;;
+            --product-name)
+                shift; product_name=$1 ;;
             --host-port-forwards)
                 shift; host_port_forwards=$1 ;;
             --vm-memory)
@@ -141,8 +148,8 @@ extract_image() {
 
 prepare_raw_images() {
     local -r image_dir=build/images/${arch}-${variant}/latest
-    local -r compressed_boot_image=${image_dir}/bottlerocket-${variant}-${arch}.img.lz4
-    local -r compressed_data_image=${image_dir}/bottlerocket-${variant}-${arch}-data.img.lz4
+    local -r compressed_boot_image=${image_dir}/${product_name}-${variant}-${arch}.img.lz4
+    local -r compressed_data_image=${image_dir}/${product_name}-${variant}-${arch}-data.img.lz4
 
     if [[ -e ${compressed_boot_image} ]]; then
         readonly boot_image=${compressed_boot_image%*.lz4}

--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2054  # Arrays are formatted for passing args to other tools
+
 shopt -s nullglob
 
 arch=${BUILDSYS_ARCH}
 variant=${BUILDSYS_VARIANT}
-product_name=bottlerocket
 host_port_forwards=tcp::2222-:22
 vm_mem=4G
 vm_cpus=4
@@ -41,9 +41,6 @@ Options:
                         BUILDSYS_ARCH environment variable is set)
     --variant           Bottlerocket variant to run (may be omitted if the
                         BUILDSYS_VARIANT environment variable is set)
-    --product-name
-                        product name used for file and directory naming used when
-                        building with the "-e BUILDSYS_NAME" option (default is bottlerocket)
     --host-port-forwards
                         list of host ports to forward to the VM; HOST_PORT_FWDS
                         must be a valid QEMU port forwarding specifier (default
@@ -95,8 +92,6 @@ parse_args() {
                 shift; arch=$1 ;;
             --variant)
                 shift; variant=$1 ;;
-            --product-name)
-                shift; product_name=$1 ;;
             --host-port-forwards)
                 shift; host_port_forwards=$1 ;;
             --vm-memory)
@@ -146,8 +141,8 @@ extract_image() {
 
 prepare_raw_images() {
     local -r image_dir=build/images/${arch}-${variant}/latest
-    local -r compressed_boot_image=${image_dir}/${product_name}-${variant}-${arch}.img.lz4
-    local -r compressed_data_image=${image_dir}/${product_name}-${variant}-${arch}-data.img.lz4
+    local -r compressed_boot_image=${image_dir}/bottlerocket-${variant}-${arch}.img.lz4
+    local -r compressed_data_image=${image_dir}/bottlerocket-${variant}-${arch}-data.img.lz4
 
     if [[ -e ${compressed_boot_image} ]]; then
         readonly boot_image=${compressed_boot_image%*.lz4}

--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2054  # Arrays are formatted for passing args to other tools
-
 shopt -s nullglob
 
 arch=${BUILDSYS_ARCH}
 variant=${BUILDSYS_VARIANT}
+product_name=bottlerocket
 host_port_forwards=tcp::2222-:22
 vm_mem=4G
 vm_cpus=4
@@ -41,6 +41,9 @@ Options:
                         BUILDSYS_ARCH environment variable is set)
     --variant           Bottlerocket variant to run (may be omitted if the
                         BUILDSYS_VARIANT environment variable is set)
+    --product-name
+                        product name used for file and directory naming used when
+                        building with the "-e BUILDSYS_NAME" option (default is bottlerocket)
     --host-port-forwards
                         list of host ports to forward to the VM; HOST_PORT_FWDS
                         must be a valid QEMU port forwarding specifier (default
@@ -92,6 +95,8 @@ parse_args() {
                 shift; arch=$1 ;;
             --variant)
                 shift; variant=$1 ;;
+            --product-name)
+                shift; product_name=$1 ;;
             --host-port-forwards)
                 shift; host_port_forwards=$1 ;;
             --vm-memory)
@@ -141,8 +146,8 @@ extract_image() {
 
 prepare_raw_images() {
     local -r image_dir=build/images/${arch}-${variant}/latest
-    local -r compressed_boot_image=${image_dir}/bottlerocket-${variant}-${arch}.img.lz4
-    local -r compressed_data_image=${image_dir}/bottlerocket-${variant}-${arch}-data.img.lz4
+    local -r compressed_boot_image=${image_dir}/${product_name}-${variant}-${arch}.img.lz4
+    local -r compressed_data_image=${image_dir}/${product_name}-${variant}-${arch}-data.img.lz4
 
     if [[ -e ${compressed_boot_image} ]]; then
         readonly boot_image=${compressed_boot_image%*.lz4}


### PR DESCRIPTION
**Issue:**
The script start-local-vm don't find the image when the image is built with a custom BUILDSYS_NAME.

```
# cargo make -e BUILDSYS_VARIANT=metal-dev -e BUILDSYS_NAME=my-bottlerocket
# ./tools/start-local-vm --arch x86_64 --inject-file net.toml --inject-file user-data.toml --variant metal-dev
Boot image not found. Did the last build fail?
```


In the `start-local-vm` the bottlerocket image name prefix is hard coded.


**Description of changes:**
Add an optionnal argument `--product-name` to the script `start-local-vm`



**Testing done:**
Verified the VM launch without  `--product-name` when the image is built without custom BUILDSYS_NAME
```
# cargo make -e BUILDSYS_VARIANT=metal-dev
# ./tools/start-local-vm --arch x86_64 --inject-file net.toml --inject-file user-data.toml --variant metal-dev 

```
--> the VM start


Verified the VM launch with argument `--product-name` supplied when the image is built custom BUILDSYS_NAME
```
# cargo make -e BUILDSYS_VARIANT=metal-dev -e BUILDSYS_NAME=my-bottlerocket
# ./tools/start-local-vm --arch x86_64 --inject-file net.toml --inject-file user-data.toml --variant metal-dev --product-name my-bottlerocket

```
--> the VM start



Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.