### PR TITLE
[1.14.x] Release.toml: add ecs-images-cleanup to 1.14.2 migration chain

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -212,4 +212,6 @@ version = "1.14.2"
     "migrate_v1.14.0_public-control-container-v0-7-2.lz4",
 ]
 "(1.14.0, 1.14.1)" = []
-"(1.14.1, 1.14.2)" = []
+"(1.14.1, 1.14.2)" = [
+    "migrate_v1.14.2_ecs-images-cleanup.lz4",
+]


### PR DESCRIPTION
(cherry picked from commit 792e65cb03685cb2d8edc4f4172e5871eb52b1aa)

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
Adds ecs-images-cleanup to 1.14.2 migration chain


**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
