### PR TITLE
k8s 1.27: remove defaults for kube-api-burst and kube-api-qps

### DIFF
--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -71,8 +71,12 @@ eventRecordQPS: {{settings.kubernetes.event-qps}}
 {{#if settings.kubernetes.event-burst includeZero=true}}
 eventBurst: {{settings.kubernetes.event-burst}}
 {{/if}}
-kubeAPIQPS: {{default 10 settings.kubernetes.kube-api-qps}}
-kubeAPIBurst: {{default 20 settings.kubernetes.kube-api-burst}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
+kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
+kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
+{{/if}}
 kubeReserved:
   cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
   {{#if settings.kubernetes.kube-reserved.memory}}


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

Removes the default value for kube-api-burst and kube-api-qps

In K8s 1.27, the defaults were increased https://github.com/kubernetes/kubernetes/pull/116121 to 50/100 which is even higher, so we can rely on those defaults now.

**Testing done:**

```sh
cargo make \
  -e BUILDSYS_VARIANT="aws-k8s-1.27" \
  -e BUILDSYS_ARCH="x86_64" \
  unit-tests
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
