### PR TITLE
kernel-5.15: Default disable panic on hung task and lockups

### DIFF
--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -195,3 +195,8 @@ CONFIG_SCSI_ISCSI_ATTRS=m
 # target side
 CONFIG_ISCSI_TARGET=m
 # CONFIG_INFINIBAND_ISERT is not set
+
+# Disable panic on hung and lockup conditions by default
+# CONFIG_BOOTPARAM_SOFTLOCKUP_PANIC is not set
+# CONFIG_BOOTPARAM_HARDLOCKUP_PANIC is not set
+# CONFIG_BOOTPARAM_HUNG_TASK_PANIC is not set


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #3087 

**Description of changes:**

Change the default for panic on hung tasks and lockups from default on to default off.
This is intended to be a discussion starter on if we want to change the default or not.

```
Setting panic as defaults for hung tasks and lockups is probably not the best
idea for the general case. In scenarios with remote storage we may see hangs
as interactions with that storage might be delayed due to network connectivity
issues. In such cases there is use cases that do not benefit from panic and reboot.

Disable the default for those panic options. This does not take away the option to
configure panic on hung tasks or lockups through either sysctl or kernel boot parameters.

As a bonus this aligns both kernels 5.10 and 5.15 on coherent settings for the panic choices.
```

**Testing done:**

Checked we are only changing the appropriate options:

```
config-aarch64-aws-dev-diff:      0 removed,   0 added,   4 changed
config-x86_64-aws-dev-diff:       0 removed,   0 added,   6 changed
```

```
==> configs_panic_disable/config-aarch64-aws-dev-diff <==
 BOOTPARAM_HUNG_TASK_PANIC y -> n
 BOOTPARAM_HUNG_TASK_PANIC_VALUE 1 -> 0
 BOOTPARAM_SOFTLOCKUP_PANIC y -> n
 BOOTPARAM_SOFTLOCKUP_PANIC_VALUE 1 -> 0

==> configs_panic_disable/config-x86_64-aws-dev-diff <==
 BOOTPARAM_HARDLOCKUP_PANIC y -> n
 BOOTPARAM_HARDLOCKUP_PANIC_VALUE 1 -> 0
 BOOTPARAM_HUNG_TASK_PANIC y -> n
 BOOTPARAM_HUNG_TASK_PANIC_VALUE 1 -> 0
 BOOTPARAM_SOFTLOCKUP_PANIC y -> n
 BOOTPARAM_SOFTLOCKUP_PANIC_VALUE 1 -> 0
```

No further testing done as these config options merely change the default value of a variable,
which may or may not be overridden at runtime or system boot through sysctl or kernel boot parameters.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
