### PR TITLE
update ncurses to 6.4

### DIFF
--- a/packages/libncurses/Cargo.toml
+++ b/packages/libncurses/Cargo.toml
@@ -12,8 +12,8 @@ path = "/dev/null"
 releases-url = "https://invisible-mirror.net/ncurses/announce.html"
 
 [[package.metadata.build-package.external-files]]
-url = "https://invisible-mirror.net/archives/ncurses/ncurses-6.2.tar.gz"
-sha512 = "4c1333dcc30e858e8a9525d4b9aefb60000cfc727bc4a1062bace06ffc4639ad9f6e54f6bdda0e3a0e5ea14de995f96b52b3327d9ec633608792c99a1e8d840d"
+url = "https://invisible-mirror.net/archives/ncurses/ncurses-6.4.tar.gz"
+sha512 = "1c2efff87a82a57e57b0c60023c87bae93f6718114c8f9dc010d4c21119a2f7576d0225dab5f0a227c2cfc6fb6bdbd62728e407f35fce5bf351bb50cf9e0fd34"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libncurses/libncurses.spec
+++ b/packages/libncurses/libncurses.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libncurses
-Version: 6.2
+Version: 6.4
 Release: 1%{?dist}
 Summary: Ncurses libraries
 License: X11

--- a/packages/libncurses/ncurses-config.patch
+++ b/packages/libncurses/ncurses-config.patch
@@ -1,18 +1,18 @@
-diff -up ncurses-6.2-20200222/misc/gen-pkgconfig.in.config ncurses-6.2-20200222/misc/gen-pkgconfig.in
---- ncurses-6.2-20200222/misc/gen-pkgconfig.in.config	2020-02-12 01:09:26.000000000 +0100
-+++ ncurses-6.2-20200222/misc/gen-pkgconfig.in	2020-02-26 15:46:18.899263947 +0100
-@@ -80,7 +80,7 @@ if [ "$includedir" != "/usr/include" ];
+diff -up ncurses-6.3-20221126/misc/gen-pkgconfig.in.config ncurses-6.3-20221126/misc/gen-pkgconfig.in
+--- ncurses-6.3-20221126/misc/gen-pkgconfig.in.config	2022-10-08 18:45:20.000000000 +0200
++++ ncurses-6.3-20221126/misc/gen-pkgconfig.in	2022-11-29 17:04:43.353766420 +0100
+@@ -83,7 +83,7 @@ if [ "$includedir" != "/usr/include" ];
  fi
  
  lib_flags=
--for opt in -L$libdir @LDFLAGS@ @EXTRA_LDFLAGS@ @LIBS@
+-for opt in -L$libdir @EXTRA_PKG_LDFLAGS@ @LIBS@
 +for opt in -L$libdir @LIBS@
  do
  	case $opt in
  	-l*) # LIBS is handled specially below
-diff -up ncurses-6.2-20200222/misc/ncurses-config.in.config ncurses-6.2-20200222/misc/ncurses-config.in
---- ncurses-6.2-20200222/misc/ncurses-config.in.config	2020-02-03 00:34:34.000000000 +0100
-+++ ncurses-6.2-20200222/misc/ncurses-config.in	2020-02-26 15:47:12.827386582 +0100
+diff -up ncurses-6.3-20221126/misc/ncurses-config.in.config ncurses-6.3-20221126/misc/ncurses-config.in
+--- ncurses-6.3-20221126/misc/ncurses-config.in.config	2022-07-26 23:36:28.000000000 +0200
++++ ncurses-6.3-20221126/misc/ncurses-config.in	2022-11-29 17:06:04.381597412 +0100
 @@ -41,7 +41,6 @@ exec_prefix="@exec_prefix@"
  
  bindir="@bindir@"
@@ -22,26 +22,32 @@ diff -up ncurses-6.2-20200222/misc/ncurses-config.in.config ncurses-6.2-20200222
  datadir="@datadir@"
  mandir="@mandir@"
 @@ -101,7 +100,7 @@ fi
- # There is no portable way to find the list of standard library directories. 
+ # There is no portable way to find the list of standard library directories.
  # Require a POSIX shell anyway, to keep this simple.
  lib_flags=
--for opt in -L$libdir @LDFLAGS@ @EXTRA_LDFLAGS@ $LIBS
+-for opt in -L$libdir @EXTRA_PKG_LDFLAGS@ $LIBS
 +for opt in $LIBS
  do
  	case $opt in
  	-specs*) # ignore linker specs-files which were used to build library
-@@ -113,9 +112,6 @@ do
- 	-L*)
- 		[ -d ${opt##-L} ] || continue
- 		case ${opt##-L} in
+@@ -120,13 +119,13 @@ do
+ 		lib_check=`echo "x$opt" | sed -e 's/^.-L//'`
+ 		[ -d "$lib_check" ] || continue
+ 		case "$lib_check" in
 -		@LD_SEARCHPATH@) # skip standard libdir
--			continue
--			;;
- 		*)
- 			found=no
- 			for check in $lib_flags
-@@ -235,7 +231,6 @@ ENDECHO
- 		echo $INCS
++		////) # skip standard libdir (disabled for multilib)
+ 			if [ "$lib_check" = "$libdir" ]
+ 			then
+ 				lib_first=yes
+ 				IFS_save="$IFS"
+ 				IFS='|'
+-				LIBDIRS="@LD_SEARCHPATH@"
++				LIBDIRS=""
+ 				for lib_check in $LIBDIRS
+ 				do
+ 					if [ -d "$lib_check" ]
+@@ -274,7 +273,6 @@ ENDECHO
+ 		echo "$INCS"
  		;;
  	--libdir)
 -		echo "${libdir}"

--- a/packages/libncurses/ncurses-kbs.patch
+++ b/packages/libncurses/ncurses-kbs.patch
@@ -1,42 +1,25 @@
-diff -up ncurses-6.1-20191109/misc/terminfo.src.kbs ncurses-6.1-20191109/misc/terminfo.src
---- ncurses-6.1-20191109/misc/terminfo.src.kbs	2019-11-12 09:23:27.079543254 +0100
-+++ ncurses-6.1-20191109/misc/terminfo.src	2019-11-12 09:24:58.622727887 +0100
-@@ -5952,7 +5952,7 @@ rxvt-basic|rxvt terminal base (X Window
+diff -up ncurses-6.4-20230107/misc/terminfo.src.kbs ncurses-6.4-20230107/misc/terminfo.src
+--- ncurses-6.4-20230107/misc/terminfo.src.kbs	2023-01-09 14:47:05.097093771 +0100
++++ ncurses-6.4-20230107/misc/terminfo.src	2023-01-09 14:47:05.100093766 +0100
+@@ -6711,7 +6711,7 @@ rxvt-basic|rxvt terminal base (X Window
  	enacs=\E(B\E)0, flash=\E[?5h$<100/>\E[?5l, home=\E[H,
  	ht=^I, hts=\EH, ich=\E[%p1%d@, il=\E[%p1%dL, il1=\E[L,
  	ind=\n, is1=\E[?47l\E=\E[?1l,
 -	is2=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;3;4;6l\E[4l, kbs=^H,
 +	is2=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;3;4;6l\E[4l,
  	kcbt=\E[Z, kmous=\E[M, rc=\E8, rev=\E[7m, ri=\EM, rmacs=^O,
- 	rmcup=\E[2J\E[?47l\E8, rmir=\E[4l, rmkx=\E>, rmso=\E[27m,
- 	rmul=\E[24m,
-@@ -5964,7 +5964,7 @@ rxvt-basic|rxvt terminal base (X Window
+ 	rmir=\E[4l, rmkx=\E>, rmso=\E[27m, rmul=\E[24m,
+ 	rs1=\E>\E[1;3;4;5;6l\E[?7h\E[m\E[r\E[2J\E[H,
+@@ -6722,7 +6722,7 @@ rxvt-basic|rxvt terminal base (X Window
  	    %p9%t\016%e\017%;,
- 	sgr0=\E[0m\017, smacs=^N, smcup=\E7\E[?47h, smir=\E[4h,
- 	smkx=\E=, smso=\E[7m, smul=\E[4m, tbc=\E[3g, use=vt100+enq,
--	use=rxvt+pcfkeys, use=vt220+keypad,
-+	use=rxvt+pcfkeys, use=vt220+keypad, use=xterm+kbs,
+ 	sgr0=\E[0m\017, smacs=^N, smir=\E[4h, smkx=\E=, smso=\E[7m,
+ 	smul=\E[4m, tbc=\E[3g, use=xterm+alt47, use=vt100+enq,
+-	use=rxvt+pcfkeys, use=vt220+cvis, use=vt220+keypad,
++	use=rxvt+pcfkeys, use=vt220+cvis, use=vt220+keypad, use=xterm+kbs,
  # Key Codes from rxvt reference:
  #
  # Note: Shift + F1-F10 generates F11-F20
-@@ -7467,7 +7467,7 @@ screen|VT 100/ANSI X3.64 virtual termina
- 	dl=\E[%p1%dM, dl1=\E[M, ed=\E[J, el=\E[K, el1=\E[1K,
- 	enacs=\E(B\E)0, flash=\Eg, home=\E[H, hpa=\E[%i%p1%dG,
- 	ht=^I, hts=\EH, ich=\E[%p1%d@, il=\E[%p1%dL, il1=\E[L,
--	ind=\n, indn=\E[%p1%dS, is2=\E)0, kbs=^H, kcbt=\E[Z,
-+	ind=\n, indn=\E[%p1%dS, is2=\E)0, kcbt=\E[Z,
- 	kcub1=\EOD, kcud1=\EOB, kcuf1=\EOC, kcuu1=\EOA,
- 	kdch1=\E[3~, kend=\E[4~, kf1=\EOP, kf10=\E[21~,
- 	kf11=\E[23~, kf12=\E[24~, kf2=\EOQ, kf3=\EOR, kf4=\EOS,
-@@ -7481,6 +7481,7 @@ screen|VT 100/ANSI X3.64 virtual termina
- 	sgr0=\E[m\017, smacs=^N, smir=\E[4h, smkx=\E[?1h\E=,
- 	smso=\E[3m, smul=\E[4m, tbc=\E[3g, vpa=\E[%i%p1%dd,
- 	E0=\E(B, S0=\E(%p1%c, use=xterm+alt1049, use=ecma+color,
-+	use=xterm+kbs,
- # The bce and status-line entries are from screen 3.9.13 (and require some
- # changes to .screenrc).
- screen-bce|VT 100/ANSI X3.64 virtual terminal with bce,
-@@ -7596,6 +7597,7 @@ screen.xterm-r6|screen customized for X1
+@@ -8523,6 +8523,7 @@ screen.xterm-r6|screen customized for X1
  # on Solaris because Sun's curses implementation gets confused.
  screen.teraterm|disable ncv in teraterm,
  	ncv#127,

--- a/packages/libncurses/ncurses-libs.patch
+++ b/packages/libncurses/ncurses-libs.patch
@@ -1,16 +1,16 @@
-diff -up ncurses-6.0-20150810/c++/Makefile.in.libs ncurses-6.0-20150810/c++/Makefile.in
---- ncurses-6.0-20150810/c++/Makefile.in.libs	2015-08-06 01:15:41.000000000 +0200
-+++ ncurses-6.0-20150810/c++/Makefile.in	2015-08-12 17:07:35.573822650 +0200
-@@ -112,7 +112,7 @@ LOCAL_LIBDIR	= @top_builddir@/lib
- 
- LINK		= @LINK_PROGS@ $(LIBTOOL_LINK) @CXXLDFLAGS@
- SHLIB_DIRS	= -L../lib
--SHLIB_LIST	= $(SHLIB_DIRS) -lform@USE_LIB_SUFFIX@ -lmenu@USE_LIB_SUFFIX@ -lpanel@USE_LIB_SUFFIX@ -lncurses@USE_LIB_SUFFIX@ @SHLIB_LIST@
-+SHLIB_LIST	= $(SHLIB_DIRS) -lform@USE_LIB_SUFFIX@ -lmenu@USE_LIB_SUFFIX@ -lpanel@USE_LIB_SUFFIX@ -lncurses@USE_LIB_SUFFIX@ #@SHLIB_LIST@
+diff -up ncurses-6.2-20210306/c++/Makefile.in.libs ncurses-6.2-20210306/c++/Makefile.in
+--- ncurses-6.2-20210306/c++/Makefile.in.libs	2021-01-23 21:42:08.000000000 +0100
++++ ncurses-6.2-20210306/c++/Makefile.in	2021-03-11 12:02:29.576741101 +0100
+@@ -118,7 +118,7 @@ SHLIB_LIST	= $(SHLIB_DIRS) \
+ 		-l@FORM_NAME@@USE_LIB_SUFFIX@ \
+ 		-l@MENU_NAME@@USE_LIB_SUFFIX@ \
+ 		-l@PANEL_NAME@@USE_LIB_SUFFIX@ \
+-		-lncurses@USE_LIB_SUFFIX@ @SHLIB_LIST@
++		-lncurses@USE_LIB_SUFFIX@ #@SHLIB_LIST@
  
  LIBROOT		= ncurses++
  
-@@ -147,8 +147,7 @@ LDFLAGS_SHARED	= $(TEST_LDFLAGS) $(CFLAG
+@@ -153,8 +153,7 @@ LDFLAGS_SHARED	= $(TEST_LDFLAGS) $(CFLAG
  LDFLAGS_DEFAULT	= $(LINK_@DFT_UPR_MODEL@) $(LDFLAGS_@DFT_UPR_MODEL@)
  
  # flags for library built by this makefile
@@ -20,10 +20,10 @@ diff -up ncurses-6.0-20150810/c++/Makefile.in.libs ncurses-6.0-20150810/c++/Make
  
  AUTO_SRC	= \
  		etip.h
-diff -up ncurses-6.0-20150810/form/Makefile.in.libs ncurses-6.0-20150810/form/Makefile.in
---- ncurses-6.0-20150810/form/Makefile.in.libs	2015-08-12 17:06:49.072684924 +0200
-+++ ncurses-6.0-20150810/form/Makefile.in	2015-08-12 17:08:14.945939259 +0200
-@@ -107,7 +107,7 @@ LINK		= $(LIBTOOL_LINK)
+diff -up ncurses-6.2-20210306/form/Makefile.in.libs ncurses-6.2-20210306/form/Makefile.in
+--- ncurses-6.2-20210306/form/Makefile.in.libs	2021-01-23 21:42:08.000000000 +0100
++++ ncurses-6.2-20210306/form/Makefile.in	2021-03-11 12:00:59.001470707 +0100
+@@ -110,7 +110,7 @@ LINK		= $(LIBTOOL_LINK)
  LDFLAGS		= @LDFLAGS@ @LD_MODEL@ @LIBS@
  
  SHLIB_DIRS	= -L../lib
@@ -32,10 +32,10 @@ diff -up ncurses-6.0-20150810/form/Makefile.in.libs ncurses-6.0-20150810/form/Ma
  
  RPATH_LIST	= @RPATH_LIST@
  RESULTING_SYMS	= @RESULTING_SYMS@
-diff -up ncurses-6.0-20150810/menu/Makefile.in.libs ncurses-6.0-20150810/menu/Makefile.in
---- ncurses-6.0-20150810/menu/Makefile.in.libs	2015-08-12 17:06:49.072684924 +0200
-+++ ncurses-6.0-20150810/menu/Makefile.in	2015-08-12 17:09:10.135102716 +0200
-@@ -107,7 +107,7 @@ LINK		= $(LIBTOOL_LINK)
+diff -up ncurses-6.2-20210306/menu/Makefile.in.libs ncurses-6.2-20210306/menu/Makefile.in
+--- ncurses-6.2-20210306/menu/Makefile.in.libs	2020-08-29 16:50:45.000000000 +0200
++++ ncurses-6.2-20210306/menu/Makefile.in	2021-03-11 12:00:59.002470754 +0100
+@@ -110,7 +110,7 @@ LINK		= $(LIBTOOL_LINK)
  LDFLAGS		= @LDFLAGS@ @LD_MODEL@ @LIBS@
  
  SHLIB_DIRS	= -L../lib
@@ -44,10 +44,10 @@ diff -up ncurses-6.0-20150810/menu/Makefile.in.libs ncurses-6.0-20150810/menu/Ma
  
  RPATH_LIST	= @RPATH_LIST@
  RESULTING_SYMS	= @RESULTING_SYMS@
-diff -up ncurses-6.0-20150810/panel/Makefile.in.libs ncurses-6.0-20150810/panel/Makefile.in
---- ncurses-6.0-20150810/panel/Makefile.in.libs	2015-08-12 17:06:49.072684924 +0200
-+++ ncurses-6.0-20150810/panel/Makefile.in	2015-08-12 17:09:33.324171396 +0200
-@@ -109,7 +109,7 @@ LINK		= $(LIBTOOL_LINK)
+diff -up ncurses-6.2-20210306/panel/Makefile.in.libs ncurses-6.2-20210306/panel/Makefile.in
+--- ncurses-6.2-20210306/panel/Makefile.in.libs	2020-08-29 16:50:45.000000000 +0200
++++ ncurses-6.2-20210306/panel/Makefile.in	2021-03-11 12:00:59.002470754 +0100
+@@ -112,7 +112,7 @@ LINK		= $(LIBTOOL_LINK)
  LDFLAGS		= @LDFLAGS@ @LD_MODEL@ @LIBS@
  
  SHLIB_DIRS	= -L../lib

--- a/packages/procps/Cargo.toml
+++ b/packages/procps/Cargo.toml
@@ -18,4 +18,3 @@ sha512 = "070076cf6bbbd8b6b342af361035f11d9c7381c5d1e2e430a5f2584ff55656254e8f86
 [build-dependencies]
 glibc = { path = "../glibc" }
 libselinux = { path = "../libselinux" }
-libncurses = { path = "../libncurses" }

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -987,7 +987,6 @@ name = "procps"
 version = "0.1.0"
 dependencies = [
  "glibc",
- "libncurses",
  "libselinux",
 ]
 


### PR DESCRIPTION
**Issue number:**

Closes #1813

**Description of changes:**
Update ncurses to 6.4, refreshing the patches from Fedora.


**Testing done:**
Verified that `bash`, `chronyc`, and `more` still work in an `aws-dev` build. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
