### PR TITLE
Standardize `sources/` binaries on argh for command line parsing

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1904,15 +1904,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -2436,6 +2427,7 @@ dependencies = [
 name = "metricdog"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "bottlerocket-release",
  "generate-readme",
  "httptest",
@@ -2444,7 +2436,6 @@ dependencies = [
  "serde",
  "simplelog",
  "snafu",
- "structopt",
  "tempfile",
  "toml",
  "url",
@@ -2989,30 +2980,6 @@ dependencies = [
  "simplelog",
  "snafu",
  "tokio",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -3676,7 +3643,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3748,30 +3715,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "subtle"
@@ -4265,12 +4208,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4315,6 +4315,7 @@ dependencies = [
 name = "updog"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "bottlerocket-release",
  "chrono",
  "log",
@@ -4330,7 +4331,6 @@ dependencies = [
  "signpost",
  "simplelog",
  "snafu",
- "structopt",
  "tempfile",
  "toml",
  "tough",

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -56,6 +56,11 @@ license-files = [
 multiple-versions = "deny"
 wildcards = "deny"
 
+deny = [
+    { name = "structopt" },
+    { name = "clap", wrappers = [ "cargo-readme" ] },
+]
+
 skip = [
 ]
 

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -62,8 +62,6 @@ skip = [
 skip-tree = [
     # hyper-proxy is using an older hyper-rustls
     { name = "hyper-proxy", version = "=0.9.1" },
-    # structopt pulls in an older version of clap
-    { name = "structopt", version = "=0.3.26" },
     # tungstenite is using an older sha-1
     { name = "tungstenite", version = "=0.16" },
     # windows-sys is not a direct dependency. mio and schannel
@@ -71,6 +69,9 @@ skip-tree = [
     # dependency tree because windows-sys has many sub-crates
     # that differ in major version.
     { name = "windows-sys", version = "=0.42.0" },
+    # generate-readme pulls in an older clap that causes some duplicate
+    # dependencies
+    { name = "generate-readme", version = "=0.1.0" }
 ]
 
 [sources]

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
+argh = "0.1"
 bottlerocket-release = { path = "../bottlerocket-release", version = "0.1" }
 log = "0.4"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 serde = { version = "1", features = ["derive"] }
 simplelog = "0.12"
 snafu = { version = "0.7" }
-structopt = "0.3"
 toml = "0.5"
 url = "2"
 

--- a/sources/metricdog/src/args.rs
+++ b/sources/metricdog/src/args.rs
@@ -1,27 +1,40 @@
+use argh::FromArgs;
 use log::LevelFilter;
 use std::path::PathBuf;
-use structopt::StructOpt;
+
+fn default_logging() -> LevelFilter {
+    LevelFilter::Info
+}
 
 /// Command line arguments for the metricdog program.
-#[derive(StructOpt)]
+#[derive(FromArgs)]
 pub(crate) struct Arguments {
-    /// Path to the TOML config file [default: /etc/metricdog]
-    #[structopt(short = "c", long = "config")]
-    pub(crate) config: Option<PathBuf>,
-    /// Logging verbosity [trace|debug|info|warn|error]
-    #[structopt(short = "l", long = "log-level", default_value = "info")]
-    pub(crate) log_level: LevelFilter,
-    /// Path to the os-release file [default: /etc/os-release]
-    #[structopt(short = "o", long = "os-release")]
-    pub(crate) os_release: Option<PathBuf>,
-    #[structopt(subcommand)]
-    pub(crate) command: Command,
+    /// path to the TOML config file [default: /etc/metricdog]
+    #[argh(option, short = 'c', long = "config")]
+    pub config: Option<PathBuf>,
+    /// logging verbosity [trace|debug|info|warn|error]
+    #[argh(option, short = 'l', long = "log-level", default = "default_logging()")]
+    pub log_level: LevelFilter,
+    /// path to the os-release file [default: /etc/os-release]
+    #[argh(option, short = 'o', long = "os-release")]
+    pub os_release: Option<PathBuf>,
+    #[argh(subcommand)]
+    pub command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(FromArgs)]
+#[argh(subcommand)]
 pub(crate) enum Command {
-    /// report a successful boot.
-    SendBootSuccess,
-    /// check services and report their health.
-    SendHealthPing,
+    SendBootSuccess(SendBootSuccess),
+    SendHealthPing(SendHealthPing),
 }
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "send-boot-success")]
+/// report a successful boot
+pub(crate) struct SendBootSuccess {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "send-health-ping")]
+/// check services and report their health
+pub(crate) struct SendHealthPing {}

--- a/sources/metricdog/src/main.rs
+++ b/sources/metricdog/src/main.rs
@@ -77,10 +77,9 @@ use log::error;
 use simplelog::{Config as LogConfig, SimpleLogger};
 use snafu::ResultExt;
 use std::process;
-use structopt::StructOpt;
 
 fn main() -> ! {
-    let args = Arguments::from_args();
+    let args: Arguments = argh::from_env();
     SimpleLogger::init(args.log_level, LogConfig::default()).expect("unable to configure logger");
     process::exit(match main_inner(args, Box::new(SystemdCheck {})) {
         Ok(()) => 0,
@@ -117,14 +116,14 @@ pub(crate) fn main_inner(arguments: Arguments, service_check: Box<dyn ServiceChe
 
     // execute the specified command
     match arguments.command {
-        Command::SendBootSuccess => {
+        Command::SendBootSuccess(_) => {
             if let Err(err) = metricdog.send_boot_success() {
                 // we don't want to fail the boot if there is a failure to send this message, so
                 // we log the error and return Ok(())
                 error!("Error while reporting boot success: {}", err);
             }
         }
-        Command::SendHealthPing => {
+        Command::SendHealthPing(_) => {
             metricdog.send_health_ping()?;
         }
     }

--- a/sources/metricdog/src/main_test.rs
+++ b/sources/metricdog/src/main_test.rs
@@ -1,4 +1,4 @@
-use crate::args::{Arguments, Command};
+use crate::args::{Arguments, Command, SendBootSuccess, SendHealthPing};
 use crate::error::Result;
 use crate::main_inner;
 use crate::service_check::{ServiceCheck, ServiceHealth};
@@ -94,7 +94,7 @@ fn send_boot_success() {
         config: Some(config_path(&tempdir)),
         log_level: LevelFilter::Off,
         os_release: Some(os_release_path(&tempdir)),
-        command: Command::SendBootSuccess,
+        command: Command::SendBootSuccess(SendBootSuccess {}),
     };
     main_inner(args, Box::new(MockCheck {})).unwrap();
 }
@@ -115,7 +115,7 @@ fn opt_out() {
         config: Some(config_path(&tempdir)),
         log_level: LevelFilter::Off,
         os_release: Some(os_release_path(&tempdir)),
-        command: Command::SendBootSuccess,
+        command: Command::SendBootSuccess(SendBootSuccess {}),
     };
     main_inner(args, Box::new(MockCheck {})).unwrap();
 }
@@ -129,7 +129,7 @@ fn send_boot_success_no_server() {
         config: Some(config_path(&tempdir)),
         log_level: LevelFilter::Off,
         os_release: Some(os_release_path(&tempdir)),
-        command: Command::SendBootSuccess,
+        command: Command::SendBootSuccess(SendBootSuccess {}),
     };
     main_inner(args, Box::new(MockCheck {})).unwrap();
 }
@@ -148,7 +148,7 @@ fn send_boot_success_404() {
         config: Some(config_path(&tempdir)),
         log_level: LevelFilter::Off,
         os_release: Some(os_release_path(&tempdir)),
-        command: Command::SendBootSuccess,
+        command: Command::SendBootSuccess(SendBootSuccess {}),
     };
     main_inner(args, Box::new(MockCheck {})).unwrap();
 }
@@ -169,7 +169,7 @@ fn send_health_ping() {
         config: Some(config_path(&tempdir)),
         log_level: LevelFilter::Off,
         os_release: Some(os_release_path(&tempdir)),
-        command: Command::SendHealthPing,
+        command: Command::SendHealthPing(SendHealthPing {}),
     };
     main_inner(args, Box::new(MockCheck {})).unwrap();
 }

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
+argh = "0.1"
 bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 log = "0.4"
@@ -25,7 +26,6 @@ snafu = "0.7"
 toml = "0.5"
 tough = { version = "0.13", features = ["http"] }
 update_metadata = { path = "../update_metadata", version = "0.1" }
-structopt = "0.3"
 url = "2"
 signal-hook = "0.3"
 models = { path = "../../models", version = "0.1" }


### PR DESCRIPTION
**Issue number:**

Related #2373

**Description of changes:**

The `structopt` crate is no longer maintained, and we've had a policy to use `argh` over `clap` for binaries that end up part of the distro due to its smaller size. 

This updates `metricdog` and `updata` to use `argh` instead of `structopt`. It also adds a `cargo deny` setting to make sure we don't accidentally add in `clap` or `structopt` for anything new we add going forward.

**Testing done:**

Built binaries and verified help output was materially the same. Built and deployed image and ran `metricdog -l TRACE $cmd` to verify same functionality.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
