### PR TITLE
[1.14.x] Update EKS-D package versions

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/19/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
-sha512 = "25b715e0308757f2dc5ceaf13f55cae1c37de0e0292ce2f49714e9c532ee6fe299398ffcb8e1654fc7f9a89328a9b1a9dcb51d966c2eef83df9f7b7ce93f0a31"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/22/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
+sha512 = "437a41e43e87ea0d3f765aa69bfbff5a32c7951349c7d53aaed171393989337742b1fa1c00a01bf18c8a9e689dd4e56b549c555baf44b57bcdb4ef75d79e9b35"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/19/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/22/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.24"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/14/artifacts/kubernetes/v1.24.12/kubernetes-src.tar.gz"
-sha512 = "516fc7e90d13dd5012fcf61384e5b535ab8d08e1f292b6f21072e221550a78de27c97d7354acb848ce4f365eaf050cf0c66c1fad29d41337d8929066d6a80261"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/17/artifacts/kubernetes/v1.24.13/kubernetes-src.tar.gz"
+sha512 = "852cfe0e953203fedad04c26d4640124de1de7dd5badd11a53f2c29fde18ec203e534315f34ee2cc41d9090e78575cde8582625ce22cbd94d85ce131d46e8dbf"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.24.12
+%global gover 1.24.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/14/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/17/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.25"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/10/artifacts/kubernetes/v1.25.8/kubernetes-src.tar.gz"
-sha512 = "5ef45379d094cf7e0a03ee77a8dd13c1c5d0b41c13b3cdb41985e07e273aa727a912e079e0a0a0b1d39073dd79f3fb0a0ad8cff279347a46a0571db29c88714f"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/13/artifacts/kubernetes/v1.25.9/kubernetes-src.tar.gz"
+sha512 = "628e45caa6b100f897d888db84d543b0eed33ca6409b9d13c842d33ea0e183d94482f160b301556926c213b3a7fe7962fb6b2f48777d6f199efee32f649880c4"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.25.8
+%global gover 1.25.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/10/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/13/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.26"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/5/artifacts/kubernetes/v1.26.2/kubernetes-src.tar.gz"
-sha512 = "da2a9b636c25f9501aa55623a321fcc5840b7509e8e611482e213f3dbb32cf4f8219008f4e90fdf9180a0446cbc8e29a679753c2a9cdaf8a3cb8fc7238b074fa"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/9/artifacts/kubernetes/v1.26.4/kubernetes-src.tar.gz"
+sha512 = "167612d66f3d5cefd3eab5be722506ae326d8726617b91230858dab9b64f4e9a8ef1cb419899ad6be27f0752fb9748bc6df8abe1c21070717d82993bd6f9eb60"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.26.2
+%global gover 1.26.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/5/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.27"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/1/artifacts/kubernetes/v1.27.1/kubernetes-src.tar.gz"
-sha512 = "bec6b87a1cf974feb041ac684057be42d0a9abd332371bc8a8a7311d7f23e4ecba923dc9f46d4db8a5a2818976ddf7e06baef7b9fd87ff5fda27b6665b956c07"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/3/artifacts/kubernetes/v1.27.1/kubernetes-src.tar.gz"
+sha512 = "1f0e9411050bc1021acc9f08059df26cfb13f54dbc2a59ea699d5c8bc3def28ed46fd54edb8ed7e87ca4b193b3ee2952825a00da2e74138fc7b55b7316e607b0"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/1/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Description of changes:**

This backports the following updates to EKS-D Kubernetes package versions.

- Updated to EKS-D 1.23-22
- Updated to EKS-D 1.24-17
- Updated to EKS-D 1.25-13
- Updated to EKS-D 1.26-9
- Updated to EKS-D 1.27-3

**Testing done:**

Testing done on package updates to `develop` branch. Additional sanity checking of building and spinning up nodes:

- [x] aws-k8s-1.23
- [x] aws-k8s-1.24
- [x] aws-k8s-1.25
- [x] aws-k8s-1.26
- [x] aws-k8s-1.27

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
