### PR TITLE
[1.14.x] remove GOPROXY=direct from env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,6 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # When Go packages are built, buildsys will vendor in dependent Go code for
-  # that package and bundle it up in a tarball. This env variable is consumed
-  # and used to configure Go to directly download code from its upstream source.
-  # This is a useful early signal during GitHub actions to see if there are
-  # upstream Go code problems.
-  GOPROXY: direct
-
 jobs:
   build:
     runs-on:


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
We've been running into 502s randomly during 'go mod vendor' for our Bottlerocket builds. This backs out the change to always use upstream sources for our go modules so that we reach out to the default go module proxy first in hopes of avoiding this error.

(cherry picked from commit 9741bf62cef47a9940475e503352edd7d10f719e)


**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
