### PR TITLE
Settings: log set operations

### DIFF
--- a/sources/api/datastore/src/lib.rs
+++ b/sources/api/datastore/src/lib.rs
@@ -38,14 +38,14 @@ pub use error::{Error, Result};
 pub use filesystem::FilesystemDataStore;
 pub use key::{Key, KeyType, KEY_SEPARATOR, KEY_SEPARATOR_STR};
 
-use log::trace;
+use log::{info, trace};
 use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 use std::collections::{HashMap, HashSet};
 
 /// Committed represents whether we want to look at pending (uncommitted) or live (committed) data
 /// in the datastore.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Committed {
     Live,
     Pending {
@@ -147,7 +147,14 @@ pub trait DataStore {
         S: AsRef<str>,
     {
         for (key, value) in pairs {
-            trace!("Setting data key {}", key.name());
+            match committed {
+                Committed::Live => {
+                    info!("Committed data key {}", key.name());
+                }
+                state => {
+                    trace!("Data key {} state changed to {:?}", key.name(), state);
+                }
+            };
             self.set_key(key, value, committed)?;
         }
         Ok(())


### PR DESCRIPTION
**Issue number:**

Related #2640

**Description of changes:**

This adds info level logging to capture some trace of setting updates in the system log at the default logging level. This is to help capture a record of system changes being made.

This is only a baby step towards addressing #2640, but it is a very minor change that can be done now until a more comprehensive plan can be put in place.

This logs updates to individual keys, even if a set of values are being updated in one call. This does cause a slew of log messages on system start up as the initial datastore is being created. This is relatively small though, and is useful in seeing what all initial settings are being set on initial boot. After that point, only individually set values should show up in the logs, and it is easy to see when settings changes have been made.

A more comprehensive audit log should be put in place, but that will require handling to make sure no sensitive data (private keys, passwords, etc) make it to the log. There are also likely other operations besides `set_setting` that should be captured. But this is a trivial change that at least gets some breadcrumbs to be able to monitor for changes.

**Testing done:**

Deployed an instance and verified updates were reflected in the system log.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
