### PR TITLE
trivial: Various spelling typos

### DIFF
--- a/PROVISIONING-METAL.md
+++ b/PROVISIONING-METAL.md
@@ -100,7 +100,7 @@ Please keep in mind that when using static addresses, DNS information must be su
 * `static6` (map): IPv6 static address settings.
   * `addresses` (list of quoted IPv6 address including prefix): The desired IPv6 IP addresses, including prefix i.e. `["2001:dead:beef::2/64"]`.  The first IP in the list will be used as the primary IP which `kubelet` will use when joining the cluster.  If IPv4 and IPv6 static addresses exist, the first IPv4 address is used.
 
-* `route` (map): Static route; multiple routes can be added. (cannot be used in conjuction with DHCP)
+* `route` (map): Static route; multiple routes can be added. (cannot be used in conjunction with DHCP)
   * `to` (`"default"` or IP address with prefix, required): Destination address.
   * `from` (IP address): Source IP address.
   * `via` (IP address): Gateway IP address.  If no gateway is provided, a scope of `link` is assumed.
@@ -144,7 +144,8 @@ Vlan tagging is configured as a new virtual network device stacked on another de
 
 * Vlan configuration (map):
   * `kind = "vlan"`: This setting is required to specify a vlan device.
-  * `device` (string for device name, not MAC address): Defines the device the vlan should be configured on. If VLAN tagging is required, this device should recieve all IP address configuration instead of the underlying device.
+  * `device` (string for device name, not MAC address): Defines the device the vlan should be configured on.
+    If VLAN tagging is required, this device should receive all IP address configuration instead of the underlying device.
   * `id` (integer): Number between 0 and 4096 specifying the vlan tag on the device
 
 Example `net.toml` version `3` with comments:

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ enable-unprivileged-ports = true
    ```
 
 The following allows for custom DNS settings, which are used to generate the `/etc/resolv.conf`.
-If either DNS setting is not populated, the system will use the DHCP lease of the primary interface to gather these setings.
+If either DNS setting is not populated, the system will use the DHCP lease of the primary interface to gather these settings.
 See the `resolv.conf` [man page](https://man7.org/linux/man-pages/man5/resolv.conf.5.html) for more detail.
 
 * `settings.dns.name-servers`: An array of IP address strings that represent the desired name server(s).

--- a/sources/updater/updog/src/bin/updata.rs
+++ b/sources/updater/updog/src/bin/updata.rs
@@ -346,7 +346,7 @@ mod tests {
         let release_path = "tests/data/release.toml";
         let example_manifest = "tests/data/example.json";
 
-        // Write example data to temp manifest so we dont' overwrite the file
+        // Write example data to temp manifest so we don't overwrite the file
         // when we call MigrationsArgs.set() below
         let temp_manifest = NamedTempFile::new().context(error::TmpFileCreateSnafu)?;
         let example_data = fs::read_to_string(example_manifest).unwrap();

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -44,9 +44,9 @@ const GO_MOD_DOCKER_SCRIPT_NAME: &str = "docker-go-script.sh";
 //
 // This script exists as an in memory template string literal and is populated
 // into a temporary file in the package directory itself to enable buildsys to
-// be as portable as possible and have no dependecy on runtime paths. Since
+// be as portable as possible and have no dependency on runtime paths. Since
 // buildsys is executed from the context of many different package directories,
-// managing a temporary file via this Rust module prevents having to aquire the
+// managing a temporary file via this Rust module prevents having to acquire the
 // path of some static script file on the host system.
 const GO_MOD_SCRIPT_TMPL: &str = r###"#!/bin/bash
 

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -54,7 +54,7 @@ omitted since the single top-level directory will authomatically be used.
 
 `bundle-output-path` is an optional argument that provides the desired path of
 the output archive. By default, this will use the name of the existing archive,
-but pre-pended with "bundled-". For example, if "my-unique-archive-name.tar.gz"
+but prepended with "bundled-". For example, if "my-unique-archive-name.tar.gz"
 is entered as the value for `bundle-output-path`, then the output directory
 will be named `my-unique-archive-name.tar.gz`. Or, by default, given the name
 of some upstream archive is "my-package.tar.gz", the output archive would be

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -485,7 +485,7 @@ pub(crate) trait CrdCreator: Sync {
                         &mut self
                             .additional_fields(&test_type.to_string())
                             .into_iter()
-                            // Add the image id incase it is needed for cluster creation
+                            // Add the image id in case it is needed for cluster creation
                             .chain(Some(("image-id".to_string(), image_id.clone())).into_iter())
                             .collect::<BTreeMap<String, String>>(),
                     )?,


### PR DESCRIPTION
**Description of changes:**

Minor clean up to fix spelling errors or typos.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
