### PR TITLE
[1.14.x] Update EKS-D package versions for k8s 1.24-1.27

### DIFF
--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.24"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/17/artifacts/kubernetes/v1.24.13/kubernetes-src.tar.gz"
-sha512 = "852cfe0e953203fedad04c26d4640124de1de7dd5badd11a53f2c29fde18ec203e534315f34ee2cc41d9090e78575cde8582625ce22cbd94d85ce131d46e8dbf"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/20/artifacts/kubernetes/v1.24.15/kubernetes-src.tar.gz"
+sha512 = "6b116aadba6d83cf92b0ecf4c454e51e1eaba669b13a1d067a4a0ff65762d0e97c94afefb46073592befe39b24848a0d7271648a1729345f6be0edb442dcb67d"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.24.13
+%global gover 1.24.15
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/17/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/20/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.25"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/13/artifacts/kubernetes/v1.25.9/kubernetes-src.tar.gz"
-sha512 = "628e45caa6b100f897d888db84d543b0eed33ca6409b9d13c842d33ea0e183d94482f160b301556926c213b3a7fe7962fb6b2f48777d6f199efee32f649880c4"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/16/artifacts/kubernetes/v1.25.11/kubernetes-src.tar.gz"
+sha512 = "75ddd4f18680c5c9127b2f023b3f15235fe8f81c4e2d720745ba58a786ba8031a8233ededa348768d3a8cae86d79716a5d68dd51f4ff119ce4b259396e83406f"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.25.9
+%global gover 1.25.11
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/13/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/16/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.26"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/9/artifacts/kubernetes/v1.26.4/kubernetes-src.tar.gz"
-sha512 = "167612d66f3d5cefd3eab5be722506ae326d8726617b91230858dab9b64f4e9a8ef1cb419899ad6be27f0752fb9748bc6df8abe1c21070717d82993bd6f9eb60"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/12/artifacts/kubernetes/v1.26.6/kubernetes-src.tar.gz"
+sha512 = "dc318e8a4ad6985c0d347c30b5589a2e52b710ae1efd39b1a06a6fd276203c915b3656a0a7f28380abaf5a37540fdddd0a5c92a91df63f14d8ba55d7b83fbdc6"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.26.4
+%global gover 1.26.6
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/12/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.27"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/3/artifacts/kubernetes/v1.27.1/kubernetes-src.tar.gz"
-sha512 = "1f0e9411050bc1021acc9f08059df26cfb13f54dbc2a59ea699d5c8bc3def28ed46fd54edb8ed7e87ca4b193b3ee2952825a00da2e74138fc7b55b7316e607b0"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/6/artifacts/kubernetes/v1.27.3/kubernetes-src.tar.gz"
+sha512 = "308fffed3f390d7abfe4abc9b83f859169121b0a05e7da46bc718cc0508cee746de58b82b05316801457cbf85e91d6a66fd57d3f915b41a3888ced4a0b07d7d6"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.1
+%global gover 1.27.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/6/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Description of changes:**

This cherry-picks the updates for:

- v1.24.15
- v1.25.11
- v1.26.6
- v1.27.3

**Testing done:**

See testing done on `develop`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
