### PR TITLE
kubelet: Set default `podPidsLimit`

### DIFF
--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -108,9 +108,7 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
-{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
-podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
-{{/if}}
+podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
 {{/if}}

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -108,9 +108,7 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
-{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
-podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
-{{/if}}
+podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
 {{/if}}

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -108,9 +108,7 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
-{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
-podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
-{{/if}}
+podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
 {{/if}}

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -108,9 +108,7 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
-{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
-podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
-{{/if}}
+podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
 {{/if}}

--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -112,9 +112,7 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
-{{#if settings.kubernetes.pod-pids-limit includeZero=true}}
-podPidsLimit: {{settings.kubernetes.pod-pids-limit}}
-{{/if}}
+podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
 {{/if}}


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Technically, unless `podPidsLimit` is set in the kubelet configuration, there is nothing restricting a pod from running a large number of pids and potentially exhausting resources on a node.

There is an implicit limit in that systemd sets `/proc/sys/kernel/pid_max` to 4194304. But that is node-wide, so it still could allow a pod to deplete resources. Reasoning for that number can be found [here](https://github.com/systemd/systemd/commit/15de23a0b24f6073d527c6a8c22556ad5101a160).

In practice it is highly unlikely one pod could get anywhere near this limit before hitting other resource limitations. But as a safety/hardening step, this defaults the `podPidsLimit` to be 25% of the systemd default. This can always be overridden by users for any specific needs by using the existing `settings.kubernetes.pod-pids-limit` setting.

**Testing done:**

Deployed node without any extra configuration settings. Checked `cat /etc/kubernetes/kubelet/config`:

```yaml
---
kind: KubeletConfiguration
apiVersion: kubelet.config.k8s.io/v1beta1
address: 0.0.0.0
# snip
podPidsLimit: 1048576
# snip
```

Changed the pid limit with `apiclient set settings.kubernetes.pod-pids-limit=9999`. Verified kubelet restarted and checked `cat /etc/kubernetes/kubelet/config`:

```yaml
podPidsLimit: 9999
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
