### PR TITLE
k8s 1.27: Fix China ECR url pattern

### DIFF
--- a/sources/models/shared-defaults/kubernetes-aws-credential-provider.toml
+++ b/sources/models/shared-defaults/kubernetes-aws-credential-provider.toml
@@ -3,7 +3,7 @@ enabled = true
 cache-duration = "12h"
 image-patterns = [
     "*.dkr.ecr.*.amazonaws.com",
-    "*.dkr.ecr.*.amazonaws.cn",
+    "*.dkr.ecr.*.amazonaws.com.cn",
     "*.dkr.ecr-fips.*.amazonaws.com",
     "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
     "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"


### PR DESCRIPTION
**Issue number:**

See https://github.com/awslabs/amazon-eks-ami/pull/1280

**Description of changes:**

The default settings for the Kubernetes ecr-credential-provider used for the 1.27 variants had a typo. This corrects that to the necessary pattern for pulling images hosted in China.

**Testing done:**

Visual inspection to verify the pattern now matches the URLs used for ECR in China.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
