### PR TITLE
testsys: Allow not-strict handlebars for clusters

### DIFF
--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -317,8 +317,7 @@ impl<'a> CrdInput<'a> {
         fields.insert("namespace".to_string(), NAMESPACE.to_string());
         fields.append(additional_fields);
 
-        let mut handlebars = Handlebars::new();
-        handlebars.set_strict_mode(true);
+        let handlebars = Handlebars::new();
         let rendered_config = handlebars.render_template(&config, &fields)?;
 
         Ok(Some(rendered_config))


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Some eksa cluster configs contain handlebars templating. In order to allow those configs to be used with testsys we need to remove strict mode.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
