### PR TITLE
Initial POC for modify-image

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -184,6 +184,12 @@ BOOT_CONFIG_INPUT = "${BUILDSYS_ROOT_DIR}/bootconfig-input"
 # Boot Configuration initrd
 BOOT_CONFIG = "${BUILDSYS_ROOT_DIR}/bootconfig.data"
 
+# CA Bundle for root of trust update
+CA_BUNDLE = { script = ['echo "${CA_BUNDLE}:${BUILDSYS_ROOT_DIR}/ca-bundle.crt"'] }
+
+# secondary root.json for update
+NEW_ROOT_JSON = { script = ['echo "${NEW_ROOT_JSON}:${PUBLISH_REPO_ROOT_JSON}"'] }
+
 # Determines the kubeconfig that should be used by testsys. If no kubeconfig was provided and the
 # default kubeconfig location does not exist, use the users default kubeconfig.
 CARGO_MAKE_TESTSYS_KUBECONFIG_ARG = {script = [
@@ -1038,6 +1044,151 @@ pubsys \
 ln -sfn "${PUBLISH_REPO_OUTPUT_DIR##*/}" "${PUBLISH_REPO_OUTPUT_DIR%/*}/latest"
 '''
 ]
+
+# This is a bash setup right now just to enable my testing
+# We should move this into the pubsys repo logic now
+[tasks.import-images]
+dependencies = ["publish-setup", "publish-tools", "tuftool"]
+script = [
+'''
+set -e
+
+export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+
+IMAGE="bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${BUILDSYS_VERSION_BUILD}"
+OUTDIR="${BUILDSYS_OUTPUT_DIR}/${BUILDSYS_VERSION_BUILD}"
+
+bootlz4="${IMAGE}-boot.ext4.lz4"
+imglz4="${IMAGE}.img.lz4"
+rootlz4="${IMAGE}-root.ext4.lz4"
+hashlz4="${IMAGE}-root.verity.lz4"
+
+# TODO - do we care about these? At the moment I don't but probably later I do - we could get the manifest.json and fetch them there
+# kmodtarxz="${IMAGE}-kmod-kit.tar.xz" #  Versioned with v
+# migrationstar="${IMAGE}-migrations.tar" # not in repo
+# datalz4="${IMAGE}-data.img.lz4" # This doesn't seem to exist in the repo
+
+# Here is the list of files actually built, from there, its up to me to figure out what ones need to be solved for *Version without v
+#bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-${HASH}-boot.ext4.lz4
+#bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-${HASH}-data.img.lz4
+#bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-${HASH}.img.lz4
+#bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${VERSION}-kmod-kit.tar.xz
+#bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${VERSION}-${HASH}-migrations.tar
+#bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-${HASH}-root.ext4.lz4
+#bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-${HASH}-root.verity.lz4
+
+if [ -s "${bootlz4}" ] || [ -s "${imglz4}" ] || [ -s "${rootlz4}" ] || [ -s "${hashlz4}" ]; then
+   echo "Image files already exist for the current version/commit - ${IMAGE} - please run 'cargo make clean' to remove them" >&2
+   exit 1
+fi
+
+# Build path
+tuftool download \
+    "${OUTDIR}" \
+    --target-name "${bootlz4}" \
+    --target-name "${imglz4}" \
+    --target-name "${rootlz4}" \
+    --target-name "${hashlz4}" \
+    --root ./root.json \
+    --metadata-url "https://updates.bottlerocket.aws/2020-07-07/${BUILDSYS_VARIANT}/${BUILDSYS_ARCH}/" \
+    --targets-url "https://updates.bottlerocket.aws/targets/"
+
+
+# Recreate symlinks so it looks like it was built from that hash
+# variant-arch
+# variant-arch-version
+# variant-arch-version(with-v)
+VERSION=$(echo "${BUILDSYS_VERSION_BUILD}"| cut -f1 -d"-")
+ln -s "${OUTDIR}/${bootlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-boot.ext4.lz"
+ln -s "${OUTDIR}/${bootlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-boot.ext4.lz"
+ln -s "${OUTDIR}/${bootlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${VERSION}-boot.ext4.lz"
+
+ln -s "${OUTDIR}/${imglz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}.img.lz4"
+ln -s "${OUTDIR}/${imglz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}.img.lz4"
+ln -s "${OUTDIR}/${imglz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${VERSION}.img.lz4"
+
+ln -s "${OUTDIR}/${rootlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-root.ext4.lz4"
+ln -s "${OUTDIR}/${rootlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-root.ext4.lz4"
+ln -s "${OUTDIR}/${rootlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${VERSION}-root.ext4.lz4"
+
+ln -s "${OUTDIR}/${hashlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-root.verity.lz4"
+ln -s "${OUTDIR}/${hashlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${VERSION}-root.verity.lz4"
+ln -s "${OUTDIR}/${hashlz4}" "${OUTDIR}/bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${VERSION}-root.verity.lz4"
+
+ln -snf "${OUTDIR##*/}" "${BUILDSYS_OUTPUT_DIR}/latest"
+'''
+]
+
+
+[tasks.modify-image]
+dependencies = ["publish-setup", "publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+IMAGE="bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${BUILDSYS_VERSION_BUILD}.img.lz4"
+
+
+run_modify_image="
+/tmp/tools/modify-image --image=/tmp/build/${BUILDSYS_VERSION_BUILD}/${IMAGE} --new-root=/tmp/root.json --ca-bundle=/tmp/ca-bundle.crt
+"
+
+echo ${run_modify_image}
+
+test_run="/tmp/tools/modify-image"
+
+set -x
+
+docker run --rm -it \
+  --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
+  -e CARGO_HOME="/tmp/.cargo" \
+  -v "${CARGO_HOME}":/tmp/.cargo \
+  -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
+  -v "${BUILDSYS_OUTPUT_DIR}":/tmp/build \
+  -v "${CA_BUNDLE}":/tmp/ca-bundle.crt \
+  -v "${NEW_ROOT_JSON}":/tmp/root.json \
+  "${BUILDSYS_SDK_IMAGE}" \
+  bash -c "${run_modify_image}"
+'''
+]
+
+[tasks.modify-image-shell]
+dependencies = ["publish-setup", "publish-tools"]
+script_runner = "bash"
+script = [
+'''
+set -e
+
+IMAGE="bottlerocket-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-${BUILDSYS_VERSION_BUILD}.img.lz4"
+
+
+run_modify_image="
+/tmp/tools/modify-image --image=/tmp/build/${BUILDSYS_VERSION_BUILD}/${IMAGE} --new-root=/tmp/root.json --ca-bundle=/tmp/ca-bundle.crt
+"
+
+echo ${run_modify_image}
+
+test_run="/tmp/tools/modify-image"
+
+set -x
+
+docker run --rm -it \
+  --user "$(id -u):$(id -g)" \
+  --security-opt label:disable \
+  -e CARGO_HOME="/tmp/.cargo" \
+  -v "${CARGO_HOME}":/tmp/.cargo \
+  -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
+  -v "${BUILDSYS_OUTPUT_DIR}":/tmp/build \
+  -v "${CA_BUNDLE}":/tmp/ca-bundle.crt \
+  -v "${NEW_ROOT_JSON}":/tmp/root.json \
+  "${BUILDSYS_SDK_IMAGE}" \
+  bash
+'''
+]
+
+
 
 [tasks.validate-repo]
 dependencies = ["publish-setup-without-key", "publish-tools"]

--- a/tools/modify-image
+++ b/tools/modify-image
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+shopt -qs failglob
+
+# check for veritysetup, debugfs, lz4
+IMAGE_PATH=""
+IMAGE=""
+OUT_IMAGE=""
+ROOTFILE=""
+CABUNDLE=""
+declare -a CHANGED_ROOTS
+
+function buildJson() {
+
+  local -n arr=$1
+  JSON_STRING=$( jq -n \
+      --arg path "${arr[Path]}" \
+      --arg nh "${arr[NewHash]}" \
+      --arg oh "${arr[OldHash]}" \
+      '{Path: $path, NewHash: $nh, OldHash: $oh}' )
+
+  CHANGED_ROOTS+=(${JSON_STRING})
+}
+
+for opt in "$@"; do
+   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
+   case "${opt}" in
+      --image=*) IMAGE_PATH="${optarg}" ;;
+      --image-out=*) OUT_IMAGE="${optarg}" ;;
+      --new-root=*) ROOTFILE="${optarg}" ;;
+      --ca-bundle=*) CABUNDLE="${optarg}" ;;
+   esac
+done
+
+echo -e "here are the vars: ${IMAGE_PATH} ${OUT_IMAGE} ${ROOTFILE} ${CABUNDLE}"
+
+DESTDIR=$(dirname ${IMAGE_PATH})
+WORKDIR="$(mktemp -d)"
+cleanup() {
+   [ -n "${WORKDIR}" ] && rm -rf "${WORKDIR}"
+}
+trap 'cleanup' EXIT
+
+cp ${IMAGE_PATH} ${WORKDIR}
+
+pushd "${WORKDIR}" >/dev/null
+
+IMAGE=$(basename "${IMAGE_PATH}")
+
+if [[ ${IMAGE} == *.lz4 ]] ; then
+echo "Extracting ${IMAGE}"
+  rm -f ${IMAGE%.*}
+  unlz4 ${IMAGE}
+  IMAGE=${IMAGE%.*}
+fi
+
+IMAGE_NAME=${IMAGE%.*}
+# step 2: extract the root filesystem
+echo -e "Starting extract of root for ${IMAGE}"
+ROOT_IMAGE="root.ext4"
+ROOT_START="$(sgdisk --print "${IMAGE}" | awk '/BOTTLEROCKET-ROOT-A/{ print $2 }')"
+echo ${ROOT_START}
+ROOT_END="$(sgdisk --print "${IMAGE}" | awk '/BOTTLEROCKET-ROOT-A/{ print $3 }')"
+echo ${ROOT_END}
+ROOT_SIZE="$(( ROOT_END - ROOT_START + 1))"
+dd if="${IMAGE}" of="${ROOT_IMAGE}" skip="${ROOT_START}" count="${ROOT_SIZE}"
+
+echo "File exists at ${ROOT_IMAGE}"
+
+# step 3: replace the trusted root.json
+# os_t is the right label for SELinux based upon defaults
+if [ -n "${ROOTFILE}" ] ; then
+  declare -A ROOT_ARR
+  JSON_STRING=""
+  ROOT_ARR[Path]='/usr/share/updog/root.json'
+  ROOT_ARR[OldHash]=$(debugfs -f <(echo cat /usr/share/updog/root.json) ${ROOT_IMAGE} 2>/dev/null | tail -n +2 | sha512sum | head -c 128)
+  ROOT_ARR[NewHash]=$(sha512sum ${ROOTFILE} | head -c 128)
+  buildJson ROOT_ARR
+cat <<EOF | debugfs -w -f - "${ROOT_IMAGE}"
+rm /usr/share/updog/root.json
+write ${ROOTFILE} /usr/share/updog/root.json
+ea_set /usr/share/updog/root.json  security.selinux system_u:object_r:os_t:s0
+EOF
+fi
+
+# replace CA Bundle if requested
+if [ -n "${CABUNDLE}" ] ; then
+declare -A CA_ARR
+JSON_STRING=""
+CA_ARR[Path]='/usr/share/factory/etc/pki/tls/certs/ca-bundle.crt'
+CA_ARR[OldHash]=$(debugfs -f <(echo cat /usr/share/factory/etc/pki/tls/certs/ca-bundle.crt) ${ROOT_IMAGE} 2>/dev/null | tail -n +2 | sha512sum | head -c 128)
+CA_ARR[NewHash]=$(sha512sum ${CABUNDLE} | head -c 128)
+buildJson CA_ARR
+cat <<EOF | debugfs -w -f - "${ROOT_IMAGE}"
+rm /usr/share/factory/etc/pki/tls/certs/ca-bundle.crt
+write ${CABUNDLE} /usr/share/factory/etc/pki/tls/certs/ca-bundle.crt
+ea_set /usr/share/factory/etc/pki/tls/certs/ca-bundle.crt security.selinux system_u:object_r:os_t:s0
+EOF
+fi
+
+# Create the full manifest of modifications for writing to trust-roots.json
+echo -e "The full list of json is: ${CHANGED_ROOTS[@]}"
+MODIFIED_JSON="$(jq --raw-output . <<<  "${CHANGED_ROOTS[@]}")"
+
+FULL_MODIFIED_JSON="$(jq --slurp 'sort_by(.Name)' <<< "${MODIFIED_JSON}" | jq '{"ModifiedRootsOfTrust": .}')"
+
+echo "${FULL_MODIFIED_JSON}" > trust-roots.json
+cat <<EOF | debugfs -w -f - "${ROOT_IMAGE}"
+rm /usr/share/bottlerocket/trust-roots.json
+write trust-roots.json /usr/share/bottlerocket/trust-roots.json
+ea_set /usr/share/bottlerocket/trust-roots.json security.selinux system_u:object_r:os_t:s0
+EOF
+
+echo -e "${FULL_MODIFIED_JSON}"
+
+
+echo "Getting root image written back"
+
+OLD_ROOT_SIZE="$(( ${ROOT_SIZE} * 512 ))"
+NEW_ROOT_SIZE="$(stat --format='%s' "${ROOT_IMAGE}")"
+if [ "${NEW_ROOT_SIZE}" -gt "${OLD_ROOT_SIZE}" ] ; then
+  echo "new root image size of ${NEW_ROOT_SIZE} bytes is greater than old size of ${OLD_ROOT_SIZE} bytes" >&2
+  exit 1
+fi
+
+# step 4: write the root filesystem back
+dd if="${ROOT_IMAGE}" of="${IMAGE}" seek="${ROOT_START}" conv=notrunc
+
+echo "Wrote files, recomputing verity"
+# step 5: regenerate the hash image
+HASH_IMAGE="verity.data"
+HASH_START="$(sgdisk --print "${IMAGE}" | awk '/BOTTLEROCKET-HASH-A/{ print $2 }')"
+HASH_END="$(sgdisk --print "${IMAGE}" | awk '/BOTTLEROCKET-HASH-A/{ print $3 }')"
+HASH_SIZE="$(( HASH_END - HASH_START + 1))"
+
+VERITY_VERSION="1"
+VERITY_HASH_ALGORITHM="sha256"
+VERITY_DATA_BLOCK_SIZE="4096"
+VERITY_HASH_BLOCK_SIZE="4096"
+VERITY_OUTPUT="$(veritysetup format \
+  --format "${VERITY_VERSION}" \
+  --hash "${VERITY_HASH_ALGORITHM}" \
+  --data-block-size "${VERITY_DATA_BLOCK_SIZE}" \
+  --hash-block-size "${VERITY_HASH_BLOCK_SIZE}" \
+  "${ROOT_IMAGE}" "${HASH_IMAGE}" | tee /dev/stderr)"
+VERITY_DATA_4K_BLOCKS="$(grep '^Data blocks:' <<<"${VERITY_OUTPUT}" | awk '{ print $NF }')"
+VERITY_DATA_512B_BLOCKS="$((VERITY_DATA_4K_BLOCKS * 8))"
+VERITY_ROOT_HASH="$(grep '^Root hash:' <<<"${VERITY_OUTPUT}" | awk '{ print $NF }')"
+VERITY_SALT="$(grep '^Salt:' <<<"${VERITY_OUTPUT}" | awk '{ print $NF }')"
+
+OLD_HASH_SIZE="$(( HASH_SIZE * 512 ))"
+NEW_HASH_SIZE="$(stat --format='%s' "${HASH_IMAGE}")"
+if [ "${NEW_HASH_SIZE}" -gt "${OLD_HASH_SIZE}" ] ; then
+  echo "new hash image size of ${NEW_HASH_SIZE} bytes is greater than old size of ${OLD_HASH_SIZE} bytes" >&2
+  exit 1
+fi
+
+# step 6: write the hash image back
+dd if="${HASH_IMAGE}" of="${IMAGE}" seek="${HASH_START}" conv=notrunc
+
+# step 7: extract the boot filesystem
+BOOT_IMAGE="boot.ext4"
+BOOT_START="$(sgdisk --print "${IMAGE}" | awk '/BOTTLEROCKET-BOOT-A/{ print $2 }')"
+BOOT_END="$(sgdisk --print "${IMAGE}" | awk '/BOTTLEROCKET-BOOT-A/{ print $3 }')"
+BOOT_SIZE="$(( BOOT_END - BOOT_START + 1))"
+dd if="${IMAGE}" of="${BOOT_IMAGE}" skip="${BOOT_START}" count="${BOOT_SIZE}"
+
+# step 8: modify grub.cfg
+echo 'cat /grub/grub.cfg' | debugfs -f - "${BOOT_IMAGE}" > grub.cfg
+
+DM_MOD_OPTS_PATTERN="[0-9]\+ verity ${VERITY_VERSION}"
+DM_MOD_OPTS="${VERITY_DATA_512B_BLOCKS} verity ${VERITY_VERSION}"
+
+VERITY_OPTS_PATTERN="[0-9]\+ [0-9]\+ [0-9]\+"
+VERITY_OPTS_PATTERN+=" 1 ${VERITY_HASH_ALGORITHM}"
+VERITY_OPTS_PATTERN+=" [0-9a-f]\+ [0-9a-f]\+"
+
+VERITY_OPTS="${VERITY_DATA_BLOCK_SIZE} ${VERITY_HASH_BLOCK_SIZE} ${VERITY_DATA_4K_BLOCKS}"
+VERITY_OPTS+=" 1 ${VERITY_HASH_ALGORITHM}"
+VERITY_OPTS+=" ${VERITY_ROOT_HASH} ${VERITY_SALT}"
+
+sed -i \
+  -e "s,\(.*\) ${DM_MOD_OPTS_PATTERN} \(.*\),\1 ${DM_MOD_OPTS} \2," \
+  -e "s,\(.*\) ${VERITY_OPTS_PATTERN} \(.*\),\1 ${VERITY_OPTS} \2," \
+  grub.cfg
+
+
+cat <<'EOF' | debugfs -w -f - "${BOOT_IMAGE}"
+rm /grub/grub.cfg
+write grub.cfg /grub/grub.cfg
+ea_set /grub/grub.cfg security.selinux system_u:object_r:os_t:s0
+EOF
+
+OLD_BOOT_SIZE="$(( BOOT_SIZE * 512 ))"
+NEW_BOOT_SIZE="$(stat --format='%s' "${BOOT_IMAGE}")"
+if [ "${NEW_BOOT_SIZE}" -gt "${OLD_BOOT_SIZE}" ] ; then
+  echo "new boot image size of ${NEW_BOOT_SIZE} bytes is greater than old size of ${OLD_BOOT_SIZE} bytes" >&2
+  exit 1
+fi
+
+# step 9: write the boot filesystem back
+dd if="${BOOT_IMAGE}" of="${IMAGE}" seek="${BOOT_START}" conv=notrunc
+
+# now that the images have been written byte for byte back, we can resize them before compressing
+resize2fs -M ${ROOT_IMAGE}
+resize2fs -M ${BOOT_IMAGE}
+
+# re compress the images
+lz4 -9f ${IMAGE}
+lz4 -9f ${ROOT_IMAGE}
+lz4 -9f ${BOOT_IMAGE}
+lz4 -9f ${HASH_IMAGE}
+
+# step 10: copy out the altered image wait for now to keep cycles happy
+echo -e "Copying ${IMAGE} back to ${DESTDIR}"
+cp "${IMAGE}.lz4" "${DESTDIR}"
+cp "${ROOT_IMAGE}.lz4" "${DESTDIR}"/${IMAGE_NAME}-root.ext4.lz4
+cp "${BOOT_IMAGE}.lz4" "${DESTDIR}"/${IMAGE_NAME}-boot.ext4.lz4
+cp "${HASH_IMAGE}.lz4" "${DESTDIR}"/${IMAGE_NAME}-root.verity.lz4
+
+popd > /dev/null


### PR DESCRIPTION


**Issue number:** 2486

Closes #

**Description of changes:**
This adds in a target for import-images and modify-image with basic support. There is more to come around SELinux and tidying up how we treat CA Bundles and tracking the changes.

This is incomplete and needs more testing, but is in an MVP of sorts. There are comments about what to do about incomplete files for bringing in the entire repo. Ideally, `import-images` moves into buildsys or pubsys anyway, so this is more of just a quick helper for the time being anyway. 

There is more work to do around  importing the kmod-kit and migrations for a complete treatment of importing artifacts one might need, but for now, this solves the "how do I modify an image" problem.


**Testing done:**
Validated with metal images via calling:
```
cargo make -e BUILDSYS_VERSION_BUILD=1.12.0-6ef1139f -e BUILDSYS_VARIANT=metal-k8s-1.25 -e BUILDSYS_ARCH=x86_64 -e BUILDSYS_CA_BUNDLE=roles/default.root.json import-images

cargo make -e BUILDSYS_VERSION_BUILD=1.12.0-6ef1139f -e BUILDSYS_VARIANT=metal-k8s-1.25 -e BUILDSYS_ARCH=x86_64 -e BUILDSYS_CA_BUNDLE=roles/default.root.json modify-image
```

Debugfs shows files have the right context:
```
$ debugfs bottlerocket-metal-k8s-1.25-x86_64-1.12.0-6ef1139f-root.ext4
debugfs 1.46.5 (30-Dec-2021)
debugfs:  ea_list /usr/share/bottlerocket/trust-roots.json
Extended attributes:
  security.selinux (25) = "system_u:object_r:os_t:s0"
debugfs:  ea_list /usr/share/factory/etc/pki/tls/certs/ca-bundle.crt
Extended attributes:
  security.selinux (25) = "system_u:object_r:os_t:s0"
debugfs:  ea_list /usr/share/factory/etc/pki/tls/certs/ca-bundle.crt^C
debugfs:  ea_list /usr/share/updog/root.json
Extended attributes:
  security.selinux (25) = "system_u:object_r:os_t:s0"
```

The `/usr/share/bottlerocket/trust-roots.json` has the contents updated:
```json
{
  "ModifiedRootsOfTrust": [
    {
      "Path": "/usr/share/updog/root.json",
      "NewHash": "b81af4d8eb86743539fbc4709d33ada7b118d9f929f0c2f6c04e1d41f46241ed80423666d169079d736ab79965b4dd25a5a6db5f01578b397496d49ce11a3aa2",
      "OldHash": "b81af4d8eb86743539fbc4709d33ada7b118d9f929f0c2f6c04e1d41f46241ed80423666d169079d736ab79965b4dd25a5a6db5f01578b397496d49ce11a3aa2"
    },
    {
      "Path": "/usr/share/factory/etc/pki/tls/certs/ca-bundle.crt",
      "NewHash": "bbd3521d79c3897aa7cd937b486369665b5c2a654401cc2151a63453b805fbb2d2484478eb195e358d2b100ee7422b6868c5d285c8ca22191cbd6a242a9ccfa6",
      "OldHash": "fbbd8d33932a5d65dd548d91927fc5bac5218d5a44b8d992591bef2eab22b09cc2154b6effb2df1c61e1aa233816e3c3e7acfb27b3e3f90672a7752bb05b710f"
    }
  ]
}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
