### PR TITLE
Revert "Revert "packages: update runc""

### DIFF
--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,9 +12,9 @@ path = "/dev/null"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.5/runc.tar.xz"
-path = "runc-v1.1.5.tar.xz"
-sha512 = "7b10c0d6739e7fe3c718b3219bdb2437ae3ed8d1995b88136b9a0e8b4e909adbe8b6af6634a751b507bf793d0d5e924f5c85525d8fd46c3daf72c664dc25ab04"
+url = "https://github.com/opencontainers/runc/releases/download/v1.1.6/runc.tar.xz"
+path = "runc-v1.1.6.tar.xz"
+sha512 = "a5b799cb5a69f7251f81e5887a9269fb8fc6573b8a7d1b2e2436a0955feea982a34cf0bc62017534fdbc75e37fa70db4a06bdaecc6e67140fb094d06642a8440"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -1,8 +1,8 @@
 %global goproject github.com/opencontainers
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
-%global commit f19387a6bec4944c770f7668ab51c4348d9c2f38
-%global gover 1.1.5
+%global commit 0f48801a0e21e3f0bc4e74643ead2a502df4818d
+%global gover 1.1.6
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/3057

**Description of changes:**
```
This reverts commit 44bb484604898d73189b1433d7baeedaa418fb73.

Now that we've updated K8s. We can update runc to match the runc library versions used in K8s.
```


**Testing done:**
No longer see the described problem in https://github.com/bottlerocket-os/bottlerocket/issues/3057


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
