### PR TITLE
pluto: add more retries for requests out to AWS

### DIFF
--- a/sources/api/pluto/src/aws.rs
+++ b/sources/api/pluto/src/aws.rs
@@ -1,0 +1,47 @@
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_config::imds;
+use aws_smithy_types::retry::{RetryConfig, RetryConfigBuilder};
+use aws_types::region::Region;
+use aws_types::SdkConfig;
+use snafu::{ResultExt, Snafu};
+use std::time::Duration;
+
+// Max request retry attempts; Retry many many times and let the caller decide when to terminate
+const MAX_ATTEMPTS: u32 = 100;
+const IMDS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display("Failed to build IMDS client: {}", source))]
+    SdkImds {
+        source: imds::client::error::BuildError,
+    },
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+async fn sdk_imds_client() -> Result<imds::Client> {
+    imds::Client::builder()
+        .max_attempts(MAX_ATTEMPTS)
+        .connect_timeout(IMDS_CONNECT_TIMEOUT)
+        .build()
+        .await
+        .context(SdkImdsSnafu)
+}
+
+fn sdk_retry_config() -> RetryConfig {
+    RetryConfigBuilder::new().max_attempts(MAX_ATTEMPTS).build()
+}
+
+pub(crate) async fn sdk_config(region: &str) -> Result<SdkConfig> {
+    let provider = DefaultCredentialsChain::builder()
+        .imds_client(sdk_imds_client().await?)
+        .build()
+        .await;
+    Ok(aws_config::from_env()
+        .region(Region::new(region.to_owned()))
+        .credentials_provider(provider)
+        .retry_config(sdk_retry_config())
+        .load()
+        .await)
+}

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -32,6 +32,7 @@ reasonable default is available.
 */
 
 mod api;
+mod aws;
 mod ec2;
 mod eks;
 mod proxy;

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.25", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.25", default-features = false, features = ["process", "macros", "rt-multi-thread"] }  # LTS
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**
```
    pluto: increase retries for requests out to AWS
    
    This adds more resiliency when pluto makes API requests out to EC2 and
    EKS. We choose a large number of retries to force the SDK to keep
    retrying until we timeout on the overall request.
    
    It's now less likely for the request to overall fail due to
    transient connection errors.

```

```
    sundog: enforce settings generator execution timeout
    
    Enforces a 6 minute timeout on settings generator execution so as to not
    hang the boot for too long before erroring out.

```


**Testing done:**
On a host where 25% of all outbound packets get dropped, I was able to call `pluto private-dns-name` where it retried the request 5 times (beyond the default 3 tries set by the SDK).

```
18:54:36 [DEBUG] (4) hyper::client::connect::dns: resolving host="ec2.us-west-2.amazonaws.com"
18:54:39 [DEBUG] (1) aws_smithy_client::retry: attempt 1 failed with Error(TransientError); retrying after 93.530282ms
18:54:39 [DEBUG] (1) aws_smithy_client::retry: retry; kind=Error(TransientError)
18:54:39 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:39 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:39 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="generate_user_agent"
18:54:39 [DEBUG] (1) aws_smithy_http_tower::map_request: async_map_request; name="retrieve_credentials"
18:54:39 [DEBUG] (1) aws_credential_types::cache::lazy_caching: loaded credentials from cache
18:54:39 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="sigv4_sign_request"
18:54:39 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="recursion_detection"
18:54:39 [DEBUG] (1) tracing::span: dispatch;
18:54:39 [DEBUG] (5) hyper::client::connect::dns: resolving host="ec2.us-west-2.amazonaws.com"
18:54:42 [DEBUG] (1) aws_smithy_client::retry: attempt 2 failed with Error(TransientError); retrying after 381.207122ms
18:54:42 [DEBUG] (1) aws_smithy_client::retry: retry; kind=Error(TransientError)
18:54:43 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:43 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:43 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="generate_user_agent"
18:54:43 [DEBUG] (1) aws_smithy_http_tower::map_request: async_map_request; name="retrieve_credentials"
18:54:43 [DEBUG] (1) aws_credential_types::cache::lazy_caching: loaded credentials from cache
18:54:43 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="sigv4_sign_request"
18:54:43 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="recursion_detection"
18:54:43 [DEBUG] (1) tracing::span: dispatch;
18:54:43 [DEBUG] (6) hyper::client::connect::dns: resolving host="ec2.us-west-2.amazonaws.com"
18:54:46 [DEBUG] (1) aws_smithy_client::retry: attempt 3 failed with Error(TransientError); retrying after 1.246607675s
18:54:46 [DEBUG] (1) aws_smithy_client::retry: retry; kind=Error(TransientError)
18:54:47 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:47 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:47 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="generate_user_agent"
18:54:47 [DEBUG] (1) aws_smithy_http_tower::map_request: async_map_request; name="retrieve_credentials"
18:54:47 [DEBUG] (1) aws_credential_types::cache::lazy_caching: loaded credentials from cache
18:54:47 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="sigv4_sign_request"
18:54:47 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="recursion_detection"
18:54:47 [DEBUG] (1) tracing::span: dispatch;
18:54:47 [DEBUG] (5) hyper::client::connect::dns: resolving host="ec2.us-west-2.amazonaws.com"
18:54:50 [DEBUG] (1) aws_smithy_client::retry: attempt 4 failed with Error(TransientError); retrying after 1.733219105s
18:54:50 [DEBUG] (1) aws_smithy_client::retry: retry; kind=Error(TransientError)
18:54:52 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:52 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="resolve_endpoint"
18:54:52 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="generate_user_agent"
18:54:52 [DEBUG] (1) aws_smithy_http_tower::map_request: async_map_request; name="retrieve_credentials"
18:54:52 [DEBUG] (1) aws_credential_types::cache::lazy_caching: loaded credentials from cache
18:54:52 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="sigv4_sign_request"
18:54:52 [DEBUG] (1) aws_smithy_http_tower::map_request: map_request; name="recursion_detection"
18:54:52 [DEBUG] (1) tracing::span: dispatch;
18:54:52 [DEBUG] (4) hyper::client::connect::dns: resolving host="ec2.us-west-2.amazonaws.com"
18:54:52 [DEBUG] (1) hyper::client::connect::http: connecting to 52.94.214.26:443
18:54:52 [DEBUG] (1) hyper::client::connect::http: connected to 52.94.214.26:443
18:54:52 [DEBUG] (1) rustls::client::hs: No cached session for DnsName(DnsName(DnsName("ec2.us-west-2.amazonaws.com")))
18:54:52 [DEBUG] (1) rustls::client::hs: Not resuming any session
18:54:52 [DEBUG] (1) rustls::client::hs: ALPN protocol is Some(b"http/1.1")
18:54:52 [DEBUG] (1) rustls::client::hs: Using ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
18:54:52 [DEBUG] (1) rustls::client::tls12: ECDHE curve is ECParameters { curve_type: NamedCurve, named_group: secp256r1 }
18:54:52 [DEBUG] (1) rustls::client::tls12: Server DNS name is DnsName(DnsName(DnsName("ec2.us-west-2.amazonaws.com")))
18:54:52 [DEBUG] (1) rustls::client::tls12: Session saved
18:54:52 [DEBUG] (2) hyper::proto::h1::io: flushed 1994 bytes
18:54:52 [DEBUG] (3) hyper::proto::h1::io: parsed 8 headers
18:54:52 [DEBUG] (3) hyper::proto::h1::conn: incoming body is chunked encoding
18:54:52 [DEBUG] (1) tracing::span: load_response;
18:54:52 [DEBUG] (1) tracing::span: parse_unloaded;
18:54:52 [DEBUG] (1) tracing::span: read_body;
18:54:52 [DEBUG] (3) hyper::proto::h1::decode: incoming chunked header: 0x2000 (8192 bytes)
18:54:52 [DEBUG] (3) hyper::proto::h1::decode: incoming chunked header: 0x10EB (4331 bytes)
18:54:52 [DEBUG] (2) hyper::proto::h1::conn: incoming body completed
18:54:52 [DEBUG] (2) hyper::client::pool: pooling idle connection for ("https", ec2.us-west-2.amazonaws.com)
18:54:52 [DEBUG] (1) tracing::span: parse_loaded;
18:54:52 [DEBUG] (1) aws_smithy_client: send_operation; status="ok"
"i-abcd1234.us-west-2.compute.internal"
18:54:52 [DEBUG] (3) rustls::conn: Sending warning alert CloseNotify

real	0m17.869s
user	0m0.022s
sys	0m0.000s
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
