### PR TITLE
netdog: Add initial networkd config structs and associated `Display` macro

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "snafu",
+ "systemd-derive",
  "tempfile",
  "tokio",
  "tokio-retry",
@@ -3815,6 +3816,17 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "systemd-derive"
+version = "0.1.0"
+dependencies = [
+ "darling",
+ "generate-readme",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -16,6 +16,7 @@ imdsclient = { path = "../../imdsclient", version = "0.1" }
 indexmap = { version = "1", features = ["serde"]}
 envy = "0.4"
 lazy_static = "1"
+systemd-derive = { path = "systemd-derive", version = "0.1" }
 quick-xml = {version = "0.26", features = ["serialize"]}
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 regex = "1"

--- a/sources/api/netdog/src/interface_id.rs
+++ b/sources/api/netdog/src/interface_id.rs
@@ -109,6 +109,12 @@ impl Serialize for MacAddress {
     }
 }
 
+impl Display for MacAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
 /// InterfaceName can only be created from a string that contains a valid network interface name.
 /// Validation is handled in the `TryFrom` implementation below.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
@@ -187,6 +193,12 @@ impl Serialize for InterfaceName {
         S: Serializer,
     {
         serializer.serialize_str(&self.inner)
+    }
+}
+
+impl Display for InterfaceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
     }
 }
 

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -38,6 +38,8 @@ mod interface_id;
 mod lease;
 mod net_config;
 #[cfg(net_backend = "systemd-networkd")]
+mod networkd;
+#[cfg(net_backend = "systemd-networkd")]
 mod networkd_status;
 mod vlan_id;
 mod wicked;

--- a/sources/api/netdog/src/networkd/config/mod.rs
+++ b/sources/api/netdog/src/networkd/config/mod.rs
@@ -1,0 +1,12 @@
+//! The config module contains the structures and methods needed to create properly formatted
+//! systemd-networkd configuration files
+mod netdev;
+mod network;
+
+use netdev::NetDevConfig;
+use network::NetworkConfig;
+
+pub(crate) enum NetworkDConfigFile {
+    Network(NetworkConfig),
+    NetDev(NetDevConfig),
+}

--- a/sources/api/netdog/src/networkd/config/netdev.rs
+++ b/sources/api/netdog/src/networkd/config/netdev.rs
@@ -1,0 +1,111 @@
+use crate::interface_id::InterfaceName;
+use crate::vlan_id::VlanId;
+use std::fmt::Display;
+use std::net::IpAddr;
+use systemd_derive::{SystemdUnit, SystemdUnitSection};
+
+#[derive(Debug, Default, SystemdUnit)]
+pub(crate) struct NetDevConfig {
+    netdev: Option<NetDevSection>,
+    vlan: Option<VlanSection>,
+    bond: Option<BondSection>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "NetDev")]
+struct NetDevSection {
+    #[systemd(entry = "Name")]
+    name: Option<InterfaceName>,
+    #[systemd(entry = "Kind")]
+    kind: Option<NetDevKind>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "VLAN")]
+struct VlanSection {
+    #[systemd(entry = "Id")]
+    id: Option<VlanId>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Bond")]
+struct BondSection {
+    #[systemd(entry = "Mode")]
+    mode: Option<BondMode>,
+    #[systemd(entry = "MinLinks")]
+    min_links: Option<usize>,
+    #[systemd(entry = "MIIMonitorSec")]
+    mii_mon_secs: Option<u32>,
+    #[systemd(entry = "UpDelaySec")]
+    up_delay_sec: Option<u32>,
+    #[systemd(entry = "DownDelaySec")]
+    down_delay_sec: Option<u32>,
+    #[systemd(entry = "ARPIntervalSec")]
+    arp_interval_secs: Option<u32>,
+    #[systemd(entry = "ARPValidate")]
+    arp_validate: Option<ArpValidate>,
+    #[systemd(entry = "ARPIPTargets")]
+    arp_targets: Vec<IpAddr>,
+    #[systemd(entry = "ARPAllTargets")]
+    arp_all_targets: Option<ArpAllTargets>,
+}
+
+#[derive(Debug)]
+enum NetDevKind {
+    Bond,
+    Vlan,
+}
+
+impl Display for NetDevKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NetDevKind::Bond => write!(f, "bond"),
+            NetDevKind::Vlan => write!(f, "vlan"),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BondMode {
+    ActiveBackup,
+}
+
+impl Display for BondMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BondMode::ActiveBackup => write!(f, "active-backup"),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ArpValidate {
+    Active,
+    All,
+    Backup,
+    r#None,
+}
+
+impl Display for ArpValidate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArpValidate::Active => write!(f, "active"),
+            ArpValidate::All => write!(f, "all"),
+            ArpValidate::Backup => write!(f, "backup"),
+            ArpValidate::r#None => write!(f, "none"),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ArpAllTargets {
+    All,
+}
+
+impl Display for ArpAllTargets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArpAllTargets::All => write!(f, "all"),
+        }
+    }
+}

--- a/sources/api/netdog/src/networkd/config/network.rs
+++ b/sources/api/netdog/src/networkd/config/network.rs
@@ -1,0 +1,123 @@
+use crate::interface_id::{InterfaceName, MacAddress};
+use ipnet::IpNet;
+use std::fmt::Display;
+use std::net::IpAddr;
+use systemd_derive::{SystemdUnit, SystemdUnitSection};
+
+#[derive(Debug, Default, SystemdUnit)]
+pub(crate) struct NetworkConfig {
+    r#match: Option<MatchSection>,
+    link: Option<LinkSection>,
+    network: Option<NetworkSection>,
+    route: Vec<RouteSection>,
+    dhcp4: Option<Dhcp4Section>,
+    dhcp6: Option<Dhcp6Section>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Match")]
+struct MatchSection {
+    #[systemd(entry = "Name")]
+    name: Option<InterfaceName>,
+    #[systemd(entry = "PermanentMACAddress")]
+    permanent_mac_address: Vec<MacAddress>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Link")]
+struct LinkSection {
+    #[systemd(entry = "RequiredForOnline")]
+    required: Option<bool>,
+    #[systemd(entry = "RequiredFamilyForOnline")]
+    required_family: Option<RequiredFamily>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Network")]
+struct NetworkSection {
+    #[systemd(entry = "Address")]
+    addresses: Vec<IpNet>,
+    #[systemd(entry = "Bond")]
+    bond: Option<InterfaceName>,
+    #[systemd(entry = "ConfigureWithoutCarrier")]
+    configure_wo_carrier: Option<bool>,
+    #[systemd(entry = "DHCP")]
+    dhcp: Option<DhcpBool>,
+    #[systemd(entry = "LinkLocalAddressing")]
+    link_local_addressing: Option<DhcpBool>,
+    #[systemd(entry = "PrimarySlave")]
+    primary_bond_worker: Option<bool>,
+    #[systemd(entry = "VLAN")]
+    vlan: Vec<InterfaceName>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Route")]
+struct RouteSection {
+    #[systemd(entry = "Destination")]
+    destination: Option<IpNet>,
+    #[systemd(entry = "Gateway")]
+    gateway: Option<IpAddr>,
+    #[systemd(entry = "Metric")]
+    metric: Option<u32>,
+    #[systemd(entry = "PreferredSource")]
+    preferred_source: Option<IpAddr>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "DHCPv4")]
+struct Dhcp4Section {
+    #[systemd(entry = "RouteMetric")]
+    metric: Option<u32>,
+    #[systemd(entry = "UseDNS")]
+    use_dns: Option<bool>,
+    #[systemd(entry = "UseDomains")]
+    use_domains: Option<bool>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "DHCPv6")]
+struct Dhcp6Section {
+    #[systemd(entry = "UseDNS")]
+    use_dns: Option<bool>,
+    #[systemd(entry = "UseDomains")]
+    use_domains: Option<bool>,
+}
+
+#[derive(Debug)]
+enum RequiredFamily {
+    Any,
+    Both,
+    Ipv4,
+    Ipv6,
+}
+
+impl Display for RequiredFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequiredFamily::Any => write!(f, "any"),
+            RequiredFamily::Both => write!(f, "both"),
+            RequiredFamily::Ipv4 => write!(f, "ipv4"),
+            RequiredFamily::Ipv6 => write!(f, "ipv6"),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum DhcpBool {
+    Ipv4,
+    Ipv6,
+    No,
+    Yes,
+}
+
+impl Display for DhcpBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DhcpBool::Ipv4 => write!(f, "ipv4"),
+            DhcpBool::Ipv6 => write!(f, "ipv6"),
+            DhcpBool::No => write!(f, "no"),
+            DhcpBool::Yes => write!(f, "yes"),
+        }
+    }
+}

--- a/sources/api/netdog/src/networkd/mod.rs
+++ b/sources/api/netdog/src/networkd/mod.rs
@@ -1,0 +1,1 @@
+mod config;

--- a/sources/api/netdog/systemd-derive/Cargo.toml
+++ b/sources/api/netdog/systemd-derive/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "systemd-derive"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[lib]
+path = "src/lib.rs"
+proc-macro = true
+
+[dependencies]
+darling = { version = "0.14", default-features = false }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", default-features = false, features = ["derive"] }
+
+[build-dependencies]
+generate-readme = { path = "../../../generate-readme", version = "0.1" }

--- a/sources/api/netdog/systemd-derive/README.md
+++ b/sources/api/netdog/systemd-derive/README.md
@@ -1,0 +1,129 @@
+# systemd-derive
+
+Current version: 0.1.0
+
+
+A macro to serialize structs to `systemd` unit file format
+
+### Description
+
+The `SystemdUnit` and `SystemdUnitSection` macros can be used to serialize structs representing
+`systemd` unit files.
+
+Under the hood, the macros implement `Display` for structs.  This allows converting the structs to
+a string suitable for writing directly to a file.
+
+The implementation is fairly rigid to the way the "INI-like" structure of `systemd` unit files is
+represented. `systemd` differs from standard INI format in that duplicate sections are allowed,
+along with duplicate keys within a section.  The macros expect there will be a "top-level" struct
+that represents the unit file, with nested structs representing the sections of said file. These
+nested structs representing sections have fields that are the configuration key/value pairs for
+that section.
+
+All struct fields must be either `Option`s or `Vec`s containing an object that implements
+`Display`.  Fields that are `Vec`s will be iterated upon and each value of the `Vec` will be
+serialized.  For structs deriving `SystemdUnit`, fields represent sections and therefore a `Vec`
+field would serialize as a repeated section. Structs deriving `SystemdUnitSection` have fields
+representing key/value pairs; a `Vec` here would serialize as a repeated entry within a section. An
+example of both types is below.
+
+### Parameters
+
+The `SystemdUnit` macro takes no parameters.
+
+The `SystemdUnitSection` macro requires the following input parameters.
+- `section`: The name of the section this struct represents.  This parameter is set on the struct.
+- `entry`: The configuration entry name (which may be different than the struct member name).  This parameter must be set on each struct member.
+
+## Example
+
+This is an abbreviated set of structs that could represent a `systemd-networkd` .network file.
+
+```rust
+use systemd_derive::{SystemdUnit, SystemdUnitSection};
+
+// This top-level struct requires no parameters; it represents the file as a whole, and contains
+// all the relevant sections.
+//
+// Pay special attention to the `route_sections` struct member.  It is a Vec, meaning that the
+// section can be repeated multiple times within the file.
+#[derive(Debug, Default, SystemdUnit)]
+struct NetworkConfig {
+    match: Option<MatchSection>,
+    network: Option<NetworkSection>,
+    route: Vec<RouteSection>,
+}
+
+// This struct represents the "Match" section.  The struct must be annoted with the section name
+// ("Match"), and each of its fields must be annoted with the configuration entry name.
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Match")]
+struct MatchSection {
+    #[systemd(entry = "Name")]
+    name: Option<String>,
+}
+
+// This struct demonstrates the use of an entry ("Address") that can be repeated within a section.
+// The "Address" entry will be serialized as multiple entries, each with a single value from the
+// given Vec.
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Network")]
+struct NetworkSection {
+    #[systemd(entry = "Address")]
+    addresses: Vec<String>,
+    #[systemd(entry = "DHCP")]
+    dhcp: Option<String>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Route")]
+struct RouteSection {
+    #[systemd(entry = "Destination")]
+    destination: Option<String>,
+}
+```
+
+The following demonstrates instantiating an instance of the above structs and the resulting serialized form from calling `to_string()`.
+
+```rust
+let cfg = NetworkConfig {
+    match: Some(MatchSection {
+        name: Some("eno1".to_string()),
+    }),
+    network: Some(NetworkSection {
+        addresses: vec!["1.2.3.4".to_string(), "2.3.4.5".to_string()],
+        dhcp: Some("ipv4".to_string()),
+    }),
+    route: vec![
+        RouteSection {
+            destination: Some("10.0.0.1".to_string()),
+        },
+        RouteSection {
+            destination: Some("11.0.0.1".to_string()),
+        },
+    ],
+};
+
+println!("{}", cfg.to_string());
+```
+
+Would result in the following being printed:
+```rust
+[Match]
+Name=eno1
+
+[Network]
+Address=1.2.3.4
+Address=2.3.4.5
+DHCP=ipv4
+
+[Route]
+Destination=10.0.0.1
+
+[Route]
+Destination=11.0.0.1
+```
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/api/netdog/systemd-derive/README.tpl
+++ b/sources/api/netdog/systemd-derive/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/api/netdog/systemd-derive/build.rs
+++ b/sources/api/netdog/systemd-derive/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_lib().unwrap();
+}

--- a/sources/api/netdog/systemd-derive/src/lib.rs
+++ b/sources/api/netdog/systemd-derive/src/lib.rs
@@ -1,0 +1,260 @@
+/*!
+
+A macro to serialize structs to `systemd` unit file format
+
+## Description
+
+The `SystemdUnit` and `SystemdUnitSection` macros can be used to serialize structs representing
+`systemd` unit files.
+
+Under the hood, the macros implement `Display` for structs.  This allows converting the structs to
+a string suitable for writing directly to a file.
+
+The implementation is fairly rigid to the way the "INI-like" structure of `systemd` unit files is
+represented. `systemd` differs from standard INI format in that duplicate sections are allowed,
+along with duplicate keys within a section.  The macros expect there will be a "top-level" struct
+that represents the unit file, with nested structs representing the sections of said file. These
+nested structs representing sections have fields that are the configuration key/value pairs for
+that section.
+
+All struct fields must be either `Option`s or `Vec`s containing an object that implements
+`Display`.  Fields that are `Vec`s will be iterated upon and each value of the `Vec` will be
+serialized.  For structs deriving `SystemdUnit`, fields represent sections and therefore a `Vec`
+field would serialize as a repeated section. Structs deriving `SystemdUnitSection` have fields
+representing key/value pairs; a `Vec` here would serialize as a repeated entry within a section. An
+example of both types is below.
+
+## Parameters
+
+The `SystemdUnit` macro takes no parameters.
+
+The `SystemdUnitSection` macro requires the following input parameters.
+- `section`: The name of the section this struct represents.  This parameter is set on the struct.
+- `entry`: The configuration entry name (which may be different than the struct member name).  This parameter must be set on each struct member.
+
+# Example
+
+This is an abbreviated set of structs that could represent a `systemd-networkd` .network file.
+
+```ignore
+use systemd_derive::{SystemdUnit, SystemdUnitSection};
+
+// This top-level struct requires no parameters; it represents the file as a whole, and contains
+// all the relevant sections.
+//
+// Pay special attention to the `route_sections` struct member.  It is a Vec, meaning that the
+// section can be repeated multiple times within the file.
+#[derive(Debug, Default, SystemdUnit)]
+struct NetworkConfig {
+    match: Option<MatchSection>,
+    network: Option<NetworkSection>,
+    route: Vec<RouteSection>,
+}
+
+// This struct represents the "Match" section.  The struct must be annoted with the section name
+// ("Match"), and each of its fields must be annoted with the configuration entry name.
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Match")]
+struct MatchSection {
+    #[systemd(entry = "Name")]
+    name: Option<String>,
+}
+
+// This struct demonstrates the use of an entry ("Address") that can be repeated within a section.
+// The "Address" entry will be serialized as multiple entries, each with a single value from the
+// given Vec.
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Network")]
+struct NetworkSection {
+    #[systemd(entry = "Address")]
+    addresses: Vec<String>,
+    #[systemd(entry = "DHCP")]
+    dhcp: Option<String>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Route")]
+struct RouteSection {
+    #[systemd(entry = "Destination")]
+    destination: Option<String>,
+}
+```
+
+The following demonstrates instantiating an instance of the above structs and the resulting serialized form from calling `to_string()`.
+
+```ignore
+let cfg = NetworkConfig {
+    match: Some(MatchSection {
+        name: Some("eno1".to_string()),
+    }),
+    network: Some(NetworkSection {
+        addresses: vec!["1.2.3.4".to_string(), "2.3.4.5".to_string()],
+        dhcp: Some("ipv4".to_string()),
+    }),
+    route: vec![
+        RouteSection {
+            destination: Some("10.0.0.1".to_string()),
+        },
+        RouteSection {
+            destination: Some("11.0.0.1".to_string()),
+        },
+    ],
+};
+
+println!("{}", cfg.to_string());
+```
+
+Would result in the following being printed:
+```ignore
+[Match]
+Name=eno1
+
+[Network]
+Address=1.2.3.4
+Address=2.3.4.5
+DHCP=ipv4
+
+[Route]
+Destination=10.0.0.1
+
+[Route]
+Destination=11.0.0.1
+```
+*/
+
+use darling::{ast, FromDeriveInput, FromField, ToTokens};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Ident};
+
+/// A macro to simplify serializing a unit file.  See the description in the lib documentation
+/// or the README.
+#[proc_macro_derive(SystemdUnit)]
+pub fn derive_systemd_unit(input: TokenStream) -> TokenStream {
+    // Parse the AST and "deserialize" into SystemdUnit
+    let ast = parse_macro_input!(input as DeriveInput);
+    let n =
+        SystemdUnit::from_derive_input(&ast).expect("Unable to parse `systemd` macro arguments");
+
+    quote!(#n).into()
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(supports(struct_named))]
+struct SystemdUnit {
+    pub ident: Ident,
+    pub data: ast::Data<(), SystemdSection>,
+}
+
+#[derive(Debug, FromField)]
+struct SystemdSection {
+    ident: Option<Ident>,
+}
+
+impl ToTokens for SystemdUnit {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let SystemdUnit { ident, data } = self;
+
+        let sections: Vec<Ident> = data
+            .as_ref()
+            .take_struct()
+            // The annotation supports(struct_named) ensures our input will always be a struct
+            .expect("Will never be anything but a struct")
+            .fields
+            .iter()
+            .filter_map(|f| f.ident.clone())
+            .collect();
+
+        tokens.extend(quote! {
+            impl std::fmt::Display for #ident {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    // `Vec`s and `Option`s are both iterators, allowing us to write the same code
+                    // for both
+                    #(for section in self.#sections.iter() {
+
+                            write!(f, "{}", section.to_string())?;
+                    })*
+                    Ok(())
+                }
+            }
+        });
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// A macro to simplify serializing a section of a unit file.  See the description in the lib
+/// documentation or the README.
+#[proc_macro_derive(SystemdUnitSection, attributes(systemd))]
+pub fn derive_systemd_unit_section(input: TokenStream) -> TokenStream {
+    // Parse the AST and "deserialize" into SystemdUnitSection
+    let ast = parse_macro_input!(input as DeriveInput);
+    let n = SystemdUnitSection::from_derive_input(&ast)
+        .expect("Unable to parse `systemd` macro arguments");
+
+    quote!(#n).into()
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(supports(struct_named))]
+#[darling(attributes(systemd))]
+struct SystemdUnitSection {
+    pub ident: Ident,
+    pub data: ast::Data<(), SystemdUnitSectionField>,
+    #[darling(rename = "section")]
+    pub section_name: String,
+}
+
+#[derive(Debug, FromField)]
+#[darling(attributes(systemd))]
+struct SystemdUnitSectionField {
+    ident: Option<Ident>,
+    entry: String,
+}
+
+impl ToTokens for SystemdUnitSection {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let SystemdUnitSection {
+            ident,
+            data,
+            section_name,
+        } = self;
+
+        let entries = data
+            .as_ref()
+            .take_struct()
+            // supports(struct_named) ensures our input will always be a struct
+            .expect("Will never be anything but a struct")
+            .fields;
+
+        // Defensively remove any brackets from the name, since we do that for the user
+        let section_name = section_name.replace(['[', ']'], "");
+
+        tokens.extend(quote! {
+            impl std::fmt::Display for #ident {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "[{}]\n", #section_name)?;
+
+                    #(#entries)*
+                    Ok(())
+                }
+            }
+
+        });
+    }
+}
+
+impl ToTokens for SystemdUnitSectionField {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let struct_field_name = self.ident.as_ref().expect("Should always have a name");
+        let systemd_entry_name = &self.entry;
+
+        tokens.extend(quote! {
+            // `Vec`s and `Option`s are both iterators, allowing us to write the same code for both
+            for field in self.#struct_field_name.iter() {
+                write!(f, "{}={}\n", #systemd_entry_name, field)?;
+
+            }
+        })
+    }
+}

--- a/sources/api/netdog/systemd-derive/tests/tests.rs
+++ b/sources/api/netdog/systemd-derive/tests/tests.rs
@@ -1,0 +1,78 @@
+use systemd_derive::{SystemdUnit, SystemdUnitSection};
+
+#[derive(Debug, Default, SystemdUnit)]
+struct NetworkConfig {
+    r#match: Option<MatchSection>,
+    network: Option<NetworkSection>,
+    route: Vec<RouteSection>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Match")]
+struct MatchSection {
+    #[systemd(entry = "Name")]
+    name: Option<String>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Network")]
+struct NetworkSection {
+    #[systemd(entry = "Address")]
+    addresses: Vec<String>,
+    #[systemd(entry = "DHCP")]
+    dhcp: Option<String>,
+}
+
+#[derive(Debug, Default, SystemdUnitSection)]
+#[systemd(section = "Route")]
+struct RouteSection {
+    #[systemd(entry = "Destination")]
+    destination: Option<String>,
+}
+
+#[test]
+fn empty() {
+    let n = NetworkConfig {
+        r#match: None,
+        network: None,
+        route: vec![],
+    };
+
+    assert_eq!(n.to_string(), "")
+}
+
+// Test all features: repeated entries and sections
+#[test]
+fn all_features() {
+    let n = NetworkConfig {
+        r#match: Some(MatchSection {
+            name: Some("eno1".to_string()),
+        }),
+        network: Some(NetworkSection {
+            addresses: vec!["1.2.3.4".to_string(), "2.3.4.5".to_string()],
+            dhcp: Some("ipv4".to_string()),
+        }),
+        route: vec![
+            RouteSection {
+                destination: Some("10.0.0.1".to_string()),
+            },
+            RouteSection {
+                destination: Some("11.0.0.1".to_string()),
+            },
+        ],
+    };
+
+    let expected = "[Match]
+Name=eno1
+[Network]
+Address=1.2.3.4
+Address=2.3.4.5
+DHCP=ipv4
+[Route]
+Destination=10.0.0.1
+[Route]
+Destination=11.0.0.1
+";
+
+    assert_eq!(n.to_string(), expected)
+}


### PR DESCRIPTION
**Issue number:**
Related to #2449 

**Description of changes:**
This is the first in a series of changes to `netdog` that add the ability to generate `systemd-networkd` config files.  This PR adds the initial set of structs that represent the two kinds of `systemd-networkd` config files we currently use: `.network` and `.netdev`.  These structs contain the config entries we currently will make use of; it is expected they will grow over time.

These structs must be serialized to file.  Though a serde library exists for INI, `systemd` doesn't strictly follow INI spec as it allows for duplicate sections and duplicate keys within a section.  Rather than hack around the library, I opted to write a proc macro that generates `Display` implementations in the `systemd` unit format for the structs so the user can serialize the structs to string/file.  The proc macro allows for annotation of structs that represent config file sections, as well as fields that represent entries within the sections.  

This allows us to write the following:
```
// Very abbreviated example
#[derive(SystemdUnit)]
struct NetworkConfig {
    match_section: Option<MatchSection>
}

#[derive(SystemdUnitSection)
#[systemd(section = "Match")] // The name of the networkd config section
struct MatchSection {
    #[systemd(entry = "Name")] // The name of the networkd config entry
    name: Option<String>
}
```

which would represent the following section of a .network file:
```
[Match]
Name=...
```


**Testing done:**
* All unit tests continue to pass
Additional integration tests to come as the code is added to build these structs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
