### PR TITLE
containerd: resource-limit settings for oci default

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,12 +756,189 @@ Each of the `resource-limits` settings below contain two numeric fields: `hard-l
 Please see the [`getrlimit` linux manpage](https://man7.org/linux/man-pages/man7/capabilities.7.html) for meanings of `hard-limit` and `soft-limit`.
 
 The full list of resource limits that can be configured in Bottlerocket are:
+<table>
+<tr>
+  <th>Resource limit</th>
+  <th>Setting</th>
+  <th>Default value</th>
+  <th>Unit</th>
+</tr>
+<tr>
+  <td rowspan="2"> <code>RLIMIT_AS</code> </td>
+  <td><code>settings.oci-defaults.resource-limits.max-address-space.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-address-space.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_CORE</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-core-file-size.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-core-file-size.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_CPU</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-cpu-time.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">seconds</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-cpu-time.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_DATA</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-data-size.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-data-size.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_LOCKS</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-file-locks.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">locks</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-file-locks.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_FSIZE</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-file-size.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-file-size.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_MEMLOCK</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-locked-memory.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-locked-memory.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_MSGQUEUE</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-msgqueue-size.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-msgqueue-size.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_NICE</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-nice-priority.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">-</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-nice-priority.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_NOFILE</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-open-files.soft-limit</code></td>
+  <td>65536</td>
+  <td rowspan="2">files</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-open-files.hard-limit</code></td>
+  <td>1048576</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_SIGPENDING</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-pending-signals.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">signals</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-pending-signals.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_NPROC</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-processes.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">processes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-processes.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_RTPRIO</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-realtime-priority.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">-</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-realtime-priority.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_RTTIME</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-realtime-timeout.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">microseconds</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-realtime-timeout.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_RSS</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-resident-set.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-resident-set.hard-limit</code></td>
+  <td>-</td>
+</tr>
+<tr>
+  <td rowspan="2"><code>RLIMIT_STACK</code></td>
+  <td><code>settings.oci-defaults.resource-limits.max-stack-size.soft-limit</code></td>
+  <td>-</td>
+  <td rowspan="2">bytes</td>
+</tr>
+<tr>
+  <td><code>settings.oci-defaults.resource-limits.max-stack-size.hard-limit</code></td>
+  <td>-</td>
+</tr>
+</table>
 
-resource limit | setting | default value
------ | ----- | -----
-`RLIMIT_NOFILE` | `settings.oci-defaults.resource-limits.max-open-files.hard-limit` | 1048576
-`RLIMIT_NOFILE` | `settings.oci-defaults.resource-limits.max-open-files.soft-limit` | 65536
-
+Limits can be any integer between 0 to `int64::MAX`. Either `-1` or `"unlimited"` can be used to remove the limit.
+* Specifying the maximum value (`i64::MAX`) for a limit:
+  ```toml
+  [settings.oci-defaults.resource-limits.<rlimit>>]
+  soft-limit = 65536
+  hard-limit = 9223372036854775807
+  ```
+* Removing a limit:
+  ```toml
+  [settings.oci-defaults.resource-limits.<rlimit>>]
+  soft-limit = 65536
+  hard-limit = "unlimited"
+  ```
+  
 #### Container image registry settings
 
 The following setting is optional and allows you to configure image registry mirrors and pull-through caches for your containers.

--- a/Release.toml
+++ b/Release.toml
@@ -221,4 +221,7 @@ version = "1.15.0"
     "migrate_v1.14.3_aws-control-container-v0-7-3.lz4",
     "migrate_v1.14.3_public-control-container-v0-7-3.lz4",
 ]
-"(1.14.3, 1.15.0)" = []
+"(1.14.3, 1.15.0)" = [
+    "migrate_v1.15.0_oci-defaults-resource-setting.lz4",
+    "migrate_v1.15.0_oci-defaults-max-open-files.lz4",
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2723,6 +2723,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-defaults-max-open-files"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
+name = "oci-defaults-resource-setting"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
 name = "oci-defaults-setting"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -57,6 +57,8 @@ members = [
     "api/migration/migrations/v1.14.3/public-admin-container-v0-10-2",
     "api/migration/migrations/v1.14.3/aws-control-container-v0-7-3",
     "api/migration/migrations/v1.14.3/public-control-container-v0-7-3",
+    "api/migration/migrations/v1.15.0/oci-defaults-resource-setting",
+    "api/migration/migrations/v1.15.0/oci-defaults-max-open-files",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.15.0/oci-defaults-max-open-files/Cargo.toml
+++ b/sources/api/migration/migrations/v1.15.0/oci-defaults-max-open-files/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "oci-defaults-max-open-files"
+version = "0.1.0"
+edition = "2021"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+serde_json = "1"
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.15.0/oci-defaults-max-open-files/build.rs
+++ b/sources/api/migration/migrations/v1.15.0/oci-defaults-max-open-files/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.15.0/oci-defaults-max-open-files/src/main.rs
+++ b/sources/api/migration/migrations/v1.15.0/oci-defaults-max-open-files/src/main.rs
@@ -1,0 +1,68 @@
+use migration_helpers::common_migrations::NoOpMigration;
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use serde_json::Value;
+use std::process;
+
+const HARD_RESOURCE_LIMIT_SETTING_NAME: &str =
+    "settings.oci-defaults.resource-limits.max-open-files.hard-limit";
+const SOFT_RESOURCE_LIMIT_SETTING_NAME: &str =
+    "settings.oci-defaults.resource-limits.max-open-files.soft-limit";
+
+/// This migration changes the hard and soft limit for rlimit_nofile to u32 from i64 on downgrade.
+/// There is no need of migration on upgrade as u32 will automatically change to i64
+pub struct ChangeMaxOpenFileResourceLimitType;
+
+fn convert_to_u32(value: &mut Value) {
+    if !value.is_i64() {
+        return;
+    }
+    let v: i64 = serde_json::from_value(value.clone()).unwrap();
+    let s = match v {
+        -1 => u32::MAX,
+        v if v > u32::MAX as i64 => u32::MAX,
+        _ => v as u32,
+    };
+
+    *value = Value::Number(s.into());
+}
+
+impl Migration for ChangeMaxOpenFileResourceLimitType {
+    /// On upgrade there is nothing to do (see above).
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        Ok(input)
+    }
+
+    /// On downgrade, if the value is an i64 integer, we need to convert it to a u32.
+    ///
+    /// Note that this potentially causes data loss, if current value of the setting
+    /// is -1 or higher than u_32::MAX we will set it to max possible value i.e. u32::MAX.
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(v) = input.data.get_mut(HARD_RESOURCE_LIMIT_SETTING_NAME) {
+            convert_to_u32(v);
+        }
+        if let Some(v) = input.data.get_mut(SOFT_RESOURCE_LIMIT_SETTING_NAME) {
+            convert_to_u32(v);
+        }
+        Ok(input)
+    }
+}
+
+fn run() -> Result<()> {
+    if cfg!(variant_runtime = "k8s") {
+        migrate(ChangeMaxOpenFileResourceLimitType)?
+    } else {
+        migrate(NoOpMigration)?;
+    }
+
+    Ok(())
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.15.0/oci-defaults-resource-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.15.0/oci-defaults-resource-setting/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "oci-defaults-resource-setting"
+version = "0.1.0"
+edition = "2021"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.15.0/oci-defaults-resource-setting/build.rs
+++ b/sources/api/migration/migrations/v1.15.0/oci-defaults-resource-setting/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.15.0/oci-defaults-resource-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.15.0/oci-defaults-resource-setting/src/main.rs
@@ -1,0 +1,40 @@
+use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new resource limit settings for configuring the default OCI runtime spec.
+fn run() -> Result<()> {
+    if cfg!(variant_runtime = "k8s") {
+        migrate(AddPrefixesMigration(vec![
+            "settings.oci-defaults.resource-limits.max-address-space",
+            "settings.oci-defaults.resource-limits.max-core-file-size",
+            "settings.oci-defaults.resource-limits.max-cpu-time",
+            "settings.oci-defaults.resource-limits.max-data-size",
+            "settings.oci-defaults.resource-limits.max-file-locks",
+            "settings.oci-defaults.resource-limits.max-file-size",
+            "settings.oci-defaults.resource-limits.max-locked-memory",
+            "settings.oci-defaults.resource-limits.max-msgqueue-size",
+            "settings.oci-defaults.resource-limits.max-nice-priority",
+            "settings.oci-defaults.resource-limits.max-pending-signals",
+            "settings.oci-defaults.resource-limits.max-processes",
+            "settings.oci-defaults.resource-limits.max-realtime-priority",
+            "settings.oci-defaults.resource-limits.max-realtime-timeout",
+            "settings.oci-defaults.resource-limits.max-resident-set",
+            "settings.oci-defaults.resource-limits.max-stack-size",
+        ]))?
+    } else {
+        migrate(NoOpMigration)?;
+    }
+
+    Ok(())
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/de.rs
+++ b/sources/models/src/de.rs
@@ -207,3 +207,127 @@ mod mirrors_tests {
         );
     }
 }
+
+// This specifies that any non negative i64 integer, -1, and "unlimited"
+/// are the valid resource-limits. The hard-limit set to "unlimited" or -1
+/// and soft-limit set to "unlimited" or -1 are converted to u64::MAX in
+/// the spec file for the container runtime which ultimately represents
+/// unlimited for that resource
+pub(crate) fn deserialize_limit<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt64 {
+        String(String),
+        Int(i64),
+    }
+
+    match StringOrInt64::deserialize(deserializer)? {
+        StringOrInt64::String(s) => {
+            if s == "unlimited" {
+                Ok(-1)
+            } else {
+                Err(Error::custom(format!(
+                    "Invalid rlimit {}, expected -1 to {} or \"unlimited\"",
+                    s,
+                    i64::MAX
+                )))
+            }
+        }
+        StringOrInt64::Int(i) => {
+            if (-1..=i64::MAX).contains(&i) {
+                Ok(i)
+            } else {
+                Err(Error::custom(format!(
+                    "Invalid rlimit {}, expected -1 to {} or \"unlimited\"",
+                    i,
+                    i64::MAX
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod oci_default_resource_limit_tests {
+    use crate::OciDefaultsResourceLimit;
+
+    #[test]
+    fn valid_any_integer_i_64() {
+        assert!(toml::from_str::<OciDefaultsResourceLimit>(
+            r#"
+          hard-limit = 200000
+          soft-limit = 10000
+       "#
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn valid_string_unlimited() {
+        assert!(toml::from_str::<OciDefaultsResourceLimit>(
+            r#"
+          hard-limit = 'unlimited'
+          soft-limit = 10000
+       "#
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn valid_integer_i_64_max() {
+        assert!(toml::from_str::<OciDefaultsResourceLimit>(
+            r#"
+          hard-limit = 9223372036854775807
+          soft-limit = 10000
+       "#
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn valid_integer_minus_one() {
+        assert!(toml::from_str::<OciDefaultsResourceLimit>(
+            r#"
+          hard-limit = -1
+          soft-limit = 10000
+       "#
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn invalid_integer_greater_than_i_64_max() {
+        assert!(toml::from_str::<OciDefaultsResourceLimit>(
+            r#"
+          hard-limit = 9223372036854775808
+          soft-limit = 10000
+       "#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn invalid_minus_2() {
+        assert!(toml::from_str::<OciDefaultsResourceLimit>(
+            r#"
+          hard-limit = -2
+          soft-limit = 10000
+       "#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn invalid_string_abc() {
+        assert!(toml::from_str::<OciDefaultsResourceLimit>(
+            r#"
+            hard-limit = 'abc'
+            soft-limit = 10000
+        "#
+        )
+        .is_err());
+    }
+}

--- a/sources/models/src/modeled_types/oci_defaults.rs
+++ b/sources/models/src/modeled_types/oci_defaults.rs
@@ -94,15 +94,46 @@ mod oci_defaults_capabilities {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Scalar, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum OciDefaultsResourceLimitType {
+    MaxAddressSpace,
+    MaxCoreFileSize,
+    MaxCpuTime,
+    MaxDataSize,
+    MaxFileLocks,
+    MaxFileSize,
+    MaxLockedMemory,
+    MaxMsgqueueSize,
+    MaxNicePriority,
     MaxOpenFiles,
+    MaxPendingSignals,
+    MaxProcesses,
+    MaxRealtimePriority,
+    MaxRealtimeTimeout,
+    MaxResidentSet,
+    MaxStackSize,
 }
 
 // We are leaving this implementation open for the easy addition of
 // future resource limits.
 impl OciDefaultsResourceLimitType {
     pub fn to_linux_string(&self) -> &'static str {
+        use OciDefaultsResourceLimitType::*;
         match self {
-            OciDefaultsResourceLimitType::MaxOpenFiles => "RLIMIT_NOFILE",
+            MaxAddressSpace => "RLIMIT_AS",
+            MaxCoreFileSize => "RLIMIT_CORE",
+            MaxCpuTime => "RLIMIT_CPU",
+            MaxDataSize => "RLIMIT_DATA",
+            MaxFileLocks => "RLIMIT_LOCKS",
+            MaxFileSize => "RLIMIT_FSIZE",
+            MaxLockedMemory => "RLIMIT_MEMLOCK",
+            MaxMsgqueueSize => "RLIMIT_MSGQUEUE",
+            MaxNicePriority => "RLIMIT_NICE",
+            MaxOpenFiles => "RLIMIT_NOFILE",
+            MaxPendingSignals => "RLIMIT_SIGPENDING",
+            MaxProcesses => "RLIMIT_NPROC",
+            MaxRealtimePriority => "RLIMIT_RTPRIO",
+            MaxRealtimeTimeout => "RLIMIT_RTTIME",
+            MaxResidentSet => "RLIMIT_RSS",
+            MaxStackSize => "RLIMIT_STACK",
         }
     }
 }
@@ -110,8 +141,11 @@ impl OciDefaultsResourceLimitType {
 #[cfg(test)]
 mod oci_defaults_rlimits {
     use super::*;
+    use OciDefaultsResourceLimitType::*;
 
-    fn check_rlimit_strings(cap: OciDefaultsResourceLimitType, bottlerocket: &str, linux: &str) {
+    fn check_rlimit_strings(
+        (cap, bottlerocket, linux): (OciDefaultsResourceLimitType, &str, &str),
+    ) {
         let actual_bottlerocket = cap.to_string();
         let actual_linux = cap.to_linux_string();
         assert_eq!(bottlerocket, actual_bottlerocket);
@@ -120,10 +154,35 @@ mod oci_defaults_rlimits {
 
     #[test]
     fn linux_rlimit_strings() {
-        check_rlimit_strings(
-            OciDefaultsResourceLimitType::MaxOpenFiles,
-            "max-open-files",
-            "RLIMIT_NOFILE",
-        );
+        let rlimits = [
+            (MaxAddressSpace, "max-address-space", "RLIMIT_AS"),
+            (MaxCoreFileSize, "max-core-file-size", "RLIMIT_CORE"),
+            (MaxCpuTime, "max-cpu-time", "RLIMIT_CPU"),
+            (MaxDataSize, "max-data-size", "RLIMIT_DATA"),
+            (MaxFileLocks, "max-file-locks", "RLIMIT_LOCKS"),
+            (MaxFileSize, "max-file-size", "RLIMIT_FSIZE"),
+            (MaxLockedMemory, "max-locked-memory", "RLIMIT_MEMLOCK"),
+            (MaxMsgqueueSize, "max-msgqueue-size", "RLIMIT_MSGQUEUE"),
+            (MaxNicePriority, "max-nice-priority", "RLIMIT_NICE"),
+            (MaxOpenFiles, "max-open-files", "RLIMIT_NOFILE"),
+            (
+                MaxPendingSignals,
+                "max-pending-signals",
+                "RLIMIT_SIGPENDING",
+            ),
+            (MaxProcesses, "max-processes", "RLIMIT_NPROC"),
+            (
+                MaxRealtimePriority,
+                "max-realtime-priority",
+                "RLIMIT_RTPRIO",
+            ),
+            (MaxRealtimeTimeout, "max-realtime-timeout", "RLIMIT_RTTIME"),
+            (MaxResidentSet, "max-resident-set", "RLIMIT_RSS"),
+            (MaxStackSize, "max-stack-size", "RLIMIT_STACK"),
+        ];
+
+        for rlimit in rlimits {
+            check_rlimit_strings(rlimit);
+        }
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #2814  #2862 

**Description of changes:**
Enable the capability to set the values for following resource limits
MaxAddressSpace,
MaxCoreFileSize,
MaxCpuTime,
MaxDataSize,
MaxFileLocks,
MaxFileSize,
MaxLockedMemory,
MaxMsgqueueSize,
MaxNicePriority,
MaxPendingSignals,
MaxProcesses,
MaxRealtimePriority,
MaxRealtimeTimeout,
MaxResidentSet,
MaxStackSize

**Testing done:**
- [x] Try setting a value for all the settings using api client -  It should show these values in etc/containerd/cri-base.json
- [x] Try setting a "unlimited" as hard-limit for max-locked-memory in the settings using api client -  It should show u64::MAX as hard limit for RLIMIT_MEMLOCK in etc/containerd/cri-base.json and the ulimit -Hl should set to  unlimited. 
- [x] Create a pod on bottlerocket host and check /proc/self/limits - It should list all the settings that has been done
         - Create a sample nginx workload container launched via kubernetes and check /proc/self/limits - This has default value for Max locked memory  as 65536.
         - Change Max locked memory setting using api client to 6536.
         - Create another container that runs the nginx image and check the /proc/self/limits - This has default value for Max locked memory  as 6536.
- [x] Migration testing 
         - Create an ami with 1.14.3 version and create instance using that.
         -  Try to set the max-locked-memory setting-  1.14.3 will not allow to do this setting.
         - Upgrade to 1.15.0 with the image in your custom TUF repo.
         - Try to set the max-locked-memory setting-  1.15.0 will allow to do memlock setting and add this in etc/containerd/cri_base.json.
         - Downgrade back to the older version 1.14.3.
         - Try to set the max-locked-memory setting-  1.14.3 will not allow to do this setting.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
