### PR TITLE
build: retry builds for createrepo_c error

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -65,7 +65,7 @@ We use (?m) for multi-line mode so we can match the message on a line of its own
 the output ourselves; we match the regexes against the whole of stdout.
 */
 lazy_static! {
-    static ref UNEXPECTED_EOF_ERROR: Regex = Regex::new("(?m)^unexpected EOF$").unwrap();
+    static ref UNEXPECTED_EOF_ERROR: Regex = Regex::new("(?m)unexpected EOF$").unwrap();
 }
 
 /*


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**
RPMs from package builds go into a shared host directory which is mounted into subsequent package builds. It is possible for new RPMs to be copied in just as `createrepo_c` is running, which can cause it to read partial RPMs and return an error.

Since the partial RPMs can't be required dependencies - or else the build would not have started yet - it would be possible to ignore the `createrepo_c` errors and continue with whatever repo was created. However, this could mask other errors that might not be expected.

`buildsys` copies RPMs into a different directory on the filesystem before renaming them into the shared directory. Calling `sync()` on one or both directories might help, but would hurt the performance of all builds for what seems to be a rare error.

Instead, treat the specific `rpmReadPackageFile()` error as retryable and attempt the build again. If a genuinely malformed RPM is written to the shared directory, the builds will ultimately fail when retries are exhausted.


**Testing done:**
Verified that normal builds succeed.

Confirmed that placing a truncated RPM into `build/rpms` triggers the same `createrepo_c` error and eventually leads to a failed build.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
