### PR TITLE
Update CHANGELOG for v.1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.14.0 (2023-05-10)
+# v1.14.0 (2023-05-11)
 
 ## OS Changes
 
@@ -18,6 +18,7 @@
 ### Kubernetes
 
 * Add Kubernetes 1.27 variants ([#3046])
+  * Switch to using Kubernetes default values for `kube-api-burst` and `kube-api-qps` ([#3094])
 * Add more Kubernetes settings ([#2930], [#2986])
   * Soft eviction policy
   * Graceful shutdown
@@ -51,6 +52,7 @@
 [#3035]: https://github.com/bottlerocket-os/bottlerocket/pull/3035
 [#3075]: https://github.com/bottlerocket-os/bottlerocket/pull/3075
 [#3046]: https://github.com/bottlerocket-os/bottlerocket/pull/3046
+[#3094]: https://github.com/bottlerocket-os/bottlerocket/pull/3094
 [#2930]: https://github.com/bottlerocket-os/bottlerocket/pull/2930
 [#2986]: https://github.com/bottlerocket-os/bottlerocket/pull/2986
 [#3070]: https://github.com/bottlerocket-os/bottlerocket/pull/3070


### PR DESCRIPTION
**Description of changes:**

This updates the planned release date and adds a reference for the k8s 1.27 change to use Kubernetes own default values for `kube-api-burst` and `kube-api-qps`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
