### PR TITLE
Add Xfs package to Bottlerocket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ ARG REPO
 ARG GRUB_SET_PRIVATE_VAR
 ARG SYSTEMD_NETWORKD
 ARG UNIFIED_CGROUP_HIERARCHY
+ARG XFS_DATA_PARTITION
 ENV SYSTEMD_NETWORKD=${SYSTEMD_NETWORKD}
 ENV VARIANT=${VARIANT}
 WORKDIR /home/builder
@@ -102,6 +103,7 @@ RUN rpmdev-setuptree \
    && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> .bconds \
    && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> .bconds \
    && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> .bconds \
+   && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> .bconds \
    && cat .bconds ${PACKAGE}.spec >> rpmbuild/SPECS/${PACKAGE}.spec \
    && find . -maxdepth 1 -not -path '*/\.*' -type f -exec mv {} rpmbuild/SOURCES/ \; \
    && echo ${NOCACHE}
@@ -197,6 +199,7 @@ ARG OS_IMAGE_PUBLISH_SIZE_GIB
 ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG KERNEL_PARAMETERS
 ARG GRUB_SET_PRIVATE_VAR
+ARG XFS_DATA_PARTITION
 ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
     KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
@@ -214,6 +217,7 @@ RUN --mount=target=/host \
       --data-image-publish-size-gib="${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
       --partition-plan="${PARTITION_PLAN}" \
       --ovf-template="/host/variants/${VARIANT}/template.ovf" \
+      ${XFS_DATA_PARTITION:+--xfs-data-partition=yes} \
       ${GRUB_SET_PRIVATE_VAR:+--with-grub-set-private-var=yes} \
     && echo ${NOCACHE}
 

--- a/packages/libinih/Cargo.toml
+++ b/packages/libinih/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "libinih"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "/dev/null"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/benhoyt/inih/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/benhoyt/inih/archive/refs/tags/r56.tar.gz"
+path = "inih-r56.tar.gz"
+sha512 = "ff3e0910990f73e5b21fddc84737ab346279f201c86c7ad864c6cad9de5bde57c3e0a433b9b8f3585b7d86feaae2ea074185f92891dcadc98c274c1c0745d2d2"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libinih/libinih.spec
+++ b/packages/libinih/libinih.spec
@@ -1,0 +1,44 @@
+Name: %{_cross_os}libinih
+Version: 56
+Release: 1%{?dist}
+Summary: Simple INI file parser library
+License: BSD-3-Clause
+URL: https://github.com/benhoyt/inih
+Source0: https://github.com/benhoyt/inih/archive/refs/tags/r%{version}.tar.gz#/inih-r%{version}.tar.gz
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: meson
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the simple INI file parser library
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n inih-r%{version}
+
+%build
+CONFIGURE_OPTS=(
+  -Dwith_INIReader=false
+)
+
+%cross_meson "${CONFIGURE_OPTS[@]}"
+%cross_meson_build
+
+%install
+%cross_meson_install
+
+%files
+%license LICENSE.txt
+%{_cross_attribution_file}
+%{_cross_libdir}/libinih.so.0
+
+%files devel
+%{_cross_pkgconfigdir}/inih.pc
+%{_cross_libdir}/libinih.so
+%{_cross_includedir}/ini.h

--- a/packages/liburcu/Cargo.toml
+++ b/packages/liburcu/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "liburcu"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "/dev/null"
+
+[package.metadata.build-package]
+releases-url = "https://lttng.org/files/urcu"
+
+[[package.metadata.build-package.external-files]]
+url = "https://lttng.org/files/urcu/userspace-rcu-latest-0.14.tar.bz2"
+sha512 = "7297e51012f4c44ee27c0e18ed9d87bf24be34db68a5398394c1e683a045bb561cf74aa913398404c0ed5cb8011af728ea12947717fa5f27627e5ca78e63a40f"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/liburcu/liburcu.spec
+++ b/packages/liburcu/liburcu.spec
@@ -1,0 +1,69 @@
+Name: %{_cross_os}liburcu
+Version: 0.14.0
+Release: 1%{?dist}
+Summary: Library for userspace RCU
+License: LGPL-2.1-only AND GPL-2.0-or-later AND MIT
+URL: http://liburcu.org
+Source0: http://lttng.org/files/urcu/userspace-rcu-latest-0.14.tar.bz2
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for userspace RCU
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n userspace-rcu-%{version}
+
+%build
+%cross_configure --disable-static
+
+# "fix" rpath
+sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
+sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+
+%make_build
+
+%install
+%make_install
+
+%files
+%license LICENSE gpl-2.0.txt lgpl-relicensing.txt lgpl-2.1.txt
+%{_cross_attribution_file}
+
+%{_cross_libdir}/liburcu.so.8*
+%{_cross_libdir}/liburcu-common.so.8*
+
+%exclude %{_cross_libdir}/liburcu-bp.so.8*
+%exclude %{_cross_libdir}/liburcu-cds.so.8*
+%exclude %{_cross_libdir}/liburcu-mb.so.8*
+%exclude %{_cross_libdir}/liburcu-memb.so.8*
+%exclude %{_cross_libdir}/liburcu-qsbr.so.8*
+%exclude %{_cross_libdir}/liburcu-signal.so.8*
+%exclude %{_cross_docdir}
+
+%files devel
+%{_cross_includedir}/*
+%{_cross_libdir}/liburcu-common.so
+%{_cross_libdir}/liburcu.so
+%{_cross_libdir}/pkgconfig/liburcu.pc
+
+%exclude %{_cross_libdir}/pkgconfig/liburcu-bp.pc
+%exclude %{_cross_libdir}/pkgconfig/liburcu-cds.pc
+%exclude %{_cross_libdir}/pkgconfig/liburcu-mb.pc
+%exclude %{_cross_libdir}/pkgconfig/liburcu-memb.pc
+%exclude %{_cross_libdir}/pkgconfig/liburcu-qsbr.pc
+%exclude %{_cross_libdir}/pkgconfig/liburcu-signal.pc
+%exclude %{_cross_libdir}/liburcu-bp.so
+%exclude %{_cross_libdir}/liburcu-cds.so
+%exclude %{_cross_libdir}/liburcu-common.so
+%exclude %{_cross_libdir}/liburcu-mb.so
+%exclude %{_cross_libdir}/liburcu-memb.so
+%exclude %{_cross_libdir}/liburcu-qsbr.so
+%exclude %{_cross_libdir}/liburcu-signal.so

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -47,3 +47,4 @@ selinux-policy = { path = "../selinux-policy" }
 systemd = { path = "../systemd" }
 util-linux = { path = "../util-linux" }
 wicked = { path = "../wicked" }
+xfsprogs = { path = "../xfsprogs" }

--- a/packages/release/local.mount
+++ b/packages/release/local.mount
@@ -7,9 +7,10 @@ After=prepare-local-fs.service
 Requires=prepare-local-fs.service
 
 [Mount]
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
 What=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
 Where=/local
-Type=ext4
+Type=${DATA_PARTITION_FILESYSTEM}
 # "noexec" omitted to allow containers and migrations to run
 Options=defaults,nosuid,nodev,noatime,private
 

--- a/packages/release/prepare-local-fs.service
+++ b/packages/release/prepare-local-fs.service
@@ -10,8 +10,9 @@ RefuseManualStop=true
 [Service]
 Type=oneshot
 
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
 # Create the filesystem on the partition, if it doesn't exist.
-ExecStart=/usr/lib/systemd/systemd-makefs ext4 /dev/disk/by-partlabel/BOTTLEROCKET-DATA
+ExecStart=/usr/lib/systemd/systemd-makefs ${DATA_PARTITION_FILESYSTEM} /dev/disk/by-partlabel/BOTTLEROCKET-DATA
 
 # Stop and mask the repart-data-* oneshots in case they're waiting on non-existent data partitions.
 # 'BOTTLEROCKET-DATA' already exists so we can move on.

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -106,6 +106,7 @@ Requires: %{_cross_os}procps
 Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}util-linux
+Requires: %{_cross_os}xfsprogs
 
 %description
 %{summary}.

--- a/packages/xfsprogs/0001-libxfs-do-not-try-to-run-the-crc32selftest.patch
+++ b/packages/xfsprogs/0001-libxfs-do-not-try-to-run-the-crc32selftest.patch
@@ -1,0 +1,44 @@
+From 3a77dfc54271059dcac305384bf6ace34fe1f3d3 Mon Sep 17 00:00:00 2001
+From: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Date: Sun, 18 Dec 2016 15:37:27 +0100
+Subject: [PATCH] libxfs: do not try to run the crc32selftest
+
+Even though the crc32selftest is natively compiled (because it is to be
+executed), it fails in cross-compilation as the host may lack the
+required headers, like uuid/uuid.h (e.g. in a minimal environment).
+
+Moreover, running the crc32selftest natively is completely wrong,
+because it passing on the host does not mean it would still pass n the
+target (because endianness or bitness or alignment differences).
+
+So, just disable running the crc32selftest altogether.
+
+Note that there's a remaining bug-in-hiding, because the crc32 table
+generator is natively built, but with the target CFLAGS.
+
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Signed-off-by: "Fabrice Fontaine" <fontaine.fabrice@gmail.com>
+[Update for 4.18.0: crc32 has been moved from libxfs to libfrog]
+---
+ libfrog/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libfrog/Makefile b/libfrog/Makefile
+index 0110708..675c1cb 100644
+--- a/libfrog/Makefile
++++ b/libfrog/Makefile
+@@ -54,9 +54,9 @@ ifeq ($(HAVE_GETMNTENT),yes)
+ LCFLAGS += -DHAVE_GETMNTENT
+ endif
+ 
+-LDIRT = gen_crc32table crc32table.h crc32selftest
++LDIRT = gen_crc32table crc32table.h
+ 
+-default: crc32selftest ltdepend $(LTLIBRARY)
++default: ltdepend $(LTLIBRARY)
+ 
+ crc32table.h: gen_crc32table.c crc32defs.h
+ 	@echo "    [CC]     gen_crc32table"
+-- 
+2.40.1
+

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "xfsprogs"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "/dev/null"
+
+[package.metadata.build-package]
+releases-url = "https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/"
+
+[[package.metadata.build-package.external-files]]
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.3.0.tar.xz"
+sha512 = "dbb3e77d0d9cf184a0e647b8231350401a7549a23a0bfd9121cf2a1b48e85f71d98329dff440fc6e984bcecfdcc2a72f0f27c4989560f3c55359f21f3fb434bb"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libinih = { path = "../libinih" }
+liburcu = { path = "../liburcu" }
+util-linux = { path = "../util-linux" }
+
+# RPM Requires
+[dependencies]
+# none - will likely change

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -23,4 +23,4 @@ util-linux = { path = "../util-linux" }
 
 # RPM Requires
 [dependencies]
-# none - will likely change
+# none

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -1,0 +1,84 @@
+Name: %{_cross_os}xfsprogs
+Version: 6.3.0
+Release: 1%{?dist}
+Summary: Utilities for managing the XFS filesystem
+License: GPL-2.0-only and LGPL-2.1-only
+URL: https://xfs.wiki.kernel.org
+Source0: http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-%{version}.tar.xz
+Patch1: 0001-libxfs-do-not-try-to-run-the-crc32selftest.patch
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libuuid-devel
+BuildRequires: %{_cross_os}libinih-devel
+BuildRequires: %{_cross_os}liburcu-devel
+BuildRequires: %{_cross_os}libblkid-devel
+
+Requires: %{_cross_os}liburcu
+Requires: %{_cross_os}libinih
+
+%description
+%{summary}.
+
+%package devel
+Summary: XFS filesystem-specific headers
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n xfsprogs-%{version} -p1
+
+%build
+%cross_configure \
+  --enable-blkid=yes \
+  --enable-lto=no \
+  --enable-editline=no \
+  --enable-scrub=no
+
+%make_build
+
+%install
+make DIST_ROOT=%{buildroot} install install-dev \
+  PKG_ROOT_SBIN_DIR=%{_cross_sbindir} PKG_ROOT_LIB_DIR=%{_cross_libdir}
+
+rm -f %{buildroot}/%{_cross_libdir}/*.{la,a}
+
+%files
+%license LICENSES/GPL-2.0 LICENSES/LGPL-2.1
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+%{_cross_sbindir}/mkfs.xfs
+%{_cross_sbindir}/xfs_copy
+%{_cross_sbindir}/xfs_db
+%{_cross_sbindir}/xfs_estimate
+%{_cross_sbindir}/xfs_fsr
+%{_cross_sbindir}/xfs_growfs
+%{_cross_sbindir}/xfs_io
+%{_cross_sbindir}/xfs_logprint
+%{_cross_sbindir}/xfs_mdrestore
+%{_cross_sbindir}/xfs_quota
+%{_cross_sbindir}/xfs_repair
+%{_cross_sbindir}/xfs_rtcp
+%{_cross_sbindir}/xfs_spaceman
+%{_cross_datadir}/xfsprogs/mkfs/*.conf
+
+# Exclude shell scripts
+%exclude %{_cross_sbindir}/fsck.xfs
+%exclude %{_cross_sbindir}/xfs_admin
+%exclude %{_cross_sbindir}/xfs_bmap
+%exclude %{_cross_sbindir}/xfs_freeze
+%exclude %{_cross_sbindir}/xfs_info
+%exclude %{_cross_sbindir}/xfs_metadump
+%exclude %{_cross_sbindir}/xfs_mkfile
+%exclude %{_cross_sbindir}/xfs_ncheck
+
+%exclude %{_cross_mandir}
+%exclude %{_cross_localedir}
+%exclude %{_cross_docdir}
+
+
+%files devel
+%dir %{_cross_includedir}/xfs
+%{_cross_includedir}/xfs/*.h
+%{_cross_libdir}/*.so

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -214,6 +214,13 @@ line arguments set in the boot configuration.
 [package.metadata.build-variant.image-features]
 unified-cgroup-hierarchy = true
 ```
+
+`xfs-data-partition` changes the filesystem for the data partition from ext4 to xfs. The
+default will remain ext4 and xfs is opt-in.
+
+```ignore
+[package.metadata.build-variant.image-features]
+xfs-data-partition = true
 */
 
 mod error;
@@ -505,6 +512,7 @@ pub enum ImageFeature {
     GrubSetPrivateVar,
     SystemdNetworkd,
     UnifiedCgroupHierarchy,
+    XfsDataPartition,
 }
 
 impl TryFrom<String> for ImageFeature {
@@ -514,6 +522,7 @@ impl TryFrom<String> for ImageFeature {
             "grub-set-private-var" => Ok(ImageFeature::GrubSetPrivateVar),
             "systemd-networkd" => Ok(ImageFeature::SystemdNetworkd),
             "unified-cgroup-hierarchy" => Ok(ImageFeature::UnifiedCgroupHierarchy),
+            "xfs-data-partition" => Ok(ImageFeature::XfsDataPartition),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -525,6 +534,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::GrubSetPrivateVar => write!(f, "GRUB_SET_PRIVATE_VAR"),
             ImageFeature::SystemdNetworkd => write!(f, "SYSTEMD_NETWORKD"),
             ImageFeature::UnifiedCgroupHierarchy => write!(f, "UNIFIED_CGROUP_HIERARCHY"),
+            ImageFeature::XfsDataPartition => write!(f, "XFS_DATA_PARTITION"),
         }
     }
 }

--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -13,6 +13,7 @@ BUILDER_ARCH="$(uname -m)"
 OVF_TEMPLATE=""
 
 GRUB_SET_PRIVATE_VAR="no"
+XFS_DATA_PARTITION="no"
 
 for opt in "$@"; do
    optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -27,6 +28,7 @@ for opt in "$@"; do
       --partition-plan=*) PARTITION_PLAN="${optarg}" ;;
       --ovf-template=*) OVF_TEMPLATE="${optarg}" ;;
       --with-grub-set-private-var=*) GRUB_SET_PRIVATE_VAR="${optarg}" ;;
+      --xfs-data-partition=*) XFS_DATA_PARTITION="${optarg}" ;;
    esac
 done
 
@@ -277,6 +279,13 @@ SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
 BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
 EOF
 
+# Set the BOTTLEROCKET-DATA Filesystem for creating/mounting
+if [ "${XFS_DATA_PARTITION}" == "yes" ] ; then
+  printf "%s\n" "DATA_PARTITION_FILESYSTEM=xfs" >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+else
+  printf "%s\n" "DATA_PARTITION_FILESYSTEM=ext4" >> "${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+fi
+
 # BOTTLEROCKET-ROOT-A
 mkdir -p "${ROOT_MOUNT}/lost+found"
 ROOT_LABELS=$(setfiles -n -d -F -m -r "${ROOT_MOUNT}" \
@@ -408,8 +417,28 @@ mkfs_data() {
   target="${1:?}"
   size="${2:?}"
   offset="${3:?}"
-  mkfs.ext4 -m 0 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" "${size}"
-  echo "${UNLABELED}" | debugfs -w -f - "${BOTTLEROCKET_DATA}"
+  # Create an XFS filesystem if requested
+  if [ "${XFS_DATA_PARTITION}" == "yes" ] ; then
+    echo "writing XFS filesystem for DATA"
+    # Create a file to write the filesystem to first
+    dd if=/dev/zero of="${BOTTLEROCKET_DATA}" bs=1M count=${size%?}
+    # block size of 4096, directory block size of 16384
+    # enable inotbtcount, bigtime, and reflink
+    # use an internal log with starting size of 64m
+    # use the minimal 2 Allocation groups, this still overprovisions when expanded
+    # set strip units of 512k and sectsize to make EBS volumes align
+    mkfs.xfs \
+      -b size=4096 -n size=16384 \
+      -m inobtcount=1,bigtime=1,reflink=1 \
+      -l internal,size=64m \
+      -d agcount=2,su=512k,sw=1,sectsize=4096 \
+      -f "${BOTTLEROCKET_DATA}"
+  else
+    # default to ext4
+    echo "writing ext4 filesystem for DATA"
+    mkfs.ext4 -m 0 -d "${DATA_MOUNT}" "${BOTTLEROCKET_DATA}" "${size}"
+    echo "${UNLABELED}" | debugfs -w -f - "${BOTTLEROCKET_DATA}"
+  fi
   dd if="${BOTTLEROCKET_DATA}" of="${target}" conv=notrunc bs=1M seek="${offset}"
 }
 

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -638,6 +638,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libinih"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "libiw"
 version = "0.1.0"
 dependencies = [

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -799,6 +799,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "liburcu"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "libxcrypt"
 version = "0.1.0"
 dependencies = [
@@ -1029,6 +1036,7 @@ dependencies = [
  "systemd",
  "util-linux",
  "wicked",
+ "xfsprogs",
 ]
 
 [[package]]
@@ -1171,4 +1179,14 @@ dependencies = [
  "libiw",
  "libnl",
  "systemd",
+]
+
+[[package]]
+name = "xfsprogs"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libinih",
+ "liburcu",
+ "util-linux",
 ]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -10,6 +10,7 @@ exclude = ["README.md"]
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
 unified-cgroup-hierarchy = true
+xfs-data-partition = true
 
 [package.metadata.build-variant]
 kernel-parameters = [

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -13,6 +13,7 @@ partition-plan = "unified"
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
 unified-cgroup-hierarchy = true
+xfs-data-partition = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -13,6 +13,7 @@ partition-plan = "unified"
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
 unified-cgroup-hierarchy = true
+xfs-data-partition = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"


### PR DESCRIPTION
**Issue number:** 3036

**Description of changes:**
This adds xfsprogs and it's dependencies to Bottlerocket. There is more work to properly make the variant boundary work but I have a rough set of changes to force the data partition into `xfs`. 

Note: We may hold back the aws-dev variant until we feel we are ready but for the time being, it simply makes the tools available, the data partition still remains `ext4` for the time being.


**Testing done:**
I build my own variant with xfs hard coded into the data partition. It boots, resizes, and you can see xfs data with xfs_* tools:
```
bash-5.1# xfs_info /local
meta-data=/dev/nvme1n1p1         isize=512    agcount=401, agsize=130816 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=1 inobtcount=1
data     =                       bsize=4096   blocks=52428288, imaxpct=25
         =                       sunit=128    swidth=128 blks
naming   =version 2              bsize=16384  ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=16384, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
