### PR TITLE
pubsys: Make AMI already registered message more visible

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -33,6 +33,8 @@ use std::path::PathBuf;
 use structopt::{clap, StructOpt};
 use wait::wait_for_ami;
 
+const WARN_SEPARATOR: &str = "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!";
+
 /// Builds Bottlerocket AMIs using latest build artifacts
 #[derive(Debug, StructOpt)]
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
@@ -146,8 +148,8 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
 
     let (ids_of_image, already_registered) = if let Some(found_id) = maybe_id {
         warn!(
-            "Found '{}' already registered in {}: {}",
-            ami_args.name, base_region, found_id
+            "\n{}\n\nFound '{}' already registered in {}: {}\n\n{0}",
+            WARN_SEPARATOR, ami_args.name, base_region, found_id
         );
         let snapshot_ids = get_snapshots(&found_id, &base_region, &base_ec2_client)
             .await


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2459

**Description of changes:**

Pubsys emits a message when asked to publish an AMI that is already found. This is currently a single line message that blends in with the other output when doing `cargo make ami` and makes it very easy to miss.

Normally this is good, but when actively developing and making local code changes, this can make it more likely that the developer will not notice the message and spend time trying to understand why their code changes are not visible when running new instances using this AMI.

This changes the warning message to be a little more visible so it is much more noticeable when trying to publish an AMI that is already registered to try to avoid these cases.

**Testing done:**

Built and published an AMI. Attempted to publish it again and verified output:

```
16:49:41 [WARN] 
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Found 'bottlerocket-aws-k8s-1.26-x86_64-v1.15.0-f2eb176d-dirty' already registered in us-east-2: ami-0e8c69958b31082ba

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
