### PR TITLE
Pin GitHub Action rust version to 1.69.0

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -34,6 +34,12 @@ runs:
           tools/.crates2.json
           tools/target
         key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
+    - name: Setup pinned rust version
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.69.0
+        override: true
+        components: rustfmt, clippy
     - run: cargo install --locked --version 0.36.0 cargo-make
       shell: bash
     - run: cargo install --locked --version 0.6.2 cargo-sweep


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds a step in the node setup to install our expected version of the rust toolchain.

**Testing done:**

To be tested by Action results.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
