### PR TITLE
netdog: Correct range for VLAN IDs

### DIFF
--- a/sources/api/netdog/src/net_config/devices/vlan.rs
+++ b/sources/api/netdog/src/net_config/devices/vlan.rs
@@ -36,10 +36,10 @@ impl<'de> Deserialize<'de> for NetVlanV1 {
             )));
         }
 
-        // Validate its a valid vlan id - 0-4095
-        if this.id > 4095 {
+        // Validate its a valid vlan id - 0-4094
+        if this.id > 4094 {
             return Err(D::Error::custom(
-                "invalid vlan ID specified, must be between 0-4095",
+                "invalid vlan ID specified, must be between 0-4094",
             ));
         }
 

--- a/sources/api/netdog/test_data/net_config/vlan/oob_id.toml
+++ b/sources/api/netdog/test_data/net_config/vlan/oob_id.toml
@@ -3,5 +3,5 @@ version = {{version}}
 [vlan6]
 kind = "vlan"
 device = "eno1"
-id = 5000
+id = 4095
 dhcp4 = true


### PR DESCRIPTION
**Description of changes:**
The correct range for a VLAN tag is 0-4094. Although 4095 is valid for some situations, it is not correct to attempt to configure a device to transmit a VLAN tag of 4095.

See https://en.wikipedia.org/wiki/IEEE_802.1Q which goes into the specifics for 0 and 4095. This also brings our range into a consistent range with tools like networkd: See https://www.freedesktop.org/software/systemd/man/systemd.netdev.html#Id=

In theory, 0 is an odd case which says "no VLAN tag" but can be used in 802.1Q for showing priority. We probably don't really use this, but it could be set whereas 4095 must not be configured or transmitted.

**Testing done:**
Ran `cargo test`



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
