### PR TITLE
thar-be-settings: truncate existing configuration files when writing

### DIFF
--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -160,7 +160,11 @@ impl RenderedConfigFile {
         };
 
         let mut binding = OpenOptions::new();
-        let options = binding.write(true).create(true).mode(DEFAULT_FILE_MODE);
+        let options = binding
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(DEFAULT_FILE_MODE);
 
         // See if this file has a config setting for a specific mode
         if let Some(mode) = &self.mode {


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

When writing configuration files in `thar-be-settings`, we would previously use [`fs::write`](https://doc.rust-lang.org/src/std/fs.rs.html#325-330), which uses [`File::create`](https://doc.rust-lang.org/std/fs/struct.File.html#method.create) under the hood. When implementing [the ability to set permissions](https://github.com/bottlerocket-os/bottlerocket/commit/cec8e203d287ea51942131e5fbbf175d2344c8e5), we missed setting the `truncate` flag to keep this behavior.


**Testing done:**

Before the fix, since the file was not truncated, any remaining bytes would still be visible. In this case, "Welcome to Bottlerocket!" has been partially overwritten.

```
$ apiclient set motd=hey
$ cat /etc/motd
hey
ome to Bottlerocket!
```

After the fix, the file is truncated and only contains the expected content: 
```
$ apiclient set motd=sup
$ cat /etc/motd
sup
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
