### PR TITLE
kernel: increase max_dgram_qlen sysctl value to 512

### DIFF
--- a/packages/kernel-5.10/1003-af_unix-increase-default-max_dgram_qlen-to-512.patch
+++ b/packages/kernel-5.10/1003-af_unix-increase-default-max_dgram_qlen-to-512.patch
@@ -1,0 +1,47 @@
+From b3983ebbfa2dc231a2b61092b0a936bd25294239 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Tue, 23 May 2023 21:24:38 +0000
+Subject: [PATCH] af_unix: increase default max_dgram_qlen to 512
+
+The net.unix.max_dgram_qlen sysctl has been defined with a default value of
+10 since before the current Git history started in 2005. Systems have more
+resources these days, and while the default values for other sysctls like
+net.core.somaxconn have been adapted, max_dgram_qlen never was.
+
+Increase the default value for max_dgram_qlen to 512. A large number of
+hosts effectively already run with this or a larger value, since systemd
+has been making sure it is set to at least 512 since 2015.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ Documentation/networking/ip-sysctl.rst | 2 +-
+ net/unix/af_unix.c                     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/networking/ip-sysctl.rst b/Documentation/networking/ip-sysctl.rst
+index 252212998..164a65667 100644
+--- a/Documentation/networking/ip-sysctl.rst
++++ b/Documentation/networking/ip-sysctl.rst
+@@ -2688,5 +2688,5 @@ addr_scope_policy - INTEGER
+ max_dgram_qlen - INTEGER
+ 	The maximum length of dgram socket receive queue
+ 
+-	Default: 10
++	Default: 512
+ 
+diff --git a/net/unix/af_unix.c b/net/unix/af_unix.c
+index 28721e957..a5f081ad8 100644
+--- a/net/unix/af_unix.c
++++ b/net/unix/af_unix.c
+@@ -2948,7 +2948,7 @@ static int __net_init unix_net_init(struct net *net)
+ {
+ 	int error = -ENOMEM;
+ 
+-	net->unx.sysctl_max_dgram_qlen = 10;
++	net->unx.sysctl_max_dgram_qlen = 512;
+ 	if (unix_sysctl_register(net))
+ 		goto out;
+ 
+-- 
+2.39.2
+

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -17,6 +17,8 @@ Source103: config-bottlerocket-vmware
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
 # Enable INITRAMFS_FORCE config option for our use case.
 Patch1002: 1002-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
+# Increase default of sysctl net.unix.max_dgram_qlen to 512.
+Patch1003: 1003-af_unix-increase-default-max_dgram_qlen-to-512.patch
 
 # Add zstd support for compressed kernel modules
 Patch2000: 2000-kbuild-move-module-strip-compression-code-into-scrip.patch

--- a/packages/kernel-5.15/1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
+++ b/packages/kernel-5.15/1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
@@ -1,0 +1,47 @@
+From e36140bfb2795377360bb92c343b10c717567c62 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Tue, 23 May 2023 17:16:44 +0000
+Subject: [PATCH] af_unix: increase default max_dgram_qlen to 512
+
+The net.unix.max_dgram_qlen sysctl has been defined with a default value of
+10 since before the current Git history started in 2005. Systems have more
+resources these days, and while the default values for other sysctls like
+net.core.somaxconn have been adapted, max_dgram_qlen never was.
+
+Increase the default value for max_dgram_qlen to 512. A large number of
+hosts effectively already run with this or a larger value, since systemd
+has been making sure it is set to at least 512 since 2015.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ Documentation/networking/ip-sysctl.rst | 2 +-
+ net/unix/af_unix.c                     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/networking/ip-sysctl.rst b/Documentation/networking/ip-sysctl.rst
+index 7890b395e..54a0be396 100644
+--- a/Documentation/networking/ip-sysctl.rst
++++ b/Documentation/networking/ip-sysctl.rst
+@@ -2885,5 +2885,5 @@ plpmtud_probe_interval - INTEGER
+ max_dgram_qlen - INTEGER
+ 	The maximum length of dgram socket receive queue
+ 
+-	Default: 10
++	Default: 512
+ 
+diff --git a/net/unix/af_unix.c b/net/unix/af_unix.c
+index a96026dbd..267ee6d29 100644
+--- a/net/unix/af_unix.c
++++ b/net/unix/af_unix.c
+@@ -3343,7 +3343,7 @@ static int __net_init unix_net_init(struct net *net)
+ {
+ 	int error = -ENOMEM;
+ 
+-	net->unx.sysctl_max_dgram_qlen = 10;
++	net->unx.sysctl_max_dgram_qlen = 512;
+ 	if (unix_sysctl_register(net))
+ 		goto out;
+ 
+-- 
+2.39.2
+

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -19,6 +19,8 @@ Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
 Patch1002: 1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
 # Enable INITRAMFS_FORCE config option for our use case.
 Patch1003: 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
+# Increase default of sysctl net.unix.max_dgram_qlen to 512.
+Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 
 # Backport from v5.15.111 upstream, drop when Amazon Linux base is v5.15.111 or later
 Patch5001: 5001-netfilter-nf_tables-deactivate-anonymous-set-from-pr.patch


### PR DESCRIPTION
**Issue number:** #3059 

**Description of changes:** Increase the kernel's default value for the net.unix.max_dgram_qlen sysctl to 512. This is a change to the kernel rather than a plain sysctl setting since systemd-sysctl only applies settings to the host, while the changed default value in the kernel also applies to every new network namespace.

I will propose this upstream as well. In case of rejection, Bottlerocket can continue to carry this downstream without any expected maintenance effort.

**Testing done:**

With a plain Fedora pod (`test`) on a aws-k8s-1.23 x86_64 node running

...with this change:

```
$ kubectl exec test -- cat /proc/sys/net/unix/max_dgram_qlen
512
```

...without this change:

```
$ kubectl exec test -- cat /proc/sys/net/unix/max_dgram_qlen
10
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
