### PR TITLE
docs: correct dm-verity text in security features

### DIFF
--- a/SECURITY_FEATURES.md
+++ b/SECURITY_FEATURES.md
@@ -68,7 +68,8 @@ The root filesystem is marked as read-only and cannot be directly modified by us
 This protects against some container escape vulnerabilities such as [CVE-2019-5736](https://www.openwall.com/lists/oss-security/2019/02/11/2).
 
 The kernel is configured to restart if corruption is detected.
-That allows the system to fail close to when the underlying block device is unexpectedly modified.
+That allows the system to fail closed if the underlying block device is unexpectedly modified and the node is in an unknown state.
+The uncontrolled reboot will disrupt running containers, which can trigger alarms and prompt administrators to investigate.
 
 Although this provides a powerful layer of protection, it is **incomplete**.
 An attacker with full access to the block device could alter both the verity metadata and the contents of the root filesystem.


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Partial revert of b7c1ee45071202a87436203c8e44d4fa2eb94420.

"Fail closed" is correct in that the kernel will panic and reboot if corruption is detected.

"Fail close to when the block device is modified" is not correct; in the absence of memory pressure to evict previously read blocks from the cache, the detection could occur after much time has passed.


**Testing done:**
Viewed the rendered doc.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
