### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"
+
+  # We maintain updates for most dependencies. This disables updates other than
+  # security ones.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "area/dependencies"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "area/dependencies"
+    open-pull-requests-limit: 0
+
+  # Enable updates for the `tools` dependencies
+  - package-ecosystem: "cargo"
+    directory: "/tools"
+    ignore:
+      # For AWS SDK for Rust, we'll update when we bump tough/coldsnap
+      - dependency-name: "aws-config"
+      - dependency-name: "aws-endpoint"
+      - dependency-name: "aws-http"
+      - dependency-name: "aws-hyper"
+      - dependency-name: "aws-sig*"
+      - dependency-name: "aws-sdk*"
+      - dependency-name: "aws-smithy*"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds a base dependabot config that does a few things:

1. Enables updates for GitHub Actions
2. Disables updates for most dependencies as we try to maintain those manually
3. Allows updates for dependencies under the `/tools` directory since our tooling doesn't need to be as strict
4. Still allows updates for any dependencies if a security issue is identified
5. Sets an appropriate label to match our label scheme instead of the default dependabot ones

**Testing done:**

Will see how dependabot behaves and tweak as necessary.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
