### PR TITLE
apiserver: Add /report endpoint for CIS reporting

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "simplelog",
  "snafu",
  "thar-be-updates",
+ "tokio",
  "toml",
  "walkdir",
 ]

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
 thar-be-updates = { path = "../thar-be-updates", version = "0.1" }
+tokio = { version = "~1.25", default-features = false, features = ["process"] }
 walkdir = "2"
 
 [build-dependencies]

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -133,6 +133,22 @@ pub enum Error {
     #[snafu(display("Failed to reboot, exit code: {}, stderr: {}", exit_code, stderr))]
     Reboot { exit_code: i32, stderr: String },
 
+    #[snafu(display("Unable to generate report: {}", source))]
+    ReportExec { source: io::Error },
+
+    #[snafu(display(
+        "Failed to generate report, exit code: {}, stderr: {}",
+        exit_code,
+        stderr
+    ))]
+    ReportResult { exit_code: i32, stderr: String },
+
+    #[snafu(display("Report type must be specified"))]
+    ReportTypeMissing {},
+
+    #[snafu(display("Report type '{}' is not supported", report_type))]
+    ReportNotSupported { report_type: String },
+
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
     // Update related errors

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -450,3 +450,51 @@ paths:
           description: "Connection upgraded to WebSocket"
         500:
           description: "Server error"
+
+  /report:
+    get:
+      summary: "Get available report types"
+      operationId: "get_reports"
+      responses:
+        200:
+          description: "Successful request"
+          content:
+            application/json:
+              schema:
+                type: array
+                $ref: "Report"
+        500:
+          description: "Server error"
+
+  /report/cis:
+    get:
+      summary: "Get CIS Bottlerocket benchmark report"
+      operationId: "cis-report"
+      parameters:
+        - in: query
+          name: level
+          description: "The CIS compliance level to test (1 or 2). Default level is 1."
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 2
+          required: false
+        - in: query
+          name: format
+          description: "The CIS compliance report format (text or json). Default format is text."
+          schema:
+            type: string
+          required: false
+      responses:
+        200:
+          description: "Successful request"
+          content:
+            application/json:
+              schema:
+                $ref: "String"
+        400:
+          description: "Bad request input"
+        422:
+          description: "Unprocessable request"
+        500:
+          description: "Server error"

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -519,3 +519,9 @@ struct OciDefaultsResourceLimit {
     hard_limit: u32,
     soft_limit: u32,
 }
+
+#[model(add_option = false)]
+struct Report {
+    name: String,
+    description: String,
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related #2731 

**Description of changes:**

This adds a new `/report` endpoint. GETs to this endpoint get a list of the available reports which can then be called directly. Initially this is only `/report/cis` that can be used to trigger a bloodhound CIS benchmark report, returning the results. The type argument controls which report to run. Right now there is only the CIS report, but this will be expanded in the future as we add other compliance or benchmark reports.

```
# apiclient -u /report
[{"name":"cis","description":"CIS Bottlerocket Benchmark"}]
```

The bloodhound options for `--level` and `--format` are supported with:

```
# apiclient -u "/report/cis&level=2&format=json"
```

**Testing done:**

```
# apiclient -u /report
[{"name":"cis","description":"CIS Bottlerocket Benchmark"}]

# apiclient -u /report/cis
Failed GET request to '/report': Status 400 when GETing /report: Report type must be specified

# apiclient -u "/report?type=cis-k8s"
Failed GET request to '/report?type=cis-k8s': Status 422 when GETing /report?type=cis-k8s: Report type 'cis-k8s' is not supported

# apiclient raw -u "/report?type=cis&level=2&format=json"

{...}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
