### PR TITLE
systemd-networkd: Conditionalize hostnamed/timedated DBUS calls

### DIFF
--- a/packages/systemd/9013-systemd-networkd-Conditionalize-hostnamed-timezoned-DBUS.patch
+++ b/packages/systemd/9013-systemd-networkd-Conditionalize-hostnamed-timezoned-DBUS.patch
@@ -1,0 +1,121 @@
+From a30b5e19083d88a9e26027488e42cc3105ad4689 Mon Sep 17 00:00:00 2001
+From: Zac Mrowicki <mrowicki@amazon.com>
+Date: Thu, 6 Jul 2023 17:50:28 +0000
+Subject: [PATCH] systemd-networkd: Conditionalize hostnamed/timezoned DBUS
+ calls
+
+systemd-networkd registers a function to call when first connecting to
+DBUS.  This function makes three calls to other DBUS services (hostnamed
+and timedated) which aren't used in Bottlerocket.  Calls to the same
+DBUS services are made in the DHCP clients.  This change makes a patch
+to systemd-networkd that conditionalizes these calls based on the
+underlying services being built, returning 0 if the service isn't built.
+
+Removing the calls to non-existent services cleans up some confusing and
+inconsequential messages in the journal on boot.
+---
+ src/network/networkd-dhcp-common.c |  2 ++
+ src/network/networkd-dhcp-common.h |  6 ++++++
+ src/network/networkd-manager.c     |  4 ++++
+ src/network/networkd-manager.h     | 13 +++++++++++++
+ 4 files changed, 25 insertions(+)
+
+diff --git a/src/network/networkd-dhcp-common.c b/src/network/networkd-dhcp-common.c
+index 4f13ead..1c1b2ec 100644
+--- a/src/network/networkd-dhcp-common.c
++++ b/src/network/networkd-dhcp-common.c
+@@ -170,6 +170,7 @@ static int get_product_uuid_handler(sd_bus_message *m, void *userdata, sd_bus_er
+         return 0;
+ }
+ 
++#if ENABLE_HOSTNAMED
+ int manager_request_product_uuid(Manager *m) {
+         static bool bus_method_is_called = false;
+         int r;
+@@ -207,6 +208,7 @@ int manager_request_product_uuid(Manager *m) {
+ 
+         return 0;
+ }
++#endif
+ 
+ int dhcp_configure_duid(Link *link, const DUID *duid) {
+         Manager *m;
+diff --git a/src/network/networkd-dhcp-common.h b/src/network/networkd-dhcp-common.h
+index c19bc10..9d13cde 100644
+--- a/src/network/networkd-dhcp-common.h
++++ b/src/network/networkd-dhcp-common.h
+@@ -72,7 +72,13 @@ static inline const DUID *link_get_dhcp6_duid(Link *link) {
+ }
+ 
+ int dhcp_configure_duid(Link *link, const DUID *duid);
++#if ENABLE_HOSTNAMED
+ int manager_request_product_uuid(Manager *m);
++#else
++static inline int manager_request_product_uuid(_unused_ Manager *m) {
++        return 0;
++}
++#endif
+ 
+ bool address_is_filtered(int family, const union in_addr_union *address, uint8_t prefixlen, Set *allow_list, Set *deny_list);
+ static inline bool in4_address_is_filtered(const struct in_addr *address, Set *allow_list, Set *deny_list) {
+diff --git a/src/network/networkd-manager.c b/src/network/networkd-manager.c
+index ff2770f..a225526 100644
+--- a/src/network/networkd-manager.c
++++ b/src/network/networkd-manager.c
+@@ -845,6 +845,7 @@ static int set_hostname_handler(sd_bus_message *m, void *userdata, sd_bus_error
+         return 1;
+ }
+ 
++#if ENABLE_HOSTNAMED
+ int manager_set_hostname(Manager *m, const char *hostname) {
+         int r;
+ 
+@@ -876,6 +877,7 @@ int manager_set_hostname(Manager *m, const char *hostname) {
+ 
+         return 0;
+ }
++#endif
+ 
+ static int set_timezone_handler(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+         const sd_bus_error *e;
+@@ -892,6 +894,7 @@ static int set_timezone_handler(sd_bus_message *m, void *userdata, sd_bus_error
+         return 1;
+ }
+ 
++#if ENABLE_TIMEDATED
+ int manager_set_timezone(Manager *m, const char *tz) {
+         int r;
+ 
+@@ -925,3 +928,4 @@ int manager_set_timezone(Manager *m, const char *tz) {
+ 
+         return 0;
+ }
++#endif
+diff --git a/src/network/networkd-manager.h b/src/network/networkd-manager.h
+index 86de529..b80c6c5 100644
+--- a/src/network/networkd-manager.h
++++ b/src/network/networkd-manager.h
+@@ -110,7 +110,20 @@ bool manager_should_reload(Manager *m);
+ 
+ int manager_enumerate(Manager *m);
+ 
++#if ENABLE_HOSTNAMED
+ int manager_set_hostname(Manager *m, const char *hostname);
++#else
++static inline int manager_set_hostname(_unused_ Manager *m, _unused_ const char *hostname) {
++        return 0;
++}
++#endif /* ENABLE_HOSTNAMED */
++
++#if ENABLE_TIMEDATED
+ int manager_set_timezone(Manager *m, const char *timezone);
++#else
++static inline int manager_set_timezone(_unused_ Manager *m, _unused_ const char *timezone) {
++        return 0;
++}
++#endif /* ENABLE_TIMEDATED */
+ 
+ DEFINE_TRIVIAL_CLEANUP_FUNC(Manager*, manager_free);
+-- 
+2.38.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -78,6 +78,10 @@ Patch9011: 9011-units-keep-modprobe-service-units-running.patch
 # allows us to exclude them when not using networkd.
 Patch9012: 9012-tmpfiles-Split-networkd-entries-into-a-separate-file.patch
 
+# Local patch to conditionalize systemd-networkd calls to hostname and timezone
+# DBUS services not used in Bottlerocket
+Patch9013: 9013-systemd-networkd-Conditionalize-hostnamed-timezoned-DBUS.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**
Related to #2449 

**Description of changes:**
```
    systemd-networkd registers a function to call when first connecting to
    DBUS.  This function makes three calls to other DBUS services (hostnamed
    and timedated) which aren't used in Bottlerocket.  This change makes a
    patch to systemd-networkd that conditionalizes these calls based on the
    underlying service being built.
    
    Removing the calls to non-existent services cleans up some confusing and
    inconsequential messages in the journal on boot.

```

An example of messages logged on boot because of nonexistent `hostnamed` DBUS service:
```
Jun 26 20:54:47 localhost systemd-networkd[968]: Could not set hostname: The name is not activatable 
```

**Testing done:**
* Build an `aws-k8s-1.24` image to ensure nothing breaks
* Build an `aws-dev` image with a hard-coded network config file and a dependency on `console-getty.service` in `preconfigured.target`.  Outside of the expected boot failures, observe that the above logs don't show up in the journal, and `systemd-networkd is running, and `networkctl` is happy.  Observe no other related messages are logged in the journal.

Testing of this change will be ongoing during development, but this patch avoids the most obvious and inconsequential failure messages.
```
bash-5.1# networkctl status
●        State: routable                       
  Online state: online                         
       Address: 172.31.61.130 on eth0
                fe80::c00:dff:fe26:6e27 on eth0
       Gateway: 172.31.48.1 on eth0
           DNS: 172.31.0.2

Jun 27 21:06:57 localhost systemd-networkd[1006]: Enumeration completed
Jun 27 21:06:57 localhost systemd-networkd[1006]: eth0: found matching network '/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/networ.
Jun 27 21:06:57 localhost systemd-networkd[1006]: eth0: Link UP
Jun 27 21:06:57 localhost systemd-networkd[1006]: eth0: Gained carrier
Jun 27 21:06:57 localhost systemd-networkd[1006]: eth0: found matching network '/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/networ.
Jun 27 21:06:57 localhost systemd[1]: Started Network Configuration.
Jun 27 21:06:57 localhost systemd-networkd[1006]: eth0: DHCPv4 address 172.31.61.130/20, gateway 172.31.48.1 acquired from 172.31.48.1
Jun 27 21:06:58 localhost systemd[1]: Starting Wait for Network to be Configured...
Jun 27 21:06:59 localhost systemd-networkd[1006]: eth0: Gained IPv6LL
Jun 27 21:06:59 localhost systemd[1]: Finished Wait for Network to be Configured.
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
