### PR TITLE
remove context for unused SIDs from SELinux policy

### DIFF
--- a/packages/selinux-policy/sid.cil
+++ b/packages/selinux-policy/sid.cil
@@ -54,25 +54,3 @@
 (sidcontext netif any)
 (sidcontext netmsg any)
 (sidcontext node any)
-
-; Most of the initial SIDs have never been used, or are no longer used.
-; We use the placeholder "unused" context for all of these, since the
-; policy isn't allowed to omit them yet. We'll need a 5.7+ kernel and
-; updated userspace tools first.
-(sidcontext fs unused)
-(sidcontext file_labels unused)
-(sidcontext init unused)
-(sidcontext igmp_packet unused)
-(sidcontext icmp_socket unused)
-(sidcontext tcp_socket unused)
-(sidcontext sysctl_modprobe unused)
-(sidcontext sysctl unused)
-(sidcontext sysctl_fs unused)
-(sidcontext sysctl_kernel unused)
-(sidcontext sysctl_net unused)
-(sidcontext sysctl_net_unix unused)
-(sidcontext sysctl_vm unused)
-(sidcontext sysctl_dev unused)
-(sidcontext kmod unused)
-(sidcontext policy unused)
-(sidcontext scmp_packet unused)

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -8,11 +8,6 @@
 (roletype system_r kernel_t)
 (context kernel (system_u system_r kernel_t s0))
 
-; Unused ISIDs.
-(type unused_t)
-(roletype system_r unused_t)
-(context unused (system_u system_r unused_t s0))
-
 ; PID 1.
 (type init_t)
 (roletype system_r init_t)


### PR DESCRIPTION
**Issue number:**

Closes #2509

**Description of changes:**
Now that the oldest supported kernel is 5.10, drop the unused context assignments for the initial SIDs removed from the kernel in the 5.7 cycle: https://github.com/torvalds/linux/commit/e3e0b582c321a.

Although the contexts are unused, they must still be defined with the `(sid ...) and `(sidorder ...)` statements to preserve ISID ordering: https://github.com/SELinuxProject/selinux/commit/8677ce5e8f592.


**Testing done:**
Confirmed that all ten valid initial SIDs were present and had the same values on systems with 5.10 (`aws-k8s-1.23`) and 5.15 (`aws-k8s-1.27`) kernels.

```
bash-5.1# ls -1 /sys/fs/selinux/initial_contexts/ | wc -l
10

bash-5.1# head /sys/fs/selinux/initial_contexts/*
==> /sys/fs/selinux/initial_contexts/any_socket <==
system_u:object_r:any_t:s0
==> /sys/fs/selinux/initial_contexts/devnull <==
system_u:system_r:kernel_t:s0
==> /sys/fs/selinux/initial_contexts/file <==
system_u:object_r:local_t:s0
==> /sys/fs/selinux/initial_contexts/kernel <==
system_u:system_r:kernel_t:s0
==> /sys/fs/selinux/initial_contexts/netif <==
system_u:object_r:any_t:s0
==> /sys/fs/selinux/initial_contexts/netmsg <==
system_u:object_r:any_t:s0
==> /sys/fs/selinux/initial_contexts/node <==
system_u:object_r:any_t:s0
==> /sys/fs/selinux/initial_contexts/port <==
system_u:object_r:any_t:s0
==> /sys/fs/selinux/initial_contexts/security <==
system_u:system_r:kernel_t:s0
==> /sys/fs/selinux/initial_contexts/unlabeled <==
system_u:object_r:local_t:s0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
