### PR TITLE
Add container images cleanup settings to API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,13 @@ Valid time units include `s`, `m`, and `h`, e.g. `1h`, `1m1s`.
 * `settings.ecs.reserved-memory`: The amount of memory, in MiB, reserved for critical system processes.
 * `settings.ecs.task-cleanup-wait`: Time to wait before the task's containers are removed after they are stopped.
 Valid time units are `s`, `m`, and `h`, e.g. `1h`, `1m1s`.
+* `settings.ecs.image-cleanup-wait`: Time to wait between image cleanup cycles.
+Valid time units are `s`, `m`, and `h`, e.g. `1h`, `1m1s`.
+* `settings.ecs.image-cleanup-delete-per-cycle`: Number of images to delete in a single image cleanup cycle.
+* `settings.ecs.image-cleanup-enabled`: Enable automatic images clean up after the tasks have been removed.
+Defaults to `false`
+* `settings.ecs.image-cleanup-age`: Time since the image was pulled to be considered for clean up.
+Valid time units are `s`, `m`, and `h`, e.g. `1h`, `1m1s`.
 
   **Note**: `metadata-service-rps` and `metadata-service-burst` directly map to the values set by the `ECS_TASK_METADATA_RPS_LIMIT` environment variable.
 

--- a/packages/ecs-agent/ecs.config
+++ b/packages/ecs-agent/ecs.config
@@ -22,3 +22,9 @@ ECS_CONTAINER_STOP_TIMEOUT="{{settings.ecs.container-stop-timeout}}"
 {{#if settings.ecs.task-cleanup-wait}}
 ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION="{{settings.ecs.task-cleanup-wait}}"
 {{/if}}
+{{#if settings.ecs.image-cleanup-wait}}
+ECS_IMAGE_CLEANUP_INTERVAL="{{settings.ecs.image-cleanup-wait}}"
+{{/if}}
+{{# if settings.ecs.image-cleanup-age}}
+ECS_IMAGE_MINIMUM_CLEANUP_AGE="{{settings.ecs.image-cleanup-age}}"
+{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1539,6 +1539,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecs-images-cleanup"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "ecs-settings-applier"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "api/migration/migrations/v1.14.0/public-admin-container-v0-10-1",
     "api/migration/migrations/v1.14.0/aws-control-container-v0-7-2",
     "api/migration/migrations/v1.14.0/public-control-container-v0-7-2",
+    "api/migration/migrations/v1.14.2/ecs-images-cleanup",
 
     "bottlerocket-release",
 

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -74,6 +74,14 @@ struct ECSConfig {
 
     #[serde(rename = "ReservedMemory", skip_serializing_if = "Option::is_none")]
     reserved_memory: Option<u16>,
+
+    #[serde(
+        rename = "NumImagesToDeletePerCycle",
+        skip_serializing_if = "Option::is_none"
+    )]
+    image_cleanup_delete_per_cycle: Option<i64>,
+
+    image_cleanup_disabled: bool,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -141,6 +149,8 @@ async fn run() -> Result<()> {
         reserved_memory: ecs.reserved_memory,
         metadata_service_rps: ecs.metadata_service_rps,
         metadata_service_burst: ecs.metadata_service_burst,
+        image_cleanup_delete_per_cycle: ecs.image_cleanup_delete_per_cycle,
+        image_cleanup_disabled: !ecs.image_cleanup_enabled.unwrap_or(true),
         ..Default::default()
     };
     if let Some(os) = settings.os {

--- a/sources/api/migration/migrations/v1.14.2/ecs-images-cleanup/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.2/ecs-images-cleanup/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ecs-images-cleanup"
+version = "0.1.0"
+edition = "2018"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.2/ecs-images-cleanup/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.2/ecs-images-cleanup/src/main.rs
@@ -1,0 +1,23 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added additional configurations for the ECS agent
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.ecs.image-cleanup-wait",
+        "settings.ecs.image-cleanup-delete-per-cycle",
+        "settings.ecs.image-cleanup-enabled",
+        "settings.ecs.image-cleanup-age",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -294,6 +294,10 @@ struct ECSSettings {
     metadata_service_rps: i64,
     metadata_service_burst: i64,
     reserved_memory: u16,
+    image_cleanup_wait: ECSDurationValue,
+    image_cleanup_delete_per_cycle: i64,
+    image_cleanup_enabled: bool,
+    image_cleanup_age: ECSDurationValue,
 }
 
 #[model]


### PR DESCRIPTION
**Issue number:**

Closes #3167

**Description of changes:**
This adds additional API settings for the ECS variants, to further tweak image clean up cycles. In the issue, only `ECS_NUM_IMAGES_DELETE_PER_CYCLE` and `ECS_IMAGE_CLEANUP_INTERVAL` were asked for. But while testing, I found that not all the images that I was expecting to be deleted were actually cleaned. This is because not all the images were old enough to be picked up by cleanup cycles. Thus, I decided to add two more settings that allow further tweaks to the cleaning cycles. The new configurations in this PR include:

`settings.ecs.image-cleanup-wait`: maps to `ECS_IMAGE_CLEANUP_INTERVAL`, which is the time to wait between image cleanup cycles.
`settings.ecs.images-to-delete-per-cycle`: maps to `ECS_NUM_IMAGES_DELETE_PER_CYCLE`, which is the number of images to be deleted per cleanup cycle
`settings.ecs.image-cleanup-age`: maps to `ECS_IMAGE_MINIMUM_CLEANUP_AGE`, which is the time that has to pass since the images were pulled to be considered for clean up
`settings.ecs.image-cleanup-disabled`: maps to `ECS_DISABLE_IMAGE_CLEANUP`, indicates whether image cleanup is disabled.


**Testing done:**
- Created two separate tasks with two different container images
- Configured an instance with these values:

```toml
[settings.ecs]
image-cleanup-wait = "10m"
images-to-delete-per-cycle = 1
image-cleanup-age = "1s"
image-cleanup-disabled = false
```
- Confirmed that only one image was deleted per cleanup cycle:

```bash
Jun 19 22:41:23 <!> msg="Candidate image for deletion: [Image: [ImageID: sha256:fddade41cfbe8e039e9c5d5c5695fc3efd22764c6bca5cf0d9b4849dd22812f9; Names: docker.io/library/fedora:35] referenced by 0 containers; PulledAt: 2023-06-19 22:32:19.863928879 +0000 UTC m=+56.779801748; LastUsedAt: 2023-06-19 22:33:41.697169747 +0000 UTC m=+138.613042609; PullSucceeded: true]" module=docker_image_manager.go
Jun 19 22:41:23 <!> msg="Candidate image for deletion: [Image: [ImageID: sha256:1d81a0524f7d02b7673be0eb1201ab507468b736188d2678a488aeb3449d266e; Names: docker.io/library/fedora:36] referenced by 0 containers; PulledAt: 2023-06-19 22:32:42.295312319 +0000 UTC m=+79.211185190; LastUsedAt: 2023-06-19 22:33:43.190129074 +0000 UTC m=+140.106001934; PullSucceeded: true]" module=docker_image_manager.go
Jun 19 22:41:23 <!> msg="Found 2 eligible images for deletion" module=docker_image_manager.go
Jun 19 22:41:23 <!> msg="Removing Image: docker.io/library/fedora:35" module=docker_image_manager.go
Jun 19 22:41:23 <!> msg="Image removed: docker.io/library/fedora:35" module=docker_image_manager.go
Jun 19 22:41:23 <!> msg="Cleaning up all tracking information for image docker.io/library/fedora:35 as it has zero references" module=docker_image_manager.go
Jun 19 22:41:23 <!> msg="Removing Image State: [Image: [ImageID: sha256:fddade41cfbe8e039e9c5d5c5695fc3efd22764c6bca5cf0d9b4849dd22812f9; Names: ] referenced by 0 containers; PulledAt: 2023-06-19 22:32:19.863928879 +0000 UTC m=+56.779801748; LastUsedAt: 2023-06-19 22:33:41.697169747 +0000 UTC m=+138.613042609; PullSucceeded: true] from Image Manager" module=docker_image_manager.go
#
# 10 mins passed .....
#
Jun 19 22:51:23 <!> msg="Begin building map of eligible unused images for deletion" module=docker_image_manager.go
Jun 19 22:51:23 <!> msg="Candidate image for deletion: [Image: [ImageID: sha256:1d81a0524f7d02b7673be0eb1201ab507468b736188d2678a488aeb3449d266e; Names: docker.io/library/fedora:36] referenced by 0 containers; PulledAt: 2023-06-19 22:32:42.295312319 +0000 UTC m=+79.211185190; LastUsedAt: 2023-06-19 22:33:43.190129074 +0000 UTC m=+140.106001934; PullSucceeded: true]" module=docker_image_manager.go
Jun 19 22:51:23 <!> msg="Found 1 eligible images for deletion" module=docker_image_manager.go
Jun 19 22:51:23 <!> msg="Removing Image: docker.io/library/fedora:36" module=docker_image_manager.go
Jun 19 22:51:23 <!> msg="Image removed: docker.io/library/fedora:36" module=docker_image_manager.go
Jun 19 22:51:23 <!> msg="Cleaning up all tracking information for image docker.io/library/fedora:36 as it has zero references" module=docker_image_manager.go
```

- Performed upgrade/downgrade testing

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "<>",
    "pretty_name": "Bottlerocket OS 1.14.1 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.14.1"
  }
}
bash-5.1# updog check-update
aws-ecs-1 1.14.2
bash-5.1# updog update -i 1.14.2 -n
Starting update to 1.14.2

Update applied: aws-ecs-1 1.14.2

### Reboot and downgrade

[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "<>",
    "pretty_name": "Bottlerocket OS 1.14.2 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.14.2"
  }
}

# Rollback commands and reboot

[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "246e3c6f-dirty",
    "pretty_name": "Bottlerocket OS 1.14.1 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.14.1"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
