### PR TITLE
add support for Secure Boot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,5 @@
 /build/rpms/*-debuginfo-*.rpm
 /build/rpms/*-debugsource-*.rpm
 **/target/*
+/sbkeys
 /tests

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /*.pem
 /keys
 /roles
+/sbkeys/**/
 /Licenses.toml
 /licenses
 *.run

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ ARG VARIANT_FAMILY
 ARG VARIANT_FLAVOR
 ARG REPO
 ARG GRUB_SET_PRIVATE_VAR
+ARG UEFI_SECURE_BOOT
 ARG SYSTEMD_NETWORKD
 ARG UNIFIED_CGROUP_HIERARCHY
 ARG XFS_DATA_PARTITION
@@ -101,6 +102,7 @@ RUN rpmdev-setuptree \
    && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> .bconds \
    && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> .bconds \
    && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> .bconds \
+   && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> .bconds \
    && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> .bconds \
    && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> .bconds \
    && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> .bconds \
@@ -200,6 +202,7 @@ ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG KERNEL_PARAMETERS
 ARG GRUB_SET_PRIVATE_VAR
 ARG XFS_DATA_PARTITION
+ARG UEFI_SECURE_BOOT
 ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
     KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
@@ -219,6 +222,7 @@ RUN --mount=target=/host \
       --ovf-template="/host/variants/${VARIANT}/template.ovf" \
       ${XFS_DATA_PARTITION:+--xfs-data-partition=yes} \
       ${GRUB_SET_PRIVATE_VAR:+--with-grub-set-private-var=yes} \
+      ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
     && echo ${NOCACHE}
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=

--- a/Dockerfile
+++ b/Dockerfile
@@ -210,6 +210,19 @@ WORKDIR /root
 
 USER root
 RUN --mount=target=/host \
+    --mount=type=secret,id=PK.crt,target=/root/sbkeys/PK.crt \
+    --mount=type=secret,id=KEK.crt,target=/root/sbkeys/KEK.crt \
+    --mount=type=secret,id=db.crt,target=/root/sbkeys/db.crt \
+    --mount=type=secret,id=vendor.crt,target=/root/sbkeys/vendor.crt \
+    --mount=type=secret,id=shim-sign.key,target=/root/sbkeys/shim-sign.key \
+    --mount=type=secret,id=shim-sign.crt,target=/root/sbkeys/shim-sign.crt \
+    --mount=type=secret,id=code-sign.key,target=/root/sbkeys/code-sign.key \
+    --mount=type=secret,id=code-sign.crt,target=/root/sbkeys/code-sign.crt \
+    --mount=type=secret,id=config-sign.key,target=/root/sbkeys/config-sign.key \
+    --mount=type=secret,id=kms-sign.json,target=/root/.config/aws-kms-pkcs11/config.json \
+    --mount=type=secret,id=aws-access-key-id.env,target=/root/.aws/aws-access-key-id.env \
+    --mount=type=secret,id=aws-secret-access-key.env,target=/root/.aws/aws-secret-access-key.env \
+    --mount=type=secret,id=aws-session-token.env,target=/root/.aws/aws-session-token.env \
     /host/tools/rpm2img \
       --package-dir=/local/rpms \
       --output-dir=/local/output \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -843,7 +843,7 @@ cargo build \
 ]
 
 [tasks.build-variant]
-dependencies = ["fetch-sdk", "build-tools", "publish-setup"]
+dependencies = ["fetch-sdk", "build-tools", "build-sbkeys", "publish-setup"]
 script = [
 '''
 export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1228,6 +1228,7 @@ pubsys \
    "${data_volume_args[@]}" \
    \
    --variant-manifest "${BUILDSYS_ROOT_DIR}/variants/${BUILDSYS_VARIANT}/Cargo.toml" \
+   --uefi-data "${BUILDSYS_SBKEYS_PROFILE_DIR}/efi-vars.aws" \
    --arch "${BUILDSYS_ARCH}" \
    --name "${ami_name}" \
    --description "${PUBLISH_AMI_DESCRIPTION:-${ami_name}}" \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,6 +10,8 @@ BUILDSYS_STATE_DIR = "${BUILDSYS_BUILD_DIR}/state"
 BUILDSYS_IMAGES_DIR = "${BUILDSYS_BUILD_DIR}/images"
 BUILDSYS_TOOLS_DIR = "${BUILDSYS_ROOT_DIR}/tools"
 BUILDSYS_SOURCES_DIR = "${BUILDSYS_ROOT_DIR}/sources"
+BUILDSYS_SBKEYS_DIR = "${BUILDSYS_ROOT_DIR}/sbkeys"
+BUILDSYS_SBKEYS_PROFILE = { script = ['echo "${BUILDSYS_SBKEYS_PROFILE:-local}"'] }
 BUILDSYS_TIMESTAMP = { script = ["date +%s"] }
 BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*' || echo 00000000"] }
 # For now, release config path can't be overridden with -e, because it's used
@@ -156,6 +158,9 @@ BUILDSYS_NAME_FRIENDLY = "${BUILDSYS_NAME_VARIANT}-v${BUILDSYS_VERSION_IMAGE}"
 
 # For variant build artifacts.
 BUILDSYS_VARIANT_DIR = "${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_VERSION_FULL}"
+
+# Depends on ${BUILDSYS_SBKEYS_DIR} and ${BUILDSYS_SBKEYS_PROFILE}.
+BUILDSYS_SBKEYS_PROFILE_DIR = "${BUILDSYS_SBKEYS_DIR}/${BUILDSYS_SBKEYS_PROFILE}"
 
 # Path to repo-specific root role.
 PUBLISH_REPO_ROOT_JSON = "${BUILDSYS_ROOT_DIR}/roles/${PUBLISH_REPO}.root.json"
@@ -677,6 +682,52 @@ cargo install \
   --root tools \
   --force \
   --quiet
+'''
+]
+
+[tasks.build-sbkeys]
+dependencies = ["fetch"]
+script_runner = "bash"
+script = [
+'''
+# Check the profile for all files needed for Secure Boot signing.
+profile="${BUILDSYS_SBKEYS_PROFILE_DIR}"
+
+found=0
+# A local profile has signing keys and certificates, while an AWS profile
+# has a config for the aws-kms-pkcs11 helper. Either type is supported.
+if [ -s "${profile}/shim-sign.key" ] && \
+   [ -s "${profile}/shim-sign.crt" ] && \
+   [ -s "${profile}/code-sign.key" ] && \
+   [ -s "${profile}/code-sign.crt" ] ; then
+   let found+=1
+elif [ -s "${profile}/kms-sign.json" ] ; then
+   let found+=1
+fi
+
+expected=1
+for f in {PK,KEK,db,vendor}.crt config-sign.key efi-vars.{json,aws} ; do
+  let expected+=1
+  [ -s "${profile}/${f}" ] && let found+=1
+done
+
+if [ "${found}" -eq "${expected}" ] ; then
+  exit 0
+fi
+
+if [ "${found}" -gt 0 ] ; then
+  echo "Incomplete Secure Boot signing profile found in ${profile}." >&2
+  echo "Missing $(( expected - found )) files." >&2
+  exit 1
+fi
+
+echo "No Secure Boot signing profile found in ${profile}." >&2
+echo "Generating local keys." >&2
+
+mkdir -p "${BUILDSYS_SBKEYS_PROFILE_DIR}"
+${BUILDSYS_SBKEYS_DIR}/generate-local-sbkeys \
+  --sdk-image "${BUILDSYS_SDK_IMAGE}" \
+  --output-dir "${BUILDSYS_SBKEYS_PROFILE_DIR}"
 '''
 ]
 

--- a/PROVISIONING-METAL.md
+++ b/PROVISIONING-METAL.md
@@ -333,3 +333,20 @@ docker run --rm \
    "${SDK_IMAGE}" \
    bootconfig -l /tmp/bootconfig.data
 ```
+
+### Enable Secure Boot
+
+Starting with metal-k8s-1.28, the Bottlerocket images for bare metal support Secure Boot when used on a platform with UEFI firmware.
+UEFI boot mode must be used, rather than legacy BIOS boot mode, and Secure Boot must be enabled.
+The UEFI firmware may provide a Compatibility Support Module (CSM) option to enable legacy BIOS emulation.
+The CSM option must not be enabled.
+These options can be set in the firmware setup menu, which can be accessed during boot by pressing a certain key (such as F2 or F12).
+
+Many Linux distros ship a copy of the [shim](https://github.com/rhboot/shim) bootloader signed by Microsoft with a key that is trusted by default.
+Although Bottlerocket also uses `shim`, its copy is not signed by Microsoft and will not be trusted without additional configuration.
+After installing Bottlerocket, the appropriate vendor certificate can be found on the EFI System Partition (ESP).
+The firmware setup menu should provide an option to import a new vendor certificate by selecting a file on the ESP.
+Either the PEM format (`db.crt`) or DER format (`db.cer`) certificate can be imported, depending on what the firmware supports.
+
+The firmware setup menu should be password-protected to prevent unauthorized changes to the Secure Boot configuration.
+Please refer to the documentation from your hardware vendor for more information on this procedure.

--- a/packages/grub/0042-util-mkimage-Bump-EFI-PE-header-size-to-accommodate-.patch
+++ b/packages/grub/0042-util-mkimage-Bump-EFI-PE-header-size-to-accommodate-.patch
@@ -1,0 +1,46 @@
+From 2dd65e321c9786dbec249e0826c58f530bcb5883 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Fri, 28 Oct 2022 13:39:03 +0000
+Subject: [PATCH] util/mkimage: Bump EFI PE header size to accommodate .sbat
+ section
+
+With the --sbat option mkimage can embed SBAT metadata into a dedicated
+.sbat section of the EFI image. However, no space was explicitly
+reserved for this section in the section table of the PE header.
+
+The miss has no adverse effects since there was enough padding in the
+header anyway due to alignment constraints. An earlier commit,
+a51f953f4ee8 ("mkimage: Align efi sections on 4k boundary"), increased
+alignment to 4 KiB, so that the extra section table entry fit
+comfortably inside the space reserved for the entire header anyway.
+
+Fixes: b11547137703 ("util/mkimage: Add an option to import SBAT metadata into a .sbat section")
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ util/mkimage.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/util/mkimage.c b/util/mkimage.c
+index c3d33aa..2db1045 100644
+--- a/util/mkimage.c
++++ b/util/mkimage.c
+@@ -65,14 +65,14 @@
+ 				    + GRUB_PE32_SIGNATURE_SIZE		\
+ 				    + sizeof (struct grub_pe32_coff_header) \
+ 				    + sizeof (struct grub_pe32_optional_header) \
+-				    + 4 * sizeof (struct grub_pe32_section_table), \
++				    + 5 * sizeof (struct grub_pe32_section_table), \
+ 				    GRUB_PE32_FILE_ALIGNMENT)
+ 
+ #define EFI64_HEADER_SIZE ALIGN_UP (GRUB_PE32_MSDOS_STUB_SIZE		\
+ 				    + GRUB_PE32_SIGNATURE_SIZE		\
+ 				    + sizeof (struct grub_pe32_coff_header) \
+ 				    + sizeof (struct grub_pe64_optional_header) \
+-				    + 4 * sizeof (struct grub_pe32_section_table), \
++				    + 5 * sizeof (struct grub_pe32_section_table), \
+ 				    GRUB_PE32_FILE_ALIGNMENT)
+ 
+ static const struct grub_install_image_target_desc image_targets[] =
+-- 
+2.39.0
+

--- a/packages/grub/0043-util-mkimage-avoid-adding-section-table-entry-outsid.patch
+++ b/packages/grub/0043-util-mkimage-avoid-adding-section-table-entry-outsid.patch
@@ -1,0 +1,98 @@
+From 45468642affc3d641b5d73c5d6e63e1578bf9150 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Fri, 28 Oct 2022 16:09:05 +0000
+Subject: [PATCH] util/mkimage: avoid adding section table entry outside PE EFI
+ header
+
+The number of sections in a PE EFI image can vary depending on the
+options passed to mkimage, but their maximum number must be known at
+compile time. Potentially adding a new section to a PE EFI image
+therefore requires changes in at least two places of the code.
+
+The prior commit fixed a situation where the maximum number of sections
+was not bumped while implementing support for an new section. Catch
+these situations at runtime rather than silently relying on sufficient
+padding being available for the new section table entry or overwriting
+part of the image.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ util/mkimage.c | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/util/mkimage.c b/util/mkimage.c
+index 2db1045..1455c94 100644
+--- a/util/mkimage.c
++++ b/util/mkimage.c
+@@ -821,6 +821,7 @@ grub_install_get_image_targets_string (void)
+  */
+ static struct grub_pe32_section_table *
+ init_pe_section(const struct grub_install_image_target_desc *image_target,
++		const char *pe_img,
+ 		struct grub_pe32_section_table *section,
+ 		const char * const name,
+ 		grub_uint32_t *vma, grub_uint32_t vsz, grub_uint32_t valign,
+@@ -828,6 +829,15 @@ init_pe_section(const struct grub_install_image_target_desc *image_target,
+ 		grub_uint32_t characteristics)
+ {
+   size_t len = strlen (name);
++  const char *pe_header_end;
++
++  if (image_target->voidp_sizeof == 4)
++    pe_header_end = pe_img + EFI32_HEADER_SIZE;
++  else
++    pe_header_end = pe_img + EFI64_HEADER_SIZE;
++
++  if ((char *) section >= pe_header_end)
++    grub_util_error (_("section table space exhausted trying to add %s"), name);
+ 
+   if (len > sizeof (section->name))
+     grub_util_error (_("section name %s length is bigger than %lu"),
+@@ -1438,7 +1448,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 	/* The sections.  */
+ 	PE_OHDR (o32, o64, code_base) = grub_host_to_target32 (vma);
+ 	PE_OHDR (o32, o64, code_size) = grub_host_to_target32 (layout.exec_size);
+-	section = init_pe_section (image_target, section, ".text",
++	section = init_pe_section (image_target, pe_img, section, ".text",
+ 				   &vma, layout.exec_size,
+ 				   image_target->section_align,
+ 				   &raw_data, layout.exec_size,
+@@ -1452,7 +1462,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 							       ALIGN_UP (total_module_size,
+ 									 GRUB_PE32_FILE_ALIGNMENT));
+ 
+-	section = init_pe_section (image_target, section, ".data",
++	section = init_pe_section (image_target, pe_img, section, ".data",
+ 				   &vma, scn_size, image_target->section_align,
+ 				   &raw_data, scn_size,
+ 				   GRUB_PE32_SCN_CNT_INITIALIZED_DATA |
+@@ -1460,7 +1470,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 				   GRUB_PE32_SCN_MEM_WRITE);
+ 
+ 	scn_size = pe_size - layout.reloc_size - sbat_size - raw_data;
+-	section = init_pe_section (image_target, section, "mods",
++	section = init_pe_section (image_target, pe_img, section, "mods",
+ 				   &vma, scn_size, image_target->section_align,
+ 				   &raw_data, scn_size,
+ 				   GRUB_PE32_SCN_CNT_INITIALIZED_DATA |
+@@ -1472,7 +1482,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 	    pe_sbat = pe_img + raw_data;
+ 	    grub_util_load_image (sbat_path, pe_sbat);
+ 
+-	    section = init_pe_section (image_target, section, ".sbat",
++	    section = init_pe_section (image_target, pe_img, section, ".sbat",
+ 				       &vma, sbat_size,
+ 				       image_target->section_align,
+ 				       &raw_data, sbat_size,
+@@ -1484,7 +1494,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 	PE_OHDR (o32, o64, base_relocation_table.rva) = grub_host_to_target32 (vma);
+ 	PE_OHDR (o32, o64, base_relocation_table.size) = grub_host_to_target32 (scn_size);
+ 	memcpy (pe_img + raw_data, layout.reloc_section, scn_size);
+-	init_pe_section (image_target, section, ".reloc",
++	init_pe_section (image_target, pe_img, section, ".reloc",
+ 			 &vma, scn_size, image_target->section_align,
+ 			 &raw_data, scn_size,
+ 			 GRUB_PE32_SCN_CNT_INITIALIZED_DATA |
+-- 
+2.39.0
+

--- a/packages/grub/0044-efi-return-virtual-size-of-section-found-by-grub_efi.patch
+++ b/packages/grub/0044-efi-return-virtual-size-of-section-found-by-grub_efi.patch
@@ -1,0 +1,93 @@
+From 076f520ec85198e82ddc0615e596df2a1ce4264b Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Wed, 2 Nov 2022 11:43:32 +0000
+Subject: [PATCH] efi: return virtual size of section found by
+ grub_efi_section_addr
+
+Return the virtual size of a section found by grub_efi_section_addr if
+the caller asked for it. Modify the few existing callers who don't care
+about the section size to fit the extended interface.
+
+This is close to the point where the implementation could do with a
+refactoring, e.g. have a separate grub_efi_find_section that returns the
+entire section table entry, and more focused convenience functions to
+access those. However, grub_efi_find_section itself is already the
+result of a Fedora refactoring, so I'm keeping the changes minimal.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ grub-core/kern/efi/efi.c  | 8 ++++++--
+ grub-core/kern/efi/init.c | 6 +++---
+ include/grub/efi/efi.h    | 2 +-
+ 3 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
+index 4ac2b27..3a4475c 100644
+--- a/grub-core/kern/efi/efi.c
++++ b/grub-core/kern/efi/efi.c
+@@ -310,9 +310,11 @@ grub_efi_get_variable (const char *var, const grub_efi_guid_t *guid,
+ #pragma GCC diagnostic ignored "-Wcast-align"
+ 
+ /* Search the mods section from the PE32/PE32+ image. This code uses
+-   a PE32 header, but should work with PE32+ as well.  */
++   a PE32 header, but should work with PE32+ as well. If vsz is not
++   NULL and the section is found, the virtual size of the section
++   is written to *vsz. */
+ grub_addr_t
+-grub_efi_section_addr (const char *section_name)
++grub_efi_section_addr (const char *section_name, grub_uint32_t *vsz)
+ {
+   grub_efi_loaded_image_t *image;
+   struct grub_pe32_header *header;
+@@ -359,6 +361,8 @@ grub_efi_section_addr (const char *section_name)
+ 
+   grub_dprintf("sections", "returning section info for section %d: \"%s\"\n",
+ 	       i, section->name);
++  if (vsz)
++    *vsz = section->virtual_size;
+   return (grub_addr_t) info;
+ }
+ 
+diff --git a/grub-core/kern/efi/init.c b/grub-core/kern/efi/init.c
+index 0574d8d..533de93 100644
+--- a/grub-core/kern/efi/init.c
++++ b/grub-core/kern/efi/init.c
+@@ -116,11 +116,11 @@ grub_efi_print_gdb_info (void)
+   grub_addr_t text;
+   grub_addr_t data;
+ 
+-  text = grub_efi_section_addr (".text");
++  text = grub_efi_section_addr (".text", NULL);
+   if (!text)
+     return;
+ 
+-  data = grub_efi_section_addr (".data");
++  data = grub_efi_section_addr (".data", NULL);
+   if (data)
+     grub_qdprintf ("gdb",
+ 		  "add-symbol-file /usr/lib/debug/usr/lib/grub/%s-%s/"
+@@ -136,7 +136,7 @@ grub_efi_print_gdb_info (void)
+ void
+ grub_efi_init (void)
+ {
+-  grub_modbase = grub_efi_section_addr ("mods");
++  grub_modbase = grub_efi_section_addr ("mods", NULL);
+   /* First of all, initialize the console so that GRUB can display
+      messages.  */
+   grub_console_init ();
+diff --git a/include/grub/efi/efi.h b/include/grub/efi/efi.h
+index 449e552..5841a2e 100644
+--- a/include/grub/efi/efi.h
++++ b/include/grub/efi/efi.h
+@@ -152,7 +152,7 @@ grub_err_t grub_arch_efi_linux_boot_image(grub_addr_t addr, grub_size_t size,
+ 					  char *args, int nx_enabled);
+ #endif
+ 
+-grub_addr_t grub_efi_section_addr (const char *section);
++grub_addr_t grub_efi_section_addr (const char *section, grub_uint32_t *vsz);
+ 
+ void grub_efi_mm_init (void);
+ void grub_efi_mm_fini (void);
+-- 
+2.39.0
+

--- a/packages/grub/0045-mkimage-pgp-move-single-public-key-into-its-own-sect.patch
+++ b/packages/grub/0045-mkimage-pgp-move-single-public-key-into-its-own-sect.patch
@@ -1,0 +1,261 @@
+From eaa371d26be8f76f9d7ce7e9c4b5d30684a48f11 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Mon, 24 Oct 2022 15:20:23 +0000
+Subject: [PATCH] mkimage, pgp: move single public key into its own section of
+ EFI image
+
+If mkimage is asked to embed a single public key for signature checking
+into an EFI image, move that key into a new .pubkey section of the PE
+file. Moving the key into its dedicated section allows for easily
+swapping the public key, e.g. using objcopy, without having to rebuild
+the image.
+
+If more than one key is to be embedded, no new section is created and
+all keys are embedded as modules just as before. The PGP signature
+verification will check both of these sources for valid keys.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ grub-core/commands/pgp.c | 28 ++++++++++++++
+ include/grub/efi/efi.h   |  2 +-
+ util/mkimage.c           | 84 +++++++++++++++++++++++++++-------------
+ 3 files changed, 87 insertions(+), 27 deletions(-)
+
+diff --git a/grub-core/commands/pgp.c b/grub-core/commands/pgp.c
+index b81ac0a..5fa1e8e 100644
+--- a/grub-core/commands/pgp.c
++++ b/grub-core/commands/pgp.c
+@@ -32,6 +32,7 @@
+ #include <grub/kernel.h>
+ #include <grub/extcmd.h>
+ #include <grub/verify.h>
++#include <grub/efi/efi.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -959,6 +960,33 @@ GRUB_MOD_INIT(pgp)
+     grub_pk_trusted = pk;
+   }
+ 
++#ifdef GRUB_MACHINE_EFI
++  {
++    grub_addr_t pubkey_section;
++    grub_uint32_t pubkey_vsz;
++
++    pubkey_section = grub_efi_section_addr (".pubkey", &pubkey_vsz);
++    if (pubkey_section)
++      {
++	struct grub_file pseudo_file;
++	struct grub_public_key *pk;
++
++	grub_memset (&pseudo_file, 0, sizeof (pseudo_file));
++
++	pseudo_file.fs = &pseudo_fs;
++	pseudo_file.size = pubkey_vsz;
++	pseudo_file.data = (char *) pubkey_section;
++
++	pk = grub_load_public_key (&pseudo_file);
++	if (!pk)
++	  grub_fatal ("error loading key from .pubkey section: %s\n", grub_errmsg);
++
++	pk->next = grub_pk_trusted;
++	grub_pk_trusted = pk;
++      }
++  }
++#endif /* GRUB_MACHINE_EFI */
++
+   if (!val)
+     grub_env_set ("check_signatures", grub_pk_trusted ? "enforce" : "no");
+ 
+diff --git a/include/grub/efi/efi.h b/include/grub/efi/efi.h
+index 5841a2e..d580b6b 100644
+--- a/include/grub/efi/efi.h
++++ b/include/grub/efi/efi.h
+@@ -152,7 +152,7 @@ grub_err_t grub_arch_efi_linux_boot_image(grub_addr_t addr, grub_size_t size,
+ 					  char *args, int nx_enabled);
+ #endif
+ 
+-grub_addr_t grub_efi_section_addr (const char *section, grub_uint32_t *vsz);
++grub_addr_t EXPORT_FUNC(grub_efi_section_addr) (const char *section, grub_uint32_t *vsz);
+ 
+ void grub_efi_mm_init (void);
+ void grub_efi_mm_fini (void);
+diff --git a/util/mkimage.c b/util/mkimage.c
+index 1455c94..01362d1 100644
+--- a/util/mkimage.c
++++ b/util/mkimage.c
+@@ -65,14 +65,14 @@
+ 				    + GRUB_PE32_SIGNATURE_SIZE		\
+ 				    + sizeof (struct grub_pe32_coff_header) \
+ 				    + sizeof (struct grub_pe32_optional_header) \
+-				    + 5 * sizeof (struct grub_pe32_section_table), \
++				    + 6 * sizeof (struct grub_pe32_section_table), \
+ 				    GRUB_PE32_FILE_ALIGNMENT)
+ 
+ #define EFI64_HEADER_SIZE ALIGN_UP (GRUB_PE32_MSDOS_STUB_SIZE		\
+ 				    + GRUB_PE32_SIGNATURE_SIZE		\
+ 				    + sizeof (struct grub_pe32_coff_header) \
+ 				    + sizeof (struct grub_pe64_optional_header) \
+-				    + 5 * sizeof (struct grub_pe32_section_table), \
++				    + 6 * sizeof (struct grub_pe32_section_table), \
+ 				    GRUB_PE32_FILE_ALIGNMENT)
+ 
+ static const struct grub_install_image_target_desc image_targets[] =
+@@ -887,12 +887,13 @@ grub_install_generate_image (const char *dir, const char *prefix,
+   char *kernel_img, *core_img;
+   size_t total_module_size, core_size;
+   size_t memdisk_size = 0, config_size = 0;
+-  size_t prefix_size = 0, dtb_size = 0, sbat_size = 0;
++  size_t prefix_size = 0, dtb_size = 0, pubkey_size = 0, sbat_size = 0;
+   char *kernel_path;
+   size_t offset;
+   struct grub_util_path_list *path_list, *p;
+   size_t decompress_size = 0;
+   struct grub_mkimage_layout layout;
++  int pubkey_section = 0;
+ 
+   if (comp == GRUB_COMPRESSION_AUTO)
+     comp = image_target->default_compression;
+@@ -911,7 +912,10 @@ grub_install_generate_image (const char *dir, const char *prefix,
+   else
+     total_module_size = sizeof (struct grub_module_info32);
+ 
+-  {
++  if (npubkeys == 1 && image_target->id == IMAGE_EFI)
++    pubkey_section = 1;
++
++  if (!pubkey_section) {
+     size_t i;
+     for (i = 0; i < npubkeys; i++)
+       {
+@@ -1048,24 +1052,25 @@ grub_install_generate_image (const char *dir, const char *prefix,
+       offset += mod_size;
+     }
+ 
+-  {
+-    size_t i;
+-    for (i = 0; i < npubkeys; i++)
+-      {
+-	size_t curs;
+-	struct grub_module_header *header;
+-
+-	curs = grub_util_get_image_size (pubkey_paths[i]);
+-
+-	header = (struct grub_module_header *) (kernel_img + offset);
+-	header->type = grub_host_to_target32 (OBJ_TYPE_GPG_PUBKEY);
+-	header->size = grub_host_to_target32 (curs + sizeof (*header));
+-	offset += sizeof (*header);
+-
+-	grub_util_load_image (pubkey_paths[i], kernel_img + offset);
+-	offset += ALIGN_ADDR (curs);
+-      }
+-  }
++  if (!pubkey_section)
++    {
++      size_t i;
++      for (i = 0; i < npubkeys; i++)
++        {
++          size_t curs;
++          struct grub_module_header *header;
++
++          curs = grub_util_get_image_size (pubkey_paths[i]);
++
++          header = (struct grub_module_header *) (kernel_img + offset);
++          header->type = grub_host_to_target32 (OBJ_TYPE_GPG_PUBKEY);
++          header->size = grub_host_to_target32 (curs + sizeof (*header));
++          offset += sizeof (*header);
++
++          grub_util_load_image (pubkey_paths[i], kernel_img + offset);
++          offset += ALIGN_ADDR (curs);
++        }
++    }
+ 
+   {
+     size_t i;
+@@ -1351,7 +1356,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+       break;
+     case IMAGE_EFI:
+       {
+-	char *pe_img, *pe_sbat, *header;
++	char *pe_img, *pe_pubkey, *pe_sbat, *header;
+ 	struct grub_pe32_section_table *section;
+ 	size_t n_sections = 4;
+ 	size_t scn_size;
+@@ -1369,6 +1374,16 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 
+ 	vma = raw_data = header_size;
+ 
++	if (pubkey_section)
++	  {
++	    pubkey_size = ALIGN_ADDR (grub_util_get_image_size (pubkey_paths[0]));
++	    pubkey_size = ALIGN_UP (pubkey_size, GRUB_PE32_FILE_ALIGNMENT);
++	    if (pubkey_size == 0)
++	      grub_util_error (
++		  _("embedding public key '%s' would result in invalid empty section"),
++		  pubkey_paths[0]);
++	  }
++
+ 	if (sbat_path != NULL)
+ 	  {
+ 	    sbat_size = ALIGN_ADDR (grub_util_get_image_size (sbat_path));
+@@ -1376,7 +1391,8 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 	  }
+ 
+ 	pe_size = ALIGN_UP (header_size + core_size, GRUB_PE32_FILE_ALIGNMENT) +
+-          ALIGN_UP (layout.reloc_size, GRUB_PE32_FILE_ALIGNMENT) + sbat_size;
++          ALIGN_UP (layout.reloc_size, GRUB_PE32_FILE_ALIGNMENT) +
++	  pubkey_size + sbat_size;
+ 	header = pe_img = xcalloc (1, pe_size);
+ 
+ 	memcpy (pe_img + raw_data, core_img, core_size);
+@@ -1391,6 +1407,9 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 					      + GRUB_PE32_SIGNATURE_SIZE);
+ 	c->machine = grub_host_to_target16 (image_target->pe_target);
+ 
++	if (pubkey_section)
++	  n_sections++;
++
+ 	if (sbat_path != NULL)
+ 	  n_sections++;
+ 
+@@ -1458,7 +1477,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 
+ 	scn_size = ALIGN_UP (layout.kernel_size - layout.exec_size, GRUB_PE32_FILE_ALIGNMENT);
+ 	/* ALIGN_UP (sbat_size, GRUB_PE32_FILE_ALIGNMENT) is done earlier. */
+-	PE_OHDR (o32, o64, data_size) = grub_host_to_target32 (scn_size + sbat_size +
++	PE_OHDR (o32, o64, data_size) = grub_host_to_target32 (scn_size + pubkey_size + sbat_size +
+ 							       ALIGN_UP (total_module_size,
+ 									 GRUB_PE32_FILE_ALIGNMENT));
+ 
+@@ -1469,7 +1488,7 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 				   GRUB_PE32_SCN_MEM_READ |
+ 				   GRUB_PE32_SCN_MEM_WRITE);
+ 
+-	scn_size = pe_size - layout.reloc_size - sbat_size - raw_data;
++	scn_size = pe_size - layout.reloc_size - pubkey_size - sbat_size - raw_data;
+ 	section = init_pe_section (image_target, pe_img, section, "mods",
+ 				   &vma, scn_size, image_target->section_align,
+ 				   &raw_data, scn_size,
+@@ -1477,6 +1496,19 @@ grub_install_generate_image (const char *dir, const char *prefix,
+ 				   GRUB_PE32_SCN_MEM_READ |
+ 				   GRUB_PE32_SCN_MEM_WRITE);
+ 
++	if (pubkey_section)
++	  {
++	    pe_pubkey = pe_img + raw_data;
++	    grub_util_load_image (pubkey_paths[0], pe_pubkey);
++
++	    section = init_pe_section (image_target, pe_img, section, ".pubkey",
++				       &vma, pubkey_size,
++				       image_target->section_align,
++				       &raw_data, pubkey_size,
++				       GRUB_PE32_SCN_CNT_INITIALIZED_DATA |
++				       GRUB_PE32_SCN_MEM_READ);
++	  }
++
+ 	if (sbat_path != NULL)
+ 	  {
+ 	    pe_sbat = pe_img + raw_data;
+-- 
+2.39.0
+

--- a/packages/grub/Cargo.toml
+++ b/packages/grub/Cargo.toml
@@ -9,5 +9,5 @@ build = "../build.rs"
 path = "/dev/null"
 
 [[package.metadata.build-package.external-files]]
-url = "https://al2022-repos-us-west-2-9761ab97.s3.dualstack.us-west-2.amazonaws.com/blobstore/aa41fdf9982b65a4c4dad5df5b49ba143b1710d60f82688221966f3c790c6c63/grub2-2.06-42.amzn2022.0.1.src.rpm"
-sha512 = "3dbfc0cc48dc7125dca445ca9b6538ecb2c548cadc77714b930eb9992697e6eaef6c5eaece6a367b232d20a2d693a4fbd93b537d79596de4791c576f3b8ecc18"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/74f9ee6e75b8f89fe91ccda86896243179968a8664ba045bece11dc5aff61f4e/grub2-2.06-61.amzn2023.0.6.src.rpm"
+sha512 = "aac3fbee3ec5e5a28176d338eab85c660c9525ef3b34ccf84f7c837c724c72b089bc2b57207e36b12c09a7cdd2c7d6e658288c98b9a66cb98e8edd650f302ba5"

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -59,6 +59,10 @@ Patch0038: 0038-gpt-report-all-revalidation-errors.patch
 Patch0039: 0039-gpt-rename-and-update-documentation-for-grub_gpt_upd.patch
 Patch0040: 0040-gpt-write-backup-GPT-first-skip-if-inaccessible.patch
 Patch0041: 0041-gptprio-Use-Bottlerocket-boot-partition-type-GUID.patch
+Patch0042: 0042-util-mkimage-Bump-EFI-PE-header-size-to-accommodate-.patch
+Patch0043: 0043-util-mkimage-avoid-adding-section-table-entry-outsid.patch
+Patch0044: 0044-efi-return-virtual-size-of-section-found-by-grub_efi.patch
+Patch0045: 0045-mkimage-pgp-move-single-public-key-into-its-own-sect.patch
 
 BuildRequires: automake
 BuildRequires: bison

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -18,6 +18,7 @@ URL: https://www.gnu.org/software/grub/
 Source0: https://cdn.amazonlinux.com/al2023/blobstore/74f9ee6e75b8f89fe91ccda86896243179968a8664ba045bece11dc5aff61f4e/grub2-2.06-61.amzn2023.0.6.src.rpm
 Source1: bios.cfg
 Source2: efi.cfg
+Source3: sbat.csv.in
 Patch0001: 0001-setup-Add-root-device-argument-to-grub-setup.patch
 Patch0002: 0002-gpt-start-new-GPT-module.patch
 Patch0003: 0003-gpt-rename-misnamed-header-location-fields.patch
@@ -156,6 +157,8 @@ popd
 mkdir efi-build
 pushd efi-build
 
+sed -e "s,__VERSION__,%{version},g" %{S:3} > sbat.csv
+
 %cross_configure \
   CFLAGS="" \
   LDFLAGS="" \
@@ -201,6 +204,7 @@ mkdir -p %{buildroot}%{efidir}
   -O "%{_cross_grub_efi_format}" \
   -o "%{buildroot}%{efidir}/%{efi_image}" \
   -p "/EFI/BOOT" \
+  --sbat sbat.csv \
   efi_gop ${MODS}
 popd
 

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -2,7 +2,7 @@
 %global __strip %{_bindir}/true
 
 %global efidir /boot/efi/EFI/BOOT
-%global efi_image boot%{_cross_efi_arch}.efi
+%global efi_image grub%{_cross_efi_arch}.efi
 %global biosdir /boot/grub
 
 # This is specific to the upstream source RPM, and will likely need to be

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -15,7 +15,7 @@ Release: 1%{?dist}
 Summary: Bootloader with support for Linux and more
 License: GPL-3.0-or-later AND Unicode-DFS-2015
 URL: https://www.gnu.org/software/grub/
-Source0: https://al2022-repos-us-west-2-9761ab97.s3.dualstack.us-west-2.amazonaws.com/blobstore/aa41fdf9982b65a4c4dad5df5b49ba143b1710d60f82688221966f3c790c6c63/grub2-2.06-42.amzn2022.0.1.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/74f9ee6e75b8f89fe91ccda86896243179968a8664ba045bece11dc5aff61f4e/grub2-2.06-61.amzn2023.0.6.src.rpm
 Source1: bios.cfg
 Source2: efi.cfg
 Patch0001: 0001-setup-Add-root-device-argument-to-grub-setup.patch

--- a/packages/grub/latest-srpm-url.sh
+++ b/packages/grub/latest-srpm-url.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cmd='dnf install -q -y --releasever=latest yum-utils && yumdownloader -q --releasever=latest --source --urls grub2'
-docker run --rm amazonlinux:2022 sh -c "${cmd}" \
+docker run --rm amazonlinux:2023 sh -c "${cmd}" \
     | grep '^http' \
     | xargs --max-args=1 --no-run-if-empty realpath --canonicalize-missing --relative-to=. \
     | sed 's_:/_://_'

--- a/packages/grub/replace-grub-pubkey
+++ b/packages/grub/replace-grub-pubkey
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -e
+
+readonly grub_image="${1:?expecting GRUB image as first argument}"
+readonly public_key="${2:?expecting GPG public key file as second argument}"
+readonly local_keys="${3:?expecting directory containing local signing keys as third argument}"
+
+
+#
+# Create unsigned image with embedded key replaced
+#
+
+rm -f "${grub_image}.unsigned"
+pesign -r -u 0 -i "${grub_image}" -o "${grub_image}.unsigned"
+objcopy --update-section .pubkey="${public_key}" "${grub_image}.unsigned"
+
+
+#
+# Re-sign resulting image (steps copied from rpm2img)
+#
+
+# Generate the PKCS12 archive for import.
+openssl pkcs12 \
+    -export \
+    -passout pass: \
+    -inkey "${local_keys}/code-sign.key" \
+    -in "${local_keys}/code-sign.crt" \
+    -certfile "${local_keys}/CA.crt" \
+    -out "${local_keys}/code-sign.p12"
+
+# Import certificates and private key archive.
+PEDB="/etc/pki/pesign"
+certutil -d "${PEDB}" -A -n CA -i "${local_keys}/CA.crt" -t "CT,C,C"
+certutil -d "${PEDB}" -A -n code-sign-key -i "${local_keys}/code-sign.crt" -t ",,P"
+pk12util -d "${PEDB}" -i "${local_keys}/code-sign.p12" -W ""
+certutil -d "${PEDB}" -L
+PESIGN_KEY="-c code-sign-key"
+
+openssl x509 \
+    -inform PEM -in "${local_keys}/CA.crt" \
+    -outform DER -out "${local_keys}/CA.der"
+
+pesign -i "${grub_image}.unsigned" -o "${grub_image}" -f -s ${PESIGN_KEY}
+pesigcheck -i "${grub_image}" -n 0 -c "${local_keys}/CA.der"

--- a/packages/grub/sbat.csv.in
+++ b/packages/grub/sbat.csv.in
@@ -1,0 +1,3 @@
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+grub,3,Free Software Foundation,grub,__VERSION__,https://www.gnu.org/software/grub/
+grub.bottlerocket,1,Bottlerocket,grub,__VERSION__,https://github.com/bottlerocket-os/bottlerocket/blob/develop/SECURITY.md

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -44,6 +44,7 @@ oci-add-hooks = { path = "../oci-add-hooks" }
 policycoreutils = { path = "../policycoreutils" }
 procps = { path = "../procps" }
 selinux-policy = { path = "../selinux-policy" }
+shim = { path = "../shim" }
 systemd = { path = "../systemd" }
 util-linux = { path = "../util-linux" }
 wicked = { path = "../wicked" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -104,6 +104,7 @@ Requires: %{_cross_os}os
 Requires: %{_cross_os}policycoreutils
 Requires: %{_cross_os}procps
 Requires: %{_cross_os}selinux-policy
+Requires: %{_cross_os}shim
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}xfsprogs

--- a/packages/shim/Cargo.toml
+++ b/packages/shim/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "shim"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "/dev/null"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/rhboot/shim/archive/15.7/shim-15.7.tar.gz"
+sha512 = "95ef9c0125269cfa0263a32e4f343d8ccc8813d71fa918a2f54850781e3a2d6a06a719249be355fdb24c935899e0e11370815501ecde1800bdd974a9a79c5612"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/rhboot/gnu-efi/archive/refs/heads/shim-15.6.tar.gz"
+path = "gnu-efi-shim-15.6.tar.gz"
+sha512 = "d09dbb9e461d60e23294326ed4178301a6ab5959ade912bf559dbeb050362d994c8e63c8e062c19569055a269e5dbb65f0572317da4725177e19aae82e3c6978"

--- a/packages/shim/shim.spec
+++ b/packages/shim/shim.spec
@@ -29,6 +29,11 @@ Source1: https://github.com/rhboot/gnu-efi/archive/refs/heads/shim-%{gnuefiver}.
 rmdir gnu-efi
 mv gnu-efi-shim-%{gnuefiver} gnu-efi
 
+# Make sure the `.vendor_cert` section is large enough to cover a replacement
+# certificate, or `objcopy` may silently retain the existing section.
+# 4096 - 16 (for cert_table structure) = 4080 bytes.
+truncate -s 4080 empty.cer
+
 %global shim_make \
 %make_build\\\
   ARCH="%{_cross_arch}"\\\
@@ -39,6 +44,7 @@ mv gnu-efi-shim-%{gnuefiver} gnu-efi
   DISABLE_REMOVABLE_LOAD_OPTIONS=y\\\
   DESTDIR="%{buildroot}"\\\
   EFIDIR="BOOT"\\\
+  VENDOR_CERT_FILE="empty.cer"\\\
 %{nil}
 
 %build

--- a/packages/shim/shim.spec
+++ b/packages/shim/shim.spec
@@ -1,0 +1,61 @@
+%global debug_package %{nil}
+%global __strip %{_bindir}/true
+
+%global efidir /boot/efi/EFI/BOOT
+%global boot_efi_image boot%{_cross_efi_arch}.efi
+%global grub_efi_image grub%{_cross_efi_arch}.efi
+%global shim_efi_image shim%{_cross_efi_arch}.efi
+%global mokm_efi_image mm%{_cross_efi_arch}.efi
+
+%global shimver 15.7
+%global gnuefiver 15.6
+%global commit 11491619f4336fef41c3519877ba242161763580
+
+Name: %{_cross_os}shim
+Version: %{shimver}
+Release: 1%{?dist}
+Summary: UEFI shim loader
+License: BSD-3-Clause
+URL: https://github.com/rhboot/shim/
+Source0: https://github.com/rhboot/shim/archive/%{shimver}/shim-%{shimver}.tar.gz
+Source1: https://github.com/rhboot/gnu-efi/archive/refs/heads/shim-%{gnuefiver}.tar.gz#/gnu-efi-shim-%{gnuefiver}.tar.gz
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n shim-%{shimver} -p1
+%setup -T -D -n shim-%{shimver} -a 1
+rmdir gnu-efi
+mv gnu-efi-shim-%{gnuefiver} gnu-efi
+
+%global shim_make \
+%make_build\\\
+  ARCH="%{_cross_arch}"\\\
+  CROSS_COMPILE="%{_cross_target}-"\\\
+  COMMIT_ID="%{commit}"\\\
+  RELEASE="%{release}"\\\
+  DEFAULT_LOADER="%{grub_efi_image}"\\\
+  DISABLE_REMOVABLE_LOAD_OPTIONS=y\\\
+  DESTDIR="%{buildroot}"\\\
+  EFIDIR="BOOT"\\\
+%{nil}
+
+%build
+%shim_make
+
+%install
+%shim_make install-as-data
+install -d %{buildroot}%{efidir}
+find %{buildroot}%{_datadir} -name '%{shim_efi_image}' -exec \
+  mv {} "%{buildroot}%{efidir}/%{boot_efi_image}" \;
+find %{buildroot}%{_datadir} -name '%{mokm_efi_image}' -exec \
+  mv {} "%{buildroot}%{efidir}/%{mokm_efi_image}" \;
+rm -rf %{buildroot}%{_datadir}
+
+%files
+%license COPYRIGHT
+%{_cross_attribution_file}
+%dir %{efidir}
+%{efidir}/%{boot_efi_image}
+%{efidir}/%{mokm_efi_image}

--- a/sbkeys/README.md
+++ b/sbkeys/README.md
@@ -1,0 +1,134 @@
+# Secure Boot Keys for Bottlerocket
+
+This document describes the tools available to generate the files needed for Secure Boot support in Bottlerocket.
+
+## Background
+
+For Secure Boot support, many different keys, certificates, and configuration files are required for building and publishing images.
+The [ArchWiki guide to Secure Boot](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Using_your_own_keys) covers the purpose of most of these files, along with sample commands to generate them.
+To keep build logic simple, a complete set of these files must be present for each build, and the files must follow the expected naming conventions.
+
+Each set of files is referred to as a Secure Boot Keys ("sbkeys") profile.
+The tools provided in this directory can be used to generate either a [local profile](#create-a-profile-with-local-resources) or an [AWS-based profile](#create-a-profile-with-aws-based-resources).
+If your preferred solution for key management is not supported, a contribution that adds a new tool or profile type would be welcome.
+
+To streamline the process of building Bottlerocket with Secure Boot support, a local profile will be generated automatically.
+This is done to minimize costs and to avoid requiring developers to set up infrastructure for key management ahead of time.
+However, because these local profiles offer direct access to private key materials, they are **strongly discouraged** for any kind of production use.
+
+Different profiles can be [specified at build time](#specify-a-profile-at-build-time) to use a custom set of keys.
+
+## Create a profile with local resources
+
+The `generate-local-sbkeys` tool can be used to create a local Secure Boot Keys profile.
+
+It uses `openssl` to generate private keys and certificate authorities (CAs), and `gpg` to create a GPG private key.
+It also uses [virt-fw-vars](https://pypi.org/project/virt-firmware/) to generate EFI variable data for the edk2 variable stores used by Amazon EC2 AMIs and QEMU.
+
+When specifying an SDK image, these dependencies are run within a container started from that image, and do not need to be installed on the host.
+
+```shell
+ARCH="$(uname -m)"
+SDK_VERSION="v0.29.0"
+./generate-local-sbkeys \
+  --sdk-image "public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:${SDK_VERSION}" \
+  --output-dir "${PWD}/my-local-profile"
+```
+
+## Create a profile with AWS-based resources
+
+The `generate-aws-sbkeys` tool can be used to create an AWS-based Secure Boot Keys profile.
+
+It uses the AWS CLI and [aws-kms-pkcs11](https://github.com/JackOfMostTrades/aws-kms-pkcs11) to obtain certificates, and the `virt-fw-vars` tool to generate EFI variable data.
+It creates an `aws-kms-pkcs11` configuration file for subsequent signing operations.
+
+When specifying an SDK image, these dependencies are run within a container started from that image, and do not need to be installed on the host.
+
+The tool expects four [AWS Private CAs](https://docs.aws.amazon.com/privateca/latest/userguide/PcaWelcome.html) and three [AWS KMS asymmetric keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#asymmetric-keys-concept) to be available.
+Note that the cost of these resources, **especially the private CAs**, is nontrivial.
+
+Although it is possible to use the same private CA and the same KMS key for all roles, doing so would weaken the security of the implementation, and is **strongly discouraged**.
+
+```shell
+ARCH="$(uname -m)"
+SDK_VERSION="v0.29.0"
+
+# AWS Private CAs
+PK_CA="arn:aws:acm-pca:us-west-2:999999999999:certificate-authority/11111111-1111-1111-1111-111111111111"
+KEK_CA="arn:aws:acm-pca:us-west-2:999999999999:certificate-authority/22222222-2222-2222-2222-222222222222"
+DB_CA="arn:aws:acm-pca:us-west-2:999999999999:certificate-authority/33333333-3333-3333-3333-333333333333"
+VENDOR_CA="arn:aws:acm-pca:us-west-2:999999999999:certificate-authority/44444444-4444-4444-4444-444444444444"
+
+# AWS KMS asymmetric keys
+SHIM_SIGN_KEY="arn:aws:kms:us-west-2:999999999999:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+CODE_SIGN_KEY="arn:aws:kms:us-west-2:999999999999:key/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+CONFIG_SIGN_KEY="arn:aws:kms:us-west-2:999999999999:key/cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+./generate-aws-sbkeys \
+  --sdk-image "public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:${SDK_VERSION}" \
+  --aws-region us-west-2 \
+  --pk-ca "${PK_CA}" \
+  --kek-ca "${KEK_CA}" \
+  --db-ca "${DB_CA}" \
+  --vendor-ca "${VENDOR_CA}" \
+  --shim-sign-key "${SHIM_SIGN_KEY}" \
+  --code-sign-key "${CODE_SIGN_KEY}" \
+  --config-sign-key "${CONFIG_SIGN_KEY}" \
+  --output-dir "${PWD}/my-aws-profile"
+```
+
+To generate the profile, the IAM user or role should have a policy like this:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "acm-pca:GetCertificate",
+        "acm-pca:GetCertificateAuthorityCertificate",
+        "acm-pca:IssueCertificate",
+        "kms:GetPublicKey",
+        "kms:Sign"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+To use the profile to sign artifacts during the build process, the IAM user or role should have a policy like this:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "kms:GetPublicKey",
+        "kms:Sign"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Specify a profile at build time
+
+To use a custom Secure Boot Keys profile, set the `BUILDSYS_SBKEYS_PROFILE` variable at build time, like this:
+
+```shell
+cargo make -e BUILDSYS_SBKEYS_PROFILE=my-custom-profile
+```
+
+Since all the files in a Secure Boot Keys profile are plain text and source-control friendly, you may wish to store them in a separate directory backed by Git or some other SCM.
+To refer to profiles in a different directory, set the `BUILDSYS_SBKEYS_DIR` variable at build time, like this:
+
+```shell
+cargo make \
+  -e BUILDSYS_SBKEYS_DIR="${HOME}/my-sbkeys" \
+  -e BUILDSYS_SBKEYS_PROFILE=my-custom-profile
+```

--- a/sbkeys/generate-aws-sbkeys
+++ b/sbkeys/generate-aws-sbkeys
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+
+# Helper script for running commands to generate Secure Boot files.
+
+set -euo pipefail
+
+usage() {
+   cat >&2 <<EOF
+usage: ${0##*/} [--sdk-image SDK_IMAGE]
+                [--aws-region AWS_REGION]
+                [--pk-ca PK_CA]
+                [--kek-ca KEK_CA]
+                [--db-ca DB_CA]
+                [--vendor-ca VENDOR_CA]
+                [--shim-sign-key SHIM_SIGN_KEY]
+                [--code-sign-key CODE_SIGN_KEY]
+                [--config-sign-key CONFIG_SIGN_KEY]
+                [--output-dir OUTPUT_DIR]
+
+Generate Secure Boot related files. AWS-aware edition.
+
+Options:
+    --sdk-image         Name of the (optional) SDK image to use.
+    --aws-region        AWS region where the resources live.
+    --pk-ca             PCA ARN for the Secure Boot Platform CA (PK).
+    --kek-ca            PCA ARN for the Secure Boot Key Exchange CA (KEK).
+    --db-ca             PCA ARN for the Secure Boot Database CA (db).
+    --vendor-ca         PCA ARN for the Secure Boot Vendor CA.
+    --shim-sign-key     KMS key ID or ARN for the shim signing key.
+    --code-sign-key     KMS key ID or ARN for the code signing key (grub, vmlinuz).
+    --config-sign-key   KMS key ID or ARN for the config signing key (grub.cfg).
+    --output-dir        Path where the keys will be written.
+    --help              shows this usage text
+EOF
+}
+
+required_arg() {
+   local arg="${1:?}"
+   local value="${2}"
+   if [ -z "${value}" ]; then
+      echo "ERROR: ${arg} is required" >&2
+      exit 2
+   fi
+}
+
+parse_args() {
+  while [ ${#} -gt 0 ] ; do
+    case "${1}" in
+        --help ) usage; exit 0 ;;
+        --sdk-image ) shift; SDK_IMAGE="${1}" ;;
+        --aws-region ) shift; AWS_REGION="${1}" ;;
+        --pk-ca ) shift; PK_CA="${1}" ;;
+        --kek-ca ) shift; KEK_CA="${1}" ;;
+        --db-ca ) shift; DB_CA="${1}" ;;
+        --vendor-ca ) shift; VENDOR_CA="${1}" ;;
+        --shim-sign-key ) shift; SHIM_SIGN_KEY="${1}" ;;
+        --code-sign-key ) shift; CODE_SIGN_KEY="${1}" ;;
+        --config-sign-key ) shift; CONFIG_SIGN_KEY="${1}" ;;
+        --output-dir ) shift; OUTPUT_DIR="${1}" ;;
+        *) ;;
+    esac
+    shift
+  done
+
+  # Required arguments
+  required_arg "--aws-region" "${AWS_REGION:-}"
+  required_arg "--pk-ca" "${PK_CA:-}"
+  required_arg "--kek-ca" "${KEK_CA:-}"
+  required_arg "--db-ca" "${DB_CA:-}"
+  required_arg "--vendor-ca" "${VENDOR_CA:-}"
+  required_arg "--shim-sign-key" "${SHIM_SIGN_KEY:-}"
+  required_arg "--code-sign-key" "${CODE_SIGN_KEY:-}"
+  required_arg "--config-sign-key" "${CONFIG_SIGN_KEY:-}"
+  required_arg "--output-dir" "${OUTPUT_DIR:-}"
+}
+
+parse_args "${@}"
+
+# To avoid needing separate scripts to parse args and launch the SDK container,
+# the logic to generate the profile is found below the separator. Copy that to
+# a temporary file so it can be executed using the desired method.
+PRELUDE_END=$(awk '/=\^\.\.\^=/ { print NR+1; exit 0; }' "${0}")
+SBKEYS_SCRIPT="$(mktemp)"
+AWS_KMS_PKCS11_CONF="$(mktemp)"
+cleanup() {
+  rm -f "${SBKEYS_SCRIPT}" "${AWS_KMS_PKCS11_CONF}"
+}
+trap 'cleanup' EXIT
+tail -n +"${PRELUDE_END}" "${0}" >"${SBKEYS_SCRIPT}"
+chmod +x "${SBKEYS_SCRIPT}"
+
+cat <<EOF > "${AWS_KMS_PKCS11_CONF}"
+{
+  "slots": [
+    {
+      "label": "shim-sign-key",
+      "kms_key_id": "${SHIM_SIGN_KEY}",
+      "aws_region": "${AWS_REGION}"
+    },
+    {
+      "label": "code-sign-key",
+      "kms_key_id": "${CODE_SIGN_KEY}",
+      "aws_region": "${AWS_REGION}"
+    },
+    {
+      "label": "config-sign-key",
+      "kms_key_id": "${CONFIG_SIGN_KEY}",
+      "aws_region": "${AWS_REGION}"
+    }
+  ]
+}
+EOF
+
+# Create the output directory with the current user, rather than letting Docker
+# create it as a root-owned directory.
+mkdir -p "${OUTPUT_DIR}"
+
+if [ -n "${SDK_IMAGE:-}" ] ; then
+  docker run -a stdin -a stdout -a stderr --rm \
+    --user "$(id -u):$(id -g)" \
+    --security-opt label:disable \
+    -v "${OUTPUT_DIR}":/tmp/output \
+    -v "${SBKEYS_SCRIPT}":/tmp/sbkeys \
+    -v "${AWS_KMS_PKCS11_CONF}":/tmp/aws-kms-pkcs11-conf \
+    ${AWS_ACCESS_KEY_ID:+-e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID} \
+    ${AWS_SECRET_ACCESS_KEY:+-e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY} \
+    ${AWS_SESSION_TOKEN:+-e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN} \
+    -e AWS_REGION="${AWS_REGION}" \
+    -e AWS_DEFAULT_REGION="${AWS_REGION}" \
+    -e PK_CA="${PK_CA}" \
+    -e KEK_CA="${KEK_CA}" \
+    -e DB_CA="${DB_CA}" \
+    -e VENDOR_CA="${VENDOR_CA}" \
+    -e SHIM_SIGN_KEY="${SHIM_SIGN_KEY}" \
+    -e CODE_SIGN_KEY="${CODE_SIGN_KEY}" \
+    -e CONFIG_SIGN_KEY="${CONFIG_SIGN_KEY}" \
+    -e AWS_KMS_PKCS11_CONF="/tmp/aws-kms-pkcs11-conf" \
+    -e OUTPUT_DIR="/tmp/output" \
+    -w /tmp \
+    "${SDK_IMAGE}" bash /tmp/sbkeys
+else
+  export PK_CA KEK_CA DB_CA VENDOR_CA
+  export CODE_SIGN_KEY CONFIG_SIGN_KEY SHIM_SIGN_KEY
+  export AWS_REGION AWS_KMS_PKCS11_CONF OUTPUT_DIR
+  bash "${SBKEYS_SCRIPT}"
+fi
+
+exit
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+set -euo pipefail
+
+WORKDIR="$(mktemp -d)"
+cd "${WORKDIR}"
+cleanup() {
+  rm -rf "${WORKDIR}"
+}
+trap 'cleanup' EXIT
+
+export XDG_CONFIG_HOME="${WORKDIR}/.config"
+mkdir -p "${XDG_CONFIG_HOME}/aws-kms-pkcs11"
+cp "${AWS_KMS_PKCS11_CONF}" "${XDG_CONFIG_HOME}/aws-kms-pkcs11/config.json"
+
+export AWS_DEFAULT_OUTPUT="text"
+export AWS_KMS_PKCS11_DEBUG=1
+export PKCS11_MODULE_PATH="/usr/lib64/pkcs11/aws_kms_pkcs11.so"
+
+# Fetch CA certificates.
+getcacert() {
+  local arn ca
+  arn="${1:?}"
+  ca="${2:?}"
+  aws acm-pca get-certificate-authority-certificate \
+    --certificate-authority-arn "${arn}" \
+    --query 'Certificate' > "${ca}.crt"
+}
+
+getcacert "${PK_CA}" "PK"
+getcacert "${KEK_CA}" "KEK"
+getcacert "${DB_CA}" "db"
+getcacert "${VENDOR_CA}" "vendor"
+
+# Add X.509 extension for code signing.
+cat <<'EOF' > codesign.json
+{
+  "Extensions": {
+    "ExtendedKeyUsage": [
+      {
+        "ExtendedKeyUsageType": "CODE_SIGNING"
+      },
+      {
+        "ExtendedKeyUsageObjectIdentifier": "1.3.6.1.4.1.311.10.3.6"
+      }
+    ]
+  }
+}
+EOF
+
+gencert() {
+  local key token cn ca_arn cert_arn
+  key="${1:?}"
+  token="${2:?}"
+  cn="${3:?}"
+  ca_arn="${4:?}"
+
+  openssl req -new \
+    -key "pkcs11:token=${token}" -keyform engine -engine pkcs11 \
+    -subj "/CN=${cn}/" \
+    -out "${key}.csr"
+
+  cert_arn="$(\
+    aws acm-pca issue-certificate \
+      --certificate-authority-arn "${ca_arn}" \
+      --template-arn arn:aws:acm-pca:::template/BlankEndEntityCertificate_APICSRPassthrough/V1 \
+      --csr "fileb://${key}.csr" \
+      --api-passthrough "file://codesign.json" \
+      --signing-algorithm "SHA256WITHRSA" \
+      --validity Value=5,Type="YEARS" \
+      --idempotency-token "${key}" \
+      --query 'CertificateArn')"
+
+    aws acm-pca wait certificate-issued \
+       --certificate-authority-arn "${ca_arn}" \
+       --certificate-arn "${cert_arn}"
+
+    aws acm-pca get-certificate \
+       --certificate-authority-arn "${ca_arn}" \
+       --certificate-arn "${cert_arn}" \
+       --query 'Certificate' \
+       > "${key}.crt"
+}
+
+# Sign shim, GRUB, kernel, and GRUB config signing keys.
+gencert shim-sign "shim-sign-key" "Bottlerocket Shim Signing Key" "${DB_CA}"
+gencert code-sign "code-sign-key" "Bottlerocket Code Signing Key" "${VENDOR_CA}"
+gencert config-sign "config-sign-key" "Bottlerocket Config Signing Key" "${VENDOR_CA}"
+
+# Encode the certs for the PKCS11 helper.
+SHIM_SIGN_CERT="$(openssl x509 -in shim-sign.crt -outform der | openssl base64 -A)"
+CODE_SIGN_CERT="$(openssl x509 -in code-sign.crt -outform der | openssl base64 -A)"
+CONFIG_SIGN_CERT="$(openssl x509 -in config-sign.crt -outform der | openssl base64 -A)"
+
+# Reconfigure the PKCS11 helper for GPG.
+cat <<EOF > "${XDG_CONFIG_HOME}/aws-kms-pkcs11/config.json"
+{
+  "slots": [
+    {
+      "label": "config-sign-key",
+      "kms_key_id": "${CONFIG_SIGN_KEY}",
+      "aws_region": "${AWS_REGION}",
+      "certificate": "${CONFIG_SIGN_CERT}"
+    }
+  ]
+}
+EOF
+
+# Ensure a clean GPG state.
+export GNUPGHOME="${WORKDIR}"
+
+# Configure the GPG agent and smartcard daemon.
+cat <<EOF >> "${GNUPGHOME}/gpg-agent.conf"
+scdaemon-program /usr/bin/gnupg-pkcs11-scd
+EOF
+
+cat <<EOF >> "${GNUPGHOME}/gnupg-pkcs11-scd.conf"
+providers kms
+provider-kms-library /usr/lib64/pkcs11/aws_kms_pkcs11.so
+log-file /dev/null
+EOF
+
+# Have GPG agent discover the key.
+gpg --card-status
+KEYGRIP=$(\
+  find "${GNUPGHOME}"/private-keys-*.d -type f -name '*.key' -printf '%P' \
+  | cut -d '.' -f1 | head -n1)
+
+# Import the config signing key into GPG.
+# 13                 Existing key
+# ${KEYGRIP}         Which key to edit
+# e                  Toggle the encrypt capability off
+# q                  Finished
+# 0                  Key does not expire
+# Bottlerocket ...   Real name
+#                    Email address
+#                    Comment
+gpg --no-tty --expert --full-generate-key --command-fd 0 <<EOF
+13
+${KEYGRIP}
+e
+q
+0
+Bottlerocket Config Signing Key
+
+
+EOF
+
+# Export the GPG key.
+gpg --armor --export > config-sign.key
+
+# Generate EFI vars for use with EC2 or others.
+GUID="$(uuidgen --random)"
+virt-fw-vars \
+  --set-pk "${GUID}" PK.crt \
+  --add-kek "${GUID}" KEK.crt \
+  --add-db "${GUID}" db.crt \
+  --secure-boot \
+  --output-json "efi-vars.json"
+
+virt-fw-vars \
+  --set-json "efi-vars.json" \
+  --output-aws "efi-vars.aws"
+
+# Create the final PKCS11 helper config.
+cat <<EOF > "kms-sign.json"
+{
+  "slots": [
+    {
+      "label": "shim-sign-key",
+      "kms_key_id": "${SHIM_SIGN_KEY}",
+      "aws_region": "${AWS_REGION}",
+      "certificate": "${SHIM_SIGN_CERT}"
+    },
+    {
+      "label": "code-sign-key",
+      "kms_key_id": "${CODE_SIGN_KEY}",
+      "aws_region": "${AWS_REGION}",
+      "certificate": "${CODE_SIGN_CERT}"
+    },
+    {
+      "label": "config-sign-key",
+      "kms_key_id": "${CONFIG_SIGN_KEY}",
+      "aws_region": "${AWS_REGION}",
+      "certificate": "${CONFIG_SIGN_CERT}"
+    }
+  ]
+}
+EOF
+
+# Copy all expected files out.
+cp -t "${OUTPUT_DIR}" \
+  PK.crt \
+  KEK.crt \
+  db.crt \
+  vendor.crt \
+  kms-sign.json \
+  config-sign.key \
+  efi-vars.{aws,json}

--- a/sbkeys/generate-local-sbkeys
+++ b/sbkeys/generate-local-sbkeys
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# Helper script for running commands to generate Secure Boot files.
+
+set -euo pipefail
+
+usage() {
+   cat >&2 <<EOF
+usage: ${0##*/} [--sdk-image SDK_IMAGE]
+                [--output-dir OUTPUT_DIR]
+
+Generate Secure Boot related files. Local-only edition.
+
+Options:
+    --sdk-image         Name of the (optional) SDK image to use.
+    --output-dir        Path where the files will be written.
+    --help              shows this usage text
+EOF
+}
+
+required_arg() {
+   local arg="${1:?}"
+   local value="${2}"
+   if [ -z "${value}" ]; then
+      echo "ERROR: ${arg} is required" >&2
+      exit 2
+   fi
+}
+
+parse_args() {
+  while [ ${#} -gt 0 ] ; do
+    case "${1}" in
+        --help ) usage; exit 0 ;;
+        --sdk-image ) shift; SDK_IMAGE="${1}" ;;
+        --output-dir ) shift; OUTPUT_DIR="${1}" ;;
+        *) ;;
+    esac
+    shift
+  done
+
+  # Required arguments
+  required_arg "--output-dir" "${OUTPUT_DIR:-}"
+}
+
+parse_args "${@}"
+
+# Create the output directory with the current user, rather than letting Docker
+# create it as a root-owned directory.
+mkdir -p "${OUTPUT_DIR}"
+
+# To avoid needing separate scripts to parse args and launch the SDK container,
+# the logic to generate the profile is found below the separator. Copy that to
+# a temporary file so it can be executed using the desired method.
+PRELUDE_END=$(awk '/=\^\.\.\^=/ { print NR+1; exit 0; }' "${0}")
+SBKEYS_SCRIPT="$(mktemp)"
+cleanup() {
+  rm -f "${SBKEYS_SCRIPT}"
+}
+trap 'cleanup' EXIT
+tail -n +"${PRELUDE_END}" "${0}" >"${SBKEYS_SCRIPT}"
+chmod +x "${SBKEYS_SCRIPT}"
+
+if [ -n "${SDK_IMAGE:-}" ] ; then
+  docker run -a stdin -a stdout -a stderr --rm \
+    --user "$(id -u):$(id -g)" \
+    --security-opt label:disable \
+    -v "${OUTPUT_DIR}":/tmp/output \
+    -v "${SBKEYS_SCRIPT}":/tmp/sbkeys \
+    -e OUTPUT_DIR="/tmp/output" \
+    -w /tmp \
+    "${SDK_IMAGE}" bash /tmp/sbkeys
+else
+  export OUTPUT_DIR
+  bash "${SBKEYS_SCRIPT}"
+fi
+
+exit
+
+# =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+set -euo pipefail
+
+WORKDIR="$(mktemp -d)"
+cd "${WORKDIR}"
+cleanup() {
+  rm -rf "${WORKDIR}"
+}
+trap 'cleanup' EXIT
+
+genca() {
+  local ca cn
+  ca="${1:?}"
+  cn="${2:?}"
+  openssl req -newkey rsa:2048 \
+    -batch -noenc -new -x509 -sha256 -days 3650 \
+    -subj "/CN=${cn}/" \
+    -keyout "${ca}.key" -out "${ca}.crt"
+}
+
+genkey() {
+  local ca key cn
+  ca="${1:?}"
+  key="${2:?}"
+  cn="${3:?}"
+  openssl genrsa -verbose \
+    -out "${key}.key" 2048
+
+  openssl req -new \
+    -key "${key}.key" \
+    -subj "/CN=${cn}/" \
+    -out "${key}.csr"
+
+  openssl req \
+    -in "${key}.csr" \
+    -CA "${ca}.crt" -CAkey "${ca}.key" \
+    -config /dev/null \
+    -days 3650 -x509 -sha256 -copy_extensions none \
+    -addext "basicConstraints=CA:FALSE" \
+    -addext "extendedKeyUsage=codeSigning,1.3.6.1.4.1.311.10.3.6" \
+    -out "${key}.crt"
+}
+
+# Generate local EFI CAs and signing keys.
+genca PK "Bottlerocket Secure Boot Platform CA"
+genca KEK "Bottlerocket Secure Boot Key Exchange CA"
+genca db "Bottlerocket Secure Boot Database CA"
+genca vendor "Bottlerocket Secure Boot Vendor CA"
+
+genkey db shim-sign "Bottlerocket Shim Signing Key"
+genkey vendor code-sign "Bottlerocket Code Signing Key"
+
+# Generate GPG key for signing grub.cfg.
+export GNUPGHOME="${WORKDIR}"
+gpg --gen-key --batch <<EOF
+Key-Type: RSA
+Key-Length: 2048
+Name-Real: Bottlerocket Config Signing Key
+Expire-Date: 0
+%no-protection
+EOF
+
+# Export the GPG key.
+gpg --armor --export-secret-keys > config-sign.key
+
+# Generate EFI vars for use with EC2 or others.
+GUID="$(uuidgen --random)"
+virt-fw-vars \
+  --set-pk "${GUID}" PK.crt \
+  --add-kek "${GUID}" KEK.crt \
+  --add-db "${GUID}" db.crt \
+  --secure-boot \
+  --output-json "efi-vars.json"
+
+virt-fw-vars \
+  --set-json "efi-vars.json" \
+  --output-aws "efi-vars.aws"
+
+# Copy all expected files out.
+cp -t "${OUTPUT_DIR}" \
+  PK.{key,crt} \
+  KEK.{key,crt} \
+  db.{key,crt} \
+  vendor.{key,crt} \
+  shim-sign.{key,crt} \
+  code-sign.{key,crt} \
+  config-sign.key \
+  efi-vars.{aws,json}

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -221,6 +221,18 @@ default will remain ext4 and xfs is opt-in.
 ```ignore
 [package.metadata.build-variant.image-features]
 xfs-data-partition = true
+```
+
+`uefi-secure-boot` means that the bootloader and kernel are signed. The grub image for the current
+variant will have a public GPG baked in, and will expect the grub config file to have a valid
+detached signature. Published artifacts such as AMIs and OVAs will enforce the signature checks
+when the platform supports it.
+
+```ignore
+[package.metadata.build-variant.image-features]
+uefi-secure-boot = true
+```
+
 */
 
 mod error;
@@ -513,6 +525,7 @@ pub enum ImageFeature {
     SystemdNetworkd,
     UnifiedCgroupHierarchy,
     XfsDataPartition,
+    UefiSecureBoot,
 }
 
 impl TryFrom<String> for ImageFeature {
@@ -523,6 +536,7 @@ impl TryFrom<String> for ImageFeature {
             "systemd-networkd" => Ok(ImageFeature::SystemdNetworkd),
             "unified-cgroup-hierarchy" => Ok(ImageFeature::UnifiedCgroupHierarchy),
             "xfs-data-partition" => Ok(ImageFeature::XfsDataPartition),
+            "uefi-secure-boot" => Ok(ImageFeature::UefiSecureBoot),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -535,6 +549,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::SystemdNetworkd => write!(f, "SYSTEMD_NETWORKD"),
             ImageFeature::UnifiedCgroupHierarchy => write!(f, "UNIFIED_CGROUP_HIERARCHY"),
             ImageFeature::XfsDataPartition => write!(f, "XFS_DATA_PARTITION"),
+            ImageFeature::UefiSecureBoot => write!(f, "UEFI_SECURE_BOOT"),
         }
     }
 }

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -50,6 +50,10 @@ pub(crate) struct AmiArgs {
     #[arg(short = 'v', long)]
     variant_manifest: PathBuf,
 
+    /// Path to the UEFI data
+    #[arg(short = 'e', long)]
+    uefi_data: PathBuf,
+
     /// The architecture of the machine image
     #[arg(short = 'a', long, value_parser = parse_arch)]
     arch: ArchitectureValues,

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -70,6 +70,13 @@ if [ "${OUTPUT_FMT}" == "vmdk" ] ; then
       exit 1
     fi
   fi
+
+  if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+    if ! grep -Fq '{{DB_CERT_DER_HEX}}' "${OVF_TEMPLATE}" ; then
+      echo "Missing CA certificate field in OVF template, which is required for Secure Boot support." >&2
+      exit 1
+    fi
+  fi
 fi
 
 # Store output artifacts in a versioned directory.
@@ -120,6 +127,8 @@ BOOT_MOUNT="$(mktemp -d)"
 DATA_MOUNT="$(mktemp -d)"
 EFI_MOUNT="$(mktemp -d)"
 PRIVATE_MOUNT="$(mktemp -d)"
+
+SBKEYS="${HOME}/sbkeys"
 
 SELINUX_ROOT="/etc/selinux"
 SELINUX_POLICY="fortified"
@@ -254,11 +263,184 @@ fi
 # package has placed the image in /boot/efi/EFI/BOOT.
 mv "${ROOT_MOUNT}/boot/efi"/* "${EFI_MOUNT}"
 
+# Do the setup required for `pesign` and `gpg` signing and
+# verification to "just work" later on, regardless of which
+# type of signing profile we have.
+if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+  declare -a SHIM_SIGN_KEY
+  declare -a CODE_SIGN_KEY
+
+  # For an AWS profile, we expect a config file for the PKCS11
+  # helper. Otherwise, there should be a local key and cert.
+  if [ -s "${HOME}/.config/aws-kms-pkcs11/config.json" ] ; then
+    # Set AWS environment variables from build secrets, if present.
+    for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN ; do
+      val="${var,,}"
+      val="${HOME}/.aws/${val//_/-}.env"
+      [ -s "${val}" ] || continue
+      declare -x "${var}=$(cat "${val}")"
+    done
+    # Verify that AWS credentials are functional.
+    aws sts get-caller-identity
+    # Log all PKCS11 helper activity, to simplify debugging.
+    export AWS_KMS_PKCS11_DEBUG=1
+    SB_KEY_SOURCE="aws"
+    SHIM_SIGN_KEY=(-c shim-sign-key -t shim-sign-key)
+    CODE_SIGN_KEY=(-c code-sign-key -t code-sign-key)
+  else
+    # Disable the PKCS11 helper.
+    rm /etc/pkcs11/modules/aws-kms-pkcs11.module
+
+    # Generate the PKCS12 archives for import.
+    openssl pkcs12 \
+      -export \
+      -passout pass: \
+      -inkey "${SBKEYS}/shim-sign.key" \
+      -in "${SBKEYS}/shim-sign.crt" \
+      -certfile "${SBKEYS}/db.crt" \
+      -out "${SBKEYS}/shim-sign.p12"
+
+    openssl pkcs12 \
+      -export \
+      -passout pass: \
+      -inkey "${SBKEYS}/code-sign.key" \
+      -in "${SBKEYS}/code-sign.crt" \
+      -certfile "${SBKEYS}/vendor.crt" \
+      -out "${SBKEYS}/code-sign.p12"
+
+    # Import certificates and private key archive.
+    PEDB="/etc/pki/pesign"
+
+    certutil -d "${PEDB}" -A -n db -i "${SBKEYS}/db.crt" -t ",,C"
+    certutil -d "${PEDB}" -A -n shim-sign-key -i "${SBKEYS}/shim-sign.crt" -t ",,P"
+    pk12util -d "${PEDB}" -i "${SBKEYS}/shim-sign.p12" -W ""
+
+    certutil -d "${PEDB}" -A -n vendor -i "${SBKEYS}/vendor.crt" -t ",,C"
+    certutil -d "${PEDB}" -A -n code-sign-key -i "${SBKEYS}/code-sign.crt" -t ",,P"
+    pk12util -d "${PEDB}" -i "${SBKEYS}/code-sign.p12" -W ""
+
+    certutil -d "${PEDB}" -L
+    SB_KEY_SOURCE="local"
+    SHIM_SIGN_KEY=(-c shim-sign-key)
+    CODE_SIGN_KEY=(-c code-sign-key)
+  fi
+
+  # Convert certificates from PEM format (ASCII) to DER (binary). This could be
+  # done when the certificates are created, but the resulting binary files are
+  # not as nice to store in source control.
+  for cert in PK KEK db vendor ; do
+    openssl x509 \
+      -inform PEM -in "${SBKEYS}/${cert}.crt" \
+      -outform DER -out "${SBKEYS}/${cert}.cer"
+  done
+
+  # For signing the grub config, we need to embed the GPG public key in binary
+  # form, which is similarly awkward to store in source control.
+  gpg --import "${SBKEYS}/config-sign.key"
+  if [ "${SB_KEY_SOURCE}" == "aws" ] ; then
+    gpg --card-status
+  fi
+  gpg --export > "${SBKEYS}/config-sign.pubkey"
+  gpg --list-keys
+fi
+
+# shim expects the following data structure in `.vendor_cert`:
+#
+# struct {
+#   uint32_t vendor_authorized_size;
+#   uint32_t vendor_deauthorized_size;
+#   uint32_t vendor_authorized_offset;
+#   uint32_t vendor_deauthorized_offset;
+# } cert_table;
+#
+cert_table() {
+  local input output size offset uint32_t
+  input="${1:?}"
+  output="${2:?}"
+  size="$(stat -c %s "${input}")"
+  rm -f "${output}"
+  # The cert payload is offset by four 4-byte uint32_t values in the header.
+  offset="$((4 * 4))"
+  for n in "${size}" 0 "${offset}" "$(( size + offset ))" ; do
+    printf -v uint32_t '\\x%02x\\x%02x\\x%02x\\x%02x' \
+      $((n & 255)) $((n >> 8 & 255)) $((n >> 16 & 255)) $((n >> 24 & 255))
+    printf "${uint32_t}" >> "${output}"
+  done
+  cat "${input}" >> "${output}"
+  # Zero-pad the output to the expected section size. Otherwise a subsequent
+  # `objcopy` operation on the same section might fail to replace it, if the
+  # new vendor certificate is larger than this one.
+  truncate -s 4096 "${output}"
+}
+
+# Helper function to log the object layout before and after changes.
+objdumpcopy() {
+  local obj objdump objcopy
+  obj="${1:?}"
+  shift
+  objdump="${ARCH}-bottlerocket-linux-gnu-objdump"
+  objcopy="${ARCH}-bottlerocket-linux-gnu-objcopy"
+  "${objdump}" -h "${obj}"
+  "${objcopy}" "${@}" "${obj}"
+  "${objdump}" -h "${obj}"
+}
+
+pushd "${EFI_MOUNT}/EFI/BOOT" >/dev/null
+shims=(boot*.efi)
+shim="${shims[0]}"
+grubs=(grub*.efi)
+grub="${grubs[0]}"
+mokms=(mm*.efi)
+mokm="${mokms[0]}"
+if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+  # Convert the vendor certificate to the expected format.
+  cert_table "${SBKEYS}/vendor.cer" "${SBKEYS}/vendor.obj"
+
+  # Replace the embedded vendor certificate, then sign shim with the db key.
+  objdumpcopy "${shim}" \
+    --update-section ".vendor_cert=${SBKEYS}/vendor.obj"
+  pesign -i "${shim}" -o "${shim}.signed" -s "${SHIM_SIGN_KEY[@]}"
+  mv "${shim}.signed" "${shim}"
+  pesigcheck -i "${shim}" -n 0 -c "${SBKEYS}/db.cer"
+
+  # Sign the MOK manager as well.
+  pesign -i "${mokm}" -o "${mokm}.signed" -s "${CODE_SIGN_KEY[@]}"
+  mv "${mokm}.signed" "${mokm}"
+  pesigcheck -i "${mokm}" -n 0 -c "${SBKEYS}/vendor.cer"
+
+  # Replace the embedded gpg public key, then sign grub with the vendor key.
+  objdumpcopy "${grub}" \
+    --file-alignment 4096 \
+    --update-section ".pubkey=${SBKEYS}/config-sign.pubkey"
+  pesign -i "${grub}" -o "${grub}.signed" -s "${CODE_SIGN_KEY[@]}"
+  mv "${grub}.signed" "${grub}"
+  pesigcheck -i "${grub}" -n 0 -c "${SBKEYS}/vendor.cer"
+else
+  # Generate a zero-sized certificate in the expected format.
+  cert_table /dev/null "${SBKEYS}/vendor.obj"
+
+  # Replace the embedded vendor certificate with the zero-sized one, which shim
+  # will ignore when Secure Boot is disabled.
+  objdumpcopy "${shim}" \
+    --update-section ".vendor_cert=${SBKEYS}/vendor.obj"
+
+   # Remove the embedded gpg public key to disable GRUB's signature checks.
+   objdumpcopy "${grub}" \
+     --file-alignment 4096 \
+     --remove-section ".pubkey"
+fi
+popd >/dev/null
+
 dd if=/dev/zero of="${EFI_IMAGE}" bs=1M count="${partsize[EFI-A]}"
 mkfs.vfat -I -S 512 "${EFI_IMAGE}" $((partsize[EFI-A] * 1024))
 mmd -i "${EFI_IMAGE}" ::/EFI
 mmd -i "${EFI_IMAGE}" ::/EFI/BOOT
 mcopy -i "${EFI_IMAGE}" "${EFI_MOUNT}/EFI/BOOT"/*.efi ::/EFI/BOOT
+if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+  # Make the signing certificate available on the EFI system partition so it
+  # can be imported through the firmware setup UI on bare metal systems.
+  mcopy -i "${EFI_IMAGE}" "${SBKEYS}"/db.{crt,cer} ::/EFI/BOOT
+fi
 dd if="${EFI_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[EFI-A]}"
 
 # Ensure that the grub directory exists.
@@ -266,6 +448,15 @@ mkdir -p "${ROOT_MOUNT}/boot/grub"
 
 # Now that we're done messing with /, move /boot out of it
 mv "${ROOT_MOUNT}/boot"/* "${BOOT_MOUNT}"
+
+if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+  pushd "${BOOT_MOUNT}" >/dev/null
+  vmlinuz="vmlinuz"
+  pesign -i "${vmlinuz}" -o "${vmlinuz}.signed" -s "${CODE_SIGN_KEY[@]}"
+  mv "${vmlinuz}.signed" "${vmlinuz}"
+  pesigcheck -i "${vmlinuz}" -n 0 -c "${SBKEYS}/vendor.cer"
+  popd >/dev/null
+fi
 
 # Set the Bottlerocket variant, version, and build-id
 SYS_ROOT="${ARCH}-bottlerocket-linux-gnu/sys-root"
@@ -352,12 +543,29 @@ else
    INITRD=""
 fi
 
-cat <<EOF > "${BOOT_MOUNT}/grub/grub.cfg"
+# If UEFI_SECURE_BOOT is set, disable interactive edits. Otherwise the intended
+# kernel command line parameters could be changed if the boot fails. Disable
+# signature checking as well, since grub.cfg will have already been verified
+# before we reach this point. bootconfig.data is generated at runtime and can't
+# be signed with a trusted key, so continuing to check signatures would prevent
+# it from being read. If boot fails, trigger an automatic reboot, since nothing
+# can be changed for troubleshooting purposes.
+if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+   echo 'set superusers=""' > "${BOOT_MOUNT}/grub/grub.cfg"
+   echo 'set check_signatures="no"' >> "${BOOT_MOUNT}/grub/grub.cfg"
+   FALLBACK=$'   echo "rebooting in 30 seconds..."\n'
+   FALLBACK+=$'   sleep 30\n'
+   FALLBACK+=$'   reboot\n'
+else
+   FALLBACK=""
+fi
+
+cat <<EOF >> "${BOOT_MOUNT}/grub/grub.cfg"
 set default="0"
 set timeout="0"
 set dm_verity_root="${DM_VERITY_ROOT[@]}"
 
-menuentry "${PRETTY_NAME} ${VERSION_ID}" {
+menuentry "${PRETTY_NAME} ${VERSION_ID}" --unrestricted {
    linux (\$root)/vmlinuz \\
        ${KERNEL_PARAMETERS} \\
        ${BOOTCONFIG} \\
@@ -371,8 +579,15 @@ menuentry "${PRETTY_NAME} ${VERSION_ID}" {
        systemd.log_color=0 \\
        systemd.show_status=true
    ${INITRD}
+   boot
+   ${FALLBACK}
 }
 EOF
+
+if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+  gpg --detach-sign "${BOOT_MOUNT}/grub/grub.cfg"
+  gpg --verify "${BOOT_MOUNT}/grub/grub.cfg.sig"
+fi
 
 # BOTTLEROCKET-BOOT-A
 mkdir -p "${BOOT_MOUNT}/lost+found"
@@ -520,6 +735,21 @@ if [ "${OUTPUT_FMT}" == "vmdk" ] ; then
      -e "s/{{OS_DISK_BYTES}}/${os_disk_bytes}/g" \
      -e "s/{{DATA_DISK_BYTES}}/${data_disk_bytes}/g" \
      > "${ova_dir}/${ovf}"
+
+  # The manifest templates for Secure Boot expect the cert data for
+  # PK, KEK, db, and dbx.
+  if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+    pk_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${SBKEYS}/PK.cer")"
+    kek_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${SBKEYS}/KEK.cer")"
+    db_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${SBKEYS}/db.cer")"
+    dbx_empty_hash_hex="$(sha256sum /dev/null | awk '{ print $1 }')"
+    sed -i \
+      -e "s/{{PK_CERT_DER_HEX}}/${pk_cert_der_hex}/g" \
+      -e "s/{{KEK_CERT_DER_HEX}}/${kek_cert_der_hex}/g" \
+      -e "s/{{DB_CERT_DER_HEX}}/${db_cert_der_hex}/g" \
+      -e "s/{{DBX_EMPTY_HASH_HEX}}/${dbx_empty_hash_hex}/g" \
+      "${ova_dir}/${ovf}"
+  fi
 
   # Make sure we replaced all the '{{...}}' fields with real values.
   if grep -F -e '{{' -e '}}' "${ova_dir}/${ovf}" ; then

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -14,6 +14,7 @@ OVF_TEMPLATE=""
 
 GRUB_SET_PRIVATE_VAR="no"
 XFS_DATA_PARTITION="no"
+UEFI_SECURE_BOOT="no"
 
 for opt in "$@"; do
    optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -29,6 +30,7 @@ for opt in "$@"; do
       --ovf-template=*) OVF_TEMPLATE="${optarg}" ;;
       --with-grub-set-private-var=*) GRUB_SET_PRIVATE_VAR="${optarg}" ;;
       --xfs-data-partition=*) XFS_DATA_PARTITION="${optarg}" ;;
+      --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
    esac
 done
 

--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2054  # Arrays are formatted for passing args to other tools
 
+#
+# Common error handling
+#
+#
+exit_trap_cmds=()
+
+on_exit() {
+    exit_trap_cmds+=( "$1" )
+}
+
+run_exit_trap_cmds() {
+    for cmd in "${exit_trap_cmds[@]}"; do
+        eval "${cmd}"
+    done
+}
+
+trap run_exit_trap_cmds exit
+
+bail() {
+    >&2 echo "$@"
+    exit 1
+}
+
 shopt -s nullglob
 
 arch=${BUILDSYS_ARCH}
@@ -15,10 +38,6 @@ declare -A extra_files=()
 boot_image=
 data_image=
 
-bail() {
-    >&2 echo "$@"
-    exit 1
-}
 
 if ! git_toplevel=$(git rev-parse --show-toplevel); then
     bail "Failed to get the root of the repo."
@@ -59,6 +78,8 @@ Options:
                         Bottlerocket image before launching the virtual machine
                         (may be given multiple times); existing data on the
                         private partition will be lost
+    --firmware-code     override the default firmware executable file
+    --firmware-vars     override the initial firmware variable storage file
     --help              shows this usage text
 
 By default, the virtual machine's port 22 (SSH) will be exposed via the local
@@ -118,6 +139,12 @@ parse_args() {
                 fi
                 extra_files[${local_file}]=${image_file}
                 ;;
+            --firmware-code)
+                shift; firmware_code=$1
+                ;;
+            --firmware-vars)
+                shift; firmware_vars=$1
+                ;;
             *)
                 usage_error "unknown option '$1'" ;;
         esac
@@ -167,6 +194,35 @@ prepare_raw_images() {
     fi
 }
 
+prepare_firmware() {
+    # Create local copies of the edk2 firmware variable storage, to help with
+    # faciliate Secure Boot testing where custom variables are needed for both
+    # architectures, but can't safely be reused across QEMU invocations. Also
+    # set reasonable defaults for both firmware files, if nothing more specific
+    # was requested.
+    local original_vars
+
+    if [[ ${arch} = x86_64 ]]; then
+        firmware_code=${firmware_code:-/usr/share/edk2/ovmf/OVMF_CODE.fd}
+        original_vars=${firmware_vars:-/usr/share/edk2/ovmf/OVMF_VARS.fd}
+        firmware_vars="$(mktemp)"
+        on_exit "rm '${firmware_vars}'"
+        cp "${original_vars}" "${firmware_vars}"
+    fi
+
+    if [[ ${arch} = aarch64 ]]; then
+        original_code=${firmware_code:-/usr/share/edk2/aarch64/QEMU_EFI.silent.fd}
+        original_vars=${firmware_vars:-/usr/share/edk2/aarch64/QEMU_VARS.fd}
+        firmware_code="$(mktemp)"
+        firmware_vars="$(mktemp)"
+        on_exit "rm '${firmware_code}' '${firmware_vars}'"
+        cat "${original_code}" /dev/zero \
+            | head -c 64m > "${firmware_code}"
+        cat "${original_vars}" /dev/zero \
+            | head -c 64m > "${firmware_vars}"
+    fi
+}
+
 create_extra_files() {
     # Explicitly instruct the kernel to send its output to the serial port on
     # x86 via a bootconfig initrd. Passing in settings via user-data would be
@@ -213,6 +269,7 @@ inject_files() {
     local private_mount private_image
     private_mount=$(mktemp -d)
     private_image=$(mktemp)
+    on_exit "rm -rf '${private_mount}' '${private_image}'"
 
     for local_file in "${!extra_files[@]}"; do
         local image_file=${extra_files[${local_file}]}
@@ -235,6 +292,8 @@ launch_vm() {
         -cpu host
         -smp "${vm_cpus}"
         -m "${vm_mem}"
+        -drive if=pflash,format=raw,unit=0,file="${firmware_code}",readonly=on
+        -drive if=pflash,format=raw,unit=1,file="${firmware_vars}"
         -drive index=0,if=virtio,format=raw,file="${boot_image}"
     )
 
@@ -251,11 +310,11 @@ launch_vm() {
     # emulated x86_64 chipset only to achieve parity.
     if [[ ${arch} = x86_64 ]]; then
         qemu_args+=( -global PIIX4_PM.acpi-root-pci-hotplug=off )
+        qemu_args+=( -machine q35,smm=on )
     fi
 
     if [[ ${arch} = aarch64 ]]; then
         qemu_args+=( -machine virt )
-        qemu_args+=( -bios /usr/share/edk2/aarch64/QEMU_EFI.silent.fd )
     fi
 
     if [[ -n ${data_image} ]]; then
@@ -267,6 +326,7 @@ launch_vm() {
 
 parse_args "$@"
 prepare_raw_images
+prepare_firmware
 create_extra_files
 inject_files
 launch_vm

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "policycoreutils",
  "procps",
  "selinux-policy",
+ "shim",
  "systemd",
  "util-linux",
  "wicked",
@@ -1049,6 +1050,10 @@ dependencies = [
 
 [[package]]
 name = "selinux-policy"
+version = "0.1.0"
+
+[[package]]
+name = "shim"
 version = "0.1.0"
 
 [[package]]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 grub-set-private-var = true
 unified-cgroup-hierarchy = true
 xfs-data-partition = true
+uefi-secure-boot = true
 
 [package.metadata.build-variant]
 kernel-parameters = [

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -14,6 +14,7 @@ partition-plan = "unified"
 grub-set-private-var = true
 unified-cgroup-hierarchy = true
 xfs-data-partition = true
+uefi-secure-boot = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/shared/template-split-secboot.ovf
+++ b/variants/shared/template-split-secboot.ovf
@@ -1,0 +1,97 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
+  <References>
+    <File ovf:id="file1" ovf:href="{{OS_DISK}}"/>
+    <File ovf:id="file2" ovf:href="{{DATA_DISK}}"/>
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks</Info>
+    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk1" ovf:capacity="{{OS_DISK_BYTES}}" ovf:fileRef="file1"/>
+    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk2" ovf:capacity="{{DATA_DISK_BYTES}}" ovf:fileRef="file2"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>The list of logical networks</Info>
+    <Network ovf:name="VM Network">
+      <Description>The network</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="image">
+    <Info>A Virtual machine</Info>
+    <OperatingSystemSection ovf:id="100" vmw:osType="other4xLinux64Guest">
+      <Info>The operating system installed</Info>
+      <Description>Other 4.x or later Linux (64-bit)</Description>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemType>vmx-15</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>8192MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>8192</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>NVMe Controller</rasd:Description>
+        <rasd:ElementName>NVMe Controller 1</rasd:ElementName>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.nvme.controller</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 1</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>1</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 2</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk2</rasd:HostResource>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>VM Network</rasd:Connection>
+        <rasd:ElementName>Network adapter 1</rasd:ElementName>
+        <rasd:InstanceID>9</rasd:InstanceID>
+        <rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+      </Item>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="disk.enableUUID" vmw:value="true"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="bios.bootOrder" vmw:value="hdd"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="bios.hddOrder" vmw:value="nvme0:1"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.PKDefault.value0" vmw:value="{{PK_CERT_DER_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.PKDefault.append" vmw:value="false"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.KEKDefault.value0" vmw:value="{{KEK_CERT_DER_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.KEKDefault.append" vmw:value="false"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbDefault.value0" vmw:value="{{DB_CERT_DER_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbDefault.append" vmw:value="false"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbxDefault.value0" vmw:value="{{DBX_EMPTY_HASH_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbxDefault.append" vmw:value="false"/>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>

--- a/variants/shared/template-unified-secboot.ovf
+++ b/variants/shared/template-unified-secboot.ovf
@@ -1,0 +1,87 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
+  <References>
+    <File ovf:id="file1" ovf:href="{{OS_DISK}}"/>
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks</Info>
+    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk1" ovf:capacity="{{OS_DISK_BYTES}}" ovf:fileRef="file1"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>The list of logical networks</Info>
+    <Network ovf:name="VM Network">
+      <Description>The network</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="image">
+    <Info>A Virtual machine</Info>
+    <OperatingSystemSection ovf:id="100" vmw:osType="other4xLinux64Guest">
+      <Info>The operating system installed</Info>
+      <Description>Other 4.x or later Linux (64-bit)</Description>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemType>vmx-15</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>8192MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>8192</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>NVMe Controller</rasd:Description>
+        <rasd:ElementName>NVMe Controller 1</rasd:ElementName>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.nvme.controller</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard Disk 1</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>VM Network</rasd:Connection>
+        <rasd:ElementName>Network adapter 1</rasd:ElementName>
+        <rasd:InstanceID>9</rasd:InstanceID>
+        <rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+      </Item>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="disk.enableUUID" vmw:value="true"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="bios.bootOrder" vmw:value="hdd"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="bios.hddOrder" vmw:value="nvme0:1"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.PKDefault.value0" vmw:value="{{PK_CERT_DER_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.PKDefault.append" vmw:value="false"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.KEKDefault.value0" vmw:value="{{KEK_CERT_DER_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.KEKDefault.append" vmw:value="false"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbDefault.value0" vmw:value="{{DB_CERT_DER_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbDefault.append" vmw:value="false"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbxDefault.value0" vmw:value="{{DBX_EMPTY_HASH_HEX}}"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="uefi.secureBoot.dbxDefault.append" vmw:value="false"/>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -14,6 +14,7 @@ partition-plan = "unified"
 grub-set-private-var = true
 unified-cgroup-hierarchy = true
 xfs-data-partition = true
+uefi-secure-boot = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"

--- a/variants/vmware-dev/template.ovf
+++ b/variants/vmware-dev/template.ovf
@@ -1,1 +1,1 @@
-../shared/template-unified.ovf
+../shared/template-unified-secboot.ovf


### PR DESCRIPTION
**Issue number:**

#2501

**Description of changes:**
The first set of commits brings GRUB up-to-date to fix any known flaws in Secure Boot support, adds shim as the initial EFI bootloader, and prepares the shim and grub binaries for modification in the final image build step.

```
packages: update grub
grub: move embedded public key into dedicated section
grub: add SBAT info
grub: add modules for GPG signature verification
tools: add script to replace the public key embedded in GRUB
packages: build shim
shim: embed placeholder for vendor cert
```

The second set of commits introduces the concept of a Secure Boot profile - all of the private keys, certificates, and configuration files necessary for Secure Boot signing - and automates the creation of a local profile. It also adds an image feature flag for Secure Boot support, along with OVF templates for VMware that include placeholders for EFI variables. 

```
build: add scripts to create Secure Boot profiles
build: auto-create a local Secure Boot profile
build: pass Secure Boot profile secrets to builds
build: add Secure Boot OVF templates
build: add image feature flag for Secure Boot
```

The third set of commits extends `buildsys` (mostly `rpm2img`) and `pubsys` to do the required signing and registration for images, OVAs, and AMIs. This is where all of the above actually pays off.

```
build: sign artifacts for Secure Boot
pubsys: register AMIs with Secure Boot support
```

The fourth set of commits is developer-oriented. It enables the feature flag for `*-dev` variants, documents the new tools for generating Secure Boot profiles, and extends `start-local-vm` to support firmware overrides for testing the functionality.

```
start-local-vm: add options to override firmware
docs: document tools to generate Secure Boot Keys
variants: enable Secure Boot for dev builds
```

**Testing done:**
Verified that Secure Boot enabled images worked on:
* AWS (for Nitro-based instance types)
* VMware (in VMC-A)
* metal (under QEMU)

Verified that older instance types could be launched from the same AMIs, and fell back to BIOS boot as expected.

Performed negative testing as well with Secure Boot enabled:
* firmware refuses to boot shim if not signed with a trusted key
* shim refuses to boot grub if not signed with a trusted key
* grub refuses to load grub.cfg if the detached signature is invalid or from an untrusted key
* grub refuses to load the Linux kernel if not signed with a trusted key


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
