### PR TITLE
[1.14.x] Pin rust version to 1.69.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,12 @@ jobs:
           key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('tools/Cargo.lock') }}
+      - name: Setup pinned rust version
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.69.0
+          override: true
+          components: rustfmt, clippy
       - run: rustup component add rustfmt
       - run: cargo install --version 0.36.0 cargo-make
       - run: cargo install --version 0.6.2 cargo-sweep


### PR DESCRIPTION
**Description of changes:**

We use rust 1.69.0 in the SDK, which does not use the cargo "sparse" protocol by default. In 1.70.0, this protocol does become the default. This should be fine, but the GitHub runner nodes just install the latest stable version of rust. Since some activity happens prior to our build in the SDK, this creates a mismatch where the cache contains sparse data that cannot be correctly consumed by the 1.69.0 rust from the SDK, causing failures.

This is just a temporary issue that currently only impacts the 1.14.x stable branch. For the time being, just pinning the rust version on the runner node on this branch should allow us to get around it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
