### PR TITLE
[1.14.x] Wicked: improve reliability of acquiring a DHCPv6 lease

### DIFF
--- a/packages/wicked/0001-dhcp6-refresh-ipv6-flags-on-staring-in-auto-mode.patch
+++ b/packages/wicked/0001-dhcp6-refresh-ipv6-flags-on-staring-in-auto-mode.patch
@@ -1,0 +1,43 @@
+From c207c8b8dfd2d6e73f2014da69bbe437e49f21db Mon Sep 17 00:00:00 2001
+From: Marius Tomaschewski <mt@suse.de>
+Date: Thu, 13 Oct 2022 14:57:15 +0200
+Subject: [PATCH] dhcp6: refresh ipv6 flags on staring in auto mode
+
+In some cases, like during an "ifup ; ifup" there is no NEWLINK
+event from kernel providing the IPv6 ready, rs-sent, ra-rcvd,
+ra-managed or ra-otherconf flags about the router advertisement
+(RA) processing we're using to reliably resolve the auto mode
+(aka follow-ra mode), so we've changed to actively query them.
+
+(cherry picked from commit 3f1604e716729ae410ed64a9512a87e1868fcf34)
+---
+ src/dhcp6/device.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/src/dhcp6/device.c b/src/dhcp6/device.c
+index 9b9bb009..f36b16c9 100644
+--- a/src/dhcp6/device.c
++++ b/src/dhcp6/device.c
+@@ -487,8 +487,7 @@ ni_dhcp6_device_start_auto_prefix(ni_dhcp6_device_t *dev)
+ 
+ 	/* refresh in case kernel forgot to send it
+ 	 * (we increment timeout between attempts) */
+-	if (dev->config->dry_run != NI_DHCP6_RUN_NORMAL)
+-		ni_dhcp6_device_refresh_mode(dev, ifp);
++	ni_dhcp6_device_refresh_mode(dev, ifp);
+ 
+ 	/* request prefix after 1/3 defer timeout */
+ 	ni_timer_get_time(&now);
+@@ -524,8 +523,7 @@ ni_dhcp6_device_start_auto(ni_dhcp6_device_t *dev)
+ 
+ 	/* refresh in case kernel forgot to send it
+ 	 * (we increment timeout between attempts) */
+-	if (dev->config->dry_run != NI_DHCP6_RUN_NORMAL)
+-		ni_dhcp6_device_refresh_mode(dev, ifp);
++	ni_dhcp6_device_refresh_mode(dev, ifp);
+ 
+ 	if (dev->config->mode & NI_BIT(NI_DHCP6_MODE_AUTO))
+ 		return ni_dhcp6_device_start_timer_arm(dev);
+-- 
+2.40.1
+

--- a/packages/wicked/1007-dhpc6-don-t-cancel-transmission-if-random-delay-happ.patch
+++ b/packages/wicked/1007-dhpc6-don-t-cancel-transmission-if-random-delay-happ.patch
@@ -1,0 +1,35 @@
+From 1a913cf6bae1e170229c1ddb49d0c2a099eb8789 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Fri, 26 May 2023 13:27:28 +0200
+Subject: [PATCH] dhpc6: don't cancel transmission if random delay happens to
+ be 0 ms
+
+If the randomized transmission delay in ni_dhcp6_device_transmit_arm_delay
+happens to be 0 ms including jitter then ni_dhcp6_fsm_set_timeout_msec will
+interpret that as the request to cancel the timer and no message will be
+sent. In the case of a Solicitation message, no lease will ever be
+acquired. Fix this by signaling the intent to transmit immediately to the
+caller if the delay happens to be 0 ms.
+
+Reported-by: Zac Mrowicki <mrowicki@amazon.com>
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ src/dhcp6/device.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/dhcp6/device.c b/src/dhcp6/device.c
+index f36b16c..e5ee99e 100644
+--- a/src/dhcp6/device.c
++++ b/src/dhcp6/device.c
+@@ -790,6 +790,8 @@ ni_dhcp6_device_transmit_arm_delay(ni_dhcp6_device_t *dev)
+ 	jitter.min = 0;
+ 	jitter.max = dev->retrans.delay;
+ 	delay = ni_timeout_randomize(0, &jitter);
++	if (delay == 0)
++		return FALSE;
+ 
+ 	ni_debug_dhcp("%s: setting initial transmit delay of 0 .. %u.%03us",
+ 			dev->ifname, NI_TIMEOUT_SEC(delay), NI_TIMEOUT_MSEC(delay));
+-- 
+2.40.1
+

--- a/packages/wicked/1008-dhcp6-reduce-maximum-initial-solicitation-delay-to-1.patch
+++ b/packages/wicked/1008-dhcp6-reduce-maximum-initial-solicitation-delay-to-1.patch
@@ -1,0 +1,36 @@
+From 5aa6eff182204b312007ac44dcfffdf4dc6b7428 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Fri, 26 May 2023 16:21:11 +0200
+Subject: [PATCH] dhcp6: reduce maximum initial solicitation delay to 100 ms
+
+While RFC 3315 requires the initial solicitation delay to be randomly
+chosen between 0 and 1000 ms to prevent a thundering herd of synchronized
+clients during mass reboots, not all clients (e.g. systemd-networkd) follow
+this. Reduce the maximum delay to 100 ms which, together with natural
+jitter during boot, still seems plenty and cuts down the time to lease.
+
+Note that the more recent RFC 8415 softened its stance a bit. The
+initial solicitation delay "SHOULD" be followed, i.e. is recommended but
+not required.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ src/dhcp6/protocol.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/dhcp6/protocol.h b/src/dhcp6/protocol.h
+index cd917ba..5f40902 100644
+--- a/src/dhcp6/protocol.h
++++ b/src/dhcp6/protocol.h
+@@ -119,7 +119,7 @@ enum NI_DHCP6_MSG_TYPE {
+  *      Parameter		  Value    Description
+  * ---------------------------------------------------------------------------
+  */
+-#define	NI_DHCP6_SOL_MAX_DELAY	   1000	/* Max delay of first Solicit  */
++#define	NI_DHCP6_SOL_MAX_DELAY	    100	/* Max delay of first Solicit  */
+ #define NI_DHCP6_SOL_TIMEOUT	   1000	/* Initial Solicit timeout     */
+ #define NI_DHCP6_SOL_MAX_RT	3600000	/* Max Solicit timeout value   */
+ #define NI_DHCP6_REQ_TIMEOUT	   1000	/* Initial Request timeout     */
+-- 
+2.40.1
+

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -47,6 +47,7 @@ Patch1003: 1003-ship-mkconst-and-schema-sources-for-runtime-use.patch
 Patch1004: 1004-adjust-safeguard-for-dhcp6-defer-timeout.patch
 Patch1005: 1005-client-validate-ethernet-namespace-node.patch
 Patch1006: 1006-server-discover-hardware-address-of-unconfigured-int.patch
+Patch1007: 1007-dhpc6-don-t-cancel-transmission-if-random-delay-happ.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libdbus-devel

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -48,6 +48,7 @@ Patch1004: 1004-adjust-safeguard-for-dhcp6-defer-timeout.patch
 Patch1005: 1005-client-validate-ethernet-namespace-node.patch
 Patch1006: 1006-server-discover-hardware-address-of-unconfigured-int.patch
 Patch1007: 1007-dhpc6-don-t-cancel-transmission-if-random-delay-happ.patch
+Patch1008: 1008-dhcp6-reduce-maximum-initial-solicitation-delay-to-1.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libdbus-devel

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -38,6 +38,7 @@ Source99: constants.xml
 %endif
 
 # upstream fixes
+Patch0001: 0001-dhcp6-refresh-ipv6-flags-on-staring-in-auto-mode.patch
 
 # local hacks
 Patch1001: 1001-avoid-gcrypt-dependency.patch


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3143

**Description of changes:**

This PR contains changes to improve the reliability and efficiency of getting a DHCPv6 lease for an interface via Wicked. The three patches are an upstream backport, a downstream fix (to be upstreamed), and a downstream modification (not to be upstreamed). For details, please see the respective commits.

**Testing done:**

Most extensively by @zmrow in #3159 (thanks!)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
