### PR TITLE
Fix pubsys publish-ami argument groups

### DIFF
--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -26,6 +26,7 @@ use std::iter::FromIterator;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
+#[group(id = "who", required = true, multiple = true)]
 pub(crate) struct ModifyOptions {
     /// User IDs to give/remove access
     #[arg(long, value_delimiter = ',', group = "who")]
@@ -43,7 +44,7 @@ pub(crate) struct ModifyOptions {
 
 /// Grants or revokes permissions to Bottlerocket AMIs
 #[derive(Debug, ClapArgs)]
-#[group(required = true, multiple = true)]
+#[group(id = "mode", required = true, multiple = false)]
 pub(crate) struct Who {
     /// Path to the JSON file containing regional AMI IDs to modify
     #[arg(long)]


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

With the upgrade to a newer version of the clap library in 91ec2a69baa636ab3a9d7bdf768ca16909fa4d3b, there was an error in translating the new derive settings for ArgGroups. This updates to the correct syntax so the correct arguments are recognized and functional.

**Testing done:**

See testing by Ethan below.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
