### PR TITLE
Remove indirect dependencies from tools

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -2507,7 +2507,6 @@ dependencies = [
  "simplelog",
  "snafu",
  "tempfile",
- "toml",
  "url",
 ]
 

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3252,8 +3252,6 @@ dependencies = [
  "bottlerocket-types",
  "bottlerocket-variant",
  "handlebars",
- "home",
- "lazy_static",
  "log",
  "maplit",
  "serde",
@@ -3262,7 +3260,6 @@ dependencies = [
  "snafu",
  "testsys-model",
  "toml",
- "url",
 ]
 
 [[package]]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1794,7 +1794,6 @@ dependencies = [
  "simplelog",
  "snafu",
  "tokio",
- "toml",
  "url",
 ]
 

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -2433,7 +2433,6 @@ dependencies = [
 name = "pubsys"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-ebs",
@@ -2450,7 +2449,6 @@ dependencies = [
  "duct",
  "futures",
  "governor",
- "http",
  "indicatif",
  "lazy_static",
  "log",

--- a/tools/infrasys/Cargo.toml
+++ b/tools/infrasys/Cargo.toml
@@ -23,7 +23,6 @@ shell-words = "1"
 simplelog = "0.12"
 snafu = "0.7"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
-toml = "0.5"
 url = "2"
 
 [dev-dependencies]

--- a/tools/pubsys-setup/Cargo.toml
+++ b/tools/pubsys-setup/Cargo.toml
@@ -17,5 +17,4 @@ shell-words = "1"
 simplelog = "0.12"
 snafu = "0.7"
 tempfile = "3"
-toml = "0.5"
 url = { version = "2", features = ["serde"] }

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
 aws-config = "0.54"
 aws-credential-types = "0.54"
 aws-sdk-ebs = "0.24"
@@ -24,7 +23,6 @@ coldsnap = { version = "0.5", default-features = false, features = ["aws-sdk-rus
 duct = "0.13"
 futures = "0.3"
 governor = "0.5"
-http = "0.2"
 indicatif = "0.17"
 lazy_static = "1"
 log = "0.4"

--- a/tools/testsys-config/Cargo.toml
+++ b/tools/testsys-config/Cargo.toml
@@ -10,8 +10,6 @@ publish = false
 bottlerocket-types = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.8", tag = "v0.0.8"}
 bottlerocket-variant = { version = "0.1", path = "../../sources/bottlerocket-variant" }
 handlebars = "4"
-home = "0.5"
-lazy_static = "1"
 log = "0.4"
 maplit="1"
 testsys-model = { git = "https://github.com/bottlerocket-os/bottlerocket-test-system", version = "0.0.8", tag = "v0.0.8"}
@@ -20,4 +18,3 @@ serde_plain = "1"
 serde_yaml = "0.8"
 snafu = "0.7"
 toml = "0.5"
-url = { version = "2", features = ["serde"] }


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Several tools had indirect dependencies included in their Cargo.toml files. These are pulled in by direct dependencies, so they should not be explicitly included in case those dependencies change and they are no longer needed, or require different versions.

**Testing done:**

Built each tool and verified no compilation errors.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
