### PR TITLE
bloodhound: Fix Bottlerocket CIS 3.4.1.1 check binary

### DIFF
--- a/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
@@ -622,7 +622,7 @@ impl Checker for BR03040101Checker {
         ];
 
         check_output_contains!(
-            SYSCTL_CMD,
+            IPTABLES_CMD,
             ["-L"],
             output,
             "unable to verify iptables settings",


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This check inspects the iptables output to look for specific entries. Somewhere in the refactoring of the checker code, the constant used for the binary run was switched from `iptables` to `sysctl` by mistake. This corrects the check to use the correct constant to run the correct binary.

**Testing done:**

Ran checker and verified it was inspecting the correct command output.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
