### PR TITLE
netdog: Add stronger typing to bond/vlan config

### DIFF
--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -39,6 +39,7 @@ mod lease;
 mod net_config;
 #[cfg(net_backend = "systemd-networkd")]
 mod networkd_status;
+mod vlan_id;
 mod wicked;
 
 use argh::FromArgs;

--- a/sources/api/netdog/src/vlan_id.rs
+++ b/sources/api/netdog/src/vlan_id.rs
@@ -1,0 +1,42 @@
+//! The vlan_id module contains the definition of a valid VLAN ID, and the code to support
+//! deserialization of the structure.  A valid VLAN ID must fall between the range of 0-4094.
+use serde::de::Error;
+use serde::{Deserialize, Deserializer};
+use std::fmt::Display;
+use std::ops::Deref;
+
+#[derive(Debug)]
+pub(crate) struct VlanId {
+    inner: u16,
+}
+
+impl<'de> Deserialize<'de> for VlanId {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let id: u16 = Deserialize::deserialize(deserializer)?;
+
+        if id > 4094 {
+            return Err(D::Error::custom(format!(
+                "invalid vlan ID '{}': must be between 0-4094",
+                id
+            )));
+        }
+
+        Ok(VlanId { inner: id })
+    }
+}
+
+impl Deref for VlanId {
+    type Target = u16;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl Display for VlanId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}

--- a/sources/api/netdog/src/wicked/mod.rs
+++ b/sources/api/netdog/src/wicked/mod.rs
@@ -289,7 +289,7 @@ where
         let config = device_tup.1;
         let mut wicked_interface = wicked_from!(name, config);
 
-        wicked_interface.vlan_tag = Some(WickedVlanTag::new(config.device.clone(), config.id));
+        wicked_interface.vlan_tag = Some(WickedVlanTag::new(config.device.clone(), *config.id));
 
         wicked_interface
     }

--- a/sources/api/netdog/test_data/net_config/bonding/net_config.toml
+++ b/sources/api/netdog/test_data/net_config/bonding/net_config.toml
@@ -1,7 +1,7 @@
 version = {{version}}
 
 [bond0]
-kind = "bond"
+kind = "Bond"
 mode = "active-backup"
 interfaces = ["eno51" , "eno52"]
 dhcp4 = true

--- a/sources/api/netdog/test_data/net_config/vlan/net_config.toml
+++ b/sources/api/netdog/test_data/net_config/vlan/net_config.toml
@@ -2,13 +2,13 @@ version = {{version}}
 
 # Basic vlan dhcp
 [vlan2]
-kind = "vlan"
+kind = "VLAN"
 device = "eno1"
 id = 2
 dhcp4 = true
 
 [vlan3]
-kind = "vlan"
+kind = "Vlan"
 device = "eno2"
 id = 3
 dhcp6 = true


### PR DESCRIPTION
**Issue number:**
Related to #3134 

**Description of changes:**
This change adds stronger types to the bond/vlan configuration, and as a side effect simplifies the deserialization.

Previously, bond/vlan config implemented validation of the `kind` field via a custom `Deserialize` implementation, which complemented the derived `Deserialize` implementation via the serde annotation `serde(remote = "Self")`.  This annotation changes the generated deserialize function from trait implementations to inherent methods, which is how we could call into `::deserialze()`.  Adding an additional Deserialize implementation is unnecessary in this case as we can achieve the validation via stronger types.  We now validate the `kind` field using a single variant enum.  (Sidenote: the `kind` field is solely used for deserialization validation)

Previously we stored the VLAN ID as a u16 and did validation through the aforementioned `Deserialize` implementation.  Since VLAN ID will be used in the upcoming networkd-related changes, it made sense to make it a stronger type.  This new `VlanId` type implements `Deserialize` and does the same validation as before (must be between 0-4094).


**Testing done:**
* All unit tests continue to pass - which cover de/serialization both at the net config unit test level and e2e netconfig -> wicked config level.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
