### PR TITLE
[1.14.x] Update Kubernetes to v1-23-eks-27

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "pkg.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/22/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
-sha512 = "437a41e43e87ea0d3f765aa69bfbff5a32c7951349c7d53aaed171393989337742b1fa1c00a01bf18c8a9e689dd4e56b549c555baf44b57bcdb4ef75d79e9b35"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/27/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
+sha512 = "10588a77eca51bc05745d4ec26a01963252ef1c509ebf6d80cc73284d3364fc5b345d978ad888c39acaa228857b9c494dea26c31b654c8be2a74a0f5d2c9155d"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/22/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/27/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Description of changes:**

Update Kubernetes 1.23 to use EKS-D v1.23.17-27.

(cherry picked from commit bd2c9796133f3fd8c64d1ec007c3c02d8ee61e75)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
