### PR TITLE
tools/diff-kernel-config: adapt to new RPM naming scheme

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -18,6 +18,10 @@ run_exit_trap_cmds() {
 
 trap run_exit_trap_cmds EXIT
 
+warn() {
+    >&2 echo "Warning: $*"
+}
+
 bail() {
     if [[ $# -gt 0 ]]; then
         >&2 echo "Error: $*"
@@ -187,6 +191,7 @@ for state in after before; do
 
             shopt -s nullglob
             kernel_rpms=(
+                ./build/rpms/bottlerocket-*kernel-"${kver}"-"${kver}".*."${arch}".rpm
                 ./build/rpms/bottlerocket-"${arch}"-*kernel-"${kver}"-"${kver}".*.rpm
             )
             shopt -u nullglob
@@ -194,10 +199,15 @@ for state in after before; do
             case ${#kernel_rpms[@]} in
                 0) bail "No kernel RPM found for ${debug_id}" ;;
                 1) kernel_rpm=${kernel_rpms[0]} ;;
-                *) bail "More than one kernel RPM found for ${debug_id}" ;;
+                *)
+                    # shellcheck disable=SC2012  # find(1) cannot sort by mtime
+                    kernel_rpm=$(ls -1t "${kernel_rpms[@]}" | head -n 1)
+                    warn "More than one kernel RPM found for ${debug_id}. Choosing '${kernel_rpm}' as the latest build."
+                    ;;
             esac
 
-            kver_full=$(echo "${kernel_rpm}" | cut -d '-' -f 5)
+            kver_full=$(rpm --query --queryformat '%{VERSION}' "${kernel_rpm}")
+
             #
             # Extract kernel config
             #
@@ -209,9 +219,9 @@ for state in after before; do
 
 
             echo "config-${arch}-${variant}-${state} -> ${kver_full}" >> "${output_dir}"/kver_mapping
-        done #arch
+        done  # arch
 
-    done #variant
+    done  # variant
 
 done  # state
 
@@ -224,7 +234,7 @@ done  # state
 # in the kernel-archive RPM from where it can be extracted. Here we extract the
 # latest version of the script, but any kernel version and arch will do.
 latest_kver=$(printf '%s\n' "${kernel_versions[@]}" | sort -V | tail -n1)
-latest_archive_rpms=( ./build/rpms/bottlerocket-aarch64-kernel-"${latest_kver}"-archive-*.rpm )
+latest_archive_rpms=( ./build/rpms/bottlerocket-*kernel-"${latest_kver}"-archive-*.rpm )
 diffconfig=$(mktemp --suffix -bottlerocket-diffconfig)
 on_exit "rm '${diffconfig}'"
 rpm2cpio "${latest_archive_rpms[0]}" \


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** With the recent cut-over to the RPM macros being sourced from the SDK (commit 6aed1b97f4c5) the naming scheme for RPMs changed. The target architecture is no longer custom encoded in the prefix of the name (with the architecture suffix indicating which architecture the package has been built on), but properly reflected in the suffix.

Adapt the `diff-kernel-config` to deal with that by adding another glob pattern. Resolve ambiguity if a change is diffed before and after that name change by picking the latest build.



**Testing done:** Added a temporary config change to `packages/kernel-6.1/config-bottlerocket` that only affected x86_64, then ran a diff for the metal-dev variant from before the RPM macros were pulled in via the SDK against that temporary change:

```
$ tools/diff-kernel-config -a HEAD^ -b a4a10399177245be08bde00aa9c6af843863bacb -v metal-dev -o ~/kernel-diff-xen-backend
[...]
    Finished dev [optimized] target(s) in 12m 51s
[cargo-make] INFO - Build Done in 973.88 seconds.
[...]
    Finished dev [optimized] target(s) in 13m 49s
[cargo-make] INFO - Build Done in 847.46 seconds.
[...]
    Finished dev [optimized] target(s) in 12m 49s
[cargo-make] INFO - Build Done in 787.23 seconds.
[...]
    Finished dev [optimized] target(s) in 13m 44s
[cargo-make] INFO - Build Done in 841.35 seconds.
Warning: More than one kernel RPM found for state=before arch=x86_64 variant=metal-dev kernel=6.1. Choosing './build/rpms/bottlerocket-x86_64-kernel-6.1-6.1.19-1.x86_64.rpm' as the latest build.

config-aarch64-metal-dev-diff:    0 removed,   0 added,   0 changed
config-x86_64-metal-dev-diff:     6 removed,   0 added,   1 changed

A full report has been placed in '/home/fedora/kernel-diff-xen-backend/diff-report'
A tabular report in csv-format has been placed in '/home/fedora/kernel-diff-xen-backend/diff-table'
```

Due to the starting from a clean slate (`cargo make clean`), build order ("after" for aarch64, then x86_64; "before" for aarch64, then x86_64) and the host being an x86_64 machine, the last build faced ambiguity that got resolved by using the latest build.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
