### PR TITLE
logdog: Add filters for recent sensitive settings

### DIFF
--- a/sources/logdog/src/log_request.rs
+++ b/sources/logdog/src/log_request.rs
@@ -34,6 +34,11 @@ const SENSITIVE_SETTINGS_PATTERNS: &[&str] = &[
     "settings.kubernetes.bootstrap-token",
     // Can contain a username:password component
     "settings.network.https-proxy",
+    "settings.kubernetes.server-key",
+    "settings.container-registry.credentials",
+    // Can be stored in settings.aws.credentials, but user can also add creds here
+    "settings.aws.config",
+    "settings.aws.credentials",
 ];
 
 /// Returns the list of log requests to run by combining `VARIANT_REQUESTS` and `COMMON_REQUESTS`.


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Logdog has a mechanism in place for filtering settings from the collected output for sensitive data if the setting matches on of the patterns to exclude. There have been a few settings added since its introduction that could potentially contain passwords or other senitive information. This adds current setting names that were not currently covered by the existing patterns.

**Testing done:**

Visual inspection.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
