### PR TITLE
docker-go: change docker run mounts

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -98,7 +98,8 @@ BUILDSYS_UPSTREAM_LICENSE_FETCH= "false"
 BUILDSYS_JOBS = "8"
 
 CARGO_HOME = "${BUILDSYS_ROOT_DIR}/.cargo"
-GO_MOD_CACHE = "${BUILDSYS_ROOT_DIR}/.gomodcache"
+# This needs to end with pkg/mod so that we can mount the parent of pkg/mod as GOPATH.
+GO_MOD_CACHE = "${BUILDSYS_ROOT_DIR}/.gomodcache/pkg/mod"
 GO_MODULES = "ecs-gpu-init host-ctr"
 DOCKER_BUILDKIT = "1"
 

--- a/tools/docker-go
+++ b/tools/docker-go
@@ -51,6 +51,9 @@ parse_args() {
   required_arg "--command" "${COMMAND}"
 }
 
+# We need to mount the ../.. parent of GO_MOD_CACHE
+GOPATH=$(cd "${GO_MOD_CACHE}/../.." && pwd)
+
 DOCKER_RUN_ARGS="--network=host"
 
 parse_args "${@}"
@@ -78,14 +81,14 @@ done
 
 docker run --rm \
   -e GOCACHE='/tmp/.cache' \
-  -e GOPATH='/tmp/go' \
+  -e GOPATH="${GOPATH}" \
   "${go_env[@]}" \
   "${proxy_env[@]}" \
   --user "$(id -u):$(id -g)" \
   --security-opt label:disable \
   ${DOCKER_RUN_ARGS} \
-  -v "${GO_MOD_CACHE}":/tmp/go/pkg/mod \
-  -v "${GO_MODULE_PATH}":/usr/src/module \
-  -w /usr/src/module \
+  -v "${GOPATH}":"${GOPATH}" \
+  -v "${GO_MODULE_PATH}":"${GO_MODULE_PATH}" \
+  -w "${GO_MODULE_PATH}" \
   "${SDK_IMAGE}" \
     bash -c "${COMMAND}"


### PR DESCRIPTION

**Issue number:**

Closes #3294

**Description of changes:**

Twoliter will be calling this script from within a container that has the host's docker socket mounted. It is necessary to match internal and external paths for any state that we wish to preserve on the host.

Because the data we want to cache is at $GOPATH/pkg/go, it was necessary to create this as a subdirectory under .gomodcache and mount that so that we could point GOPATH to .gomodcache.

**Testing done:**

`cargo make unit-test` works and the cached items are found where expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
