### PR TITLE
tools/diff-kernel-config: Fixup example to reflect current syntax

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -40,10 +40,11 @@ Compare kernel configurations before and after a series of commits.
 
 Example invocation:
 
-    This compares the config changes for kernels 5.10 and 5.15 before and
-    after the most recent commit has been applied:
+    This compares the config changes for kernels 5.10 (through metal-k8s-1.23)
+    and 5.15 (through metal-k8s-1.26) before and after the most recent commit
+    has been applied:
 
-        $0 -b HEAD^ -a HEAD -k 5.10 -k 5.15 -o configs
+        $0 -b HEAD^ -a HEAD -v metal-k8s-1.23 -v metal-k8s-1.26 -o configs
 
 Notes:
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** -

**Description of changes:**

```
Fix the help message to reflect the current interface in the example. In
    43234d3cc46b1b  tools/diff-kernel-config: Adjust script to work on variants
we moved from specifying kernel versions to compare to comparing kernels bound to specific variants. We forgot to adjust the example accordingly.
```

**Testing done:**

No testing done, as this concerns only the content of the tools help text.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
