### PR TITLE
build: use static files instead of /dev/null

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -77,7 +77,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "http://downloads.sourceforge.net/libwoof/libwoof-1.0.0.tar.xz"

--- a/packages/acpid/Cargo.toml
+++ b/packages/acpid/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://downloads.sourceforge.net/acpid2"

--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.815.0/amazon-ssm-agent-3.2.815.0.tar.gz"

--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"

--- a/packages/bash/Cargo.toml
+++ b/packages/bash/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://ftp.gnu.org/gnu/bash"

--- a/packages/binutils/Cargo.toml
+++ b/packages/binutils/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://mirrors.kernel.org/gnu/binutils/binutils-2.38.tar.xz"

--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://curl.se/docs/caextract.html"

--- a/packages/chrony/Cargo.toml
+++ b/packages/chrony/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://download.tuxfamily.org/chrony"

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/containernetworking/plugins/releases"

--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/containernetworking/cni/releases"

--- a/packages/conntrack-tools/Cargo.toml
+++ b/packages/conntrack-tools/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://www.netfilter.org/projects/conntrack-tools/files"

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/containerd/containerd/releases"

--- a/packages/coreutils/Cargo.toml
+++ b/packages/coreutils/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://ftp.gnu.org/gnu/coreutils"

--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/bus1/dbus-broker/releases/"

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/docker/cli/releases"

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/moby/moby/releases"

--- a/packages/docker-init/Cargo.toml
+++ b/packages/docker-init/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/krallin/tini/releases"

--- a/packages/docker-proxy/Cargo.toml
+++ b/packages/docker-proxy/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/docker/libnetwork/releases"

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs"

--- a/packages/ecr-credential-provider-1.27/Cargo.toml
+++ b/packages/ecr-credential-provider-1.27/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "ecr-credential-provider-1.27"

--- a/packages/ecr-credential-provider/Cargo.toml
+++ b/packages/ecr-credential-provider/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 # ECS agent
 [package.metadata.build-package]

--- a/packages/ecs-gpu-init/Cargo.toml
+++ b/packages/ecs-gpu-init/Cargo.toml
@@ -9,7 +9,7 @@ build = "../build.rs"
 source-groups = [ "ecs-gpu-init" ]
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://kernel.org/pub/software/network/ethtool/"

--- a/packages/filesystem/Cargo.toml
+++ b/packages/filesystem/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"

--- a/packages/findutils/Cargo.toml
+++ b/packages/findutils/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://ftp.gnu.org/pub/gnu/findutils"

--- a/packages/glibc/Cargo.toml
+++ b/packages/glibc/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://ftp.gnu.org/gnu/glibc"

--- a/packages/grep/Cargo.toml
+++ b/packages/grep/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://mirrors.kernel.org/gnu/grep"

--- a/packages/grub/Cargo.toml
+++ b/packages/grub/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://cdn.amazonlinux.com/al2023/blobstore/74f9ee6e75b8f89fe91ccda86896243179968a8664ba045bece11dc5aff61f4e/grub2-2.06-61.amzn2023.0.6.src.rpm"

--- a/packages/host-ctr/Cargo.toml
+++ b/packages/host-ctr/Cargo.toml
@@ -9,7 +9,7 @@ build = "../build.rs"
 source-groups = [ "host-ctr" ]
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/hotdog/Cargo.toml
+++ b/packages/hotdog/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/bottlerocket-os/hotdog/archive/v1.0.6/hotdog-1.0.6.tar.gz"

--- a/packages/iproute/Cargo.toml
+++ b/packages/iproute/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "http://kernel.org/pub/linux/utils/net/iproute2"

--- a/packages/iptables/Cargo.toml
+++ b/packages/iptables/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://www.netfilter.org/projects/iptables/files"

--- a/packages/iputils/Cargo.toml
+++ b/packages/iputils/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/iputils/iputils/releases"

--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -10,7 +10,7 @@ variant-sensitive = "platform"
 package-name = "kernel-5.10"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -10,7 +10,7 @@ variant-sensitive = "platform"
 package-name = "kernel-5.15"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -10,7 +10,7 @@ variant-sensitive = "platform"
 package-name = "kernel-6.1"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.

--- a/packages/kexec-tools/Cargo.toml
+++ b/packages/kexec-tools/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://kernel.org/pub/linux/utils/kernel/kexec"

--- a/packages/keyutils/Cargo.toml
+++ b/packages/keyutils/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://people.redhat.com/~dhowells/keyutils/"

--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kmod-5.10-nvidia"

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kmod-5.15-nvidia"

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kmod-6.1-nvidia"

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod"

--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kubernetes-1.23"

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kubernetes-1.24"

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kubernetes-1.25"

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kubernetes-1.26"

--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 package-name = "kubernetes-1.27"

--- a/packages/libacl/Cargo.toml
+++ b/packages/libacl/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://download-mirror.savannah.gnu.org/releases/acl"

--- a/packages/libattr/Cargo.toml
+++ b/packages/libattr/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://download-mirror.savannah.gnu.org/releases/attr"

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/linux-audit/audit-userspace/releases"

--- a/packages/libbzip2/Cargo.toml
+++ b/packages/libbzip2/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://sourceware.org/pub/bzip2"

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/"

--- a/packages/libdbus/Cargo.toml
+++ b/packages/libdbus/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://dbus.freedesktop.org/releases/dbus"

--- a/packages/libelf/Cargo.toml
+++ b/packages/libelf/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://sourceware.org/elfutils/ftp/"

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/libexpat/libexpat/releases/"

--- a/packages/libffi/Cargo.toml
+++ b/packages/libffi/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/libffi/libffi/releases/"

--- a/packages/libgcc/Cargo.toml
+++ b/packages/libgcc/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://download.gnome.org/sources/glib"

--- a/packages/libinih/Cargo.toml
+++ b/packages/libinih/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/benhoyt/inih/releases"

--- a/packages/libiw/Cargo.toml
+++ b/packages/libiw/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://hewlettpackard.github.io/wireless-tools/Tools.html"

--- a/packages/liblzma/Cargo.toml
+++ b/packages/liblzma/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://tukaani.org/xz"

--- a/packages/libmnl/Cargo.toml
+++ b/packages/libmnl/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "http://netfilter.org/projects/libmnl/files"

--- a/packages/libncurses/Cargo.toml
+++ b/packages/libncurses/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://invisible-mirror.net/ncurses/announce.html"

--- a/packages/libnetfilter_conntrack/Cargo.toml
+++ b/packages/libnetfilter_conntrack/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://netfilter.org/projects/libnetfilter_conntrack/files"

--- a/packages/libnetfilter_cthelper/Cargo.toml
+++ b/packages/libnetfilter_cthelper/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://netfilter.org/projects/libnetfilter_cthelper/files"

--- a/packages/libnetfilter_cttimeout/Cargo.toml
+++ b/packages/libnetfilter_cttimeout/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://netfilter.org/projects/libnetfilter_cttimeout/files"

--- a/packages/libnetfilter_queue/Cargo.toml
+++ b/packages/libnetfilter_queue/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://netfilter.org/projects/libnetfilter_queue/files"

--- a/packages/libnfnetlink/Cargo.toml
+++ b/packages/libnfnetlink/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "http://netfilter.org/projects/libnfnetlink/files"

--- a/packages/libnftnl/Cargo.toml
+++ b/packages/libnftnl/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://netfilter.org/projects/libnftnl/files"

--- a/packages/libnl/Cargo.toml
+++ b/packages/libnl/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/thom311/libnl/releases"

--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"

--- a/packages/libpcre/Cargo.toml
+++ b/packages/libpcre/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/PhilipHazel/pcre2/releases"

--- a/packages/libseccomp/Cargo.toml
+++ b/packages/libseccomp/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/seccomp/libseccomp/releases/"

--- a/packages/libselinux/Cargo.toml
+++ b/packages/libselinux/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/SELinuxProject/selinux/releases/"

--- a/packages/libsemanage/Cargo.toml
+++ b/packages/libsemanage/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/SELinuxProject/selinux/releases/"

--- a/packages/libsepol/Cargo.toml
+++ b/packages/libsepol/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/SELinuxProject/selinux/releases/"

--- a/packages/libstd-rust/Cargo.toml
+++ b/packages/libstd-rust/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"

--- a/packages/libtirpc/Cargo.toml
+++ b/packages/libtirpc/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://sourceforge.net/projects/libtirpc/files/libtirpc/"

--- a/packages/liburcu/Cargo.toml
+++ b/packages/liburcu/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://lttng.org/files/urcu"

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/besser82/libxcrypt/releases"

--- a/packages/libz/Cargo.toml
+++ b/packages/libz/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://www.zlib.net"

--- a/packages/libzstd/Cargo.toml
+++ b/packages/libzstd/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/facebook/zstd/releases"

--- a/packages/log4j2-hotpatch/Cargo.toml
+++ b/packages/log4j2-hotpatch/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/corretto/hotpatch-for-apache-log4j2/archive/1.3.0/1.3.0.tar.gz"

--- a/packages/login/Cargo.toml
+++ b/packages/login/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/makedumpfile/makedumpfile/releases"

--- a/packages/microcode/Cargo.toml
+++ b/packages/microcode/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 # Use latest-srpm-urls.sh to get these.
 

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"

--- a/packages/oci-add-hooks/Cargo.toml
+++ b/packages/oci-add-hooks/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/awslabs/oci-add-hooks/archive/ef29fe312d2e1858d5eb28ab0abe0cbee298a165/oci-add-hooks-ef29fe3.tar.gz"

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/vmware/open-vm-tools/releases/"

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -26,7 +26,7 @@ source-groups = [
 package-features = [ "systemd-networkd" ]
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/packages.rs
+++ b/packages/packages.rs
@@ -1,0 +1,7 @@
+/*!
+
+This is an intentionally empty file that all of the package `Cargo.toml` files can point to as their
+`lib.rs`. The build system uses `build.rs` to invoke `buildsys` but Cargo needs something to compile
+so we give it an empty `lib.rs` file.
+
+!*/

--- a/packages/pigz/Cargo.toml
+++ b/packages/pigz/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://zlib.net/pigz/pigz-2.7.tar.gz"

--- a/packages/policycoreutils/Cargo.toml
+++ b/packages/policycoreutils/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/SELinuxProject/selinux/releases/"

--- a/packages/procps/Cargo.toml
+++ b/packages/procps/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://gitlab.com/procps-ng/procps/-/tags"

--- a/packages/readline/Cargo.toml
+++ b/packages/readline/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://ftp.gnu.org/gnu/readline"

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/opencontainers/runc/releases/"

--- a/packages/selinux-policy/Cargo.toml
+++ b/packages/selinux-policy/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"

--- a/packages/shim/Cargo.toml
+++ b/packages/shim/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/rhboot/shim/archive/15.7/shim-15.7.tar.gz"

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://strace.io/files"

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/systemd/systemd-stable/releases"

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"

--- a/packages/wicked/Cargo.toml
+++ b/packages/wicked/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/openSUSE/wicked/releases"

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 build = "../build.rs"
 
 [lib]
-path = "/dev/null"
+path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/"

--- a/variants/README.md
+++ b/variants/README.md
@@ -369,7 +369,7 @@ data-image-size-gib = 20
 partition-plan = "unified"
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 "my-agent" = { path = "../../packages/my-agent" }

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -40,7 +40,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 # core

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -34,7 +34,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 # core

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -27,7 +27,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 # core

--- a/variants/aws-k8s-1.23-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.23-nvidia/Cargo.toml
@@ -36,7 +36,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.23/Cargo.toml
+++ b/variants/aws-k8s-1.23/Cargo.toml
@@ -30,7 +30,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.24-nvidia/Cargo.toml
@@ -36,7 +36,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.24/Cargo.toml
+++ b/variants/aws-k8s-1.24/Cargo.toml
@@ -30,7 +30,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.25-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.25-nvidia/Cargo.toml
@@ -36,7 +36,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.25/Cargo.toml
+++ b/variants/aws-k8s-1.25/Cargo.toml
@@ -30,7 +30,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.26-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.26-nvidia/Cargo.toml
@@ -37,7 +37,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.26/Cargo.toml
+++ b/variants/aws-k8s-1.26/Cargo.toml
@@ -31,7 +31,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.27-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.27-nvidia/Cargo.toml
@@ -37,7 +37,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/aws-k8s-1.27/Cargo.toml
+++ b/variants/aws-k8s-1.27/Cargo.toml
@@ -31,7 +31,7 @@ kernel-parameters = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -39,7 +39,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 # core

--- a/variants/metal-k8s-1.23/Cargo.toml
+++ b/variants/metal-k8s-1.23/Cargo.toml
@@ -32,7 +32,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/metal-k8s-1.24/Cargo.toml
+++ b/variants/metal-k8s-1.24/Cargo.toml
@@ -32,7 +32,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/metal-k8s-1.25/Cargo.toml
+++ b/variants/metal-k8s-1.25/Cargo.toml
@@ -32,7 +32,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/metal-k8s-1.26/Cargo.toml
+++ b/variants/metal-k8s-1.26/Cargo.toml
@@ -33,7 +33,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/metal-k8s-1.27/Cargo.toml
+++ b/variants/metal-k8s-1.27/Cargo.toml
@@ -33,7 +33,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/variants.rs
+++ b/variants/variants.rs
@@ -1,0 +1,7 @@
+/*!
+
+This is an intentionally empty file that all of the variant `Cargo.toml` files can point to as their
+`lib.rs`. The build system uses `build.rs` to invoke `buildsys` but Cargo needs something to compile
+so we give it an empty `lib.rs` file.
+
+!*/

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -45,7 +45,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 # core

--- a/variants/vmware-k8s-1.23/Cargo.toml
+++ b/variants/vmware-k8s-1.23/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/vmware-k8s-1.24/Cargo.toml
+++ b/variants/vmware-k8s-1.24/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/vmware-k8s-1.25/Cargo.toml
+++ b/variants/vmware-k8s-1.25/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/vmware-k8s-1.26/Cargo.toml
+++ b/variants/vmware-k8s-1.26/Cargo.toml
@@ -37,7 +37,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }

--- a/variants/vmware-k8s-1.27/Cargo.toml
+++ b/variants/vmware-k8s-1.27/Cargo.toml
@@ -37,7 +37,7 @@ included-packages = [
 ]
 
 [lib]
-path = "/dev/null"
+path = "../variants.rs"
 
 [build-dependencies]
 cni = { path = "../../packages/cni" }


### PR DESCRIPTION

**Issue number:**

Related to #2669 and [Twoliter #14](https://github.com/bottlerocket-os/twoliter/issues/14)

**Description of changes:**

An unintended consequence of this `path = "/dev/null"` in the Cargo.toml files of packages and variants is that a change to the device causes a complete rebuild of all of Bottlerocket. So, for example, restarting a machine would cause Bottlerocket to rebuild all packages.

This was an issue in the new Twoliter build system because each time Twoliter is executed, a container is created with a different /dev/null device, triggering a full rebuild.

Though less cool, this commit points all packages at a single packages.rs file and all variants at a variants.rs file to fix this problem.

**Testing done:**

`cargo make` works. It fixes the Twoliter problem.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
