### PR TITLE
generate sbkeys scripts: change docker mounts 

### DIFF
--- a/sbkeys/generate-aws-sbkeys
+++ b/sbkeys/generate-aws-sbkeys
@@ -117,11 +117,12 @@ mkdir -p "${OUTPUT_DIR}"
 
 if [ -n "${SDK_IMAGE:-}" ] ; then
   docker run -a stdin -a stdout -a stderr --rm \
+    --network=host \
     --user "$(id -u):$(id -g)" \
     --security-opt label:disable \
-    -v "${OUTPUT_DIR}":/tmp/output \
-    -v "${SBKEYS_SCRIPT}":/tmp/sbkeys \
-    -v "${AWS_KMS_PKCS11_CONF}":/tmp/aws-kms-pkcs11-conf \
+    -v "${OUTPUT_DIR}":"${OUTPUT_DIR}" \
+    -v "${SBKEYS_SCRIPT}":"${SBKEYS_SCRIPT}" \
+    -v "${AWS_KMS_PKCS11_CONF}":"${AWS_KMS_PKCS11_CONF}" \
     ${AWS_ACCESS_KEY_ID:+-e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID} \
     ${AWS_SECRET_ACCESS_KEY:+-e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY} \
     ${AWS_SESSION_TOKEN:+-e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN} \
@@ -134,10 +135,10 @@ if [ -n "${SDK_IMAGE:-}" ] ; then
     -e SHIM_SIGN_KEY="${SHIM_SIGN_KEY}" \
     -e CODE_SIGN_KEY="${CODE_SIGN_KEY}" \
     -e CONFIG_SIGN_KEY="${CONFIG_SIGN_KEY}" \
-    -e AWS_KMS_PKCS11_CONF="/tmp/aws-kms-pkcs11-conf" \
-    -e OUTPUT_DIR="/tmp/output" \
+    -e AWS_KMS_PKCS11_CONF="${AWS_KMS_PKCS11_CONF}" \
+    -e OUTPUT_DIR="${OUTPUT_DIR}" \
     -w /tmp \
-    "${SDK_IMAGE}" bash /tmp/sbkeys
+    "${SDK_IMAGE}" bash "${SBKEYS_SCRIPT}"
 else
   export PK_CA KEK_CA DB_CA VENDOR_CA
   export CODE_SIGN_KEY CONFIG_SIGN_KEY SHIM_SIGN_KEY

--- a/sbkeys/generate-local-sbkeys
+++ b/sbkeys/generate-local-sbkeys
@@ -64,11 +64,10 @@ if [ -n "${SDK_IMAGE:-}" ] ; then
   docker run -a stdin -a stdout -a stderr --rm \
     --user "$(id -u):$(id -g)" \
     --security-opt label:disable \
-    -v "${OUTPUT_DIR}":/tmp/output \
-    -v "${SBKEYS_SCRIPT}":/tmp/sbkeys \
-    -e OUTPUT_DIR="/tmp/output" \
-    -w /tmp \
-    "${SDK_IMAGE}" bash /tmp/sbkeys
+    -v "${OUTPUT_DIR}":"${OUTPUT_DIR}" \
+    -v "${SBKEYS_SCRIPT}":"${SBKEYS_SCRIPT}" \
+    -e OUTPUT_DIR="${OUTPUT_DIR}" \
+    "${SDK_IMAGE}" bash "${SBKEYS_SCRIPT}"
 else
   export OUTPUT_DIR
   bash "${SBKEYS_SCRIPT}"


### PR DESCRIPTION
**Issue number:**

Related to #2669 and [Twoliter #14](https://github.com/bottlerocket-os/twoliter/issues/14)

**Description of changes:**

Because the new Twoliter build tool will execute docker run commands
from within a container that has the host docker socket mounted, it is
necessary for "inner" and "outer" bind mount paths to match.

Additionally, it was found that generate-aws-sbkeys needed
--network=host on at least some systems.

**Testing done:**

`cargo make build-sbkeys` works.

```
cargo make build-sbkeys
$ tree sbkeys
sbkeys
├── generate-aws-sbkeys
├── generate-local-sbkeys
├── local
│   ├── code-sign.crt
│   ├── code-sign.key
│   ├── config-sign.key
│   ├── db.crt
│   ├── db.key
│   ├── efi-vars.aws
│   ├── efi-vars.json
│   ├── KEK.crt
│   ├── KEK.key
│   ├── PK.crt
│   ├── PK.key
│   ├── shim-sign.crt
│   ├── shim-sign.key
│   ├── vendor.crt
│   └── vendor.key
└── README.md
```

I ran:

```
$ ./generate-aws-sbkeys \
  --sdk-image public.ecr.aws/bottlerocket/bottlerocket-sdk-x86_64:v0.33.0 \
  --aws-region us-west-2 \
  --pk-ca arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/aae216e7-e06c-4a3e-b47d-a6954a8bf9bc \
  --kek-ca arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/727a99c4-d5e3-4022-8814-14013150cdd8 \
  --db-ca arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/55e6854a-d705-484a-b645-9b99e510da9b \
  --vendor-ca arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/ae007fb7-d9d2-4205-9811-a809387c2698 \
  --shim-sign-key arn:aws:kms:us-west-2:123456789012:key/mrk-304fc2402af049908b9d370363cf2cb3 \
  --code-sign-key arn:aws:kms:us-west-2:123456789012:key/mrk-9da6264259be415d9e75a8ed423455b7 \
  --config-sign-key arn:aws:kms:us-west-2:123456789012:key/mrk-5e12880d47854da6baa0a7eec1f8eb94 \
  --output-dir ${PWD}/aws-sb-test-3
```

It worked and I got:

```
$ tree sbkeys
sbkeys
├── aws-sb-test-3
│   ├── config-sign.key
│   ├── db.crt
│   ├── efi-vars.aws
│   ├── efi-vars.json
│   ├── KEK.crt
│   ├── kms-sign.json
│   ├── PK.crt
│   └── vendor.crt
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
