### PR TITLE
host-ctr: add support for pulling private ECR images from `il-central-1`

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main_test.go
+++ b/sources/host-ctr/cmd/host-ctr/main_test.go
@@ -160,3 +160,39 @@ func TestBadRegistryHosts(t *testing.T) {
 	_, err := f("docker.io")
 	assert.Error(t, err)
 }
+
+func TestEcrParserSpecialRegion(t *testing.T) {
+	test := struct {
+		name           string
+		ecrImgURI      string
+		expectedString string
+	}{
+
+		"Parse ECR repo URL for special-case region",
+		"111111111111.dkr.ecr.il-central-1.amazonaws.com/bottlerocket/container:1.2.3",
+		"ecr.aws/arn:aws:ecr:il-central-1:111111111111:repository/bottlerocket/container:1.2.3",
+	}
+
+	t.Run(test.name, func(t *testing.T) {
+		result, err := parseImageURISpecialRegions(test.ecrImgURI)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expectedString, result)
+	})
+}
+
+func TestEcrParserUnsupportedSpecialRegions(t *testing.T) {
+	test := struct {
+		name           string
+		ecrImgURI      string
+		expectedString string
+	}{
+		"Unsupported special region",
+		"111111111111.dkr.ecr.outer-space.amazonaws.com/bottlerocket/container:1.2.3",
+		"",
+	}
+
+	t.Run(test.name, func(t *testing.T) {
+		_, err := parseImageURISpecialRegions(test.ecrImgURI)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
```
    host-ctr: add temporary workaround for bypassing checks for parsing ECR ref
    
    In order to support pulling images from ECR repositories from
    il-central-1, we need to generate our own canonical ECR image reference
    since the region is not officially supported by aws-go-sdk yet.
```


**Testing done:**
I am able to pull images from `il-central-1`:
```
$ ./host-ctr -s /run/containerd/containerd.sock pull-image --source 777777777777.dkr.ecr.il-central-1.amazonaws.com/eks/pause:3.2-eksbuild.1
time="2023-05-17T18:13:49-07:00" level=info msg="Image does not exist, proceeding to pull image from source." ref="ecr.aws/arn:aws:ecr:il-central-1:777777777777:repository/eks/pause:3.2-eksbuild.1"
time="2023-05-17T18:13:49-07:00" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:il-central-1:777777777777:repository/eks/pause:3.2-eksbuild.1"
time="2023-05-17T18:13:54-07:00" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:il-central-1:777777777777:repository/eks/pause:3.2-eksbuild.1"
time="2023-05-17T18:13:54-07:00" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:il-central-1:777777777777:repository/eks/pause:3.2-eksbuild.1"
time="2023-05-17T18:13:54-07:00" level=info msg="tagging image" img="777777777777.dkr.ecr.il-central-1.amazonaws.com/eks/pause:3.2-eksbuild.1"

$ ./host-ctr -s /run/containerd/containerd.sock pull-image --source 777777777777.dkr.ecr.il-central-1.amazonaws.com/bottlerocket-admin:v0.10.1
time="2023-05-17T18:12:52-07:00" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:il-central-1:777777777777:repository/bottlerocket-admin:v0.10.1"
time="2023-05-17T18:12:53-07:00" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:il-central-1:777777777777:repository/bottlerocket-admin:v0.10.1"
time="2023-05-17T18:12:53-07:00" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:il-central-1:777777777777:repository/bottlerocket-admin:v0.10.1"
time="2023-05-17T18:12:53-07:00" level=info msg="tagging image" img="777777777777.dkr.ecr.il-central-1.amazonaws.com/bottlerocket-admin:v0.10.1"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
