### PR TITLE
netdog: Add systemd-networkd config generation

### DIFF
--- a/packages/os/etc-systemd-network.mount
+++ b/packages/os/etc-systemd-network.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=systemd-networkd configuration directory
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/systemd/network
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:lease_t:s0,mode=0755
+
+[Install]
+WantedBy=systemd-networkd.service

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -48,6 +48,10 @@ Source119: reboot-if-required.service
 Source120: warm-pool-wait.service
 Source121: disable-udp-offload.service
 Source122: has-boot-ever-succeeded.service
+Source123: etc-systemd-network.mount
+
+# Drop-ins
+Source150: requires-mounts-network-config.conf
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -416,6 +420,12 @@ install -p -m 0644 \
   %{S:113} %{S:114} %{S:118} %{S:119} %{S:122} \
   %{buildroot}%{_cross_unitdir}
 
+%if %{with systemd_networkd}
+install -d %{buildroot}%{_cross_unitdir}/generate-network-config.service.d
+install -p -m 0644 %{S:150} %{buildroot}%{_cross_unitdir}/generate-network-config.service.d
+install -p -m 0644 %{S:123} %{buildroot}%{_cross_unitdir}
+%endif
+
 %if %{with nvidia_flavor}
 sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:115} > link-kernel-modules.service
 sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:116} > load-kernel-modules.service
@@ -455,6 +465,12 @@ install -p -m 0644 %{S:121} %{buildroot}%{_cross_unitdir}
 
 %files
 %{_cross_attribution_vendor_dir}
+
+%if %{with systemd_networkd}
+%dir %{_cross_unitdir}/generate-network-config.service.d
+%{_cross_unitdir}/generate-network-config.service.d/requires-mounts-network-config.conf
+%{_cross_unitdir}/etc-systemd-network.mount
+%endif
 
 %files -n %{_cross_os}apiserver
 %{_cross_bindir}/apiserver

--- a/packages/os/requires-mounts-network-config.conf
+++ b/packages/os/requires-mounts-network-config.conf
@@ -1,0 +1,2 @@
+[Unit]
+RequiresMountsFor=/etc/systemd/network

--- a/sources/api/netdog/src/cli/mod.rs
+++ b/sources/api/netdog/src/cli/mod.rs
@@ -183,9 +183,9 @@ mod tests {
 mod error {
     #[cfg(net_backend = "wicked")]
     use crate::lease;
-    #[cfg(net_backend = "systemd-networkd")]
-    use crate::networkd_status;
     use crate::{dns, interface_id, net_config, wicked};
+    #[cfg(net_backend = "systemd-networkd")]
+    use crate::{networkd, networkd_status};
     use snafu::Snafu;
     use std::ffi::OsString;
     use std::io;
@@ -255,6 +255,14 @@ mod error {
 
         #[snafu(display("Unable to find an interface with MAC address '{}'", mac))]
         NonExistentMac { mac: String },
+
+        #[cfg(net_backend = "systemd-networkd")]
+        #[snafu(display("Unable to create systemd-networkd config: {}", source))]
+        NetworkDConfigCreate { source: net_config::Error },
+
+        #[cfg(net_backend = "systemd-networkd")]
+        #[snafu(display("Failed to write network interface configuration: {}", source))]
+        NetworkDConfigWrite { source: networkd::Error },
 
         #[snafu(display("Unable to read '{}': {}", path.display(), source))]
         PathRead {

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -34,15 +34,18 @@ mod bonding;
 mod cli;
 mod dns;
 mod interface_id;
+mod net_config;
+mod vlan_id;
+
 #[cfg(net_backend = "wicked")]
 mod lease;
-mod net_config;
+#[cfg(net_backend = "wicked")]
+mod wicked;
+
 #[cfg(net_backend = "systemd-networkd")]
 mod networkd;
 #[cfg(net_backend = "systemd-networkd")]
 mod networkd_status;
-mod vlan_id;
-mod wicked;
 
 use argh::FromArgs;
 use std::process;

--- a/sources/api/netdog/src/net_config/devices/bond.rs
+++ b/sources/api/netdog/src/net_config/devices/bond.rs
@@ -8,7 +8,7 @@ use crate::net_config::devices::generate_addressing_validation;
 use serde::Deserialize;
 use snafu::ensure;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct NetBondV1 {
     pub(crate) primary: Option<bool>,
@@ -30,7 +30,7 @@ pub(crate) struct NetBondV1 {
 
 // Single variant enum only used to direct deserialization.  If the kind is not "Bond" or "bond",
 // deserialization will fail.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 enum BondKind {
     #[serde(alias = "bond")]
     Bond,

--- a/sources/api/netdog/src/net_config/devices/interface.rs
+++ b/sources/api/netdog/src/net_config/devices/interface.rs
@@ -4,7 +4,7 @@ use crate::addressing::{RouteV1, StaticConfigV1};
 use crate::net_config::devices::generate_addressing_validation;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct NetInterfaceV2 {
     // Use this interface as the primary interface for the system

--- a/sources/api/netdog/src/net_config/devices/mod.rs
+++ b/sources/api/netdog/src/net_config/devices/mod.rs
@@ -13,7 +13,7 @@ use interface::NetInterfaceV2;
 use serde::Deserialize;
 use vlan::NetVlanV1;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 pub(crate) enum NetworkDeviceV1 {
     Interface(NetInterfaceV2),

--- a/sources/api/netdog/src/net_config/devices/vlan.rs
+++ b/sources/api/netdog/src/net_config/devices/vlan.rs
@@ -6,7 +6,7 @@ use crate::net_config::devices::generate_addressing_validation;
 use crate::vlan_id::VlanId;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct NetVlanV1 {
     pub(crate) primary: Option<bool>,
@@ -24,7 +24,7 @@ pub(crate) struct NetVlanV1 {
 
 // Single variant enum only used to direct deserialization.  If the kind is not "VLAN", "Vlan", or
 // "vlan" deserialization will fail.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 enum VlanKind {
     #[serde(alias = "VLAN")]
     #[serde(alias = "vlan")]

--- a/sources/api/netdog/src/net_config/error.rs
+++ b/sources/api/netdog/src/net_config/error.rs
@@ -3,6 +3,9 @@ use snafu::Snafu;
 use std::io;
 use std::path::PathBuf;
 
+#[cfg(net_backend = "systemd-networkd")]
+use crate::networkd;
+
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub(crate) enum Error {
@@ -38,6 +41,10 @@ pub(crate) enum Error {
 
     #[snafu(display("Failed to parse network config: {}", source))]
     NetConfigParse { source: toml::de::Error },
+
+    #[cfg(net_backend = "systemd-networkd")]
+    #[snafu(display("Unable to create systemd-networkd config: {}", source))]
+    NetworkDConfigCreate { source: networkd::Error },
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sources/api/netdog/src/net_config/mod.rs
+++ b/sources/api/netdog/src/net_config/mod.rs
@@ -12,7 +12,6 @@ mod v3;
 
 use crate::addressing::StaticConfigV1;
 use crate::interface_id::InterfaceId;
-use crate::wicked::WickedInterface;
 pub(crate) use error::{Error, Result};
 use ipnet::IpNet;
 use serde::Deserialize;
@@ -21,6 +20,9 @@ use std::fs;
 use std::path::Path;
 use std::str::FromStr;
 pub(crate) use v1::NetConfigV1;
+
+#[cfg(net_backend = "wicked")]
+use crate::wicked::WickedInterface;
 
 #[cfg(net_backend = "systemd-networkd")]
 use crate::networkd;

--- a/sources/api/netdog/src/net_config/v1.rs
+++ b/sources/api/netdog/src/net_config/v1.rs
@@ -3,16 +3,16 @@
 
 use super::{error, Error, Interfaces, Result, Validate};
 use crate::addressing::{Dhcp4ConfigV1, Dhcp4OptionsV1, Dhcp6ConfigV1, Dhcp6OptionsV1};
-use crate::{
-    interface_id::{InterfaceId, InterfaceName},
-    wicked::{WickedDhcp4, WickedDhcp6, WickedInterface},
-};
+use crate::interface_id::{InterfaceId, InterfaceName};
 use indexmap::indexmap;
 use indexmap::IndexMap;
 use serde::Deserialize;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::{collections::HashSet, str::FromStr};
 use std::{convert::TryInto, ops::Deref};
+
+#[cfg(net_backend = "wicked")]
+use crate::wicked::{WickedDhcp4, WickedDhcp6, WickedInterface};
 
 #[cfg(net_backend = "systemd-networkd")]
 use crate::networkd::NetworkDConfig;

--- a/sources/api/netdog/src/net_config/v2.rs
+++ b/sources/api/netdog/src/net_config/v2.rs
@@ -4,12 +4,14 @@
 use super::{error, Interfaces, Result, Validate};
 use crate::interface_id::{InterfaceId, InterfaceName};
 use crate::net_config::devices::interface::NetInterfaceV2;
-use crate::wicked::{
-    wicked_from, WickedDhcp4, WickedDhcp6, WickedInterface, WickedRoutes, WickedStaticAddress,
-};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use snafu::ensure;
+
+#[cfg(net_backend = "wicked")]
+use crate::wicked::{
+    wicked_from, WickedDhcp4, WickedDhcp6, WickedInterface, WickedRoutes, WickedStaticAddress,
+};
 
 #[cfg(net_backend = "systemd-networkd")]
 use crate::networkd::NetworkDConfig;

--- a/sources/api/netdog/src/net_config/v3.rs
+++ b/sources/api/netdog/src/net_config/v3.rs
@@ -4,11 +4,13 @@
 use super::devices::NetworkDeviceV1;
 use super::{error, Interfaces, Result, Validate};
 use crate::interface_id::{InterfaceId, InterfaceName};
-use crate::wicked::{WickedInterface, WickedLinkConfig};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use snafu::ensure;
 use std::collections::HashSet;
+
+#[cfg(net_backend = "wicked")]
+use crate::wicked::{WickedInterface, WickedLinkConfig};
 
 #[cfg(net_backend = "systemd-networkd")]
 use crate::networkd::NetworkDConfig;

--- a/sources/api/netdog/src/networkd/config/mod.rs
+++ b/sources/api/netdog/src/networkd/config/mod.rs
@@ -39,7 +39,11 @@ mod private {
     pub enum Bond {}
     pub enum Interface {}
     pub enum Vlan {}
-    pub enum BondWorker {} // interfaces that are bound to a bond
+    // Interfaces that are bound to a bond
+    pub enum BondWorker {}
+    // Interfaces without config, used as the link for a VLAN: typically
+    // "tagged-only" setups
+    pub enum VlanLink {}
 
     // The devices for which we are generating a configuration file.  All device types should
     // implement this trait.
@@ -48,12 +52,19 @@ mod private {
     impl Device for Interface {}
     impl Device for Vlan {}
     impl Device for BondWorker {}
+    impl Device for VlanLink {}
 
     // Devices not bound to a bond, i.e. everything EXCEPT BondWorker(s)
     pub trait NotBonded {}
     impl NotBonded for Bond {}
     impl NotBonded for Interface {}
     impl NotBonded for Vlan {}
+
+    // Devices able to be members of VLANs
+    pub trait CanHaveVlans {}
+    impl CanHaveVlans for Bond {}
+    impl CanHaveVlans for Interface {}
+    impl CanHaveVlans for VlanLink {}
 }
 
 #[cfg(test)]

--- a/sources/api/netdog/src/networkd/config/mod.rs
+++ b/sources/api/netdog/src/networkd/config/mod.rs
@@ -71,8 +71,7 @@ mod private {
 mod tests {
     use crate::networkd::devices::{NetworkDBond, NetworkDInterface, NetworkDVlan};
     use serde::Deserialize;
-    use std::fs;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
 
     pub(super) const BUILDER_DATA: &str = include_str!("../../../test_data/networkd/builder.toml");
 

--- a/sources/api/netdog/src/networkd/config/netdev.rs
+++ b/sources/api/netdog/src/networkd/config/netdev.rs
@@ -1,5 +1,5 @@
 use super::private::{Bond, Device, Vlan};
-use super::{CONFIG_FILE_PREFIX, NETWORKD_CONFIG_DIR};
+use super::CONFIG_FILE_PREFIX;
 use crate::bonding::{ArpMonitoringConfigV1, ArpValidateV1, BondModeV1, MiiMonitoringConfigV1};
 use crate::interface_id::InterfaceName;
 use crate::networkd::{error, Result};
@@ -105,8 +105,10 @@ impl Display for ArpValidate {
     }
 }
 
+// The `All` variant isn't currently used, but is valid
 #[derive(Debug)]
 enum ArpAllTargets {
+    #[allow(dead_code)]
     All,
     Any,
 }

--- a/sources/api/netdog/src/networkd/config/network.rs
+++ b/sources/api/netdog/src/networkd/config/network.rs
@@ -164,6 +164,23 @@ impl NetworkConfig {
         }
     }
 
+    /// The name of the device that corresponds to this config
+    // This method is useful but is only used in tests so far
+    #[cfg(test)]
+    pub(crate) fn name(&self) -> Option<InterfaceId> {
+        let maybe_name = self.r#match.as_ref().and_then(|m| m.name.as_ref());
+        let maybe_mac = self
+            .r#match
+            .as_ref()
+            .and_then(|m| m.permanent_mac_address.first());
+
+        match (maybe_name, maybe_mac) {
+            (Some(name), _) => Some(InterfaceId::from(name.clone())),
+            (None, Some(mac)) => Some(InterfaceId::from(mac.clone())),
+            (None, None) => None,
+        }
+    }
+
     /// Add config to accept IPv6 router advertisements
     // TODO: expose a network config option for this
     pub(crate) fn accept_ra(&mut self) {

--- a/sources/api/netdog/src/networkd/config/network.rs
+++ b/sources/api/netdog/src/networkd/config/network.rs
@@ -1,7 +1,7 @@
 use super::private::{
     Bond, BondWorker, CanHaveVlans, Device, Interface, NotBonded, Vlan, VlanLink,
 };
-use super::{CONFIG_FILE_PREFIX, NETWORKD_CONFIG_DIR};
+use super::CONFIG_FILE_PREFIX;
 use crate::addressing::{Dhcp4ConfigV1, Dhcp6ConfigV1, RouteTo, RouteV1, StaticConfigV1};
 use crate::interface_id::InterfaceId;
 use crate::interface_id::{InterfaceName, MacAddress};
@@ -103,6 +103,8 @@ struct Dhcp6Section {
     use_domains: Option<bool>,
 }
 
+// The `Any` variant isn't currently used, but is valid
+#[allow(dead_code)]
 #[derive(Debug)]
 enum RequiredFamily {
     Any,
@@ -231,10 +233,6 @@ impl NetworkConfig {
     // are convenience methods to access the referenced structs (which are `Option`s) since they
     // may need to be accessed in multiple places during the builder's construction process. (And
     // no one wants to call `get_or_insert_with()` everywhere)
-    fn match_mut(&mut self) -> &mut MatchSection {
-        self.r#match.get_or_insert_with(MatchSection::default)
-    }
-
     fn link_mut(&mut self) -> &mut LinkSection {
         self.link.get_or_insert_with(LinkSection::default)
     }

--- a/sources/api/netdog/src/networkd/config/network.rs
+++ b/sources/api/netdog/src/networkd/config/network.rs
@@ -164,6 +164,12 @@ impl NetworkConfig {
         }
     }
 
+    /// Add config to accept IPv6 router advertisements
+    // TODO: expose a network config option for this
+    pub(crate) fn accept_ra(&mut self) {
+        self.network_mut().ipv6_accept_ra = Some(true)
+    }
+
     /// Write the config to the proper directory with the proper prefix and file extention
     pub(crate) fn write_config_file<P: AsRef<Path>>(&self, config_dir: P) -> Result<()> {
         let cfg_path = self.config_path(config_dir)?;

--- a/sources/api/netdog/src/networkd/conversions.rs
+++ b/sources/api/netdog/src/networkd/conversions.rs
@@ -1,0 +1,126 @@
+//! The conversions module contains all of the trait implementations necessary to convert net
+//! config structures to their corresponding networkd device structures
+use super::devices::{NetworkDBond, NetworkDDevice, NetworkDInterface, NetworkDVlan};
+use super::error;
+use crate::interface_id::{InterfaceId, InterfaceName};
+use crate::net_config::devices::bond::NetBondV1;
+use crate::net_config::devices::vlan::NetVlanV1;
+use crate::net_config::devices::{interface::NetInterfaceV2, NetworkDeviceV1};
+use crate::net_config::NetInterfaceV1;
+
+impl TryFrom<(InterfaceId, NetworkDeviceV1)> for NetworkDDevice {
+    type Error = error::Error;
+
+    fn try_from(value: (InterfaceId, NetworkDeviceV1)) -> Result<Self, Self::Error> {
+        let (name, config) = value;
+        match config {
+            NetworkDeviceV1::Interface(i) => (name, i).try_into(),
+            NetworkDeviceV1::BondDevice(b) => (name, b).try_into(),
+            NetworkDeviceV1::VlanDevice(v) => (name, v).try_into(),
+        }
+    }
+}
+
+impl TryFrom<(InterfaceName, NetInterfaceV1)> for NetworkDDevice {
+    type Error = error::Error;
+
+    fn try_from(value: (InterfaceName, NetInterfaceV1)) -> Result<Self, Self::Error> {
+        let (name, config) = value;
+        Ok(NetworkDDevice::Interface(NetworkDInterface {
+            name: name.into(),
+            dhcp4: config.dhcp4,
+            dhcp6: config.dhcp6,
+            static4: None,
+            static6: None,
+            routes: None,
+        }))
+    }
+}
+
+impl TryFrom<(InterfaceName, NetInterfaceV2)> for NetworkDDevice {
+    type Error = error::Error;
+
+    fn try_from(value: (InterfaceName, NetInterfaceV2)) -> Result<Self, Self::Error> {
+        let (name, config) = value;
+        Ok(NetworkDDevice::Interface(NetworkDInterface {
+            name: name.into(),
+            dhcp4: config.dhcp4,
+            dhcp6: config.dhcp6,
+            static4: config.static4,
+            static6: config.static6,
+            routes: config.routes,
+        }))
+    }
+}
+
+impl TryFrom<(InterfaceId, NetInterfaceV2)> for NetworkDDevice {
+    type Error = error::Error;
+
+    fn try_from(value: (InterfaceId, NetInterfaceV2)) -> Result<Self, Self::Error> {
+        let (name, config) = value;
+        Ok(NetworkDDevice::Interface(NetworkDInterface {
+            name,
+            dhcp4: config.dhcp4,
+            dhcp6: config.dhcp6,
+            static4: config.static4,
+            static6: config.static6,
+            routes: config.routes,
+        }))
+    }
+}
+
+impl TryFrom<(InterfaceId, NetBondV1)> for NetworkDDevice {
+    type Error = error::Error;
+
+    fn try_from(value: (InterfaceId, NetBondV1)) -> Result<Self, Self::Error> {
+        let (name, config) = value;
+        let name = if let InterfaceId::Name(n) = name {
+            n
+        } else {
+            return error::InvalidWithMacSnafu {
+                what: "bond".to_string(),
+            }
+            .fail();
+        };
+
+        Ok(NetworkDDevice::Bond(NetworkDBond {
+            name,
+            dhcp4: config.dhcp4,
+            dhcp6: config.dhcp6,
+            static4: config.static4,
+            static6: config.static6,
+            routes: config.routes,
+            mode: config.mode,
+            min_links: config.min_links,
+            monitoring_config: config.monitoring_config,
+            interfaces: config.interfaces,
+        }))
+    }
+}
+
+impl TryFrom<(InterfaceId, NetVlanV1)> for NetworkDDevice {
+    type Error = error::Error;
+
+    fn try_from(value: (InterfaceId, NetVlanV1)) -> Result<Self, Self::Error> {
+        let (name, config) = value;
+        let name = if let InterfaceId::Name(n) = name {
+            n
+        } else {
+            return error::InvalidWithMacSnafu {
+                what: "vlan".to_string(),
+            }
+            .fail();
+        };
+
+        Ok(NetworkDDevice::Vlan(NetworkDVlan {
+            name,
+            dhcp4: config.dhcp4,
+            dhcp6: config.dhcp6,
+            static4: config.static4,
+            static6: config.static6,
+            routes: config.routes,
+            device: config.device,
+            id: config.id,
+        }))
+    }
+}

--- a/sources/api/netdog/src/networkd/devices/bond.rs
+++ b/sources/api/netdog/src/networkd/devices/bond.rs
@@ -1,6 +1,9 @@
 use crate::addressing::{Dhcp4ConfigV1, Dhcp6ConfigV1, RouteV1, StaticConfigV1};
 use crate::bonding::{BondModeV1, BondMonitoringConfigV1};
-use crate::interface_id::{InterfaceId, InterfaceName};
+use crate::interface_id::InterfaceName;
+use crate::networkd::config::{NetDevBuilder, NetDevConfig, NetworkBuilder, NetworkConfig};
+use crate::networkd::devices::maybe_add_some;
+use crate::networkd::{NetDevFileCreator, NetworkFileCreator, Vlans};
 
 #[cfg(test)]
 use serde::Deserialize;
@@ -21,4 +24,84 @@ pub(crate) struct NetworkDBond {
     pub(crate) min_links: Option<usize>,
     pub(crate) monitoring_config: BondMonitoringConfigV1,
     pub(crate) interfaces: Vec<InterfaceName>,
+}
+
+impl NetDevFileCreator for NetworkDBond {
+    fn create_netdev(&self) -> NetDevConfig {
+        // Destructure self to ensure we are intentional about skipping or using fields, especially
+        // as new fields are added in the future.  The compiler will keep the code honest if fields
+        // are accidentally skipped.
+        let Self {
+            name,
+            dhcp4: _, // DHCP / static addressing isn't used in .netdev files
+            dhcp6: _,
+            static4: _,
+            static6: _,
+            routes: _,
+            mode,
+            min_links,
+            monitoring_config,
+            interfaces: _, // Used in .network files, not here
+        } = self;
+
+        let mut netdev = NetDevBuilder::new_bond(name.clone());
+        netdev.with_mode(mode.clone());
+        maybe_add_some!(netdev, with_min_links, min_links);
+
+        match monitoring_config.clone() {
+            BondMonitoringConfigV1::MiiMon(miimon) => netdev.with_miimon_config(miimon),
+            BondMonitoringConfigV1::ArpMon(arpmon) => netdev.with_arpmon_config(arpmon),
+        }
+
+        netdev.build()
+    }
+}
+
+impl NetworkFileCreator for NetworkDBond {
+    fn create_networks(&self, vlans: &Vlans) -> Vec<NetworkConfig> {
+        let mut configs = Vec::new();
+
+        // Destructure self to ensure we are intentional about skipping or using fields, especially
+        // as new fields are added in the future.  The compiler will keep the code honest if fields
+        // are accidentally skipped.
+        let Self {
+            name,
+            dhcp4,
+            dhcp6,
+            static4,
+            static6,
+            routes,
+            mode: _, // mode / min_links / monitoring are used in .netdev files
+            min_links: _,
+            monitoring_config: _,
+            interfaces,
+        } = self;
+
+        let mut network = NetworkBuilder::new_bond(name.clone());
+        network.with_dhcp(dhcp4.clone(), dhcp6.clone());
+        maybe_add_some!(network, with_static_config, static4);
+        maybe_add_some!(network, with_static_config, static6);
+        maybe_add_some!(network, with_routes, routes);
+
+        // Attach VLANs to this interface, if any
+        if let Some(vlans) = vlans.get(name) {
+            network.with_vlans(vlans.to_vec())
+        }
+
+        configs.push(network.build());
+
+        // Create the .network files for the worker interfaces
+        for (index, worker_name) in interfaces.iter().enumerate() {
+            let mut worker = NetworkBuilder::new_bond_worker(worker_name.clone());
+            worker.bound_to_bond(name.clone());
+
+            // The first worker in the list is the primary
+            if index == 0 {
+                worker.primary_bond_worker();
+            }
+            configs.push(worker.build());
+        }
+
+        configs
+    }
 }

--- a/sources/api/netdog/src/networkd/devices/interface.rs
+++ b/sources/api/netdog/src/networkd/devices/interface.rs
@@ -1,5 +1,8 @@
 use crate::addressing::{Dhcp4ConfigV1, Dhcp6ConfigV1, RouteV1, StaticConfigV1};
 use crate::interface_id::InterfaceId;
+use crate::networkd::config::{NetworkBuilder, NetworkConfig};
+use crate::networkd::devices::maybe_add_some;
+use crate::networkd::{NetworkFileCreator, Vlans};
 
 #[cfg(test)]
 use serde::Deserialize;
@@ -15,4 +18,70 @@ pub(crate) struct NetworkDInterface {
     pub(crate) static4: Option<StaticConfigV1>,
     pub(crate) static6: Option<StaticConfigV1>,
     pub(crate) routes: Option<Vec<RouteV1>>,
+}
+
+impl NetworkDInterface {
+    fn is_unconfigured(&self) -> bool {
+        // Destructure self to ensure all applicable Option fields are checked, especially as new
+        // fields are added in the future.  The compiler will keep the code honest if fields are
+        // accidentally skipped.
+        let Self {
+            name: _, // name is not an Option
+            dhcp4,
+            dhcp6,
+            static4,
+            static6,
+            routes,
+        } = self;
+        dhcp4.is_none()
+            && dhcp6.is_none()
+            && static4.is_none()
+            && static6.is_none()
+            && routes.is_none()
+    }
+}
+
+impl NetworkFileCreator for NetworkDInterface {
+    fn create_networks(&self, vlans: &Vlans) -> Vec<NetworkConfig> {
+        // Destructure self to ensure we are intentional about skipping or using fields, especially
+        // as new fields are added in the future.  The compiler will keep the code honest if fields
+        // are accidentally skipped.
+        let Self {
+            name,
+            dhcp4,
+            dhcp6,
+            static4,
+            static6,
+            routes,
+        } = self;
+
+        // Attach VLANs to this interface if configured with a name.
+        let attached_vlans = if let InterfaceId::Name(n) = name {
+            vlans.get(n)
+        } else {
+            None
+        };
+
+        // If this interface has attached VLANs but no config, we treat it solely as the link for
+        // the VLANs
+        if self.is_unconfigured() && attached_vlans.is_some() {
+            let mut network = NetworkBuilder::new_vlan_link(name.clone());
+            if let Some(vlans) = attached_vlans {
+                network.with_vlans(vlans.to_vec())
+            }
+
+            vec![network.build()]
+        } else {
+            let mut network = NetworkBuilder::new_interface(name.clone());
+            network.with_dhcp(dhcp4.clone(), dhcp6.clone());
+            maybe_add_some!(network, with_static_config, static4);
+            maybe_add_some!(network, with_static_config, static6);
+            maybe_add_some!(network, with_routes, routes);
+            if let Some(vlans) = attached_vlans {
+                network.with_vlans(vlans.to_vec())
+            }
+
+            vec![network.build()]
+        }
+    }
 }

--- a/sources/api/netdog/src/networkd/devices/mod.rs
+++ b/sources/api/netdog/src/networkd/devices/mod.rs
@@ -4,6 +4,8 @@ mod bond;
 mod interface;
 mod vlan;
 
+use super::config::NetworkDConfigFile;
+use super::{NetDevFileCreator, NetworkFileCreator, Vlans};
 pub(crate) use bond::NetworkDBond;
 pub(crate) use interface::NetworkDInterface;
 pub(crate) use vlan::NetworkDVlan;
@@ -13,3 +15,53 @@ pub(crate) enum NetworkDDevice {
     Bond(NetworkDBond),
     Vlan(NetworkDVlan),
 }
+
+impl NetworkDDevice {
+    pub(super) fn create_files(&self, vlans: &Vlans) -> Vec<NetworkDConfigFile> {
+        let mut configs = Vec::new();
+
+        match self {
+            NetworkDDevice::Interface(i) => {
+                configs.extend(
+                    i.create_networks(vlans)
+                        .into_iter()
+                        .map(NetworkDConfigFile::Network),
+                );
+            }
+            NetworkDDevice::Bond(b) => {
+                configs.push(NetworkDConfigFile::NetDev(b.create_netdev()));
+                configs.extend(
+                    b.create_networks(vlans)
+                        .into_iter()
+                        .map(NetworkDConfigFile::Network),
+                );
+            }
+            NetworkDDevice::Vlan(v) => {
+                configs.push(NetworkDConfigFile::NetDev(v.create_netdev()));
+                configs.extend(
+                    v.create_networks(vlans)
+                        .into_iter()
+                        .map(NetworkDConfigFile::Network),
+                );
+            }
+        };
+
+        configs
+    }
+}
+
+/// A tiny macro to ease calling builder methods only if an `Option` is `Some()`.  NetworkDDevices
+/// contain quite a few `Option`s (and probably more in the future), so when driving the config
+/// builders there becomes a bit of `if let Some()` boilerplate.  This macro reduces that
+/// boilerplate to a single line.
+///
+/// The first argument is the builder, the second is the builder method, and the third is the
+/// Option from which you need to add.
+macro_rules! maybe_add_some {
+    ($builder:ident, $method:ident, $option:ident) => {
+        if let Some(thing) = $option.clone() {
+            $builder.$method(thing)
+        }
+    };
+}
+pub(self) use maybe_add_some;

--- a/sources/api/netdog/src/networkd/devices/mod.rs
+++ b/sources/api/netdog/src/networkd/devices/mod.rs
@@ -6,6 +6,7 @@ mod vlan;
 
 use super::config::NetworkDConfigFile;
 use super::{NetDevFileCreator, NetworkFileCreator, Vlans};
+use crate::interface_id::InterfaceId;
 pub(crate) use bond::NetworkDBond;
 pub(crate) use interface::NetworkDInterface;
 pub(crate) use vlan::NetworkDVlan;
@@ -47,6 +48,14 @@ impl NetworkDDevice {
         };
 
         configs
+    }
+
+    pub(super) fn name(&self) -> InterfaceId {
+        match self {
+            NetworkDDevice::Interface(i) => i.name.clone(),
+            NetworkDDevice::Bond(b) => b.name.clone().into(),
+            NetworkDDevice::Vlan(v) => v.name.clone().into(),
+        }
     }
 }
 

--- a/sources/api/netdog/src/networkd/devices/vlan.rs
+++ b/sources/api/netdog/src/networkd/devices/vlan.rs
@@ -1,5 +1,8 @@
 use crate::addressing::{Dhcp4ConfigV1, Dhcp6ConfigV1, RouteV1, StaticConfigV1};
-use crate::interface_id::{InterfaceId, InterfaceName};
+use crate::interface_id::InterfaceName;
+use crate::networkd::config::{NetDevBuilder, NetDevConfig, NetworkBuilder, NetworkConfig};
+use crate::networkd::devices::maybe_add_some;
+use crate::networkd::{NetDevFileCreator, NetworkFileCreator, Vlans};
 use crate::vlan_id::VlanId;
 
 #[cfg(test)]
@@ -16,6 +19,58 @@ pub(crate) struct NetworkDVlan {
     pub(crate) static4: Option<StaticConfigV1>,
     pub(crate) static6: Option<StaticConfigV1>,
     pub(crate) routes: Option<Vec<RouteV1>>,
+    // The device field isn't used in the creation of the .network or .netdev files for this VLAN.
+    // It is used to create a map of device -> VLANs to ensure the device's contain the "VLAN"
+    // entry for this VLAN
     pub(crate) device: InterfaceName,
     pub(crate) id: VlanId,
+}
+
+impl NetDevFileCreator for NetworkDVlan {
+    fn create_netdev(&self) -> NetDevConfig {
+        // Destructure self to ensure we are intentional about skipping or using fields, especially
+        // as new fields are added in the future.  The compiler will keep the code honest if fields
+        // are accidentally skipped.
+        let Self {
+            name,
+            dhcp4: _, // DHCP / static addressing isn't used in .netdev files
+            dhcp6: _,
+            static4: _,
+            static6: _,
+            routes: _,
+            device: _, // Device isn't used in .netdev files
+            id,
+        } = self;
+
+        let mut netdev = NetDevBuilder::new_vlan(name.clone());
+        netdev.with_vlan_id(id.clone());
+
+        netdev.build()
+    }
+}
+
+impl NetworkFileCreator for NetworkDVlan {
+    fn create_networks(&self, _vlans: &Vlans) -> Vec<NetworkConfig> {
+        // Destructure self to ensure we are intentional about skipping or using fields, especially
+        // as new fields are added in the future.  The compiler will keep the code honest if fields
+        // are accidentally skipped.
+        let Self {
+            name,
+            dhcp4,
+            dhcp6,
+            static4,
+            static6,
+            routes,
+            device: _, // device and id aren't used in .network files
+            id: _,
+        } = self;
+
+        let mut network = NetworkBuilder::new_vlan(name.clone());
+        network.with_dhcp(dhcp4.clone(), dhcp6.clone());
+        maybe_add_some!(network, with_static_config, static4);
+        maybe_add_some!(network, with_static_config, static6);
+        maybe_add_some!(network, with_routes, routes);
+
+        vec![network.build()]
+    }
 }

--- a/sources/api/netdog/src/networkd/mod.rs
+++ b/sources/api/netdog/src/networkd/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config;
+mod conversions;
 mod devices;
 
 use self::config::{NetDevConfig, NetworkConfig, NetworkDConfigFile};
@@ -93,6 +94,12 @@ mod error {
         #[snafu(display("Unable to create '{}', missing name or MAC", what))]
         ConfigMissingName { what: String },
 
+        #[snafu(display(
+            "Unable to create systemd-networkd '{}' with MAC address, must use a name",
+            what
+        ))]
+        InvalidWithMac { what: String },
+
         #[snafu(display("Unable to write {} to {}: {}", what, path.display(), source))]
         NetworkDConfigWrite {
             what: String,
@@ -101,4 +108,253 @@ mod error {
         },
     }
 }
+pub(crate) use error::Error;
 pub(crate) type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::devices::{NetworkDBond, NetworkDInterface, NetworkDVlan};
+    use super::*;
+    use crate::net_config::{self, Interfaces, NetConfigV1};
+    use handlebars::Handlebars;
+    use serde::Serialize;
+    use std::fmt::Display;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::str::FromStr;
+
+    static NET_CONFIG_VERSIONS: &[u8] = &[1, 2, 3];
+    const NET_CONFIG: &str = include_str!("../../test_data/net_config.toml");
+
+    fn networkd_data() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("test_data")
+            .join("networkd")
+    }
+
+    // Only needed for test purposes to easily create a string from the underlying config
+    impl Display for NetworkDConfigFile {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                NetworkDConfigFile::Network(nw) => write!(f, "{}", nw.to_string()),
+                NetworkDConfigFile::NetDev(nd) => write!(f, "{}", nd.to_string()),
+            }
+        }
+    }
+
+    fn device_name(device: &NetworkDDevice) -> String {
+        match device {
+            NetworkDDevice::Interface(i) => i.name.to_string(),
+            NetworkDDevice::Bond(b) => b.name.to_string(),
+            NetworkDDevice::Vlan(v) => v.name.to_string(),
+        }
+    }
+
+    // Test the end-to-end trip: "net config from cmdline -> networkd config -> serialized config"
+    #[test]
+    fn interface_config_from_str() {
+        // Interface names here coincide with config files, some of which are shared with the
+        // `net_config` test below
+        let ok = &[
+            "eno1:dhcp4",
+            "eno2:dhcp6",
+            "eno9:dhcp4?",
+            "eno10:dhcp6?",
+            "eno5:dhcp4,dhcp6",
+            "eno5:dhcp6,dhcp4",
+            "eno7:dhcp4,dhcp6?",
+            "eno7:dhcp6?,dhcp4",
+            "eno8:dhcp6?,dhcp4?",
+            "eno8:dhcp4?,dhcp6?",
+        ];
+        for ok_str in ok {
+            let net_config = NetConfigV1::from_str(ok_str).unwrap();
+
+            let networkd_config = net_config.as_networkd_config().unwrap();
+            for device in networkd_config.devices {
+                let name = device_name(&device);
+                let configs = device.create_files(&networkd_config.vlans);
+
+                // We know the array of strings only creates interface configs, which are 1:1 with
+                // the device.
+                assert!(configs.len() == 1);
+                for mut config in configs {
+                    let mut path = networkd_data().join("network").join(&name);
+                    path.set_extension("network");
+
+                    let expected = fs::read_to_string(&path).unwrap();
+                    let generated = config.to_string();
+                    assert_eq!(
+                        expected,
+                        generated,
+                        "Generated output does not match file: {}",
+                        path.display()
+                    );
+
+                    // Add IPv6 `accept-ra` config to the interface, regenerate it, and ensure the
+                    // generated config contains the added IPv6 option
+                    if let NetworkDConfigFile::Network(ref mut n) = config {
+                        n.accept_ra();
+                    }
+                    let generated = config.to_string();
+                    let mut path = networkd_data()
+                        .join("network")
+                        .join(format!("{}-ra", &name));
+                    path.set_extension("network");
+                    let expected = fs::read_to_string(&path).unwrap();
+
+                    assert_eq!(
+                        expected,
+                        generated,
+                        "Generated output does not match file: {}",
+                        path.display()
+                    )
+                }
+            }
+        }
+    }
+
+    // Test the end-to-end trip: "net config -> networkd config -> serialized config"
+    #[test]
+    fn net_config_to_networkd_config() {
+        for version in NET_CONFIG_VERSIONS {
+            let temp_config = tempfile::NamedTempFile::new().unwrap();
+            render_config_template(NET_CONFIG, &temp_config, version);
+            let net_config = net_config::from_path(&temp_config).unwrap().unwrap();
+
+            let networkd_config = net_config.as_networkd_config().unwrap();
+            for device in networkd_config.devices {
+                validate_device_config(device, &networkd_config.vlans)
+            }
+        }
+    }
+
+    fn validate_device_config(device: NetworkDDevice, vlans: &Vlans) {
+        let configs = device.create_files(vlans);
+        match device {
+            NetworkDDevice::Interface(i) => validate_interface_config(i, configs),
+            NetworkDDevice::Bond(b) => validate_bond_config(b, configs),
+            NetworkDDevice::Vlan(v) => validate_vlan_config(v, configs),
+        }
+    }
+
+    fn validate_interface_config(i: NetworkDInterface, configs: Vec<NetworkDConfigFile>) {
+        let msg = format!(
+            "Interfaces ({}) should create 1 .network file and 0 .netdev files",
+            &i.name.to_string(),
+        );
+
+        let (networks, netdevs): (Vec<NetworkDConfigFile>, Vec<NetworkDConfigFile>) = configs
+            .into_iter()
+            .partition(|f| matches!(f, NetworkDConfigFile::Network(_)));
+
+        // Interfaces should create a single network file with the interface's name
+        assert!(networks.len() == 1, "{}", msg);
+        assert!(netdevs.len() == 0, "{}", msg);
+        for network in networks {
+            validate_config_file(&i.name.to_string(), network)
+        }
+    }
+
+    fn validate_vlan_config(v: NetworkDVlan, configs: Vec<NetworkDConfigFile>) {
+        let msg = format!(
+            "VLANs ({}) should create 1 .network file and 1 .netdev files",
+            &v.name.to_string(),
+        );
+
+        let (networks, netdevs): (Vec<NetworkDConfigFile>, Vec<NetworkDConfigFile>) = configs
+            .into_iter()
+            .partition(|f| matches!(f, NetworkDConfigFile::Network(_)));
+
+        // VLANs should create 1 netdev and 1 network, both named with the VLAN's name
+        assert!(networks.len() == 1, "{}", msg);
+        assert!(netdevs.len() == 1, "{}", msg);
+
+        for config in networks.into_iter().chain(netdevs.into_iter()) {
+            validate_config_file(&v.name.to_string(), config)
+        }
+    }
+
+    fn validate_bond_config(b: NetworkDBond, configs: Vec<NetworkDConfigFile>) {
+        let msg = format!(
+            "Bonds ({}) should create 1 .netdev file, and enough .network files for itself and its workers",
+            &b.name.to_string(),
+        );
+
+        let (networks, netdevs): (Vec<NetworkDConfigFile>, Vec<NetworkDConfigFile>) = configs
+            .into_iter()
+            .partition(|f| matches!(f, NetworkDConfigFile::Network(_)));
+
+        // Bonds should create enough network interfaces for itself and its workers
+        let network_count = 1 + b.interfaces.len();
+        assert!(networks.len() == network_count, "{}", msg);
+
+        // Create a Vec of all the interface names for which we expect to have a .network file
+        let mut interfaces: Vec<String> = b.interfaces.iter().map(|i| i.to_string()).collect();
+        interfaces.push(b.name.to_string());
+
+        // Validate we have a config file for each of the interfaces in the above list (bond +
+        // workers)
+        for network in networks {
+            // We know networks only contains NetworkDConfigFile::Network, but we need to access
+            // the NetworkConfig inside to get at the name
+            if let NetworkDConfigFile::Network(nw) = network {
+                let network_name = nw.name().unwrap().to_string();
+
+                // Ensure our list contains an interface with this name, then pop it off the list
+                assert!(interfaces.contains(&network_name));
+                interfaces.retain(|iface_name| iface_name != &network_name);
+
+                validate_config_file(&network_name, NetworkDConfigFile::Network(nw))
+            }
+        }
+        // This Vec should be empty at this point, since we removed all the interfaces we have
+        // files for in the above loop
+        assert!(interfaces.is_empty(), "{}", msg);
+
+        // Bonds should create a single netdev named with the bond's name
+        assert!(netdevs.len() == 1, "{}", msg);
+        for netdev in netdevs {
+            validate_config_file(&b.name.to_string(), netdev)
+        }
+    }
+
+    fn validate_config_file(device_name: &str, config: NetworkDConfigFile) {
+        // Handle MAC addresses; this also happens in the device's methods to write the config file
+        // and is unit tested there.
+        let device_name = device_name.to_lowercase().replace(':', "");
+        let config_type = match config {
+            NetworkDConfigFile::Network(_) => "network",
+            NetworkDConfigFile::NetDev(_) => "netdev",
+        };
+
+        let mut path = networkd_data().join(config_type).join(device_name);
+        path.set_extension(config_type);
+
+        let expected = fs::read_to_string(&path).unwrap();
+        let generated = config.to_string();
+        assert_eq!(
+            expected,
+            generated,
+            "Generated output does not match file: {}",
+            path.display()
+        );
+    }
+
+    fn render_config_template<P1>(template: &str, output_path: P1, version: &u8)
+    where
+        P1: AsRef<Path>,
+    {
+        #[derive(Serialize)]
+        struct Context {
+            version: u8,
+        }
+
+        let mut hb = Handlebars::new();
+        hb.register_template_string("template", &template).unwrap();
+
+        let context = Context { version: *version };
+        let rendered = hb.render("template", &context).unwrap();
+        fs::write(output_path.as_ref(), rendered).unwrap()
+    }
+}

--- a/sources/api/netdog/src/networkd/mod.rs
+++ b/sources/api/netdog/src/networkd/mod.rs
@@ -1,4 +1,4 @@
-mod config;
+pub(crate) mod config;
 mod devices;
 
 use self::config::{NetDevConfig, NetworkConfig, NetworkDConfigFile};

--- a/sources/api/netdog/src/networkd/mod.rs
+++ b/sources/api/netdog/src/networkd/mod.rs
@@ -1,6 +1,25 @@
 mod config;
 mod devices;
 
+use self::config::{NetDevConfig, NetworkConfig};
+use crate::interface_id::InterfaceName;
+use std::collections::HashMap;
+
+// A map of network device -> associated VLANs.  This type exists to assist in generating a
+// device's network configuration, which must contain it's associated VLANs.
+pub(self) type Vlans = HashMap<InterfaceName, Vec<InterfaceName>>;
+
+/// Devices implement this trait if they require a .netdev file
+trait NetDevFileCreator {
+    fn create_netdev(&self) -> NetDevConfig;
+}
+
+/// Devices implement this trait if they require one or more .network files (bonds, for example,
+/// create multiple .network files for the bond and it's workers)
+trait NetworkFileCreator {
+    fn create_networks(&self, vlans: &Vlans) -> Vec<NetworkConfig>;
+}
+
 mod error {
     use snafu::Snafu;
     use std::io;

--- a/sources/api/netdog/src/networkd/mod.rs
+++ b/sources/api/netdog/src/networkd/mod.rs
@@ -1,13 +1,75 @@
 mod config;
 mod devices;
 
-use self::config::{NetDevConfig, NetworkConfig};
-use crate::interface_id::InterfaceName;
+use self::config::{NetDevConfig, NetworkConfig, NetworkDConfigFile};
+use self::devices::{NetworkDDevice, NetworkDInterface};
+use crate::interface_id::{InterfaceId, InterfaceName};
 use std::collections::HashMap;
 
 // A map of network device -> associated VLANs.  This type exists to assist in generating a
 // device's network configuration, which must contain it's associated VLANs.
 pub(self) type Vlans = HashMap<InterfaceName, Vec<InterfaceName>>;
+
+pub(crate) struct NetworkDConfig {
+    devices: Vec<NetworkDDevice>,
+    vlans: Vlans,
+}
+
+impl NetworkDConfig {
+    pub(crate) fn new<T>(network_devices: Vec<T>) -> Result<Self>
+    where
+        T: TryInto<NetworkDDevice, Error = self::error::Error>,
+    {
+        let mut devices = network_devices
+            .into_iter()
+            .map(|d| d.try_into())
+            .collect::<Result<Vec<NetworkDDevice>>>()?;
+
+        let mut device_names = Vec::with_capacity(devices.len());
+        let mut vlans = HashMap::new();
+        for device in &devices {
+            device_names.push(device.name());
+            // VLANs are typically attached to a network device (bond/interface). Net config
+            // specifies the bond or interface in the VLAN config. In systemd-networkd config, the
+            // VLAN is specified in the device config. Create a map of interface/bond name to list
+            // of attached VLANs to assist with config generation later
+            if let NetworkDDevice::Vlan(vlan) = device {
+                vlans
+                    .entry(vlan.device.clone())
+                    .or_insert_with(Vec::new)
+                    .push(vlan.name.clone())
+            }
+        }
+
+        // If the VLANs map contains a device we don't otherwise have config for, it means the
+        // device is used only as a link for the VLAN.  This is used in VLAN "tagged only" type
+        // setups.  Add an empty NetworkDInterface to the list of config to be generated.  An empty
+        // device will get a .network file so it is managed and becomes a member of the VLAN, but
+        // will otherwise have all DHCP and addressing config turned off.
+        for vlan_device in vlans.keys() {
+            if !device_names.contains(&InterfaceId::from(vlan_device.clone())) {
+                devices.push(NetworkDDevice::Interface(NetworkDInterface {
+                    name: InterfaceId::Name(vlan_device.clone()),
+                    dhcp4: None,
+                    dhcp6: None,
+                    static4: None,
+                    static6: None,
+                    routes: None,
+                }))
+            }
+        }
+
+        Ok(Self { devices, vlans })
+    }
+
+    /// Generate systemd-networkd configuration files for all known devices
+    pub(crate) fn create_files(self) -> Vec<NetworkDConfigFile> {
+        self.devices
+            .iter()
+            .flat_map(|d| d.create_files(&self.vlans))
+            .collect()
+    }
+}
 
 /// Devices implement this trait if they require a .netdev file
 trait NetDevFileCreator {

--- a/sources/api/netdog/src/vlan_id.rs
+++ b/sources/api/netdog/src/vlan_id.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer};
 use std::fmt::Display;
 use std::ops::Deref;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct VlanId {
     inner: u16,
 }

--- a/sources/api/netdog/src/wicked/mod.rs
+++ b/sources/api/netdog/src/wicked/mod.rs
@@ -322,6 +322,7 @@ mod error {
 
 type Result<T> = std::result::Result<T, error::Error>;
 
+#[cfg(net_backend = "wicked")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -397,7 +398,7 @@ mod tests {
     #[test]
     #[allow(clippy::to_string_in_format_args)]
     fn net_config_to_interface_config() {
-        let net_config_path = wicked_config().join("net_config.toml");
+        let net_config_path = test_data().join("net_config.toml");
 
         for version in NET_CONFIG_VERSIONS {
             let temp_config = tempfile::NamedTempFile::new().unwrap();

--- a/sources/api/netdog/test_data/net_config.toml
+++ b/sources/api/netdog/test_data/net_config.toml
@@ -143,7 +143,7 @@ via = "2001:beef:beef::1"
 {{#if (eq version 3)}}
 [myvlan]
 kind = "vlan"
-device = "eno1"
+device = "eno100"
 id = 42
 dhcp4 = true
 

--- a/sources/api/netdog/test_data/net_config.toml
+++ b/sources/api/netdog/test_data/net_config.toml
@@ -155,6 +155,17 @@ id = 42
 [mystaticvlan.static4]
 addresses = ["192.168.1.100/24"]
 
+# This interface is a member of a VLAN but also has its own addressing
+[eno1001]
+dhcp4 = true
+
+# This VLAN uses a device that also has its own addressing config
+[vlancfgdev]
+kind = "vlan"
+device = "eno1001"
+id = 1
+dhcp4 = true
+
 [bond0]
 kind = "bond"
 mode = "active-backup"

--- a/sources/api/netdog/test_data/networkd/builder.toml
+++ b/sources/api/netdog/test_data/networkd/builder.toml
@@ -182,7 +182,6 @@ name = "bond1"
 mode = "active-backup"
 interfaces = ["eno53" , "eno54"]
 dhcp4 = true
-dhcp6 = true
 [bond.monitoring_config]
 arpmon-interval-ms = 200
 arpmon-validate = "all"

--- a/sources/api/netdog/test_data/networkd/netdev/vlancfgdev.netdev
+++ b/sources/api/netdog/test_data/networkd/netdev/vlancfgdev.netdev
@@ -1,0 +1,5 @@
+[NetDev]
+Name=vlancfgdev
+Kind=vlan
+[VLAN]
+Id=1

--- a/sources/api/netdog/test_data/networkd/network/eno1-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno1-ra.network
@@ -1,10 +1,10 @@
 [Match]
-Name=bond1
+Name=eno1
 [Link]
 RequiredForOnline=true
 [Network]
-ConfigureWithoutCarrier=true
 DHCP=ipv4
+IPv6AcceptRA=true
 [DHCPv4]
 UseDNS=true
 UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/eno10-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno10-ra.network
@@ -1,0 +1,10 @@
+[Match]
+Name=eno10
+[Link]
+RequiredForOnline=false
+[Network]
+DHCP=ipv6
+IPv6AcceptRA=true
+[DHCPv6]
+UseDNS=true
+UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/eno100.network
+++ b/sources/api/netdog/test_data/networkd/network/eno100.network
@@ -1,0 +1,6 @@
+[Match]
+Name=eno100
+[Network]
+IPv6AcceptRA=false
+LinkLocalAddressing=no
+VLAN=myvlan

--- a/sources/api/netdog/test_data/networkd/network/eno1000.network
+++ b/sources/api/netdog/test_data/networkd/network/eno1000.network
@@ -1,0 +1,6 @@
+[Match]
+Name=eno1000
+[Network]
+IPv6AcceptRA=false
+LinkLocalAddressing=no
+VLAN=mystaticvlan

--- a/sources/api/netdog/test_data/networkd/network/eno1001.network
+++ b/sources/api/netdog/test_data/networkd/network/eno1001.network
@@ -1,0 +1,10 @@
+[Match]
+Name=eno1001
+[Link]
+RequiredForOnline=true
+[Network]
+DHCP=ipv4
+VLAN=vlancfgdev
+[DHCPv4]
+UseDNS=true
+UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/eno2-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno2-ra.network
@@ -1,10 +1,10 @@
 [Match]
-Name=bond1
+Name=eno2
 [Link]
 RequiredForOnline=true
 [Network]
-ConfigureWithoutCarrier=true
-DHCP=ipv4
-[DHCPv4]
+DHCP=ipv6
+IPv6AcceptRA=true
+[DHCPv6]
 UseDNS=true
 UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/eno5-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno5-ra.network
@@ -1,0 +1,14 @@
+[Match]
+Name=eno5
+[Link]
+RequiredForOnline=true
+RequiredFamilyForOnline=both
+[Network]
+DHCP=yes
+IPv6AcceptRA=true
+[DHCPv4]
+UseDNS=true
+UseDomains=true
+[DHCPv6]
+UseDNS=true
+UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/eno53.network
+++ b/sources/api/netdog/test_data/networkd/network/eno53.network
@@ -1,0 +1,6 @@
+[Match]
+Name=eno53
+[Network]
+Bond=bond1
+LinkLocalAddressing=no
+PrimarySlave=true

--- a/sources/api/netdog/test_data/networkd/network/eno54.network
+++ b/sources/api/netdog/test_data/networkd/network/eno54.network
@@ -1,0 +1,5 @@
+[Match]
+Name=eno54
+[Network]
+Bond=bond1
+LinkLocalAddressing=no

--- a/sources/api/netdog/test_data/networkd/network/eno55.network
+++ b/sources/api/netdog/test_data/networkd/network/eno55.network
@@ -1,0 +1,6 @@
+[Match]
+Name=eno55
+[Network]
+Bond=bond2
+LinkLocalAddressing=no
+PrimarySlave=true

--- a/sources/api/netdog/test_data/networkd/network/eno56.network
+++ b/sources/api/netdog/test_data/networkd/network/eno56.network
@@ -1,0 +1,5 @@
+[Match]
+Name=eno56
+[Network]
+Bond=bond2
+LinkLocalAddressing=no

--- a/sources/api/netdog/test_data/networkd/network/eno57.network
+++ b/sources/api/netdog/test_data/networkd/network/eno57.network
@@ -1,0 +1,5 @@
+[Match]
+Name=eno57
+[Network]
+Bond=bond2
+LinkLocalAddressing=no

--- a/sources/api/netdog/test_data/networkd/network/eno7-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno7-ra.network
@@ -1,0 +1,14 @@
+[Match]
+Name=eno7
+[Link]
+RequiredForOnline=true
+RequiredFamilyForOnline=ipv4
+[Network]
+DHCP=yes
+IPv6AcceptRA=true
+[DHCPv4]
+UseDNS=true
+UseDomains=true
+[DHCPv6]
+UseDNS=true
+UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/eno8-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno8-ra.network
@@ -1,0 +1,13 @@
+[Match]
+Name=eno8
+[Link]
+RequiredForOnline=false
+[Network]
+DHCP=yes
+IPv6AcceptRA=true
+[DHCPv4]
+UseDNS=true
+UseDomains=true
+[DHCPv6]
+UseDNS=true
+UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/eno9-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno9-ra.network
@@ -1,10 +1,10 @@
 [Match]
-Name=bond1
+Name=eno9
 [Link]
-RequiredForOnline=true
+RequiredForOnline=false
 [Network]
-ConfigureWithoutCarrier=true
 DHCP=ipv4
+IPv6AcceptRA=true
 [DHCPv4]
 UseDNS=true
 UseDomains=true

--- a/sources/api/netdog/test_data/networkd/network/f874a4d53265.network
+++ b/sources/api/netdog/test_data/networkd/network/f874a4d53265.network
@@ -1,9 +1,8 @@
 [Match]
-Name=bond1
+PermanentMACAddress=f8:74:a4:d5:32:65
 [Link]
 RequiredForOnline=true
 [Network]
-ConfigureWithoutCarrier=true
 DHCP=ipv4
 [DHCPv4]
 UseDNS=true

--- a/sources/api/netdog/test_data/networkd/network/f874a4d53266.network
+++ b/sources/api/netdog/test_data/networkd/network/f874a4d53266.network
@@ -1,9 +1,8 @@
 [Match]
-Name=bond1
+PermanentMACAddress=f8:74:a4:d5:32:66
 [Link]
 RequiredForOnline=true
 [Network]
-ConfigureWithoutCarrier=true
 DHCP=ipv4
 [DHCPv4]
 UseDNS=true

--- a/sources/api/netdog/test_data/networkd/network/vlancfgdev.network
+++ b/sources/api/netdog/test_data/networkd/network/vlancfgdev.network
@@ -1,0 +1,10 @@
+[Match]
+Name=vlancfgdev
+[Link]
+RequiredForOnline=true
+[Network]
+ConfigureWithoutCarrier=true
+DHCP=ipv4
+[DHCPv4]
+UseDNS=true
+UseDomains=true

--- a/sources/api/netdog/test_data/wicked/eno1001.xml
+++ b/sources/api/netdog/test_data/wicked/eno1001.xml
@@ -1,0 +1,1 @@
+<interface><name>eno1001</name><control><mode>boot</mode><link-detection><require-link></require-link></link-detection></control><ipv4:dhcp><enabled>true</enabled></ipv4:dhcp></interface>

--- a/sources/api/netdog/test_data/wicked/myvlan.xml
+++ b/sources/api/netdog/test_data/wicked/myvlan.xml
@@ -1,1 +1,1 @@
-<interface><name>myvlan</name><control><mode>boot</mode><link-detection><require-link></require-link></link-detection></control><ipv4:dhcp><enabled>true</enabled></ipv4:dhcp><vlan><device>eno1</device><tag>42</tag></vlan></interface>
+<interface><name>myvlan</name><control><mode>boot</mode><link-detection><require-link></require-link></link-detection></control><ipv4:dhcp><enabled>true</enabled></ipv4:dhcp><vlan><device>eno100</device><tag>42</tag></vlan></interface>

--- a/sources/api/netdog/test_data/wicked/vlancfgdev.xml
+++ b/sources/api/netdog/test_data/wicked/vlancfgdev.xml
@@ -1,0 +1,1 @@
+<interface><name>vlancfgdev</name><control><mode>boot</mode><link-detection><require-link></require-link></link-detection></control><ipv4:dhcp><enabled>true</enabled></ipv4:dhcp><vlan><device>eno1001</device><tag>1</tag></vlan></interface>


### PR DESCRIPTION
**Issue number:**
Related to bottlerocket-os/bottlerocket#2449 

**Description of changes:**
*This PR is probably best read in commit order :)*

This is the grand finale, yes, the PR that puts all the pieces together for `systemd-networkd` config generation!

This PR drives the [previously added](https://github.com/bottlerocket-os/bottlerocket/pull/3220) network/netdev config builders via the `systemd-networkd` devices structs to create `systemd-networkd` config files.  

It also adds a new top-level type: `NetworkDConfig`.  This is the main type that gets created from net config; it contains the devices and a map of VLANs.  The devices are created via conversions of the various versions of net config; these conversions are contained in the newly added `conversions.rs`.  `NetworkDConfig` has a method `create_files()` that outputs all of the necessary configuration files for all configured devices.  Under the hood, each of the contained devices is driven to create the appropriate files for the device.  The device structs implement traits depending on their need for `.network` or `.netdev` files.  Inside the trait implementations, the devices drive the builders.

Conditional compilation bits are also tidied up, ensuring wicked stuff isn't included anywhere in builds that don't include it.

To update the diagram from bottlerocket-os/bottlerocket#3220 , this PR implements the left side of the diagram: the conversion of netconfig to `systemd-networkd` devices, and driving the builders to create config.

```
          This PR
 -------------------------------------           MERGED bottlerocket-os/bottlerocket#3220                            MERGED bottlerocket-os/bottlerocket#3134
           NET CONFIG                   -----------------------------------    --------------------
+---------------+                               NETWORKD DEVICES                 NETWORKD CONFIG
|               |
| InterfaceV1   +-----------------+   +-----------------+      Builder
|               |                 |   |                 +----------------+
+---------------+                 +-> |NetworkdInterface|                |
+---------------+                 +-> |                 |                |     +-----------------+
|               |                 |   |                 |                +---> |                 |
| InterfaceV2   +-----------------+   +-----------------+                      |                 |
|               |                                                 +----------> | .network        |
+---------------+                     +-----------------+ Builder |            |                 |
                                      |                 +---------+            |                 |
+---------------+               +---> | NetworkdBond    |              +-----> +-----------------+
|               |               |     |                 +---------+    |
|               +---------------+     |                 | Builder |    |       +-----------------+
| BondV1        |                     +-----------------+         |    |       |                 |
|               |                                                 +----+-----> |                 |
+---------------+                     +-----------------+              |       | .netdev         |
                                      |                 +--------------+       |                 |
+---------------+                     | NetworkdVlan    |                 +->  |                 |
|               |                +--> |                 |   Builder       |    +-----------------+
|               |                |    |                 +-----------------+
| VlanV1        +----------------+    +-----------------+
|               |
+---------------+
```



**Testing done:**
* Build an `aws-k8s-1.24` (with wicked) image to ensure nothing is broken over there: all good
* Boot an `aws-dev` (with systemd-networkd) image configured for early console in `preconfigured.target`, and observe the proper files being generated and network online!
```
bash-5.1# cat /run/systemd/network/10-eth0.network 
[Match]
Name=eth0
[Link]
RequiredForOnline=true
RequiredFamilyForOnline=ipv4
[Network]
DHCP=yes
IPv6AcceptRA=true
[DHCPv4]
UseDNS=true
UseDomains=true
[DHCPv6]
UseDNS=true
UseDomains=true

bash-5.1# networkctl status eth0
● 2: eth0                                                                                                      
                     Link File: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/network/80-release.link
                  Network File: /run/systemd/network/10-eth0.network
                          Type: ether
                         State: routable (configured)
                  Online state: online 
...
```
* Built and booted a `metal-dev` image with the following `net.toml` and observed the box boot, not hang waiting for optional DHCP6, and both interface come up and get DHCP4 addresses.  Found the proper config files in `/run/systemd/network/10-{eno1,eno2}.network`.  I also pulled the network cable from eno1, and observed the box wait for it to become online and `systemd-networkd-wait-online.service` fail, proving the `RequiredForOnline` bit is working.

```
bash-5.1# cat /var/lib/bottlerocket/net.toml
version=3
[eno1]
dhcp4=true
primary=true
[eno2]
dhcp4=true
[eno2.dhcp6]
enabled=true
optional=true

bash-5.1# cat /run/systemd/network/10-eno1.network
[Match]
Name=eno1
[Link]
RequiredForOnline=true
[Network]
DHCP=ipv4
[DHCPv4]
UseDNS=true
UseDomains=true

bash-5.1# cat /run/systemd/network/10-eno2.network
[Match]
Name=eno2
[Link]
RequiredForOnline=true
RequiredFamilyForOnline=ipv4
[Network]
DHCP=yes
[DHCPv4]
UseDNS=true
UseDomains=true
[DHCPv6]
UseDNS=true
UseDomains=true
```
* Using the same metal image, tested that configuration via MAC address (static and DHCP) functions properly.
* Using the same metal image, ensure simple bond configuration works properly with 2 devices.
* Ensure the `/etc/systemd/network` directory gets the proper context:
```
bash-5.1# ls -lahZ /etc/systemd/
...
drwxr-xr-x.  2 root root system_u:object_r:lease_t:s0  60 Aug  3 20:15 network
...
```






**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
