### PR TITLE
Update host containers for v1.14.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -206,4 +206,6 @@ version = "1.14.0"
     "migrate_v1.14.0_kubelet-config-settings.lz4",
     "migrate_v1.14.0_kubelet-prefix-config-settings.lz4",
     "migrate_v1.14.0_k8s-services-mode.lz4",
+    "migrate_v1.14.0_aws-admin-container-v0-10-1.lz4",
+    "migrate_v1.14.0_public-admin-container-v0-10-1.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -208,4 +208,6 @@ version = "1.14.0"
     "migrate_v1.14.0_k8s-services-mode.lz4",
     "migrate_v1.14.0_aws-admin-container-v0-10-1.lz4",
     "migrate_v1.14.0_public-admin-container-v0-10-1.lz4",
+    "migrate_v1.14.0_aws-control-container-v0-7-2.lz4",
+    "migrate_v1.14.0_public-control-container-v0-7-2.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -498,6 +498,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-10-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-admin-container-v0-9-4"
 version = "0.1.0"
 dependencies = [
@@ -2998,6 +3005,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-10-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-10-1"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -555,6 +555,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3040,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-2"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -50,6 +50,8 @@ members = [
     "api/migration/migrations/v1.14.0/k8s-services-mode",
     "api/migration/migrations/v1.14.0/aws-admin-container-v0-10-1",
     "api/migration/migrations/v1.14.0/public-admin-container-v0-10-1",
+    "api/migration/migrations/v1.14.0/aws-control-container-v0-7-2",
+    "api/migration/migrations/v1.14.0/public-control-container-v0-7-2",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -48,6 +48,8 @@ members = [
     "api/migration/migrations/v1.14.0/kubelet-config-settings",
     "api/migration/migrations/v1.14.0/kubelet-prefix-config-settings",
     "api/migration/migrations/v1.14.0/k8s-services-mode",
+    "api/migration/migrations/v1.14.0/aws-admin-container-v0-10-1",
+    "api/migration/migrations/v1.14.0/public-admin-container-v0-10-1",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.14.0/aws-admin-container-v0-10-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/aws-admin-container-v0-10-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-10-1"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.0/aws-admin-container-v0-10-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/aws-admin-container-v0-10-1/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.0";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.1";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.14.0/aws-control-container-v0-7-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/aws-control-container-v0-7-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-2"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.0/aws-control-container-v0-7-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/aws-control-container-v0-7-2/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.1";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.2";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.14.0/public-admin-container-v0-10-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/public-admin-container-v0-10-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-10-1"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.0/public-admin-container-v0-10-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/public-admin-container-v0-10-1/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.0";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.14.0/public-control-container-v0-7-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.0/public-control-container-v0-7-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-2"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.0/public-control-container-v0-7-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.0/public-control-container-v0-7-2/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.1";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.0"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.1"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.1"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.2"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.1"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Issue number:** ~n/a~ Closes #2997

**Description of changes:** Update the default admin and control container images to [v0.10.1](https://github.com/bottlerocket-os/bottlerocket-admin-container/releases/tag/v0.10.1) and [v0.7.2](https://github.com/bottlerocket-os/bottlerocket-control-container/releases/tag/v0.7.2), respectively.


**Testing done:** Container images have been tested as part of their respective release process. My testing here looked at the migrations and new defaults using an x86_64 aws-k8s-1.23 AMI:

* `cargo make check-migrations` (new in #3051) was happy.
* An instance booting using a v1.14.0 AMI has the new host container images configured by default.
* A v1.13.5 AMI can be upgraded to v1.14.0 and then uses the new host container images.
* An updated v1.14.0 can be rolled back to v1.13.5 and then uses the old host container images.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
