### PR TITLE
Add aws-ecs-2 variants

### DIFF
--- a/packages/docker-engine/daemon-json
+++ b/packages/docker-engine/daemon-json
@@ -3,7 +3,6 @@
   "live-restore": true,
   "max-concurrent-downloads": 10,
   "storage-driver": "overlay2",
-  "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "data-root": "/var/lib/docker",
   "default-runtime": "shimpei",
   "runtimes": { "shimpei": { "path": "shimpei" } },

--- a/packages/docker-engine/daemon-nvidia-json
+++ b/packages/docker-engine/daemon-nvidia-json
@@ -3,7 +3,6 @@
   "live-restore": true,
   "max-concurrent-downloads": 10,
   "storage-driver": "overlay2",
-  "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "data-root": "/var/lib/docker",
   "default-runtime": "shimpei",
   "runtimes": { "shimpei": { "path": "shimpei" }, "nvidia": { "path": "nvidia-oci" } },

--- a/sources/logdog/conf/logdog.aws-ecs-2-nvidia.conf
+++ b/sources/logdog/conf/logdog.aws-ecs-2-nvidia.conf
@@ -1,0 +1,1 @@
+logdog.aws-ecs-1.conf

--- a/sources/logdog/conf/logdog.aws-ecs-2.conf
+++ b/sources/logdog/conf/logdog.aws-ecs-2.conf
@@ -1,0 +1,1 @@
+logdog.aws-ecs-1.conf

--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -82,6 +82,11 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-ecs-1-nvidia/mod.rs)
 * [Default settings](src/aws-ecs-1-nvidia/defaults.d/)
 
+### aws-ecs-2: Amazon ECS
+
+* [Model](src/aws-ecs-1/mod.rs)
+* [Default settings](src/aws-ecs-1/defaults.d/)
+
 ### aws-dev: AWS development build
 
 * [Model](src/aws-dev/mod.rs)

--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -87,6 +87,11 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-ecs-1/mod.rs)
 * [Default settings](src/aws-ecs-1/defaults.d/)
 
+### aws-ecs-2-nvidia: Amazon ECS NVIDIA
+
+* [Model](src/aws-ecs-1-nvidia/mod.rs)
+* [Default settings](src/aws-ecs-1-nvidia/defaults.d/)
+
 ### aws-dev: AWS development build
 
 * [Model](src/aws-dev/mod.rs)

--- a/sources/models/README.md
+++ b/sources/models/README.md
@@ -77,6 +77,11 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-ecs-1/mod.rs)
 * [Default settings](src/aws-ecs-1/defaults.d/)
 
+### aws-ecs-1-nvidia: Amazon ECS NVIDIA
+
+* [Model](src/aws-ecs-1-nvidia/mod.rs)
+* [Default settings](src/aws-ecs-1-nvidia/defaults.d/)
+
 ### aws-dev: AWS development build
 
 * [Model](src/aws-dev/mod.rs)

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/10-defaults.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/20-aws-host-containers.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/25-cf-signal.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/30-metrics.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/51-docker-services.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/51-docker-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-services.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/52-aws-ecs-1.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/52-aws-ecs-1.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/ecs.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/53-docker-daemon.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/53-docker-daemon.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-daemon-nvidia.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/54-docker-pki.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/54-docker-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-pki.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/60-lockdown-none.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/60-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-oci-hooks-docker.toml

--- a/sources/models/src/aws-ecs-2-nvidia/defaults.d/80-boot.toml
+++ b/sources/models/src/aws-ecs-2-nvidia/defaults.d/80-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -1,0 +1,33 @@
+use model_derive::model;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
+
+// Note: we have to use 'rename' here because the top-level Settings structure is the only one
+// that uses its name in serialization; internal structures use the field name that points to it
+#[model(rename = "settings", impl_default = true)]
+struct Settings {
+    motd: String,
+    updates: UpdatesSettings,
+    host_containers: HashMap<Identifier, HostContainer>,
+    bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
+    ntp: NtpSettings,
+    network: NetworkSettings,
+    kernel: KernelSettings,
+    boot: BootSettings,
+    aws: AwsSettings,
+    ecs: ECSSettings,
+    metrics: MetricsSettings,
+    pki: HashMap<Identifier, PemCertificate>,
+    container_registry: RegistrySettings,
+    oci_hooks: OciHooks,
+    cloudformation: CloudFormationSettings,
+    autoscaling: AutoScalingSettings,
+    dns: DnsSettings,
+}

--- a/sources/models/src/aws-ecs-2/defaults.d/10-defaults.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/15-aws-tuf.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/20-aws-host-containers.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/25-cf-signal.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/26-aws-autoscaling.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/30-metrics.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/31-send-metrics-aws.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/51-docker-services.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/51-docker-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-services.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/52-aws-ecs-1.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/52-aws-ecs-1.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/ecs.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/53-docker-pki.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/53-docker-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/docker-pki.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/60-lockdown-integrity.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/70-oci-hooks.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/models/src/aws-ecs-2/defaults.d/80-boot.toml
+++ b/sources/models/src/aws-ecs-2/defaults.d/80-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -1,0 +1,33 @@
+use model_derive::model;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::modeled_types::Identifier;
+use crate::{
+    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
+    NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+};
+
+// Note: we have to use 'rename' here because the top-level Settings structure is the only one
+// that uses its name in serialization; internal structures use the field name that points to it
+#[model(rename = "settings", impl_default = true)]
+struct Settings {
+    motd: String,
+    updates: UpdatesSettings,
+    host_containers: HashMap<Identifier, HostContainer>,
+    bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
+    ntp: NtpSettings,
+    network: NetworkSettings,
+    kernel: KernelSettings,
+    boot: BootSettings,
+    aws: AwsSettings,
+    ecs: ECSSettings,
+    metrics: MetricsSettings,
+    pki: HashMap<Identifier, PemCertificate>,
+    container_registry: RegistrySettings,
+    oci_hooks: OciHooks,
+    cloudformation: CloudFormationSettings,
+    autoscaling: AutoScalingSettings,
+    dns: DnsSettings,
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -74,6 +74,11 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-ecs-1/mod.rs)
 * [Default settings](src/aws-ecs-1/defaults.d/)
 
+## aws-ecs-1-nvidia: Amazon ECS NVIDIA
+
+* [Model](src/aws-ecs-1-nvidia/mod.rs)
+* [Default settings](src/aws-ecs-1-nvidia/defaults.d/)
+
 ## aws-dev: AWS development build
 
 * [Model](src/aws-dev/mod.rs)

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -79,6 +79,11 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-ecs-1-nvidia/mod.rs)
 * [Default settings](src/aws-ecs-1-nvidia/defaults.d/)
 
+## aws-ecs-2: Amazon ECS
+
+* [Model](src/aws-ecs-1/mod.rs)
+* [Default settings](src/aws-ecs-1/defaults.d/)
+
 ## aws-dev: AWS development build
 
 * [Model](src/aws-dev/mod.rs)

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -84,6 +84,11 @@ The `#[model]` attribute on Settings and its sub-structs reduces duplication and
 * [Model](src/aws-ecs-1/mod.rs)
 * [Default settings](src/aws-ecs-1/defaults.d/)
 
+## aws-ecs-2-nvidia: Amazon ECS NVIDIA
+
+* [Model](src/aws-ecs-1-nvidia/mod.rs)
+* [Default settings](src/aws-ecs-1-nvidia/defaults.d/)
+
 ## aws-dev: AWS development build
 
 * [Model](src/aws-dev/mod.rs)

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -75,6 +75,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-ecs-2-nvidia"
+version = "0.1.0"
+dependencies = [
+ "docker-cli",
+ "docker-engine",
+ "docker-init",
+ "docker-proxy",
+ "ecs-agent",
+ "ecs-gpu-init",
+ "kernel-6_1",
+ "kmod-6_1-nvidia",
+ "nvidia-container-toolkit",
+ "release",
+]
+
+[[package]]
 name = "aws-iam-authenticator"
 version = "0.1.0"
 dependencies = [
@@ -518,6 +534,14 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "kernel-5_15",
+]
+
+[[package]]
+name = "kmod-6_1-nvidia"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "kernel-6_1",
 ]
 
 [[package]]

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -62,6 +62,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-ecs-2"
+version = "0.1.0"
+dependencies = [
+ "docker-cli",
+ "docker-engine",
+ "docker-init",
+ "docker-proxy",
+ "ecs-agent",
+ "kernel-6_1",
+ "release",
+]
+
+[[package]]
 name = "aws-iam-authenticator"
 version = "0.1.0"
 dependencies = [

--- a/variants/Cargo.toml
+++ b/variants/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "aws-dev",
     "aws-ecs-1",
+    "aws-ecs-2",
     "aws-ecs-1-nvidia",
     "aws-k8s-1.23",
     "aws-k8s-1.23-nvidia",

--- a/variants/Cargo.toml
+++ b/variants/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "aws-ecs-1",
     "aws-ecs-2",
     "aws-ecs-1-nvidia",
+    "aws-ecs-2-nvidia",
     "aws-k8s-1.23",
     "aws-k8s-1.23-nvidia",
     "aws-k8s-1.24",

--- a/variants/README.md
+++ b/variants/README.md
@@ -114,6 +114,11 @@ The [aws-ecs-1-nvidia](aws-ecs-1-nvidia/Cargo.toml) variant includes the package
 container instance in AWS.
 It also includes the required packages to configure containers to leverage NVIDIA GPUs.
 
+### aws-ecs-2: Amazon ECS container instance
+
+The [aws-ecs-2](aws-ecs-2/Cargo.toml) variant includes the packages needed to run an [Amazon ECS](https://ecs.aws)
+container instance in AWS.
+
 ### aws-dev: AWS development build
 
 The [aws-dev](aws-dev/Cargo.toml) variant has useful packages for local development of the OS.

--- a/variants/README.md
+++ b/variants/README.md
@@ -119,6 +119,12 @@ It also includes the required packages to configure containers to leverage NVIDI
 The [aws-ecs-2](aws-ecs-2/Cargo.toml) variant includes the packages needed to run an [Amazon ECS](https://ecs.aws)
 container instance in AWS.
 
+### aws-ecs-2-nvidia: Amazon ECS container instance
+
+The [aws-ecs-2-nvidia](aws-ecs-2-nvidia/Cargo.toml) variant includes the packages needed to run an [Amazon ECS](https://ecs.aws)
+container instance in AWS.
+It also includes the required packages to configure containers to leverage NVIDIA GPUs.
+
 ### aws-dev: AWS development build
 
 The [aws-dev](aws-dev/Cargo.toml) variant has useful packages for local development of the OS.

--- a/variants/aws-ecs-2-nvidia/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "aws-ecs-2-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+uefi-secure-boot = true
+xfs-data-partition = true
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+    "docker-proxy",
+# ecs
+    "ecs-agent",
+# NVIDIA support
+    "ecs-gpu-init",
+    "nvidia-container-toolkit",
+    "kmod-6.1-nvidia-tesla-535",
+]
+
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-6_1 = { path = "../../packages/kernel-6.1" }
+# docker
+docker-cli = { path = "../../packages/docker-cli" }
+docker-engine = { path = "../../packages/docker-engine" }
+docker-init = { path = "../../packages/docker-init" }
+docker-proxy = { path = "../../packages/docker-proxy" }
+# ecs
+ecs-agent = { path = "../../packages/ecs-agent" }
+# NVIDIA
+ecs-gpu-init = { path = "../../packages/ecs-gpu-init" }
+nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+kmod-6_1-nvidia = { path = "../../packages/kmod-6.1-nvidia" }

--- a/variants/aws-ecs-2/Cargo.toml
+++ b/variants/aws-ecs-2/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "aws-ecs-2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+uefi-secure-boot = true
+xfs-data-partition = true
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+    "docker-proxy",
+# ecs
+    "ecs-agent",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-6_1 = { path = "../../packages/kernel-6.1" }
+# docker
+docker-cli = { path = "../../packages/docker-cli" }
+docker-engine = { path = "../../packages/docker-engine" }
+docker-init = { path = "../../packages/docker-init" }
+docker-proxy = { path = "../../packages/docker-proxy" }
+# ecs
+ecs-agent = { path = "../../packages/ecs-agent" }


### PR DESCRIPTION
**Issue number:**

Closes #2164

**Description of changes:**

This adds the `aws-ecs-2` variants family. Features included in these variants include:
- Secure Boot enabled
- Kernel 6.1
- Use XFS for the data partition
- Support for cgroups v2 by default

**Testing done:**
- [X] Internal ECS testing suite ran successfully for `aws-ecs-2`
- [x] Internal ECS testing suite ran successfully for `aws-ecs-2-nvidia`

I confirmed all the mentioned features are enabled:

**`aws-ecs-2`**
```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "24877a20",
    "pretty_name": "Bottlerocket OS 1.15.0 (aws-ecs-2)",
    "variant_id": "aws-ecs-2",
    "version_id": "1.15.0"
  }

### New kernel
bash-5.1# uname -r
6.1.29

### Secure Boot enabled
bash-5.1# journalctl -k | grep Secure
Jul 19 01:13:09 localhost kernel: Secure boot enabled

### cgroupsV2
bash-5.1# stat -fc %T /sys/fs/cgroup/
cgroup2fs

### Boot configs
[ssm-user@control]$ apiclient get settings.boot
{
  "settings": {
    "boot": {
      "init": {
        "systemd.log_level": [
          "info"
        ]
      },
      "kernel": {
        "console": [
          "tty0",
          "ttyS1,115200n8"
        ]
      }
    }
  }
}
[ssm-user@control]$ cat /proc/bootconfig
kernel.console = "tty0", "ttyS1,115200n8"
init.systemd.log_level = "info"


### XFS for data partition
bash-5.1# xfs_spaceman -c info /local
meta-data=/dev/nvme1n1p1         isize=512    agcount=41, agsize=130816 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=0
data     =                       bsize=4096   blocks=5242368, imaxpct=25
         =                       sunit=128    swidth=128 blks
naming   =version 2              bsize=16384  ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=16384, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0

```

**`aws-ecs-2-nvidia`**
```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "24877a20",
    "pretty_name": "Bottlerocket OS 1.15.0 (aws-ecs-2-nvidia)",
    "variant_id": "aws-ecs-2-nvidia",
    "version_id": "1.15.0"
  }
}

### New kernel
bash-5.1# uname -r
6.1.29

### Secure Boot enabled
bash-5.1# journalctl -k | grep Secure
Jul 19 16:38:26 localhost kernel: Secure boot enabled

### cgroupsV2
bash-5.1# stat -fc %T /sys/fs/cgroup/
cgroup2fs

### Boot configs
[ssm-user@control]$ apiclient get settings.boot
{
  "settings": {
    "boot": {
      "init": {
        "systemd.log_level": [
          "info"
        ]
      },
      "kernel": {
        "console": [
          "tty0",
          "ttyS1,115200n8"
        ]
      }
    }
  }
}
[ssm-user@control]$ cat /proc/bootconfig
kernel.console = "tty0", "ttyS1,115200n8"
init.systemd.log_level = "info"


### XFS for data partition
bash-5.1# xfs_spaceman -c info /local
meta-data=/dev/nvme1n1p1         isize=512    agcount=37, agsize=130816 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=0
data     =                       bsize=4096   blocks=4718080, imaxpct=25
         =                       sunit=128    swidth=128 blks
naming   =version 2              bsize=16384  ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=16384, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0

### NVIDIA driver working:
bash-5.1# docker exec 6443448d5e32 nvidia-smi -L
GPU 0: Tesla T4 (UUID: GPU-69f2de54-cb1b-153e-bfdf-81bf722ad6ed)
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
