### PR TITLE
Issue template: Add note to contact AWS support

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -10,6 +10,15 @@ Tips:
 - Please include details about the environment you're running in.
 -->
 
+<!--
+Note:
+
+If you are an AWS customer and experiencing an urgent issue you
+believe is related to AWS, please contact support:
+
+https://aws.amazon.com/contact-us/
+
+-->
 **What I'd like:**
 
 

--- a/.github/ISSUE_TEMPLATE/image.md
+++ b/.github/ISSUE_TEMPLATE/image.md
@@ -11,6 +11,15 @@ Tips:
 - Please include any error messages you received, with any required context.
 -->
 
+<!--
+Note:
+
+If you are an AWS customer and experiencing an urgent issue you
+believe is related to AWS, please contact support:
+
+https://aws.amazon.com/contact-us/
+
+-->
 **Image I'm using:**
 
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds a note to point to AWS customers that they are able, and should, contact customer support for any service issues they are encountering.

**Testing done:**

To be reviewed and tweaked if necessary once template is available.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
