### PR TITLE
actions: Use larger runners for nightly checks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on:
       group: bottlerocket
       labels: bottlerocket_ubuntu-latest_32-core
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       matrix:
         variant: ${{ fromJson(needs.list-variants.outputs.variants) }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,9 @@ jobs:
 
   build:
     needs: list-variants
-    runs-on: ubuntu-latest
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_32-core
     continue-on-error: true
     strategy:
       matrix:


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The nightly checks were recently added for performing extra validation by bypassing the GOPROXY cache. These have been failing due to using the default runners for execution.

This updates the job definition to use the same runners we use for the per-PR build workflow to make sure there is enough disk space and other resources to actually perform the build.

Also flips the job's `continue-on-failure` value to `false` so any failures will be reflected in the overall workflow status.

**Testing done:**

Will watch nightly runs after merge to make sure they are able to run as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
