### PR TITLE
glossary: add shimpei, prairiedog and oci-add-hooks

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -27,6 +27,8 @@
   It finds settings that need generation by way of metadata in the API, and calls helper programs specified by that metadata.
 * [**thar-be-settings**](sources/api/thar-be-settings): A program that writes out system configuration files, replacing template variables with settings from the API.
 * [**updog**](sources/updater/updog): An update client that interfaces with a specified TUF updates repository to upgrade or downgrade Bottlerocket hosts to different image versions.
+* [**prairiedog**](sources/api/prairiedog): A program that handles various boot related operations.
+* [**shimpei**](sources/shimpei): An OCI compatible shim wrapper around `oci-add-hooks`. Its sole purpose is to call `oci-add-hooks` with the additional `--hook-config-path` and `--runtime-path` parameters that can't be provided by containerd.
 
 ## Non-Bottlerocket terms
 
@@ -42,3 +44,4 @@
 * **TUF**: [The Update Framework](https://theupdateframework.io/).
   A framework that helps developers maintain the security of software update systems.
 * [**wicked**](https://github.com/openSUSE/wicked): A network interface framework and management system.
+* [**oci-add-hooks**](https://github.com/awslabs/oci-add-hooks): An OCI runtime that injects the OCI `prestart`, `poststart`, and `poststop` hooks into a container `config.json` before passing along to an OCI compatible runtime.


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

Adds `shimpei`, `prairiedog` and `oci-add-hooks` to glossary

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
