### PR TITLE
Add package linux-firmware and use it on metal-* variants

### DIFF
--- a/packages/linux-firmware/0001-linux-firmware-snd-remove-firmware-for-snd-audio-dev.patch
+++ b/packages/linux-firmware/0001-linux-firmware-snd-remove-firmware-for-snd-audio-dev.patch
@@ -1,0 +1,1979 @@
+From c5e85907233a5ddc7df414744561f0fd848e907f Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Tue, 25 Jul 2023 09:22:51 +0000
+Subject: [PATCH] linux-firmware: snd: remove firmware for snd/audio devices
+
+Bottlerocket does not configure drivers for audio devices for any of its
+kernels. Hence, we do not need to ship firmware for these devices. The
+following list maps the drivers as they are named in WHENCE to the
+kernel config option for reference and easy searchability should we need
+to find the right firmware to add when adding a driver to our kernel
+configuation:
+
+* snd-korg1212 - CONFIG_SND_KORG1212
+* snd-maestro3 - CONFIG_SND_MAESTRO3
+* snd-ymfpci - CONFIG_SND_YMFPCI
+* snd-sb16_csp - CONFIG_SND_SB16_CSP
+* snd-wavefront - CONFIG_SND_WAVEFRONT
+* mtk-sof - CONFIG_SND_SOC_SOF_MTK_TOPLEVEL
+* snd-hda-codex-ca0132 - CONFIG_SND_HDA_INTEL && CONFIG_SND_HDA_CODEC_CA0132
+* snd_soc_sst_acpi - CONFIG_SND_SOC_INTEL_SST_ACPI
+* snd_intel_sst_core - CONFIG_SND_SOC_INTEL_SST
+* snd_soc_catpt - CONFIG_SND_SOC_INTEL_CATPT
+* snd_soc_avs - CONFIG_SND_SOC_INTEL_AVS
+* snd_soc_skl - CONFIG_SND_SOC_INTEL_SKL
+* cs35l41_hda - CONFIG_SND_SOC_C35L41* && SND_HDA_SCODEC_CS35L41*
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.IntcSST2    |  39 --
+ LICENCE.adsp_sst    | 999 --------------------------------------------
+ LICENCE.ca0132      |  47 ---
+ LICENCE.fw_sst_0f28 |  40 --
+ LICENSE.cirrus      | 182 --------
+ WHENCE              | 545 ------------------------
+ 6 files changed, 1852 deletions(-)
+ delete mode 100644 LICENCE.IntcSST2
+ delete mode 100644 LICENCE.adsp_sst
+ delete mode 100644 LICENCE.ca0132
+ delete mode 100644 LICENCE.fw_sst_0f28
+ delete mode 100644 LICENSE.cirrus
+
+diff --git a/LICENCE.IntcSST2 b/LICENCE.IntcSST2
+deleted file mode 100644
+index d4f1609..0000000
+--- a/LICENCE.IntcSST2
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Copyright (c) 2014, Intel Corporation.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-* Neither the name of Intel Corporation nor the names of its suppliers
+-  may be used to endorse or promote products derived from this software
+-  without specific prior written permission.
+-* No reverse engineering, decompilation, or disassembly of this software
+-  is permitted.
+-
+-Limited patent license.  Intel Corporation grants a world-wide,
+-royalty-free, non-exclusive license under patents it now or hereafter
+-owns or controls to make, have made, use, import, offer to sell and
+-sell ("Utilize") this software, but solely to the extent that any
+-such patent is necessary to Utilize the software alone, or in
+-combination with an operating system licensed under an approved Open
+-Source license as listed by the Open Source Initiative at
+-http://opensource.org/licenses.  The patent license shall not apply to
+-any other combinations which include this software.  No hardware per
+-se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+diff --git a/LICENCE.adsp_sst b/LICENCE.adsp_sst
+deleted file mode 100644
+index c66b1b2..0000000
+--- a/LICENCE.adsp_sst
++++ /dev/null
+@@ -1,999 +0,0 @@
+-***** INTEL BINARY FIRMWARE RELEASE LICENCE ********************************
+-
+-Copyright (c) 2014-15 Intel Corporation.
+-All rights reserved.
+-
+-Redistribution.
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met:
+-*    Redistributions must reproduce the above copyright notice and the
+-     following disclaimer in the documentation and/or other materials provided
+-     with the distribution.
+-*    Neither the name of Intel Corporation nor the names of its suppliers may
+-     be used to endorse or promote products derived from this software without
+-     specific prior written permission.
+-*    No reverse engineering, decompilation, or disassembly of this software is
+-     permitted.
+-
+-
+-Limited patent license.
+-
+-Intel Corporation grants a world-wide, royalty-free, non-exclusive license
+-under patents it now or hereafter owns or controls to make, have made, use,
+-import, offer to sell and sell ("Utilize") this software, but solely to the
+-extent that any such patent is necessary to Utilize the software alone. The
+-patent license shall not apply to any combinations which include this software.
+-No hardware per se is licensed hereunder.
+-
+-
+-DISCLAIMER.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGE.
+-
+-
+-***** NEW LIBC LICENCE********************************
+-
+-The newlib subdirectory is a collection of software from several sources.
+-
+-Each file may have its own copyright/license that is embedded in the source 
+-file.  Unless otherwise noted in the body of the source file(s), the following copyright
+-notices will apply to the contents of the newlib subdirectory:
+-
+-(1) Red Hat Incorporated
+-
+-Copyright (c) 1994-2009  Red Hat, Inc. All rights reserved.
+-
+-This copyrighted material is made available to anyone wishing to use,
+-modify, copy, or redistribute it subject to the terms and conditions
+-of the BSD License.   This program is distributed in the hope that 
+-it will be useful, but WITHOUT ANY WARRANTY expressed or implied, 
+-including the implied warranties of MERCHANTABILITY or FITNESS FOR 
+-A PARTICULAR PURPOSE.  A copy of this license is available at 
+-http://www.opensource.org/licenses. Any Red Hat trademarks that are
+-incorporated in the source code or documentation are not subject to
+-the BSD License and may only be used or replicated with the express
+-permission of Red Hat, Inc.
+-
+-(2) University of California, Berkeley
+-
+-Copyright (c) 1981-2000 The Regents of the University of California.
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without modification,
+-are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice, 
+-      this list of conditions and the following disclaimer.
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-      this list of conditions and the following disclaimer in the documentation
+-      and/or other materials provided with the distribution.
+-    * Neither the name of the University nor the names of its contributors 
+-      may be used to endorse or promote products derived from this software 
+-      without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+-IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+-OF SUCH DAMAGE.
+-
+-(3) David M. Gay (AT&T 1991, Lucent 1998)
+-
+-The author of this software is David M. Gay.
+-
+-Copyright (c) 1991 by AT&T.
+-
+-Permission to use, copy, modify, and distribute this software for any
+-purpose without fee is hereby granted, provided that this entire notice
+-is included in all copies of any software which is or includes a copy
+-or modification of this software and in all copies of the supporting
+-documentation for such software.
+-
+-THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+-WARRANTY.  IN PARTICULAR, NEITHER THE AUTHOR NOR AT&T MAKES ANY
+-REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
+-OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+-
+--------------------------------------------------------------------
+-
+-The author of this software is David M. Gay.
+-
+-Copyright (C) 1998-2001 by Lucent Technologies
+-All Rights Reserved
+-
+-Permission to use, copy, modify, and distribute this software and
+-its documentation for any purpose and without fee is hereby
+-granted, provided that the above copyright notice appear in all
+-copies and that both that the copyright notice and this
+-permission notice and warranty disclaimer appear in supporting
+-documentation, and that the name of Lucent or any of its entities
+-not be used in advertising or publicity pertaining to
+-distribution of the software without specific, written prior
+-permission.
+-
+-LUCENT DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+-INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.
+-IN NO EVENT SHALL LUCENT OR ANY OF ITS ENTITIES BE LIABLE FOR ANY
+-SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+-IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+-ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+-THIS SOFTWARE.
+-
+-
+-(4) Advanced Micro Devices
+-
+-Copyright 1989, 1990 Advanced Micro Devices, Inc.
+-
+-This software is the property of Advanced Micro Devices, Inc  (AMD)  which
+-specifically  grants the user the right to modify, use and distribute this
+-software provided this notice is not removed or altered.  All other rights
+-are reserved by AMD.
+-
+-AMD MAKES NO WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, WITH REGARD TO THIS
+-SOFTWARE.  IN NO EVENT SHALL AMD BE LIABLE FOR INCIDENTAL OR CONSEQUENTIAL
+-DAMAGES IN CONNECTION WITH OR ARISING FROM THE FURNISHING, PERFORMANCE, OR
+-USE OF THIS SOFTWARE.
+-
+-So that all may benefit from your experience, please report  any  problems
+-or  suggestions about this software to the 29K Technical Support Center at
+-800-29-29-AMD (800-292-9263) in the USA, or 0800-89-1131  in  the  UK,  or
+-0031-11-1129 in Japan, toll free.  The direct dial number is 512-462-4118.
+-
+-Advanced Micro Devices, Inc.
+-29K Support Products
+-Mail Stop 573
+-5900 E. Ben White Blvd.
+-Austin, TX 78741
+-800-292-9263
+-
+-(5) 
+-
+-(6)
+-
+-(7) Sun Microsystems
+-
+-Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+-
+-Developed at SunPro, a Sun Microsystems, Inc. business.
+-Permission to use, copy, modify, and distribute this
+-software is freely granted, provided that this notice is preserved.
+-
+-(8) Hewlett Packard
+-
+-(c) Copyright 1986 HEWLETT-PACKARD COMPANY
+-
+-To anyone who acknowledges that this file is provided "AS IS"
+-without any express or implied warranty:
+-    permission to use, copy, modify, and distribute this file
+-for any purpose is hereby granted without fee, provided that
+-the above copyright notice and this notice appears in all
+-copies, and that the name of Hewlett-Packard Company not be
+-used in advertising or publicity pertaining to distribution
+-of the software without specific, written prior permission.
+-Hewlett-Packard Company makes no representations about the
+-suitability of this software for any purpose.
+-
+-(9) Hans-Peter Nilsson
+-
+-Copyright (C) 2001 Hans-Peter Nilsson
+-
+-Permission to use, copy, modify, and distribute this software is
+-freely granted, provided that the above copyright notice, this notice
+-and the following disclaimer are preserved with no changes.
+-
+-THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+-PURPOSE.
+-
+-(10) Stephane Carrez (m68hc11-elf/m68hc12-elf targets only)
+-
+-Copyright (C) 1999, 2000, 2001, 2002 Stephane Carrez (stcarrez@nerim.fr)
+-
+-The authors hereby grant permission to use, copy, modify, distribute,
+-and license this software and its documentation for any purpose, provided
+-that existing copyright notices are retained in all copies and that this
+-notice is included verbatim in any distributions. No written agreement,
+-license, or royalty fee is required for any of the authorized uses.
+-Modifications to this software may be copyrighted by their authors
+-and need not follow the licensing terms described here, provided that
+-the new terms are clearly indicated on the first page of each file where
+-they apply.
+-
+-(11) Christopher G. Demetriou
+-
+-Copyright (c) 2001 Christopher G. Demetriou
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-3. The name of the author may not be used to endorse or promote products
+-   derived from this software without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+-IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-(12) SuperH, Inc.
+-
+-Copyright 2002 SuperH, Inc. All rights reserved
+-
+-This software is the property of SuperH, Inc (SuperH) which specifically
+-grants the user the right to modify, use and distribute this software
+-provided this notice is not removed or altered.  All other rights are
+-reserved by SuperH.
+-
+-SUPERH MAKES NO WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, WITH REGARD TO
+-THIS SOFTWARE.  IN NO EVENT SHALL SUPERH BE LIABLE FOR INDIRECT, SPECIAL,
+-INCIDENTAL OR CONSEQUENTIAL DAMAGES IN CONNECTION WITH OR ARISING FROM
+-THE FURNISHING, PERFORMANCE, OR USE OF THIS SOFTWARE.
+-
+-So that all may benefit from your experience, please report any problems
+-or suggestions about this software to the SuperH Support Center via
+-e-mail at softwaresupport@superh.com .
+-
+-SuperH, Inc.
+-405 River Oaks Parkway
+-San Jose
+-CA 95134
+-USA
+-
+-(13) Royal Institute of Technology
+-
+-Copyright (c) 1999 Kungliga Tekniska Högskolan
+-(Royal Institute of Technology, Stockholm, Sweden).
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-3. Neither the name of KTH nor the names of its contributors may be
+-   used to endorse or promote products derived from this software without
+-   specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY KTH AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+-PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL KTH OR ITS CONTRIBUTORS BE
+-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+-OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-(14) Alexey Zelkin
+-
+-Copyright (c) 2000, 2001 Alexey Zelkin <phantom@FreeBSD.org>
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+-(15) Andrey A. Chernov
+-
+-Copyright (C) 1997 by Andrey A. Chernov, Moscow, Russia.
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+-(16) FreeBSD
+-
+-Copyright (c) 1997-2002 FreeBSD Project.
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+-(17) S. L. Moshier
+-
+-Author:  S. L. Moshier.
+-
+-Copyright (c) 1984,2000 S.L. Moshier
+-
+-Permission to use, copy, modify, and distribute this software for any
+-purpose without fee is hereby granted, provided that this entire notice
+-is included in all copies of any software which is or includes a copy
+-or modification of this software and in all copies of the supporting
+-documentation for such software.
+-
+-THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+-WARRANTY.  IN PARTICULAR,  THE AUTHOR MAKES NO REPRESENTATION
+-OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY OF THIS
+-SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+-
+-(18) Citrus Project
+-
+-Copyright (c)1999 Citrus Project,
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+-(19) Todd C. Miller
+-
+-Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-3. The name of the author may not be used to endorse or promote products
+-   derived from this software without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+-THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+-OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+-OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-(20) DJ Delorie (i386)
+-Copyright (C) 1991 DJ Delorie
+-All rights reserved.
+-
+-Redistribution, modification, and use in source and binary forms is permitted
+-provided that the above copyright notice and following paragraph are
+-duplicated in all such forms.
+-
+-This file is distributed WITHOUT ANY WARRANTY; without even the implied
+-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+-(21) Free Software Foundation LGPL License (*-linux* targets only)
+-
+-   Copyright (C) 1990-1999, 2000, 2001    Free Software Foundation, Inc.
+-   This file is part of the GNU C Library.
+-   Contributed by Mark Kettenis <kettenis@phys.uva.nl>, 1997.
+-
+-   The GNU C Library is free software; you can redistribute it and/or
+-   modify it under the terms of the GNU Lesser General Public
+-   License as published by the Free Software Foundation; either
+-   version 2.1 of the License, or (at your option) any later version.
+-
+-   The GNU C Library is distributed in the hope that it will be useful,
+-   but WITHOUT ANY WARRANTY; without even the implied warranty of
+-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-   Lesser General Public License for more details.
+-
+-   You should have received a copy of the GNU Lesser General Public
+-   License along with the GNU C Library; if not, write to the Free
+-   Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+-   02110-1301 USA.
+-
+-(22) Xavier Leroy LGPL License (i[3456]86-*-linux* targets only)
+-
+-Copyright (C) 1996 Xavier Leroy (Xavier.Leroy@inria.fr)
+-
+-This program is free software; you can redistribute it and/or
+-modify it under the terms of the GNU Library General Public License
+-as published by the Free Software Foundation; either version 2
+-of the License, or (at your option) any later version.
+-
+-This program is distributed in the hope that it will be useful,
+-but WITHOUT ANY WARRANTY; without even the implied warranty of
+-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-GNU Library General Public License for more details.
+-
+-(23) Intel (i960)
+-
+-Copyright (c) 1993 Intel Corporation
+-
+-Intel hereby grants you permission to copy, modify, and distribute this
+-software and its documentation.  Intel grants this permission provided
+-that the above copyright notice appears in all copies and that both the
+-copyright notice and this permission notice appear in supporting
+-documentation.  In addition, Intel grants this permission provided that
+-you prominently mark as "not part of the original" any modifications
+-made to this software or documentation, and that the name of Intel
+-Corporation not be used in advertising or publicity pertaining to
+-distribution of the software or the documentation without specific,
+-written prior permission.
+-
+-Intel Corporation provides this AS IS, WITHOUT ANY WARRANTY, EXPRESS OR
+-IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTY OF MERCHANTABILITY
+-OR FITNESS FOR A PARTICULAR PURPOSE.  Intel makes no guarantee or
+-representations regarding the use of, or the results of the use of,
+-the software and documentation in terms of correctness, accuracy,
+-reliability, currentness, or otherwise; and you rely on the software,
+-documentation and results solely at your own risk.
+-
+-IN NO EVENT SHALL INTEL BE LIABLE FOR ANY LOSS OF USE, LOSS OF BUSINESS,
+-LOSS OF PROFITS, INDIRECT, INCIDENTAL, SPECIAL OR CONSEQUENTIAL DAMAGES
+-OF ANY KIND.  IN NO EVENT SHALL INTEL'S TOTAL LIABILITY EXCEED THE SUM
+-PAID TO INTEL FOR THE PRODUCT LICENSED HEREUNDER.
+-
+-(24) Hewlett-Packard  (hppa targets only)
+-
+-(c) Copyright 1986 HEWLETT-PACKARD COMPANY
+-
+-To anyone who acknowledges that this file is provided "AS IS"
+-without any express or implied warranty:
+-    permission to use, copy, modify, and distribute this file
+-for any purpose is hereby granted without fee, provided that
+-the above copyright notice and this notice appears in all
+-copies, and that the name of Hewlett-Packard Company not be
+-used in advertising or publicity pertaining to distribution
+-of the software without specific, written prior permission.
+-Hewlett-Packard Company makes no representations about the
+-suitability of this software for any purpose.
+-
+-(25) Henry Spencer (only *-linux targets)
+-
+-Copyright 1992, 1993, 1994 Henry Spencer.  All rights reserved.
+-This software is not subject to any license of the American Telephone
+-and Telegraph Company or of the Regents of the University of California.
+-
+-Permission is granted to anyone to use this software for any purpose on
+-any computer system, and to alter it and redistribute it, subject
+-to the following restrictions:
+-
+-1. The author is not responsible for the consequences of use of this
+-   software, no matter how awful, even if they arise from flaws in it.
+-
+-2. The origin of this software must not be misrepresented, either by
+-   explicit claim or by omission.  Since few users ever read sources,
+-   credits must appear in the documentation.
+-
+-3. Altered versions must be plainly marked as such, and must not be
+-   misrepresented as being the original software.  Since few users
+-   ever read sources, credits must appear in the documentation.
+-
+-4. This notice may not be removed or altered.
+-
+-(26) Mike Barcroft
+-
+-Copyright (c) 2001 Mike Barcroft <mike@FreeBSD.org>
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+-(27) Konstantin Chuguev (--enable-newlib-iconv)
+-
+-Copyright (c) 1999, 2000
+-   Konstantin Chuguev.  All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+-   iconv (Charset Conversion Library) v2.0
+-
+-(28) Artem Bityuckiy (--enable-newlib-iconv)
+-
+-Copyright (c) 2003, Artem B. Bityuckiy, SoftMine Corporation.
+-Rights transferred to Franklin Electronic Publishers.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+-(29) IBM, Sony, Toshiba (only spu-* targets)
+-
+-  (C) Copyright 2001,2006,
+-  International Business Machines Corporation,
+-  Sony Computer Entertainment, Incorporated,
+-  Toshiba Corporation,
+-
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without
+-  modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-      this list of conditions and the following disclaimer.
+-    * Redistributions in binary form must reproduce the above copyright
+-      notice, this list of conditions and the following disclaimer in the
+-      documentation and/or other materials provided with the distribution.
+-    * Neither the names of the copyright holders nor the names of their
+-      contributors may be used to endorse or promote products derived from this
+-      software without specific prior written permission.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-  POSSIBILITY OF SUCH DAMAGE.
+-
+-(30) - Alex Tatmanjants (targets using libc/posix)
+-
+-  Copyright (c) 1995 Alex Tatmanjants <alex@elvisti.kiev.ua>
+- 		at Electronni Visti IA, Kiev, Ukraine.
+- 			All rights reserved.
+- 
+-  Redistribution and use in source and binary forms, with or without
+-  modification, are permitted provided that the following conditions
+-  are met:
+-  1. Redistributions of source code must retain the above copyright
+-     notice, this list of conditions and the following disclaimer.
+-  2. Redistributions in binary form must reproduce the above copyright
+-     notice, this list of conditions and the following disclaimer in the
+-     documentation and/or other materials provided with the distribution.
+- 
+-  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND
+-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE
+-  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-  SUCH DAMAGE.
+-
+-(31) - M. Warner Losh (targets using libc/posix)
+-
+-  Copyright (c) 1998, M. Warner Losh <imp@freebsd.org>
+-  All rights reserved.
+- 
+-  Redistribution and use in source and binary forms, with or without
+-  modification, are permitted provided that the following conditions
+-  are met:
+-  1. Redistributions of source code must retain the above copyright
+-     notice, this list of conditions and the following disclaimer.
+-  2. Redistributions in binary form must reproduce the above copyright
+-     notice, this list of conditions and the following disclaimer in the
+-     documentation and/or other materials provided with the distribution.
+- 
+-  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-  SUCH DAMAGE.
+-
+-(32) - Andrey A. Chernov (targets using libc/posix)
+-
+-  Copyright (C) 1996 by Andrey A. Chernov, Moscow, Russia.
+-  All rights reserved.
+- 
+-  Redistribution and use in source and binary forms, with or without
+-  modification, are permitted provided that the following conditions
+-  are met:
+-  1. Redistributions of source code must retain the above copyright
+-     notice, this list of conditions and the following disclaimer.
+-  2. Redistributions in binary form must reproduce the above copyright
+-     notice, this list of conditions and the following disclaimer in the
+-     documentation and/or other materials provided with the distribution.
+- 
+-  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND
+-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-  ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+-  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-  SUCH DAMAGE.
+-
+-(33) - Daniel Eischen (targets using libc/posix)
+-
+-  Copyright (c) 2001 Daniel Eischen <deischen@FreeBSD.org>.
+-  All rights reserved.
+- 
+-  Redistribution and use in source and binary forms, with or without
+-  modification, are permitted provided that the following conditions
+-  are met:
+-  1. Redistributions of source code must retain the above copyright
+-     notice, this list of conditions and the following disclaimer.
+-  2. Redistributions in binary form must reproduce the above copyright
+-     notice, this list of conditions and the following disclaimer in the
+-     documentation and/or other materials provided with the distribution.
+- 
+-  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-  ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+-  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-  SUCH DAMAGE.
+-
+-
+-(34) - Jon Beniston (only lm32-* targets)
+-
+- Contributed by Jon Beniston <jon@beniston.com>
+-
+- Redistribution and use in source and binary forms, with or without
+- modification, are permitted provided that the following conditions
+- are met:
+- 1. Redistributions of source code must retain the above copyright
+- notice, this list of conditions and the following disclaimer.
+- 2. Redistributions in binary form must reproduce the above copyright
+- notice, this list of conditions and the following disclaimer in the
+- documentation and/or other materials provided with the distribution.
+-
+- THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+- ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+- OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+- HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+- LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+- OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+- SUCH DAMAGE.
+-
+-
+-(35) - ARM Ltd (arm and thumb variant targets only)
+-
+- Copyright (c) 2009 ARM Ltd
+- All rights reserved.
+- 
+- Redistribution and use in source and binary forms, with or without
+- modification, are permitted provided that the following conditions
+- are met:
+- 1. Redistributions of source code must retain the above copyright
+-    notice, this list of conditions and the following disclaimer.
+- 2. Redistributions in binary form must reproduce the above copyright
+-    notice, this list of conditions and the following disclaimer in the
+-    documentation and/or other materials provided with the distribution.
+- 3. The name of the company may not be used to endorse or promote
+-    products derived from this software without specific prior written
+-    permission.
+-
+- THIS SOFTWARE IS PROVIDED BY ARM LTD ``AS IS'' AND ANY EXPRESS OR IMPLIED
+- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+- IN NO EVENT SHALL ARM LTD BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+- TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+- PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+- NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-(36) - Xilinx, Inc. (microblaze-* and powerpc-* targets)
+-
+-Copyright (c) 2004, 2009 Xilinx, Inc.  All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-1.  Redistributions source code must retain the above copyright notice,
+-this list of conditions and the following disclaimer.
+-
+-2.  Redistributions in binary form must reproduce the above copyright
+-notice, this list of conditions and the following disclaimer in the
+-documentation and/or other materials provided with the distribution.
+-
+-3.  Neither the name of Xilinx nor the names of its contributors may be
+-used to endorse or promote products derived from this software without
+-specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-
+-(37) Texas Instruments Incorporated (tic6x-*, *-tirtos targets)
+-
+-Copyright (c) 1996-2010,2014 Texas Instruments Incorporated
+-http://www.ti.com/
+-
+- Redistribution and  use in source  and binary forms, with  or without
+- modification,  are permitted provided  that the  following conditions
+- are met:
+-
+-    Redistributions  of source  code must  retain the  above copyright
+-    notice, this list of conditions and the following disclaimer.
+-
+-    Redistributions in binary form  must reproduce the above copyright
+-    notice, this  list of conditions  and the following  disclaimer in
+-    the  documentation  and/or   other  materials  provided  with  the
+-    distribution.
+-
+-    Neither the  name of Texas Instruments Incorporated  nor the names
+-    of its  contributors may  be used to  endorse or  promote products
+-    derived  from   this  software  without   specific  prior  written
+-    permission.
+-
+- THIS SOFTWARE  IS PROVIDED BY THE COPYRIGHT  HOLDERS AND CONTRIBUTORS
+- "AS IS"  AND ANY  EXPRESS OR IMPLIED  WARRANTIES, INCLUDING,  BUT NOT
+- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+- A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+- SPECIAL,  EXEMPLARY,  OR CONSEQUENTIAL  DAMAGES  (INCLUDING, BUT  NOT
+- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+- THEORY OF  LIABILITY, WHETHER IN CONTRACT, STRICT  LIABILITY, OR TORT
+- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-(38) National Semiconductor (cr16-* and crx-* targets)
+-
+-Copyright (c) 2004 National Semiconductor Corporation
+-
+-The authors hereby grant permission to use, copy, modify, distribute,
+-and license this software and its documentation for any purpose, provided
+-that existing copyright notices are retained in all copies and that this
+-notice is included verbatim in any distributions. No written agreement,
+-license, or royalty fee is required for any of the authorized uses.
+-Modifications to this software may be copyrighted by their authors
+-and need not follow the licensing terms described here, provided that
+-the new terms are clearly indicated on the first page of each file where
+-they apply. 
+-
+-(39) - Adapteva, Inc. (epiphany-* targets)
+-
+-Copyright (c) 2011, Adapteva, Inc.
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+- * Redistributions of source code must retain the above copyright notice, this
+-   list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright notice,
+-   this list of conditions and the following disclaimer in the documentation
+-   and/or other materials provided with the distribution.
+- * Neither the name of Adapteva nor the names of its contributors may be used
+-   to endorse or promote products derived from this software without specific
+-   prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-(40) - Altera Corportion (nios2-* targets)
+-
+-Copyright (c) 2003 Altera Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-
+-   o Redistributions of source code must retain the above copyright
+-     notice, this list of conditions and the following disclaimer. 
+-   o Redistributions in binary form must reproduce the above copyright
+-     notice, this list of conditions and the following disclaimer in the 
+-     documentation and/or other materials provided with the distribution. 
+-   o Neither the name of Altera Corporation nor the names of its 
+-     contributors may be used to endorse or promote products derived from
+-     this software without specific prior written permission. 
+- 
+-THIS SOFTWARE IS PROVIDED BY ALTERA CORPORATION, THE COPYRIGHT HOLDER,
+-AND ITS CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-(41) Ed Schouten - Free BSD
+-
+-Copyright (c) 2008 Ed Schouten <ed@FreeBSD.org>
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-
+diff --git a/LICENCE.ca0132 b/LICENCE.ca0132
+deleted file mode 100644
+index 411750a..0000000
+--- a/LICENCE.ca0132
++++ /dev/null
+@@ -1,47 +0,0 @@
+-Copyright (c) 2012, Creative Technology Ltd
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-* Neither the name of Creative Technology Ltd or its affiliates ("CTL")
+-  nor the names of its suppliers may be used to endorse or promote
+-  products derived from this software without specific prior written
+-  permission.
+-* No reverse engineering, decompilation, or disassembly of this software
+-  (or any part thereof) is permitted.
+-
+-Limited patent license. CTL grants a limited, world-wide,
+-royalty-free, non-exclusive license under patents it now or hereafter
+-owns or controls to make, have made, use, import, offer to sell and
+-sell ("Utilize") this software, but strictly only to the extent that any
+-such patent is necessary to Utilize the software alone, or in
+-combination with an operating system licensed under an approved Open
+-Source license as listed by the Open Source Initiative at
+-http://opensource.org/licenses.  The patent license shall not be
+-applicable, to any other combinations which include this software.
+-No hardware per se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+-
+-NO OTHER RIGHTS GRANTED. USER HEREBY ACKNOWLEDGES AND AGREES THAT USE OF
+-THIS SOFTWARE SHALL NOT CREATE OR GIVE GROUNDS FOR A LICENSE BY
+-IMPLICATION, ESTOPPEL, OR OTHERWISE TO ANY INTELLECTUAL PROPERTY RIGHTS
+-(PATENT, COPYRIGHT, TRADE SECRET, MASK WORK, OR OTHER PROPRIETARY RIGHT)
+-EMBODIED IN ANY OTHER CTL HARDWARE OR SOFTWARE WHETHER SOLELY OR IN
+-COMBINATION WITH THIS SOFTWARE.
+diff --git a/LICENCE.fw_sst_0f28 b/LICENCE.fw_sst_0f28
+deleted file mode 100644
+index 247e35f..0000000
+--- a/LICENCE.fw_sst_0f28
++++ /dev/null
+@@ -1,40 +0,0 @@
+-Copyright (c) 2014 Intel Corporation.
+-All rights reserved.
+-
+-Redistribution.
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met:
+-*    Redistributions must reproduce the above copyright notice and the
+-     following disclaimer in the documentation and/or other materials provided
+-     with the distribution.
+-*    Neither the name of Intel Corporation nor the names of its suppliers may
+-     be used to endorse or promote products derived from this software without
+-     specific prior written permission.
+-*    No reverse engineering, decompilation, or disassembly of this software is
+-     permitted.
+-
+-
+-Limited patent license.
+-
+-Intel Corporation grants a world-wide, royalty-free, non-exclusive license
+-under patents it now or hereafter owns or controls to make, have made, use,
+-import, offer to sell and sell ("Utilize") this software, but solely to the
+-extent that any such patent is necessary to Utilize the software alone. The
+-patent license shall not apply to any combinations which include this software.
+-No hardware per se is licensed hereunder.
+-
+-
+-DISCLAIMER.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.cirrus b/LICENSE.cirrus
+deleted file mode 100644
+index c9d7c22..0000000
+--- a/LICENSE.cirrus
++++ /dev/null
+@@ -1,182 +0,0 @@
+-Use, distribution, or reproduction of this CIRRUS LOGIC software is governed by
+-the terms of this Agreement.   Any use, distribution or reproduction of this
+-CIRRUS LOGIC software constitutes your acceptance of the following terms and
+-conditions.
+-
+-1.	DEFINED TERMS
+-
+-“CIRRUS LOGIC” means either Cirrus Logic, Inc., a Delaware Corporation (for
+-licensees based in the United States), or Cirrus Logic International (UK) Ltd, a
+-company registered in Scotland (for licensees based outside the United States).
+-
+-“Licensee” means the party which has accepted these terms, including by
+-distributing, reproducing and/or using the Software.
+-“Software” means software provided to Licensee in binary code form, that runs or
+-is intended to run on a processor embedded in an end product (and related files
+-and documentation) (“Software”).
+-
+-2.	GRANT OF LICENSE
+-
+-a.	Subject to the terms, conditions, and limitations of this Agreement, CIRRUS
+-LOGIC grants to Licensee a non-exclusive , non-transferable license (the
+-“License”) to (i) use and integrate the Software  with other software, and (ii)
+-reproduce and distribute the Software in its complete and unmodified form,
+-provided all use of the Software is in connection with CIRRUS LOGIC
+-semiconductor devices. These license rights do not automatically extend to any
+-third-party software within the Software for which a separate license is
+-required to enable use by the Licensee.  Licensee must agree applicable license
+-terms with the relevant third-party licensors to use such software.
+-b.	Licensee (i) shall not remove or obscure any copyright and/or trademark
+-notices from the Software, and (ii) shall maintain and reproduce all copyright
+-and other proprietary notices on any copy in the same form and manner that such
+-notices are included on the Software (except if the Software is embedded such
+-that it is not readily accessible to an end user).
+-c.	Licensee may not make any modifications to the Software and may only
+-distribute the Software under the terms of this Agreement.  Recipients of the
+-Software must be provided with a copy of this Agreement.
+-
+-3.	TERMINATION
+-
+-a.	This Agreement will automatically terminate if Licensee does not comply with
+-its terms.
+-b.	In the event of termination:
+-i.	Licensee must destroy all copies of the Software (and parts thereof), and all
+-Proprietary Information (as defined below), including any original, backup, or
+-archival copy that Licensee may have installed, downloaded, or recorded on any
+-medium.  Upon written request from CIRRUS LOGIC, Licensee will certify in
+-writing that it has complied with this provision and has not retained any copies
+-of the Software or any Proprietary Information;
+-ii.	the rights and licenses granted to Licensee under this Agreement will
+-immediately terminate;
+-iii.	all rights and obligations under this Agreement which by their nature
+-should survive termination, will remain in full force and effect.
+-
+-4.	OWNERSHIP, RIGHTS, USE LIMITATIONS, AND DUTIES
+-
+-a.	CIRRUS LOGIC and/or its licensors own all proprietary rights in the Software.
+- Whilst this Agreement is in effect,  Licensee hereby covenants that it will not
+-assert any claim that the Software infringes any intellectual property rights
+-owned or controlled by Licensee.
+-b.	Other than as expressly set forth in this Agreement, CIRRUS LOGIC does not
+-grant, and Licensee does not receive, any ownership right, title or interest in
+-any intellectual property rights relating to the Software, nor in any copy of
+-any part of the foregoing.  No license is granted to Licensee in any human
+-readable code of the Software (source code).
+-c.	Licensee shall not (i) use, license, sell or otherwise distribute the
+-Software except as provided in this Agreement, (ii) attempt to modify in any
+-way, reverse engineer, decompile or disassemble any portion of the Software; or
+-(iii) use the Software or other material in violation of any applicable law or
+-regulation.
+-d.	The Software is not intended or authorized for use in or with products for
+-which CIRRUS LOGIC semiconductor devices are not designed, tested or intended,
+-as detailed in the CIRRUS LOGIC Terms and Conditions of Sale, available at
+-www.cirrus.com/legal (as the same may be updated from time to time), which shall
+-apply to Licensee’s use of Software, insofar as relevant thereto.
+-e.	CIRRUS LOGIC may require Licensee to cease using a version of the Software,
+-and may require use of an updated version, where (a) a third-party has claimed
+-that the Software infringes its intellectual property rights, and/or (b) for
+-technical reasons CIRRUS LOGIC is no longer able to permit ongoing use of the
+-version of the Software being used by Licensee.
+-f.	If Licensee requests support, CIRRUS LOGIC has no obligation to provide any
+-such support but if it agrees to do so any such support will be on a reasonable
+-efforts basis.
+-g.	Licensee shall keep complete and accurate records of its use of the Software
+-and shall, on request, promptly provide to CIRRUS LOGIC a certificate evidencing
+-the extent of such use.
+-
+-5.	CONFIDENTIALITY
+-
+-a.	Licensee may obtain or be provided with information relating to the Software,
+-including in documentation provided to it (“Proprietary Information”).  Such
+-Proprietary Information shall belong solely to CIRRUS LOGIC and/or its
+-affiliates (or, as the case may be, relevant third parties).
+-b.	During and after the term of this Agreement, Licensee agrees  to maintain all
+-such Proprietary Information in strict confidence and to not use (except as
+-expressly authorized in this Agreement), disclose, or provide any third-party
+-with access to any Proprietary Information except under a written agreement with
+-terms at least as protective as the terms of this Agreement.  Licensee also
+-agrees to exercise the same degree of care and diligence as it uses in respect
+-of its own confidential and proprietary information when dealing with CIRRUS
+-LOGIC Proprietary Information, and in any event no less than reasonable care and
+-diligence.
+-c.	Information will not be considered Proprietary Information if (i) it becomes
+-public knowledge other than through any act or omission constituting a breach of
+-the Licensee’s obligations under this Agreement; (ii) the Licensee can prove it
+-was already in the Licensee’s possession and at its free disposal before the
+-disclosure hereunder; and (iii) it was received in good faith from a third party
+-having no obligation of confidentiality and which is free to disclose such
+-Confidential Information
+-
+-6.	NO WARRANTIES OR LIABILITIES
+-
+-LICENSEE EXPRESSLY ACKNOWLEDGES AND AGREES THAT THE SOFTWARE IS PROVIDED BY
+-CIRRUS LOGIC “AS IS” WITHOUT ANY WARRANTIES WHATSOEVER AND THAT THE
+-INSTALLATION, OPERATION AND USE OF THE SOFTWARE IS AT LICENSEE’S OWN RISK.
+-CIRRUS LOGIC MAKES NO WARRANTIES, EXPRESS, IMPLIED OR STATUTORY, AND EXPRESSLY
+-DISCLAIMS ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+-PURPOSE, GOOD TITLE, NON-INFRINGEMENT, SATISFACTORY QUALITY OR PERFORMANCE OR
+-WHICH MAY ARISE FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.  CIRRUS LOGIC
+-PROVIDES NO WARRANTY THAT THE SOFTWARE IS FREE FROM DEFECTS OR CHARACTERISTICS
+-THAT COULD CAUSE VULNERABILITY TO CYBER-ATTACK, DATA BREACH OR PRIVACY
+-VIOLATIONS. CIRRUS LOGIC SHALL IN NO EVENT BE LIABLE TO LICENSEE OR ANYONE ELSE
+-FOR ANY LOSS, INJURY OR DAMAGE CAUSED IN WHOLE OR PART BY THE INSTALLATION,
+-OPERATION OR USE OF THE SOFTWARE, LICENSEE’S INCORRECT USE OF THE SOFTWARE
+-INCLUDING ANY FAILURE TO PROPERLY INSTALL ANY UPDATES TO THE SOFTWARE OR OTHER
+-SOFTWARE WITH WHICH THE SOFTWARE OPERATES OR WHICH IT UPDATES, OR IS INTENDED TO
+-OPERATE WITH OR UPDATE, OR THE RESULTS PRODUCED BY, OR FAILURES, DELAYS, OR
+-INTERRUPTIONS OF THE SOFTWARE.  WITHOUT LIMITING THE FOREGOING GENERALITY,
+-CIRRUS LOGIC SHALL IN NO EVENT BE LIABLE WITH RESPECT TO ANY INTELLECTUAL
+-PROPERTY INFRINGEMENT CLAIMS WHICH ARISE FROM, OR IN ANY WAY RELATE TO, USE OF
+-THE SOFTWARE, INCLUDING, WITHOUT LIMITATION, ANY CLAIMS RELATING TO HAPTICS ON A
+-COMPONENT OR SYSTEM LEVEL.  CIRRUS LOGIC AND ITS LICENSORS SHALL IN NO EVENT BE
+-LIABLE TO LICENSEE OR ANYONE ELSE FOR ANY DIRECT, CONSEQUENTIAL, INCIDENTAL OR
+-SPECIAL DAMAGES, INCLUDING BUT NOT LIMITED TO ANY LOST PROFITS ARISING OUT OF OR
+-RELATING TO THE INSTALLATION, OPERATION OR USE OF THE SOFTWARE.    BECAUSE SOME
+-JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF CERTAIN WARRANTIES OR
+-TYPES OF CLAIM OR LOSS THEN IN SUCH INSTANCES THE ABOVE EXCLUSIONS SHALL BE
+-INTERPRETED TO APPLY TO THE EXTENT PERMITTED BY LOCAL LAW.  SUBJECT TO THE
+-FOREGOING, THE TOTAL LIABILITY OF CIRRUS LOGIC AND ITS LICENSORS TO LICENSEE
+-UNDER THIS AGREEMENT, AND/OR ARISING FROM, OR IN CONNECTION WITH, THE USE OF (OR
+-INABILITY TO USE) THE SOFTWARE, WHETHER ARISING IN CONTRACT, TORT (INCLUDING
+-NEGLIGENCE), QUASI TORT, OR OTHERWISE SHALL NOT EXCEED THE LICENSE FEES (IF ANY)
+-PAID BY LICENSEE FOR THE SOFTWARE THAT GAVE RISE TO THE CLAIM, OR TEN THOUSAND
+-U.S. DOLLARS (U.S. $10,000), WHICHEVER IS GREATER.
+-
+-7.	EXPORT AND END USE RESTRICTIONS
+-
+-Licensee acknowledges that the Software is subject to United States and other
+-applicable export related laws and  regulations (“Export Laws”).  Licensee
+-agrees that it may not export, re-export or transfer the Software or any direct
+-product of the Software other than in accordance with those Export Laws.
+-Licensee further agrees to be bound by, and to act in accordance with,
+-provisions of the CIRRUS LOGIC Terms and Conditions of Sale available at
+-www.cirrus.com/legal (as updated from time to time), including insofar as they
+-relate to export/end use restrictions.
+-
+-8.	GENERAL PROVISIONS
+-
+-This Agreement is not assignable or sub-licensable by Licensee without the prior
+-written consent of CIRRUS LOGIC.  CIRRUS LOGIC may sub-license or assign any or
+-all of its rights and obligations under this Agreement without Licensee’s
+-consent.  The waiver by either party of a breach of this Agreement shall not
+-constitute a waiver of any subsequent breach of this Agreement; nor shall any
+-delay to exercise any right under this Agreement operate as a waiver of such
+-right.  This Agreement shall be deemed to have been made in, and shall be
+-construed pursuant to the laws of, the State of Texas without regard to
+-conflicts of laws provisions thereof.  Both parties hereby consent to the
+-exclusive jurisdiction of the State of Texas and the locale of Austin therein.
+-The prevailing party in any action to enforce this Agreement shall be entitled
+-to recover costs and expenses including, without limitation, attorneys' fees.
+-The parties agree that  CIRRUS LOGIC and its licensors shall be entitled to
+-equitable relief in addition to any remedies it may have hereunder or at law.
+-
+-9.	ENTIRE AGREEMENT
+-
+-This Agreement and any terms referenced or incorporated herein, constitutes the
+-entire agreement between Licensee and CIRRUS LOGIC with respect to the Software
+-provided pursuant to this Agreement and supersedes any other agreement between
+-Licensee and CIRRUS LOGIC with respect thereto (including terms presented and/or
+-accepted as part of an installation process), but does not otherwise replace,
+-modify or cancel any other written agreement between Licensee and CIRRUS LOGIC.
+-If there is any inconsistency between these terms and those presented as part of
+-the process to install the Software, these terms will prevail.
+diff --git a/WHENCE b/WHENCE
+index e6309eb..116d04d 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -17,43 +17,6 @@ Licence: Redistributable. See LICENCE.cypress for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: snd-korg1212 -- Korg 1212 IO audio device
+-
+-File: korg/k1212.dsp
+-
+-Licence: Unknown
+-
+-Found in alsa-firmware package in hex form; no licensing information.
+-
+---------------------------------------------------------------------------
+-
+-Driver: snd-maestro3 -- ESS Allegro Maestro3 audio device
+-
+-File: ess/maestro3_assp_kernel.fw
+-File: ess/maestro3_assp_minisrc.fw
+-
+-Licence: Unknown
+-
+-Found in alsa-firmware package in hex form with a comment claiming to
+-be GPLv2+, but without source -- and with another comment saying "ESS
+-drops binary dsp code images on our heads, but we don't get to see
+-specs on the dsp."
+-
+---------------------------------------------------------------------------
+-
+-Driver: snd-ymfpci -- Yamaha YMF724/740/744/754 audio devices
+-
+-File: yamaha/ds1_ctrl.fw
+-File: yamaha/ds1_dsp.fw
+-File: yamaha/ds1e_ctrl.fw
+-
+-Licence: Unknown
+-
+-Found alsa-firmware package in hex form, with the following comment:
+-   Copyright (c) 1997-1999 Yamaha Corporation. All Rights Reserved.
+-
+---------------------------------------------------------------------------
+-
+ Driver: advansys - AdvanSys SCSI
+ 
+ File: advansys/mcode.bin
+@@ -360,24 +323,6 @@ http://www.zdomain.com/a56.html
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: snd-sb16-csp - Sound Blaster 16/AWE CSP support
+-
+-File: sb16/mulaw_main.csp
+-File: sb16/alaw_main.csp
+-File: sb16/ima_adpcm_init.csp
+-File: sb16/ima_adpcm_playback.csp
+-File: sb16/ima_adpcm_capture.csp
+-
+-Licence: Allegedly GPLv2+, but no source visible. Marked:
+-/*
+- *  Copyright (c) 1994 Creative Technology Ltd.
+- *  Microcode files for SB16 Advanced Signal Processor
+- */
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: qla2xxx - QLogic QLA2XXX Fibre Channel
+ 
+ File: ql2100_fw.bin
+@@ -1383,17 +1328,6 @@ ARM assembly source code from https://linuxtv.org/downloads/firmware/Boot.S
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: snd-wavefront - ISA WaveFront sound card
+-
+-File: yamaha/yss225_registers.bin
+-
+-Licence: Allegedly GPLv2+, but no source visible.
+-
+-Found in hex form in kernel source, with the following comment:
+-   Copyright (c) 1998-2002 by Paul Davis <pbd@op.net>
+-
+---------------------------------------------------------------------------
+-
+ Driver: rt61pci - Ralink RT2561, RT2561S, RT2661 wireless MACs
+ 
+ File: rt2561.bin
+@@ -3605,17 +3539,6 @@ Licence: GPLv2. Some build scripts use the New BSD (3-clause) licence.. See GPL-
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: snd-hda-codec-ca0132 - Creative Sound Core3D codec
+-
+-File: ctefx.bin
+-File: ctspeq.bin
+-
+-Licence: Redistributable. See LICENCE.ca0132 for details
+-
+-Found also in alsa-firmware package.
+-
+---------------------------------------------------------------------------
+-
+ Driver: btusb - Bluetooth USB driver
+ 
+ File: intel/ibt-hw-37.7.bseq
+@@ -4044,14 +3967,6 @@ Licence: Redistributable. See LICENCE.r8a779x_usb3 for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: snd_soc_sst_acpi
+-
+-File: intel/fw_sst_0f28.bin-48kHz_i2s_master
+-
+-License: Redistributable. See LICENCE.fw_sst_0f28 for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: as102 - Abilis Systems Single DVB-T Receiver
+ 
+ File: as102_data1_st.hex
+@@ -4070,104 +3985,6 @@ Licence: Redistributable. See LICENCE.it913x for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: snd_soc_catpt -- Intel AudioDSP driver for HSW/BDW platforms
+-
+-File: intel/catpt/bdw/dsp_basefw.bin
+-Version: 44b81c4d5397a63108356f58f036953d9b288c4e
+-Link: intel/IntcSST2.bin -> catpt/bdw/dsp_basefw.bin
+-
+-License: Redistributable. See LICENCE.IntcSST2 for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: snd_soc_avs -- Intel AudioDSP driver for cAVS platforms
+-
+-File: intel/avs/skl/dsp_basefw.bin
+-File: intel/avs/skl/dsp_mod_7CAD0808-AB10-CD23-EF45-12AB34CD56EF.bin
+-Version: 9.21.00.4899
+-Link: intel/dsp_fw_release.bin -> avs/skl/dsp_basefw.bin
+-Link: intel/dsp_fw_kbl.bin -> avs/skl/dsp_basefw.bin
+-File: intel/avs/apl/dsp_basefw.bin
+-Version: 9.22.01.4908
+-Link: intel/dsp_fw_bxtn.bin -> avs/apl/dsp_basefw.bin
+-Link: intel/dsp_fw_glk.bin -> avs/apl/dsp_basefw.bin
+-File: intel/avs/cnl/dsp_basefw.bin
+-Version: 10.23.00.8551
+-Link: intel/dsp_fw_cnl.bin -> avs/cnl/dsp_basefw.bin
+-
+-License: Redistributable. See LICENCE.adsp_sst for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: snd_intel_sst_core
+-
+-File: intel/fw_sst_0f28.bin
+-File: intel/fw_sst_0f28_ssp0.bin
+-
+-License: Redistributable. See LICENCE.fw_sst_0f28 for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: snd_intel_sst_core
+-
+-File: intel/fw_sst_22a8.bin
+-Version: 01.0B.02.02
+-
+-License: Redistributable. See LICENCE.fw_sst_0f28 for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: snd-soc-skl
+-
+-File: intel/dsp_fw_release_v969.bin
+-Version: 8.20.00.969
+-File: intel/dsp_fw_release_v3402.bin
+-Version: 9.21.00.3402_161
+-
+-License: Redistributable. See LICENCE.adsp_sst for details
+-
+-File: intel/dsp_fw_bxtn_v2219.bin
+-Version: 9.22.01.2219_64
+-File: intel/dsp_fw_bxtn_v3366.bin
+-Version: 9.22.01.3366_157
+-
+-License: Redistributable. See LICENCE.adsp_sst for details
+-
+-File: intel/dsp_fw_kbl_v701.bin
+-Version: 9.21.00.701
+-File: intel/dsp_fw_kbl_v1037.bin
+-Version: 09.21.00.1037
+-File: intel/dsp_fw_kbl_v2042.bin
+-Version: 9.21.00.2042_46
+-File: intel/dsp_fw_kbl_v2630.bin
+-Version: 9.21.00.2630_97
+-File: intel/dsp_fw_kbl_v3266.bin
+-Version: 9.21.00.3266_144
+-File: intel/dsp_fw_kbl_v3420.bin
+-Version: 9.21.00.3420_163
+-File: intel/dsp_fw_kbl_v3402.bin
+-Version: 9.21.00.3402_161
+-
+-License: Redistributable. See LICENCE.adsp_sst for details
+-
+-File: intel/dsp_fw_glk_v1814.bin
+-Version: 9.92.01.1814
+-File: intel/dsp_fw_glk_v2880.bin
+-Version: 9.22.00.2880
+-File: intel/dsp_fw_glk_v2768.bin
+-Version: 9.22.01.2768
+-File: intel/dsp_fw_glk_v3366.bin
+-Version: 9.22.01.3366_157
+-
+-File: intel/dsp_fw_cnl_v1191.bin
+-Version: 10.00.00.1191
+-File: intel/dsp_fw_cnl_v1858.bin
+-Version: 10.23.00.1858
+-
+-License: Redistributable. See LICENCE.adsp_sst for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: smsmdtv - Siano MDTV Core module
+ 
+ File: cmmb_vega_12mhz.inp
+@@ -5935,368 +5752,6 @@ Licence: Redistributable. See LICENSE.amphion_vpu for details
+ 
+ ---------------------------------------------------------------------------
+ 
+-Driver: cs35l41_hda - CS35l41 ALSA HDA audio driver
+-
+-File: cirrus/cs35l41-dsp1-spk-prot.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot.bin
+-File: cirrus/cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8971.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8971.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8972.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8972.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8973.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8973.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8974.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8974.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8975.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8975.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c896e.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c896e.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c89c3.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c89c3.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8981.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8981.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c898e.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c898e.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c898f.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c898f.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8991.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8991.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8992.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8992.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8994.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8994.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8995.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8995.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c89c6.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c89c6.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8971.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8971.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8972.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8972.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8973.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8973.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8974.bin -> cs35l41-dsp1-spk-prot-103c8972.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8974.bin -> cs35l41-dsp1-spk-cali-103c8972.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8975-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8975-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8975-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8975-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c896e-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c896e-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c896e-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c896e-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c898e.bin -> cs35l41-dsp1-spk-prot-103c8971.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c898e.bin -> cs35l41-dsp1-spk-cali-103c8971.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c898f.bin -> cs35l41-dsp1-spk-prot-103c8971.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c898f.bin -> cs35l41-dsp1-spk-cali-103c8971.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8991.bin -> cs35l41-dsp1-spk-prot-103c8972.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8991.bin -> cs35l41-dsp1-spk-cali-103c8972.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8992.bin -> cs35l41-dsp1-spk-prot-103c8972.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8992.bin -> cs35l41-dsp1-spk-cali-103c8972.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8994.bin -> cs35l41-dsp1-spk-prot-103c8973.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8994.bin -> cs35l41-dsp1-spk-cali-103c8973.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8995.bin -> cs35l41-dsp1-spk-prot-103c8973.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8995.bin -> cs35l41-dsp1-spk-cali-103c8973.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c89c6-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c89c6-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c89c6-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c89c6-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c89c3-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c89c3-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c89c3-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c89c3-r1.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c89c3-l0.bin -> cs35l41-dsp1-spk-prot-103c89c3-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c89c3-l0.bin -> cs35l41-dsp1-spk-cali-103c89c3-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c89c3-l1.bin -> cs35l41-dsp1-spk-prot-103c89c3-r1.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c89c3-l1.bin -> cs35l41-dsp1-spk-cali-103c89c3-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8981-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8981-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8981-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8981-l1.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8981-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8981-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8981-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8981-l1.bin
+-File: cirrus/cs35l41/v6.39.0/halo_cspl_RAM_revB2_29.41.0.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa3847.wmfw -> cs35l41/v6.39.0/halo_cspl_RAM_revB2_29.41.0.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa3847.wmfw -> cs35l41/v6.39.0/halo_cspl_RAM_revB2_29.41.0.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3847-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3847-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa3847-spkid0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3847-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3847-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa3847-spkid1.bin
+-File: cirrus/cs35l41/v6.47.0/halo_cspl_RAM_revB2_29.49.0.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa3855.wmfw -> cs35l41/v6.47.0/halo_cspl_RAM_revB2_29.49.0.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa3855.wmfw -> cs35l41/v6.47.0/halo_cspl_RAM_revB2_29.49.0.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3855-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3855-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa3855-spkid0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3855-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa3855-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa3855-spkid1.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa22f1.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa22f1.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa22f2.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa22f2.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa22f3.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa22f3.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa22f1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa22f1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa22f1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa22f1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa22f2-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa22f2-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa22f2-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa22f2-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa22f3-l0.bin -> cs35l41-dsp1-spk-prot-17aa22f2-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa22f3-r0.bin -> cs35l41-dsp1-spk-prot-17aa22f2-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa22f3-l0.bin -> cs35l41-dsp1-spk-cali-17aa22f2-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa22f3-r0.bin -> cs35l41-dsp1-spk-cali-17aa22f2-r0.bin
+-File: cirrus/cs35l41/v6.63.0/halo_cspl_RAM_revB2_29.65.0.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-104312af.wmfw -> cs35l41/v6.63.0/halo_cspl_RAM_revB2_29.65.0.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-104312af.wmfw -> cs35l41/v6.63.0/halo_cspl_RAM_revB2_29.65.0.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-104312af-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-104312af-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-104312af-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-104312af-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-104312af-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-104312af-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-104312af-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-104312af-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431a8f.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431a8f.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-10431a8f-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431a8f-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431a8f-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431a8f-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431a8f-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431a8f-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431a8f-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431a8f-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431e02.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431e02.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e02-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e02-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e02-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e02-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e02-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e02-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e02-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e02-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431f12.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431f12.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-cali-10431f12-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431f12-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431f12-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431f12-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431f12-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431f12-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431f12-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431f12-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431e12.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431e12.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e12-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e12-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e12-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431e12-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e12-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e12-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e12-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431e12-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431b93.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431b93.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431a20.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431a20.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431a30.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431a30.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431a40.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431a40.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431a50.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431a50.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-10431a60.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-10431a60.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-10431b93-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431b93-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431b93-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10431b93-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431b93-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431b93-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431b93-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10431b93-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a20-spkid0-l0.bin -> cs35l41-dsp1-spk-prot-10431b93-spkid0-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a20-spkid0-r0.bin -> cs35l41-dsp1-spk-prot-10431b93-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a20-spkid1-l0.bin -> cs35l41-dsp1-spk-prot-10431b93-spkid1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a20-spkid1-r0.bin -> cs35l41-dsp1-spk-prot-10431b93-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a20-spkid0-l0.bin -> cs35l41-dsp1-spk-cali-10431b93-spkid0-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a20-spkid0-r0.bin -> cs35l41-dsp1-spk-cali-10431b93-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a20-spkid1-l0.bin -> cs35l41-dsp1-spk-cali-10431b93-spkid1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a20-spkid1-r0.bin -> cs35l41-dsp1-spk-cali-10431b93-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a30-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a30-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a30-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a30-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a30-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a30-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a30-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a30-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a40-spkid0-l0.bin -> cs35l41-dsp1-spk-prot-10433a30-spkid0-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a40-spkid0-r0.bin -> cs35l41-dsp1-spk-prot-10433a30-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a40-spkid1-l0.bin -> cs35l41-dsp1-spk-prot-10433a30-spkid1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-10433a40-spkid1-r0.bin -> cs35l41-dsp1-spk-prot-10433a30-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a40-spkid0-l0.bin -> cs35l41-dsp1-spk-cali-10433a30-spkid0-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a40-spkid0-r0.bin -> cs35l41-dsp1-spk-cali-10433a30-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a40-spkid1-l0.bin -> cs35l41-dsp1-spk-cali-10433a30-spkid1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-10433a40-spkid1-r0.bin -> cs35l41-dsp1-spk-cali-10433a30-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a50-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a50-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a50-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a50-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a50-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a50-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a50-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a50-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a60-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a60-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a60-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a60-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a60-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a60-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-10433a60-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-10433a60-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2316.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2316.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2317.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2317.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa2316-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa2316-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa2316-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-17aa2316-spkid1-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa2316-spkid0-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa2316-spkid0-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa2316-spkid1-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-17aa2316-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2317-spkid0-l0.bin -> cs35l41-dsp1-spk-prot-17aa2316-spkid0-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2317-spkid0-r0.bin -> cs35l41-dsp1-spk-prot-17aa2316-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2317-spkid1-l0.bin -> cs35l41-dsp1-spk-prot-17aa2316-spkid1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2317-spkid1-r0.bin -> cs35l41-dsp1-spk-prot-17aa2316-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2317-spkid0-l0.bin -> cs35l41-dsp1-spk-cali-17aa2316-spkid0-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2317-spkid0-r0.bin -> cs35l41-dsp1-spk-cali-17aa2316-spkid0-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2317-spkid1-l0.bin -> cs35l41-dsp1-spk-cali-17aa2316-spkid1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2317-spkid1-r0.bin -> cs35l41-dsp1-spk-cali-17aa2316-spkid1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2318.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2318.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2319.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2319.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa231a.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa231a.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2318-l0.bin -> cs35l41-dsp1-spk-prot-17aa22f1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2318-r0.bin -> cs35l41-dsp1-spk-prot-17aa22f1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2318-l0.bin -> cs35l41-dsp1-spk-cali-17aa22f1-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2318-r0.bin -> cs35l41-dsp1-spk-cali-17aa22f1-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2319-l0.bin -> cs35l41-dsp1-spk-prot-17aa22f2-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa2319-r0.bin -> cs35l41-dsp1-spk-prot-17aa22f2-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2319-l0.bin -> cs35l41-dsp1-spk-cali-17aa22f2-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa2319-r0.bin -> cs35l41-dsp1-spk-cali-17aa22f2-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa231a-l0.bin -> cs35l41-dsp1-spk-prot-17aa22f2-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-17aa231a-r0.bin -> cs35l41-dsp1-spk-prot-17aa22f2-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa231a-l0.bin -> cs35l41-dsp1-spk-cali-17aa22f2-l0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-17aa231a-r0.bin -> cs35l41-dsp1-spk-cali-17aa22f2-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8c26.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8c26.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b42.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b42.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b43.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b43.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b44.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b44.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b45.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b45.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b46.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b46.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b47.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b47.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b63.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b63.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b70.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b70.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b72.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b72.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b74.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b74.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b77.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b77.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b8f.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b92.wmfw -> cs35l41/v6.61.1/halo_cspl_RAM_revB2_29.63.1.wmfw
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b42.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b42.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b43.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b43.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b44.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b44.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b45.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b45.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b46.bin -> cs35l41-dsp1-spk-prot-103c8b45.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b46.bin -> cs35l41-dsp1-spk-cali-103c8b45.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b47.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b47.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b63-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b63-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b63-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b63-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b63-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b63-l0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b63-l1.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b63-l1.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b70.bin -> cs35l41-dsp1-spk-prot-103c8b42.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b70.bin -> cs35l41-dsp1-spk-cali-103c8b42.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b72.bin -> cs35l41-dsp1-spk-prot-103c8b45.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b72.bin -> cs35l41-dsp1-spk-cali-103c8b45.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b74.bin -> cs35l41-dsp1-spk-prot-103c8b47.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b74.bin -> cs35l41-dsp1-spk-cali-103c8b47.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b77.bin -> cs35l41-dsp1-spk-prot-103c8b45.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b77.bin -> cs35l41-dsp1-spk-cali-103c8b45.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b8f-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b8f-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b8f-r0.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b8f-r1.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b8f-l0.bin -> cs35l41-dsp1-spk-prot-103c8b8f-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8b8f-l1.bin -> cs35l41-dsp1-spk-prot-103c8b8f-r1.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b8f-l0.bin -> cs35l41-dsp1-spk-cali-103c8b8f-r0.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8b8f-l1.bin -> cs35l41-dsp1-spk-cali-103c8b8f-r1.bin
+-File: cirrus/cs35l41-dsp1-spk-prot-103c8b92.bin
+-File: cirrus/cs35l41-dsp1-spk-cali-103c8b92.bin
+-Link: cirrus/cs35l41-dsp1-spk-prot-103c8c26.bin -> cs35l41-dsp1-spk-prot-103c8b45.bin
+-Link: cirrus/cs35l41-dsp1-spk-cali-103c8c26.bin -> cs35l41-dsp1-spk-cali-103c8b45.bin
+-
+-License: Redistributable. See LICENSE.cirrus for details.
+-
+-Use of Cirrus Logic drivers, firmware and other materials is permitted
+-only in connection with Cirrus Logic hardware products.
+-
+-Copyright © 2022 Cirrus Logic, Inc. and Cirrus Logic International
+-Semiconductor Ltd. All Rights Reserved.
+-
+----------------------------------------------------------------------------
+-
+-Driver: mtk-sof - MediaTek Sound Open Firmware driver
+-
+-File: mediatek/sof/sof-mt8186.ri
+-File: mediatek/sof/sof-mt8186.ldc
+-File: mediatek/sof-tplg/sof-mt8186.tplg
+-Version: v0.2.1
+-
+-File: mediatek/sof/sof-mt8195.ri
+-File: mediatek/sof/sof-mt8195.ldc
+-File: mediatek/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682.tplg
+-File: mediatek/sof-tplg/sof-mt8195-mt6359-rt1019-rt5682-dts.tplg
+-Version: v0.4.1
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: nxp-sr1xx - NXP Ultra Wide Band driver
+ File: nxp/sr150_fw.bin
+ Version: 35.00.03
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0002-linux-firmware-video-Remove-firmware-for-video-broad.patch
+++ b/packages/linux-firmware/0002-linux-firmware-video-Remove-firmware-for-video-broad.patch
@@ -1,0 +1,1630 @@
+From 80d430aa70fec3a2d0fdbe59f3a102c8aeaa564a Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Tue, 25 Jul 2023 09:43:12 +0000
+Subject: [PATCH] linux-firmware: video: Remove firmware for video/broadcast
+ devices
+
+Bottlerocket does not configure any special video encoding/decoding
+hardware, DVB/DAB tuner, TV cards, and V4L2 hardware. We do not need
+to ship firmware for devices we do not ship drivers for. The following
+list maps the drivers as named in WHENCE to kernel config options to
+easily check if we need to ship additional firmware in the future.
+
+* cpia2 - CONFIG_VIDEO_CPIA2
+* dabusb - CONFIG_USB_DABUSB (not available since 2.6.39)
+* vicam - CONFIG_USB_GSPCA_VICAM
+* ipu3-imgu - CONFIG_VIDEO_IPU3_IMGU
+* cx231xx - CONFIG_VIDEO_CX231XX
+* cx23418 - CONFIG_VIDEO_CX18
+* cx23885 - CONFIG_VIDEO_CX23885
+* cx25840 - CONFIG_VIDEO_CX25840
+* mtk-vpu - CONFIG_VIDEO_MEDIATEK_VPU
+* ti-vpe - CONFIG_VIDEO_TI_VPE
+* tlg2300 - CONFIG_VIDEO_TLG2300
+* s5p-mfc - CONFIG_VIDEO_SAMSUNG_S5P_MFC
+* go7007 - CONFIG_VIDEO_GO7007
+* venus - CONFIG_VIDEO_QCOM_VENUS
+* meson-vdec - CONFIG_VIDEO_MESON_VDEC
+* wave5 - CONFIG_VIDEO_WAVE_VPU (driver not yet included upstream)
+* amphion - CONFIG_VIDEO_AMPHION_VPU
+* dvb-ttusb-budget - CONFIG_DVB_TTUSB_BUDGET
+* dvb-ttpci - CONFIG_DVB_AV7110
+* xc4000 - CONFIG_MEDIA_TUNER_XC4000
+* xc5000 - CONFIG_MEDIA_TUNER_XC5000
+* dib0700 - CONFIG_DVB_USB_DIB0700
+* lsg8gxx - CONFIG_DVB_LGS8GXX
+* drxk - CONFIG_DVB_DRXK
+* as102 - CONFIG_DVB_AS102
+* it9135 - CONFIG_MEDIA_TUNER_IT913X
+* smsmdtv - CONFIG_SMS_SIANO_MDTV
+* tegra-vix - CONFIG_DRM_TEGRA
+* rk3399-dptx - CONFIG_ROCKCHIP_CDN_DP
+* cdns-mhdp - CONFIG_DRM_CDNS_MHDP8546
+* lt9611uxc - CONFIG_DRM_LONTIUM_LT9611UXC
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.Abilis        |  22 --
+ LICENCE.cadence       |  63 ------
+ LICENCE.cnm           |  23 ---
+ LICENCE.go7007        | 457 ------------------------------------------
+ LICENCE.it913x        |  17 --
+ LICENCE.rockchip      |  41 ----
+ LICENCE.siano         |  31 ---
+ LICENCE.ti-tspa       |  46 -----
+ LICENCE.xc4000        |  23 ---
+ LICENCE.xc5000        |  23 ---
+ LICENCE.xc5000c       |  23 ---
+ LICENSE.Lontium       |   2 -
+ LICENSE.amlogic_vdec  |  15 --
+ LICENSE.amphion_vpu   |  48 -----
+ LICENSE.dib0700       |  22 --
+ LICENSE.ipu3_firmware |  36 ----
+ WHENCE                | 400 ------------------------------------
+ 17 files changed, 1292 deletions(-)
+ delete mode 100644 LICENCE.Abilis
+ delete mode 100644 LICENCE.cadence
+ delete mode 100644 LICENCE.cnm
+ delete mode 100644 LICENCE.go7007
+ delete mode 100644 LICENCE.it913x
+ delete mode 100644 LICENCE.rockchip
+ delete mode 100644 LICENCE.siano
+ delete mode 100644 LICENCE.ti-tspa
+ delete mode 100644 LICENCE.xc4000
+ delete mode 100644 LICENCE.xc5000
+ delete mode 100644 LICENCE.xc5000c
+ delete mode 100644 LICENSE.Lontium
+ delete mode 100644 LICENSE.amlogic_vdec
+ delete mode 100644 LICENSE.amphion_vpu
+ delete mode 100644 LICENSE.dib0700
+ delete mode 100644 LICENSE.ipu3_firmware
+
+diff --git a/LICENCE.Abilis b/LICENCE.Abilis
+deleted file mode 100644
+index 9050d2b..0000000
+--- a/LICENCE.Abilis
++++ /dev/null
+@@ -1,22 +0,0 @@
+-Firmware provided by Pierrick Hascoet <pierrick.hascoet@abiliss.com> to Devin
+-Heitmueller <dheitmueller@kernellabs.com> on January 15, 2010.
+-
+-The USB firmware files "dvb-as102_data1_st.hex" and "as102_data2_st.hex" for
+-Abilis's AS10X, used together with the AS10X USB Kernel driver, is provided
+-under the following licensing terms:
+-
+-Copyright (c) 2010, Abilis Systems Sarl
+-
+-Permission to use, copy, modify, and/or distribute this software for
+-any purpose with or without fee is hereby granted, provided that the
+-above copyright notice and this permission notice appear in all
+-copies.
+-
+-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-TORTUOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-PERFORMANCE OF THIS SOFTWARE.
+diff --git a/LICENCE.cadence b/LICENCE.cadence
+deleted file mode 100644
+index b3564c2..0000000
+--- a/LICENCE.cadence
++++ /dev/null
+@@ -1,63 +0,0 @@
+-Copyright (c) 2018, Cadence Design Systems, Inc.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-
+-* Neither the name of Cadence Design Systems, Inc., its products
+-  nor the names of its suppliers may be used to endorse or promote products
+-  derived from this Software without specific prior written permission.
+-
+-* No reverse engineering, decompilation, or disassembly of this software
+-  is permitted.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+-
+-This software contains:
+-
+-HDCP Cipher is licensed under the FreeBSD license. A copy of the FreeBSD
+-license can be found at
+-https://www.freebsd.org/copyright/freebsd-license.html.
+-The source code for HDCP Cipher can is available here:
+-http://www3.cs.stonybrook.edu/~rob/hdcp.html
+-
+-SSL Library is licensed under the Apache License, Version 2.0.
+-A copy of the Apache License, Version 2.0 can be found at
+-http://www.apache.org/licenses/LICENSE-2.0.
+-The original source code for SSL Library can is available here:
+-https://tls.mbed.org/download
+-
+-Fast discrete Fourier and cosine transforms and inverses
+-author: Monty <xiphmont@mit.edu>
+-modifications by: Monty
+-last modification date: Jul 1 1996
+-
+-/* These Fourier routines were originally based on the Fourier
+-routines of the same names from the NETLIB bihar and fftpack
+-fortran libraries developed by Paul N. Swarztrauber at the National
+-Center for Atmospheric Research in Boulder, CO USA.  They have been
+-reimplemented in C and optimized in a few ways for OggSquish. */
+-
+-/* As the original fortran libraries are public domain, the C Fourier
+-routines in this file are hereby released to the public domain as
+-well.  The C routines here produce output exactly equivalent to the
+-original fortran routines.  Of particular interest are the facts
+-that (like the original fortran), these routines can work on
+-arbitrary length vectors that need not be powers of two in
+-length. */
+diff --git a/LICENCE.cnm b/LICENCE.cnm
+deleted file mode 100644
+index 48d23ea..0000000
+--- a/LICENCE.cnm
++++ /dev/null
+@@ -1,23 +0,0 @@
+-Copyright (C) 2021 Chips&Media, Inc.
+-All rights reserved.
+-
+-Redistribution and use in binary form is permitted provided that the following
+-conditions are met:
+-
+-1. Redistributions must reproduce the above copyright notice, this list of
+-conditions and the following disclaimer in the documentation and/or other
+-materials provided with the distribution.
+-
+-2. Redistribution and use shall be used only with Texas Instruments Incorporateds
+-silicon products. Any other use, reproduction, modification, translation,
+-or compilation of the Software is prohibited.
+-
+-3. No reverse engineering, decompilation, or disassembly is permitted.
+-
+-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THIS SOFTWARE IS PROVIDED
+-"AS IS" WITHOUT WARRANTY OF ANY KIND, INCLUDING, WITHOUT LIMITATION, ANY EXPRESS
+-OR IMPLIED WARRANTIES OF MERCHANTABILITY, ACCURACY, FITNESS OR SUFFICIENCY FOR A
+-PARTICULAR PURPOSE, SATISFACTORY QUALITY, CORRESPONDENCE WITH DESCRIPTION, QUIET
+-ENJOYMENT OR NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS.
+-CHIPS&MEDIA, INC., ITS AFFILIATES AND THEIR SUPPLIERS DISCLAIM ANY WARRANTY THAT THE
+-DELIVERABLES WILL OPERATE WITHOUT INTERRUPTION OR BE ERROR-FREE.
+diff --git a/LICENCE.go7007 b/LICENCE.go7007
+deleted file mode 100644
+index 3689f3b..0000000
+--- a/LICENCE.go7007
++++ /dev/null
+@@ -1,457 +0,0 @@
+-The README file from the original package from Micronas appears below. Only
+-the part about the firmware redistribution in section 0 is relevant, all
+-other sections are completely obsolete.
+-
+----------------------------------------------------------------------------
+-                     WIS GO7007SB Public Linux Driver
+----------------------------------------------------------------------------
+-
+-
+-*** Please see the file RELEASE-NOTES for important last-minute updates ***
+-
+-
+-  0. OVERVIEW AND LICENSING/DISCLAIMER
+-
+-
+-This driver kit contains Linux drivers for the WIS GO7007SB multi-format
+-video encoder.  Only kernel version 2.6.x is supported.  The video stream
+-is available through the Video4Linux2 API and the audio stream is available
+-through the ALSA API (or the OSS emulation layer of the ALSA system).
+-
+-The files in kernel/ and hotplug/ are licensed under the GNU General Public
+-License Version 2 from the Free Software Foundation.  A copy of the license
+-is included in the file COPYING.
+-
+-The example applications in apps/ and C header files in include/ are
+-licensed under a permissive license included in the source files which
+-allows copying, modification and redistribution for any purpose without
+-attribution.
+-
+-The firmware files included in the firmware/ directory may be freely
+-redistributed only in conjunction with this document; but modification,
+-tampering and reverse engineering are prohibited.
+-
+-MICRONAS USA, INC., MAKES NO WARRANTIES TO ANY PERSON OR ENTITY WITH
+-RESPECT TO THE SOFTWARE OR ANY DERIVATIVES THEREOF OR ANY SERVICES OR
+-LICENSES AND DISCLAIMS ALL IMPLIED WARRANTIES, INCLUDING WITHOUT LIMITATION
+-WARRANTIES OF MERCHANTABILITY, SUPPORT, AND FITNESS FOR A PARTICULAR
+-PURPOSE AND NON-INFRINGEMENT.
+-
+-
+-  1. SYSTEM REQUIREMENTS
+-
+-
+-This driver requires Linux kernel 2.6.  Kernel 2.4 is not supported.  Using
+-kernel 2.6.10 or later is recommended, as earlier kernels are known to have
+-unstable USB 2.0 support.
+-
+-A fully built kernel source tree must be available.  Typically this will be
+-linked from "/lib/modules/<KERNEL VERSION>/build" for convenience.  If this
+-link does not exist, an extra parameter will need to be passed to the
+-`make` command.
+-
+-All vendor-built kernels should already be configured properly.  However,
+-for custom-built kernels, the following options need to be enabled in the
+-kernel as built-in or modules:
+-
+-        CONFIG_HOTPLUG           - Support for hot-pluggable devices
+-        CONFIG_MODULES           - Enable loadable module support
+-        CONFIG_KMOD              - Automatic kernel module loading
+-        CONFIG_FW_LOADER         - Hotplug firmware loading support
+-        CONFIG_I2C               - I2C support
+-        CONFIG_VIDEO_DEV         - Video For Linux
+-        CONFIG_SOUND             - Sound card support
+-        CONFIG_SND               - Advanced Linux Sound Architecture
+-        CONFIG_USB               - Support for Host-side USB
+-        CONFIG_USB_DEVICEFS      - USB device filesystem
+-        CONFIG_USB_EHCI_HCD      - EHCI HCD (USB 2.0) support
+-
+-Additionally, to use the example application, the following options need to
+-be enabled in the ALSA section:
+-
+-        CONFIG_SND_MIXER_OSS     - OSS Mixer API
+-        CONFIG_SND_PCM_OSS       - OSS PCM (digital audio) API
+-
+-The hotplug scripts, along with the fxload utility, must also be installed.
+-These scripts can be obtained from <http://linux-hotplug.sourceforge.net/>.
+-Hotplugging is used for loading firmware into the Cypruss EZ-USB chip using
+-fxload and for loading firmware into the driver using the firmware agent.
+-
+-
+-  2. COMPILING AND INSTALLING THE DRIVER
+-
+-
+-Most users should be able to compile the driver by simply running:
+-
+-        $ make
+-
+-in the top-level directory of the driver kit.  First the kernel modules
+-will be built, followed by the example applications.
+-
+-If the build system is unable to locate the kernel source tree for the
+-currently-running kernel, or if the module should be built for a kernel
+-other than the currently-running kernel, an additional parameter will need
+-to be passed to make to specify the appropriate kernel source directory:
+-
+-        $ make KERNELSRC=/usr/src/linux-2.6.10-custom3
+-
+-Once the compile completes, the driver and firmware files should be
+-installed by running:
+-
+-        $ make install
+-
+-The kernel modules will be placed in "/lib/modules/<KERNEL VERSION>/extra"
+-and the firmware files will be placed in the appropriate hotplug firmware
+-directory, usually /lib/firmware.  In addition, USB maps and scripts will
+-be placed in /etc/hotplug/usb to enable fxload to initialize the EZ-USB
+-control chip when the device is connected.
+-
+-
+-  3. PAL/SECAM TUNER CONFIGURATION (TV402U-EU only)
+-
+-
+-The PAL model of the Plextor ConvertX TV402U may require additional
+-configuration to correctly select the appropriate TV frequency band and
+-audio subchannel.
+-
+-Users with a device other than the Plextor ConvertX TV402U-EU should skip
+-this section.
+-
+-The wide variety of PAL TV systems used in Europe requires that additional
+-information about the local TV standards be passed to the driver in order
+-to properly tune TV channels.  The two necessary parameters are (a) the PAL
+-TV band, and (b) the audio subchannel format in use.
+-
+-In many cases, the appropriate TV band selection is passed to the driver
+-from applications.  However, in some cases, the application only specifies
+-that the driver should use PAL but not the specific information about the
+-appropriate TV band.  To work around this issue, the correct TV band may be
+-specified in the "force_band" parameter to the wis-sony-tuner module:
+-
+-     TV band           force_band
+-     -------           ----------
+-     PAL B/G                B
+-     PAL I                  I
+-     PAL D/K                D
+-     SECAM L                L
+-
+-If the "force_band" parameter is specified, the driver will ignore any TV
+-band specified by applications and will always use the band provided in the
+-module parameter.
+-
+-The other parameter that can be specified is the audio subchannel format.
+-There are several stereo audio carrier systems in use, including NICAM and
+-three varieties of A2.  To receive audio broadcast on one of these stereo
+-carriers, the "force_mpx_mode" parameter must be specified to the
+-wis-sony-tuner module.
+-
+-     TV band           Audio subcarrier       force_mpx_mode
+-     -------           ----------------       --------------
+-     PAL B/G            Mono (default)               1
+-     PAL B/G                  A2                     2
+-     PAL B/G                 NICAM                   3
+-     PAL I              Mono (default)               4
+-     PAL I                   NICAM                   5
+-     PAL D/K            Mono (default)               6
+-     PAL D/K                 A2 (1)                  7
+-     PAL D/K                 A2 (2)                  8
+-     PAL D/K                 A2 (3)                  9
+-     PAL D/K                 NICAM                  10
+-     SECAM L            Mono (default)              11
+-     SECAM L                 NICAM                  12
+-
+-If the "force_mpx_mode" parameter is not specified, the correct mono-only
+-mode will be chosen based on the TV band.  However, the tuner will not
+-receive stereo audio or bilingual broadcasts correctly.
+-
+-To pass the "force_band" or "force_mpx_mode" parameters to the
+-wis-sony-tuner module, the following line must be added to the modprobe
+-configuration file, which varies from one Linux distribution to another.
+-
+-     options wis-sony-tuner force_band=B force_mpx_mode=2
+-
+-The above example would force the tuner to the PAL B/G TV band and receive
+-stereo audio broadcasts on the A2 carrier.
+-
+-To verify that the configuration has been placed in the correct location,
+-execute:
+-
+-        $ modprobe -c | grep wis-sony-tuner
+-
+-If the configuration line appears, then modprobe will pass the parameters
+-correctly the next time the wis-sony-tuner module is loaded into the
+-kernel.
+-
+-
+-  4. TESTING THE DRIVER
+-
+-
+-Because few Linux applications are able to correctly capture from
+-Video4Linux2 devices with only compressed formats supported, the new driver
+-should be tested with the "gorecord" application in the apps/ directory.
+-
+-First connect a video source to the device, such as a DVD player or VCR.
+-This will be captured to a file for testing the driver.  If an input source
+-is unavailable, a test file can still be captured, but the video will be
+-black and the audio will be silent.
+-
+-This application will auto-detect the V4L2 and ALSA/OSS device names of the
+-hardware and will record video and audio to an AVI file for a specified
+-number of seconds.  For example:
+-
+-        $ apps/gorecord -duration 60 capture.avi
+-
+-If this application does not successfully record an AVI file, the error
+-messages produced by gorecord and recorded in the system log (usually in
+-/var/log/messages) should provide information to help resolve the problem.
+-
+-Supplying no parameters to gorecord will cause it to probe the available
+-devices and exit.  Use the -help flag for usage information.
+-
+-
+-  5. USING THE DRIVER
+-
+-
+-The V4L2 device implemented by the driver provides a standard compressed
+-format API, within the following criteria:
+-
+-  * Applications that only support the original Video4Linux1 API will not
+-    be able to communicate with this driver at all.
+-
+-  * No raw video modes are supported, so applications like xawtv that
+-    expect only uncompressed video will not function.
+-
+-  * Supported compression formats are: Motion-JPEG, MPEG1, MPEG2 and MPEG4.
+-
+-  * MPEG video formats are delivered as Video Elementary Streams only.
+-    Program Stream (PS), Transport Stream (TS) and Packetized Elementary
+-    Stream (PES) formats are not supported.
+-
+-  * Video parameters such as format and input port may not be changed while
+-    the encoder is active.
+-
+-  * The audio capture device only functions when the video encoder is
+-    actively capturing video.  Attempts to read from the audio device when
+-    the encoder is inactive will result in an I/O error.
+-
+-  * The native format of the audio device is 48Khz 2-channel 16-bit
+-    little-endian PCM, delivered through the ALSA system.  No audio
+-    compression is implemented in the hardware.  ALSA may convert to other
+-    uncompressed formats on the fly.
+-
+-The include/ directory contains a C header file describing non-standard
+-features of the GO7007SB encoder, which are described below:
+-
+-
+-  GO7007IOC_S_COMP_PARAMS, GO7007IOC_G_COMP_PARAMS
+-
+-    These ioctls are used to negotiate general compression parameters.
+-
+-    To query the current parameters, call the GO7007IOC_G_COMP_PARAMS ioctl
+-    with a pointer to a struct go7007_comp_params.  If the driver is not
+-    set to MPEG format, the EINVAL error code will be returned.
+-
+-    To change the current parameters, initialize all fields of a struct
+-    go7007_comp_params and call the GO7007_IOC_S_COMP_PARAMS ioctl with a
+-    pointer to this structure.  The driver will return the current
+-    parameters with any necessary changes to conform to the limitations of
+-    the hardware or current compression mode.  Any or all fields can be set
+-    to zero to request a reasonable default value.  If the driver is not
+-    set to MPEG format, the EINVAL error code will be returned.  When I/O
+-    is in progress, the EBUSY error code will be returned.
+-
+-    Fields in struct go7007_comp_params:
+-
+-        __u32                        The maximum number of frames in each
+-          gop_size                   Group Of Pictures; i.e. the maximum
+-                                     number of frames minus one between
+-                                     each key frame.
+-
+-        __u32                        The maximum number of sequential
+-          max_b_frames               bidirectionally-predicted frames.
+-                                     (B-frames are not yet supported.)
+-
+-        enum go7007_aspect_ratio     The aspect ratio to be encoded in the
+-          aspect_ratio               meta-data of the compressed format.
+-
+-                                     Choices are:
+-                                        GO7007_ASPECT_RATIO_1_1
+-                                        GO7007_ASPECT_RATIO_4_3_NTSC
+-                                        GO7007_ASPECT_RATIO_4_3_PAL
+-                                        GO7007_ASPECT_RATIO_16_9_NTSC
+-                                        GO7007_ASPECT_RATIO_16_9_PAL
+-
+-        __u32                        Bit-wise OR of control flags (below)
+-          flags
+-
+-    Flags in struct go7007_comp_params:
+-
+-        GO7007_COMP_CLOSED_GOP       Only produce self-contained GOPs, used
+-                                     to produce streams appropriate for
+-                                     random seeking.
+-
+-        GO7007_COMP_OMIT_SEQ_HEADER  Omit the stream sequence header.
+-
+-
+-  GO7007IOC_S_MPEG_PARAMS, GO7007IOC_G_MPEG_PARAMS
+-
+-    These ioctls are used to negotiate MPEG-specific stream parameters when
+-    the pixelformat has been set to V4L2_PIX_FMT_MPEG.
+-
+-    To query the current parameters, call the GO7007IOC_G_MPEG_PARAMS ioctl
+-    with a pointer to a struct go7007_mpeg_params.  If the driver is not
+-    set to MPEG format, the EINVAL error code will be returned.
+-
+-    To change the current parameters, initialize all fields of a struct
+-    go7007_mpeg_params and call the GO7007_IOC_S_MPEG_PARAMS ioctl with a
+-    pointer to this structure.  The driver will return the current
+-    parameters with any necessary changes to conform to the limitations of
+-    the hardware or selected MPEG mode.  Any or all fields can be set to
+-    zero to request a reasonable default value.  If the driver is not set
+-    to MPEG format, the EINVAL error code will be returned.  When I/O is in
+-    progress, the EBUSY error code will be returned.
+-
+-    Fields in struct go7007_mpeg_params:
+-
+-        enum go7007_mpeg_video_standard
+-          mpeg_video_standard        The MPEG video standard in which to
+-                                     compress the video.
+-
+-                                     Choices are:
+-                                        GO7007_MPEG_VIDEO_MPEG1
+-                                        GO7007_MPEG_VIDEO_MPEG2
+-                                        GO7007_MPEG_VIDEO_MPEG4
+-
+-        __u32                        Bit-wise OR of control flags (below)
+-          flags
+-
+-        __u32                        The profile and level indication to be
+-          pali                       stored in the sequence header.  This
+-                                     is only used as an indicator to the
+-                                     decoder, and does not affect the MPEG
+-                                     features used in the video stream.
+-                                     Not valid for MPEG1.
+-
+-                                     Choices for MPEG2 are:
+-                                        GO7007_MPEG2_PROFILE_MAIN_MAIN
+-
+-                                     Choices for MPEG4 are:
+-                                        GO7007_MPEG4_PROFILE_S_L0
+-                                        GO7007_MPEG4_PROFILE_S_L1
+-                                        GO7007_MPEG4_PROFILE_S_L2
+-                                        GO7007_MPEG4_PROFILE_S_L3
+-                                        GO7007_MPEG4_PROFILE_ARTS_L1
+-                                        GO7007_MPEG4_PROFILE_ARTS_L2
+-                                        GO7007_MPEG4_PROFILE_ARTS_L3
+-                                        GO7007_MPEG4_PROFILE_ARTS_L4
+-                                        GO7007_MPEG4_PROFILE_AS_L0
+-                                        GO7007_MPEG4_PROFILE_AS_L1
+-                                        GO7007_MPEG4_PROFILE_AS_L2
+-                                        GO7007_MPEG4_PROFILE_AS_L3
+-                                        GO7007_MPEG4_PROFILE_AS_L4
+-                                        GO7007_MPEG4_PROFILE_AS_L5
+-
+-    Flags in struct go7007_mpeg_params:
+-
+-        GO7007_MPEG_FORCE_DVD_MODE   Force all compression parameters and
+-                                     bitrate control settings to comply
+-                                     with DVD MPEG2 stream requirements.
+-                                     This overrides most compression and
+-                                     bitrate settings!
+-
+-        GO7007_MPEG_OMIT_GOP_HEADER  Omit the GOP header.
+-
+-        GO7007_MPEG_REPEAT_SEQHEADER Repeat the MPEG sequence header at
+-                                     the start of each GOP.
+-
+-
+-  GO7007IOC_S_BITRATE, GO7007IOC_G_BITRATE
+-
+-    These ioctls are used to set and query the target bitrate value for the
+-    compressed video stream.  The bitrate may be selected by storing the
+-    target bits per second in an int and calling GO7007IOC_S_BITRATE with a
+-    pointer to the int.  The bitrate may be queried by calling
+-    GO7007IOC_G_BITRATE with a pointer to an int where the current bitrate
+-    will be stored.
+-
+-    Note that this is the primary means of controlling the video quality
+-    for all compression modes, including V4L2_PIX_FMT_MJPEG.  The
+-    VIDIOC_S_JPEGCOMP ioctl is not supported.
+-
+-
+-----------------------------------------------------------------------------
+-                   Installing the WIS PCI Voyager Driver
+----------------------------------------------------------------------------
+-
+-The WIS PCI Voyager driver requires several patches to the Linux 2.6.11.x
+-kernel source tree before compiling the driver.  These patches update the
+-in-kernel SAA7134 driver to the newest development version and patch bugs
+-in the TDA8290/TDA8275 tuner driver.
+-
+-The following patches must be downloaded from Gerd Knorr's website and
+-applied in the order listed:
+-
+-	http://dl.bytesex.org/patches/2.6.11-2/i2c-tuner
+-	http://dl.bytesex.org/patches/2.6.11-2/i2c-tuner2
+-	http://dl.bytesex.org/patches/2.6.11-2/v4l2-api-mpeg
+-	http://dl.bytesex.org/patches/2.6.11-2/saa7134-update
+-
+-The following patches are included with this SDK and can be applied in any
+-order:
+-
+-	patches/2.6.11/saa7134-voyager.diff
+-	patches/2.6.11/tda8275-newaddr.diff
+-	patches/2.6.11/tda8290-ntsc.diff
+-
+-Check to make sure the CONFIG_VIDEO_SAA7134 option is enabled in the kernel
+-configuration, and build and install the kernel.
+-
+-After rebooting into the new kernel, the GO7007 driver can be compiled and
+-installed:
+-
+-	$ make SAA7134_BUILD=y
+-	$ make install
+-	$ modprobe saa7134-go7007
+-
+-There will be two V4L video devices associated with the PCI Voyager.  The
+-first device (most likely /dev/video0) provides access to the raw video
+-capture mode of the SAA7133 device and is used to configure the source
+-video parameters and tune the TV tuner.  This device can be used with xawtv
+-or other V4L(2) video software as a standard uncompressed device.
+-
+-The second device (most likely /dev/video1) provides access to the
+-compression functions of the GO7007.  It can be tested using the gorecord
+-application in the apps/ directory of this SDK:
+-
+-	$ apps/gorecord -vdevice /dev/video1 -noaudio test.avi
+-
+-Currently the frame resolution is fixed at 720x480 (NTSC) or 720x576 (PAL),
+-and the video standard must be specified to both the raw and the compressed
+-video devices (xawtv and gorecord, for example).
+-
+-
+---------------------------------------------------------------------------
+-RELEASE NOTES FOR WIS GO7007SB LINUX DRIVER
+----------------------------------------------------------------------------
+-
+-Last updated: 5 November 2005
+-
+- - Release 0.9.7 includes new support for using udev to run fxload.  The
+-   install script should automatically detect whether the old hotplug
+-   scripts or the new udev rules should be used.  To force the use of
+-   hotplug, run "make install USE_UDEV=n".  To force the use of udev, run
+-   "make install USE_UDEV=y".
+-
+- - Motion detection is supported but undocumented.  Try the `modet` app
+-   for a demonstration of how to use the facility.
+-
+- - Using USB2.0 devices such as the TV402U with USB1.1 HCDs or hubs can
+-   cause buffer overruns and frame drops, even at low framerates, due to
+-   inconsistency in the bitrate control mechanism.
+-
+- - On devices with an SAA7115, including the Plextor ConvertX, video height
+-   values of 96, 128, 160, 192, 256, 320, and 384 do not work in NTSC mode.
+-   All valid heights up to 512 work correctly in PAL mode.
+-
+- - The WIS Star Trek and PCI Voyager boards have no support yet for audio
+-   or the TV tuner.
+diff --git a/LICENCE.it913x b/LICENCE.it913x
+deleted file mode 100644
+index ec8f56c..0000000
+--- a/LICENCE.it913x
++++ /dev/null
+@@ -1,17 +0,0 @@
+-Copyright (c) 2014, ITE Tech. Inc.
+-
+-The firmware files "dvb-usb-it9135-01.fw" and "dvb-usb-it9135-02.fw"
+-are for ITEtech it9135 Ax and Bx chip versions.
+-
+-Permission to use, copy, modify, and/or distribute this software for
+-any purpose with or without fee is hereby granted, provided that the
+-above copyright notice and this permission notice appear in all copies.
+-
+-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE
+-FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+-DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+-WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+-ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+-SOFTWARE.
+diff --git a/LICENCE.rockchip b/LICENCE.rockchip
+deleted file mode 100644
+index d23b4c4..0000000
+--- a/LICENCE.rockchip
++++ /dev/null
+@@ -1,41 +0,0 @@
+-Copyright (c) 2016, Fuzhou Rockchip Electronics Co.Ltd
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-
+-* Neither the name of Fuzhou Rockchip Electronics Co.Ltd, its products
+-  nor the names of its suppliers may be used to endorse or promote products
+-  derived from this Software without specific prior written permission.
+-
+-* No reverse engineering, decompilation, or disassembly of this software
+-  is permitted.
+-
+-Limited patent license. Fuzhou Rockchip Electronics Co.Ltd grants a world-wide,
+-royalty-free, non-exclusive license under patents it now or hereafter
+-owns or controls to make, have made, use, import, offer to sell and
+-sell ("Utilize") this software, but solely to the extent that any
+-such patent is necessary to Utilize the software alone, or in
+-combination with an operating system licensed under an approved Open
+-Source license as listed by the Open Source Initiative at
+-http://opensource.org/licenses.  The patent license shall not apply to
+-any other combinations which include this software.  No hardware per
+-se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+diff --git a/LICENCE.siano b/LICENCE.siano
+deleted file mode 100644
+index 97e5440..0000000
+--- a/LICENCE.siano
++++ /dev/null
+@@ -1,31 +0,0 @@
+-FIRMWARE LICENSE TERMS
+-
+-Copyright (c) 2005-2014 Siano Mobile Silicon Ltd.
+-All rights reserved.
+-
+-Redistribution. Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-following disclaimer in the documentation and/or other materials
+-provided with the distribution.
+-
+-* Neither the name of Siano Mobile Silicon Ltd. nor the names of its
+-suppliers may be used to endorse or promote products derived from this
+-software without specific prior written permission.
+-
+-* No reverse engineering, decompilation, or disassembly of this software
+-is permitted.
+-
+-DISCLAIMER. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+-USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+diff --git a/LICENCE.ti-tspa b/LICENCE.ti-tspa
+deleted file mode 100644
+index 728fc2b..0000000
+--- a/LICENCE.ti-tspa
++++ /dev/null
+@@ -1,46 +0,0 @@
+-TI TSPA License
+-TECHNOLOGY AND SOFTWARE PUBLICLY AVAILABLE
+-SOFTWARE LICENSE
+-
+-Copyright (c) 2020, Texas Instruments Incorporated.
+-
+-All rights reserved not granted herein.
+-
+-Limited License.
+-
+-Texas Instruments Incorporated grants a world-wide, royalty-free, non-exclusive
+-license under copyrights and patents it now or hereafter owns or controls to
+-make, have made, use, import, offer to sell and sell ("Utilize") this software,
+-but solely to the extent that any such patent is necessary to Utilize the
+-software alone. The patent license shall not apply to any combinations which
+-include this software.  No hardware per se is licensed hereunder.
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met:
+-
+-* Redistributions must preserve existing copyright notices and reproduce this
+-license (including the above copyright notice and the disclaimer below) in the
+-documentation and/or other materials provided with the distribution.
+-
+-* Neither the name of Texas Instruments Incorporated nor the names of its
+-suppliers may be used to endorse or promote products derived from this software
+-without specific prior written permission.
+-
+-* No reverse engineering, decompilation, or disassembly of this software is
+-permitted.
+-
+-* Nothing shall obligate TI to provide you with source code for the software
+-licensed and provided to you in object code.
+-
+-DISCLAIMER.
+-
+-THIS SOFTWARE IS PROVIDED BY TI AND TI’S LICENSORS "AS IS" AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+-EVENT SHALL TI AND TI’S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+-EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.xc4000 b/LICENCE.xc4000
+deleted file mode 100644
+index e3cd261..0000000
+--- a/LICENCE.xc4000
++++ /dev/null
+@@ -1,23 +0,0 @@
+-The following XC4000 firmware file "dvb-fe-xc4000-1.4.1.fw" was
+-created based on version 1.4 of "xc4000_firmwares.h".
+-
+-Firmware provided as part of an XC4000 Linux developers kit by Brian
+-Mathews <bmathews@xceive.com> to Devin Heitmueller
+-<dheitmueller@kernellabs.org> on July 1, 2009.
+-
+-The code was released by Xceive under the following license:
+-
+-// Copyright (c) 2009, Xceive Corporation <info@xceive.com>
+-//
+-// Permission to use, copy, modify, and/or distribute this software, only
+-// for use with Xceive ICs, for any purpose with or without fee is hereby
+-// granted, provided that the above copyright notice and this permission
+-// notice appear in all source code copies.
+-//
+-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+diff --git a/LICENCE.xc5000 b/LICENCE.xc5000
+deleted file mode 100644
+index 0ac8557..0000000
+--- a/LICENCE.xc5000
++++ /dev/null
+@@ -1,23 +0,0 @@
+-The following XC500 firmware file "dvb-fe-xc5000-1.6.114.fw" was
+-created based on "xc5000_firmwares_32000Khz.h".
+-
+-Firmware provided as part of an XC5000 Linux developers kit by Brian
+-Mathews <bmathews@xceive.com> to Devin Heitmueller <dheitmueller@linuxtv.org>
+-on July 1, 2009.
+-
+-The code was released by Xceive under the following license:
+-
+-// Copyright (c) 2009, Xceive Corporation <info@xceive.com>
+-//
+-// Permission to use, copy, modify, and/or distribute this software, only
+-// for use with Xceive ICs, for any purpose with or without fee is hereby
+-// granted, provided that the above copyright notice and this permission
+-// notice appear in all source code copies.
+-//
+-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+diff --git a/LICENCE.xc5000c b/LICENCE.xc5000c
+deleted file mode 100644
+index 23b81e7..0000000
+--- a/LICENCE.xc5000c
++++ /dev/null
+@@ -1,23 +0,0 @@
+-The following XC500C firmware file "dvb-fe-xc5000C-4.1.30.7.fw" was created
+-based on "Xc5200_firmwares_32000Khz.h".
+-
+-Firmware provided as part of an XC5000C Linux developers kit by Ramon Cazares
+-<Ramon.Cazares@CrestaTech.com> to Devin Heitmueller dheitmueller@linuxtv.org
+-on July 25, 2012.
+-
+-The code was released by Cresta Technology under the following license:
+-
+-// Copyright (c) 2012, Cresta Technology Corporation <info@crestatech.com>
+-//
+-// Permission to use, copy, modify, and/or distribute this software, only
+-// for use with Cresta Technlogy ICs, for any purpose with or without fee is
+-// hereby granted, provided that the above copyright notice and this
+-// permission notice appear in all source code copies.
+-//
+-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+diff --git a/LICENSE.Lontium b/LICENSE.Lontium
+deleted file mode 100644
+index 2989473..0000000
+--- a/LICENSE.Lontium
++++ /dev/null
+@@ -1,2 +0,0 @@
+-Lontium Semiconductor Corp. grants permission to use and redistribute aforementioned firmware file for the use with devices containing Lontium chipsets, but not as part of the Linux kernel or in any other form which would require the file itself to be covered by the terms of the GNU General Public License or the GNU Lesser General Public License.
+-The firmware file is distributed in the hope that it will be useful, but is provided WITHOUT ANY WARRANTY, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+diff --git a/LICENSE.amlogic_vdec b/LICENSE.amlogic_vdec
+deleted file mode 100644
+index ac48f20..0000000
+--- a/LICENSE.amlogic_vdec
++++ /dev/null
+@@ -1,15 +0,0 @@
+----------------------------------------------------------------------
+-Amlogic Co., Inc. grants permission to use and redistribute
+-aforementioned firmware files for the use with devices containing
+-Amlogic chipsets, but not as part of the Linux kernel or in any other
+-form which would require these files themselves to be covered by the
+-terms of the GNU General Public License or the GNU Lesser General
+-Public License.
+-
+-These firmware files are distributed in the hope that they will be
+-useful, but are provided WITHOUT ANY WARRANTY, INCLUDING BUT NOT
+-LIMITED TO IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR A
+-PARTICULAR PURPOSE.
+-
+-Amlogic Contact: Arden Jin <Arden.Jin@amlogic.com>
+----------------------------------------------------------------------
+diff --git a/LICENSE.amphion_vpu b/LICENSE.amphion_vpu
+deleted file mode 100644
+index 31840ec..0000000
+--- a/LICENSE.amphion_vpu
++++ /dev/null
+@@ -1,48 +0,0 @@
+-Copyright 2015, Amphion Semiconductor Ltd
+-Copyright 2021, NXP
+-All rights reserved.
+-
+-Redistribution. Reproduction and redistribution in binary form, without
+-modification, for use solely in conjunction with a NXP
+-chipset, is permitted provided that the following conditions are met:
+-
+-  . Redistributions must reproduce the above copyright notice and the following
+-    disclaimer in the documentation and/or other materials provided with the
+-    distribution.
+-
+-  . Neither the name of NXP nor the names of its suppliers
+-    may be used to endorse or promote products derived from this Software
+-    without specific prior written permission.
+-
+-  . No reverse engineering, decompilation, or disassembly of this Software is
+-    permitted.
+-
+-Limited patent license. NXP (.Licensor.) grants you
+-(.Licensee.) a limited, worldwide, royalty-free, non-exclusive license under
+-the Patents to make, have made, use, import, offer to sell and sell the
+-Software. No hardware per se is licensed hereunder.
+-The term .Patents. as used in this agreement means only those patents or patent
+-applications owned solely and exclusively by Licensor as of the date of
+-Licensor.s submission of the Software and any patents deriving priority (i.e.,
+-having a first effective filing date) therefrom. The term .Software. as used in
+-this agreement means the firmware image submitted by Licensor, under the terms
+-of this license, to git://git.kernel.org/pub/scm/linux/kernel/git/firmware/
+-linux-firmware.git.
+-Notwithstanding anything to the contrary herein, Licensor does not grant and
+-Licensee does not receive, by virtue of this agreement or the Licensor's
+-submission of any Software, any license or other rights under any patent or
+-patent application owned by any affiliate of Licensor or any other entity
+-(other than Licensor), whether expressly, impliedly, by virtue of estoppel or
+-exhaustion, or otherwise.
+-
+-DISCLAIMER. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.dib0700 b/LICENSE.dib0700
+deleted file mode 100644
+index fdb6bde..0000000
+--- a/LICENSE.dib0700
++++ /dev/null
+@@ -1,22 +0,0 @@
+-Firmware provided by Patrick Boettcher <pboettcher@dibcom.fr> to Devin
+-Heitmueller <dheitmueller@kernellabs.com> on October 8, 2009.
+-
+-The USB firmware file "dvb-usb-dib0700.1.20.fw" for DiBcom's DiB0700,
+-used together with the Linux driver module dvb-usb-dib0700, is
+-provided under the following licensing terms:
+-
+-Copyright (c) 2009, DiBcom
+-
+-Permission to use, copy, modify, and/or distribute this software for
+-any purpose with or without fee is hereby granted, provided that the
+-above copyright notice and this permission notice appear in all
+-copies.
+-
+-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-PERFORMANCE OF THIS SOFTWARE.
+diff --git a/LICENSE.ipu3_firmware b/LICENSE.ipu3_firmware
+deleted file mode 100644
+index 2559884..0000000
+--- a/LICENSE.ipu3_firmware
++++ /dev/null
+@@ -1,36 +0,0 @@
+-Copyright (c) 2017, Intel Corporation.
+-All rights reserved.
+-
+-Redistribution. Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-* Neither the name of Intel Corporation nor the names of its suppliers
+-  may be used to endorse or promote products derived from this software
+-  without specific prior written permission.
+-* No reverse engineering, decompilation, or disassembly of this software
+-  is permitted.
+-
+-Limited patent license. Intel Corporation grants a world-wide,
+-royalty-free, non-exclusive license under patents it now or hereafter
+-owns or controls to make, have made, use, import, offer to sell and
+-sell (“Utilize”) this software, but solely to the extent that any
+-such patent is necessary to Utilize the software alone. The patent license
+-shall not apply to any combinations which include this software. No hardware
+-per se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+diff --git a/WHENCE b/WHENCE
+index 116d04d..d78e45e 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -53,16 +53,6 @@ Found in hex form in the kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: dvb-ttusb-budget -- Technotrend/Hauppauge Nova-USB devices
+-
+-File: ttusb-budget/dspbootcode.bin
+-
+-Licence: Unknown
+-
+-Found in hex form in the kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: keyspan -- USB Keyspan USA-xxx serial device
+ 
+ File: keyspan/mpr.fw
+@@ -236,45 +226,6 @@ Converted from Intel HEX files, used in our binary representation of ihex.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: cpia2 -- cameras based on Vision's CPiA2
+-
+-File: cpia2/stv0672_vp4.bin
+-
+-Licence: Allegedly GPLv2+, but no source visible. Marked:
+-	Copyright (C) 2001 STMicroelectronics, Inc.
+-	Contact:  steve.miller@st.com
+-	Description: This file contains patch data for the CPiA2 (stv0672) VP4.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: dabusb -- Digital Audio Broadcasting (DAB) Receiver for USB and Linux
+-
+-File: dabusb/firmware.fw
+-File: dabusb/bitstream.bin
+-
+-Licence: Distributable
+-
+- * Copyright (C) 1999 BayCom GmbH
+- *
+- * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that redistributions of source
+- * code retain the above copyright notice and this comment without
+- * modification.
+-
+---------------------------------------------------------------------------
+-
+-Driver: vicam -- USB 3com HomeConnect (aka vicam)
+-
+-File: vicam/firmware.fw
+-
+-Licence: Unknown
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: io_edgeport - USB Inside Out Edgeport Serial Driver
+ 
+ File: edgeport/boot.fw
+@@ -1038,17 +989,6 @@ Also available from http://wireless.kernel.org/en/users/Drivers/iwlwifi#Firmware
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ipu3-imgu - Intel IPU3 (3rd Gen Image Processing Unit) driver
+-
+-File: intel/irci_irci_ecr-master_20161208_0213_20170112_1500.bin
+-Version: irci_irci_ecr-master_20161208_0213_20170112_1500
+-md5sum: 59abc311fce49c5a180b5a8a3917912d
+-Link: intel/ipu3-fw.bin -> irci_irci_ecr-master_20161208_0213_20170112_1500.bin
+-
+-Licence: Redistributable. See LICENSE.ipu3_firmware for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: tehuti - Tehuti Networks 10G Ethernet
+ 
+ File: tehuti/bdx.bin
+@@ -1203,36 +1143,6 @@ Found in hex form in kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: cx231xx - Conexant Cx23100/101/102 USB broadcast A/V decoder
+-
+-File: v4l-cx231xx-avcore-01.fw
+-
+-Driver: cx23418 - Conexant PCI Broadcast A/V with MPEG encoder
+-
+-File: v4l-cx23418-apu.fw
+-File: v4l-cx23418-cpu.fw
+-File: v4l-cx23418-dig.fw
+-
+-Driver: cx23885 - Conexant PCI Express Broadcast A/V decoder
+-
+-File: v4l-cx23885-avcore-01.fw
+-
+-Driver: cx23840 - Conexant sideport Broadcast A/V decoder
+-
+-File: v4l-cx25840.fw
+-
+-Licence: Redistributable.
+-
+-  Conexant grants permission to use and redistribute these firmware
+-  files for use with Conexant devices, but not as a part of the Linux
+-  kernel or in any other form which would require these files themselves
+-  to be covered by the terms of the GNU General Public License.
+-  These firmware files are distributed in the hope that they will be
+-  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+-  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+---------------------------------------------------------------------------
+-
+ Driver: qlogicpti - PTI Qlogic, ISP Driver
+ 
+ File: qlogic/isp1000.bin
+@@ -1316,18 +1226,6 @@ Available from http://ldriver.qlogic.com/firmware/netxen_nic/new/
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: dvb-ttpci -- AV7110 cards
+-
+-File: av7110/bootcode.bin
+-Source: av7110/Boot.S
+-Source: av7110/Makefile
+-
+-Licence: GPLv2 or later. See GPL-2 and GPL-3 for details.
+-
+-ARM assembly source code from https://linuxtv.org/downloads/firmware/Boot.S
+-
+---------------------------------------------------------------------------
+-
+ Driver: rt61pci - Ralink RT2561, RT2561S, RT2661 wireless MACs
+ 
+ File: rt2561.bin
+@@ -1421,35 +1319,6 @@ Provided from the author, Bernd Porr <BerndPorr@f2s.com>
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: xc4000 - Xceive 4000 Tuner driver
+-
+-File: dvb-fe-xc4000-1.4.1.fw
+-Version: 1.4.1
+-
+-Licence: Redistributable. See LICENCE.xc4000 for details
+-
+---------------------------------------------------------------------------
+-Driver: xc5000 - Xceive 5000 Tuner driver
+-
+-File: dvb-fe-xc5000-1.6.114.fw
+-Version: 1.6.114
+-
+-File: dvb-fe-xc5000c-4.1.30.7.fw
+-Version: 4.1.30.7
+-
+-Licence: Redistributable. See LICENCE.xc5000 and LICENCE.xc5000c for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: dib0700 - DiBcom dib0700 USB DVB bridge driver
+-
+-File: dvb-usb-dib0700-1.20.fw
+-Version: 1.20
+-
+-Licence: Redistributable. See LICENSE.dib0700 for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: ath3k - DFU Driver for Atheros bluetooth chipset AR3011
+ 
+ File: ath3k-1.fw
+@@ -2387,14 +2256,6 @@ Licence: Redistributable, provided by Realtek in their driver
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: lgs8gxx - Legend Silicon GB20600 demodulator driver
+-
+-File: lgs8g75.fw
+-
+-Licence: Unknown
+-
+---------------------------------------------------------------------------
+-
+ Driver: ib_qib - QLogic Infiniband
+ 
+ File: qlogic/sd7220.fw
+@@ -2671,14 +2532,6 @@ Licence: GPLv2. See GPL-2 for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ti-vpe - Texas Instruments V4L2 driver for Video Processing Engine
+-
+-File: ti/vpdma-1b8.bin
+-
+-Licence: Redistributable. See LICENCE.ti-tspa for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: wl1251 - Texas Instruments 802.11 WLAN driver for WiLink4 chips
+ 
+ File: ti-connectivity/wl1251-fw.bin
+@@ -2807,23 +2660,6 @@ Licence: Redistributable. See LICENCE.ti-connectivity for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: tlg2300 - Telgent 2300 V4L/DVB driver.
+-
+-File: tlg2300_firmware.bin
+-
+-Licence: Redistributable.
+-
+-  Telegent System grants permission to use and redistribute these
+-  firmware files for use with devices containing the chip tlg2300, but
+-  not as a part of the Linux kernel or in any other form which would
+-  require these files themselves to be covered by the terms of the GNU
+-  General Public License. These firmware files are distributed in the
+-  hope that they will be useful, but WITHOUT ANY WARRANTY; without even
+-  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+-  PURPOSE.
+-
+---------------------------------------------------------------------------
+-
+ Driver: r8712u - Realtek 802.11n WLAN driver for RTL8712U
+ 
+ File: rtlwifi/rtl8712u.bin
+@@ -3459,23 +3295,6 @@ License: Redistributable. See LICENCE.atheros_firmware for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: drxk - Micronas DRX-K demodulator driver
+-
+-File: dvb-usb-terratec-h5-drxk.fw
+-
+-Licence: Redistributable.
+-
+-TERRATEC grants permission to use and redistribute these firmware
+-files for use with TERRATEC devices, but not as part of the Linux
+-kernel or in any other form which would require these files themselves
+-to be covered by the terms of the GNU General Public License.
+-
+-These firmware files are distributed in the hope that they will be
+-useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+-of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+---------------------------------------------------------------------------
+-
+ Driver: ene-ub6250 -- ENE UB6250 SD card reader driver
+ 
+ File: ene-ub6250/sd_init1.bin
+@@ -3506,27 +3325,6 @@ Licence: Redistributable. See LICENCE.atheros_firmware for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: s5p-mfc - Samsung MFC video encoder/decoder driver
+-
+-File: s5p-mfc.fw
+-File: s5p-mfc-v6.fw
+-File: s5p-mfc-v6-v2.fw
+-File: s5p-mfc-v7.fw
+-File: s5p-mfc-v8.fw
+-
+-Licence: Redistributable.
+-
+-Samsung grants permission to use and redistribute aforementioned firmware
+-files for the use with Exynos series devices, but not as part of the Linux
+-kernel, or in any other form which would require these files themselves
+-to be covered by the terms of the GNU General Public License.
+-
+-These firmware files are distributed in the hope that they will be
+-useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+-of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+---------------------------------------------------------------------------
+-
+ Driver: carl9170 -- Atheros AR9170 802.11 draft-n USB driver
+ 
+ File: carl9170-1.fw
+@@ -3770,33 +3568,6 @@ of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: go7007
+-
+-File: go7007/s2250-1.fw
+-File: go7007/s2250-2.fw
+-Link: s2250.fw -> go7007/s2250-2.fw
+-Link: s2250_loader.fw -> go7007/s2250-1.fw
+-
+-Licence:
+-  Sensoray grants permission to use and redistribute these firmware
+-  files for use with Sensoray devices, but not as a part of the Linux
+-  kernel or in any other form which would require these files themselves
+-  to be covered by the terms of the GNU General Public License.
+-  These firmware files are distributed in the hope that they will be
+-  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+-  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+-File: go7007/go7007fw.bin
+-File: go7007/go7007tv.bin
+-File: go7007/lr192.fw
+-File: go7007/px-m402u.fw
+-File: go7007/px-tv402u.fw
+-File: go7007/wis-startrek.fw
+-
+-Licence: Redistributable. See LICENCE.go7007 for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: ccp - Platform Security Processor (PSP) device
+ 
+ File: amd/amd_sev_fam17h_model0xh.sbin
+@@ -3967,44 +3738,6 @@ Licence: Redistributable. See LICENCE.r8a779x_usb3 for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: as102 - Abilis Systems Single DVB-T Receiver
+-
+-File: as102_data1_st.hex
+-File: as102_data2_st.hex
+-
+-License: Redistributable. See LICENCE.Abilis for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: it9135 -- ITEtech IT913x DVB-T USB driver
+-
+-File: dvb-usb-it9135-01.fw
+-File: dvb-usb-it9135-02.fw
+-
+-Licence: Redistributable. See LICENCE.it913x for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: smsmdtv - Siano MDTV Core module
+-
+-File: cmmb_vega_12mhz.inp
+-File: cmmb_venice_12mhz.inp
+-File: dvb_nova_12mhz.inp
+-File: dvb_nova_12mhz_b0.inp
+-File: isdbt_nova_12mhz.inp
+-File: isdbt_nova_12mhz_b0.inp
+-File: isdbt_rio.inp
+-File: sms1xxx-hcw-55xxx-dvbt-02.fw
+-File: sms1xxx-hcw-55xxx-isdbt-02.fw
+-File: sms1xxx-nova-a-dvbt-01.fw
+-File: sms1xxx-nova-b-dvbt-01.fw
+-File: sms1xxx-stellar-dvbt-01.fw
+-File: tdmb_nova_12mhz.inp
+-
+-Licence: Redistributable. See LICENCE.siano for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: xhci-tegra -- NVIDIA Tegra XHCI driver
+ 
+ File: nvidia/tegra124/xusb.bin
+@@ -4023,23 +3756,6 @@ Licence: Redistributable. See LICENCE.nvidia for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: tegra-vic -- NVIDIA Tegra VIC driver
+-
+-File: nvidia/tegra124/vic03_ucode.bin
+-Link: nvidia/tegra124/vic.bin -> vic03_ucode.bin
+-
+-File: nvidia/tegra210/vic04_ucode.bin
+-Link: nvidia/tegra210/vic.bin -> vic04_ucode.bin
+-
+-File: nvidia/tegra186/vic04_ucode.bin
+-Link: nvidia/tegra186/vic.bin -> vic04_ucode.bin
+-
+-File: nvidia/tegra194/vic.bin
+-
+-Licence: Redistributable. See LICENCE.nvidia for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: atusb - ATUSB IEEE 802.15.4 transceiver driver
+ 
+ File: atusb/atusb-0.2.dfu
+@@ -4995,17 +4711,6 @@ Licence: Redistributable. See LICENCE.Marvell for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: mtk-vpu - MediaTek VPU video processing unit driver
+-
+-File: mediatek/mt8173/vpu_d.bin
+-File: mediatek/mt8173/vpu_p.bin
+-Link: vpu_d.bin -> mediatek/mt8173/vpu_d.bin
+-Link: vpu_p.bin -> mediatek/mt8173/vpu_p.bin
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: mtk_scp - MediaTek SCP System Control Processing Driver
+ 
+ File: mediatek/mt8183/scp.img
+@@ -5035,15 +4740,6 @@ Licence: Redistributable. See LICENCE.mediatek for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: rk3399-dptx - ROCKCHIP rk3399 dptx firmware
+-
+-File: rockchip/dptx.bin
+-Version: 3.1
+-
+-Licence: Redistributable. See LICENCE.rockchip for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: mt76x0 - MediaTek MT76x0 Wireless MACs
+ 
+ File: mediatek/mt7610u.bin
+@@ -5323,44 +5019,6 @@ Licence: Redistributable. See LICENSE.QualcommAtheros_ath10k for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: venus - Qualcomm Venus video codec accelerator
+-
+-File: qcom/venus-1.8/venus.mbn
+-Link: qcom/venus-1.8/venus.mdt -> venus.mbn
+-
+-Version: 1.8-00109
+-
+-File: qcom/venus-4.2/venus.mbn
+-Link: qcom/venus-4.2/venus.mdt -> venus.mbn
+-
+-Version: 4.2
+-
+-File: qcom/venus-5.2/venus.mbn
+-Link: qcom/venus-5.2/venus.mdt -> venus.mbn
+-
+-Version: 5.2-00023
+-
+-File: qcom/venus-5.4/venus.mbn
+-Link: qcom/venus-5.4/venus.mdt -> venus.mbn
+-
+-Version: 5.4-00053
+-
+-File: qcom/vpu-1.0/venus.mbn
+-Link: qcom/vpu-1.0/venus.mdt -> venus.mbn
+-
+-Version: VIDEO.VPU.1.0-00087-PROD-1
+-
+-File: qcom/vpu-2.0/venus.mbn
+-
+-Version: VIDEO.VPU.2.0-00049-PROD-1
+-
+-Licence: Redistributable. See LICENSE.qcom and qcom/NOTICE.txt for details
+-
+-Binary files supplied originally from
+-https://developer.qualcomm.com/hardware/dragonboard-410c/tools
+-
+---------------------------------------------------------------------------
+-
+ Driver: imx-sdma - support for i.MX SDMA driver
+ 
+ File: imx/sdma/sdma-imx6q.bin
+@@ -5582,15 +5240,6 @@ Licence:
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: cdns-mhdp - Cadence MHDP8546 DP bridge
+-
+-File: cadence/mhdp8546.bin
+-Version: 2.1.0
+-
+-Licence: Redistributable. See LICENCE.cadence for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: fsl-mc bus - NXP Management Complex Bus Driver
+ 
+ File: dpaa2/mc/mc_10.10.0_ls1088a.itb
+@@ -5622,28 +5271,6 @@ Licence: Redistributable. See LICENCE.microchip for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: meson-vdec - Amlogic video decoder
+-
+-File: meson/vdec/g12a_h264.bin
+-File: meson/vdec/g12a_hevc_mmu.bin
+-File: meson/vdec/g12a_vp9.bin
+-File: meson/vdec/gxbb_h264.bin
+-File: meson/vdec/gxl_h263.bin
+-File: meson/vdec/gxl_h264.bin
+-File: meson/vdec/gxl_hevc.bin
+-File: meson/vdec/gxl_hevc_mmu.bin
+-File: meson/vdec/gxl_mjpeg.bin
+-File: meson/vdec/gxl_mpeg12.bin
+-File: meson/vdec/gxl_mpeg4_5.bin
+-File: meson/vdec/gxl_vp9.bin
+-File: meson/vdec/gxm_h264.bin
+-File: meson/vdec/sm1_hevc_mmu.bin
+-File: meson/vdec/sm1_vp9_mmu.bin
+-
+-Licence: Redistributable. See LICENSE.amlogic_vdec for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: ice - Intel(R) Ethernet Connection E800 Series
+ 
+ File: intel/ice/ddp/ice-1.3.30.0.pkg
+@@ -5685,14 +5312,6 @@ Licence: Redistributable. See LICENCE.Marvell for details.
+ 
+ ------------------------------------------------
+ 
+-Driver: lt9611uxc - Lontium DSI to HDMI bridge
+-
+-File: lt9611uxc_fw.bin
+-
+-License: Redistributable. See LICENSE.Lontium for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: wfx - Silicon Labs Wi-Fi Transceiver
+ 
+ File: wfx/wfm_wf200_C0.sec
+@@ -5713,14 +5332,6 @@ https://github.com/SiliconLabs/wfx-linux-tools
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: wave5 - Chips&Media, Inc. video codec driver
+-
+-File: cnm/wave521c_k3_codec_fw.bin
+-
+-Licence: Redistributable. See LICENCE.cnm for details.
+-
+----------------------------------------------------------------------------
+-
+ Driver: rvu_cptpf - Marvell CPT driver
+ 
+ File: mrvl/cpt01/ae.out
+@@ -5741,17 +5352,6 @@ Licence: Redistributable. See LICENCE.Marvell for details.
+ 
+ ---------------------------------------------------------------------------
+ 
+-Driver: amphion - Amphion VPU(Video Processing Unit) Codec IP driver
+-
+-File: amphion/vpu/vpu_fw_imx8_dec.bin
+-Version: 1.8.8
+-File: amphion/vpu/vpu_fw_imx8_enc.bin
+-Version: 1.3.4
+-
+-Licence: Redistributable. See LICENSE.amphion_vpu for details
+-
+----------------------------------------------------------------------------
+-
+ Driver: nxp-sr1xx - NXP Ultra Wide Band driver
+ File: nxp/sr150_fw.bin
+ Version: 35.00.03
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0003-linux-firmware-bt-wifi-Remove-firmware-for-Bluetooth.patch
+++ b/packages/linux-firmware/0003-linux-firmware-bt-wifi-Remove-firmware-for-Bluetooth.patch
@@ -1,0 +1,3657 @@
+From 8330b130d288943c11658a69c033e97f02a69591 Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Tue, 25 Jul 2023 10:29:08 +0000
+Subject: [PATCH] linux-firmware: bt/wifi: Remove firmware for Bluetooth/WiFi
+ devices
+
+Bottlerocket does not configure any drivers for Bluetooth or WiFi
+devices. Without the drivers the firmware is useless and does not need
+to be shipped. The following list matches driver names as listed in
+WHENCE to the kernel config options enabling those driver in case we do
+add drivers in the future we can easily check if we need to add firmware
+binaries.
+
+* ar9170 - CONFIG_CARL9170
+* carl9170 - CONFIG_CARL9170
+* ath9k_htc - CONFIG_ATH9K_HTC
+* ath3k - CONFIG_BT_ATH3K
+* DFU Driver [...] AR3012 - CONFIG_BT_ATH3K
+* Atheros AR300x UART [...] - CONFIG_BT_HCIUART_ATH3K
+* ath6kl - CONFIG_ATH6KL
+* ath10k - CONFIG_ATH10K
+* ath11k - CONFIG_ATH11K
+* ar5523 - CONFIG_AR5523
+* btqca - CONFIG_BT_QCA
+* qca - CONFIG_QCA7000
+* mt7601u - CONFIG_MT7601U
+* btmtk_usb - CONFIG_BT_HCIBTUSB_MTK
+* btmtk - CONFIG_BT_MTK
+* mt76x0 - CONFIG_MT76x0U && CONFIG_MT76x0E
+* mt76x2e - CONFIG_MT76x2E
+* mt76x2u - CONFIG_MT76x2U
+* mt7615e - CONFIG_MT7615E
+* mt7622 - CONFIG_MT7622WMAC
+* mt7663 - CONFIG_MT7663U && CONFIG_MT7663S
+* mt7915e - CONFIG_MT7915E
+* mt7921 - CONFIG_MT7921U && CONFIG_MT7921S && CONFIG_MT7921E
+* mt7922 - CONFIG_MT7921U && CONFIG_MT7921S && CONFIG_MT7921E
+* brcmsmac - CONFIG_BRCMSMAC
+* brcmfmac - CONFIG_BRCMFMAC
+* BCM-0bb4-0306 - CONFIG_BT_BCM
+* wl1251 - CONFIG_WL1251
+* wl12xx - CONFIG_WL12XX
+* wl18xx - CONFIG_WL18XX
+* TI_ST - CONFIG_TI_ST
+* r8152 - CONFIG_USB_RTL8152
+* r8169 - CONFIG_R8169
+* r8712u - CONFIG_R8712U
+* rtl8188ee - CONFIG_RTL8188EE
+* rtl8192e - CONFIG_RTL8192E
+* rtl8192ce - CONFIG_RTL8192CE
+* rtl8192cu - CONFIG_RTL8192CU
+* rtl8192de - CONFIG_RTL8192DE
+* rtl8192ee - CONFIG_RTL8192EE
+* rtl8192se - CONFIG_RTL8192SE
+* rtl8723be - CONFIG_RTL8723BE
+* rtl8723bs - CONFIG_RTL8723BS
+* rtl8723de - CONFIG_RTL8723_COMMON
+* rtl8723e - CONFIG_RTL8723_COMMON
+* rtl8821ae - CONFIG_RTL8821AE
+* rtl8822be - CONFIG_RTW88_8822BE
+* rtl8xxxu - CONFIG_RTL8XXXU
+* rtw88 - CONFIG_RTW88
+* rtw89 - CONFIG_RTW89
+* btusb - CONFIG_BT_HCIBTUSB
+* nxp-sr1xx - CONFIG_NXP_UWB (driver has yet to be accepted upstream)
+* btnxpuart - CONFIG_BT_NXPUART
+* cw1200 - CONFIG_CW1200
+* rsi - CONFIG_RSI_91X
+* wilc1000 - CONFIG_WILC1000
+* qcom_q6v5_pas - CONFIG_QCOM_Q6V5_PAS
+* qcom_q6v5_mss - CONFIG_QCOM_Q6V5_MSS
+* iwlwifi - CONFIG_IWLWIFI
+* rt2800pci - CONFIG_RT2800PCI
+* rt2800usb - CONFIG_RT2800USB
+* rt2860sta - CONFIG_RT2800PCI && CONFIG_RT2800USB
+* rt2870sta - CONFIG_RT2800PCI && CONFIG_RT2800USB
+* rt61pci - CONFIG_RT61PCI
+* rt73usb - CONFIG_RT73USB
+* wfx - CONFIG_WFX
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.NXP                                |   22 -
+ LICENCE.OLPC                               |   33 -
+ LICENCE.atheros_firmware                   |   38 -
+ LICENCE.broadcom_bcm43xx                   |   65 -
+ LICENCE.cw1200                             |   35 -
+ LICENCE.cypress                            |  138 --
+ LICENCE.ibt_firmware                       |   39 -
+ LICENCE.iwlwifi_firmware                   |   39 -
+ LICENCE.open-ath9k-htc-firmware            |  206 --
+ LICENCE.ralink-firmware.txt                |   39 -
+ LICENCE.ralink_a_mediatek_company_firmware |   39 -
+ LICENCE.rtlwifi_firmware.txt               |   39 -
+ LICENCE.ti-connectivity                    |   61 -
+ LICENCE.wl1251                             |   59 -
+ LICENSE.QualcommAtheros_ar3k               |   47 -
+ LICENSE.QualcommAtheros_ath10k             |   47 -
+ LICENSE.atmel                              |   36 -
+ LICENSE.nxp                                |   26 -
+ WHENCE                                     | 2279 +-------------------
+ 19 files changed, 27 insertions(+), 3260 deletions(-)
+ delete mode 100644 LICENCE.NXP
+ delete mode 100644 LICENCE.OLPC
+ delete mode 100644 LICENCE.atheros_firmware
+ delete mode 100644 LICENCE.broadcom_bcm43xx
+ delete mode 100644 LICENCE.cw1200
+ delete mode 100644 LICENCE.cypress
+ delete mode 100644 LICENCE.ibt_firmware
+ delete mode 100644 LICENCE.iwlwifi_firmware
+ delete mode 100644 LICENCE.open-ath9k-htc-firmware
+ delete mode 100644 LICENCE.ralink-firmware.txt
+ delete mode 100644 LICENCE.ralink_a_mediatek_company_firmware
+ delete mode 100644 LICENCE.rtlwifi_firmware.txt
+ delete mode 100644 LICENCE.ti-connectivity
+ delete mode 100644 LICENCE.wl1251
+ delete mode 100644 LICENSE.QualcommAtheros_ar3k
+ delete mode 100644 LICENSE.QualcommAtheros_ath10k
+ delete mode 100644 LICENSE.atmel
+ delete mode 100644 LICENSE.nxp
+
+diff --git a/LICENCE.NXP b/LICENCE.NXP
+deleted file mode 100644
+index 96215f1..0000000
+--- a/LICENCE.NXP
++++ /dev/null
+@@ -1,22 +0,0 @@
+-Copyright � 2019.  NXP B.V.  All rights reserved.
+-
+-Redistribution and use in binary form is permitted provided that the following
+-conditions are met:
+-
+-1. Redistributions must reproduce the above copyright notice, this list of
+-conditions and the following disclaimer in the documentation and/or other
+-materials provided with the distribution.
+-
+-2. Redistribution and use shall be used only with NXP B.V. silicon products.
+-Any other use, reproduction, modification, translation, or compilation of the
+-Software is prohibited.
+-
+-3. No reverse engineering, decompilation, or disassembly is permitted.
+-
+-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THIS SOFTWARE IS PROVIDED
+-"AS IS" WITHOUT WARRANTY OF ANY KIND, INCLUDING, WITHOUT LIMITATION, ANY EXPRESS
+-OR IMPLIED WARRANTIES OF MERCHANTABILITY, ACCURACY, FITNESS OR SUFFICIENCY FOR A
+-PARTICULAR PURPOSE, SATISFACTORY QUALITY, CORRESPONDENCE WITH DESCRIPTION, QUIET
+-ENJOYMENT OR NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS.
+-NXP B.V., ITS AFFILIATES AND THEIR SUPPLIERS DISCLAIM ANY WARRANTY THAT THE
+-DELIVERABLES WILL OPERATE WITHOUT INTERRUPTION OR BE ERROR-FREE.
+diff --git a/LICENCE.OLPC b/LICENCE.OLPC
+deleted file mode 100644
+index a740952..0000000
+--- a/LICENCE.OLPC
++++ /dev/null
+@@ -1,33 +0,0 @@
+-Copyright (c) 2006, One Laptop per Child and Marvell Corporation.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without 
+-modification, are permitted provided that the following conditions are 
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the 
+-  following disclaimer in the documentation and/or other materials 
+-  provided with the distribution.
+-* Neither the name of Marvell Corporation nor the names of its suppliers 
+-  may be used to endorse or promote products derived from this software 
+-  without specific prior written permission.
+-* No reverse engineering, decompilation, or disassembly of this software 
+-  is permitted.
+-* You may not use or attempt to use this software in conjunction with
+-  any product that is offered by a third party as a replacement,
+-  substitute or alternative to a Marvell Product where a Marvell Product
+-  is defined as a proprietary wireless LAN embedded client solution of
+-  Marvell or a Marvell Affiliate.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, 
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS 
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+-DAMAGE.
+diff --git a/LICENCE.atheros_firmware b/LICENCE.atheros_firmware
+deleted file mode 100644
+index e0ebdac..0000000
+--- a/LICENCE.atheros_firmware
++++ /dev/null
+@@ -1,38 +0,0 @@
+-Copyright (c) 2008-2010, Atheros Communications, Inc.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-
+-* Neither the name of Atheros Communications, Inc. nor the names of
+-  its suppliers may be used to endorse or promote products derived
+-  from this software without specific prior written permission.
+-
+-* No reverse engineering, decompilation, or disassembly of this
+-  software is permitted.
+-
+-Limited patent license.  Atheros Communications, Inc. grants a
+-world-wide, royalty-free, non-exclusive license under patents it
+-now or hereafter owns or controls to make, have made, use, import,
+-offer to sell and sell ("Utilize") this software, but solely to
+-the extent that any such patent is necessary to Utilize the software
+-in conjunction with an Atheros Chipset. The patent license shall not
+-apply to any other combinations which include this software. No
+-hardware per se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.broadcom_bcm43xx b/LICENCE.broadcom_bcm43xx
+deleted file mode 100644
+index ff26fdd..0000000
+--- a/LICENCE.broadcom_bcm43xx
++++ /dev/null
+@@ -1,65 +0,0 @@
+-SOFTWARE LICENSE AGREEMENT
+-
+-The accompanying software in binary code form (“Software”), is licensed to you,
+-or, if you are accepting on behalf of an entity, the entity and its affiliates
+-exercising rights hereunder (“Licensee”) subject to the terms of this software
+-license agreement (“Agreement”), unless Licensee and Broadcom Corporation
+-(“Broadcom”) execute a separate written software license agreement governing
+-use of the Software. ANY USE, REPRODUCTION, OR DISTRIBUTION OF THE SOFTWARE
+-CONSTITUTES LICENSEE’S ACCEPTANCE OF THIS AGREEMENT.
+-
+-1.	License. Subject to the terms and conditions of this Agreement,
+-Broadcom hereby grants to Licensee a limited, non-exclusive, non-transferable,
+-royalty-free license: (i) to use and integrate the Software with any other
+-software; and (ii) to reproduce and distribute the Software complete,
+-unmodified, and as provided by Broadcom, solely for use with Broadcom
+-proprietary integrated circuit product(s) sold by Broadcom with which the
+-Software was designed to be used, or their successors.
+-
+-2.	Restrictions. Licensee shall distribute Software with a copy of this
+-Agreement. Licensee shall not remove, efface or obscure any copyright or
+-trademark notices from the Software. Reproductions of the Broadcom copyright
+-notice shall be included with each copy of the Software, except where such
+-Software is embedded in a manner not readily accessible to the end user.
+-Licensee shall not: (i) use, license, sell or otherwise distribute the Software
+-except as provided in this Agreement; (ii) attempt to modify in any way,
+-reverse engineer, decompile or disassemble any portion of the Software; or
+-(iii) use the Software or other material in violation of any applicable law or
+-regulation, including but not limited to any regulatory agency. This Agreement
+-shall automatically terminate upon Licensee’s failure to comply with any of the
+-terms of this Agreement. In such event, Licensee will destroy all copies of the
+-Software and its component parts.
+-
+-3.	Ownership. The Software is licensed and not sold.  Title to and
+-ownership of the Software, including all intellectual property rights thereto,
+-and any portion thereof remain with Broadcom or its licensors. Licensee hereby
+-covenants that it will not assert any claim that the Software created by or for
+-Broadcom infringe any intellectual property right owned or controlled by
+-Licensee.
+-
+-4.     	Disclaimer. THE SOFTWARE IS OFFERED “AS IS,” AND BROADCOM PROVIDES AND
+-GRANTS AND LICENSEE RECEIVES NO SUPPORT AND NO WARRANTIES OF ANY KIND, EXPRESS
+-OR IMPLIED, BY STATUTE, COMMUNICATION OR CONDUCT WITH LICENSEE, OR OTHERWISE.
+-BROADCOM SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A SPECIFIC PURPOSE, OR NONINFRINGEMENT CONCERNING THE SOFTWARE OR
+-ANY UPGRADES TO OR DOCUMENTATION FOR THE SOFTWARE. WITHOUT LIMITATION OF THE
+-ABOVE, BROADCOM GRANTS NO WARRANTY THAT THE SOFTWARE IS ERROR-FREE OR WILL
+-OPERATE WITHOUT INTERRUPTION, AND GRANTS NO WARRANTY REGARDING ITS USE OR THE
+-RESULTS THEREFROM INCLUDING, WITHOUT LIMITATION, ITS CORRECTNESS, ACCURACY, OR
+-RELIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL BROADCOM
+-OR ANY OF ITS LICENSORS HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES, HOWEVER CAUSED AND ON ANY THEORY
+-OF LIABILITY, WHETHER FOR BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE) OR
+-OTHERWISE, ARISING OUT OF THIS AGREEMENT OR USE, REPRODUCTION, OR DISTRIBUTION
+-OF THE SOFTWARE, INCLUDING BUT NOT LIMITED TO LOSS OF DATA AND LOSS OF PROFITS,
+-EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THESE
+-LIMITATIONS SHALL APPLY NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY
+-LIMITED REMEDY.
+-
+-5. 	Export Laws.  LICENSEE UNDERSTANDS AND AGREES THAT THE SOFTWARE IS
+-SUBJECT TO UNITED STATES AND OTHER APPLICABLE EXPORT-RELATED LAWS AND
+-REGULATIONS AND THAT LICENSEE MAY NOT EXPORT, RE-EXPORT OR TRANSFER THE
+-SOFTWARE OR ANY DIRECT PRODUCT OF THE SOFTWARE EXCEPT AS PERMITTED UNDER THOSE
+-LAWS. WITHOUT LIMITING THE FOREGOING, EXPORT, RE-EXPORT, OR TRANSFER OF THE
+-SOFTWARE TO CUBA, IRAN, NORTH KOREA, SUDAN, AND SYRIA IS PROHIBITED.
+-
+diff --git a/LICENCE.cw1200 b/LICENCE.cw1200
+deleted file mode 100644
+index 1016eca..0000000
+--- a/LICENCE.cw1200
++++ /dev/null
+@@ -1,35 +0,0 @@
+-Copyright (c) 2007-2013, ST Microelectronics NV.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without modification, 
+-are permitted provided that the following conditions are met:
+-
+-* Redistributions must reproduce the above copyright notice and the following 
+-disclaimer in the documentation and/or other materials provided with the 
+-distribution.
+-
+-* Neither the name of ST Microelectronics NV.  nor the names of its suppliers 
+-may be used to endorse or promote products derived from this software without 
+-specific prior written permission.
+-
+-* No reverse engineering, decompilation, or disassembly of this software is 
+-permitted.
+-
+-Limited patent license.  ST Microelectronics NV. grants a world-wide, royalty-free,
+- non-exclusive license under patents it now or hereafter owns or controls to make, 
+- have made, use, import, offer to sell and sell ("Utilize") this software, but 
+- solely to the extent that any such patent is necessary to Utilize the software in 
+-conjunction with an ST Microelectronics chipset. The patent license shall not 
+-apply to any other combinations which include this software. No hardware per se 
+-is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ANDCONTRIBUTORS 
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.cypress b/LICENCE.cypress
+deleted file mode 100644
+index 070ef66..0000000
+--- a/LICENCE.cypress
++++ /dev/null
+@@ -1,138 +0,0 @@
+-### CYPRESS WIRELESS CONNECTIVITY DEVICES
+-### DRIVER END USER LICENSE AGREEMENT (SOURCE AND BINARY DISTRIBUTION)
+-
+-PLEASE READ THIS END USER LICENSE AGREEMENT ("Agreement") CAREFULLY BEFORE
+-DOWNLOADING, INSTALLING, OR USING THIS SOFTWARE, ANY ACCOMPANYING
+-DOCUMENTATION, OR ANY UPDATES PROVIDED BY CYPRESS ("Software").  BY
+-DOWNLOADING, INSTALLING, OR USING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND
+-BY THIS AGREEMENT.  IF YOU DO NOT AGREE TO ALL OF THE TERMS OF THIS
+-AGREEMENT, PROMPTLY RETURN AND DO NOT USE THE SOFTWARE.  IF YOU HAVE
+-PURCHASED THE SOFTWARE, YOUR RIGHT TO RETURN THE SOFTWARE EXPIRES 30 DAYS
+-AFTER YOUR PURCHASE AND APPLIES ONLY TO THE ORIGINAL PURCHASER.
+-
+-Software Provided in Binary Code Form.  This paragraph applies to any Software
+-provided in binary code form.  Subject to the terms and conditions of this
+-Agreement, Cypress Semiconductor Corporation ("Cypress") grants you a
+-non-exclusive, non-transferable license under its copyright rights in the
+-Software to reproduce and distribute the Software in object code form only,
+-solely for use in connection with Cypress integrated circuit products
+-("Purpose").
+-
+-Software Provided in Source Code Form.  This paragraph applies to any Software
+-provided in source code form ("Cypress Source Code").  Subject to the terms and
+-conditions of this Agreement, Cypress grants you a non-exclusive,
+-non-transferable license under its copyright rights in the Cypress Source Code
+-to reproduce, modify, compile, and distribute the Cypress Source Code (whether
+-in source code form or as compiled into binary code form) solely for the
+-Purpose.  Cypress retains ownership of the Cypress Source Code and any compiled
+-version thereof.  Subject to Cypress' ownership of the underlying Cypress
+-Source Code, you retain ownership of any modifications you make to the
+-Cypress Source Code.  You agree not to remove any Cypress copyright or other
+-notices from the Cypress Source Code and any modifications thereof.  Any
+-reproduction, modification, translation, compilation, or representation of
+-the Cypress Source Code except as permitted in this paragraph is prohibited
+-without the express written permission of Cypress.
+-
+-Free and Open Source Software.  Portions of the Software may be licensed under
+-free and/or open source licenses such as the GNU General Public License
+-("FOSS").  FOSS is subject to the applicable license agreement and not this
+-Agreement.  If you are entitled to receive the source code from Cypress for any
+-FOSS included with the Software, either the source code will  be included with
+-the Software or you may obtain the source code at no charge from
+-<http://www.cypress.com/go/opensource>.  The applicable license terms will
+-accompany each source code package.  To review the license terms applicable to
+-any FOSS for which Cypress is not required to provide you with source code,
+-please see the Software's installation directory on your computer.
+-
+-Proprietary Rights.  The Software, including all intellectual property rights
+-therein, is and will remain the sole and exclusive property of Cypress or its
+-suppliers.  Except as otherwise expressly provided in this Agreement, you may
+-not: (i) modify, adapt, or create derivative works based upon the Software;
+-(ii) copy the Software; (iii) except and only to the extent explicitly
+-permitted by applicable law despite this limitation, decompile, translate,
+-reverse engineer, disassemble or otherwise reduce the Software to
+-human-readable form; or (iv) use the Software other than for the Purpose.
+-
+-No Support.  Cypress may, but is not required to, provide technical support for
+-the Software.
+-
+-Term and Termination.  This Agreement is effective until terminated.  This
+-Agreement and Your license rights will terminate immediately without notice
+-from Cypress if you fail to comply with any provision of this Agreement.  Upon
+-termination, you must destroy all copies of Software in your possession or
+-control.  Termination of this Agreement will not affect any licenses validly
+-granted as of the termination date to any end users of the Software.  The
+-following paragraphs shall survive any termination of this Agreement: "Free and
+-Open Source Software," "Proprietary Rights," "Compliance With Law,"
+-"Disclaimer," "Limitation of Liability," and "General."
+-
+-Compliance With Law.  Each party agrees to comply with all applicable laws,
+-rules and regulations in connection with its activities under this Agreement.
+-Without limiting the foregoing, the Software may be subject to export control
+-laws and regulations of the United States and other countries.  You agree to
+-comply strictly with all such laws and regulations and acknowledge that you
+-have the responsibility to obtain licenses to export, re-export, or import
+-the Software.
+-
+-Disclaimer.  TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, CYPRESS MAKES
+-NO WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, WITH REGARD TO THE SOFTWARE,
+-INCLUDING, BUT NOT LIMITED TO, INFRINGEMENT AND THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress reserves the
+-right to make changes to the Software without notice. Cypress does not assume
+-any liability arising out of the application or use of Software or any
+-product or circuit described in the Software. Cypress does not authorize its
+-products for use as critical components in life-support systems where a
+-malfunction or failure may reasonably be expected to result in significant
+-injury to the user. The inclusion of Cypress' product in a life-support
+-system or application implies that the manufacturer of such system or
+-application assumes all risk of such use and in doing so indemnifies Cypress
+-against all charges.
+-
+-Limitation of Liability.  IN NO EVENT WILL CYPRESS OR ITS SUPPLIERS,
+-RESELLERS, OR DISTRIBUTORS BE LIABLE FOR ANY LOST REVENUE, PROFIT, OR DATA,
+-OR FOR SPECIAL, INDIRECT, CONSEQUENTIAL, INCIDENTAL, OR PUNITIVE DAMAGES
+-HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE
+-USE OF OR INABILITY TO USE THE SOFTWARE EVEN IF CYPRESS OR ITS SUPPLIERS,
+-RESELLERS, OR DISTRIBUTORS HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGES.  IN NO EVENT SHALL CYPRESS' OR ITS SUPPLIERS' RESELLERS', OR
+-DISTRIBUTORS' TOTAL LIABILITY TO YOU, WHETHER IN CONTRACT, TORT (INCLUDING
+-NEGLIGENCE), OR OTHERWISE, EXCEED THE PRICE PAID BY YOU FOR THE SOFTWARE.
+-THE FOREGOING LIMITATIONS SHALL APPLY EVEN IF THE ABOVE-STATED WARRANTY FAILS
+-OF ITS ESSENTIAL PURPOSE.  BECAUSE SOME STATES OR JURISDICTIONS DO NOT ALLOW
+-LIMITATION OR EXCLUSION OF CONSEQUENTIAL OR INCIDENTAL DAMAGES, THE ABOVE
+-LIMITATION MAY NOT APPLY TO YOU.
+-
+-Restricted Rights.  The Software under this Agreement is commercial computer
+-software as that term is described in 48 C.F.R. 252.227-7014(a)(1).  If
+-acquired by or on behalf of a civilian agency, the U.S. Government acquires
+-this commercial computer software and/or commercial computer software
+-documentation subject to the terms of this Agreement as specified in 48
+-C.F.R. 12.212 (Computer Software) and 12.211 (Technical Data) of the Federal
+-Acquisition Regulations ("FAR") and its successors.  If acquired by or on
+-behalf of any agency within the Department of Defense ("DOD"), the U.S.
+-Government acquires this commercial computer software and/or commercial
+-computer software documentation subject to the terms of this Agreement as
+-specified in 48 C.F.R. 227.7202-3 of the DOD FAR Supplement ("DFAR") and its
+-successors.
+-
+-General.  This Agreement will bind and inure to the benefit of each party's
+-successors and assigns, provided that you may not assign or transfer this
+-Agreement, in whole or in part, without Cypress' written consent.  This
+-Agreement shall be governed by and construed in accordance with the laws of
+-the State of California, United States of America, as if performed wholly
+-within the state and without giving effect to the principles of conflict of
+-law.  The parties consent to personal and exclusive jurisdiction of and venue
+-in, the state and federal courts within Santa Clara County, California;
+-provided however, that nothing in this Agreement will limit Cypress' right to
+-bring legal action in any venue in order to protect or enforce its
+-intellectual property rights.  No failure of either party to exercise or
+-enforce any of its rights under this Agreement will act as a waiver of such
+-rights.  If any portion hereof is found to be void or unenforceable, the
+-remaining provisions of this Agreement shall remain in full force and
+-effect.  This Agreement is the complete and exclusive agreement between the
+-parties with respect to the subject matter hereof, superseding and replacing
+-any and all prior agreements, communications, and understandings (both
+-written and oral) regarding such subject matter.  Any notice to Cypress will
+-be deemed effective when actually received and must be sent to Cypress
+-Semiconductor Corporation, ATTN: Chief Legal Officer, 198 Champion Court, San
+-Jose, CA 95134 USA.
+diff --git a/LICENCE.ibt_firmware b/LICENCE.ibt_firmware
+deleted file mode 100644
+index f878c6a..0000000
+--- a/LICENCE.ibt_firmware
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Copyright © 2014, Intel Corporation.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-* Neither the name of Intel Corporation nor the names of its suppliers
+-  may be used to endorse or promote products derived from this software
+-  without specific prior written permission.
+-* No reverse engineering, decompilation, or disassembly of this software
+-  is permitted.
+-
+-Limited patent license.  Intel Corporation grants a world-wide,
+-royalty-free, non-exclusive license under patents it now or hereafter
+-owns or controls to make, have made, use, import, offer to sell and
+-sell ("Utilize") this software, but solely to the extent that any
+-such patent is necessary to Utilize the software alone, or in
+-combination with an operating system licensed under an approved Open
+-Source license as listed by the Open Source Initiative at
+-http://opensource.org/licenses.  The patent license shall not apply to
+-any other combinations which include this software.  No hardware per
+-se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+diff --git a/LICENCE.iwlwifi_firmware b/LICENCE.iwlwifi_firmware
+deleted file mode 100644
+index 6bdd16d..0000000
+--- a/LICENCE.iwlwifi_firmware
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Copyright (c) 2006-2021, Intel Corporation.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-* Neither the name of Intel Corporation nor the names of its suppliers
+-  may be used to endorse or promote products derived from this software
+-  without specific prior written permission.
+-* No reverse engineering, decompilation, or disassembly of this software
+-  is permitted.
+-
+-Limited patent license.  Intel Corporation grants a world-wide,
+-royalty-free, non-exclusive license under patents it now or hereafter
+-owns or controls to make, have made, use, import, offer to sell and
+-sell ("Utilize") this software, but solely to the extent that any
+-such patent is necessary to Utilize the software alone, or in
+-combination with an operating system licensed under an approved Open
+-Source license as listed by the Open Source Initiative at
+-http://opensource.org/licenses.  The patent license shall not apply to
+-any other combinations which include this software.  No hardware per
+-se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+diff --git a/LICENCE.open-ath9k-htc-firmware b/LICENCE.open-ath9k-htc-firmware
+deleted file mode 100644
+index 36655b7..0000000
+--- a/LICENCE.open-ath9k-htc-firmware
++++ /dev/null
+@@ -1,206 +0,0 @@
+-This is a concatenation of LICENCE.txt and NOTICE.txt from the
+-open-ath9k-htc-firmware repository describing licensing terms for the
+-firmware image and its sources.
+-
+-The source code repository is publicly available at
+-https://github.com/qca/open-ath9k-htc-firmware .
+-
+-
+-LICENCE.txt
+------------
+-
+-Files with a Qualcomm Atheros / Atheros licence fall under the following
+-licence.  Please see NOTICES.TXT for information about other files in this
+-repository.
+-
+-----
+-
+-Copyright (c) 2013 Qualcomm Atheros, Inc.
+-
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted (subject to the limitations in the
+-disclaimer below) provided that the following conditions are met:
+-
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the
+-   distribution.
+-
+- * Neither the name of Qualcomm Atheros nor the names of its
+-   contributors may be used to endorse or promote products derived
+-   from this software without specific prior written permission.
+-
+-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+-GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+-HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+-IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-----
+-
+-
+-NOTICE.TXT
+-----------
+-
+-This NOTICE.TXT file contains certain notices of software components included
+-with the software that QUALCOMM ATHEROS Incorporated ('Qualcomm Atheros') is
+-required to provide you. Notwithstanding anything in the notices in this file,
+-your use of these software components together with the Qualcomm Atheros
+-software (Qualcomm Atheros software hereinafter referred to as 'Software') is
+-subject to the terms of your license from Qualcomm Atheros.  Compliance with
+-all copyright laws and software license agreements included in the notice
+-section of this file are the responsibility of the user.  Except as may be
+-granted by separate express written agreement, this file provides no license
+-to any Qualcomm Atheros patents, trademarks, copyrights, or other intellectual
+-property.
+-
+-Copyright (c) 2013 QUALCOMM ATHEROS Incorporated.  All rights reserved.
+-
+-QUALCOMM ATHEROS� is a registered trademark and registered service mark of
+-QUALCOMM ATHEROS Incorporated.  All other trademarks and service marks are
+-the property of their respective owners.
+-
+-NOTICES:
+-
+-/*
+- * Copyright (c) 2005-2012 Atheros Communications Inc.
+- *
+- * Permission to use, copy, modify, and/or distribute this software for any
+- * purpose with or without fee is hereby granted, provided that the above
+- * copyright notice and this permission notice appear in all copies.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+- */
+-
+-/*
+- * Copyright (c) 2002-2005 Sam Leffler, Errno Consulting
+- * Copyright (c) 2002-2005 Atheros Communications, Inc.
+- * Copyright (c) 2008-2010, Atheros Communications Inc.
+- *
+- * Redistribution and use in source and binary forms are permitted
+- * provided that the following conditions are met:
+- * 1. The materials contained herein are unmodified and are used
+- *    unmodified.
+- * 2. Redistributions of source code must retain the above copyright
+- *    notice, this list of conditions and the following NO
+- *    ''WARRANTY'' disclaimer below (''Disclaimer''), without
+- *    modification.
+- * 3. Redistributions in binary form must reproduce at minimum a
+- *    disclaimer similar to the Disclaimer below and any redistribution
+- *    must be conditioned upon including a substantially similar
+- *    Disclaimer requirement for further binary redistribution.
+- * 4. Neither the names of the above-listed copyright holders nor the
+- *    names of any contributors may be used to endorse or promote
+- *    product derived from this software without specific prior written
+- *    permission.
+- *
+- * NO WARRANTY
+- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+- * ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+- * LIMITED TO, THE IMPLIED WARRANTIES OF NONINFRINGEMENT,
+- * MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+- * IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+- * FOR SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+- * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+- * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+- * SUCH DAMAGES.
+- */
+-
+-----
+-
+-The following files are from ECoS with a GPLv2 licence with modification
+-and linking caveats. Please see the licence below for more information:
+-
+-target_firmware/magpie_fw_dev/build/magpie_1_1/sboot/cmnos/printf/src/cmnos_printf.c
+-target_firmware/magpie_fw_dev/target/cmnos/cmnos_printf.c
+-target_firmware/magpie_fw_dev/target/cmnos/k2_fw_cmnos_printf.c
+-
+-//####ECOSGPLCOPYRIGHTBEGIN####
+-// -------------------------------------------
+-// This file is part of eCos, the Embedded Configurable Operating System.
+-// Copyright (C) 1998, 1999, 2000, 2001, 2002 Red Hat, Inc.
+-// Copyright (C) 2002 Gary Thomas
+-//
+-// eCos is free software; you can redistribute it and/or modify it under
+-// the terms of the GNU General Public License as published by the Free
+-// Software Foundation; either version 2 or (at your option) any later version.
+-//
+-// eCos is distributed in the hope that it will be useful, but WITHOUT ANY
+-// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+-// for more details.
+-//
+-// You should have received a copy of the GNU General Public License along
+-// with eCos; if not, write to the Free Software Foundation, Inc.,
+-// 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+-//
+-// As a special exception, if other files instantiate templates or use macros
+-// or inline functions from this file, or you compile this file and link it
+-// with other works to produce a work based on this file, this file does not
+-// by itself cause the resulting work to be covered by the GNU General Public
+-// License. However the source code for this file must still be made available
+-// in accordance with section (3) of the GNU General Public License.
+-//
+-// This exception does not invalidate any other reasons why a work based on
+-// this file might be covered by the GNU General Public License.
+-//
+-// Alternative licenses for eCos may be arranged by contacting Red Hat, Inc.
+-// at http://sources.redhat.com/ecos/ecos-license/
+-// -------------------------------------------
+-//####ECOSGPLCOPYRIGHTEND####
+-
+-----
+-
+-Some of the source code is sourced from Tensilica, Inc.
+-
+-Although most of the files fall under the MIT licence, some of the source
+-files generated as part of the system development have a proprietary
+-Tensilica licence.
+-
+-With permission from Tensilica, Inc, these files have been relicenced
+-under the following licence:
+-
+-/*
+- * Copyright (c) 2013 Tensilica Inc.
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining
+- * a copy of this software and associated documentation files (the
+- * "Software"), to deal in the Software without restriction, including
+- * without limitation the rights to use, copy, modify, merge, publish,
+- * distribute, sublicense, and/or sell copies of the Software, and to
+- * permit persons to whom the Software is furnished to do so, subject to
+- * the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be included
+- * in all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- */
+diff --git a/LICENCE.ralink-firmware.txt b/LICENCE.ralink-firmware.txt
+deleted file mode 100644
+index 18dd038..0000000
+--- a/LICENCE.ralink-firmware.txt
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Copyright (c) 2007, Ralink Technology Corporation 
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without 
+-modification, are permitted provided that the following conditions are 
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the 
+-  following disclaimer in the documentation and/or other materials 
+-  provided with the distribution. 
+-* Neither the name of Ralink Technology Corporation nor the names of its
+-  suppliers may be used to endorse or promote products derived from this
+-  software without specific prior written permission. 
+-* No reverse engineering, decompilation, or disassembly of this software 
+-  is permitted.
+-
+-Limited patent license. Ralink Technology Corporation grants a world-wide, 
+-royalty-free, non-exclusive license under patents it now or hereafter 
+-owns or controls to make, have made, use, import, offer to sell and 
+-sell ("Utilize") this software, but solely to the extent that any 
+-such patent is necessary to Utilize the software alone, or in 
+-combination with an operating system licensed under an approved Open 
+-Source license as listed by the Open Source Initiative at 
+-http://opensource.org/licenses.  The patent license shall not apply to 
+-any other combinations which include this software.  No hardware per 
+-se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, 
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS 
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+-DAMAGE.
+diff --git a/LICENCE.ralink_a_mediatek_company_firmware b/LICENCE.ralink_a_mediatek_company_firmware
+deleted file mode 100644
+index fef16b6..0000000
+--- a/LICENCE.ralink_a_mediatek_company_firmware
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Copyright (c) 2013, Ralink, A MediaTek Company 
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without 
+-modification, are permitted provided that the following conditions are 
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the 
+-  following disclaimer in the documentation and/or other materials 
+-  provided with the distribution. 
+-* Neither the name of Ralink Technology Corporation nor the names of its
+-  suppliers may be used to endorse or promote products derived from this
+-  software without specific prior written permission. 
+-* No reverse engineering, decompilation, or disassembly of this software 
+-  is permitted.
+-
+-Limited patent license. Ralink Technology Corporation grants a world-wide, 
+-royalty-free, non-exclusive license under patents it now or hereafter 
+-owns or controls to make, have made, use, import, offer to sell and 
+-sell ("Utilize") this software, but solely to the extent that any 
+-such patent is necessary to Utilize the software alone, or in 
+-combination with an operating system licensed under an approved Open 
+-Source license as listed by the Open Source Initiative at 
+-http://opensource.org/licenses.  The patent license shall not apply to 
+-any other combinations which include this software.  No hardware per 
+-se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, 
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS 
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+-DAMAGE.
+diff --git a/LICENCE.rtlwifi_firmware.txt b/LICENCE.rtlwifi_firmware.txt
+deleted file mode 100644
+index d70921f..0000000
+--- a/LICENCE.rtlwifi_firmware.txt
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Copyright (c) 2010, Realtek Semiconductor Corporation 
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without 
+-modification, are permitted provided that the following conditions are 
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the 
+-  following disclaimer in the documentation and/or other materials 
+-  provided with the distribution. 
+-* Neither the name of Realtek Semiconductor Corporation nor the names of its
+-  suppliers may be used to endorse or promote products derived from this
+-  software without specific prior written permission. 
+-* No reverse engineering, decompilation, or disassembly of this software 
+-  is permitted.
+-
+-Limited patent license. Realtek Semiconductor Corporation grants a world-wide, 
+-royalty-free, non-exclusive license under patents it now or hereafter 
+-owns or controls to make, have made, use, import, offer to sell and 
+-sell ("Utilize") this software, but solely to the extent that any 
+-such patent is necessary to Utilize the software alone, or in 
+-combination with an operating system licensed under an approved Open 
+-Source license as listed by the Open Source Initiative at 
+-http://opensource.org/licenses.  The patent license shall not apply to 
+-any other combinations which include this software.  No hardware per 
+-se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, 
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS 
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+-DAMAGE.
+diff --git a/LICENCE.ti-connectivity b/LICENCE.ti-connectivity
+deleted file mode 100644
+index 22f617f..0000000
+--- a/LICENCE.ti-connectivity
++++ /dev/null
+@@ -1,61 +0,0 @@
+-Copyright (c) 2016 Texas Instruments Incorporated
+-
+-All rights reserved not granted herein.
+-
+-Limited License.
+-
+-Texas Instruments Incorporated grants a world-wide, royalty-free, non-exclusive
+-license under copyrights and patents it now or hereafter owns or controls to
+-make, have made, use, import, offer to sell and sell ("Utilize") this software
+-subject to the terms herein. With respect to the foregoing patent license, such
+-license is granted solely to the extent that any such patent is necessary to
+-Utilize the software alone. The patent license shall not apply to any
+-combinations which include this software, other than combinations with devices
+-manufactured by or for TI (“TI Devices”). No hardware patent is licensed
+-hereunder.
+-
+-Redistributions must preserve existing copyright notices and reproduce this
+-license (including the above copyright notice and the disclaimer and
+-(if applicable) source code license limitations below) in the documentation
+-and/or other materials provided with the distribution
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met:
+-
+-	* No reverse engineering, decompilation, or disassembly of this
+-	  software is permitted with respect to any software provided in binary
+-	  form.
+-
+-	* any redistribution and use are licensed by TI for use only with TI
+-	  Devices.
+-
+-	* Nothing shall obligate TI to provide you with source code for the
+-	  software licensed and provided to you in object code.
+-
+-If software source code is provided to you, modification and redistribution of
+-the source code are permitted provided that the following conditions are met:
+-
+-	* any redistribution and use of the source code, including any
+-	  resulting derivative works, are licensed by TI for use only with TI
+-	  Devices.
+-
+-	* any redistribution and use of any object code compiled from the
+-	  source code and any resulting derivative works, are licensed by TI
+-	  for use only with TI Devices.
+-
+-Neither the name of Texas Instruments Incorporated nor the names of its
+-suppliers may be used to endorse or promote products derived from this
+-software without specific prior written permission.
+-
+-DISCLAIMER.
+-
+-THIS SOFTWARE IS PROVIDED BY TI AND TI’S LICENSORS "AS IS" AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+-EVENT SHALL TI AND TI’S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.wl1251 b/LICENCE.wl1251
+deleted file mode 100644
+index bd0f5f1..0000000
+--- a/LICENCE.wl1251
++++ /dev/null
+@@ -1,59 +0,0 @@
+-Copyright (c) 2000 – 2013 Texas Instruments Incorporated
+-
+-All rights reserved not granted herein.
+-
+-Limited License.
+-
+-Texas Instruments Incorporated grants a world-wide, royalty-free, non-exclusive
+-license under copyrights and patents it now or hereafter owns or controls to
+-make, have made, use, import, offer to sell and sell ("Utilize") this software
+-subject to the terms herein.  With respect to the foregoing patent license,
+-such license is granted  solely to the extent that any such patent is necessary
+-to Utilize the software alone.  The patent license shall not apply to any
+-combinations which include this software, other than combinations with devices
+-manufactured by or for TI (“TI Devices”).  No hardware patent is licensed
+-hereunder.
+-
+-Redistributions must preserve existing copyright notices and reproduce this
+-license (including the above copyright notice and the disclaimer and (if
+-applicable) source code license limitations below) in the documentation and/or
+-other materials provided with the distribution
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met:
+-
+-*	No reverse engineering, decompilation, or disassembly of this software
+-	is permitted with respect to any software provided in binary form.
+-
+-*	any redistribution and use are licensed by TI for use only with TI
+-	Devices.
+-
+-*	Nothing shall obligate TI to provide you with source code for the
+-	software licensed and provided to you in object code.
+-
+-If software source code is provided to you, modification and redistribution of
+-the source code are permitted provided that the following conditions are met:
+-
+-*	any redistribution and use of the source code, including any resulting
+-	derivative works, are licensed by TI for use only with TI Devices.
+-
+-*	any redistribution and use of any object code compiled from the source
+-	code and any resulting derivative works, are licensed by TI for use
+-	only with TI Devices.
+-
+-Neither the name of Texas Instruments Incorporated nor the names of its
+-suppliers may be used to endorse or promote products derived from this software
+-without specific prior written permission.
+-
+-DISCLAIMER.
+-
+-THIS SOFTWARE IS PROVIDED BY TI AND TI’S LICENSORS "AS IS" AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+-EVENT SHALL TI AND TI’S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.QualcommAtheros_ar3k b/LICENSE.QualcommAtheros_ar3k
+deleted file mode 100644
+index 7fae632..0000000
+--- a/LICENSE.QualcommAtheros_ar3k
++++ /dev/null
+@@ -1,47 +0,0 @@
+-Copyright (c) 2015, Qualcomm Atheros, Inc.
+-All rights reserved.
+-
+-Redistribution. Reproduction and redistribution in binary form, without
+-modification, for use solely in conjunction with a Qualcomm Atheros, Inc.
+-chipset, is permitted provided that the following conditions are met:
+-
+-  • Redistributions must reproduce the above copyright notice and the following
+-    disclaimer in the documentation and/or other materials provided with the
+-    distribution.
+-
+-  • Neither the name of Qualcomm Atheros, Inc. nor the names of its suppliers
+-    may be used to endorse or promote products derived from this Software
+-    without specific prior written permission.
+-
+-  • No reverse engineering, decompilation, or disassembly of this Software is
+-    permitted.
+-
+-Limited patent license. Qualcomm Atheros, Inc. (“Licensor”) grants you
+-(“Licensee”) a limited, worldwide, royalty-free, non-exclusive license under
+-the Patents to make, have made, use, import, offer to sell and sell the
+-Software. No hardware per se is licensed hereunder.
+-The term “Patents” as used in this agreement means only those patents or patent
+-applications owned solely and exclusively by Licensor as of the date of
+-Licensor’s submission of the Software and any patents deriving priority (i.e.,
+-having a first effective filing date) therefrom. The term “Software” as used in
+-this agreement means the firmware image submitted by Licensor, under the terms
+-of this license, to git://git.kernel.org/pub/scm/linux/kernel/git/firmware/
+-linux-firmware.git.
+-Notwithstanding anything to the contrary herein, Licensor does not grant and
+-Licensee does not receive, by virtue of this agreement or the Licensor’s
+-submission of any Software, any license or other rights under any patent or
+-patent application owned by any affiliate of Licensor or any other entity
+-(other than Licensor), whether expressly, impliedly, by virtue of estoppel or
+-exhaustion, or otherwise.
+-
+-DISCLAIMER. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.QualcommAtheros_ath10k b/LICENSE.QualcommAtheros_ath10k
+deleted file mode 100644
+index c68935c..0000000
+--- a/LICENSE.QualcommAtheros_ath10k
++++ /dev/null
+@@ -1,47 +0,0 @@
+-Copyright (c) 2015-2017, Qualcomm Atheros, Inc.
+-All rights reserved.
+-
+-Redistribution. Reproduction and redistribution in binary form, without
+-modification, for use solely in conjunction with a Qualcomm Atheros, Inc.
+-chipset, is permitted provided that the following conditions are met:
+-
+-  • Redistributions must reproduce the above copyright notice and the following
+-    disclaimer in the documentation and/or other materials provided with the
+-    distribution.
+-
+-  • Neither the name of Qualcomm Atheros, Inc. nor the names of its suppliers
+-    may be used to endorse or promote products derived from this Software
+-    without specific prior written permission.
+-
+-  • No reverse engineering, decompilation, or disassembly of this Software is
+-    permitted.
+-
+-Limited patent license. Qualcomm Atheros, Inc. (“Licensor”) grants you
+-(“Licensee”) a limited, worldwide, royalty-free, non-exclusive license under
+-the Patents to make, have made, use, import, offer to sell and sell the
+-Software. No hardware per se is licensed hereunder.
+-The term “Patents” as used in this agreement means only those patents or patent
+-applications owned solely and exclusively by Licensor as of the date of
+-Licensor’s submission of the Software and any patents deriving priority (i.e.,
+-having a first effective filing date) therefrom. The term “Software” as used in
+-this agreement means the firmware image submitted by Licensor, under the terms
+-of this license, to git://git.kernel.org/pub/scm/linux/kernel/git/firmware/
+-linux-firmware.git.
+-Notwithstanding anything to the contrary herein, Licensor does not grant and
+-Licensee does not receive, by virtue of this agreement or the Licensor’s
+-submission of any Software, any license or other rights under any patent or
+-patent application owned by any affiliate of Licensor or any other entity
+-(other than Licensor), whether expressly, impliedly, by virtue of estoppel or
+-exhaustion, or otherwise.
+-
+-DISCLAIMER. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.atmel b/LICENSE.atmel
+deleted file mode 100644
+index 5feb313..0000000
+--- a/LICENSE.atmel
++++ /dev/null
+@@ -1,36 +0,0 @@
+-Copyright (C) 2015 Atmel Corporation. All rights reserved.
+-
+-REDISTRIBUTION: Permission is hereby granted by Atmel Corporation (Atmel), free
+-of any license fees, to any person obtaining a copy of this firmware (the
+-"Software"), to install, reproduce, copy and distribute copies, in binary form,
+-in hexadecimal or equivalent formats, of the Software and to permit persons to
+-whom the Software is provided to do the same, subject to the following
+-conditions:
+-
+-* Any redistribution of the Software must reproduce the above copyright notice,
+-  this license notice, and the following disclaimers and notices in the
+-  documentation and/or other materials provided with the Software.
+-
+-* Neither the name of Atmel Corporation, its products nor the names of its
+-  suppliers may be used to endorse or promote products derived from this
+-  Software without specific prior written permission.
+-
+-* All matters arising out of or in connection with this License and/or Software
+-  shall be governed by California law and the parties agree to the exclusive
+-  jurisdiction of the Californian courts to decide all disputes arising.
+-
+-* The licensee shall defend and indemnify Atmel against any and all claims,
+-  costs, losses and damages (including reasonable legal fees) incurred by tme
+-  arising out of any claim relating to the Software due to the licensee’s use or
+-  sub-licensing of the Software
+-
+-DISCLAIMER: THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+-DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.nxp b/LICENSE.nxp
+deleted file mode 100644
+index bfd2c70..0000000
+--- a/LICENSE.nxp
++++ /dev/null
+@@ -1,26 +0,0 @@
+-LA_OPT_BINARY_FIRMWARE_ONLY rev2 June 2020
+-
+-Copyright © 2018 NXP. All rights reserved.
+-
+-Software License Agreement (“Agreement”)
+-
+-ANY USE, REPRODUCTION, OR DISTRIBUTION OF THE ACCOMPANYING BINARY SOFTWARE CONSTITUTES LICENSEE'S ACCEPTANCE OF THE TERMS AND CONDITIONS OF THIS AGREEMENT.
+-
+-Licensed Software. “Binary Software” means the software in binary form supplied directly by NXP pursuant to this Agreement. Subject to the terms and conditions of this Agreement, NXP USA, Inc. ("Licensor"), grants to you (“Licensee”) a worldwide, non-exclusive, and royalty-free copyright license to reproduce and distribute the Binary Software in its complete and unmodified binary form as provided by Licensor, for use solely in conjunction with a programmable processing unit supplied directly or indirectly from Licensor.
+-
+-Restrictions. Licensee must reproduce the Licensor copyright notice above with each binary copy of the Binary Software or in the accompanying documentation. Licensee must not reverse engineer, decompile, disassemble or modify in any way the Binary Software. Licensee must not use the Binary Software in violation of any applicable law or regulation. This Agreement shall automatically terminate upon Licensee's breach of any term or condition of this Agreement in which case, Licensee shall destroy all copies of the Binary Software. Neither the name of Licensor nor the names of its suppliers may be used to endorse or promote products derived from this Binary Software without specific prior written permission.
+-Disclaimer.  TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR EXPRESSLY DISCLAIMS ANY WARRANTY FOR THE BINARY SOFTWARE.  THE BINARY SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.  WITHOUT LIMITING THE GENERALITY OF THE FOREGOING, LICENSOR DOES NOT WARRANT THAT THE BINARY SOFTWARE IS ERROR-FREE OR WILL OPERATE WITHOUT INTERRUPTION, AND LICENSOR GRANTS NO WARRANTY REGARDING ITS USE OR THE RESULTS THEREFROM, INCLUDING ITS CORRECTNESS, ACCURACY, OR RELIABILITY.
+-
+-Limitation of Liability. IN NO EVENT WILL LICENSOR, OR ANY OF LICENSOR'S LICENSORS HAVE ANY LIABILITY HEREUNDER FOR ANY INDIRECT, SPECIAL, OR
+-CONSEQUENTIAL DAMAGES, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER FOR BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, ARISING OUT OF THIS AGREEMENT, INCLUDING DAMAGES FOR LOSS OF PROFITS, OR THE COST OF PROCUREMENT OF SUBSTITUTE GOODS, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. LICENSOR’S TOTAL LIABILITY FOR ALL COSTS, DAMAGES, CLAIMS, OR LOSSES WHATSOEVER ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT OR THE BINARY SOFTWARE SUPPLIED UNDER THIS AGREEMENT IS LIMITED TO THE AGGREGATE AMOUNT PAID BY LICENSEE TO LICENSOR IN CONNECTION WITH THE BINARY SOFTWARE TO WHICH LOSSES OR DAMAGES ARE CLAIMED.
+-
+-Trade Compliance.  Licensee shall comply with all applicable export and import control laws and regulations including but not limited to the US Export Administration Regulation (including restrictions on certain military end uses and military end users as specified in Section 15 C.F.R. § 744.21 and prohibited party lists issued by other federal governments), Catch-all regulations and all national and international embargoes. Licensee further agrees that it will not knowingly transfer, divert, export or re-export, directly or indirectly, any product, software, including software source code, or technology restricted by such regulations or by other applicable national regulations, received from Licensor under this Agreement, or any direct product of such software or technical data to any person, firm, entity, country or destination to which such transfer, diversion, export or re-export is restricted or prohibited, without obtaining prior written authorization from the applicable competent government authorities to the extent required by those laws. Licensee acknowledge that the “restricted encryption software” that is subject to the US Export Administration Regulations (EAR), is not intended for use by a government end user, as defined in part 772 of the EAR. This provision shall survive termination or expiration of this Agreement. 
+-
+-Assignment.  Licensee may not assign this Agreement without the prior written consent of Licensor.  Licensor may assign this Agreement without Licensee’s consent.
+-
+-Governing Law.  This Agreement will be governed by, construed, and enforced in accordance with the laws of the State of Texas, USA, without regard to conflicts of laws principles, will apply to all matters relating to this Agreement or the Binary Software, and Licensee agrees that any litigation will be subject to the exclusive jurisdiction of the state or federal courts Texas, USA.  The United Nations Convention on Contracts for the International Sale of Goods will not apply to this Agreement.
+-Restrictions, Disclaimer, Limitation of Liability, Trade Compliance, Assignment, and Governing Law shall survive termination or expiration of this Agreement.
+-
+-
+-
+-
+diff --git a/WHENCE b/WHENCE
+index d78e45e..edf6f75 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -8,15 +8,6 @@ kernel.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: BCM-0bb4-0306 Cypress Bluetooth firmware for HTC Vive
+-
+-File: brcm/BCM-0bb4-0306.hcd
+-Link: brcm/BCM-0a5c-6410.hcd -> BCM-0bb4-0306.hcd
+-
+-Licence: Redistributable. See LICENCE.cypress for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: advansys - AdvanSys SCSI
+ 
+ File: advansys/mcode.bin
+@@ -306,36 +297,6 @@ Licence: Redistributable. See LICENCE.agere for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ar9170 - Atheros 802.11n "otus" USB
+-
+-File: ar9170-1.fw
+-File: ar9170-2.fw
+-
+-Licence: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: ath9k_htc - Atheros HTC devices (USB)
+-
+-File: ar9271.fw
+-File: ar7010.fw
+-File: ar7010_1_1.fw
+-File: htc_9271.fw
+-Version: 1.3.1
+-File: htc_7010.fw
+-Version: 1.3.1
+-
+-Licence: Redistributable. See LICENCE.atheros_firmware for details
+-
+-File: ath9k_htc/htc_7010-1.4.0.fw
+-Version: 1.4.0
+-File: ath9k_htc/htc_9271-1.4.0.fw
+-Version: 1.4.0
+-
+-Licence: Free software. See LICENCE.open-ath9k-htc-firmware for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: cassini - Sun Cassini
+ 
+ File: sun/cassini.bin
+@@ -516,479 +477,6 @@ Found in hex form in kernel source, with the following notice:
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: libertas - Marvell Libertas fullmac-type 802.11b/g cards
+-
+-File: libertas/cf8381.bin
+-File: libertas/cf8381_helper.bin
+-File: libertas/cf8385.bin
+-File: libertas/cf8385_helper.bin
+-File: libertas/gspi8682.bin
+-File: libertas/gspi8682_helper.bin
+-File: libertas/gspi8686_v9.bin
+-File: libertas/gspi8686_v9_helper.bin
+-File: libertas/gspi8688.bin
+-File: libertas/gspi8688_helper.bin
+-File: libertas/sd8385.bin
+-File: libertas/sd8385_helper.bin
+-File: libertas/sd8682.bin
+-File: libertas/sd8682_helper.bin
+-File: libertas/sd8686_v8.bin
+-File: libertas/sd8686_v8_helper.bin
+-File: libertas/sd8686_v9.bin
+-File: libertas/sd8686_v9_helper.bin
+-File: libertas/usb8388_v5.bin
+-File: libertas/usb8388_v9.bin
+-File: libertas/usb8682.bin
+-File: mrvl/sd8688.bin
+-Link: libertas/sd8688.bin -> ../mrvl/sd8688.bin
+-File: mrvl/sd8688_helper.bin
+-Link: libertas/sd8688_helper.bin -> ../mrvl/sd8688_helper.bin
+-
+-Licence: Redistributable. See LICENCE.Marvell for details.  Extracted from
+-Linux driver tarballs downloaded from Marvell's "Extranet" with permission.
+-
+---------------------------------------------------------------------------
+-
+-Driver: libertas - Marvell Libertas 802.11b/g cards, OLPC firmware
+-
+-File: libertas/lbtf_sdio.bin
+-Version: 9.0.7.p4
+-
+-File: lbtf_usb.bin
+-Version: 5.132.3.p1
+-
+-File: libertas/usb8388_olpc.bin
+-Version: 5.110.22.p23
+-
+-Licence: Redistributable. See LICENCE.OLPC for details.
+-
+-Available from http://dev.laptop.org/pub/firmware/libertas/
+-
+---------------------------------------------------------------------------
+-
+-Driver: mwl8k - Marvell Libertas softmac-type 802.11b/g/n cards
+-
+-File: mwl8k/fmimage_8687.fw
+-File: mwl8k/helper_8687.fw
+-File: mwl8k/fmimage_8366.fw
+-File: mwl8k/fmimage_8366_ap-1.fw
+-File: mwl8k/fmimage_8366_ap-2.fw
+-File: mwl8k/fmimage_8366_ap-3.fw
+-Version: 5.2.8.16
+-File: mwl8k/helper_8366.fw
+-
+-File: mwl8k/fmimage_8764_ap-1.fw
+-Version: 7.4.0.9
+-
+-Licence: Redistributable. See LICENCE.Marvell for details.  8687 images
+-downloaded from Marvell's "Extranet" with permission.  8366 images contributed
+-directly by Marvell.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mwifiex - Marvell Wi-Fi fullmac-type 802.11n/ac cards
+-
+-File: mrvl/sd8787_uapsta.bin
+-Version: W14.68.35.p66
+-
+-File: mrvl/usb8766_uapsta.bin
+-Version: 14.68.22.p16
+-
+-File: mrvl/sd8797_uapsta.bin
+-Version: W14.68.29.p59
+-
+-File: mrvl/usb8797_uapsta.bin
+-Version: W14.68.29.p60
+-
+-File: mrvl/sd8897_uapsta.bin
+-Version: W15.68.19.17
+-
+-File: mrvl/usb8897_uapsta.bin
+-Version: 15.68.4.p103
+-
+-File: mrvl/pcie8897_uapsta.bin
+-Version: W15.68.19.p21
+-
+-File: mrvl/sd8887_uapsta.bin
+-Version: W15.68.7.p189
+-
+-File: mrvl/sd8801_uapsta.bin
+-Version: W14.68.36.p204
+-
+-File: mrvl/usb8801_uapsta.bin
+-Version: W14.68.36.p138
+-
+-File: mrvl/pcieuart8997_combo_v4.bin
+-Version: W16.68.1.p179
+-
+-File: mrvl/pcieusb8997_combo_v4.bin
+-Version: W16.68.1.p195
+-
+-File: mrvl/pcie8997_wlan_v4.bin
+-Version: W16.68.1.p195
+-
+-File: mrvl/usbusb8997_combo_v4.bin
+-Version: W16.68.1.p183
+-
+-File: mrvl/sdsd8997_combo_v4.bin
+-Version: W16.68.1.p179
+-
+-File: mrvl/sdsd8977_combo_v2.bin
+-Version: W16.68.1.p195
+-
+-Licence: Redistributable. See LICENCE.NXP for details.
+-Originates from https://github.com/NXP/mwifiex-firmware.git
+-
+---------------------------------------------------------------------------
+-
+-
+-Driver: iwlwifi - Intel Wireless Wifi
+-
+-File: iwlwifi-3945-2.ucode
+-Version: 15.32.2.9
+-
+-File: iwlwifi-4965-2.ucode
+-Version: 228.61.2.24
+-
+-File: iwlwifi-5000-5.ucode
+-Version: 8.83.5.1
+-
+-File: iwlwifi-5150-2.ucode
+-Version: 8.24.2.2
+-
+-File: iwlwifi-1000-5.ucode
+-Version: 39.31.5.1
+-
+-File: iwlwifi-6000-4.ucode
+-Version: 9.221.4.1
+-
+-File: iwlwifi-6050-5.ucode
+-Version: 41.28.5.1
+-
+-File: iwlwifi-6000g2a-6.ucode
+-Version: 18.168.6.1
+-
+-File: iwlwifi-6000g2b-6.ucode
+-Version: 18.168.6.1
+-
+-File: iwlwifi-135-6.ucode
+-Version: 18.168.6.1
+-
+-File: iwlwifi-100-5.ucode
+-Version: 39.31.5.1
+-
+-File: iwlwifi-105-6.ucode
+-Version: 18.168.6.1
+-
+-File: iwlwifi-2030-6.ucode
+-Version: 18.168.6.1
+-
+-File: iwlwifi-2000-6.ucode
+-Version: 18.168.6.1
+-
+-File: iwlwifi-7260-17.ucode
+-Version: 17.bfb58538.0
+-
+-File: iwlwifi-3160-17.ucode
+-Version: 17.bfb58538.0
+-
+-File: iwlwifi-7265-17.ucode
+-Version: 17.bfb58538.0
+-
+-File: iwlwifi-7265D-29.ucode
+-Version: 29.f2390aa8.0
+-
+-File: iwlwifi-3168-29.ucode
+-Version: 29.0bd893f3.0
+-
+-File: iwlwifi-8000C-34.ucode
+-Version: 34.610288.0
+-
+-File: iwlwifi-8000C-36.ucode
+-Version: 36.ca7b901d.0
+-
+-File: iwlwifi-8265-34.ucode
+-Version: 34.610288.0
+-
+-File: iwlwifi-8265-36.ucode
+-Version: 36.ca7b901d.0
+-
+-File: iwlwifi-9000-pu-b0-jf-b0-34.ucode
+-Version: 34.ba501b11.0
+-
+-File: iwlwifi-9000-pu-b0-jf-b0-38.ucode
+-Version: 38.755cfdd8.0
+-
+-File: iwlwifi-9000-pu-b0-jf-b0-46.ucode
+-Version: 46.ff18e32a.0
+-
+-File: iwlwifi-9260-th-b0-jf-b0-34.ucode
+-Version: 34.ba501b11.0
+-
+-File: iwlwifi-9260-th-b0-jf-b0-38.ucode
+-Version: 38.755cfdd8.0
+-
+-File: iwlwifi-9260-th-b0-jf-b0-46.ucode
+-Version: 46.ff18e32a.0
+-
+-File: iwlwifi-cc-a0-50.ucode
+-Version: 50.3e391d3e.0
+-
+-File: iwlwifi-Qu-b0-hr-b0-50.ucode
+-Version: 50.3e391d3e.0
+-
+-File: iwlwifi-Qu-b0-jf-b0-50.ucode
+-Version: 50.3e391d3e.0
+-
+-File: iwlwifi-Qu-c0-hr-b0-50.ucode
+-Version: 50.3e391d3e.0
+-
+-File: iwlwifi-Qu-c0-jf-b0-50.ucode
+-Version: 50.3e391d3e.0
+-
+-File: iwlwifi-QuZ-a0-hr-b0-50.ucode
+-Version: 50.3e391d3e.0
+-
+-File: iwlwifi-QuZ-a0-jf-b0-50.ucode
+-Version: 50.3e391d3e.0
+-
+-File: iwlwifi-cc-a0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-Qu-b0-hr-b0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-Qu-b0-jf-b0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-Qu-c0-hr-b0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-Qu-c0-jf-b0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-QuZ-a0-hr-b0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-QuZ-a0-jf-b0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-so-a0-gf-a0.pnvm
+-
+-File: iwlwifi-so-a0-gf4-a0.pnvm
+-
+-File: iwlwifi-ty-a0-gf-a0-59.ucode
+-Version: 59.601f3a66.0
+-
+-File: iwlwifi-cc-a0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-Qu-b0-hr-b0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-Qu-b0-jf-b0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-Qu-c0-hr-b0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-Qu-c0-jf-b0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-QuZ-a0-hr-b0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-QuZ-a0-jf-b0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-ty-a0-gf-a0-66.ucode
+-Version: 66.f1c864e0.0
+-
+-File: iwlwifi-cc-a0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-Qu-b0-hr-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-Qu-b0-jf-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-Qu-c0-hr-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-Qu-c0-jf-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-QuZ-a0-hr-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-QuZ-a0-jf-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-ty-a0-gf-a0-72.ucode
+-Version: 72.a764baac.0
+-
+-File: iwlwifi-so-a0-gf4-a0-72.ucode
+-Version: 72.a764baac.0
+-
+-File: iwlwifi-so-a0-gf-a0-72.ucode
+-Version: 72.a764baac.0
+-
+-File: iwlwifi-so-a0-hr-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-so-a0-jf-b0-72.ucode
+-Version: 72.daa05125.0
+-
+-File: iwlwifi-cc-a0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-Qu-b0-hr-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-Qu-b0-jf-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-Qu-c0-hr-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-Qu-c0-jf-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-QuZ-a0-hr-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-QuZ-a0-jf-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-ty-a0-gf-a0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-so-a0-gf4-a0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-so-a0-gf-a0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-so-a0-hr-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-so-a0-jf-b0-73.ucode
+-Version: 73.35c0a2c6.0
+-
+-File: iwlwifi-cc-a0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-Qu-b0-hr-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-Qu-b0-jf-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-Qu-c0-hr-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-Qu-c0-jf-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-QuZ-a0-hr-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-QuZ-a0-jf-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-ty-a0-gf-a0-74.ucode
+-Version: 74.fe17486e.0
+-
+-File: iwlwifi-so-a0-gf4-a0-74.ucode
+-Version: 74.fe17486e.0
+-
+-File: iwlwifi-so-a0-gf-a0-74.ucode
+-Version: 74.fe17486e.0
+-
+-File: iwlwifi-so-a0-hr-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-so-a0-jf-b0-74.ucode
+-Version: 74.a5e9588b.0
+-
+-File: iwlwifi-cc-a0-77.ucode
+-Version: 74.206b0184.0
+-
+-File: iwlwifi-Qu-b0-hr-b0-77.ucode
+-Version: 74.206b0184.0
+-
+-File: iwlwifi-Qu-b0-jf-b0-77.ucode
+-Version: 74.206b0184.0
+-
+-File: iwlwifi-Qu-c0-hr-b0-77.ucode
+-Version: 74.206b0184.0
+-
+-File: iwlwifi-Qu-c0-jf-b0-77.ucode
+-Version: 74.206b0184.0
+-
+-File: iwlwifi-QuZ-a0-hr-b0-77.ucode
+-Version: 74.206b0184.0
+-
+-File: iwlwifi-QuZ-a0-jf-b0-77.ucode
+-Version: 74.206b0184.0
+-
+-File: iwlwifi-ty-a0-gf-a0-77.ucode
+-Version: 74.f92b5fed.0
+-
+-File: iwlwifi-ty-a0-gf-a0-78.ucode
+-Version: 75.3bfdc55f.0
+-
+-File: iwlwifi-ty-a0-gf-a0-79.ucode
+-Version: 76.27f1c37b.0
+-
+-File: iwlwifi-ty-a0-gf-a0-81.ucode
+-Version: 78.31fc9ae6.0
+-
+-File: iwlwifi-so-a0-gf4-a0-77.ucode
+-Version: 74.f92b5fed.0
+-
+-File: iwlwifi-so-a0-gf4-a0-78.ucode
+-Version: 75.3bfdc55f.0
+-
+-File: iwlwifi-so-a0-gf4-a0-79.ucode
+-Version: 76.27f1c37b.0
+-
+-File: iwlwifi-so-a0-gf4-a0-81.ucode
+-Version: 78.31fc9ae6.0
+-
+-File: iwlwifi-so-a0-gf-a0-77.ucode
+-Version: 74.f92b5fed.0
+-
+-File: iwlwifi-so-a0-gf-a0-78.ucode
+-Version: 74.3bfdc55f.0
+-
+-File: iwlwifi-so-a0-gf-a0-79.ucode
+-Version: 75.27f1c37b.0
+-
+-File: iwlwifi-so-a0-gf-a0-81.ucode
+-Version: 78.31fc9ae6.0
+-
+-File: iwlwifi-so-a0-hr-b0-77.ucode
+-Version: 74.f92b5fed.0
+-
+-File: iwlwifi-so-a0-hr-b0-79.ucode
+-Version: 75.27f1c37b.0
+-
+-File: iwlwifi-so-a0-hr-b0-81.ucode
+-Version: 78.31fc9ae6.0
+-
+-File: iwlwifi-so-a0-jf-b0-77.ucode
+-Version: 74.f92b5fed.0
+-
+-File: iwlwifi-ty-a0-gf-a0.pnvm
+-
+-Licence: Redistributable. See LICENCE.iwlwifi_firmware for details
+-
+-Also available from http://wireless.kernel.org/en/users/Drivers/iwlwifi#Firmware
+-
+---------------------------------------------------------------------------
+-
+ Driver: tehuti - Tehuti Networks 10G Ethernet
+ 
+ File: tehuti/bdx.bin
+@@ -1226,86 +714,6 @@ Available from http://ldriver.qlogic.com/firmware/netxen_nic/new/
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: rt61pci - Ralink RT2561, RT2561S, RT2661 wireless MACs
+-
+-File: rt2561.bin
+-File: rt2561s.bin
+-File: rt2661.bin
+-
+-Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+-
+-Downloaded from http://www.ralinktech.com/ralink/Home/Support/Linux.html
+-
+---------------------------------------------------------------------------
+-
+-Driver: rt73usb - Ralink RT2571W, RT2671 wireless MACs
+-
+-File: rt73.bin
+-
+-Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+-
+-Downloaded from http://www.ralinktech.com/ralink/Home/Support/Linux.html
+-
+----------------------------------------------------------------------------
+-
+-Driver: mt7601u - MediaTek MT7601U Wireless MACs
+-
+-File: mediatek/mt7601u.bin
+-Version: 34
+-Link: mt7601u.bin -> mediatek/mt7601u.bin
+-
+-Licence: Redistributable. See LICENCE.ralink_a_mediatek_company_firmware for details
+-
+-Downloaded from http://www.mediatek.com/en/downloads/
+-
+---------------------------------------------------------------------------
+-
+-Driver: rt2800pci - Ralink RT2860, RT2890, RT3090, RT3290, RT5390 wireless MACs
+-
+-File: rt2860.bin
+-Version: 40
+-
+-File: rt3290.bin
+-Version: 37
+-
+-Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+-
+-Binary file supplied originally by Shiang Tu <shiang_tu@ralinktech.com>, latest
+-from http://www.mediatek.com/en/downloads1/downloads/
+-
+---------------------------------------------------------------------------
+-
+-Driver: rt2860sta - Ralink RT3090 wireless MACs
+-
+-Link: rt3090.bin -> rt2860.bin
+-
+-Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: rt2800usb - Ralink RT2870, RT3070, RT3071, RT3072, RT5370 wireless MACs
+-
+-File: rt2870.bin
+-Version: 36
+-
+-Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+-
+-Binary file supplied originally by Shiang Tu <shiang_tu@ralinktech.com>, latest
+-from http://www.mediatek.com/en/downloads1/downloads/
+-
+---------------------------------------------------------------------------
+-
+-Driver: rt2870sta - Ralink RT2870, RT3070, RT3071 wireless MACs
+-
+-Link: rt3070.bin -> rt2870.bin
+-File: rt3071.bin
+-
+-Licence: Redistributable. See LICENCE.ralink-firmware.txt for details
+-
+-rt3071.bin is a copy of bytes 4096-8191 of rt2870.bin for compatibility.
+-
+---------------------------------------------------------------------------
+-
+ Driver: usbdux/usbduxfast/usbduxsigma - usbdux data acquisition cards
+ 
+ File: usbdux_firmware.bin
+@@ -1319,17 +727,6 @@ Provided from the author, Bernd Porr <BerndPorr@f2s.com>
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ath3k - DFU Driver for Atheros bluetooth chipset AR3011
+-
+-File: ath3k-1.fw
+-Version: 1.0
+-
+-Fix EEPROM radio table issue and change PID to 3005
+-
+-Licence: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: mga - Matrox G200/G400/G550
+ 
+ File: matrox/g200_warp.fw
+@@ -2245,17 +1642,6 @@ Licence: Redistributable.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: rtl8192e - Realtek 8192 PCI wireless driver
+-
+-File: RTL8192E/boot.img
+-File: RTL8192E/data.img
+-File: RTL8192E/main.img
+-
+-Licence: Redistributable, provided by Realtek in their driver
+-         source download.
+-
+---------------------------------------------------------------------------
+-
+ Driver: ib_qib - QLogic Infiniband
+ 
+ File: qlogic/sd7220.fw
+@@ -2388,1167 +1774,51 @@ Licence:
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: brcmsmac - Broadcom 802.11n softmac wireless LAN driver.
++Driver: vt6656 - VIA VT6656 USB wireless driver
+ 
+-File: brcm/bcm43xx-0.fw
+-File: brcm/bcm43xx_hdr-0.fw
+-Version: 610.812
++File: vntwusb.fw
+ 
+-Licence: Redistributable. See LICENCE.broadcom_bcm43xx for details.
++Licence: Redistributable. See LICENCE.via_vt6656 for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: brcmfmac - Broadcom 802.11n fullmac wireless LAN driver.
+-
+-File: brcm/bcm4329-fullmac-4.bin
+-File: brcm/brcmfmac43236b.bin
+-File: brcm/brcmfmac4329-sdio.bin
+-File: brcm/brcmfmac4330-sdio.bin
+-File: brcm/brcmfmac4334-sdio.bin
+-File: brcm/brcmfmac4335-sdio.bin
+-File: brcm/brcmfmac43241b0-sdio.bin
+-File: brcm/brcmfmac43241b4-sdio.bin
+-File: brcm/brcmfmac43241b5-sdio.bin
+-File: brcm/brcmfmac43242a.bin
+-File: brcm/brcmfmac43143.bin
+-File: brcm/brcmfmac43143-sdio.bin
+-File: brcm/brcmfmac43430a0-sdio.bin
+-File: brcm/brcmfmac4350c2-pcie.bin
+-File: brcm/brcmfmac4350-pcie.bin
+-File: brcm/brcmfmac43569.bin
+-File: brcm/brcmfmac4358-pcie.bin
+-File: brcm/brcmfmac43602-pcie.bin
+-File: brcm/brcmfmac43602-pcie.ap.bin
+-File: brcm/brcmfmac4366b-pcie.bin
+-File: brcm/brcmfmac4366c-pcie.bin
+-File: brcm/brcmfmac4371-pcie.bin
+-
+-Licence: Redistributable. See LICENCE.broadcom_bcm43xx for details.
+-
+-File: brcm/brcmfmac4373.bin
+-File: cypress/cyfmac43012-sdio.bin
+-Link: brcm/brcmfmac43012-sdio.bin -> ../cypress/cyfmac43012-sdio.bin
+-File: cypress/cyfmac43012-sdio.clm_blob
+-Link: brcm/brcmfmac43012-sdio.clm_blob -> ../cypress/cyfmac43012-sdio.clm_blob
+-File: cypress/cyfmac43340-sdio.bin
+-Link: brcm/brcmfmac43340-sdio.bin -> ../cypress/cyfmac43340-sdio.bin
+-File: cypress/cyfmac43362-sdio.bin
+-Link: brcm/brcmfmac43362-sdio.bin -> ../cypress/cyfmac43362-sdio.bin
+-File: cypress/cyfmac4339-sdio.bin
+-Link: brcm/brcmfmac4339-sdio.bin -> ../cypress/cyfmac4339-sdio.bin
+-File: cypress/cyfmac43430-sdio.bin
+-Link: brcm/brcmfmac43430-sdio.bin -> ../cypress/cyfmac43430-sdio.bin
+-File: cypress/cyfmac43430-sdio.clm_blob
+-Link: brcm/brcmfmac43430-sdio.clm_blob -> ../cypress/cyfmac43430-sdio.clm_blob
+-File: cypress/cyfmac43455-sdio.bin
+-Link: brcm/brcmfmac43455-sdio.bin -> ../cypress/cyfmac43455-sdio.bin
+-File: cypress/cyfmac43455-sdio.clm_blob
+-Link: brcm/brcmfmac43455-sdio.clm_blob -> ../cypress/cyfmac43455-sdio.clm_blob
+-File: cypress/cyfmac4354-sdio.bin
+-Link: brcm/brcmfmac4354-sdio.bin -> ../cypress/cyfmac4354-sdio.bin
+-File: cypress/cyfmac4354-sdio.clm_blob
+-Link: brcm/brcmfmac4354-sdio.clm_blob -> ../cypress/cyfmac4354-sdio.clm_blob
+-File: cypress/cyfmac4356-pcie.bin
+-Link: brcm/brcmfmac4356-pcie.bin -> ../cypress/cyfmac4356-pcie.bin
+-File: cypress/cyfmac4356-pcie.clm_blob
+-Link: brcm/brcmfmac4356-pcie.clm_blob -> ../cypress/cyfmac4356-pcie.clm_blob
+-File: cypress/cyfmac4356-sdio.bin
+-Link: brcm/brcmfmac4356-sdio.bin -> ../cypress/cyfmac4356-sdio.bin
+-File: cypress/cyfmac4356-sdio.clm_blob
+-Link: brcm/brcmfmac4356-sdio.clm_blob -> ../cypress/cyfmac4356-sdio.clm_blob
+-File: cypress/cyfmac43570-pcie.bin
+-Link: brcm/brcmfmac43570-pcie.bin -> ../cypress/cyfmac43570-pcie.bin
+-File: cypress/cyfmac43570-pcie.clm_blob
+-Link: brcm/brcmfmac43570-pcie.clm_blob -> ../cypress/cyfmac43570-pcie.clm_blob
+-File: cypress/cyfmac4373-sdio.bin
+-Link: brcm/brcmfmac4373-sdio.bin -> ../cypress/cyfmac4373-sdio.bin
+-File: cypress/cyfmac4373-sdio.clm_blob
+-Link: brcm/brcmfmac4373-sdio.clm_blob -> ../cypress/cyfmac4373-sdio.clm_blob
+-File: cypress/cyfmac54591-pcie.bin
+-Link: brcm/brcmfmac54591-pcie.bin -> ../cypress/cyfmac54591-pcie.bin
+-File: cypress/cyfmac54591-pcie.clm_blob
+-Link: brcm/brcmfmac54591-pcie.clm_blob -> ../cypress/cyfmac54591-pcie.clm_blob
+-
+-Licence: Redistributable. See LICENCE.cypress for details.
+-
+-File: "brcm/brcmfmac43241b4-sdio.Advantech-MICA-071.txt"
+-File: "brcm/brcmfmac43241b4-sdio.Intel Corp.-VALLEYVIEW C0 PLATFORM.txt"
+-File: "brcm/brcmfmac4330-sdio.Prowise-PT301.txt"
+-File: "brcm/brcmfmac43340-sdio.ASUSTeK COMPUTER INC.-TF103CE.txt"
+-File: "brcm/brcmfmac43340-sdio.meegopad-t08.txt"
+-File: "brcm/brcmfmac43340-sdio.pov-tab-p1006w-data.txt"
+-File: "brcm/brcmfmac43340-sdio.predia-basic.txt"
+-File: "brcm/brcmfmac43362-sdio.WC121.txt"
+-File: "brcm/brcmfmac43362-sdio.cubietech,cubietruck.txt"
+-Link: brcm/brcmfmac43362-sdio.kobo,aura.txt -> brcmfmac43362-sdio.WC121.txt
+-Link: brcm/brcmfmac43362-sdio.kobo,tolino-shine2hd.txt -> brcmfmac43362-sdio.WC121.txt
+-Link: brcm/brcmfmac43362-sdio.lemaker,bananapro.txt -> brcmfmac43362-sdio.cubietech,cubietruck.txt
+-File: "brcm/brcmfmac43430a0-sdio.ilife-S806.txt"
+-File: "brcm/brcmfmac43430a0-sdio.jumper-ezpad-mini3.txt"
+-File: "brcm/brcmfmac43430a0-sdio.ONDA-V80 PLUS.txt"
+-File: "brcm/brcmfmac43430-sdio.AP6212.txt"
+-Link: brcm/brcmfmac43430-sdio.sinovoip,bpi-m2-plus.txt -> brcmfmac43430-sdio.AP6212.txt
+-Link: brcm/brcmfmac43430-sdio.sinovoip,bpi-m2-zero.txt -> brcmfmac43430-sdio.AP6212.txt
+-Link: brcm/brcmfmac43430-sdio.sinovoip,bpi-m2-ultra.txt -> brcmfmac43430-sdio.AP6212.txt
+-Link: brcm/brcmfmac43430-sdio.sinovoip,bpi-m3.txt -> brcmfmac43430-sdio.AP6212.txt
+-Link: brcm/brcmfmac43430-sdio.friendlyarm,nanopi-r1.txt -> brcmfmac43430-sdio.AP6212.txt
+-Link: brcm/brcmfmac43430-sdio.starfive,visionfive-v1.txt -> brcmfmac43430-sdio.AP6212.txt
+-Link: brcm/brcmfmac43430-sdio.beagle,beaglev-starlight-jh7100-a1.txt -> brcmfmac43430-sdio.AP6212.txt
+-Link: brcm/brcmfmac43430-sdio.beagle,beaglev-starlight-jh7100-r0.txt -> brcmfmac43430-sdio.AP6212.txt
+-File: "brcm/brcmfmac43430-sdio.Hampoo-D2D3_Vi8A1.txt"
+-File: "brcm/brcmfmac43430-sdio.MUR1DX.txt"
+-File: "brcm/brcmfmac43430-sdio.raspberrypi,3-model-b.txt"
+-Link: brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.txt -> brcmfmac43430-sdio.raspberrypi,3-model-b.txt
+-Link: brcm/brcmfmac43430-sdio.raspberrypi,model-zero-2-w.txt -> brcmfmac43430-sdio.raspberrypi,3-model-b.txt
+-File: "brcm/brcmfmac43455-sdio.acepc-t8.txt"
+-File: "brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt"
+-Link: brcm/brcmfmac43455-sdio.raspberrypi,3-model-a-plus.txt -> brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt
+-File: "brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.txt"
+-Link: brcm/brcmfmac43455-sdio.Raspberry\ Pi\ Foundation-Raspberry\ Pi\ 4\ Model\ B.txt -> brcmfmac43455-sdio.raspberrypi,4-model-b.txt
+-Link: brcm/brcmfmac43455-sdio.Raspberry\ Pi\ Foundation-Raspberry\ Pi\ Compute\ Module\ 4.txt -> brcmfmac43455-sdio.raspberrypi,4-model-b.txt
+-File: "brcm/brcmfmac43455-sdio.MINIX-NEO Z83-4.txt"
+-File: "brcm/brcmfmac4356-pcie.gpd-win-pocket.txt"
+-File: "brcm/brcmfmac4356-pcie.Intel Corporation-CHERRYVIEW D1 PLATFORM.txt"
+-File: "brcm/brcmfmac4356-pcie.Xiaomi Inc-Mipad2.txt"
+-File: brcm/brcmfmac4356-sdio.AP6356S.txt
+-Link: brcm/brcmfmac4356-sdio.firefly,firefly-rk3399.txt -> brcmfmac4356-sdio.AP6356S.txt
+-Link: brcm/brcmfmac4356-sdio.khadas,vim2.txt -> brcmfmac4356-sdio.AP6356S.txt
+-Link: brcm/brcmfmac4356-sdio.vamrs,rock960.txt -> brcmfmac4356-sdio.AP6356S.txt
+-File: brcm/brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.beagle,am5729-beagleboneai.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,pinebook-pro.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,pinenote-v1.1.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,pinenote-v1.2.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,pinephone-pro.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,quartz64-a.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,quartz64-b.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,rockpro64-v2.0.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,rockpro64-v2.1.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,soquartz-model-a.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,soquartz-cm4io.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.pine64,soquartz-blade.txt -> brcmfmac43455-sdio.AW-CM256SM.txt
++Driver: myri10ge - Myri10GE 10GbE NIC driver
+ 
+-Licence: GPLv2. See GPL-2 for details.
++File: myri10ge_eth_z8e.dat
++File: myri10ge_ethp_z8e.dat
++File: myri10ge_rss_eth_z8e.dat
++File: myri10ge_rss_ethp_z8e.dat
++File: myri10ge_eth_big_z8e.dat
++File: myri10ge_ethp_big_z8e.dat
++File: myri10ge_rss_eth_big_z8e.dat
++File: myri10ge_rss_ethp_big_z8e.dat
++Version: 1.4.57
++
++License: Redistributable.  See LICENCE.myri10ge_firmware for details.
+ 
+ --------------------------------------------------------------------------
++Driver: ene-ub6250 -- ENE UB6250 SD card reader driver
+ 
+-Driver: wl1251 - Texas Instruments 802.11 WLAN driver for WiLink4 chips
++File: ene-ub6250/sd_init1.bin
++File: ene-ub6250/sd_init2.bin
++File: ene-ub6250/sd_rdwr.bin
++File: ene-ub6250/ms_init.bin
++File: ene-ub6250/msp_rdwr.bin
++File: ene-ub6250/ms_rdwr.bin
+ 
+-File: ti-connectivity/wl1251-fw.bin
+-Version: 4.0.4.3.7
++Licence: Redistributable. See LICENCE.ene_firmware for details.
+ 
+-File: ti-connectivity/wl1251-nvs.bin
++--------------------------------------------------------------------------
+ 
+-Licence: Redistributable. See LICENCE.wl1251 for details.
++Driver: isci -- Intel C600 SAS controller driver
+ 
+-The published NVS files are for testing only.  Every device needs to
+-have a unique NVS which is properly calibrated for best results.
+-
+-The driver expects to find the firmwares under a ti-connectivity subdirectory.
+-So if your system looks for firmwares in /lib/firmware, the firmwares for
+-wl12xx chips must be located in /lib/firmware/ti-connectivity/.
+-
+---------------------------------------------------------------------------
+-
+-Driver: wl12xx - Texas Instruments 802.11 WLAN driver for WiLink6/7 chips
+-
+-File: ti-connectivity/wl1271-fw.bin
+-Version: 6.1.0.50.350 (STA-only)
+-File: ti-connectivity/wl1271-fw-2.bin
+-Version: 6.1.5.50.74 (STA-only)
+-File: ti-connectivity/wl1271-fw-ap.bin
+-Version: 6.2.1.0.54 (AP-only)
+-File: ti-connectivity/wl127x-fw-3.bin
+-Version: 6.3.0.0.77
+-File: ti-connectivity/wl127x-fw-plt-3.bin
+-Version: 6.3.0.0.77 (PLT-only)
+-File: ti-connectivity/wl127x-fw-4-sr.bin
+-Version: 6.3.5.0.98 (Single-role)
+-File: ti-connectivity/wl127x-fw-4-mr.bin
+-Version: 6.5.2.0.15 (Multi-role)
+-File: ti-connectivity/wl127x-fw-4-plt.bin
+-Version: 6.3.5.0.98 (PLT-only)
+-File: ti-connectivity/wl127x-fw-5-sr.bin
+-Version: 6.3.10.0.142 (Single-role)
+-File: ti-connectivity/wl127x-fw-5-mr.bin
+-Version: 6.5.7.0.50 (Multi-role)
+-File: ti-connectivity/wl127x-fw-5-plt.bin
+-Version: 6.3.10.0.142 (PLT-only)
+-
+-File: ti-connectivity/wl128x-fw.bin
+-Version: 7.1.5.50.74 (STA-only)
+-File: ti-connectivity/wl128x-fw-ap.bin
+-Version: 7.2.1.0.54 (AP-only)
+-File: ti-connectivity/wl128x-fw-3.bin
+-Version: 7.3.0.0.77
+-File: ti-connectivity/wl128x-fw-plt-3.bin
+-Version: 7.3.0.0.77
+-File: ti-connectivity/wl128x-fw-4-sr.bin
+-Version: 7.3.5.0.98 (Single-role)
+-File: ti-connectivity/wl128x-fw-4-mr.bin
+-Version: 7.5.2.0.15 (Multi-role)
+-File: ti-connectivity/wl128x-fw-4-plt.bin
+-Version: 7.3.5.0.98 (PLT)
+-File: ti-connectivity/wl128x-fw-5-sr.bin
+-Version: 7.3.10.0.142 (Single-role)
+-File: ti-connectivity/wl128x-fw-5-mr.bin
+-Version: 7.5.7.0.50 (Multi-role)
+-File: ti-connectivity/wl128x-fw-5-plt.bin
+-Version: 7.3.10.2.142 (PLT-only)
+-
+-File: ti-connectivity/wl127x-nvs.bin
+-File: ti-connectivity/wl128x-nvs.bin
+-Link: ti-connectivity/wl12xx-nvs.bin -> wl127x-nvs.bin
+-Link: ti-connectivity/wl1271-nvs.bin -> wl127x-nvs.bin
+-
+-Licence: Redistributable. See LICENCE.ti-connectivity for details.
+-
+-The NVS file includes two parts:
+-	 - radio calibration
+-	 - HW configuration parameters (aka. INI values)
+-
+-The published NVS files are for testing only.  Every device needs to
+-hava a unique NVS which is properly calibrated for best results.  You
+-can find more information about NVS generation for your device here:
+-
+-http://wireless.kernel.org/en/users/Drivers/wl12xx/calibrator
+-
+-If you're using a wl127x based device, use a symbolic link called
+-wl1271-nvs.bin that links to the wl127x-nvs.bin file.  If you are
+-using wl128x, link to wl128x-nvs.bin instead.
+-
+-The driver expects to find the firmwares under a ti-connectivity
+-subdirectory.  So if your system looks for firmwares in /lib/firmware,
+-the firmwares for wl12xx chips must be located in
+-/lib/firmware/ti-connectivity/.
+-
+---------------------------------------------------------------------------
+-
+-Driver: wl18xx - Texas Instruments 802.11 WLAN driver for WiLink8 chips
+-
+-File: ti-connectivity/wl18xx-fw.bin
+-Version: 8.2.0.0.100
+-File: ti-connectivity/wl18xx-fw-2.bin
+-Version: 8.5.0.0.55
+-File: ti-connectivity/wl18xx-fw-3.bin
+-Version: 8.8.0.0.13
+-File: ti-connectivity/wl18xx-fw-4.bin
+-Version: 8.9.0.0.79
+-
+-Licence: Redistributable. See LICENCE.ti-connectivity for details.
+-
+-The driver expects to find the firmwares under a ti-connectivity
+-subdirectory.  So if your system looks for firmwares in /lib/firmware,
+-the firmwares for wl18xx chips must be located in
+-/lib/firmware/ti-connectivity/.
+-
+---------------------------------------------------------------------------
+-
+-Driver: TI_ST - Texas Instruments bluetooth driver
+-
+-File: ti-connectivity/TIInit_6.2.31.bts
+-Version: 2.44 (TI_P31.123)
+-File: ti-connectivity/TIInit_6.6.15.bts
+-Version: 2.14 (TI_P6_15.93)
+-File: ti-connectivity/TIInit_7.2.31.bts
+-
+-Licence: Redistributable. See LICENCE.ti-connectivity for details.
+-
+-	TIInit_7.2.31.bts version 7.2.31
+-
+-	In order to use that file copy it to /lib/firmware/ti-connectivity.
+-
+---------------------------------------------------------------------------
+-
+-Driver: r8712u - Realtek 802.11n WLAN driver for RTL8712U
+-
+-File: rtlwifi/rtl8712u.bin
+-Info: From Vendor's rtl8712_8188_8191_8192SU_usb_linux_v7_0.20100831
+-      Reverted rtl8188C_8192C_8192D_usb_linux_v3.4.2_3727.20120404
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8192ce - Realtek 802.11n WLAN driver for RTL8192CE
+-
+-File: rtlwifi/rtl8192cfw.bin
+-File: rtlwifi/rtl8192cfwU.bin
+-File: rtlwifi/rtl8192cfwU_B.bin
+-Info: From Vendor's realtek/rtlwifi_linux_mac80211_0019.0320.2014V628 driver
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8192cu - Realtek 802.11n WLAN driver for RTL8192CU
+-
+-File: rtlwifi/rtl8192cufw.bin
+-File: rtlwifi/rtl8192cufw_A.bin
+-File: rtlwifi/rtl8192cufw_B.bin
+-File: rtlwifi/rtl8192cufw_TMSC.bin
+-Info: From Vendor's rtl8188C_8192C_usb_linux_v4.0.1_6911.20130308 driver
+-      All files extracted from driver/hal/rtl8192c/usb/Hal8192CUHWImg.c
+-      Relevant variables (CONFIG_BT_COEXISTENCE not set):
+-        - rtlwifi/rtl8192cufw_A.bin: Rtl8192CUFwUMCACutImgArray
+-        - rtlwifi/rtl8192cufw_B.bin: Rtl8192CUFwUMCBCutImgArray
+-        - rtlwifi/rtl8192cufw_TMSC.bin: Rtl8192CUFwTSMCImgArray
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8192se - Realtek 802.11n WLAN driver for RTL8192SE
+-
+-Info: updated from rtl_92ce_92se_92de_linux_mac80211_0004.0816.2011 driver version
+-File: rtlwifi/rtl8192sefw.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8192de - Realtek 802.11n WLAN driver for RTL8192DE
+-
+-Info: Updated from Realtek version rtl_92ce_92se_92de_8723ae_linux_mac80211_0007.0809.2012
+-File: rtlwifi/rtl8192defw.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8723e - Realtek 802.11n WLAN driver for RTL8723E
+-
+-Info: Taken from Realtek version rtl_92ce_92se_92de_8723ae_linux_mac80211_0007.0809.2012
+-File: rtlwifi/rtl8723fw.bin
+-File: rtlwifi/rtl8723fw_B.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8723be - Realtek 802.11n WLAN driver for RTL8723BE
+-
+-Info: From Vendor's realtek/rtlwifi_linux_mac80211_0019.0320.2014V628 driver
+-File: rtlwifi/rtl8723befw.bin
+-Info: Update to version 36 - Sent by Realtek
+-File: rtlwifi/rtl8723befw_36.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8723de - Realtek 802.11ac WLAN driver for RTL8723DE
+-
+-Info: Supplied by Vendor at https://github.com/pkshih/rtlwifi_rtl8723de
+-File: rtlwifi/rtl8723defw.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8188ee - Realtek 802.11n WLAN driver for RTL8188EE
+-
+-Info: Taken from Realtek version rtl_92ce_92se_92de_8723ae_88ee_linux_mac80211_0010.0109.2013
+-File: rtlwifi/rtl8188efw.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8821ae - Realtek 802.11n WLAN driver for RTL8812AE
+-
+-Info: From Vendor's realtek/rtlwifi_linux_mac80211_0019.0320.2014V628 driver
+-File: rtlwifi/rtl8812aefw.bin
+-File: rtlwifi/rtl8812aefw_wowlan.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8821ae - Realtek 802.11n WLAN driver for RTL8821AE
+-
+-Info: From Vendor's realtek/rtlwifi_linux_mac80211_0019.0320.2014V628 driver
+-File: rtlwifi/rtl8821aefw.bin
+-File: rtlwifi/rtl8821aefw_wowlan.bin
+-Info: Update to version 29 - Sent by Realtek
+-File: rtlwifi/rtl8821aefw_29.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8822be - Realtek 802.11n WLAN driver for RTL8822BE
+-
+-Info: Sent to Larry Finger by Realtek engineer Ping-Ke Shih <pkshih@realtek.com>
+-File: rtlwifi/rtl8822befw.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtw88 - Realtek 802.11ac WLAN driver for RTL8822BE and RTL8822CE
+-
+-Info: Sent to Larry Finger by Realtek engineer Yan-Hsuan Chuang <yhchuang@realtek.com>
+-File: rtw88/rtw8822b_fw.bin
+-File: rtw88/rtw8822c_fw.bin
+-File: rtw88/rtw8822c_wow_fw.bin
+-File: rtw88/README
+-File: rtw88/rtw8723d_fw.bin
+-File: rtw88/rtw8821c_fw.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+-    These firmware should be put under /lib/firmware/rtw88/
+-    And note that the rtw88 driver is able to support wake-on-wireless LAN
+-    for RTL8822C devices, after kernel v5.6+. So, make sure the firmware
+-    rtw88/rtw8822c_wow_fw.bin is also packed, otherwise the firmware load
+-    fail could be a problem.
+-    Although RTL8723D devices are 802.11n device, they are also supported
+-    by rtw88 because the hardware arch is similar.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtw89 - Realtek 802.11ax WLAN driver for RTL8851B/RTL8852A/RTL8852B/RTL8852C
+-
+-File: rtw89/rtw8851b_fw.bin
+-File: rtw89/rtw8852a_fw.bin
+-File: rtw89/rtw8852b_fw.bin
+-File: rtw89/rtw8852b_fw-1.bin
+-File: rtw89/rtw8852c_fw.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8192ee - Realtek 802.11n WLAN driver for RTL8192EE
+-
+-Info: Initial version taken from Realtek version
+-      rtl_92ce_92se_92de_8723ae_88ee_8723be_92ee_linux_mac80211_0017.1224.2013
+-      Updated Jan. 14, 2015 with file added by Realtek to
+-      http://github.com/lwfinger/rtlwifi_new.git.
+-      Same firmware rtl8192eu_nic.bin so just link them
+-Link: rtlwifi/rtl8192eefw.bin -> rtl8192eu_nic.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8723bs - Realtek 802.11n WLAN driver for RTL8723BS
+-
+-Info: Firmware files extracted from data statements in Realtek driver
+-      v4.3.5.5_12290.20140916_BTCOEX20140507-4E40.
+-File: rtlwifi/rtl8723bs_bt.bin
+-Link: rtlwifi/rtl8723bs_nic.bin -> rtl8723bu_nic.bin
+-Link: rtlwifi/rtl8723bs_ap_wowlan.bin -> rtl8723bu_ap_wowlan.bin
+-Link: rtlwifi/rtl8723bs_wowlan.bin -> rtl8723bu_wowlan.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rtl8xxxu - Realtek 802.11n WLAN driver for RTL8XXX USB devices
+-
+-Info: rtl8723au taken from Realtek driver
+-      rtl8723A_WiFi_linux_v4.1.3_6044.20121224
+-      Firmware is embedded in the driver as data statements. This info
+-      has been extracted into a binary file.
+-File: rtlwifi/rtl8723aufw_A.bin
+-File: rtlwifi/rtl8723aufw_B.bin
+-File: rtlwifi/rtl8723aufw_B_NoBT.bin
+-
+-Info: rtl8723bu taken from Realtek driver
+-      rtl8723BU_WiFi_linux_v4.3.16_14189.20150519_BTCOEX20150119-5844
+-      Firmware is embedded in the driver as data statements. This info
+-      has been extracted into a binary file.
+-File: rtlwifi/rtl8723bu_nic.bin
+-File: rtlwifi/rtl8723bu_wowlan.bin
+-File: rtlwifi/rtl8723bu_ap_wowlan.bin
+-
+-Info: rtl8192eu taken from Realtek driver
+-      rtl8192EU_WiFi_linux_v5.11.2.1-18-g8e7df912b.20210527_COEX20171113-0047
+-      Firmware is embedded in the driver as data statements. This info
+-      has been extracted into a binary file.
+-File: rtlwifi/rtl8192eu_nic.bin
+-Version: 35.7
+-File: rtlwifi/rtl8192eu_wowlan.bin
+-Version: 35.7
+-File: rtlwifi/rtl8192eu_ap_wowlan.bin
+-Version: 18.0
+-
+-Info: rtl8188fu taken from Realtek driver
+-      RTL8188FU_Linux_v4.3.23.6_20964.20170110
+-      Firmware was embedded in the driver as data statements. This info
+-      has been extracted into a binary file.
+-File: rtlwifi/rtl8188fufw.bin
+-
+-File: rtlwifi/rtl8710bufw_SMIC.bin
+-Version: 16.0
+-File: rtlwifi/rtl8710bufw_UMC.bin
+-Version: 16.0
+-
+-Info: rtl8188eu taken from Realtek driver version
+-      v5.2.2.4_25483.20171222.
+-      Firmware is embedded in the driver as data statements. This info
+-      has been extracted into a binary file.
+-File: rtlwifi/rtl8188eufw.bin
+-Version: 28.0
+-
+-Info: rtl8192fu taken from Realtek driver version
+-      v5.8.6.2_35538.20191028_COEX20190910-0d02.
+-      Firmware is embedded in the driver as data statements. This info
+-      has been extracted into a binary file.
+-File: rtlwifi/rtl8192fufw.bin
+-Version: 6.0
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: r8169 - RealTek 8169/8168/8101 ethernet driver.
+-
+-File: rtl_nic/rtl8168d-1.fw
+-File: rtl_nic/rtl8168d-2.fw
+-File: rtl_nic/rtl8105e-1.fw
+-File: rtl_nic/rtl8168e-1.fw
+-File: rtl_nic/rtl8168e-2.fw
+-
+-File: rtl_nic/rtl8168e-3.fw
+-Version: 0.0.4
+-
+-File: rtl_nic/rtl8168f-1.fw
+-Version: 0.0.5
+-
+-File: rtl_nic/rtl8168f-2.fw
+-Version: 0.0.4
+-
+-File: rtl_nic/rtl8411-1.fw
+-Version: 0.0.3
+-
+-File: rtl_nic/rtl8411-2.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8402-1.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8106e-1.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8106e-2.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8168g-1.fw
+-Version: 0.0.3
+-
+-File: rtl_nic/rtl8168g-2.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8168g-3.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8168h-1.fw
+-Version: 0.0.2
+-
+-File: rtl_nic/rtl8168h-2.fw
+-Version: 0.0.2
+-
+-File: rtl_nic/rtl8168fp-3.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8107e-1.fw
+-Version: 0.0.2
+-
+-File: rtl_nic/rtl8107e-2.fw
+-Version: 0.0.2
+-
+-File: rtl_nic/rtl8125a-3.fw
+-Version: 0.0.1
+-
+-File: rtl_nic/rtl8125b-1.fw
+-Version: 0.0.2
+-
+-File: rtl_nic/rtl8125b-2.fw
+-Version: 0.0.2
+-
+-Licence:
+- * Copyright © 2011-2013, Realtek Semiconductor Corporation
+- *
+- * Permission is hereby granted for the distribution of this firmware
+- * data in hexadecimal or equivalent format, provided this copyright
+- * notice is accompanying it.
+-
+---------------------------------------------------------------------------
+-
+-Driver: r8152 - Realtek RTL8152/RTL8153 Based USB Ethernet Adapters
+-
+-File: rtl_nic/rtl8153a-2.fw
+-File: rtl_nic/rtl8153a-3.fw
+-File: rtl_nic/rtl8153a-4.fw
+-File: rtl_nic/rtl8153b-2.fw
+-File: rtl_nic/rtl8153c-1.fw
+-File: rtl_nic/rtl8156a-2.fw
+-File: rtl_nic/rtl8156b-2.fw
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: vt6656 - VIA VT6656 USB wireless driver
+-
+-File: vntwusb.fw
+-
+-Licence: Redistributable. See LICENCE.via_vt6656 for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: DFU Driver for Atheros bluetooth chipset AR3012
+-
+-File: ar3k/AthrBT_0x01020001.dfu
+-File: ar3k/ramps_0x01020001_26.dfu
+-File: ar3k/AthrBT_0x01020200.dfu
+-File: ar3k/ramps_0x01020200_26.dfu
+-File: ar3k/ramps_0x01020200_40.dfu
+-File: ar3k/AthrBT_0x31010000.dfu
+-File: ar3k/ramps_0x31010000_40.dfu
+-File: ar3k/AthrBT_0x11020000.dfu
+-File: ar3k/ramps_0x11020000_40.dfu
+-File: ar3k/ramps_0x01020201_26.dfu
+-File: ar3k/ramps_0x01020201_40.dfu
+-File: ar3k/AthrBT_0x41020000.dfu
+-File: ar3k/ramps_0x41020000_40.dfu
+-File: ar3k/AthrBT_0x11020100.dfu
+-File: ar3k/ramps_0x11020100_40.dfu
+-File: ar3k/AthrBT_0x31010100.dfu
+-File: ar3k/ramps_0x31010100_40.dfu
+-
+-Licence: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: DFU Driver for Atheros bluetooth chipset AR3012
+-
+-File: ar3k/AthrBT_0x01020201.dfu
+-File: ar3k/1020201coex/ramps_0x01020201_26_HighPriority.dfu
+-
+-Licence: Redistributable. See LICENSE.QualcommAtheros_ar3k for details
+-
+---------------------------------------------------------------------------
+-
+-Driver:Atheros AR300x UART HCI Bluetooth Chip driver
+-
+-File: ar3k/1020201/PS_ASIC.pst
+-File: ar3k/1020201/RamPatch.txt
+-File: ar3k/1020200/ar3kbdaddr.pst
+-File: ar3k/1020200/PS_ASIC.pst
+-File: ar3k/1020200/RamPatch.txt
+-File: ar3k/30101/ar3kbdaddr.pst
+-File: ar3k/30101/PS_ASIC.pst
+-File: ar3k/30101/RamPatch.txt
+-File: ar3k/30000/ar3kbdaddr.pst
+-File: ar3k/30000/PS_ASIC.pst
+-File: ar3k/30000/RamPatch.txt
+-
+-Licence: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: ath6kl - Atheros support for AR6003
+-
+-File: ath6k/AR6004/hw1.3/fw-3.bin
+-File: ath6k/AR6004/hw1.3/bdata.bin
+-File: ath6k/AR6004/hw1.2/fw-2.bin
+-File: ath6k/AR6004/hw1.2/bdata.bin
+-File: ath6k/AR6003/hw1.0/otp.bin.z77
+-File: ath6k/AR6003/hw1.0/bdata.SD31.bin
+-File: ath6k/AR6003/hw1.0/bdata.SD32.bin
+-File: ath6k/AR6003/hw1.0/data.patch.bin
+-File: ath6k/AR6003/hw1.0/bdata.WB31.bin
+-File: ath6k/AR6003/hw1.0/athwlan.bin.z77
+-File: ath6k/AR6003/hw2.1.1/fw-2.bin
+-File: ath6k/AR6003/hw2.1.1/fw-3.bin
+-File: ath6k/AR6003/hw2.1.1/otp.bin
+-File: ath6k/AR6003/hw2.1.1/athwlan.bin
+-File: ath6k/AR6003/hw2.1.1/endpointping.bin
+-File: ath6k/AR6003/hw2.1.1/bdata.SD31.bin
+-File: ath6k/AR6003/hw2.1.1/bdata.SD32.bin
+-File: ath6k/AR6003/hw2.1.1/data.patch.bin
+-File: ath6k/AR6003/hw2.1.1/bdata.WB31.bin
+-File: ath6k/AR6003/hw2.0/otp.bin.z77
+-File: ath6k/AR6003/hw2.0/bdata.SD31.bin
+-File: ath6k/AR6003/hw2.0/bdata.SD32.bin
+-File: ath6k/AR6003/hw2.0/data.patch.bin
+-File: ath6k/AR6003/hw2.0/bdata.WB31.bin
+-File: ath6k/AR6003/hw2.0/athwlan.bin.z77
+-File: ath6k/AR6002/eeprom.data
+-File: ath6k/AR6002/eeprom.bin
+-File: ath6k/AR6002/athwlan.bin.z77
+-File: ath6k/AR6002/data.patch.hw2_0.bin
+-
+-Licence: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: ath10k - Qualcomm Atheros support for QCA988x family of chips
+-
+-File: ath10k/QCA988X/hw2.0/board.bin
+-File: ath10k/QCA988X/hw2.0/firmware-4.bin
+-Version: 10.2.4.45
+-File: ath10k/QCA988X/hw2.0/notice_ath10k_firmware-4.txt
+-File: ath10k/QCA988X/hw2.0/firmware-5.bin
+-Version: 10.2.4-1.0-00047
+-File: ath10k/QCA988X/hw2.0/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA6174/hw2.1/board.bin
+-File: ath10k/QCA6174/hw2.1/board-2.bin
+-File: ath10k/QCA6174/hw2.1/firmware-5.bin
+-Version: SW_RM.1.1.1-00157-QCARMSWPZ-1
+-File: ath10k/QCA6174/hw2.1/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA6174/hw3.0/board.bin
+-File: ath10k/QCA6174/hw3.0/board-2.bin
+-File: ath10k/QCA6174/hw3.0/firmware-4.bin
+-Version: WLAN.RM.2.0-00180-QCARMSWPZ-1
+-File: ath10k/QCA6174/hw3.0/notice_ath10k_firmware-4.txt
+-File: ath10k/QCA6174/hw3.0/firmware-6.bin
+-Version: WLAN.RM.4.4.1-00288-QCARMSWPZ-1
+-File: ath10k/QCA6174/hw3.0/notice_ath10k_firmware-6.txt
+-File: ath10k/QCA6174/hw3.0/firmware-sdio-6.bin
+-Version: WLAN.RMH.4.4.1-00174
+-File: ath10k/QCA6174/hw3.0/notice_ath10k_firmware-sdio-6.txt
+-File: ath10k/QCA9377/hw1.0/board.bin
+-File: ath10k/QCA9377/hw1.0/board-2.bin
+-File: ath10k/QCA9377/hw1.0/firmware-5.bin
+-Version: WLAN.TF.1.0-00002-QCATFSWPZ-5
+-File: ath10k/QCA9377/hw1.0/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA9377/hw1.0/firmware-sdio-5.bin
+-Version: WLAN.TF.1.1.1-00061-QCATFSWPZ-1
+-File: ath10k/QCA9377/hw1.0/notice_ath10k_firmware-sdio-5.txt
+-File: ath10k/QCA99X0/hw2.0/board-2.bin
+-File: ath10k/QCA99X0/hw2.0/firmware-5.bin
+-Version: 10.4.1.00030-1
+-File: ath10k/QCA99X0/hw2.0/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA4019/hw1.0/board-2.bin
+-File: ath10k/QCA4019/hw1.0/firmware-5.bin
+-Version: 10.4-3.6-00140
+-File: ath10k/QCA4019/hw1.0/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA9887/hw1.0/board.bin
+-File: ath10k/QCA9887/hw1.0/firmware-5.bin
+-Version: 10.2.4-1.0-00047
+-File: ath10k/QCA9887/hw1.0/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA9888/hw2.0/board-2.bin
+-File: ath10k/QCA9888/hw2.0/firmware-5.bin
+-Version: 10.4-3.9.0.2-00157
+-File: ath10k/QCA9888/hw2.0/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA9984/hw1.0/board-2.bin
+-File: ath10k/QCA9984/hw1.0/firmware-5.bin
+-Version: 10.4-3.9.0.2-00157
+-File: ath10k/QCA9984/hw1.0/notice_ath10k_firmware-5.txt
+-File: ath10k/QCA9377/hw1.0/firmware-6.bin
+-Version: WLAN.TF.2.1-00021-QCARMSWP-1
+-File: ath10k/QCA9377/hw1.0/notice_ath10k_firmware-6.txt
+-File: ath10k/WCN3990/hw1.0/board-2.bin
+-File: ath10k/WCN3990/hw1.0/firmware-5.bin
+-File: ath10k/WCN3990/hw1.0/wlanmdsp.mbn
+-Link: qcom/sdm845/wlanmdsp.mbn -> ../../ath10k/WCN3990/hw1.0/wlanmdsp.mbn
+-Version: WLAN.HL.2.0-01387-QCAHLSWMTPLZ-1
+-File: ath10k/WCN3990/hw1.0/notice.txt_wlanmdsp
+-
+-Licence: Redistributable. See LICENSE.QualcommAtheros_ath10k for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: ath11k - Qualcomm Technologies 802.11ax chipset support
+-
+-File: ath11k/IPQ6018/hw1.0/board-2.bin
+-File: ath11k/IPQ6018/hw1.0/m3_fw.b00
+-File: ath11k/IPQ6018/hw1.0/m3_fw.b01
+-File: ath11k/IPQ6018/hw1.0/m3_fw.b02
+-File: ath11k/IPQ6018/hw1.0/m3_fw.flist
+-File: ath11k/IPQ6018/hw1.0/m3_fw.mdt
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b00
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b01
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b02
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b03
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b04
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b05
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b07
+-File: ath11k/IPQ6018/hw1.0/q6_fw.b08
+-File: ath11k/IPQ6018/hw1.0/q6_fw.flist
+-File: ath11k/IPQ6018/hw1.0/q6_fw.mdt
+-Version: WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+-File: ath11k/IPQ6018/hw1.0/Notice.txt
+-File: ath11k/IPQ8074/hw2.0/board-2.bin
+-File: ath11k/IPQ8074/hw2.0/m3_fw.b00
+-File: ath11k/IPQ8074/hw2.0/m3_fw.b01
+-File: ath11k/IPQ8074/hw2.0/m3_fw.b02
+-File: ath11k/IPQ8074/hw2.0/m3_fw.flist
+-File: ath11k/IPQ8074/hw2.0/m3_fw.mdt
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b00
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b01
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b02
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b03
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b04
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b05
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b07
+-File: ath11k/IPQ8074/hw2.0/q6_fw.b08
+-File: ath11k/IPQ8074/hw2.0/q6_fw.flist
+-File: ath11k/IPQ8074/hw2.0/q6_fw.mdt
+-Version: WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+-File: ath11k/IPQ8074/hw2.0/Notice.txt
+-File: ath11k/QCA6390/hw2.0/board-2.bin
+-File: ath11k/QCA6390/hw2.0/amss.bin
+-File: ath11k/QCA6390/hw2.0/m3.bin
+-Version: WLAN.HST.1.0.1-05266-QCAHSTSWPLZ_V2_TO_X86-1
+-File: ath11k/QCA6390/hw2.0/Notice.txt
+-File: ath11k/WCN6855/hw2.0/regdb.bin
+-File: ath11k/WCN6855/hw2.0/board-2.bin
+-File: ath11k/WCN6855/hw2.0/amss.bin
+-File: ath11k/WCN6855/hw2.0/m3.bin
+-Version: WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.23
+-File: ath11k/WCN6855/hw2.0/Notice.txt
+-Link: ath11k/WCN6855/hw2.1/regdb.bin -> ../hw2.0/regdb.bin
+-Link: ath11k/WCN6855/hw2.1/board-2.bin -> ../hw2.0/board-2.bin
+-Link: ath11k/WCN6855/hw2.1/amss.bin -> ../hw2.0/amss.bin
+-Link: ath11k/WCN6855/hw2.1/m3.bin -> ../hw2.0/m3.bin
+-File: ath11k/QCN9074/hw1.0/board-2.bin
+-File: ath11k/QCN9074/hw1.0/amss.bin
+-File: ath11k/QCN9074/hw1.0/m3.bin
+-Version: WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+-File: ath11k/QCN9074/hw1.0/Notice.txt
+-File: ath11k/WCN6750/hw1.0/board-2.bin
+-File: ath11k/WCN6750/hw1.0/wpss.b00
+-File: ath11k/WCN6750/hw1.0/wpss.b01
+-File: ath11k/WCN6750/hw1.0/wpss.b02
+-File: ath11k/WCN6750/hw1.0/wpss.b03
+-File: ath11k/WCN6750/hw1.0/wpss.b04
+-File: ath11k/WCN6750/hw1.0/wpss.b05
+-File: ath11k/WCN6750/hw1.0/wpss.b06
+-File: ath11k/WCN6750/hw1.0/wpss.b07
+-File: ath11k/WCN6750/hw1.0/wpss.b08
+-File: ath11k/WCN6750/hw1.0/wpss.mdt
+-Version: WLAN.MSL.1.0.1-01160-QCAMSLSWPLZ-1
+-File: ath11k/WCN6750/hw1.0/Notice.txt
+-File: ath11k/IPQ5018/hw1.0/board-2.bin
+-File: ath11k/IPQ5018/hw1.0/m3_fw.b00
+-File: ath11k/IPQ5018/hw1.0/m3_fw.b01
+-File: ath11k/IPQ5018/hw1.0/m3_fw.b02
+-File: ath11k/IPQ5018/hw1.0/m3_fw.flist
+-File: ath11k/IPQ5018/hw1.0/m3_fw.mdt
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b00
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b01
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b02
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b03
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b04
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b05
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b07
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b08
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b09
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b10
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b11
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b13
+-File: ath11k/IPQ5018/hw1.0/q6_fw.b14
+-File: ath11k/IPQ5018/hw1.0/q6_fw.flist
+-File: ath11k/IPQ5018/hw1.0/q6_fw.mdt
+-Version: WLAN.HK.2.6.0.1-00861-QCAHKSWPL_SILICONZ-1
+-File: ath11k/IPQ5018/hw1.0/Notice.txt
+-
+-Licence: Redistributable. See LICENSE.QualcommAtheros_ath10k for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: myri10ge - Myri10GE 10GbE NIC driver
+-
+-File: myri10ge_eth_z8e.dat
+-File: myri10ge_ethp_z8e.dat
+-File: myri10ge_rss_eth_z8e.dat
+-File: myri10ge_rss_ethp_z8e.dat
+-File: myri10ge_eth_big_z8e.dat
+-File: myri10ge_ethp_big_z8e.dat
+-File: myri10ge_rss_eth_big_z8e.dat
+-File: myri10ge_rss_ethp_big_z8e.dat
+-Version: 1.4.57
+-
+-License: Redistributable.  See LICENCE.myri10ge_firmware for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: ath6kl - Atheros support for AR6003 WiFi-Bluetooth combo module
+-
+-File: ath6k/AR6003.1/hw2.1.1/athwlan.bin
+-File: ath6k/AR6003.1/hw2.1.1/bdata.SD31.bin
+-File: ath6k/AR6003.1/hw2.1.1/bdata.SD32.bin
+-File: ath6k/AR6003.1/hw2.1.1/bdata.WB31.bin
+-File: ath6k/AR6003.1/hw2.1.1/data.patch.bin
+-File: ath6k/AR6003.1/hw2.1.1/endpointping.bin
+-File: ath6k/AR6003.1/hw2.1.1/otp.bin
+-
+-License: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: ath6kl - Atheros support for AR3001 WiFi-Bluetooth combo module
+-
+-File: ar3k/30101coex/ar3kbdaddr.pst
+-File: ar3k/30101coex/PS_ASIC_aclLowPri.pst
+-File: ar3k/30101coex/PS_ASIC_aclHighPri.pst
+-File: ar3k/30101coex/PS_ASIC.pst
+-File: ar3k/30101coex/RamPatch.txt
+-
+-License: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: ene-ub6250 -- ENE UB6250 SD card reader driver
+-
+-File: ene-ub6250/sd_init1.bin
+-File: ene-ub6250/sd_init2.bin
+-File: ene-ub6250/sd_rdwr.bin
+-File: ene-ub6250/ms_init.bin
+-File: ene-ub6250/msp_rdwr.bin
+-File: ene-ub6250/ms_rdwr.bin
+-
+-Licence: Redistributable. See LICENCE.ene_firmware for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: isci -- Intel C600 SAS controller driver
+-
+-File: isci/isci_firmware.bin
+-Source: isci/
++File: isci/isci_firmware.bin
++Source: isci/
+ 
+ Licence: GPLv2. See GPL-2 for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ar5523 -- Atheros AR5523 based USB Wifi dongles
+-
+-File: ar5523.bin
+-
+-Licence: Redistributable. See LICENCE.atheros_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: carl9170 -- Atheros AR9170 802.11 draft-n USB driver
+-
+-File: carl9170-1.fw
+-Version: 1.9.6
+-Source: carl9170fw/
+-
+-Downloaded from http://linuxwireless.org/en/users/Drivers/carl9170
+-
+-Licence: GPLv2. Some build scripts use the New BSD (3-clause) licence.. See GPL-2 for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: btusb - Bluetooth USB driver
+-
+-File: intel/ibt-hw-37.7.bseq
+-Version: 1316.02.00
+-File: intel/ibt-hw-37.7.10-fw-1.80.2.3.d.bseq
+-Version: BT_WilkinsPeak_B3_REL_87_0001
+-File: intel/ibt-hw-37.7.10-fw-1.0.2.3.d.bseq
+-Version: BT_WilkinsPeak_B3_REL_87_0001
+-File: intel/ibt-hw-37.7.10-fw-1.80.1.2d.d.bseq
+-Version: BT_WilkinsPeak_B5_REL_42_0001
+-File: intel/ibt-hw-37.7.10-fw-1.0.1.2d.d.bseq
+-Version: BT_WilkinsPeak_B5_REL_42_0001
+-File: intel/ibt-hw-37.8.bseq
+-Version: 1339_02.00
+-File: intel/ibt-hw-37.8.10-fw-1.10.2.27.d.bseq
+-Version: BT_StonePeak_C0_REL_59_0001
+-File: intel/ibt-hw-37.8.10-fw-1.10.3.11.e.bseq
+-Version: BT_StonePeak_D0_REL_50_0002
+-File: intel/ibt-hw-37.8.10-fw-22.50.19.14.f.bseq
+-Version: BT_StonePeak_D1_REL_67_1278
+-File: intel/ibt-11-5.ddc
+-Version: LnP/SfP_REL1294
+-File: intel/ibt-11-5.sfi
+-Version: BT_LightningPeak_REL0487
+-File: intel/ibt-12-16.ddc
+-Version: BT_WindStormPeak_REL1299
+-File: intel/ibt-12-16.sfi
+-Version: BT_WindStormPeak_REL1299
+-File: intel/ibt-17-16-1.sfi
+-Version: BT_JeffersonPeak_B0_B0_REL20332
+-File: intel/ibt-17-16-1.ddc
+-Version: BT_JeffersonPeak_B0_B0_REL20332
+-File: intel/ibt-17-2.sfi
+-Version: BT_JeffersonPeak_B0_B0_REL20332
+-File: intel/ibt-17-2.ddc
+-Version: BT_JeffersonPeak_B0_B0_REL20332
+-File: intel/ibt-17-0-1.sfi
+-Version: BT_JeffersonPeak_A0_B0_REL0201
+-File: intel/ibt-17-0-1.ddc
+-Version: BT_JeffersonPeak_A0_B0_REL0201
+-File: intel/ibt-17-1.sfi
+-Version: BT_JeffersonPeak_A0_B0_REL0201
+-File: intel/ibt-17-1.ddc
+-Version: BT_JeffersonPeak_A0_B0_REL0201
+-File: intel/ibt-18-16-1.sfi
+-Version: BT_ThunderPeak_B0_B0_REL20182
+-File: intel/ibt-18-16-1.ddc
+-Version: BT_ThunderPeak_B0_B0_REL20182
+-File: intel/ibt-18-2.sfi
+-Version: BT_ThunderPeak_B0_B0_REL20182
+-File: intel/ibt-18-2.ddc
+-Version: BT_ThunderPeak_B0_B0_REL20182
+-File: intel/ibt-18-0-1.sfi
+-Version: BT_ThunderPeak_A0_B0_REL0201
+-File: intel/ibt-18-0-1.ddc
+-Version: BT_ThunderPeak_A0_B0_REL0201
+-File: intel/ibt-18-1.sfi
+-Version: BT_ThunderPeak_A0_B0_REL0201
+-File: intel/ibt-18-1.ddc
+-Version: BT_ThunderPeak_A0_B0_REL0201
+-File:intel/ibt-20-0-3.sfi
+-Version: BT_CyclonePeak_A0_REL53392
+-File:intel/ibt-20-0-3.ddc
+-Version: BT_CyclonePeak_A0_REL53392
+-File:intel/ibt-20-1-3.sfi
+-Version: BT_CyclonePeak_A0_REL53392
+-File:intel/ibt-20-1-3.ddc
+-Version: BT_CyclonePeak_A0_REL53392
+-File:intel/ibt-20-1-4.sfi
+-Version: BT_CyclonePeak_A0_REL53392
+-File:intel/ibt-20-1-4.ddc
+-Version: BT_CyclonePeak_A0_REL53392
+-File:intel/ibt-19-0-0.sfi
+-Version: BT_Quasar_REL53392
+-File:intel/ibt-19-0-0.ddc
+-Version: BT_Quasar_REL53392
+-File:intel/ibt-19-0-1.sfi
+-Version: BT_Quasar_REL53392
+-File:intel/ibt-19-0-1.ddc
+-Version: BT_Quasar_REL53392
+-File:intel/ibt-19-0-3.sfi
+-Version: BT_Quasar_REL53263
+-File:intel/ibt-19-0-3.ddc
+-Version: BT_Quasar_REL53263
+-File:intel/ibt-19-0-4.sfi
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-0-4.ddc
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-16-4.sfi
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-16-4.ddc
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-32-1.sfi
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-32-1.ddc
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-32-0.sfi
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-32-0.ddc
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-32-4.sfi
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-32-4.ddc
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-240-1.sfi
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-240-1.ddc
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-240-4.sfi
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-19-240-4.ddc
+-Version: BT_HarrisonPeak_REL53392
+-File:intel/ibt-0041-0041.sfi
+-Version: BT_TyphoonPeak_REL62562
+-File:intel/ibt-0041-0041.ddc
+-Version: BT_TyphoonPeak_REL62562
+-File:intel/ibt-0040-0041.sfi
+-Version: BT_Solar_GfP2_REL62562
+-File:intel/ibt-0040-0041.ddc
+-Version: BT_Solar_GfP2_REL62562
+-File:intel/ibt-1040-0041.sfi
+-Version: BT_SolarF_GfP2_REL62562
+-File:intel/ibt-1040-0041.ddc
+-Version: BT_SolarF_GfP2_REL62562
+-
+-File:intel/ibt-0040-1020.sfi
+-Version: BT_Solar_JfP1_REL59564
+-File:intel/ibt-0040-1020.ddc
+-Version: BT_Solar_JfP1_REL59564
+-File:intel/ibt-1040-1020.sfi
+-Version: BT_SolarF_JfP1_REL59564
+-File:intel/ibt-1040-1020.ddc
+-Version: BT_SolarF_JfP1_REL59564
+-
+-File:intel/ibt-0040-2120.sfi
+-Version: BT_Solar_JfP2_REL52159
+-File:intel/ibt-0040-2120.ddc
+-Version: BT_Solar_JfP2_REL52159
+-File:intel/ibt-1040-2120.sfi
+-Version: BT_SolarF_JfP2_REL59564
+-File:intel/ibt-1040-2120.ddc
+-Version: BT_SolarF_JfP2_REL59564
+-
+-File:intel/ibt-0040-4150.sfi
+-Version: BT_Solar_JnP2_REL62562
+-File:intel/ibt-0040-4150.ddc
+-Version: BT_Solar_JnP2_REL62562
+-File:intel/ibt-1040-4150.sfi
+-Version: BT_SolarF_JnP2_REL62562
+-File:intel/ibt-1040-4150.ddc
+-Version: BT_SolarF_JnP2_REL62562
+-
+-Licence: Redistributable. See LICENCE.ibt_firmware for details
+-
+-File: rtl_bt/rtl8192ee_fw.bin
+-File: rtl_bt/rtl8192eu_fw.bin
+-File: rtl_bt/rtl8723a_fw.bin
+-File: rtl_bt/rtl8723b_fw.bin
+-File: rtl_bt/rtl8723bs_fw.bin
+-File: rtl_bt/rtl8723bs_config-OBDA8723.bin
+-Link: rtl_bt/rtl8723bs_config-OBDA0623.bin -> rtl8723bs_config-OBDA8723.bin
+-File: rtl_bt/rtl8761a_fw.bin
+-File: rtl_bt/rtl8761b_fw.bin
+-File: rtl_bt/rtl8761b_config.bin
+-File: rtl_bt/rtl8761bu_fw.bin
+-File: rtl_bt/rtl8761bu_config.bin
+-File: rtl_bt/rtl8812ae_fw.bin
+-File: rtl_bt/rtl8821a_fw.bin
+-Link: rtl_bt/rtl8821a_config.bin -> rtl8821c_config.bin
+-File: rtl_bt/rtl8822b_fw.bin
+-File: rtl_bt/rtl8822b_config.bin
+-File: rtl_bt/rtl8723d_fw.bin
+-File: rtl_bt/rtl8723d_config.bin
+-File: rtl_bt/rtl8821c_fw.bin
+-File: rtl_bt/rtl8821c_config.bin
+-File: rtl_bt/rtl8821cs_fw.bin
+-File: rtl_bt/rtl8821cs_config.bin
+-File: rtl_bt/rtl8822cu_fw.bin
+-File: rtl_bt/rtl8822cu_config.bin
+-File: rtl_bt/rtl8822cs_fw.bin
+-File: rtl_bt/rtl8822cs_config.bin
+-File: rtl_bt/rtl8852au_fw.bin
+-File: rtl_bt/rtl8852au_config.bin
+-File: rtl_bt/rtl8852bu_fw.bin
+-File: rtl_bt/rtl8852bu_config.bin
+-File: rtl_bt/rtl8852cu_fw.bin
+-File: rtl_bt/rtl8852cu_config.bin
+-File: rtl_bt/rtl8851bu_fw.bin
+-File: rtl_bt/rtl8851bu_config.bin
+-
+-Licence: Redistributable. See LICENCE.rtlwifi_firmware.txt for details.
+-
+-Found in vendor driver, linux_bt_usb_2.11.20140423_8723be.rar
+-From https://github.com/troy-tan/driver_store
+-Files rtl_bt/rtl8822b_* came directly from Realtek. These files are
+-updated on April 14, 2017.
+-
+-Found in vendor driver, 20200806_LINUX_BT_DRIVER_RTL8761B_COEX_v0202.zip
+-File rtl_bt/rtl8761b_config.bin
+-File rtl_bt/rtl8761bu_config.bin
+-
+---------------------------------------------------------------------------
+-
+-Driver: btmtk_usb - Bluetooth USB driver
+-
+-File: mediatek/mt7650.bin
+-Link: mt7650.bin -> mediatek/mt7650.bin
+-
+-Licence: Redistributable. See LICENCE.ralink_a_mediatek_company_firmware for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: rp2 -- Comtrol RocketPort 2 serial driver
+ 
+ File: rp2.fw
+@@ -3632,56 +1902,6 @@ License: Redistributable. See LICENCE.moxa for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: cw1200 - ST-E CW1100/CW1200 WLAN driver
+-
+-File: wsm_22.bin
+-Version: WSM395
+-Licence: Redistributable. See LICENCE.cw1200 for details.
+-
+-File: sdd_sagrad_1091_1098.bin
+-
+-License:
+-  Copyright (c) 2011-2013 Sagrad, Inc.
+-
+-  This SDD ("Static Dynamic Data") file is licensed strictly for use with
+-  the Sagrad WiFi modules (such as the SG901-1091/1098) that utilize the
+-  cw1200 driver. There is no warranty expressed or implied about its
+-  fitness for any purpose.
+-
+-  Permission is hereby granted for the distribution of this SDD file as
+-  part of Linux or other Open Source operating system kernel in text or
+-  binary form as required.
+-
+-  (Please note that the actual device firmware is separately licensed)
+-
+---------------------------------------------------------------------------
+-
+-Driver: BFA/BNA - QLogic BR-series Adapter FC/FCOE drivers
+-
+-File: cbfw-3.2.5.1.bin
+-File: ctfw-3.2.5.1.bin
+-File: ct2fw-3.2.5.1.bin
+-
+-Licence:
+-
+-This file contains firmware data derived from proprietary unpublished
+-source code.
+-Copyright (c) 2013-2014 Brocade Communications Systems, Inc.
+-Copyright (c) 2014-2015 QLogic Corporation.
+-
+-Permission is hereby granted for the distribution of this firmware data
+-in hexadecimal or equivalent format, provided this copyright notice is
+-accompanying it.
+-
+-QLogic grants permission to use and redistribute these firmware files
+-for use with QLogic BR-series devices, but not as a part of the Linux
+-kernel or in any other form which would require these files themselves
+-to be covered by the terms of the GNU General Public License.
+-These firmware files are distributed in the hope that they will be
+-useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+-of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+---------------------------------------------------------------------------
+ Driver: qat - Intel(R) QAT crypto accelerator
+ 
+ File: qat_895xcc.bin
+@@ -3698,36 +1918,6 @@ Licence: Redistributable. See LICENCE.qat_firmware for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: rsi -- Redpine Signals Inc 91x driver
+-
+-File: rsi_91x.fw
+-
+-File: rsi/rs9113_wlan_qspi.rps
+-Version: 1.6.1
+-
+-File: rsi/rs9113_wlan_bt_dual_mode.rps
+-Version: 1.6.1
+-
+-File: rsi/rs9113_ap_bt_dual_mode.rps
+-Version: 1.6.1
+-
+-File: rsi/rs9116_wlan.rps
+-Version: 1.0.5b
+-
+-File: rsi/rs9116_wlan_bt_classic.rps
+-Version: 1.0.5b
+-
+-Licence:
+- * Firmware is:
+- *	Derived from proprietary unpublished source code,
+- *	Copyright (C) 2019 Redpine Signals Inc.
+- *
+- *	Permission is hereby granted for the distribution of this firmware
+- *	as part of Linux or other Open Source operating system kernel
+- *	provided this copyright notice is accompanying it.
+-
+---------------------------------------------------------------------------
+-
+ Driver: xhci-rcar -- Renesas R-Car Gen2/3 USB 3.0 host controller driver
+ 
+ File: r8a779x_usb3_v1.dlmem
+@@ -3770,86 +1960,6 @@ Licence: GPLv2 or later. See GPL-2 and GPL-3 for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: btqca - Qualcomm Atheros Bluetooth support for QCA61x4 chips
+-
+-File: qca/nvm_usb_00000201.bin
+-File: qca/nvm_usb_00000200.bin
+-File: qca/nvm_usb_00000300.bin
+-File: qca/nvm_usb_00000302.bin
+-File: qca/nvm_00130300.bin
+-File: qca/nvm_00130302.bin
+-File: qca/nvm_00230302.bin
+-File: qca/rampatch_usb_00000200.bin
+-File: qca/rampatch_usb_00000201.bin
+-File: qca/rampatch_usb_00000300.bin
+-File: qca/rampatch_usb_00000302.bin
+-File: qca/rampatch_00130300.bin
+-File: qca/rampatch_00130302.bin
+-File: qca/rampatch_00230302.bin
+-File: qca/nvm_00440302.bin
+-File: qca/rampatch_00440302.bin
+-File: qca/nvm_00440302_eu.bin
+-File: qca/nvm_00440302_i2s_eu.bin
+-File: qca/nvm_usb_00000302_eu.bin
+-File: qca/htbtfw20.tlv
+-File: qca/htnv20.bin
+-File: qca/rampatch_usb_00130200.bin
+-File: qca/nvm_usb_00130200.bin
+-File: qca/nvm_usb_00130200_0104.bin
+-File: qca/nvm_usb_00130200_0105.bin
+-File: qca/nvm_usb_00130200_0106.bin
+-File: qca/nvm_usb_00130200_0107.bin
+-File: qca/nvm_usb_00130200_0109.bin
+-File: qca/nvm_usb_00130200_0110.bin
+-File: qca/rampatch_usb_00130201.bin
+-File: qca/nvm_usb_00130201.bin
+-File: qca/nvm_usb_00130201_010a.bin
+-File: qca/nvm_usb_00130201_010b.bin
+-File: qca/nvm_usb_00130201_0303.bin
+-File: qca/nvm_usb_00130201_gf.bin
+-File: qca/nvm_usb_00130201_gf_010a.bin
+-File: qca/nvm_usb_00130201_gf_010b.bin
+-File: qca/nvm_usb_00130201_gf_0303.bin
+-File: qca/rampatch_usb_00190200.bin
+-File: qca/nvm_usb_00190200.bin
+-
+-Licence: Redistributable. See LICENSE.QualcommAtheros_ath10k and qca/NOTICE.txt for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: qca - Qualcomm Atheros Bluetooth support for WCN399x chips
+-
+-File: qca/crbtfw21.tlv
+-File: qca/crnv21.bin
+-File: qca/crbtfw32.tlv
+-File: qca/crnv32.bin
+-File: qca/crnv32u.bin
+-
+-Driver: qca - Qualcomm Atheros Bluetooth support for WCN6750 chips
+-
+-File: qca/msbtfw11.mbn
+-File: qca/msbtfw11.tlv
+-File: qca/msnv11.bin
+-File: qca/msnv11.b0a
+-File: qca/msnv11.b09
+-
+-Licence: Redistributable. See LICENSE.QualcommAtheros_ath10k and qca/NOTICE.txt for details
+-
+-Driver: qca - Qualcomm Atheros Bluetooth support for QCA2066 chips
+-
+-File: qca/hpbtfw21.tlv
+-File: qca/hpnv21.bin
+-File: qca/hpnv21g.bin
+-File: qca/hpnv21.301
+-File: qca/hpnv21.302
+-File: qca/hpnv21g.301
+-File: qca/hpnv21g.302
+-
+-
+-Licence: Redistributable. See LICENSE.QualcommAtheros_ath10k and qca/NOTICE.txt for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: liquidio -- Cavium LiquidIO driver
+ 
+ File: liquidio/lio_23xx_nic.bin
+@@ -4663,19 +2773,6 @@ Licence: Redistributable. See LICENCE.nvidia for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: wilc1000 - Atmel 802.11n WLAN driver for WILC1000
+-
+-File: atmel/wilc1000_fw.bin
+-File: atmel/wilc1000_ap_fw.bin
+-File: atmel/wilc1000_p2p_fw.bin
+-File: atmel/wilc1000_wifi_firmware.bin
+-File: atmel/wilc1000_wifi_firmware-1.bin
+-Version: 16.0
+-
+-License: Redistributable. See LICENSE.atmel for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: hfi1 - Intel OPA Gen 1 adapter
+ 
+ File: hfi1_dc8051.fw
+@@ -4699,18 +2796,6 @@ Licence: Redistributable. See LICENCE.ti-keystone for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: mwlwifi - Marvell mac80211 driver for 80211ac cards.
+-
+-File: mwlwifi/88W8864.bin
+-Version: 7.2.8.6
+-
+-File: mwlwifi/88W8897.bin
+-Version: 8.2.0.10
+-
+-Licence: Redistributable. See LICENCE.Marvell for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: mtk_scp - MediaTek SCP System Control Processing Driver
+ 
+ File: mediatek/mt8183/scp.img
+@@ -4726,195 +2811,6 @@ Licence: Redistributable. See LICENCE.mediatek for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: btmtk - MediaTek Bluetooth Driver
+-
+-File: mediatek/mt7622pr2h.bin
+-Version: 20180621204904
+-File: mediatek/mt7668pr2h.bin
+-Version: 20180517181834
+-# Note: explicitly commented out, since it's duplicated further down
+-# File: mediatek/mt7663pr2h.bin
+-# Version: 7663e2ccn04-2006030247
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt76x0 - MediaTek MT76x0 Wireless MACs
+-
+-File: mediatek/mt7610u.bin
+-File: mediatek/mt7610e.bin
+-Version: 2.6
+-File: mediatek/mt7650e.bin
+-Version: 1.0.07-b370
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+----------------------------------------------------------------------------
+-
+-Driver: mt76x2e - MediaTek MT76x2 Wireless MACs
+-
+-File: mediatek/mt7662.bin
+-Version: 1.9
+-Link: mt7662.bin -> mediatek/mt7662.bin
+-
+-File: mediatek/mt7662_rom_patch.bin
+-Version: 0.0.2_P69
+-Link: mt7662_rom_patch.bin -> mediatek/mt7662_rom_patch.bin
+-
+-Licence: Redistributable. See LICENCE.ralink_a_mediatek_company_firmware for details
+-
+----------------------------------------------------------------------------
+-
+-Driver: mt76x2u - MediaTek MT76x2u Wireless MACs
+-
+-File: mediatek/mt7662u.bin
+-Version: 1.5
+-
+-File: mediatek/mt7662u_rom_patch.bin
+-Version: 0.0.2_P48
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7615e - MediaTek MT7615e Wireless MACs
+-
+-File: mediatek/mt7615_n9.bin
+-Version: 20200814
+-File: mediatek/mt7615_cr4.bin
+-Version: 20190114
+-File: mediatek/mt7615_rom_patch.bin
+-Version: 20190114
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7622 - MediaTek MT7622 Wireless MACs
+-
+-File: mediatek/mt7622_n9.bin
+-Version: 20200630
+-File: mediatek/mt7622_rom_patch.bin
+-Version: 20190114
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7663 - MediaTek MT7663 Wireless MACs
+-
+-File: mediatek/mt7663pr2h.bin
+-Version: 7663e2ccn04-2006030247
+-File: mediatek/mt7663_n9_v3.bin
+-Version: v3.1.1
+-
+-File: mediatek/mt7663pr2h_rebb.bin
+-Version: 7663e2-1802-19091404338b809
+-File: mediatek/mt7663_n9_rebb.bin
+-Version: 7663mp1827-20190914043434
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7915e - MediaTek Wireless MACs for MT7915/MT7916/MT7986/MT7981
+-
+-File: mediatek/mt7915_wm.bin
+-Version: 20220929104145
+-File: mediatek/mt7915_wa.bin
+-Version: 20220929104205
+-File: mediatek/mt7915_rom_patch.bin
+-Version: 20220929104113a
+-File: mediatek/mt7915_eeprom.bin
+-Version: 20200821
+-File: mediatek/mt7915_eeprom_dbdc.bin
+-Version: 20200821
+-
+-File: mediatek/mt7916_wm.bin
+-Version: 20230202145005
+-File: mediatek/mt7916_wa.bin
+-Version: 20230202143332
+-File: mediatek/mt7916_rom_patch.bin
+-Version: 20230202144915a
+-File: mediatek/mt7916_eeprom.bin
+-Version: 20211130
+-
+-File: mediatek/mt7986_wm.bin
+-Version: 20221012174725
+-File: mediatek/mt7986_wm_mt7975.bin
+-Version: 20221012174805
+-File: mediatek/mt7986_wa.bin
+-Version: 20221012174937
+-File: mediatek/mt7986_rom_patch.bin
+-Version: 20221012174648a
+-File: mediatek/mt7986_rom_patch_mt7975.bin
+-Version: 20221012174743a
+-File: mediatek/mt7986_wo_0.bin
+-Version: 20221012175005
+-File: mediatek/mt7986_wo_1.bin
+-Version: 20221012175032
+-File: mediatek/mt7986_eeprom_mt7976.bin
+-Version: 20211105
+-File: mediatek/mt7986_eeprom_mt7976_dbdc.bin
+-Version: 20220223
+-File: mediatek/mt7986_eeprom_mt7976_dual.bin
+-Version: 20211115
+-File: mediatek/mt7986_eeprom_mt7975_dual.bin
+-Version: 20220208
+-
+-File: mediatek/mt7981_wm.bin
+-Version: 20221208201806
+-File: mediatek/mt7981_wa.bin
+-Version: 20221208202048
+-File: mediatek/mt7981_rom_patch.bin
+-Version: 20221208201745a
+-File: mediatek/mt7981_wo.bin
+-Version: 20221208202138
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7921 - MediaTek MT7921 Wireless MACs
+-
+-File: mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin
+-Version: 20230526130917a
+-File: mediatek/WIFI_RAM_CODE_MT7961_1.bin
+-Version: 20230526130958
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7921 - MediaTek MT7921 bluetooth chipset
+-
+-File: mediatek/BT_RAM_CODE_MT7961_1_2_hdr.bin
+-Version: 20230526131214
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7922 - MediaTek MT7922 Wireless MACs
+-
+-File: mediatek/WIFI_MT7922_patch_mcu_1_1_hdr.bin
+-Version: 20230530123154a
+-File: mediatek/WIFI_RAM_CODE_MT7922_1.bin
+-Version: 20230530123236
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: mt7922 - MediaTek MT7922 bluetooth chipset
+-
+-File: mediatek/BT_RAM_CODE_MT7922_1_1_hdr.bin
+-Version: 20230530123531
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+ Driver: nfp - Netronome Flow Processor
+ 
+ Link: netronome/nic_AMDA0081-0001_1x40.nffw -> nic/nic_AMDA0081-0001_1x40.nffw
+@@ -5009,16 +2905,6 @@ Licence: Redistributable. See LICENCE.Netronome for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: wil6210 - Qualcomm Atheros support for 11ad family of chips
+-
+-File: wil6210.fw
+-File: wil6210.brd
+-Version: 5.2.0.18
+-
+-Licence: Redistributable. See LICENSE.QualcommAtheros_ath10k for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: imx-sdma - support for i.MX SDMA driver
+ 
+ File: imx/sdma/sdma-imx6q.bin
+@@ -5077,69 +2963,6 @@ https://github.com/genesi/linux-legacy/tree/master/drivers/mxc/amd-gpu
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: qcom_q6v5_pas - Qualcomm remoteproc firmware
+-
+-File: qcom/apq8016/mba.mbn
+-File: qcom/apq8016/modem.mbn
+-File: qcom/apq8016/wcnss.mbn
+-File: qcom/apq8016/WCNSS_qcom_wlan_nv_sbc.bin
+-File: qcom/apq8096/adsp.mbn
+-File: qcom/apq8096/adspr.jsn
+-File: qcom/apq8096/adspua.jsn
+-File: qcom/apq8096/mba.mbn
+-File: qcom/apq8096/modem.mbn
+-File: qcom/apq8096/modemr.jsn
+-File: qcom/sdm845/adsp.mbn
+-File: qcom/sdm845/adspr.jsn
+-File: qcom/sdm845/adspua.jsn
+-File: qcom/sdm845/cdsp.mbn
+-File: qcom/sdm845/cdspr.jsn
+-File: qcom/sm8250/adsp.mbn
+-File: qcom/sm8250/adspr.jsn
+-File: qcom/sm8250/adspua.jsn
+-File: qcom/sm8250/cdsp.mbn
+-File: qcom/sm8250/cdspr.jsn
+-File: qcom/sc8280xp/LENOVO/21BX/adspr.jsn
+-File: qcom/sc8280xp/LENOVO/21BX/adspua.jsn
+-File: qcom/sc8280xp/LENOVO/21BX/battmgr.jsn
+-File: qcom/sc8280xp/LENOVO/21BX/cdspr.jsn
+-File: qcom/sc8280xp/LENOVO/21BX/qcadsp8280.mbn
+-File: qcom/sc8280xp/LENOVO/21BX/qccdsp8280.mbn
+-File: qcom/sc8280xp/LENOVO/21BX/qcslpi8280.mbn
+-Link: qcom/LENOVO/21BX -> ../sc8280xp/LENOVO/21BX
+-
+-Licence: Redistributable. See LICENSE.qcom and qcom/NOTICE.txt for details
+-
+-Binary files supplied originally from
+-http://releases.linaro.org/96boards/dragonboard410c/qualcomm/firmware/linux-board-support-package-r1036.1.zip
+-http://releases.linaro.org/96boards/dragonboard845c/qualcomm/firmware/RB3_firmware_20221121000000-v5.zip
+-http://releases.linaro.org/96boards/rb5/qualcomm/firmware/RB5_firmware_20210331-v4.zip
+-
+-adsp.mbn has been converted from 20-adsp_split/firmware/adsp.* using
+-https://github.com/andersson/pil-squasher
+-
+-cdsp.mbn has been converted from 21-cdsp_split/firmware/cdsp.* using
+-https://github.com/andersson/pil-squasher
+-
+---------------------------------------------------------------------------
+-
+-Driver: qcom_q6v5_mss - Qualcomm modem subsystem firmware
+-
+-File: qcom/sdm845/mba.mbn
+-File: qcom/sdm845/modem_nm.mbn
+-File: qcom/sdm845/modemuw.jsn
+-Link: qcom/sdm845/modem.mbn -> modem_nm.mbn
+-
+-Licence: Redistributable. See LICENSE.qcom and qcom/NOTICE.txt for details
+-
+-Binary files supplied originally from
+-http://releases.linaro.org/96boards/dragonboard845c/qualcomm/firmware/RB3_firmware_20221121000000-v5.zip
+-
+-modem.mbn has been converted from 28-modem/modem.* using
+-https://github.com/andersson/pil-squasher
+-
+---------------------------------------------------------------------------
+-
+ Driver: mlxsw_spectrum - Mellanox Spectrum switch
+ 
+ File: mellanox/mlxsw_spectrum-13.1420.122.mfa2
+@@ -5312,26 +3135,6 @@ Licence: Redistributable. See LICENCE.Marvell for details.
+ 
+ ------------------------------------------------
+ 
+-Driver: wfx - Silicon Labs Wi-Fi Transceiver
+-
+-File: wfx/wfm_wf200_C0.sec
+-Version: 3.14
+-
+-File: wfx/brd4001a.pds
+-File: wfx/brd8022a.pds
+-File: wfx/brd8023a.pds
+-
+-Licence: Redistributable. See wfx/LICENCE.wf200 for details.
+-
+-The firmware itself originates from https://github.com/SiliconLabs/wfx-firmware
+-
+-The *.pds files come from https://github.com/SiliconLabs/wfx-pds
+-
+-They have been processed with the tool "pds_compress" available on
+-https://github.com/SiliconLabs/wfx-linux-tools
+-
+---------------------------------------------------------------------------
+-
+ Driver: rvu_cptpf - Marvell CPT driver
+ 
+ File: mrvl/cpt01/ae.out
+@@ -5351,31 +3154,3 @@ Version: v1.21
+ Licence: Redistributable. See LICENCE.Marvell for details.
+ 
+ ---------------------------------------------------------------------------
+-
+-Driver: nxp-sr1xx - NXP Ultra Wide Band driver
+-File: nxp/sr150_fw.bin
+-Version: 35.00.03
+-
+-Licence: Redistributable. See LICENSE.nxp for details
+-Originates from https://github.com/NXP/uwb-NXPUWB-FW.git
+---------------------------------------------------------------------------
+-
+-Driver: btnxpuart - NXP BT UART driver
+-
+-File: nxp/uartuart8997_bt_v4.bin
+-File: nxp/uartiw416_bt_v0.bin
+-File: nxp/helper_uart_3000000.bin
+-Version: 16.92.21.p81
+-
+-File: nxp/uartuart8987_bt.bin
+-Version: 16.92.21.p76.5
+-
+-File: nxp/uartuart9098_bt_v1.bin
+-Version: 17.92.1.p136.24
+-
+-File: nxp/uartspi_n61x_v1.bin.se
+-Version: 18.99.1.p154.40
+-
+-Licence: Redistributable. See LICENSE.nxp for details
+-
+---------------------------------------------------------------------------
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0004-linux-firmware-scsi-Remove-firmware-for-SCSI-devices.patch
+++ b/packages/linux-firmware/0004-linux-firmware-scsi-Remove-firmware-for-SCSI-devices.patch
@@ -1,0 +1,191 @@
+From 8d9ded48714bc49d16a2250e1b477244c66d16a9 Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Tue, 25 Jul 2023 12:12:03 +0000
+Subject: [PATCH] linux-firmware: scsi: Remove firmware for SCSI devices
+
+Bottlerocket does not configure drivers for most SCSI devices for any of
+its kernels. Without the driver support, there is no point in providing
+firmware for these devices. The list below maps driver names as
+specified in WHENCE and maps them to kernel config options to enable us
+to easily add firmware when necessitated by driver addition.
+
+* advansys - CONFIG_SCSI_ADVANSYS
+* qla1280 - CONFIG_SCSI_QLOGIC_1280
+* qlogicpti - CONFIG_SCSI_QLOGICPTI
+* isci - CONFIG_SCSI_ISCI
+* BFA/BNA - CONFIG_BNA && CONFIG_SCSI_BFA
+* qla2xxx - CONFIG_TCM_QLA2XXX
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.qla1280 | 23 ------------------
+ LICENCE.qla2xxx | 31 ------------------------
+ WHENCE          | 63 -------------------------------------------------
+ 3 files changed, 117 deletions(-)
+ delete mode 100644 LICENCE.qla1280
+ delete mode 100644 LICENCE.qla2xxx
+
+diff --git a/LICENCE.qla1280 b/LICENCE.qla1280
+deleted file mode 100644
+index 00cd353..0000000
+--- a/LICENCE.qla1280
++++ /dev/null
+@@ -1,23 +0,0 @@
+-Copyright (C) 1995, 1996, 1997, 1998, 1999, 2000 QLogic, Inc.
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms are permitted provided
+-that the following conditions are met:
+-1. Redistribution of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistribution in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-3. The name of the author may not be used to endorse or promote products
+-   derived from this software without specific prior written permission
+-
+-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+-IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.qla2xxx b/LICENCE.qla2xxx
+deleted file mode 100644
+index 6b3d8ff..0000000
+--- a/LICENCE.qla2xxx
++++ /dev/null
+@@ -1,31 +0,0 @@
+-Copyright (c) 2003-2017 QLogic Corporation
+-QLogic Linux Fibre Channel Adapter Firmware
+-
+-Redistribution and use in binary form, without modification, for use in conjunction
+-with QLogic authorized products is permitted provided that the following conditions
+-are met:
+-
+-1. Redistribution in binary form must reproduce the above copyright notice, this
+-   list of conditions and the following disclaimer in the documentation and/or
+-   other materials provided with the distribution.
+-2. The name of QLogic Corporation may not be used to endorse or promote products
+-   derived from this software without specific prior written permission.
+-3. Reverse engineering, decompilation, or disassembly of this firmware is not
+-   permitted.
+-
+-REGARDLESS OF WHAT LICENSING MECHANISM IS USED OR APPLICABLE,THIS PROGRAM IS
+-PROVIDED BY QLOGIC CORPORATION "AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+-GOODS OR SERVICES; LOSS OF USE,DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-LIABILITY,OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-USER ACKNOWLEDGES AND AGREES THAT USE OF THIS PROGRAM WILL NOT CREATE OR GIVE
+-GROUNDS FOR A LICENSE BY IMPLICATION, ESTOPPEL, OR OTHERWISE IN ANY INTELLECTUAL
+-PROPERTY RIGHTS (PATENT, COPYRIGHT, TRADE SECRET, MASK WORK, OR OTHER PROPRIETARY
+-RIGHT) EMBODIED IN ANY OTHER QLOGIC HARDWARE OR SOFTWARE EITHER SOLELY OR IN
+-COMBINATION WITH THIS PROGRAM.
+diff --git a/WHENCE b/WHENCE
+index edf6f75..bf5204f 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -8,29 +8,6 @@ kernel.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: advansys - AdvanSys SCSI
+-
+-File: advansys/mcode.bin
+-File: advansys/3550.bin
+-File: advansys/38C0800.bin
+-File: advansys/38C1600.bin
+-
+-Licence: BSD, no source available.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: qla1280 - Qlogic QLA 1240/1x80/1x160 SCSI support
+-
+-File: qlogic/1040.bin
+-File: qlogic/1280.bin
+-File: qlogic/12160.bin
+-
+-Licence: Redistributable. See LICENCE.qla1280 for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: kaweth -- USB KLSI KL5USB101-based Ethernet device
+ 
+ File: kaweth/new_code.bin
+@@ -265,27 +242,6 @@ http://www.zdomain.com/a56.html
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: qla2xxx - QLogic QLA2XXX Fibre Channel
+-
+-File: ql2100_fw.bin
+-Version: 1.19.38 TP
+-File: ql2200_fw.bin
+-Version: 2.02.08 TP
+-File: ql2300_fw.bin
+-Version: 3.03.28 IPX
+-File: ql2322_fw.bin
+-Version: 3.03.28 IPX
+-File: ql2400_fw.bin
+-Version: 8.07.00 MID
+-File: ql2500_fw.bin
+-Version: 8.07.00 MIDQ
+-
+-Licence: Redistributable. See LICENCE.qla2xxx for details
+-
+-Available from http://ldriver.qlogic.com/firmware/
+-
+---------------------------------------------------------------------------
+-
+ Driver: orinoco - Agere/Prism/Symbol Orinoco support
+ 
+ File: agere_sta_fw.bin
+@@ -631,16 +587,6 @@ Found in hex form in kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: qlogicpti - PTI Qlogic, ISP Driver
+-
+-File: qlogic/isp1000.bin
+-
+-Licence: Unknown
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: myri_sbus - MyriCOM Gigabit Ethernet
+ 
+ File: myricom/lanai.bin
+@@ -1810,15 +1756,6 @@ Licence: Redistributable. See LICENCE.ene_firmware for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: isci -- Intel C600 SAS controller driver
+-
+-File: isci/isci_firmware.bin
+-Source: isci/
+-
+-Licence: GPLv2. See GPL-2 for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: rp2 -- Comtrol RocketPort 2 serial driver
+ 
+ File: rp2.fw
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0005-linux-firmware-usb-remove-firmware-for-USB-Serial-PC.patch
+++ b/packages/linux-firmware/0005-linux-firmware-usb-remove-firmware-for-USB-Serial-PC.patch
@@ -1,0 +1,901 @@
+From abd8555549e48367b9edb9baaa61b40afcfd6231 Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Tue, 25 Jul 2023 14:27:14 +0000
+Subject: [PATCH] linux-firmware: usb: remove firmware for USB/Serial/PCMCIA
+ devices
+
+Bottlerocket does not configure most drivers for USB,PCMCIA, and serial devices
+for any of its kernels. Without those drivers, the firmware for these
+devices is not of use and does not need to be shipped by us.
+
+The following list maps the driver names as specified in WHENCE to
+kernel config options enabling drivers. That way we are able to find the
+firmware for any driver we may be enabling in the future.
+
+* kaweth - CONFIG_USB_KAWETH
+* keyspan - CONFIG_SERIAL_KEYSPAN
+* keyspan_pda - CONFIG_SERIAL_KEYSPAN_PDA
+* emi26 - CONFIG_USB_EMI26
+* emi62 - CONFIG_USB_EMI62
+* ti_usb_3410_5052 - CONFIG_USB_SERIAL_TI
+* whiteheat - CONFIG_USB_SERIAL_WHITEHEAT
+* io_edgeport - CONFIG_USB_SERIAL_EDGEPORT
+* io_ti - CONFIG_USB_SERIAL_EDGEPORT_TI
+* orinoco - CONFIG_ORINOCO_USB
+* usbdux - CONFIG_COMEDI_USBDUX
+* usbduxfast - CONFIG_COMEDI_USBDUXFAST
+* usbduxsigma - CONFIG_COMEDI_USBDUXSIGMA
+* s2255drv - CONFIG_USB_S2255
+* ueagle-atm - CONFIG_USB_EAGLEATM
+* vt6656 - CONFIG_VT6656
+* ene-ub6250 - CONFIG_USB_STORAGE_ENE_UB6250
+* mxu11x0 - CONFIG_USB_SERIAL_MXUPORT11
+* mxuport - CONFIG_USB_SERIAL_MXUPORT
+* xhci-rcar - CONFIG_USB_XHCI_RCAR
+* xhci-tegra - CONFIG_USB_XHCI_TEGRA
+* atusb - CONFIG_IEEE802154_ATUSB
+* pcnet_cs - CONFIG_PCMCIA_PCNET
+* 3c589_cs - CONFIG_PCMCIA_3C589
+* 3c574_cs - CONFIG_PCMCIA_3C574
+* serial_cs - CONFIG_SERIAL_8250_CS
+* smc91c92_cs - CONFIG_PCMCIA_SMC91C92
+* rp2 - CONFIG_SERIAL_RP2
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.agere                |  77 ------
+ LICENCE.ene_firmware         |  14 -
+ LICENCE.kaweth               |  28 --
+ LICENCE.moxa                 |  16 --
+ LICENCE.r8a779x_usb3         |  26 --
+ LICENCE.ueagle-atm4-firmware |  39 ---
+ LICENCE.via_vt6656           |  25 --
+ WHENCE                       | 495 -----------------------------------
+ 8 files changed, 720 deletions(-)
+ delete mode 100644 LICENCE.agere
+ delete mode 100644 LICENCE.ene_firmware
+ delete mode 100644 LICENCE.kaweth
+ delete mode 100644 LICENCE.moxa
+ delete mode 100644 LICENCE.r8a779x_usb3
+ delete mode 100644 LICENCE.ueagle-atm4-firmware
+ delete mode 100644 LICENCE.via_vt6656
+
+diff --git a/LICENCE.agere b/LICENCE.agere
+deleted file mode 100644
+index c11466c..0000000
+--- a/LICENCE.agere
++++ /dev/null
+@@ -1,77 +0,0 @@
+-agere_sta_fw.bin -- 9.48 Hermes I
+-agere_ap_fw.bin  -- 9.48 Hermes I
+-
+-The above firmware images were compiled from the Agere linux driver
+-wl_lkm_718_release.tar.gz, and dumped. The driver is coverred by the
+-following copyright and software license.
+-
+- * SOFTWARE LICENSE
+- *
+- * This software is provided subject to the following terms and conditions,
+- * which you should read carefully before using the software.  Using this
+- * software indicates your acceptance of these terms and conditions.  If you do
+- * not agree with these terms and conditions, do not use the software.
+- *
+- * COPYRIGHT © 1994 - 1995  by AT&T.                All Rights Reserved
+- * COPYRIGHT © 1996 - 2000 by Lucent Technologies.  All Rights Reserved
+- * COPYRIGHT © 2001 - 2004  by Agere Systems Inc.   All Rights Reserved
+- * All rights reserved.
+- *
+- * Redistribution and use in source or binary forms, with or without
+- * modifications, are permitted provided that the following conditions are met:
+- *
+- * . Redistributions of source code must retain the above copyright notice, this
+- *    list of conditions and the following Disclaimer as comments in the code as
+- *    well as in the documentation and/or other materials provided with the
+- *    distribution.
+- *
+- * . Redistributions in binary form must reproduce the above copyright notice,
+- *    this list of conditions and the following Disclaimer in the documentation
+- *    and/or other materials provided with the distribution.
+- *
+- * . Neither the name of Agere Systems Inc. nor the names of the contributors
+- *    may be used to endorse or promote products derived from this software
+- *    without specific prior written permission.
+- *
+- * Disclaimer
+- *
+- * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+- * INCLUDING, BUT NOT LIMITED TO, INFRINGEMENT AND THE IMPLIED WARRANTIES OF
+- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  ANY
+- * USE, MODIFICATION OR DISTRIBUTION OF THIS SOFTWARE IS SOLELY AT THE USERS OWN
+- * RISK. IN NO EVENT SHALL AGERE SYSTEMS INC. OR CONTRIBUTORS BE LIABLE FOR ANY
+- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+- * ON ANY THEORY OF LIABILITY, INCLUDING, BUT NOT LIMITED TO, CONTRACT, STRICT
+- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+- * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+- * DAMAGE.
+-
+-The following statement from Agere clarifies the status of the firmware
+-
+----
+-I would like to confirm that the two drivers; Linux LKM Wireless Driver
+-Source Code, Version 7.18 and Linux LKM Wireless Driver Source Code,
+-Version 7.22 comply with Open Source BSD License. Therefore the source
+-code can be distributed in unmodified or modified form consistent with
+-the terms of the license.
+-
+-The Linux driver architecture was based on two modules, the MSF (Module
+-specific functions) and the HCF (Hardware Control Functions).  Included
+-in the HCF is run-time firmware (binary format) which is downloaded into
+-the RAM of the Hermes 1/2/2.5 WMAC.
+-
+-This hex coded firmware is not based on any open source software and
+-hence it is not subject to any Open Source License.  The firmware was
+-developed by Agere and runs on the DISC processor embedded within the
+-Hermes 1/2/2.5 Wireless MAC devices. 
+-
+-Hope this helps.
+-
+-Sincerely,
+-
+-Viren Pathare
+-Intellectual Property Licensing Manager
+-Agere
+----
+diff --git a/LICENCE.ene_firmware b/LICENCE.ene_firmware
+deleted file mode 100644
+index 08f2b01..0000000
+--- a/LICENCE.ene_firmware
++++ /dev/null
+@@ -1,14 +0,0 @@
+-copyright (c) 2011, ENE TECHNOLOGY INC.
+-
+-Permission to use, copy, modify, and/or distribute this software for any purpose
+-with or without fee is hereby granted, provided that the above copyright notice
+-and this permission notice appear in all copies.
+-
+-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT
+-SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+-CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+-NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+-WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+diff --git a/LICENCE.kaweth b/LICENCE.kaweth
+deleted file mode 100644
+index 75a59c0..0000000
+--- a/LICENCE.kaweth
++++ /dev/null
+@@ -1,28 +0,0 @@
+-Copyright 1999 Kawasaki LSI.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+-1. Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+-2. Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in the
+-   documentation and/or other materials provided with the distribution.
+-3. All advertising materials mentioning features or use of this software
+-   must display the following acknowledgement:
+-       This product includes software developed by Kawasaki LSI.
+-4. Neither the name of the company nor the names of its contributors
+-   may be used to endorse or promote products derived from this software
+-   without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY KAWASAKI LSI ``AS IS'' AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED.  IN NO EVENT SHALL KAWASAKI LSI BE LIABLE FOR ANY DIRECT,
+-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.moxa b/LICENCE.moxa
+deleted file mode 100644
+index 120017b..0000000
+--- a/LICENCE.moxa
++++ /dev/null
+@@ -1,16 +0,0 @@
+-The software accompanying this license statement (the “Software”)
+-is the property of Moxa Inc. (the “Moxa”), and is protected by
+-United States and International Copyright Laws and International
+-treaty provisions. No ownership rights are granted by this
+-Agreement or possession of the Software. Therefore, you must treat
+-the Licensed Software like any other copyrighted material. Your
+-rights and obligations in its use are described as follows:
+-
+-1. You may freely redistribute this software under this license.
+-2. You may freely download and use this software on Moxa's device.
+-3. You may not modify or attempt to reverse engineer the software, or
+-   make any attempt to change or even examine the source code of the
+-   software.
+-4. You may not re-license or sub-license the software to any person or
+-   business, using any other license.
+-5. Moxa(r) is worldwide registered trademark.
+diff --git a/LICENCE.r8a779x_usb3 b/LICENCE.r8a779x_usb3
+deleted file mode 100644
+index e2afcc9..0000000
+--- a/LICENCE.r8a779x_usb3
++++ /dev/null
+@@ -1,26 +0,0 @@
+-Copyright (c) 2014, Renesas Electronics Corporation
+-All rights reserved.
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met:
+-
+-1. Redistribution in binary form must reproduce the above copyright notice,
+-   this list of conditions and the following disclaimer in the documentation
+-   and/or other materials provided with the distribution.
+-2. The name of Renesas Electronics Corporation may not be used to endorse or
+-   promote products derived from this software without specific prior written
+-   permission.
+-3. Reverse engineering, decompilation, or disassembly of this software is
+-   not permitted.
+-
+-THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS ELECTRONICS CORPORATION DISCLAIMS
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, AND
+-NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL RENESAS ELECTRONICS
+-CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+-OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.ueagle-atm4-firmware b/LICENCE.ueagle-atm4-firmware
+deleted file mode 100644
+index 333675d..0000000
+--- a/LICENCE.ueagle-atm4-firmware
++++ /dev/null
+@@ -1,39 +0,0 @@
+-This license applies to eagle4 firmware & DSPcode
+-namely, the files eagleIV.fw  DSP4p.bin*
+-
+-| Copyright (2006) Ikanos Communications, Inc. 
+-| 
+-| Redistribution and use in source and binary forms, with or without 
+-| modification, are permitted provided that the following 
+-| conditions are met: 
+-| 
+-| * Redistribution of source code must retain the above copyright 
+-| notice, this list of conditions and the following disclaimer. 
+-| 
+-| * Redistribution in binary form must reproduce the above 
+-| copyright notice, this list of conditions and the following 
+-| disclaimer in the documentation and/or other materials provided 
+-| with the distribution. 
+-| 
+-| * The name of Ikanos Corporation may not be used to endorse         
+-|   or promote products derived from this source code without specific     
+-|   prior written consent of Ikanos Corporation. 
+-| 
+-| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+-| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+-| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+-| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+-| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+-| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+-| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+-| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+-| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+-| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+-| USER ACKNOWLEDGES AND AGREES THAT THE PURCHASE OR USE OF THIS SOFTWARE WILL 
+-| NOT CREATE OR GIVE GROUNDS FOR A     
+-|  LICENSE BY IMPLICATION, ESTOPPEL, OR OTHERWISE IN ANY INTELLECTUAL         
+-|  PROPERTY RIGHTS (PATENT, COPYRIGHT, TRADE SECRET, MASK WORK, OR OTHER   
+-|  PROPRIETARY RIGHT) EMBODIED IN ANY OTHER IKANOS HARDWARE OR SOFTWARE         
+-|  EITHER SOLELY OR IN COMBINATION WITH THIS SOFTWARE. 
+-
+diff --git a/LICENCE.via_vt6656 b/LICENCE.via_vt6656
+deleted file mode 100644
+index f231f98..0000000
+--- a/LICENCE.via_vt6656
++++ /dev/null
+@@ -1,25 +0,0 @@
+-The following license applies to the binary-only VT6656 firmware
+-as contained in the file "vntwusb.fw"
+-================================================================
+-Copyright 1998-2010 VIA Technologies, Inc. All Rights Reserved.
+-
+-Permission is hereby granted, free of charge, to any person
+-obtaining a copy of this software and associated documentation
+-files (the "Software"), to deal in the Software without
+-restriction, including without limitation the rights to use,
+-copy, modify, merge, publish, distribute, sublicense, and/or sell
+-copies of the Software, and to permit persons to whom the
+-Software is furnished to do so, subject to the following
+-conditions:
+-
+-The above copyright notice and this permission notice shall be
+-included in all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+-OTHER DEALINGS IN THE SOFTWARE.
+diff --git a/WHENCE b/WHENCE
+index bf5204f..2ed9e9a 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -8,226 +8,6 @@ kernel.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: kaweth -- USB KLSI KL5USB101-based Ethernet device
+-
+-File: kaweth/new_code.bin
+-File: kaweth/new_code_fix.bin
+-File: kaweth/trigger_code.bin
+-File: kaweth/trigger_code_fix.bin
+-
+-Licence: Redistributable. See LICENCE.kaweth for details
+-
+-Found in hex form in the kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: keyspan -- USB Keyspan USA-xxx serial device
+-
+-File: keyspan/mpr.fw
+-File: keyspan/usa18x.fw
+-File: keyspan/usa19.fw
+-File: keyspan/usa19qi.fw
+-File: keyspan/usa19qw.fw
+-File: keyspan/usa19w.fw
+-File: keyspan/usa28.fw
+-File: keyspan/usa28xa.fw
+-File: keyspan/usa28xb.fw
+-File: keyspan/usa28x.fw
+-File: keyspan/usa49w.fw
+-File: keyspan/usa49wlc.fw
+-
+-Converted from Intel HEX files, used in our binary representation of ihex.
+-
+-Original licence information:
+-
+-		Copyright (C) 1999-2001
+-		Keyspan, A division of InnoSys Incorporated ("Keyspan")
+-
+-	as an unpublished work. This notice does not imply unrestricted or
+-	public access to the source code from which this firmware image is
+-	derived.  Except as noted below this firmware image may not be
+-	reproduced, used, sold or transferred to any third party without
+-	Keyspan's prior written consent.  All Rights Reserved.
+-
+-	Permission is hereby granted for the distribution of this firmware
+-	image as part of a Linux or other Open Source operating system kernel
+-	in text or binary form as required.
+-
+-	This firmware may not be modified and may only be used with
+-	Keyspan hardware.  Distribution and/or Modification of the
+-	keyspan.c driver which includes this firmware, in whole or in
+-	part, requires the inclusion of this statement."
+-
+---------------------------------------------------------------------------
+-
+-Driver: keyspan_pda -- USB Keyspan PDA single-port serial device
+-
+-File: keyspan_pda/keyspan_pda.fw
+-Source: keyspan_pda/keyspan_pda.S
+-
+-File: keyspan_pda/xircom_pgs.fw
+-Source: keyspan_pda/xircom_pgs.S
+-
+-Source: keyspan_pda/Makefile
+-
+-Licence: GPLv2 or later. See GPL-2 and GPL-3 for details.
+-
+-Compiled from original 8051 source into Intel HEX, used in our binary ihex form.
+-
+---------------------------------------------------------------------------
+-
+-Driver: emi26 -- EMI 2|6 USB Audio interface
+-
+-File: emi26/bitstream.fw
+-Version: 1.1.1.131
+-Info: DATE=2001dec06
+-
+-File: emi26/firmware.fw
+-Version: 1.0.2.916
+-Info: DATE=12.02.2002
+-
+-File: emi26/loader.fw
+-
+-Converted from Intel HEX files, used in our binary representation of ihex.
+-
+-Original licence information:
+-/*
+- * This firmware is for the Emagic EMI 2|6 Audio Interface
+- *
+- * The firmware contained herein is Copyright (c) 1999-2002 Emagic
+- * as an unpublished work. This notice does not imply unrestricted
+- * or public access to this firmware which is a trade secret of Emagic,
+- * and which may not be reproduced, used, sold or transferred to
+- * any third party without Emagic's written consent. All Rights Reserved.
+- *
+- * Permission is hereby granted for the distribution of this firmware
+- * image as part of a Linux or other Open Source operating system kernel
+- * in text or binary form as required.
+- *
+- * This firmware may not be modified and may only be used with the
+- * Emagic EMI 2|6 Audio Interface. Distribution and/or Modification of
+- * any driver which includes this firmware, in whole or in part,
+- * requires the inclusion of this statement.
+- */
+-
+---------------------------------------------------------------------------
+-
+-Driver: emi62 -- EMI 6|2m USB Audio interface
+-
+-File: emi62/bitstream.fw
+-Version: 1.0.0.191
+-Info: DATE= 2002oct28
+-
+-File: emi62/loader.fw
+-Version: 1.0.2.002
+-Info: DATE=10.01.2002
+-
+-File: emi62/midi.fw
+-Version: 1.04.062
+-Info: DATE=16.10.2002
+-
+-File: emi62/spdif.fw
+-Version: 1.04.062
+-Info: DATE=16.10.2002
+-
+-Converted from Intel HEX files, used in our binary representation of ihex.
+-
+-Original licence information: None
+-
+---------------------------------------------------------------------------
+-
+-Driver: ti_usb_3410_5052 -- USB TI 3410/5052 serial device
+-
+-File: ti_3410.fw
+-Info: firmware 9/10/04 FW3410_Special_StartWdogOnStartPort
+-
+-File: ti_5052.fw
+-Info: firmware 9/18/04
+-
+-Licence: Allegedly GPLv2+, but no source visible. Marked:
+-	 Copyright (C) 2004 Texas Instruments
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: ti_usb_3410_5052 -- Multi-Tech USB cell modems
+-
+-File: mts_cdma.fw
+-File: mts_gsm.fw
+-File: mts_edge.fw
+-
+-Licence: "all firmware components are redistributable in binary form"
+-         per support@multitech.com
+-	 Copyright (C) 2005 Multi-Tech Systems, Inc.
+-
+-Found in hex form in ftp://ftp.multitech.com/wireless/wireless_linux.zip
+-
+---------------------------------------------------------------------------
+-
+-Driver: ti_usb_3410_5052 -- Multi-Tech USB fax modems
+-
+-File: mts_mt9234mu.fw
+-File: mts_mt9234zba.fw
+-
+-Licence: Unknown
+-
+---------------------------------------------------------------------------
+-
+-Driver: whiteheat -- USB ConnectTech WhiteHEAT serial device
+-
+-File: whiteheat.fw
+-Version: 4.06
+-
+-File: whiteheat_loader.fw
+-
+-Licence: Allegedly GPLv2, but no source visible. Marked:
+-	 Copyright (C) 2000-2002  ConnectTech Inc
+-
+-Debug loader claims the following behaviour:
+-	Port 1 LED flashes when the vend_ax program is running
+-	Port 2 LED flashes when any SETUP command arrives
+-	Port 3 LED flashes when any valid VENDOR request occurs
+-	Port 4 LED flashes when the EXTERNAL RAM DOWNLOAD request occurs
+-
+-Converted from Intel HEX files, used in our binary representation of ihex.
+-
+---------------------------------------------------------------------------
+-
+-Driver: io_edgeport - USB Inside Out Edgeport Serial Driver
+-
+-File: edgeport/boot.fw
+-File: edgeport/boot2.fw
+-File: edgeport/down.fw
+-File: edgeport/down2.fw
+-
+-Licence: Allegedly GPLv2+, but no source visible. Marked:
+-//**************************************************************
+-//* Edgeport/4 Binary Image
+-//* Generated by HEX2C v1.06
+-//* Copyright (C) 1998 Inside Out Networks, All rights reserved.
+-//**************************************************************
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: io_ti - USB Inside Out Edgeport Serial Driver
+-(TI Devices)
+-
+-File: edgeport/down3.bin
+-
+-Licence:
+-//**************************************************************
+-//* Edgeport Binary Image (for TI based products)
+-//* Generated by TIBin2C v2.00 (watchport)
+-//* Copyright (C) 2001 Inside Out Networks, All rights reserved.
+-//**************************************************************
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: dsp56k - Atari DSP56k support
+ 
+ File: dsp56k/bootstrap.bin
+@@ -242,17 +22,6 @@ http://www.zdomain.com/a56.html
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: orinoco - Agere/Prism/Symbol Orinoco support
+-
+-File: agere_sta_fw.bin
+-Version: 9.48 Hermes I
+-File: agere_ap_fw.bin
+-Version: 9.48 Hermes I
+-
+-Licence: Redistributable. See LICENCE.agere for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: cassini - Sun Cassini
+ 
+ File: sun/cassini.bin
+@@ -503,90 +272,6 @@ Found in hex form in kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: pcnet_cs - NE2000 compatible PCMCIA adapter
+-
+-File: cis/LA-PCM.cis
+-File: cis/PCMLM28.cis
+-File: cis/DP83903.cis
+-File: cis/NE2K.cis
+-File: cis/tamarack.cis
+-File: cis/PE-200.cis
+-File: cis/PE520.cis
+-Source: cis/
+-
+-Licence: Dual GPLv2/MPL
+-
+-Originally developed by the pcmcia-cs project
+-Copyright (C) 1998, 1999, 2000 David A. Hinds
+-
+---------------------------------------------------------------------------
+-
+-Driver: 3c589_cs - 3Com PCMCIA adapter
+-
+-File: cis/3CXEM556.cis
+-Source: cis/src/3CXEM556.cis
+-
+-Licence: Dual GPLv2/MPL
+-
+-Originally developed by the pcmcia-cs project
+-Copyright (C) 1998, 1999, 2000 David A. Hinds
+-
+---------------------------------------------------------------------------
+-
+-Driver: 3c574_cs - 3Com PCMCIA adapter
+-
+-File: cis/3CCFEM556.cis
+-Source: cis/src/3CCFEM556.cis
+-
+-Licence: Dual GPLv2/MPL
+-
+-Originally developed by the pcmcia-cs project
+-Copyright (C) 1998, 1999, 2000 David A. Hinds
+-
+---------------------------------------------------------------------------
+-
+-Driver: serial_cs - Serial PCMCIA adapter
+-
+-File: cis/MT5634ZLX.cis
+-File: cis/RS-COM-2P.cis
+-File: cis/COMpad2.cis
+-File: cis/COMpad4.cis
+-Source: cis/src/MT5634ZLX.cis
+-Source: cis/src/RS-COM-2P.cis
+-Source: cis/src/COMpad2.cis
+-Source: cis/src/COMpad4.cis
+-
+-Licence: Dual GPLv2/MPL
+-
+-Originally developed by the pcmcia-cs project
+-Copyright (C) 1998, 1999, 2000 David A. Hinds
+-
+---------------------------------------------------------------------------
+-
+-Driver: serial_cs - Serial PCMCIA adapter
+-
+-File: cis/SW_555_SER.cis
+-File: cis/SW_7xx_SER.cis
+-File: cis/SW_8xx_SER.cis
+-
+-Licence: GPLv3. See GPL-3 for details.
+-
+-Copyright Sierra Wireless
+-
+---------------------------------------------------------------------------
+-
+-Driver: smc91c92_cs - SMC 91Cxx PCMCIA
+-
+-File: ositech/Xilinx7OD.bin
+-
+-Licence: Allegedly GPL, but no source visible. Marked:
+-    This file contains the firmware of Seven of Diamonds from OSITECH.
+-    (Special thanks to Kevin MacPherson of OSITECH)
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: myri_sbus - MyriCOM Gigabit Ethernet
+ 
+ File: myricom/lanai.bin
+@@ -660,19 +345,6 @@ Available from http://ldriver.qlogic.com/firmware/netxen_nic/new/
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: usbdux/usbduxfast/usbduxsigma - usbdux data acquisition cards
+-
+-File: usbdux_firmware.bin
+-File: usbduxfast_firmware.bin
+-File: usbduxsigma_firmware.bin
+-Source: usbdux/
+-
+-Licence: GPLv2. See GPL-2 for details.
+-
+-Provided from the author, Bernd Porr <BerndPorr@f2s.com>
+-
+---------------------------------------------------------------------------
+-
+ Driver: mga - Matrox G200/G400/G550
+ 
+ File: matrox/g200_warp.fw
+@@ -1571,23 +1243,6 @@ Licence: Redistributable. See LICENSE.amdgpu for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: s2255drv
+-
+-File: f2255usb.bin
+-Version: 1.2.8
+-
+-Licence: Redistributable.
+-
+-  Sensoray grants permission to use and redistribute these firmware
+-  files for use with Sensoray devices, but not as a part of the Linux
+-  kernel or in any other form which would require these files themselves
+-  to be covered by the terms of the GNU General Public License.
+-  These firmware files are distributed in the hope that they will be
+-  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+-  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+---------------------------------------------------------------------------
+-
+ Driver: ib_qib - QLogic Infiniband
+ 
+ File: qlogic/sd7220.fw
+@@ -1662,47 +1317,6 @@ Licence:
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ueagle-atm - Driver for USB ADSL Modems based on Eagle IV Chipset
+-
+-File: ueagle-atm/CMV4p.bin.v2
+-File: ueagle-atm/DSP4p.bin
+-File: ueagle-atm/eagleIV.fw
+-Version: 1.0
+-
+-Licence: Redistributable. See LICENCE.ueagle-atm4-firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: ueagle-atm - Driver for USB ADSL Modems based on Eagle I,II,III
+-
+-File: ueagle-atm/930-fpga.bin
+-File: ueagle-atm/CMVeiWO.bin
+-File: ueagle-atm/CMVepFR10.bin
+-File: ueagle-atm/DSP9p.bin
+-File: ueagle-atm/eagleIII.fw
+-File: ueagle-atm/adi930.fw
+-File: ueagle-atm/CMVep.bin
+-File: ueagle-atm/CMVepFR.bin
+-File: ueagle-atm/DSPei.bin
+-File: ueagle-atm/CMV9i.bin
+-File: ueagle-atm/CMVepES03.bin
+-File: ueagle-atm/CMVepIT.bin
+-File: ueagle-atm/DSPep.bin
+-File: ueagle-atm/CMV9p.bin
+-File: ueagle-atm/CMVepES.bin
+-File: ueagle-atm/CMVepWO.bin
+-File: ueagle-atm/eagleI.fw
+-File: ueagle-atm/CMVei.bin
+-File: ueagle-atm/CMVepFR04.bin
+-File: ueagle-atm/DSP9i.bin
+-File: ueagle-atm/eagleII.fw
+-Version: 1.1
+-
+-Licence: Redistributable. Based on
+-         https://mail.gna.org/public/eagleusb-dev/2004-11/msg00172.html
+-
+---------------------------------------------------------------------------
+-
+ Driver: vxge - Exar X3100 Series 10GbE PCIe I/O Virtualized Server Adapter
+ 
+ File: vxge/X3fw.ncf
+@@ -1720,14 +1334,6 @@ Licence:
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: vt6656 - VIA VT6656 USB wireless driver
+-
+-File: vntwusb.fw
+-
+-Licence: Redistributable. See LICENCE.via_vt6656 for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: myri10ge - Myri10GE 10GbE NIC driver
+ 
+ File: myri10ge_eth_z8e.dat
+@@ -1742,37 +1348,6 @@ Version: 1.4.57
+ 
+ License: Redistributable.  See LICENCE.myri10ge_firmware for details.
+ 
+---------------------------------------------------------------------------
+-Driver: ene-ub6250 -- ENE UB6250 SD card reader driver
+-
+-File: ene-ub6250/sd_init1.bin
+-File: ene-ub6250/sd_init2.bin
+-File: ene-ub6250/sd_rdwr.bin
+-File: ene-ub6250/ms_init.bin
+-File: ene-ub6250/msp_rdwr.bin
+-File: ene-ub6250/ms_rdwr.bin
+-
+-Licence: Redistributable. See LICENCE.ene_firmware for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: rp2 -- Comtrol RocketPort 2 serial driver
+-
+-File: rp2.fw
+-
+-Licence: Redistributable.
+-
+-Copyright (C) 2013 Comtrol Corporation
+-
+-Comtrol grants permission to use and redistribute these firmware
+-files for use with Comtrol devices, but not as part of the Linux
+-kernel or in any other form which would require these files themselves
+-to be covered by the terms of the GNU General Public License.
+-
+-These firmware files are distributed in the hope that they will be
+-useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+-of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-
+ --------------------------------------------------------------------------
+ 
+ Driver: ccp - Platform Security Processor (PSP) device
+@@ -1811,34 +1386,6 @@ License: Redistributable. See LICENSE.amd-ucode for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: mxu11x0 - MOXA UPort 11x0 USB Serial hub driver
+-
+-File: moxa/moxa-1110.fw
+-File: moxa/moxa-1130.fw
+-File: moxa/moxa-1131.fw
+-File: moxa/moxa-1150.fw
+-File: moxa/moxa-1151.fw
+-
+-License: Redistributable. See LICENCE.moxa for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: mxuport - MOXA UPort USB Serial hub driver
+-
+-File: moxa/moxa-1250.fw
+-File: moxa/moxa-1251.fw
+-File: moxa/moxa-1410.fw
+-File: moxa/moxa-1450.fw
+-File: moxa/moxa-1451.fw
+-File: moxa/moxa-1613.fw
+-File: moxa/moxa-1618.fw
+-File: moxa/moxa-1653.fw
+-File: moxa/moxa-1658.fw
+-
+-License: Redistributable. See LICENCE.moxa for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: qat - Intel(R) QAT crypto accelerator
+ 
+ File: qat_895xcc.bin
+@@ -1855,48 +1402,6 @@ Licence: Redistributable. See LICENCE.qat_firmware for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: xhci-rcar -- Renesas R-Car Gen2/3 USB 3.0 host controller driver
+-
+-File: r8a779x_usb3_v1.dlmem
+-File: r8a779x_usb3_v2.dlmem
+-File: r8a779x_usb3_v3.dlmem
+-
+-Licence: Redistributable. See LICENCE.r8a779x_usb3 for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: xhci-tegra -- NVIDIA Tegra XHCI driver
+-
+-File: nvidia/tegra124/xusb.bin
+-Version: v45.46
+-
+-File: nvidia/tegra210/xusb.bin
+-Version: v50.24
+-
+-File: nvidia/tegra186/xusb.bin
+-Version: v55.15
+-
+-File: nvidia/tegra194/xusb.bin
+-Version: v60.06
+-
+-Licence: Redistributable. See LICENCE.nvidia for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: atusb - ATUSB IEEE 802.15.4 transceiver driver
+-
+-File: atusb/atusb-0.2.dfu
+-Version: 0.2
+-File: atusb/atusb-0.3.dfu
+-Version: 0.3
+-File: atusb/rzusb-0.3.bin
+-Version: 0.3
+-Info: atusb/ChangeLog
+-
+-Licence: GPLv2 or later. See GPL-2 and GPL-3 for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: liquidio -- Cavium LiquidIO driver
+ 
+ File: liquidio/lio_23xx_nic.bin
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0006-linux-firmware-ethernet-Remove-firmware-for-ethernet.patch
+++ b/packages/linux-firmware/0006-linux-firmware-ethernet-Remove-firmware-for-ethernet.patch
@@ -1,0 +1,539 @@
+From 138cb336108faab12961813bdf7ccc1ae4e1822b Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Wed, 26 Jul 2023 08:40:14 +0000
+Subject: [PATCH] linux-firmware: ethernet: Remove firmware for ethernet/IB
+ devices
+
+Bottlerocket does not ship drivers for older network equipment. Without
+the drivers shipping the firmware for thesde devices does not make
+sense. Drop the firmware to reduce image size.
+
+The following list maps driver names as specified in WHENCE to kernel
+config options enabling the driver. This way we can easily decide if we
+need to add firmware back into the package when we enable new drivers.
+
+* cassini - CONFIG_CASSINI
+* slicoss - CONFIG_SLICOSS
+* sxg - CONFIG_SXG
+* cxgb3 - CONFIG_CHELSIO_T3
+* e100 - CONFIG_E100
+* acenic - CONFIG_ACENIC
+* tehuti - CONFIG_TEHUTI
+* bnx2 - CONFIG_BNX2
+* ib_qib - CONFIG_INFINIBAND_QIB
+* myri_sbus - CONFIG_MYRI_SBUS (dropped upstream after 3.0)
+* hfi1 - CONFIG_INFINIBAND_HFI1
+* starfire - CONFIG_ADAPTEC_STARFIRE
+* typhoon - CONFIG_TYPHOON
+* vxge - CONFIG_VXGE
+* mscc-phy - CONFIG_MICROSEMI_PHY
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.e100          |  28 ----
+ LICENCE.microchip     |  40 ------
+ LICENSE.hfi1_firmware |  39 ------
+ WHENCE                | 303 ------------------------------------------
+ 4 files changed, 410 deletions(-)
+ delete mode 100644 LICENCE.e100
+ delete mode 100644 LICENCE.microchip
+ delete mode 100644 LICENSE.hfi1_firmware
+
+diff --git a/LICENCE.e100 b/LICENCE.e100
+deleted file mode 100644
+index 0553817..0000000
+--- a/LICENCE.e100
++++ /dev/null
+@@ -1,28 +0,0 @@
+-Copyright (c) 1999-2001, Intel Corporation
+-
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+- 1. Redistributions of source code must retain the above copyright notice,
+-    this list of conditions and the following disclaimer.
+-
+- 2. Redistributions in binary form must reproduce the above copyright notice,
+-    this list of conditions and the following disclaimer in the documentation
+-    and/or other materials provided with the distribution.
+-
+- 3. Neither the name of Intel Corporation nor the names of its contributors
+-    may be used to endorse or promote products derived from this software
+-    without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+-EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENCE.microchip b/LICENCE.microchip
+deleted file mode 100644
+index f270c99..0000000
+--- a/LICENCE.microchip
++++ /dev/null
+@@ -1,40 +0,0 @@
+-Copyright (C) 2018 Microchip Technology Incorporated and its subsidiaries.
+-All rights reserved.
+-
+-REDISTRIBUTION: Permission is hereby granted by Microchip Technology
+-Incorporated (Microchip), free of any license fees, to any person obtaining a
+-copy of this firmware (the "Software"), to install, reproduce, copy and
+-distribute copies, in binary form, hexadecimal or equivalent formats only, the
+-Software and to permit persons to whom the Software is provided to do the same,
+-subject to the following conditions:
+-
+-* Any redistribution of the Software must reproduce the above copyright notice,
+-  this license notice, and the following disclaimers and notices in the
+-  documentation and/or other materials provided with the Software.
+-
+-* Neither the name of Microchip, its products nor the names of its suppliers
+-  may be used to endorse or promote products derived from this Software without
+-  specific prior written permission.
+-
+-* No reverse engineering, decompilation, or disassembly of this Software is
+-  permitted.
+-
+-Limited patent license.  Microchip grants a world-wide, royalty-free,
+-non-exclusive, revocable license under any patents that it now has or hereafter
+-may have, own or control related to the Software to make, have made, use,
+-import, offer to sell and sell ("Utilize") this Software, but solely to the
+-extent that any such patent is necessary to Utilize the Software in conjunction
+-with Microchip processors. The patent license shall not apply to any other
+-combinations which include this Software nor to any other Microchip patents or
+-patent rights. No hardware per se is licensed hereunder.
+-
+-DISCLAIMER: THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+-DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.hfi1_firmware b/LICENSE.hfi1_firmware
+deleted file mode 100644
+index 01f0932..0000000
+--- a/LICENSE.hfi1_firmware
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Copyright (c) 2015, Intel Corporation. 
+-All rights reserved. 
+-
+-Redistribution.
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met: 
+-*    Redistributions must reproduce the above copyright notice and the
+-     following disclaimer in the documentation and/or other materials provided
+-     with the distribution. 
+-*    Neither the name of Intel Corporation nor the names of its suppliers may
+-     be used to endorse or promote products derived from this software without
+-     specific prior written permission. 
+-*    No reverse engineering, decompilation, or disassembly of this software is
+-     permitted. 
+-
+-Limited patent license.
+-
+-Intel Corporation grants a world-wide, royalty-free, non-exclusive license
+-under patents it now or hereafter owns or controls to make, have made, use,
+-import, offer to sell and sell (“Utilize”) this software, but solely to the
+-extent that any such patent is necessary to Utilize the software alone. The
+-patent license shall not apply to any combinations which include this software.
+-No hardware per se is licensed hereunder. 
+-
+-
+-DISCLAIMER.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+-
+diff --git a/WHENCE b/WHENCE
+index 2ed9e9a..f6b0299 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -22,98 +22,6 @@ http://www.zdomain.com/a56.html
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: cassini - Sun Cassini
+-
+-File: sun/cassini.bin
+-
+-Licence: Unknown
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: slicoss - Alacritech IS-NIC products
+-
+-File: slicoss/gbdownload.sys
+-File: slicoss/gbrcvucode.sys
+-File: slicoss/oasisdbgdownload.sys
+-File: slicoss/oasisdownload.sys
+-File: slicoss/oasisrcvucode.sys
+-
+-Licence:
+-		Copyright (C) 1999-2009 Alacritech, Inc.
+-
+-	as an unpublished work. This notice does not imply unrestricted or
+-	public access to the source code from which this firmware image is
+-	derived.  Except as noted below this firmware image may not be
+-	reproduced, used, sold or transferred to any third party without
+-	Alacritech's prior written consent.  All Rights Reserved.
+-
+-	Permission is hereby granted for the distribution of this firmware
+-	image as part of a Linux or other Open Source operating system kernel
+-	in text or binary form as required.
+-
+-	This firmware may not be modified.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: sxg - Alacritech IS-NIC products
+-
+-File: sxg/saharadownloadB.sys
+-File: sxg/saharadbgdownloadB.sys
+-
+-Licence:
+-		Copyright (C) 1999-2009 Alacritech, Inc.
+-
+-	as an unpublished work. This notice does not imply unrestricted or
+-	public access to the source code from which this firmware image is
+-	derived.  Except as noted below this firmware image may not be
+-	reproduced, used, sold or transferred to any third party without
+-	Alacritech's prior written consent.  All Rights Reserved.
+-
+-	Permission is hereby granted for the distribution of this firmware
+-	image as part of a Linux or other Open Source operating system kernel
+-	in text or binary form as required.
+-
+-	This firmware may not be modified.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: cxgb3 - Chelsio Terminator 3 1G/10G Ethernet adapter
+-
+-File: cxgb3/t3b_psram-1.1.0.bin
+-File: cxgb3/t3c_psram-1.1.0.bin
+-File: cxgb3/t3fw-7.0.0.bin
+-File: cxgb3/t3fw-7.1.0.bin
+-File: cxgb3/t3fw-7.4.0.bin
+-File: cxgb3/t3fw-7.10.0.bin
+-File: cxgb3/t3fw-7.12.0.bin
+-
+-Licence: GPLv2 or OpenIB.org BSD license, no source visible
+-
+---------------------------------------------------------------------------
+-
+-Driver: cxgb3 - Chelsio Terminator 3 1G/10G Ethernet adapter
+-
+-File: cxgb3/ael2005_opt_edc.bin
+-File: cxgb3/ael2005_twx_edc.bin
+-File: cxgb3/ael2020_twx_edc.bin
+-
+-Licence:
+- *	Copyright (c) 2007-2009 NetLogic Microsystems, Inc.
+- *
+- *	Permission is hereby granted for the distribution of this firmware
+- *	data in hexadecimal or equivalent format, provided this copyright
+- *	notice is accompanying it.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: cxgb4 - Chelsio Terminator 4/5/6 1/10/25/40/100G Ethernet adapter
+ 
+ File: cxgb4/t4fw-1.14.4.0.bin
+@@ -141,28 +49,6 @@ Licence: Redistributable. See LICENCE.chelsio_firmware for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: e100 -- Intel PRO/100 Ethernet NIC
+-
+-File: e100/d101m_ucode.bin
+-File: e100/d101s_ucode.bin
+-File: e100/d102e_ucode.bin
+-
+-Licence: Redistributable. See LICENCE.e100 for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: acenic -- Alteon AceNIC Gigabit Ethernet card
+-
+-File: acenic/tg1.bin
+-File: acenic/tg2.bin
+-
+-Licence: Unknown
+-
+-Found in hex form in kernel source, but source allegedly available at
+-http://alteon.shareable.org/
+-
+---------------------------------------------------------------------------
+-
+ Driver: tg3 -- Broadcom Tigon3 based gigabit Ethernet cards
+ 
+ File: tigon/tg3.bin
+@@ -183,83 +69,6 @@ Found in hex form in kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: starfire - Adaptec Starfire/DuraLAN support
+-
+-File: adaptec/starfire_rx.bin
+-File: adaptec/starfire_tx.bin
+-
+-Licence: Allegedly GPLv2, but no source visible.
+-
+-Found in hex form in kernel source, with the following notice:
+-
+- BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE IT IS LICENSED "AS IS" AND
+- THERE IS NO WARRANTY FOR THE PROGRAM, INCLUDING BUT NOT LIMITED TO THE
+- IMPLIED WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR A PARTICULAR PURPOSE
+- (TO THE EXTENT PERMITTED BY APPLICABLE LAW). USE OF THE PROGRAM IS AT YOUR
+- OWN RISK. IN NO EVENT WILL ADAPTEC OR ITS LICENSORS BE LIABLE TO YOU FOR
+- DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+- ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM.
+-
+---------------------------------------------------------------------------
+-
+-Driver: tehuti - Tehuti Networks 10G Ethernet
+-
+-File: tehuti/bdx.bin
+-
+-Licence:
+-
+- Copyright (C) 2007 Tehuti Networks Ltd.
+-
+- Permission is hereby granted for the distribution of this firmware data
+- in hexadecimal or equivalent format, provided this copyright notice is
+- accompanying it.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: typhoon - 3cr990 series Typhoon
+-
+-File: 3com/typhoon.bin
+-
+-Licence:
+-/*
+- * Copyright 1999-2004 3Com Corporation.  All Rights Reserved.
+- *
+- * Redistribution and use in source and binary forms of the 3c990img.h
+- * microcode software are permitted provided that the following conditions
+- * are met:
+- * 1. Redistribution of source code must retain the above copyright
+- *    notice, this list of conditions and the following disclaimer.
+- * 2. Redistribution in binary form must reproduce the above copyright
+- *    notice, this list of conditions and the following disclaimer in the
+- *    documentation and/or other materials provided with the distribution.
+- * 3. The name of 3Com may not be used to endorse or promote products
+- *    derived from this software without specific prior written permission
+- *
+- * THIS SOFTWARE IS PROVIDED BY 3COM ``AS IS'' AND ANY EXPRESS OR
+- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+- * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- *
+- * USER ACKNOWLEDGES AND AGREES THAT PURCHASE OR USE OF THE 3c990img.h
+- * MICROCODE SOFTWARE WILL NOT CREATE OR GIVE GROUNDS FOR A LICENSE BY
+- * IMPLICATION, ESTOPPEL, OR OTHERWISE IN ANY INTELLECTUAL PROPERTY RIGHTS
+- * (PATENT, COPYRIGHT, TRADE SECRET, MASK WORK, OR OTHER PROPRIETARY RIGHT)
+- * EMBODIED IN ANY OTHER 3COM HARDWARE OR SOFTWARE EITHER SOLELY OR IN
+- * COMBINATION WITH THE 3c990img.h MICROCODE SOFTWARE
+- */
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: yam - YAM driver for AX.25
+ 
+ File: yam/1200.bin
+@@ -272,16 +81,6 @@ Found in hex form in kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: myri_sbus - MyriCOM Gigabit Ethernet
+-
+-File: myricom/lanai.bin
+-
+-Licence: Unknown
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: bnx2x: Broadcom Everest
+ 
+ File: bnx2x/bnx2x-e1-7.13.1.0.fw
+@@ -313,27 +112,6 @@ Found in hex form in kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: bnx2 - Broadcom NetXtremeII
+-
+-File: bnx2/bnx2-mips-06-6.2.3.fw
+-File: bnx2/bnx2-mips-09-6.2.1b.fw
+-File: bnx2/bnx2-rv2p-06-6.0.15.fw
+-File: bnx2/bnx2-rv2p-09-6.0.17.fw
+-File: bnx2/bnx2-rv2p-09ax-6.0.17.fw
+-
+-Licence:
+-
+- This file contains firmware data derived from proprietary unpublished
+- source code, Copyright (c) 2004 - 2010 Broadcom Corporation.
+-
+- Permission is hereby granted for the distribution of this firmware data
+- in hexadecimal or equivalent format, provided this copyright notice is
+- accompanying it.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: netxen_nic - NetXen Multi port (1/10) Gigabit Ethernet NIC
+ 
+ File: phanfw.bin
+@@ -1243,46 +1021,6 @@ Licence: Redistributable. See LICENSE.amdgpu for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ib_qib - QLogic Infiniband
+-
+-File: qlogic/sd7220.fw
+-
+-Licence:
+-
+- * Copyright (c) 2007, 2008 QLogic Corporation. All rights reserved.
+- *
+- * This software is available to you under a choice of one of two
+- * licenses.  You may choose to be licensed under the terms of the GNU
+- * General Public License (GPL) Version 2, available from the file
+- * COPYING in the main directory of this source tree, or the
+- * OpenIB.org BSD license below:
+- *
+- *     Redistribution and use in source and binary forms, with or
+- *     without modification, are permitted provided that the following
+- *     conditions are met:
+- *
+- *      - Redistributions of source code must retain the above
+- *        copyright notice, this list of conditions and the following
+- *        disclaimer.
+- *
+- *      - Redistributions in binary form must reproduce the above
+- *        copyright notice, this list of conditions and the following
+- *        disclaimer in the documentation and/or other materials
+- *        provided with the distribution.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+- * SOFTWARE.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: qed - QLogic 4xxxx Ethernet Driver Core Module.
+ 
+ File: qed/qed_init_values_zipped-8.4.2.0.bin
+@@ -1317,23 +1055,6 @@ Licence:
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: vxge - Exar X3100 Series 10GbE PCIe I/O Virtualized Server Adapter
+-
+-File: vxge/X3fw.ncf
+-File: vxge/X3fw-pxe.ncf
+-Version: 1.8.1
+-
+-Licence:
+-
+- This file contains firmware data derived from proprietary unpublished
+- source code, Copyright (c) 2010 Exar Corporation.
+-
+- Permission is hereby granted for the distribution of this firmware data
+- in hexadecimal or equivalent format, provided this copyright notice is
+- accompanying it.
+-
+---------------------------------------------------------------------------
+-
+ Driver: myri10ge - Myri10GE 10GbE NIC driver
+ 
+ File: myri10ge_eth_z8e.dat
+@@ -2215,21 +1936,6 @@ Licence: Redistributable. See LICENCE.nvidia for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: hfi1 - Intel OPA Gen 1 adapter
+-
+-File: hfi1_dc8051.fw
+-Version: 1.27.0
+-File: hfi1_fabric.fw
+-Version: 0x1055
+-File: hfi1_pcie.fw
+-Version: 0x4755
+-File: hfi1_sbus.fw
+-Version: 0x10130001
+-
+-Licence: Redistributable. See LICENSE.hfi1_firmware for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: knav_qmss_queue - TI Keystone 2 QMSS driver
+ 
+ File: ti-keystone/ks2_qmss_pdsp_acc48_k2_le_1_0_0_9.bin
+@@ -2527,15 +2233,6 @@ Licence: Redistributable. See LICENSE.nxp_mc_firmware for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: mscc-phy - Microchip PHY drivers
+-
+-File: microchip/mscc_vsc8574_revb_int8051_29e8.bin
+-File: microchip/mscc_vsc8584_revb_int8051_fb48.bin
+-
+-Licence: Redistributable. See LICENCE.microchip for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: ice - Intel(R) Ethernet Connection E800 Series
+ 
+ File: intel/ice/ddp/ice-1.3.30.0.pkg
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0007-linux-firmware-Remove-firmware-for-Accelarator-devic.patch
+++ b/packages/linux-firmware/0007-linux-firmware-Remove-firmware-for-Accelarator-devic.patch
@@ -1,0 +1,836 @@
+From eaa004914098930239abf2f3c2e9f4acc79c10b0 Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Wed, 26 Jul 2023 11:06:45 +0000
+Subject: [PATCH] linux-firmware: Remove firmware for Accelarator devices
+
+Bottlerocket does not ship drivers for specialty accelarator hardware.
+Without those drivers the firmware is of no use. Drop the firmware from
+our images to reduce image size.
+
+The following list maps the driver names as specified in WHENCE to
+kernel config options. This creates an easy reference should we need to
+ship addiitonal firmware when adding drivers.
+
+* rvu_cptpf - CONFIG_CRYPTO_DEV_OCTEONTX_CPT &&
+  CONFIG_CRYPTO_DEV_OCTEONTX2_CPT
+* ccp - CONFIG_CRYPTO_DEV_CCP
+* qat - CONFIG_CRYPTO_DEV_QAT
+* liquidio - CONFIG_LIQUIDIO
+* nitrox - CONFIG_NITROX
+* knav_qmss_queue - CONFIG_KEYSTONE_NAVIGATOR_QMSS
+* nfp - CONFIG_NFP
+* fsl_mc bus - CONFIG_FSL_MC_BUS
+* inside-secure - CONFIG_CRYPTO_DEV_SAFEXCEL
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.Netronome       |  65 ------------
+ LICENCE.cavium          |  59 -----------
+ LICENCE.cavium_liquidio |  68 -------------
+ LICENCE.qat_firmware    |  36 -------
+ LICENCE.ti-keystone     |  61 -----------
+ LICENSE.amd-sev         |  64 ------------
+ LICENSE.nxp_mc_firmware | 127 -----------------------
+ WHENCE                  | 218 ----------------------------------------
+ 8 files changed, 698 deletions(-)
+ delete mode 100644 LICENCE.Netronome
+ delete mode 100644 LICENCE.cavium
+ delete mode 100644 LICENCE.cavium_liquidio
+ delete mode 100644 LICENCE.qat_firmware
+ delete mode 100644 LICENCE.ti-keystone
+ delete mode 100644 LICENSE.amd-sev
+ delete mode 100644 LICENSE.nxp_mc_firmware
+
+diff --git a/LICENCE.Netronome b/LICENCE.Netronome
+deleted file mode 100644
+index 1ed7a7c..0000000
+--- a/LICENCE.Netronome
++++ /dev/null
+@@ -1,65 +0,0 @@
+-Copyright (c) 2017, NETRONOME Systems, Inc. All rights reserved.
+-
+-Agilio(r) Firmware License Agreement (the "AGREEMENT")
+-
+-BY INSTALLING OR USING IN ANY MANNER THE SOFTWARE THAT ACCOMPANIES THIS
+-AGREEMENT (THE "SOFTWARE") YOU (THE "LICENSEE") ACKNOWLEDGE TO BE BOUND
+-BY ALL OF THE TERMS OF THIS AGREEMENT.
+-
+-LICENSE GRANT. Subject to the terms and conditions set forth herein,
+-Netronome Systems, Inc. ("NETRONOME") hereby grants LICENSEE a non-
+-exclusive license to use, reproduce and distribute the SOFTWARE
+-exclusively in object form.
+-
+-Restrictions. LICENSEE agrees that, (a) unless explicitly provided by
+-NETRONOME, the source code of the SOFTWARE is not being provided to
+-LICENSEE and is confidential and proprietary to NETRONOME and that
+-LICENSEE has no right to access or use such source code. Accordingly,
+-LICENSEE agrees that it shall not cause or permit the disassembly,
+-decompilation or reverse engineering of the SOFTWARE or otherwise attempt
+-to gain access to the source code for the SOFTWARE; and (b) LICENSEE
+-agrees that it shall not subject the SOFTWARE in whole or in part, to the
+-terms of any software license that requires, as a condition of use,
+-modification and/or distribution that the source code of the SOFTWARE, or
+-the SOFTWARE be i) disclosed or distributed in source code form; ii)
+-licensed for the purpose of making derivative works of the source code of
+-the SOFTWARE; or iii) redistribution of the source code of the SOFTWARE
+-at no charge.
+-
+-DISCLAIMER OF ALL WARRANTIES. THE SOFTWARE IS PROVIDED "AS IS" AND WITH
+-ALL FAULTS AND NETRONOME AND ITS LICENSORS HEREBY DISCLAIM ALL EXPRESS OR
+-IMPLIED WARRANTIES OF ANY KIND, INCLUDING, WITHOUT LIMITATION, ANY
+-WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT AND FITNESS FOR A
+-PARTICULAR PURPOSE.
+-
+-LIMITATIONS OF LIABILITY. EXCEPT WHERE PROHIBITED BY LAW, IN NO EVENT
+-SHALL NETRONOME OR ANY OTHER PARTY INVOLVED IN THE CREATION, PRODUCTION,
+-OR DELIVERY OF THE SOFTWARE BE LIABLE FOR ANY LOSS OF PROFITS, DATA, USE
+-OF THE SOFTWARE, DOCUMENTATION OR EQUIPMENT, OR FOR ANY SPECIAL,
+-INCIDENTAL, CONSEQUENTIAL, EXEMPLARY, PUNITIVE, MULTIPLE OR OTHER
+-DAMAGES, ARISING FROM OR IN CONNECTION WITH THE SOFTWARE EVEN IF
+-NETRONOME OR ITS LICENSORS HAVE BEEN MADE AWARE OF THE POSSIBILITY OF
+-SUCH DAMAGES AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY
+-LIMITED REMEDY.
+-
+-EXPORT COMPLIANCE. LICENSEE shall not use or export or transmit the
+-SOFTWARE, directly or indirectly, to any restricted countries or in any
+-other manner that would violate any applicable US and other export
+-control and other regulations and laws as shall from time to time govern
+-the delivery, license and use of technology, including without limitation
+-the Export Administration Act of 1979, as amended, and any regulations
+-issued thereunder.
+-
+-PROHIBITION OF SOFTWARE USE IN HIGH RISK ACTIVITIES AND LIFE
+-SUPPORT APPLICATIONS. The SOFTWARE is not designed, manufactured or
+-intended for use as on-line control equipment in hazardous environments
+-requiring fail-safe performance, such as in the operation of nuclear
+-facilities, aircraft navigation or communications systems, air traffic
+-control, life support systems, human implantation or any other
+-application where product failure could lead to loss of life or
+-catastrophic property damage or weapons systems, in which the failure of
+-the SOFTWARE could lead directly to death, personal injury, or severe
+-physical or environmental damage ("High Risk Activities"). Accordingly
+-NETRONOME and, where applicable, NETRONOME'S third party licensors
+-specifically disclaim any express or implied warranty of fitness for High
+-Risk Activities.
+diff --git a/LICENCE.cavium b/LICENCE.cavium
+deleted file mode 100644
+index 5d2a2bb..0000000
+--- a/LICENCE.cavium
++++ /dev/null
+@@ -1,59 +0,0 @@
+-Copyright © 2015, Cavium, Inc. All rights reserved.
+-
+-Software License Agreement
+-
+-ANY USE, REPRODUCTION, OR DISTRIBUTION OF THE ACCOMPANYING BINARY SOFTWARE
+-CONSTITUTES LICENSEEE'S ACCEPTANCE OF THE TERMS AND CONDITIONS OF THIS AGREEMENT.
+-
+-Licensed Software. Subject to the terms and conditions of this Agreement,
+-Cavium, Inc. ("Cavium") grants to Licensee a worldwide, non-exclusive, and
+-royalty-free license to use, reproduce, and distribute the binary software in
+-its complete and unmodified form as provided by Cavium.
+-
+-Restrictions. Licensee must reproduce the Cavium copyright notice above with
+-each binary software copy. Licensee must not reverse engineer, decompile,
+-disassemble or modify in any way the binary software. Licensee must not use
+-the binary software in violation of any applicable law or regulation. This
+-Agreement shall automatically terminate upon Licensee's breach of any term or
+-condition of this Agreement in which case, Licensee shall destroy all copies of
+-the binary software.
+-
+-Warranty Disclaimer.  THE LICENSED SOFTWARE IS OFFERED "AS IS," AND CAVIUM
+-GRANTS AND LICENSEE RECEIVES NO WARRANTIES OF ANY KIND, WHETHER EXPRESS,
+-IMPLIED, STATUTORY, OR BY COURSE OF COMMUNICATION OR DEALING WITH LICENSEE, OR
+-OTHERWISE.  CAVIUM AND ITS LICENSORS SPECIFICALLY DISCLAIM ANY IMPLIED
+-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, OR
+-NONINFRINGEMENT OF THIRD PARTY RIGHTS, CONCERNING THE LICENSED SOFTWARE,
+-DERIVATIVE WORKS, OR ANY DOCUMENTATION PROVIDED WITH THE FOREGOING.  WITHOUT
+-LIMITING THE GENERALITY OF THE FOREGOING, CAVIUM DOES NOT WARRANT THAT THE
+-LICENSED SOFTWARE IS ERROR-FREE OR WILL OPERATE WITHOUT INTERRUPTION, AND
+-CAVIUM GRANTS NO WARRANTY REGARDING ITS USE OR THE RESULTS THEREFROM, INCLUDING
+-ITS CORRECTNESS, ACCURACY, OR RELIABILITY.
+-
+-Limitation of Liability. IN NO EVENT WILL LICENSEE, CAVIUM, OR ANY OF CAVIUM'S
+-LICENSORS HAVE ANY LIABILITY HEREUNDER FOR ANY INDIRECT, SPECIAL, OR
+-CONSEQUENTIAL DAMAGES, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+-FOR BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, ARISING OUT
+-OF THIS AGREEMENT, INCLUDING DAMAGES FOR LOSS OF PROFITS, OR THE COST OF
+-PROCUREMENT OF SUBSTITUTE GOODS, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGES.
+-
+-Export and Import Laws.  Licensee acknowledges and agrees that the Licensed
+-Software (including technical data and related technology) may be controlled by
+-the export control laws, rules, regulations, restrictions and national security
+-controls of the United States and other applicable foreign agencies (the
+-"Export Controls"), and agrees not export or re-export, or allow the export or
+-re-export of export-controlled the Licensed Software (including technical data
+-and related technology) or any copy, portion or direct product of the foregoing
+-in violation of the Export Controls. Licensee hereby represents that
+-(i) Licensee is not an entity or person to whom provision of the Licensed
+-Software (including technical data and related technology) is restricted or
+-prohibited by the Export Controls; and (ii) Licensee will not export, re-export
+-or otherwise transfer the export-controlled Licensed Software (including
+-technical data and related technology) in violation of U.S. sanction programs
+-or export control regulations to (a) any country, or  national or resident of
+-any country, subject to a United States trade embargo, (b) any person or entity
+-to whom shipment is restricted or prohibited by the Export Controls, or
+-(c) anyone who is engaged in activities related to the design, development,
+-production, or use of nuclear materials, nuclear facilities, nuclear weapons,
+-missiles or chemical or biological weapons.
+diff --git a/LICENCE.cavium_liquidio b/LICENCE.cavium_liquidio
+deleted file mode 100644
+index 250b9fe..0000000
+--- a/LICENCE.cavium_liquidio
++++ /dev/null
+@@ -1,68 +0,0 @@
+-This file contains licences pertaining to the following firmwares for
+-LiquidIO (c) adapters
+-
+-1. lio_nic_23xx.bin, lio_210nv_nic.bin, lio_410nv_nic.bin
+-
+-###########################################################################
+-
+-1. lio_nic_23xx.bin, lio_210nv_nic.bin, lio_410nv_nic.bin
+-
+-Copyright (c) 2018, Cavium, Inc. All rights reserved.
+-
+-Software License Agreement
+-
+-ANY USE, REPRODUCTION, OR DISTRIBUTION OF THE ACCOMPANYING BINARY SOFTWARE
+-CONSTITUTES LICENSEEE'S ACCEPTANCE OF THE TERMS AND CONDITIONS OF THIS AGREEMENT.
+-
+-Licensed Software. Subject to the terms and conditions of this Agreement,
+-Cavium, Inc. ("Cavium") grants to Licensee a worldwide, non-exclusive, and
+-royalty-free license to use, reproduce, and distribute the binary software in
+-its complete and unmodified form as provided by Cavium.
+-
+-Restrictions. Licensee must reproduce the Cavium copyright notice above with
+-each binary software copy. Licensee must not reverse engineer, decompile,
+-disassemble or modify in any way the binary software. Licensee must not use
+-the binary software in violation of any applicable law or regulation. This
+-Agreement shall automatically terminate upon Licensee's breach of any term or
+-condition of this Agreement in which case, Licensee shall destroy all copies of
+-the binary software.
+-
+-Warranty Disclaimer.  THE LICENSED SOFTWARE IS OFFERED "AS IS," AND CAVIUM
+-GRANTS AND LICENSEE RECEIVES NO WARRANTIES OF ANY KIND, WHETHER EXPRESS,
+-IMPLIED, STATUTORY, OR BY COURSE OF COMMUNICATION OR DEALING WITH LICENSEE, OR
+-OTHERWISE.  CAVIUM AND ITS LICENSORS SPECIFICALLY DISCLAIM ANY IMPLIED
+-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, OR
+-NONINFRINGEMENT OF THIRD PARTY RIGHTS, CONCERNING THE LICENSED SOFTWARE,
+-DERIVATIVE WORKS, OR ANY DOCUMENTATION PROVIDED WITH THE FOREGOING.  WITHOUT
+-LIMITING THE GENERALITY OF THE FOREGOING, CAVIUM DOES NOT WARRANT THAT THE
+-LICENSED SOFTWARE IS ERROR-FREE OR WILL OPERATE WITHOUT INTERRUPTION, AND
+-CAVIUM GRANTS NO WARRANTY REGARDING ITS USE OR THE RESULTS THEREFROM, INCLUDING
+-ITS CORRECTNESS, ACCURACY, OR RELIABILITY.
+-
+-Limitation of Liability. IN NO EVENT WILL LICENSEE, CAVIUM, OR ANY OF CAVIUM'S
+-LICENSORS HAVE ANY LIABILITY HEREUNDER FOR ANY INDIRECT, SPECIAL, OR
+-CONSEQUENTIAL DAMAGES, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+-FOR BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, ARISING OUT
+-OF THIS AGREEMENT, INCLUDING DAMAGES FOR LOSS OF PROFITS, OR THE COST OF
+-PROCUREMENT OF SUBSTITUTE GOODS, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGES.
+-
+-Export and Import Laws.  Licensee acknowledges and agrees that the Licensed
+-Software (including technical data and related technology) may be controlled by
+-the export control laws, rules, regulations, restrictions and national security
+-controls of the United States and other applicable foreign agencies (the
+-"Export Controls"), and agrees not export or re-export, or allow the export or
+-re-export of export-controlled the Licensed Software (including technical data
+-and related technology) or any copy, portion or direct product of the foregoing
+-in violation of the Export Controls. Licensee hereby represents that
+-(i) Licensee is not an entity or person to whom provision of the Licensed
+-Software (including technical data and related technology) is restricted or
+-prohibited by the Export Controls; and (ii) Licensee will not export, re-export
+-or otherwise transfer the export-controlled Licensed Software (including
+-technical data and related technology) in violation of U.S. sanction programs
+-or export control regulations to (a) any country, or  national or resident of
+-any country, subject to a United States trade embargo, (b) any person or entity
+-to whom shipment is restricted or prohibited by the Export Controls, or
+-(c) anyone who is engaged in activities related to the design, development,
+-production, or use of nuclear materials, nuclear facilities, nuclear weapons,
+-missiles or chemical or biological weapons.
+diff --git a/LICENCE.qat_firmware b/LICENCE.qat_firmware
+deleted file mode 100644
+index 75a4ff1..0000000
+--- a/LICENCE.qat_firmware
++++ /dev/null
+@@ -1,36 +0,0 @@
+-Copyright (c) 2014-2023 Intel Corporation.
+-All rights reserved.
+-
+-Redistribution.  Redistribution and use in binary form, without
+-modification, are permitted provided that the following conditions are
+-met:
+-
+-* Redistributions must reproduce the above copyright notice and the
+-  following disclaimer in the documentation and/or other materials
+-  provided with the distribution.
+-* Neither the name of Intel Corporation nor the names of its suppliers
+-  may be used to endorse or promote products derived from this software
+-  without specific prior written permission.
+-* No reverse engineering, decompilation, or disassembly of this software
+-  is permitted.
+-
+-Limited patent license.  Intel Corporation grants a world-wide,
+-royalty-free, non-exclusive license under patents it now or hereafter
+-owns or controls to make, have made, use, import, offer to sell and
+-sell ("Utilize") this software, but solely to the extent that any
+-such patent is necessary to Utilize the software alone. The patent
+-license shall not apply to any other combinations which include this
+-software. No hardware per se is licensed hereunder.
+-
+-DISCLAIMER.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+-DAMAGE.
+diff --git a/LICENCE.ti-keystone b/LICENCE.ti-keystone
+deleted file mode 100644
+index 62cc3b3..0000000
+--- a/LICENCE.ti-keystone
++++ /dev/null
+@@ -1,61 +0,0 @@
+-Copyright (c) 2015 Texas Instruments Incorporated
+-
+-All rights reserved not granted herein.
+-
+-Limited License.
+-
+-Texas Instruments Incorporated grants a world-wide, royalty-free, non-exclusive
+-license under copyrights and patents it now or hereafter owns or controls to
+-make, have made, use, import, offer to sell and sell ("Utilize") this software
+-subject to the terms herein. With respect to the foregoing patent license, such
+-license is granted solely to the extent that any such patent is necessary to
+-Utilize the software alone. The patent license shall not apply to any
+-combinations which include this software, other than combinations with devices
+-manufactured by or for TI (“TI Devices”). No hardware patent is licensed
+-hereunder.
+-
+-Redistributions must preserve existing copyright notices and reproduce this
+-license (including the above copyright notice and the disclaimer and
+-(if applicable) source code license limitations below) in the documentation
+-and/or other materials provided with the distribution
+-
+-Redistribution and use in binary form, without modification, are permitted
+-provided that the following conditions are met:
+-
+-	* No reverse engineering, decompilation, or disassembly of this
+-	  software is permitted with respect to any software provided in binary
+-	  form.
+-
+-	* any redistribution and use are licensed by TI for use only with TI
+-	  Devices.
+-
+-	* Nothing shall obligate TI to provide you with source code for the
+-	  software licensed and provided to you in object code.
+-
+-If software source code is provided to you, modification and redistribution of
+-the source code are permitted provided that the following conditions are met:
+-
+-	* any redistribution and use of the source code, including any
+-	  resulting derivative works, are licensed by TI for use only with TI
+-	  Devices.
+-
+-	* any redistribution and use of any object code compiled from the
+-	  source code and any resulting derivative works, are licensed by TI
+-	  for use only with TI Devices.
+-
+-Neither the name of Texas Instruments Incorporated nor the names of its
+-suppliers may be used to endorse or promote products derived from this
+-software without specific prior written permission.
+-
+-DISCLAIMER.
+-
+-THIS SOFTWARE IS PROVIDED BY TI AND TI’S LICENSORS "AS IS" AND ANY EXPRESS OR
+-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+-EVENT SHALL TI AND TI’S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.amd-sev b/LICENSE.amd-sev
+deleted file mode 100644
+index de4d948..0000000
+--- a/LICENSE.amd-sev
++++ /dev/null
+@@ -1,64 +0,0 @@
+-Copyright (C) 2015-2019 Advanced Micro Devices, Inc., All rights reserved.
+-
+-Permission is hereby granted by Advanced Micro Devices, Inc. ("AMD"),
+-free of any license fees, to any person obtaining a copy of this
+-microcode in binary form (the "Software") ("You"), to install,
+-reproduce, copy and distribute copies of the Software and to permit
+-persons to whom the Software is provided to do the same, subject to
+-the following terms and conditions.  Your use of any portion of the
+-Software shall constitute Your acceptance of the following terms and
+-conditions. If You do not agree to the following terms and conditions,
+-do not use, retain or redistribute any portion of the Software.
+-
+-If You redistribute this Software, You must reproduce the above
+-copyright notice and this license with the Software.
+-Without specific, prior, written permission from AMD, You may not
+-reference AMD or AMD products in the promotion of any product derived
+-from or incorporating this Software in any manner that implies that
+-AMD endorses or has certified such product derived from or
+-incorporating this Software.
+-
+-You may not reverse engineer, decompile, or disassemble this Software
+-or any portion thereof.
+-
+-THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED
+-WARRANTY OF ANY KIND, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+-MERCHANTABILITY, NONINFRINGEMENT, TITLE, FITNESS FOR ANY PARTICULAR
+-PURPOSE, OR WARRANTIES ARISING FROM CONDUCT, COURSE OF DEALING, OR
+-USAGE OF TRADE. IN NO EVENT SHALL AMD OR ITS LICENSORS BE LIABLE FOR
+-ANY DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR
+-LOSS OF PROFITS, BUSINESS INTERRUPTION, OR LOSS OF DATA OR
+-INFORMATION) ARISING OUT OF AMD'S NEGLIGENCE, GROSS NEGLIGENCE, THE
+-USE OF OR INABILITY TO USE THE SOFTWARE, EVEN IF AMD HAS BEEN ADVISED
+-OF THE POSSIBILITY OF SUCH DAMAGES. BECAUSE SOME JURISDICTIONS
+-PROHIBIT THE EXCLUSION OR LIMITATION OF LIABILITY FOR CONSEQUENTIAL OR
+-INCIDENTAL DAMAGES OR THE EXCLUSION OF IMPLIED WARRANTIES, THE ABOVE
+-LIMITATION MAY NOT APPLY TO YOU.
+-
+-Without limiting the foregoing, the Software may implement third party
+-technologies for which You must obtain licenses from parties other
+-than AMD. You agree that AMD has not obtained or conveyed to You, and
+-that You shall be responsible for obtaining the rights to use and/or
+-distribute the applicable underlying intellectual property rights
+-related to the third party technologies. These third party
+-technologies are not licensed hereunder.
+-
+-If You use the Software (in whole or in part), You shall adhere to all
+-applicable U.S., European, and other export laws, including but not
+-limited to the U.S. Export Administration Regulations ("EAR"), (15
+-C.F.R. Sections 730 through 774), and E.U. Council Regulation (EC) No
+-1334/2000 of 22 June 2000. Further, pursuant to Section 740.6  of the
+-EAR, You hereby certify that, except pursuant to a license granted by
+-the United States Department of Commerce Bureau of Industry and
+-Security or as otherwise permitted pursuant to a License Exception
+-under the U.S. Export Administration Regulations ("EAR"), You will not
+-(1) export, re-export or release to a national of a country in Country
+-Groups D:1, E:1 or E:2 any restricted technology, software, or source
+-code You receive hereunder, or (2) export to Country Groups D:1, E:1
+-or E:2 the direct product of such technology or software, if such
+-foreign produced direct product is subject to national security
+-controls as identified on the Commerce Control List (currently found
+-in Supplement 1 to Part 774 of EAR). For the most current Country
+-Group listings, or for additional information about the EAR or Your
+-obligations under those regulations, please refer to the U.S. Bureau
+-of Industry and Security’s website at ttp://www.bis.doc.gov/.
+diff --git a/LICENSE.nxp_mc_firmware b/LICENSE.nxp_mc_firmware
+deleted file mode 100644
+index 4b12f58..0000000
+--- a/LICENSE.nxp_mc_firmware
++++ /dev/null
+@@ -1,127 +0,0 @@
+-Copyright (c) 2018 NXP. All rights reserved.
+-
+-Software License Agreement ("Agreement")
+-
+-ANY USE, REPRODUCTION, OR DISTRIBUTION OF THE ACCOMPANYING BINARY SOFTWARE
+-CONSTITUTES LICENSEE'S ACCEPTANCE OF THE TERMS AND CONDITIONS OF THIS AGREEMENT.
+-
+-Licensed Software. "Binary Software" means software in binary form specified in
+-ANNEX A. Subject to the terms and conditions of this Agreement, NXP USA, Inc.
+-("Licensor"), grants to you ("Licensee") a worldwide, non-exclusive, and
+-royalty-free license to reproduce and distribute the Binary Software in its
+-complete and unmodified binary form as provided by Licensor, for use solely in
+-conjunction with a programmable processing unit supplied directly or indirectly
+-from Licensor.
+-
+-Restrictions. Licensee must reproduce the Licensor copyright notice above with
+-each binary copy of the Binary Software or in the accompanying documentation.
+-Licensee must not reverse engineer, decompile, disassemble or modify in any way
+-the Binary Software. Licensee must not use the Binary Software in violation of
+-any applicable law or regulation. This Agreement shall automatically terminate
+-upon Licensee's breach of any term or condition of this Agreement in which case,
+-Licensee shall destroy all copies of the Binary Software. Neither the name of
+-Licensor nor the names of its suppliers may be used to endorse or promote
+-products derived from this Binary Software without specific prior written
+-permission.
+-
+-Disclaimer. TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR EXPRESSLY
+-DISCLAIMS ANY WARRANTY FOR THE BINARY SOFTWARE. THE BINARY SOFTWARE IS PROVIDED
+-"AS IS", WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+-WITHOUT LIMITATION THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+-PARTICULAR PURPOSE, OR NON-INFRINGEMENT. WITHOUT LIMITING THE GENERALITY OF THE
+-FOREGOING, LICENSOR DOES NOT WARRANT THAT THE BINARY SOFTWARE IS ERROR-FREE OR
+-WILL OPERATE WITHOUT INTERRUPTION, AND LICENSOR GRANTS NO WARRANTY REGARDING ITS
+-USE OR THE RESULTS THEREFROM, INCLUDING ITS CORRECTNESS, ACCURACY, OR
+-RELIABILITY.
+-
+-Limitation of Liability. IN NO EVENT WILL LICENSOR, OR ANY OF LICENSOR'S
+-LICENSORS HAVE ANY LIABILITY HEREUNDER FOR ANY INDIRECT, SPECIAL, OR
+-CONSEQUENTIAL DAMAGES, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+-FOR BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, ARISING OUT
+-OF THIS AGREEMENT, INCLUDING DAMAGES FOR LOSS OF PROFITS, OR THE COST OF
+-PROCUREMENT OF SUBSTITUTE GOODS, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGES. LICENSOR'S TOTAL LIABILITY FOR ALL COSTS, DAMAGES,
+-CLAIMS, OR LOSSES WHATSOEVER ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT
+-OR THE BINARY SOFTWARE SUPPLIED UNDER THIS AGREEMENT IS LIMITED TO THE AGGREGATE
+-AMOUNT PAID BY LICENSEE TO LICENSOR IN CONNECTION WITH THE BINARY SOFTWARE TO
+-WHICH LOSSES OR DAMAGES ARE CLAIMED.
+-
+-Trade Compliance.  Licensee shall comply with all applicable export and import
+-control laws and regulations including but not limited to the US Export
+-Administration Regulation (including prohibited party lists issued by other
+-federal governments), Catch-all regulations and all national and international
+-embargoes. Licensee further agrees that it will not knowingly transfer, divert,
+-export or re-export, directly or indirectly, any product, software, including
+-software source code, or technology restricted by such regulations or by other
+-applicable national regulations, received from Licensor under this Agreement,
+-or any direct product of such software or technical data to any person, firm,
+-entity, country or destination to which such transfer, diversion, export or
+-re-export is restricted or prohibited, without obtaining prior written
+-authorization from the applicable competent government authorities to the extent
+-required by those laws. Licensee acknowledge that the "restricted encryption
+-software" that is subject to the US Export Administration Regulations (EAR), is
+-not intended for use by a government end user, as defined in part 772 of the
+-EAR. This provision shall survive termination or expiration of this Agreement.
+-
+-Assignment. Licensee may not assign this Agreement without the prior written
+-consent of Licensor. Licensor may assign this Agreement without Licensee's
+-consent.
+-
+-Governing Law. This Agreement will be governed by, construed, and enforced in
+-accordance with the laws of the State of Texas, USA, without regard to conflicts
+-of laws principles, will apply to all matters relating to this Agreement or the
+-Binary Software, and Licensee agrees that any litigation will be subject to the
+-exclusive jurisdiction of the state or federal courts Texas, USA. The United
+-Nations Convention on Contracts for the International Sale of Goods will not
+-apply to this Agreement.
+-
+-Restrictions, Warranty Disclaimer, Limitation of Liability, Trade Compliance,
+-Assignment, Governing Law, and Third Party Terms shall survive termination or
+-expiration of this Agreement.
+-
+-Third Party Terms. The licensed Binary Software includes the following third
+-party software for which the following terms apply:
+-
+-Libfdt - Flat Device Tree manipulation
+-Copyright (c) 2006 David Gibson, IBM Corporation
+-All rights reserved.
+-
+-Redistributions must reproduce the above copyright notice, this list of
+-conditions and the following disclaimer in the documentation and/or other
+-materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-LibElf
+-Copyright (c) 2006,2008-2011 Joseph Koshy
+-All rights reserved.
+-
+-Redistributions must reproduce the above copyright notice, this list of
+-conditions and the following disclaimer in the documentation and/or other
+-materials provided with the distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-
+-ANNEX A
+-BINARY SOFTWARE
+-Only software in binary form may be provided under this Agreement
+-
+diff --git a/WHENCE b/WHENCE
+index f6b0299..58e9ca1 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -1071,19 +1071,6 @@ License: Redistributable.  See LICENCE.myri10ge_firmware for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: ccp - Platform Security Processor (PSP) device
+-
+-File: amd/amd_sev_fam17h_model0xh.sbin
+-Version: 2022-2-25
+-File: amd/amd_sev_fam17h_model3xh.sbin
+-Version: 2022-2-25
+-File: amd/amd_sev_fam19h_model0xh.sbin
+-Version: 2022-2-25
+-
+-License: Redistributable. See LICENSE.amd-sev for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: microcode_amd - AMD CPU Microcode Update Driver for Linux
+ 
+ File: amd-ucode/microcode_amd.bin
+@@ -1107,52 +1094,6 @@ License: Redistributable. See LICENSE.amd-ucode for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: qat - Intel(R) QAT crypto accelerator
+-
+-File: qat_895xcc.bin
+-File: qat_895xcc_mmp.bin
+-File: qat_c3xxx.bin
+-File: qat_c3xxx_mmp.bin
+-File: qat_c62x.bin
+-File: qat_c62x_mmp.bin
+-Link: qat_mmp.bin -> qat_895xcc_mmp.bin
+-File: qat_4xxx.bin
+-File: qat_4xxx_mmp.bin
+-
+-Licence: Redistributable. See LICENCE.qat_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: liquidio -- Cavium LiquidIO driver
+-
+-File: liquidio/lio_23xx_nic.bin
+-Version: v1.7.2
+-
+-File: liquidio/lio_210nv_nic.bin
+-Version: v1.7.2
+-
+-File: liquidio/lio_210sv_nic.bin
+-Version: v1.7.2
+-
+-File: liquidio/lio_410nv_nic.bin
+-Version: v1.7.2
+-
+-Licence: Redistributable. See LICENCE.cavium_liquidio for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: nitrox -- Cavium CNN55XX crypto driver
+-
+-File: cavium/cnn55xx_ae.fw
+-Version: v01
+-
+-File: cavium/cnn55xx_se.fw
+-Version: v10
+-
+-Licence: Redistributable. See LICENCE.cavium for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: i915 -- Intel Integrated Graphics driver
+ 
+ File: i915/skl_dmc_ver1_23.bin
+@@ -1936,14 +1877,6 @@ Licence: Redistributable. See LICENCE.nvidia for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: knav_qmss_queue - TI Keystone 2 QMSS driver
+-
+-File: ti-keystone/ks2_qmss_pdsp_acc48_k2_le_1_0_0_9.bin
+-
+-Licence: Redistributable. See LICENCE.ti-keystone for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: mtk_scp - MediaTek SCP System Control Processing Driver
+ 
+ File: mediatek/mt8183/scp.img
+@@ -1959,100 +1892,6 @@ Licence: Redistributable. See LICENCE.mediatek for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: nfp - Netronome Flow Processor
+-
+-Link: netronome/nic_AMDA0081-0001_1x40.nffw -> nic/nic_AMDA0081-0001_1x40.nffw
+-Link: netronome/nic_AMDA0097-0001_2x40.nffw -> nic/nic_AMDA0097-0001_2x40.nffw
+-Link: netronome/nic_AMDA0099-0001_2x10.nffw -> nic/nic_AMDA0099-0001_2x10.nffw
+-Link: netronome/nic_AMDA0081-0001_4x10.nffw -> nic/nic_AMDA0081-0001_4x10.nffw
+-Link: netronome/nic_AMDA0097-0001_4x10_1x40.nffw -> nic/nic_AMDA0097-0001_4x10_1x40.nffw
+-Link: netronome/nic_AMDA0099-0001_1x10_1x25.nffw -> nic/nic_AMDA0099-0001_1x10_1x25.nffw
+-Link: netronome/nic_AMDA0099-0001_2x25.nffw -> nic/nic_AMDA0099-0001_2x25.nffw
+-Link: netronome/nic_AMDA0096-0001_2x10.nffw -> nic/nic_AMDA0096-0001_2x10.nffw
+-Link: netronome/nic_AMDA0097-0001_8x10.nffw -> nic/nic_AMDA0097-0001_8x10.nffw
+-Link: netronome/nic_AMDA0058-0011_2x40.nffw -> nic/nic_AMDA0058-0011_2x40.nffw
+-Link: netronome/nic_AMDA0058-0012_2x40.nffw -> nic/nic_AMDA0058-0012_2x40.nffw
+-Link: netronome/nic_AMDA0078-0011_1x100.nffw -> nic/nic_AMDA0078-0011_1x100.nffw
+-File: netronome/nic/nic_AMDA0081-0001_1x40.nffw
+-File: netronome/nic/nic_AMDA0097-0001_2x40.nffw
+-File: netronome/nic/nic_AMDA0099-0001_2x10.nffw
+-File: netronome/nic/nic_AMDA0081-0001_4x10.nffw
+-File: netronome/nic/nic_AMDA0097-0001_4x10_1x40.nffw
+-File: netronome/nic/nic_AMDA0099-0001_1x10_1x25.nffw
+-File: netronome/nic/nic_AMDA0099-0001_2x25.nffw
+-File: netronome/nic/nic_AMDA0096-0001_2x10.nffw
+-File: netronome/nic/nic_AMDA0097-0001_8x10.nffw
+-File: netronome/nic/nic_AMDA0058-0011_2x40.nffw
+-File: netronome/nic/nic_AMDA0058-0012_2x40.nffw
+-File: netronome/nic/nic_AMDA0078-0011_1x100.nffw
+-File: netronome/nic-sriov/nic_AMDA0081-0001_1x40.nffw
+-File: netronome/nic-sriov/nic_AMDA0097-0001_2x40.nffw
+-File: netronome/nic-sriov/nic_AMDA0099-0001_2x10.nffw
+-File: netronome/nic-sriov/nic_AMDA0081-0001_4x10.nffw
+-File: netronome/nic-sriov/nic_AMDA0097-0001_4x10_1x40.nffw
+-File: netronome/nic-sriov/nic_AMDA0099-0001_1x10_1x25.nffw
+-File: netronome/nic-sriov/nic_AMDA0099-0001_2x25.nffw
+-File: netronome/nic-sriov/nic_AMDA0096-0001_2x10.nffw
+-File: netronome/nic-sriov/nic_AMDA0097-0001_8x10.nffw
+-File: netronome/nic-sriov/nic_AMDA0058-0011_2x40.nffw
+-File: netronome/nic-sriov/nic_AMDA0058-0012_2x40.nffw
+-File: netronome/nic-sriov/nic_AMDA0078-0011_1x100.nffw
+-
+-Version: v2.1.16.1
+-
+-File: netronome/flower/nic_AMDA0099.nffw
+-File: netronome/flower/nic_AMDA0096.nffw
+-File: netronome/flower/nic_AMDA0097.nffw
+-File: netronome/flower/nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0081.nffw -> nic_AMDA0097.nffw
+-Link: netronome/flower/nic_AMDA0081-0001_1x40.nffw -> nic_AMDA0081.nffw
+-Link: netronome/flower/nic_AMDA0097-0001_2x40.nffw -> nic_AMDA0097.nffw
+-Link: netronome/flower/nic_AMDA0099-0001_2x10.nffw -> nic_AMDA0099.nffw
+-Link: netronome/flower/nic_AMDA0081-0001_4x10.nffw -> nic_AMDA0081.nffw
+-Link: netronome/flower/nic_AMDA0097-0001_4x10_1x40.nffw -> nic_AMDA0097.nffw
+-Link: netronome/flower/nic_AMDA0099-0001_2x25.nffw -> nic_AMDA0099.nffw
+-Link: netronome/flower/nic_AMDA0096-0001_2x10.nffw -> nic_AMDA0096.nffw
+-Link: netronome/flower/nic_AMDA0097-0001_8x10.nffw -> nic_AMDA0097.nffw
+-Link: netronome/flower/nic_AMDA0099-0001_1x10_1x25.nffw -> nic_AMDA0099.nffw
+-Link: netronome/flower/nic_AMDA0058-0011_1x100.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0058-0011_2x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0058-0011_4x10_1x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0058-0011_8x10.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0058-0012_1x100.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0058-0012_2x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0058-0012_4x10_1x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0058-0012_8x10.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0011_1x100.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0011_2x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0011_4x10_1x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0011_8x10.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0012_1x100.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0012_2x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0012_4x10_1x40.nffw -> nic_AMDA0058.nffw
+-Link: netronome/flower/nic_AMDA0078-0012_8x10.nffw -> nic_AMDA0058.nffw
+-
+-Version: AOTC-2.14.A.6
+-
+-File: netronome/bpf/nic_AMDA0081-0001_1x40.nffw
+-File: netronome/bpf/nic_AMDA0097-0001_2x40.nffw
+-File: netronome/bpf/nic_AMDA0099-0001_2x10.nffw
+-File: netronome/bpf/nic_AMDA0081-0001_4x10.nffw
+-File: netronome/bpf/nic_AMDA0097-0001_4x10_1x40.nffw
+-File: netronome/bpf/nic_AMDA0099-0001_1x10_1x25.nffw
+-File: netronome/bpf/nic_AMDA0099-0001_2x25.nffw
+-File: netronome/bpf/nic_AMDA0096-0001_2x10.nffw
+-File: netronome/bpf/nic_AMDA0097-0001_8x10.nffw
+-File: netronome/bpf/nic_AMDA0058-0011_2x40.nffw
+-File: netronome/bpf/nic_AMDA0058-0012_2x40.nffw
+-File: netronome/bpf/nic_AMDA0078-0011_1x100.nffw
+-
+-Version: v2.0.6.124
+-
+-
+-Licence: Redistributable. See LICENCE.Netronome for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: imx-sdma - support for i.MX SDMA driver
+ 
+ File: imx/sdma/sdma-imx6q.bin
+@@ -2211,28 +2050,6 @@ Licence:
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: fsl-mc bus - NXP Management Complex Bus Driver
+-
+-File: dpaa2/mc/mc_10.10.0_ls1088a.itb
+-File: dpaa2/mc/mc_10.10.0_ls2088a.itb
+-File: dpaa2/mc/mc_10.10.0_lx2160a.itb
+-File: dpaa2/mc/mc_10.14.3_ls1088a.itb
+-File: dpaa2/mc/mc_10.14.3_ls2088a.itb
+-File: dpaa2/mc/mc_10.14.3_lx2160a.itb
+-File: dpaa2/mc/mc_10.16.2_ls1088a.itb
+-File: dpaa2/mc/mc_10.16.2_ls2088a.itb
+-File: dpaa2/mc/mc_10.16.2_lx2160a.itb
+-File: dpaa2/mc/mc_10.18.0_ls1088a.itb
+-File: dpaa2/mc/mc_10.18.0_ls2088a.itb
+-File: dpaa2/mc/mc_10.18.0_lx2160a.itb
+-File: dpaa2/mc/mc_10.28.1_ls1088a.itb
+-File: dpaa2/mc/mc_10.28.1_ls2088a.itb
+-File: dpaa2/mc/mc_10.28.1_lx2160a.itb
+-
+-Licence: Redistributable. See LICENSE.nxp_mc_firmware for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: ice - Intel(R) Ethernet Connection E800 Series
+ 
+ File: intel/ice/ddp/ice-1.3.30.0.pkg
+@@ -2247,21 +2064,6 @@ License: Redistributable. See LICENSE.ice_enhanced for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: inside-secure -- Inside Secure EIP197 crypto driver
+-
+-File: inside-secure/eip197_minifw/ipue.bin
+-File: inside-secure/eip197_minifw/ifpp.bin
+-
+-Licence: Redistributable.
+-Copyright (c) 2019 Verimatrix, Inc.
+-
+-Derived from proprietary unpublished source code.
+-Permission is hereby granted for the distribution of this firmware
+-as part of Linux or other Open Source operating system kernel,
+-provided this copyright notice is accompanying it.
+-
+-------------------------------------------------
+-
+ Driver: prestera - Marvell driver for Prestera family ASIC devices
+ 
+ File: mrvl/prestera/mvsw_prestera_fw-v2.0.img
+@@ -2273,23 +2075,3 @@ File: mrvl/prestera/mvsw_prestera_fw_arm64-v4.1.img
+ Licence: Redistributable. See LICENCE.Marvell for details.
+ 
+ ------------------------------------------------
+-
+-Driver: rvu_cptpf - Marvell CPT driver
+-
+-File: mrvl/cpt01/ae.out
+-File: mrvl/cpt01/se.out
+-File: mrvl/cpt01/ie.out
+-File: mrvl/cpt02/ae.out
+-File: mrvl/cpt02/se.out
+-File: mrvl/cpt02/ie.out
+-File: mrvl/cpt03/ae.out
+-File: mrvl/cpt03/se.out
+-File: mrvl/cpt03/ie.out
+-File: mrvl/cpt04/ae.out
+-File: mrvl/cpt04/se.out
+-File: mrvl/cpt04/ie.out
+-Version: v1.21
+-
+-Licence: Redistributable. See LICENCE.Marvell for details.
+-
+----------------------------------------------------------------------------
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0008-linux-firmware-gpu-Remove-firmware-for-GPU-devices.patch
+++ b/packages/linux-firmware/0008-linux-firmware-gpu-Remove-firmware-for-GPU-devices.patch
@@ -1,0 +1,1923 @@
+From 2819be643186fa19869700e0af67444872d677c7 Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Wed, 26 Jul 2023 11:16:37 +0000
+Subject: [PATCH] linux-firmware: gpu: Remove firmware for GPU devices
+
+Bottlerocket does not provide drivers for any GPUs for any of its
+kernels. Thus, shipping firmware for any of these non-supported devices
+makes no sense. One exception is the nvidia drivers for tesla devices in
+aws-*-nvidia variants. These variants include drivers through
+kmod-*-nvidia packages which ship device specific firmware for supported
+cards.
+
+The following list maps drivers as specified in WHENCE to kernel config
+options for easy reference, should firmware be needed through driver
+addition.
+
+* mga - CONFIG_DRM_MGA && CONFIG_DRM_MGAG200
+* r128 - CONFIG_DRM_R128
+* radeon - CONFIG_DRM_RADEON
+* amdgpu - CONFIG_DRM_AMDGPU
+* nouveau - CONFIG_DRM_NOUVEAU
+* adreno - CONFIG_DRM_MSM
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.nvidia      |  131 -----
+ LICENSE.amdgpu      |   51 --
+ LICENSE.qcom        |  206 -------
+ LICENSE.qcom_yamato |   25 -
+ LICENSE.radeon      |   51 --
+ WHENCE              | 1363 -------------------------------------------
+ 6 files changed, 1827 deletions(-)
+ delete mode 100644 LICENCE.nvidia
+ delete mode 100644 LICENSE.amdgpu
+ delete mode 100644 LICENSE.qcom
+ delete mode 100644 LICENSE.qcom_yamato
+ delete mode 100644 LICENSE.radeon
+
+diff --git a/LICENCE.nvidia b/LICENCE.nvidia
+deleted file mode 100644
+index b99d5a3..0000000
+--- a/LICENCE.nvidia
++++ /dev/null
+@@ -1,131 +0,0 @@
+-           License For Customer Use of NVIDIA Software
+-
+-
+-IMPORTANT NOTICE -- READ CAREFULLY: This License For Customer Use of
+-NVIDIA Software ("LICENSE") is the agreement which governs use of
+-the software of NVIDIA Corporation and its subsidiaries ("NVIDIA")
+-downloadable herefrom, including computer software and associated
+-printed materials ("SOFTWARE").  By downloading, installing, copying,
+-or otherwise using the SOFTWARE, you agree to be bound by the terms
+-of this LICENSE.  If you do not agree to the terms of this LICENSE,
+-do not download the SOFTWARE.
+-
+-RECITALS
+-
+-Use of NVIDIA's products requires three elements: the SOFTWARE, the
+-hardware, and a personal computer. The SOFTWARE is protected by copyright
+-laws and international copyright treaties, as well as other intellectual
+-property laws and treaties.  The SOFTWARE may be protected by various
+-patents, and is not sold, and instead is only licensed for use, strictly
+-in accordance with this document.  The hardware is protected by various
+-patents, and is sold, but this agreement does not cover that sale, since
+-it may not necessarily be sold as a package with the SOFTWARE.  This
+-agreement sets forth the terms and conditions of the SOFTWARE LICENSE only.
+-
+-1.  DEFINITIONS
+-
+-1.1  Customer.  Customer means the entity or individual that
+-downloads or otherwise obtains the SOFTWARE.
+-
+-2.  GRANT OF LICENSE
+-
+-2.1  Rights and Limitations of Grant.  NVIDIA hereby grants Customer
+-the following non-exclusive, non-transferable right to use the
+-SOFTWARE, with the following limitations:
+-
+-2.1.1  Rights.  Customer may install and use multiple copies of the
+-SOFTWARE on a shared computer or concurrently on different computers,
+-and make multiple back-up copies of the SOFTWARE, solely for Customer's
+-use within Customer's Enterprise. "Enterprise" shall mean individual use
+-by Customer or any legal entity (such as a corporation or university)
+-and the subsidiaries it owns by more than fifty percent (50%).
+-
+-2.1.2  Open Source Exception.  Notwithstanding the foregoing terms
+-of Section 2.1.1, SOFTWARE may be copied and redistributed solely for
+-use on operating systems distributed under the terms of an OSI-approved
+-open source license as listed by the Open Source Initiative at
+-http://opensource.org, provided that the binary files thereof are not
+-modified, and Customer provides a copy of this license with the SOFTWARE.
+-
+-2.1.3  Limitations.
+-
+-No Reverse Engineering.  Customer may not reverse engineer,
+-decompile, or disassemble the SOFTWARE, nor attempt in any other
+-manner to obtain the source code.
+-
+-Usage. SOFTWARE is licensed only for use with microprocessor(s) which have
+-been (i) designed by NVIDIA and (ii) either (a) sold by or (b) licensed by
+-NVIDIA. Customer shall not use SOFTWARE in conjunction with, nor cause
+-SOFTWARE to be executed by, any other microprocessor.
+-
+-No Translation. Customer shall not translate SOFTWARE, nor cause or permit
+-SOFTWARE to be translated, from the architecture or language in which it is
+-originally provided by NVIDIA, into any other architecture or language.
+-
+-No Rental.  Customer may not rent or lease the SOFTWARE to someone
+-else.
+-
+-3.  TERMINATION
+-
+-This LICENSE will automatically terminate if Customer fails to
+-comply with any of the terms and conditions hereof.  In such event,
+-Customer must destroy all copies of the SOFTWARE and all of its
+-component parts.
+-
+-Defensive Suspension.  If Customer commences or participates in any legal
+-proceeding against NVIDIA, then NVIDIA may, in its sole discretion,
+-suspend or terminate all license grants and any other rights provided
+-under this LICENSE during the pendency of such legal proceedings.
+-
+-4.  COPYRIGHT
+-
+-All title and copyrights in and to the SOFTWARE (including but
+-not limited to all images, photographs, animations, video, audio,
+-music, text, and other information incorporated into the SOFTWARE),
+-the accompanying printed materials, and any copies of the SOFTWARE,
+-are owned by NVIDIA, or its suppliers.  The SOFTWARE is protected
+-by copyright laws and international treaty provisions.  Accordingly,
+-Customer is required to treat the SOFTWARE like any other copyrighted
+-material, except as otherwise allowed pursuant to this LICENSE
+-and that it may make one copy of the SOFTWARE solely for backup or
+-archive purposes.
+-
+-5.  APPLICABLE LAW
+-
+-This agreement shall be deemed to have been made in, and shall be
+-construed pursuant to, the laws of the State of California.
+-
+-6.  DISCLAIMER OF WARRANTIES AND LIMITATION ON LIABILITY
+-
+-6.1  No Warranties.  TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE
+-LAW, THE SOFTWARE IS PROVIDED "AS IS" AND NVIDIA AND ITS SUPPLIERS
+-DISCLAIM ALL WARRANTIES, EITHER EXPRESS OR IMPLIED, INCLUDING, BUT
+-NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE.
+-
+-6.2  No Liability for Consequential Damages.  TO THE MAXIMUM
+-EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL NVIDIA OR
+-ITS SUPPLIERS BE LIABLE FOR ANY SPECIAL, INCIDENTAL, INDIRECT, OR
+-CONSEQUENTIAL DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION,
+-DAMAGES FOR LOSS OF BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS
+-OF BUSINESS INFORMATION, OR ANY OTHER PECUNIARY LOSS) ARISING OUT
+-OF THE USE OF OR INABILITY TO USE THE SOFTWARE, EVEN IF NVIDIA HAS
+-BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+-
+-7.  MISCELLANEOUS
+-
+-The United Nations Convention on Contracts for the International
+-Sale of Goods is specifically disclaimed.  If any provision of this
+-LICENSE is inconsistent with, or cannot be fully enforced under,
+-the law, such provision will be construed as limited to the extent
+-necessary to be consistent with and fully enforceable under the law.
+-This agreement is the final, complete and exclusive agreement between
+-the parties relating to the subject matter hereof, and supersedes
+-all prior or contemporaneous understandings and agreements relating
+-to such subject matter, whether oral or written.  Customer agrees
+-that it will not ship, transfer or export the SOFTWARE into any
+-country, or use the SOFTWARE in any manner, prohibited by the
+-United States Bureau of Export Administration or any export laws,
+-restrictions or regulations.  This LICENSE may only be modified in
+-writing signed by an authorized officer of NVIDIA.
+-
+diff --git a/LICENSE.amdgpu b/LICENSE.amdgpu
+deleted file mode 100644
+index 349e207..0000000
+--- a/LICENSE.amdgpu
++++ /dev/null
+@@ -1,51 +0,0 @@
+-Copyright (C) 2023  Advanced Micro Devices, Inc. All rights reserved.
+-
+-REDISTRIBUTION: Permission is hereby granted, free of any license fees,
+-to any person obtaining a copy of this microcode (the "Software"), to
+-install, reproduce, copy and distribute copies, in binary form only, of
+-the Software and to permit persons to whom the Software is provided to
+-do the same, provided that the following conditions are met:
+-
+-No reverse engineering, decompilation, or disassembly of this Software
+-is permitted.
+-
+-Redistributions must reproduce the above copyright notice, this
+-permission notice, and the following disclaimers and notices in the
+-Software documentation and/or other materials provided with the
+-Software.
+-
+-DISCLAIMER: THE USE OF THE SOFTWARE IS AT YOUR SOLE RISK.  THE SOFTWARE
+-IS PROVIDED "AS IS" AND WITHOUT WARRANTY OF ANY KIND AND COPYRIGHT
+-HOLDER AND ITS LICENSORS EXPRESSLY DISCLAIM ALL WARRANTIES, EXPRESS AND
+-IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+-COPYRIGHT HOLDER AND ITS LICENSORS DO NOT WARRANT THAT THE SOFTWARE WILL
+-MEET YOUR REQUIREMENTS, OR THAT THE OPERATION OF THE SOFTWARE WILL BE
+-UNINTERRUPTED OR ERROR-FREE.  THE ENTIRE RISK ASSOCIATED WITH THE USE OF
+-THE SOFTWARE IS ASSUMED BY YOU.  FURTHERMORE, COPYRIGHT HOLDER AND ITS
+-LICENSORS DO NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE
+-OR THE RESULTS OF THE USE OF THE SOFTWARE IN TERMS OF ITS CORRECTNESS,
+-ACCURACY, RELIABILITY, CURRENTNESS, OR OTHERWISE.
+-
+-DISCLAIMER: UNDER NO CIRCUMSTANCES INCLUDING NEGLIGENCE, SHALL COPYRIGHT
+-HOLDER AND ITS LICENSORS OR ITS DIRECTORS, OFFICERS, EMPLOYEES OR AGENTS
+-("AUTHORIZED REPRESENTATIVES") BE LIABLE FOR ANY INCIDENTAL, INDIRECT,
+-SPECIAL OR CONSEQUENTIAL DAMAGES (INCLUDING DAMAGES FOR LOSS OF BUSINESS
+-PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, AND THE
+-LIKE) ARISING OUT OF THE USE, MISUSE OR INABILITY TO USE THE SOFTWARE,
+-BREACH OR DEFAULT, INCLUDING THOSE ARISING FROM INFRINGEMENT OR ALLEGED
+-INFRINGEMENT OF ANY PATENT, TRADEMARK, COPYRIGHT OR OTHER INTELLECTUAL
+-PROPERTY RIGHT EVEN IF COPYRIGHT HOLDER AND ITS AUTHORIZED
+-REPRESENTATIVES HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  IN
+-NO EVENT SHALL COPYRIGHT HOLDER OR ITS AUTHORIZED REPRESENTATIVES TOTAL
+-LIABILITY FOR ALL DAMAGES, LOSSES, AND CAUSES OF ACTION (WHETHER IN
+-CONTRACT, TORT (INCLUDING NEGLIGENCE) OR OTHERWISE) EXCEED THE AMOUNT OF
+-US$10.
+-
+-Notice:  The Software is subject to United States export laws and
+-regulations.  You agree to comply with all domestic and international
+-export laws and regulations that apply to the Software, including but
+-not limited to the Export Administration Regulations administered by the
+-U.S. Department of Commerce and International Traffic in Arm Regulations
+-administered by the U.S. Department of State.  These laws include
+-restrictions on destinations, end users and end use.
+diff --git a/LICENSE.qcom b/LICENSE.qcom
+deleted file mode 100644
+index faacf9c..0000000
+--- a/LICENSE.qcom
++++ /dev/null
+@@ -1,206 +0,0 @@
+-PLEASE READ THIS LICENSE AGREEMENT ("AGREEMENT") CAREFULLY.  THIS AGREEMENT IS
+-A BINDING LEGAL AGREEMENT ENTERED INTO BY AND BETWEEN YOU (OR IF YOU ARE
+-ENTERING INTO THIS AGREEMENT ON BEHALF OF AN ENTITY, THEN THE ENTITY THAT YOU
+-REPRESENT) AND QUALCOMM TECHNOLOGIES, INC. ("QTI" "WE" "OUR" OR "US").  THIS IS
+-THE AGREEMENT THAT APPLIES TO YOUR USE OF THE DESIGNATED AND/OR LINKED
+-APPLICATIONS, THE ENCLOSED QUALCOMM TECHNOLOGIES' MATERIALS, INCLUDING RELATED
+-DOCUMENTATION AND ANY UPDATES OR IMPROVEMENTS THEREOF
+-(COLLECTIVELY, "MATERIALS").  BY USING OR COMPLETING THE INSTALLATION OF THE
+-MATERIALS, YOU ARE ACCEPTING THIS AGREEMENT AND YOU AGREE TO BE BOUND BY ITS
+-TERMS AND CONDITIONS.  IF YOU DO NOT AGREE TO THESE TERMS, QTI IS UNWILLING TO
+-AND DOES NOT LICENSE THE MATERIALS TO YOU. IF YOU DO NOT AGREE TO THESE TERMS
+-YOU MUST DISCONTINUE THE INSTALLATION PROCESS AND YOU MAY NOT USE THE MATERIALS
+-OR RETAIN ANY COPIES OF THE MATERIALS. ANY USE OR POSSESSION OF THE MATERIALS
+-BY YOU IS SUBJECT TO THE TERMS AND CONDITIONS SET FORTH IN THIS AGREEMENT.
+-
+-1. RIGHT TO USE DELIVERABLES; RESTRICTIONS.
+-
+-  1.1 License.  Subject to the terms and conditions of this Agreement,
+-  including, without limitation, the restrictions, conditions, limitations and
+-  exclusions set forth in this Agreement, QTI hereby grants to you a
+-  nonexclusive, limited license under QTI's copyrights to:  (i) install and use
+-  the Materials; and (ii) to reproduce and redistribute the binary code portions
+-  of the Materials (the "Redistributable Binary Code").  You may make and use a
+-  reasonable number of copies of any documentation.
+-
+-  1.2 Redistribution Restrictions.  Distribution of the Redistributable Binary
+-  Code is subject to the following restrictions: (i) Redistributable Binary Code
+-  may only be distributed in binary format and may not be distributed in source
+-  code format:; (ii)  the Redistributable Binary Code may only operate in
+-  conjunction with platforms incorporating Qualcomm Technologies, Inc. chipsets;
+-  (iii) redistribution of the Redistributable Binary Code must include the .txt
+-  file setting forth the terms and condition of this Agreement; (iv) you may not
+-  use Qualcomm Technologies' or its affiliates or subsidiaries name, logo or
+-  trademarks; and (v) copyright, trademark, patent and any other notices that
+-  appear on the Materials may not be removed or obscured.
+-
+-  1.3 Additional Restrictions.  Except as expressly permitted by this Agreement,
+-  you shall have no right to sublicense, transfer or otherwise disclose the
+-  Materials to any third party.  You shall not reverse engineer, reverse
+-  assemble, reverse translate, decompile or reduce to source code form any
+-  portion of the Materials provided in object code form or executable form.
+-  Except for the purposes expressly permitted in this Agreement, You shall not
+-  use the Materials for any other purpose.  QTI (or its licensors) shall retain
+-  title and all ownership rights in and to the Materials and any alterations,
+-  modifications (including all derivative works), translations or adaptations
+-  made of the Materials, and all copies thereof, and nothing herein shall be
+-  deemed to grant any right to You under any of QTI's or its affiliates'
+-  patents.  You shall not subject the Materials to any third party license
+-  terms (e.g., open source license terms).  You shall not use the Materials for
+-  the purpose of identifying or providing evidence to support any potential
+-  patent infringement claim against QTI, its affiliates, or any of QTI's or
+-  QTI's affiliates' suppliers and/or direct or indirect customers.  QTI hereby
+-  reserves all rights not expressly granted herein.
+-
+-  1.4 Third Party Software and Materials.  The Software may contain or link to
+-  certain software and/or materials that are written or owned by third parties.
+-  Such third party code and materials may be licensed under separate or
+-  different terms and conditions and are not licensed to you under the terms of
+-  this Agreement.  You agree to comply with all terms and conditions imposed on
+-  you in the applicable third party licenses.  Such terms and conditions may
+-  impose certain obligations on you as a condition to the permitted use of such
+-  third party code and materials.  QTI does not represent or warrant that such
+-  third party licensors have or will continue to license or make available their
+-  code and materials to you.
+-
+-  1.5 Feedback.  QTI may from time to time receive suggestions, feedback or
+-  other information from You regarding the Materials.  Any suggestions, feedback
+-  or other disclosures received from You are and shall be entirely voluntary on
+-  the part of You.  Notwithstanding any other term in this Agreement, QTI shall
+-  be free to use suggestions, feedback or other information received from You,
+-  without obligation of any kind to You.  The Parties agree that all inventions,
+-  product improvements, and modifications conceived of or made by QTI that are
+-  based, either in whole or in part, on ideas, feedback, suggestions, or
+-  recommended improvements received from You are the exclusive property of QTI,
+-  and all right, title and interest in and to any such inventions, product
+-  improvements, and modifications will vest solely in QTI.
+-
+-  1.6 No Technical Support.  QTI is under no obligation to provide any form of
+-  technical support for the Materials, and if QTI, in its sole discretion,
+-  chooses to provide any form of support or information relating to the
+-  Materials, such support and information shall be deemed confidential and
+-  proprietary to QTI.
+-
+-2. WARRANTY DISCLAIMER.  YOU EXPRESSLY ACKNOWLEDGE AND AGREE THAT THE USE OF
+-THE MATERIALS IS AT YOUR SOLE RISK.  THE MATERIALS AND TECHNICAL SUPPORT, IF
+-ANY, ARE PROVIDED "AS IS" AND WITHOUT WARRANTY OF ANY KIND, WHETHER EXPRESS OR
+-IMPLIED.  QTI ITS LICENSORS AND AFFILIATES MAKE NO WARRANTIES, EXPRESS OR
+-IMPLIED, WITH RESPECT TO THE MATERIALS OR ANY OTHER INFORMATION OR DOCUMENTATION
+-PROVIDED UNDER THIS AGREEMENT, INCLUDING BUT NOT LIMITED TO ANY WARRANTY OF
+-MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE OR AGAINST INFRINGEMENT, OR
+-ANY EXPRESS OR IMPLIED WARRANTY ARISING OUT OF TRADE USAGE OR OUT OF A COURSE OF
+-DEALING OR COURSE OF PERFORMANCE.  NOTHING CONTAINED IN THIS AGREEMENT SHALL BE
+-CONSTRUED AS (I) A WARRANTY OR REPRESENTATION BY QTI, ITS LICENSORS OR
+-AFFILIATES AS TO THE VALIDITY OR SCOPE OF ANY PATENT, COPYRIGHT OR OTHER
+-INTELLECTUAL PROPERTY RIGHT OR (II) A WARRANTY OR REPRESENTATION BY QTI THAT ANY
+-MANUFACTURE OR USE WILL BE FREE FROM INFRINGEMENT OF PATENTS, COPYRIGHTS OR
+-OTHER INTELLECTUAL PROPERTY RIGHTS OF OTHERS, AND IT SHALL BE THE SOLE
+-RESPONSIBILITY OF YOU TO MAKE SUCH DETERMINATION AS IS NECESSARY WITH RESPECT TO
+-THE ACQUISITION OF LICENSES UNDER PATENTS AND OTHER INTELLECTUAL PROPERTY OF
+-THIRD PARTIES.
+-
+-3. NO OTHER LICENSES OR INTELLECTUAL PROPERTY RIGHTS. Neither this Agreement,
+-nor any act by QTI or any of its affiliates pursuant to this Agreement or
+-relating to the Materials (including, without limitation, the provision by QTI
+-or its affiliates of the Materials), shall provide to You any license or any
+-other rights whatsoever under any patents, trademarks, trade secrets, copyrights
+-or any other intellectual property of QTI or any of its affiliates, except for
+-the copyright rights expressly licensed under this Agreement. You understand and
+-agree that:
+-
+-  (i) Neither this Agreement, nor delivery of the Materials, grants any right to
+-  practice, or any other right at all with respect to, any patent of QTI or any
+-  of its affiliates; and
+-
+-  (ii) A separate license agreement from QUALCOMM Incorporated is needed to use
+-  or practice any patent of QUALCOMM Incorporated. You agree not to contend in
+-  any context that, as a result of the provision or use of the Materials, either
+-  QTI or any of its affiliates has any obligation to extend, or You or any other
+-  party has obtained any right to, any license, whether express or implied, with
+-  respect to any patent of QTI or any of its affiliates for any purpose.
+-
+-4. TERMINATION.  This Agreement shall be effective upon acceptance, or access or
+-use of the Materials (whichever occurs first) by You and shall continue until
+-terminated. You may terminate the Agreement at any time by deleting and
+-destroying all copies of the Materials and all related information in Your
+-possession or control. This Agreement terminates immediately and automatically,
+-with or without notice, if You fail to comply with any provision hereof.
+-Additionally, QTI may at any time terminate this Agreement, without cause, upon
+-notice to You. Upon termination You must, to the extent possible, delete or
+-destroy all copies of the Materials in Your possession and the license granted
+-to You in this Agreement shall terminate. Sections 1.2 through 10 shall survive
+-the termination of this Agreement. In the event that any restrictions,
+-conditions, limitations are found to be either invalid or unenforceable, the
+-rights granted to You in Section 1 (License) shall be null, void and ineffective
+-from the Effective Date, and QTI shall also have the right to terminate this
+-Agreement immediately, and with retroactive effect to the effective date.
+-
+-5. LIMITATION OF LIABILITY.  IN NO EVENT SHALL QTI, QTI's AFFILIATES OR ITS
+-LICENSORS BE LIABLE TO YOU FOR ANY INCIDENTAL, CONSEQUENTIAL OR SPECIAL DAMAGES,
+-INCLUDING BUT NOT LIMITED TO ANY LOST PROFITS, LOST SAVINGS, OR OTHER INCIDENTAL
+-DAMAGES, ARISING OUT OF THE USE OR INABILITY TO USE, OR THE DELIVERY OR FAILURE
+-TO DELIVER, ANY OF THE DELIVERABLES, OR ANY BREACH OF ANY OBLIGATION UNDER THIS
+-AGREEMENT, EVEN IF QTI HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+-THE FOREGOING LIMITATION OF LIABILITY SHALL REMAIN IN FULL FORCE AND EFFECT
+-REGARDLESS OF WHETHER YOUR REMEDIES HEREUNDER ARE DETERMINED TO HAVE FAILED OF
+-THEIR ESSENTIAL PURPOSE.  THE ENTIRE LIABILITY OF QTI, QTI's AFFILIATES AND ITS
+-LICENSORS, AND THE SOLE AND EXCLUSIVE REMEDY OF YOU, FOR ANY CLAIM OR CAUSE OF
+-ACTION ARISING HEREUNDER (WHETHER IN CONTRACT, TORT, OR OTHERWISE) SHALL NOT
+-EXCEED US$50.
+-
+-6. INDEMNIFICATION.  You agree to indemnify and hold harmless QTI and its
+-officers, directors, employees and successors and assigns against any and all
+-third party claims, demands, causes of action, losses, liabilities, damages,
+-costs and expenses, incurred by QTI (including but not limited to costs of
+-defense, investigation and reasonable attorney's fees) arising out of, resulting
+-from or related to: (i) any breach of this Agreement by You; and (ii) your acts,
+-omissions, products and services.  If requested by QTI, You agree to defend QTI
+-in connection with any third party claims, demands, or causes of action
+-resulting from, arising out of or in connection with any of the foregoing.
+-
+-7. ASSIGNMENT.  You shall not assign this Agreement or any right or interest
+-under this Agreement, nor delegate any obligation to be performed under this
+-Agreement, without QTI's prior written consent.  For purposes of this Section 7,
+-an "assignment" by You under this Section shall be deemed to include, without
+-limitation, any merger, consolidation, sale of all or substantially all of its
+-assets, or any substantial change in the management or control of You.
+-Any attempted assignment in contravention of this Section 9 shall be void.
+-QTI may freely assign this Agreement or delegate any or all of its rights and
+-obligations hereunder to any third party.
+-
+-8. COMPLIANCE WITH LAWS; APPLICABLE LAW.  You agree to comply with all
+-applicable local, international and national laws and regulations and with U.S.
+-Export Administration Regulations, as they apply to the subject matter of this
+-Agreement.  This Agreement is governed by the laws of the State of California,
+-excluding California's choice of law rules.
+-
+-9. CONTRACTING PARTIES.  If the Materials are downloaded on any computer owned
+-by a corporation or other legal entity, then this Agreement is formed by and
+-between QTI and such entity.  The individual accepting the terms of this
+-Agreement represents and warrants to QTI that they have the authority to bind
+-such entity to the terms and conditions of this Agreement.
+-
+-10. MISCELLANEOUS PROVISIONS.  This Agreement, together with all exhibits
+-attached hereto, which are incorporated herein by this reference, constitutes
+-the entire agreement between QTI and You and supersedes all prior negotiations,
+-representations and agreements between the parties with respect to the subject
+-matter hereof.  No addition or modification of this Agreement shall be effective
+-unless made in writing and signed by the respective representatives of QTI and
+-You.  The restrictions, limitations, exclusions and conditions set forth in this
+-Agreement shall apply even if QTI or any of its affiliates becomes aware of or
+-fails to act in a manner to address any violation or failure to comply
+-therewith.  You hereby acknowledge and agree that the restrictions, limitations,
+-conditions and exclusions imposed in this Agreement on the rights granted in
+-this Agreement are not a derogation of the benefits of such rights.  You further
+-acknowledges that, in the absence of such restrictions, limitations, conditions
+-and exclusions, QTI would not have entered into this Agreement with You.  Each
+-party shall be responsible for and shall bear its own expenses in connection
+-with this Agreement.  If any of the provisions of this Agreement are determined
+-to be invalid, illegal, or otherwise unenforceable, the remaining provisions
+-shall remain in full force and effect.  This Agreement is entered into solely
+-in the English language, and if for any reason any other language version is
+-prepared by any party, it shall be solely for convenience and the English
+-version shall govern and control all aspects.  If You are located in the
+-province of Quebec, Canada, the following applies: The Parties hereby confirm
+-they have requested this Agreement and all related documents be prepared
+-in English.
+diff --git a/LICENSE.qcom_yamato b/LICENSE.qcom_yamato
+deleted file mode 100644
+index 1fd702b..0000000
+--- a/LICENSE.qcom_yamato
++++ /dev/null
+@@ -1,25 +0,0 @@
+-Copyright (c) 2008-2011, QUALCOMM Incorporated. All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-    * Redistributions of source code must retain the above copyright
+-      notice, this list of conditions and the following disclaimer.
+-    * Redistributions in binary form must reproduce the above copyright
+-      notice, this list of conditions and the following disclaimer in the
+-      documentation and/or other materials provided with the distribution.
+-    * Neither the name of QUALCOMM Incorporated nor
+-      the names of its contributors may be used to endorse or promote
+-      products derived from this software without specific prior written
+-      permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-POSSIBILITY OF SUCH DAMAGE.
+diff --git a/LICENSE.radeon b/LICENSE.radeon
+deleted file mode 100644
+index b05e714..0000000
+--- a/LICENSE.radeon
++++ /dev/null
+@@ -1,51 +0,0 @@
+-Copyright (C) 2009-2017  Advanced Micro Devices, Inc. All rights reserved.
+-
+-REDISTRIBUTION: Permission is hereby granted, free of any license fees,
+-to any person obtaining a copy of this microcode (the "Software"), to
+-install, reproduce, copy and distribute copies, in binary form only, of
+-the Software and to permit persons to whom the Software is provided to
+-do the same, provided that the following conditions are met:
+-
+-No reverse engineering, decompilation, or disassembly of this Software
+-is permitted.
+-
+-Redistributions must reproduce the above copyright notice, this
+-permission notice, and the following disclaimers and notices in the
+-Software documentation and/or other materials provided with the
+-Software.
+-
+-DISCLAIMER: THE USE OF THE SOFTWARE IS AT YOUR SOLE RISK.  THE SOFTWARE
+-IS PROVIDED "AS IS" AND WITHOUT WARRANTY OF ANY KIND AND COPYRIGHT
+-HOLDER AND ITS LICENSORS EXPRESSLY DISCLAIM ALL WARRANTIES, EXPRESS AND
+-IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+-COPYRIGHT HOLDER AND ITS LICENSORS DO NOT WARRANT THAT THE SOFTWARE WILL
+-MEET YOUR REQUIREMENTS, OR THAT THE OPERATION OF THE SOFTWARE WILL BE
+-UNINTERRUPTED OR ERROR-FREE.  THE ENTIRE RISK ASSOCIATED WITH THE USE OF
+-THE SOFTWARE IS ASSUMED BY YOU.  FURTHERMORE, COPYRIGHT HOLDER AND ITS
+-LICENSORS DO NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE
+-OR THE RESULTS OF THE USE OF THE SOFTWARE IN TERMS OF ITS CORRECTNESS,
+-ACCURACY, RELIABILITY, CURRENTNESS, OR OTHERWISE.
+-
+-DISCLAIMER: UNDER NO CIRCUMSTANCES INCLUDING NEGLIGENCE, SHALL COPYRIGHT
+-HOLDER AND ITS LICENSORS OR ITS DIRECTORS, OFFICERS, EMPLOYEES OR AGENTS
+-("AUTHORIZED REPRESENTATIVES") BE LIABLE FOR ANY INCIDENTAL, INDIRECT,
+-SPECIAL OR CONSEQUENTIAL DAMAGES (INCLUDING DAMAGES FOR LOSS OF BUSINESS
+-PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, AND THE
+-LIKE) ARISING OUT OF THE USE, MISUSE OR INABILITY TO USE THE SOFTWARE,
+-BREACH OR DEFAULT, INCLUDING THOSE ARISING FROM INFRINGEMENT OR ALLEGED
+-INFRINGEMENT OF ANY PATENT, TRADEMARK, COPYRIGHT OR OTHER INTELLECTUAL
+-PROPERTY RIGHT EVEN IF COPYRIGHT HOLDER AND ITS AUTHORIZED
+-REPRESENTATIVES HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  IN
+-NO EVENT SHALL COPYRIGHT HOLDER OR ITS AUTHORIZED REPRESENTATIVES TOTAL
+-LIABILITY FOR ALL DAMAGES, LOSSES, AND CAUSES OF ACTION (WHETHER IN
+-CONTRACT, TORT (INCLUDING NEGLIGENCE) OR OTHERWISE) EXCEED THE AMOUNT OF
+-US$10.
+-
+-Notice:  The Software is subject to United States export laws and
+-regulations.  You agree to comply with all domestic and international
+-export laws and regulations that apply to the Software, including but
+-not limited to the Export Administration Regulations administered by the
+-U.S. Department of Commerce and International Traffic in Arm Regulations
+-administered by the U.S. Department of State.  These laws include
+-restrictions on destinations, end users and end use.
+diff --git a/WHENCE b/WHENCE
+index 58e9ca1..3bb6523 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -123,904 +123,6 @@ Available from http://ldriver.qlogic.com/firmware/netxen_nic/new/
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: mga - Matrox G200/G400/G550
+-
+-File: matrox/g200_warp.fw
+-File: matrox/g400_warp.fw
+-
+-Licence:
+-
+-Copyright 1999 Matrox Graphics Inc.
+-All Rights Reserved.
+-
+-Permission is hereby granted, free of charge, to any person obtaining a
+-copy of this software and associated documentation files (the "Software"),
+-to deal in the Software without restriction, including without limitation
+-the rights to use, copy, modify, merge, publish, distribute, sublicense,
+-and/or sell copies of the Software, and to permit persons to whom the
+-Software is furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included
+-in all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+-MATROX GRAPHICS INC., OR ANY OTHER CONTRIBUTORS BE LIABLE FOR ANY CLAIM,
+-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+-OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: r128 - ATI Rage 128
+-
+-File: r128/r128_cce.bin
+-
+-Licence:
+-
+-Copyright 2000 Advanced Micro Devices, Inc.
+-
+- * Permission is hereby granted, free of charge, to any person obtaining a
+- * copy of this software and associated documentation files (the "Software"),
+- * to deal in the Software without restriction, including without limitation
+- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+- * and/or sell copies of the Software, and to permit persons to whom the
+- * Software is furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice (including the next
+- * paragraph) shall be included in all copies or substantial portions of the
+- * Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+- * PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+- * DEALINGS IN THE SOFTWARE.
+-
+-Found in decimal form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: radeon - ATI Radeon
+-
+-File: radeon/R100_cp.bin
+-File: radeon/R200_cp.bin
+-File: radeon/R300_cp.bin
+-File: radeon/R420_cp.bin
+-File: radeon/RS600_cp.bin
+-File: radeon/RS690_cp.bin
+-File: radeon/R520_cp.bin
+-File: radeon/R600_pfp.bin
+-File: radeon/R600_me.bin
+-File: radeon/RV610_pfp.bin
+-File: radeon/RV610_me.bin
+-File: radeon/RV630_pfp.bin
+-File: radeon/RV630_me.bin
+-File: radeon/RV620_pfp.bin
+-File: radeon/RV620_me.bin
+-File: radeon/RV635_pfp.bin
+-File: radeon/RV635_me.bin
+-File: radeon/RV670_pfp.bin
+-File: radeon/RV670_me.bin
+-File: radeon/RS780_pfp.bin
+-File: radeon/RS780_me.bin
+-File: radeon/RV770_pfp.bin
+-File: radeon/RV770_me.bin
+-File: radeon/RV730_pfp.bin
+-File: radeon/RV730_me.bin
+-File: radeon/RV710_pfp.bin
+-File: radeon/RV710_me.bin
+-
+-Licence:
+-
+- * Copyright 2007-2009 Advanced Micro Devices, Inc.
+- * All Rights Reserved.
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a
+- * copy of this software and associated documentation files (the "Software"),
+- * to deal in the Software without restriction, including without limitation
+- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+- * and/or sell copies of the Software, and to permit persons to whom the
+- * Software is furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice (including the next
+- * paragraph) shall be included in all copies or substantial portions of the
+- * Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+- * IN NO EVENT SHALL THE COPYRIGHT OWNER(S) AND/OR ITS SUPPLIERS BE
+- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+- * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+-Driver: radeon - ATI Radeon
+-
+-File: radeon/R600_rlc.bin
+-File: radeon/R600_uvd.bin
+-File: radeon/RS780_uvd.bin
+-File: radeon/R700_rlc.bin
+-File: radeon/RV710_uvd.bin
+-File: radeon/RV710_smc.bin
+-File: radeon/RV730_smc.bin
+-File: radeon/RV740_smc.bin
+-File: radeon/RV770_smc.bin
+-File: radeon/RV770_uvd.bin
+-File: radeon/CEDAR_me.bin
+-File: radeon/CEDAR_pfp.bin
+-File: radeon/CEDAR_rlc.bin
+-File: radeon/CEDAR_smc.bin
+-File: radeon/CYPRESS_me.bin
+-File: radeon/CYPRESS_pfp.bin
+-File: radeon/CYPRESS_rlc.bin
+-File: radeon/CYPRESS_uvd.bin
+-File: radeon/CYPRESS_smc.bin
+-File: radeon/JUNIPER_me.bin
+-File: radeon/JUNIPER_pfp.bin
+-File: radeon/JUNIPER_rlc.bin
+-File: radeon/JUNIPER_smc.bin
+-File: radeon/REDWOOD_me.bin
+-File: radeon/REDWOOD_pfp.bin
+-File: radeon/REDWOOD_rlc.bin
+-File: radeon/REDWOOD_smc.bin
+-File: radeon/PALM_me.bin
+-File: radeon/PALM_pfp.bin
+-File: radeon/SUMO_rlc.bin
+-File: radeon/SUMO_uvd.bin
+-File: radeon/BARTS_mc.bin
+-File: radeon/BARTS_me.bin
+-File: radeon/BARTS_pfp.bin
+-File: radeon/BARTS_smc.bin
+-File: radeon/BTC_rlc.bin
+-File: radeon/CAICOS_mc.bin
+-File: radeon/CAICOS_me.bin
+-File: radeon/CAICOS_pfp.bin
+-File: radeon/CAICOS_smc.bin
+-File: radeon/TURKS_mc.bin
+-File: radeon/TURKS_me.bin
+-File: radeon/TURKS_pfp.bin
+-File: radeon/TURKS_smc.bin
+-File: radeon/CAYMAN_mc.bin
+-File: radeon/CAYMAN_me.bin
+-File: radeon/CAYMAN_pfp.bin
+-File: radeon/CAYMAN_rlc.bin
+-File: radeon/CAYMAN_smc.bin
+-File: radeon/SUMO_pfp.bin
+-File: radeon/SUMO_me.bin
+-File: radeon/SUMO2_pfp.bin
+-File: radeon/SUMO2_me.bin
+-File: radeon/ARUBA_me.bin
+-File: radeon/ARUBA_pfp.bin
+-File: radeon/ARUBA_rlc.bin
+-File: radeon/PITCAIRN_ce.bin
+-File: radeon/PITCAIRN_mc.bin
+-File: radeon/PITCAIRN_mc2.bin
+-File: radeon/PITCAIRN_me.bin
+-File: radeon/PITCAIRN_pfp.bin
+-File: radeon/PITCAIRN_rlc.bin
+-File: radeon/PITCAIRN_smc.bin
+-File: radeon/TAHITI_ce.bin
+-File: radeon/TAHITI_mc.bin
+-File: radeon/TAHITI_mc2.bin
+-File: radeon/TAHITI_me.bin
+-File: radeon/TAHITI_pfp.bin
+-File: radeon/TAHITI_rlc.bin
+-File: radeon/TAHITI_uvd.bin
+-File: radeon/TAHITI_smc.bin
+-File: radeon/TAHITI_vce.bin
+-File: radeon/VERDE_ce.bin
+-File: radeon/VERDE_mc.bin
+-File: radeon/VERDE_mc2.bin
+-File: radeon/VERDE_me.bin
+-File: radeon/VERDE_pfp.bin
+-File: radeon/VERDE_rlc.bin
+-File: radeon/VERDE_smc.bin
+-File: radeon/OLAND_ce.bin
+-File: radeon/OLAND_mc.bin
+-File: radeon/OLAND_mc2.bin
+-File: radeon/OLAND_me.bin
+-File: radeon/OLAND_pfp.bin
+-File: radeon/OLAND_rlc.bin
+-File: radeon/OLAND_smc.bin
+-File: radeon/HAINAN_ce.bin
+-File: radeon/HAINAN_mc.bin
+-File: radeon/HAINAN_mc2.bin
+-File: radeon/HAINAN_me.bin
+-File: radeon/HAINAN_pfp.bin
+-File: radeon/HAINAN_rlc.bin
+-File: radeon/HAINAN_smc.bin
+-File: radeon/BONAIRE_ce.bin
+-File: radeon/BONAIRE_mc.bin
+-File: radeon/BONAIRE_mc2.bin
+-File: radeon/BONAIRE_me.bin
+-File: radeon/BONAIRE_mec.bin
+-File: radeon/BONAIRE_pfp.bin
+-File: radeon/BONAIRE_rlc.bin
+-File: radeon/BONAIRE_sdma.bin
+-File: radeon/BONAIRE_uvd.bin
+-File: radeon/BONAIRE_smc.bin
+-File: radeon/BONAIRE_vce.bin
+-File: radeon/KABINI_ce.bin
+-File: radeon/KABINI_me.bin
+-File: radeon/KABINI_mec.bin
+-File: radeon/KABINI_pfp.bin
+-File: radeon/KABINI_rlc.bin
+-File: radeon/KABINI_sdma.bin
+-File: radeon/KAVERI_ce.bin
+-File: radeon/KAVERI_me.bin
+-File: radeon/KAVERI_mec.bin
+-File: radeon/KAVERI_pfp.bin
+-File: radeon/KAVERI_rlc.bin
+-File: radeon/KAVERI_sdma.bin
+-File: radeon/HAWAII_ce.bin
+-File: radeon/HAWAII_mc.bin
+-File: radeon/HAWAII_mc2.bin
+-File: radeon/HAWAII_me.bin
+-File: radeon/HAWAII_mec.bin
+-File: radeon/HAWAII_pfp.bin
+-File: radeon/HAWAII_rlc.bin
+-File: radeon/HAWAII_sdma.bin
+-File: radeon/HAWAII_smc.bin
+-File: radeon/MULLINS_ce.bin
+-File: radeon/MULLINS_me.bin
+-File: radeon/MULLINS_mec.bin
+-File: radeon/MULLINS_pfp.bin
+-File: radeon/MULLINS_rlc.bin
+-File: radeon/MULLINS_sdma.bin
+-File: radeon/pitcairn_ce.bin
+-File: radeon/pitcairn_k_smc.bin
+-File: radeon/pitcairn_mc.bin
+-File: radeon/pitcairn_me.bin
+-File: radeon/pitcairn_pfp.bin
+-File: radeon/pitcairn_rlc.bin
+-File: radeon/pitcairn_smc.bin
+-File: radeon/tahiti_ce.bin
+-File: radeon/tahiti_k_smc.bin
+-File: radeon/tahiti_mc.bin
+-File: radeon/tahiti_me.bin
+-File: radeon/tahiti_pfp.bin
+-File: radeon/tahiti_rlc.bin
+-File: radeon/tahiti_smc.bin
+-File: radeon/verde_ce.bin
+-File: radeon/verde_k_smc.bin
+-File: radeon/verde_mc.bin
+-File: radeon/verde_me.bin
+-File: radeon/verde_pfp.bin
+-File: radeon/verde_rlc.bin
+-File: radeon/verde_smc.bin
+-File: radeon/oland_ce.bin
+-File: radeon/oland_k_smc.bin
+-File: radeon/oland_mc.bin
+-File: radeon/oland_me.bin
+-File: radeon/oland_pfp.bin
+-File: radeon/oland_rlc.bin
+-File: radeon/oland_smc.bin
+-File: radeon/hainan_ce.bin
+-File: radeon/hainan_k_smc.bin
+-File: radeon/hainan_mc.bin
+-File: radeon/hainan_me.bin
+-File: radeon/hainan_pfp.bin
+-File: radeon/hainan_rlc.bin
+-File: radeon/hainan_smc.bin
+-File: radeon/bonaire_ce.bin
+-File: radeon/bonaire_k_smc.bin
+-File: radeon/bonaire_mc.bin
+-File: radeon/bonaire_me.bin
+-File: radeon/bonaire_mec.bin
+-File: radeon/bonaire_pfp.bin
+-File: radeon/bonaire_rlc.bin
+-File: radeon/bonaire_sdma.bin
+-File: radeon/bonaire_sdma1.bin
+-File: radeon/bonaire_smc.bin
+-File: radeon/bonaire_uvd.bin
+-File: radeon/bonaire_vce.bin
+-File: radeon/kabini_ce.bin
+-File: radeon/kabini_me.bin
+-File: radeon/kabini_mec.bin
+-File: radeon/kabini_pfp.bin
+-File: radeon/kabini_rlc.bin
+-File: radeon/kabini_sdma.bin
+-File: radeon/kabini_sdma1.bin
+-File: radeon/kabini_uvd.bin
+-File: radeon/kabini_vce.bin
+-File: radeon/kaveri_ce.bin
+-File: radeon/kaveri_me.bin
+-File: radeon/kaveri_mec.bin
+-File: radeon/kaveri_mec2.bin
+-File: radeon/kaveri_pfp.bin
+-File: radeon/kaveri_rlc.bin
+-File: radeon/kaveri_sdma.bin
+-File: radeon/kaveri_sdma1.bin
+-File: radeon/kaveri_uvd.bin
+-File: radeon/kaveri_vce.bin
+-File: radeon/hawaii_ce.bin
+-File: radeon/hawaii_k_smc.bin
+-File: radeon/hawaii_mc.bin
+-File: radeon/hawaii_me.bin
+-File: radeon/hawaii_mec.bin
+-File: radeon/hawaii_pfp.bin
+-File: radeon/hawaii_rlc.bin
+-File: radeon/hawaii_sdma.bin
+-File: radeon/hawaii_sdma1.bin
+-File: radeon/hawaii_smc.bin
+-File: radeon/hawaii_uvd.bin
+-File: radeon/hawaii_vce.bin
+-File: radeon/mullins_ce.bin
+-File: radeon/mullins_me.bin
+-File: radeon/mullins_mec.bin
+-File: radeon/mullins_pfp.bin
+-File: radeon/mullins_rlc.bin
+-File: radeon/mullins_sdma.bin
+-File: radeon/mullins_sdma1.bin
+-File: radeon/mullins_uvd.bin
+-File: radeon/mullins_vce.bin
+-File: radeon/banks_k_2_smc.bin
+-File: radeon/si58_mc.bin
+-
+-Licence: Redistributable. See LICENSE.radeon for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: amdgpu - AMD Radeon
+-
+-File: amdgpu/tahiti_ce.bin
+-File: amdgpu/tahiti_k_smc.bin
+-File: amdgpu/tahiti_mc.bin
+-File: amdgpu/tahiti_me.bin
+-File: amdgpu/tahiti_pfp.bin
+-File: amdgpu/tahiti_rlc.bin
+-File: amdgpu/tahiti_smc.bin
+-File: amdgpu/tahiti_uvd.bin
+-File: amdgpu/pitcairn_ce.bin
+-File: amdgpu/pitcairn_k_smc.bin
+-File: amdgpu/pitcairn_mc.bin
+-File: amdgpu/pitcairn_me.bin
+-File: amdgpu/pitcairn_pfp.bin
+-File: amdgpu/pitcairn_rlc.bin
+-File: amdgpu/pitcairn_smc.bin
+-File: amdgpu/pitcairn_uvd.bin
+-File: amdgpu/verde_ce.bin
+-File: amdgpu/verde_k_smc.bin
+-File: amdgpu/verde_mc.bin
+-File: amdgpu/verde_me.bin
+-File: amdgpu/verde_pfp.bin
+-File: amdgpu/verde_rlc.bin
+-File: amdgpu/verde_smc.bin
+-File: amdgpu/verde_uvd.bin
+-File: amdgpu/hainan_ce.bin
+-File: amdgpu/hainan_k_smc.bin
+-File: amdgpu/hainan_mc.bin
+-File: amdgpu/hainan_me.bin
+-File: amdgpu/hainan_pfp.bin
+-File: amdgpu/hainan_rlc.bin
+-File: amdgpu/hainan_smc.bin
+-File: amdgpu/oland_ce.bin
+-File: amdgpu/oland_k_smc.bin
+-File: amdgpu/oland_mc.bin
+-File: amdgpu/oland_me.bin
+-File: amdgpu/oland_pfp.bin
+-File: amdgpu/oland_rlc.bin
+-File: amdgpu/oland_smc.bin
+-File: amdgpu/oland_uvd.bin
+-File: amdgpu/si58_mc.bin
+-File: amdgpu/banks_k_2_smc.bin
+-File: amdgpu/bonaire_ce.bin
+-File: amdgpu/bonaire_k_smc.bin
+-File: amdgpu/bonaire_mc.bin
+-File: amdgpu/bonaire_me.bin
+-File: amdgpu/bonaire_mec.bin
+-File: amdgpu/bonaire_pfp.bin
+-File: amdgpu/bonaire_rlc.bin
+-File: amdgpu/bonaire_sdma.bin
+-File: amdgpu/bonaire_sdma1.bin
+-File: amdgpu/bonaire_smc.bin
+-File: amdgpu/bonaire_uvd.bin
+-File: amdgpu/bonaire_vce.bin
+-File: amdgpu/hawaii_ce.bin
+-File: amdgpu/hawaii_k_smc.bin
+-File: amdgpu/hawaii_mc.bin
+-File: amdgpu/hawaii_me.bin
+-File: amdgpu/hawaii_mec.bin
+-File: amdgpu/hawaii_pfp.bin
+-File: amdgpu/hawaii_rlc.bin
+-File: amdgpu/hawaii_sdma.bin
+-File: amdgpu/hawaii_sdma1.bin
+-File: amdgpu/hawaii_smc.bin
+-File: amdgpu/hawaii_uvd.bin
+-File: amdgpu/hawaii_vce.bin
+-File: amdgpu/kabini_ce.bin
+-File: amdgpu/kabini_me.bin
+-File: amdgpu/kabini_mec.bin
+-File: amdgpu/kabini_pfp.bin
+-File: amdgpu/kabini_rlc.bin
+-File: amdgpu/kabini_sdma.bin
+-File: amdgpu/kabini_sdma1.bin
+-File: amdgpu/kabini_uvd.bin
+-File: amdgpu/kabini_vce.bin
+-File: amdgpu/mullins_ce.bin
+-File: amdgpu/mullins_me.bin
+-File: amdgpu/mullins_mec.bin
+-File: amdgpu/mullins_pfp.bin
+-File: amdgpu/mullins_rlc.bin
+-File: amdgpu/mullins_sdma.bin
+-File: amdgpu/mullins_sdma1.bin
+-File: amdgpu/mullins_uvd.bin
+-File: amdgpu/mullins_vce.bin
+-File: amdgpu/kaveri_ce.bin
+-File: amdgpu/kaveri_me.bin
+-File: amdgpu/kaveri_mec.bin
+-File: amdgpu/kaveri_mec2.bin
+-File: amdgpu/kaveri_pfp.bin
+-File: amdgpu/kaveri_rlc.bin
+-File: amdgpu/kaveri_sdma.bin
+-File: amdgpu/kaveri_sdma1.bin
+-File: amdgpu/kaveri_uvd.bin
+-File: amdgpu/kaveri_vce.bin
+-File: amdgpu/topaz_ce.bin
+-File: amdgpu/topaz_k_smc.bin
+-File: amdgpu/topaz_mc.bin
+-File: amdgpu/topaz_me.bin
+-File: amdgpu/topaz_mec2.bin
+-File: amdgpu/topaz_mec.bin
+-File: amdgpu/topaz_pfp.bin
+-File: amdgpu/topaz_rlc.bin
+-File: amdgpu/topaz_sdma1.bin
+-File: amdgpu/topaz_sdma.bin
+-File: amdgpu/topaz_smc.bin
+-File: amdgpu/tonga_ce.bin
+-File: amdgpu/tonga_k_smc.bin
+-File: amdgpu/tonga_mc.bin
+-File: amdgpu/tonga_me.bin
+-File: amdgpu/tonga_mec2.bin
+-File: amdgpu/tonga_mec.bin
+-File: amdgpu/tonga_pfp.bin
+-File: amdgpu/tonga_rlc.bin
+-File: amdgpu/tonga_sdma1.bin
+-File: amdgpu/tonga_sdma.bin
+-File: amdgpu/tonga_smc.bin
+-File: amdgpu/tonga_uvd.bin
+-File: amdgpu/tonga_vce.bin
+-File: amdgpu/carrizo_ce.bin
+-File: amdgpu/carrizo_me.bin
+-File: amdgpu/carrizo_mec2.bin
+-File: amdgpu/carrizo_mec.bin
+-File: amdgpu/carrizo_pfp.bin
+-File: amdgpu/carrizo_rlc.bin
+-File: amdgpu/carrizo_sdma1.bin
+-File: amdgpu/carrizo_sdma.bin
+-File: amdgpu/carrizo_uvd.bin
+-File: amdgpu/carrizo_vce.bin
+-File: amdgpu/fiji_ce.bin
+-File: amdgpu/fiji_mc.bin
+-File: amdgpu/fiji_me.bin
+-File: amdgpu/fiji_mec2.bin
+-File: amdgpu/fiji_mec.bin
+-File: amdgpu/fiji_pfp.bin
+-File: amdgpu/fiji_rlc.bin
+-File: amdgpu/fiji_sdma1.bin
+-File: amdgpu/fiji_sdma.bin
+-File: amdgpu/fiji_smc.bin
+-File: amdgpu/fiji_uvd.bin
+-File: amdgpu/fiji_vce.bin
+-File: amdgpu/stoney_ce.bin
+-File: amdgpu/stoney_me.bin
+-File: amdgpu/stoney_mec.bin
+-File: amdgpu/stoney_pfp.bin
+-File: amdgpu/stoney_rlc.bin
+-File: amdgpu/stoney_sdma.bin
+-File: amdgpu/stoney_uvd.bin
+-File: amdgpu/stoney_vce.bin
+-File: amdgpu/polaris10_ce.bin
+-File: amdgpu/polaris10_ce_2.bin
+-File: amdgpu/polaris10_mc.bin
+-File: amdgpu/polaris10_k_mc.bin
+-File: amdgpu/polaris10_me.bin
+-File: amdgpu/polaris10_me_2.bin
+-File: amdgpu/polaris10_mec2.bin
+-File: amdgpu/polaris10_mec2_2.bin
+-File: amdgpu/polaris10_mec.bin
+-File: amdgpu/polaris10_mec_2.bin
+-File: amdgpu/polaris10_pfp.bin
+-File: amdgpu/polaris10_pfp_2.bin
+-File: amdgpu/polaris10_rlc.bin
+-File: amdgpu/polaris10_sdma1.bin
+-File: amdgpu/polaris10_sdma.bin
+-File: amdgpu/polaris10_smc.bin
+-File: amdgpu/polaris10_k_smc.bin
+-File: amdgpu/polaris10_k2_smc.bin
+-File: amdgpu/polaris10_smc_sk.bin
+-File: amdgpu/polaris10_uvd.bin
+-File: amdgpu/polaris10_vce.bin
+-File: amdgpu/polaris11_ce.bin
+-File: amdgpu/polaris11_ce_2.bin
+-File: amdgpu/polaris11_mc.bin
+-File: amdgpu/polaris11_k_mc.bin
+-File: amdgpu/polaris11_me.bin
+-File: amdgpu/polaris11_me_2.bin
+-File: amdgpu/polaris11_mec2.bin
+-File: amdgpu/polaris11_mec2_2.bin
+-File: amdgpu/polaris11_mec.bin
+-File: amdgpu/polaris11_mec_2.bin
+-File: amdgpu/polaris11_pfp.bin
+-File: amdgpu/polaris11_pfp_2.bin
+-File: amdgpu/polaris11_rlc.bin
+-File: amdgpu/polaris11_sdma1.bin
+-File: amdgpu/polaris11_sdma.bin
+-File: amdgpu/polaris11_smc.bin
+-File: amdgpu/polaris11_k_smc.bin
+-File: amdgpu/polaris11_k2_smc.bin
+-File: amdgpu/polaris11_smc_sk.bin
+-File: amdgpu/polaris11_uvd.bin
+-File: amdgpu/polaris11_vce.bin
+-File: amdgpu/polaris12_ce.bin
+-File: amdgpu/polaris12_ce_2.bin
+-File: amdgpu/polaris12_mc.bin
+-File: amdgpu/polaris12_k_mc.bin
+-File: amdgpu/polaris12_32_mc.bin
+-File: amdgpu/polaris12_me.bin
+-File: amdgpu/polaris12_me_2.bin
+-File: amdgpu/polaris12_mec.bin
+-File: amdgpu/polaris12_mec_2.bin
+-File: amdgpu/polaris12_mec2.bin
+-File: amdgpu/polaris12_mec2_2.bin
+-File: amdgpu/polaris12_pfp.bin
+-File: amdgpu/polaris12_pfp_2.bin
+-File: amdgpu/polaris12_rlc.bin
+-File: amdgpu/polaris12_sdma.bin
+-File: amdgpu/polaris12_sdma1.bin
+-File: amdgpu/polaris12_smc.bin
+-File: amdgpu/polaris12_k_smc.bin
+-File: amdgpu/polaris12_uvd.bin
+-File: amdgpu/polaris12_vce.bin
+-File: amdgpu/vegam_ce.bin
+-File: amdgpu/vegam_me.bin
+-File: amdgpu/vegam_mec.bin
+-File: amdgpu/vegam_mec2.bin
+-File: amdgpu/vegam_pfp.bin
+-File: amdgpu/vegam_rlc.bin
+-File: amdgpu/vegam_sdma.bin
+-File: amdgpu/vegam_sdma1.bin
+-File: amdgpu/vegam_smc.bin
+-File: amdgpu/vegam_uvd.bin
+-File: amdgpu/vegam_vce.bin
+-File: amdgpu/vega10_acg_smc.bin
+-File: amdgpu/vega10_asd.bin
+-File: amdgpu/vega10_ce.bin
+-File: amdgpu/vega10_gpu_info.bin
+-File: amdgpu/vega10_me.bin
+-File: amdgpu/vega10_mec.bin
+-File: amdgpu/vega10_mec2.bin
+-File: amdgpu/vega10_pfp.bin
+-File: amdgpu/vega10_rlc.bin
+-File: amdgpu/vega10_sdma.bin
+-File: amdgpu/vega10_sdma1.bin
+-File: amdgpu/vega10_smc.bin
+-File: amdgpu/vega10_sos.bin
+-File: amdgpu/vega10_uvd.bin
+-File: amdgpu/vega10_vce.bin
+-File: amdgpu/vega12_asd.bin
+-File: amdgpu/vega12_ce.bin
+-File: amdgpu/vega12_gpu_info.bin
+-File: amdgpu/vega12_me.bin
+-File: amdgpu/vega12_mec.bin
+-File: amdgpu/vega12_mec2.bin
+-File: amdgpu/vega12_pfp.bin
+-File: amdgpu/vega12_rlc.bin
+-File: amdgpu/vega12_sdma.bin
+-File: amdgpu/vega12_sdma1.bin
+-File: amdgpu/vega12_smc.bin
+-File: amdgpu/vega12_sos.bin
+-File: amdgpu/vega12_uvd.bin
+-File: amdgpu/vega12_vce.bin
+-File: amdgpu/vega20_asd.bin
+-File: amdgpu/vega20_ce.bin
+-File: amdgpu/vega20_me.bin
+-File: amdgpu/vega20_mec.bin
+-File: amdgpu/vega20_mec2.bin
+-File: amdgpu/vega20_pfp.bin
+-File: amdgpu/vega20_rlc.bin
+-File: amdgpu/vega20_sdma.bin
+-File: amdgpu/vega20_sdma1.bin
+-File: amdgpu/vega20_smc.bin
+-File: amdgpu/vega20_sos.bin
+-File: amdgpu/vega20_uvd.bin
+-File: amdgpu/vega20_vce.bin
+-File: amdgpu/vega20_ta.bin
+-File: amdgpu/raven_asd.bin
+-File: amdgpu/raven_ce.bin
+-File: amdgpu/raven_gpu_info.bin
+-File: amdgpu/raven_me.bin
+-File: amdgpu/raven_mec.bin
+-File: amdgpu/raven_mec2.bin
+-File: amdgpu/raven_pfp.bin
+-File: amdgpu/raven_rlc.bin
+-File: amdgpu/raven_sdma.bin
+-File: amdgpu/raven_vcn.bin
+-File: amdgpu/raven_dmcu.bin
+-File: amdgpu/raven_kicker_rlc.bin
+-File: amdgpu/raven_ta.bin
+-File: amdgpu/picasso_asd.bin
+-File: amdgpu/picasso_ce.bin
+-File: amdgpu/picasso_gpu_info.bin
+-File: amdgpu/picasso_me.bin
+-File: amdgpu/picasso_mec.bin
+-File: amdgpu/picasso_mec2.bin
+-File: amdgpu/picasso_pfp.bin
+-File: amdgpu/picasso_rlc.bin
+-File: amdgpu/picasso_rlc_am4.bin
+-File: amdgpu/picasso_sdma.bin
+-File: amdgpu/picasso_vcn.bin
+-File: amdgpu/picasso_ta.bin
+-File: amdgpu/raven2_asd.bin
+-File: amdgpu/raven2_ce.bin
+-File: amdgpu/raven2_gpu_info.bin
+-File: amdgpu/raven2_me.bin
+-File: amdgpu/raven2_mec.bin
+-File: amdgpu/raven2_mec2.bin
+-File: amdgpu/raven2_pfp.bin
+-File: amdgpu/raven2_rlc.bin
+-File: amdgpu/raven2_sdma.bin
+-File: amdgpu/raven2_vcn.bin
+-File: amdgpu/raven2_ta.bin
+-File: amdgpu/navi10_asd.bin
+-File: amdgpu/navi10_ce.bin
+-File: amdgpu/navi10_gpu_info.bin
+-File: amdgpu/navi10_me.bin
+-File: amdgpu/navi10_mec.bin
+-File: amdgpu/navi10_mec2.bin
+-File: amdgpu/navi10_pfp.bin
+-File: amdgpu/navi10_rlc.bin
+-File: amdgpu/navi10_sdma.bin
+-File: amdgpu/navi10_sdma1.bin
+-File: amdgpu/navi10_smc.bin
+-File: amdgpu/navi10_sos.bin
+-File: amdgpu/navi10_vcn.bin
+-File: amdgpu/navi10_ta.bin
+-File: amdgpu/navi14_asd.bin
+-File: amdgpu/navi14_ce.bin
+-File: amdgpu/navi14_ce_wks.bin
+-File: amdgpu/navi14_gpu_info.bin
+-File: amdgpu/navi14_me.bin
+-File: amdgpu/navi14_me_wks.bin
+-File: amdgpu/navi14_mec.bin
+-File: amdgpu/navi14_mec_wks.bin
+-File: amdgpu/navi14_mec2.bin
+-File: amdgpu/navi14_mec2_wks.bin
+-File: amdgpu/navi14_pfp.bin
+-File: amdgpu/navi14_pfp_wks.bin
+-File: amdgpu/navi14_rlc.bin
+-File: amdgpu/navi14_sdma.bin
+-File: amdgpu/navi14_sdma1.bin
+-File: amdgpu/navi14_smc.bin
+-File: amdgpu/navi14_sos.bin
+-File: amdgpu/navi14_vcn.bin
+-File: amdgpu/navi14_ta.bin
+-File: amdgpu/navi12_asd.bin
+-File: amdgpu/navi12_ce.bin
+-File: amdgpu/navi12_dmcu.bin
+-File: amdgpu/navi12_gpu_info.bin
+-File: amdgpu/navi12_me.bin
+-File: amdgpu/navi12_mec.bin
+-File: amdgpu/navi12_mec2.bin
+-File: amdgpu/navi12_pfp.bin
+-File: amdgpu/navi12_rlc.bin
+-File: amdgpu/navi12_sdma.bin
+-File: amdgpu/navi12_sdma1.bin
+-File: amdgpu/navi12_smc.bin
+-File: amdgpu/navi12_sos.bin
+-File: amdgpu/navi12_vcn.bin
+-File: amdgpu/navi12_ta.bin
+-File: amdgpu/renoir_asd.bin
+-File: amdgpu/renoir_ce.bin
+-File: amdgpu/renoir_gpu_info.bin
+-File: amdgpu/renoir_me.bin
+-File: amdgpu/renoir_mec.bin
+-File: amdgpu/renoir_mec2.bin
+-File: amdgpu/renoir_pfp.bin
+-File: amdgpu/renoir_rlc.bin
+-File: amdgpu/renoir_sdma.bin
+-File: amdgpu/renoir_vcn.bin
+-File: amdgpu/renoir_dmcub.bin
+-File: amdgpu/renoir_ta.bin
+-File: amdgpu/sienna_cichlid_ce.bin
+-File: amdgpu/sienna_cichlid_dmcub.bin
+-File: amdgpu/sienna_cichlid_me.bin
+-File: amdgpu/sienna_cichlid_mec.bin
+-File: amdgpu/sienna_cichlid_mec2.bin
+-File: amdgpu/sienna_cichlid_pfp.bin
+-File: amdgpu/sienna_cichlid_rlc.bin
+-File: amdgpu/sienna_cichlid_sdma.bin
+-File: amdgpu/sienna_cichlid_smc.bin
+-File: amdgpu/sienna_cichlid_sos.bin
+-File: amdgpu/sienna_cichlid_ta.bin
+-File: amdgpu/sienna_cichlid_vcn.bin
+-File: amdgpu/green_sardine_asd.bin
+-File: amdgpu/green_sardine_ce.bin
+-File: amdgpu/green_sardine_dmcub.bin
+-File: amdgpu/green_sardine_me.bin
+-File: amdgpu/green_sardine_mec2.bin
+-File: amdgpu/green_sardine_mec.bin
+-File: amdgpu/green_sardine_pfp.bin
+-File: amdgpu/green_sardine_rlc.bin
+-File: amdgpu/green_sardine_sdma.bin
+-File: amdgpu/green_sardine_ta.bin
+-File: amdgpu/green_sardine_vcn.bin
+-File: amdgpu/navy_flounder_ce.bin
+-File: amdgpu/navy_flounder_dmcub.bin
+-File: amdgpu/navy_flounder_me.bin
+-File: amdgpu/navy_flounder_mec.bin
+-File: amdgpu/navy_flounder_mec2.bin
+-File: amdgpu/navy_flounder_pfp.bin
+-File: amdgpu/navy_flounder_rlc.bin
+-File: amdgpu/navy_flounder_sdma.bin
+-File: amdgpu/navy_flounder_smc.bin
+-File: amdgpu/navy_flounder_sos.bin
+-File: amdgpu/navy_flounder_ta.bin
+-File: amdgpu/navy_flounder_vcn.bin
+-File: amdgpu/arcturus_asd.bin
+-File: amdgpu/arcturus_gpu_info.bin
+-File: amdgpu/arcturus_mec2.bin
+-File: amdgpu/arcturus_mec.bin
+-File: amdgpu/arcturus_rlc.bin
+-File: amdgpu/arcturus_sdma.bin
+-File: amdgpu/arcturus_smc.bin
+-File: amdgpu/arcturus_sos.bin
+-File: amdgpu/arcturus_ta.bin
+-File: amdgpu/arcturus_vcn.bin
+-File: amdgpu/dimgrey_cavefish_ce.bin
+-File: amdgpu/dimgrey_cavefish_dmcub.bin
+-File: amdgpu/dimgrey_cavefish_me.bin
+-File: amdgpu/dimgrey_cavefish_mec.bin
+-File: amdgpu/dimgrey_cavefish_mec2.bin
+-File: amdgpu/dimgrey_cavefish_pfp.bin
+-File: amdgpu/dimgrey_cavefish_rlc.bin
+-File: amdgpu/dimgrey_cavefish_sdma.bin
+-File: amdgpu/dimgrey_cavefish_smc.bin
+-File: amdgpu/dimgrey_cavefish_sos.bin
+-File: amdgpu/dimgrey_cavefish_ta.bin
+-File: amdgpu/dimgrey_cavefish_vcn.bin
+-File: amdgpu/vangogh_asd.bin
+-File: amdgpu/vangogh_ce.bin
+-File: amdgpu/vangogh_dmcub.bin
+-File: amdgpu/vangogh_me.bin
+-File: amdgpu/vangogh_mec2.bin
+-File: amdgpu/vangogh_mec.bin
+-File: amdgpu/vangogh_pfp.bin
+-File: amdgpu/vangogh_rlc.bin
+-File: amdgpu/vangogh_sdma.bin
+-File: amdgpu/vangogh_toc.bin
+-File: amdgpu/vangogh_vcn.bin
+-File: amdgpu/yellow_carp_asd.bin
+-File: amdgpu/yellow_carp_ce.bin
+-File: amdgpu/yellow_carp_dmcub.bin
+-File: amdgpu/yellow_carp_me.bin
+-File: amdgpu/yellow_carp_mec.bin
+-File: amdgpu/yellow_carp_mec2.bin
+-File: amdgpu/yellow_carp_pfp.bin
+-File: amdgpu/yellow_carp_rlc.bin
+-File: amdgpu/yellow_carp_sdma.bin
+-File: amdgpu/yellow_carp_ta.bin
+-File: amdgpu/yellow_carp_toc.bin
+-File: amdgpu/yellow_carp_vcn.bin
+-File: amdgpu/beige_goby_ce.bin
+-File: amdgpu/beige_goby_dmcub.bin
+-File: amdgpu/beige_goby_me.bin
+-File: amdgpu/beige_goby_mec.bin
+-File: amdgpu/beige_goby_mec2.bin
+-File: amdgpu/beige_goby_pfp.bin
+-File: amdgpu/beige_goby_rlc.bin
+-File: amdgpu/beige_goby_sdma.bin
+-File: amdgpu/beige_goby_smc.bin
+-File: amdgpu/beige_goby_sos.bin
+-File: amdgpu/beige_goby_ta.bin
+-File: amdgpu/beige_goby_vcn.bin
+-File: amdgpu/cyan_skillfish2_ce.bin
+-File: amdgpu/cyan_skillfish2_me.bin
+-File: amdgpu/cyan_skillfish2_mec.bin
+-File: amdgpu/cyan_skillfish2_mec2.bin
+-File: amdgpu/cyan_skillfish2_pfp.bin
+-File: amdgpu/cyan_skillfish2_rlc.bin
+-File: amdgpu/cyan_skillfish2_sdma.bin
+-File: amdgpu/cyan_skillfish2_sdma1.bin
+-File: amdgpu/aldebaran_mec2.bin
+-File: amdgpu/aldebaran_mec.bin
+-File: amdgpu/aldebaran_rlc.bin
+-File: amdgpu/aldebaran_sdma.bin
+-File: amdgpu/aldebaran_sjt_mec2.bin
+-File: amdgpu/aldebaran_sjt_mec.bin
+-File: amdgpu/aldebaran_smc.bin
+-File: amdgpu/aldebaran_sos.bin
+-File: amdgpu/aldebaran_ta.bin
+-File: amdgpu/aldebaran_vcn.bin
+-File: amdgpu/gc_10_3_6_ce.bin
+-File: amdgpu/gc_10_3_6_me.bin
+-File: amdgpu/gc_10_3_6_mec.bin
+-File: amdgpu/gc_10_3_6_mec2.bin
+-File: amdgpu/gc_10_3_6_pfp.bin
+-File: amdgpu/gc_10_3_6_rlc.bin
+-File: amdgpu/gc_10_3_7_ce.bin
+-File: amdgpu/gc_10_3_7_me.bin
+-File: amdgpu/gc_10_3_7_mec.bin
+-File: amdgpu/gc_10_3_7_mec2.bin
+-File: amdgpu/gc_10_3_7_pfp.bin
+-File: amdgpu/gc_10_3_7_rlc.bin
+-File: amdgpu/gc_11_0_0_imu.bin
+-File: amdgpu/gc_11_0_0_me.bin
+-File: amdgpu/gc_11_0_0_mec.bin
+-File: amdgpu/gc_11_0_0_mes1.bin
+-File: amdgpu/gc_11_0_0_mes.bin
+-File: amdgpu/gc_11_0_0_mes_2.bin
+-File: amdgpu/gc_11_0_0_pfp.bin
+-File: amdgpu/gc_11_0_0_rlc.bin
+-File: amdgpu/gc_11_0_1_imu.bin
+-File: amdgpu/gc_11_0_1_me.bin
+-File: amdgpu/gc_11_0_1_mec.bin
+-File: amdgpu/gc_11_0_1_mes.bin
+-File: amdgpu/gc_11_0_1_mes1.bin
+-File: amdgpu/gc_11_0_1_mes_2.bin
+-File: amdgpu/gc_11_0_1_pfp.bin
+-File: amdgpu/gc_11_0_1_rlc.bin
+-File: amdgpu/gc_11_0_2_imu.bin
+-File: amdgpu/gc_11_0_2_me.bin
+-File: amdgpu/gc_11_0_2_mec.bin
+-File: amdgpu/gc_11_0_2_mes1.bin
+-File: amdgpu/gc_11_0_2_mes.bin
+-File: amdgpu/gc_11_0_2_mes_2.bin
+-File: amdgpu/gc_11_0_2_pfp.bin
+-File: amdgpu/gc_11_0_2_rlc.bin
+-File: amdgpu/gc_11_0_4_imu.bin
+-File: amdgpu/gc_11_0_4_me.bin
+-File: amdgpu/gc_11_0_4_mec.bin
+-File: amdgpu/gc_11_0_4_mes.bin
+-File: amdgpu/gc_11_0_4_mes1.bin
+-File: amdgpu/gc_11_0_4_mes_2.bin
+-File: amdgpu/gc_11_0_4_pfp.bin
+-File: amdgpu/gc_11_0_4_rlc.bin
+-File: amdgpu/dcn_3_1_4_dmcub.bin
+-File: amdgpu/dcn_3_1_5_dmcub.bin
+-File: amdgpu/dcn_3_1_6_dmcub.bin
+-File: amdgpu/dcn_3_2_0_dmcub.bin
+-File: amdgpu/dcn_3_2_1_dmcub.bin
+-File: amdgpu/psp_13_0_0_sos.bin
+-File: amdgpu/psp_13_0_0_ta.bin
+-File: amdgpu/psp_13_0_4_ta.bin
+-File: amdgpu/psp_13_0_4_toc.bin
+-File: amdgpu/psp_13_0_5_asd.bin
+-File: amdgpu/psp_13_0_5_ta.bin
+-File: amdgpu/psp_13_0_5_toc.bin
+-File: amdgpu/psp_13_0_7_sos.bin
+-File: amdgpu/psp_13_0_7_ta.bin
+-File: amdgpu/psp_13_0_8_asd.bin
+-File: amdgpu/psp_13_0_8_ta.bin
+-File: amdgpu/psp_13_0_8_toc.bin
+-File: amdgpu/psp_13_0_11_ta.bin
+-File: amdgpu/psp_13_0_11_toc.bin
+-File: amdgpu/sdma_5_2_6.bin
+-File: amdgpu/sdma_5_2_7.bin
+-File: amdgpu/sdma_6_0_0.bin
+-File: amdgpu/sdma_6_0_1.bin
+-File: amdgpu/sdma_6_0_2.bin
+-File: amdgpu/smu_13_0_0.bin
+-File: amdgpu/smu_13_0_7.bin
+-File: amdgpu/vcn_3_1_2.bin
+-File: amdgpu/vcn_4_0_0.bin
+-File: amdgpu/vcn_4_0_2.bin
+-File: amdgpu/vcn_4_0_4.bin
+-
+-Licence: Redistributable. See LICENSE.amdgpu for details.
+-
+---------------------------------------------------------------------------
+-
+ Driver: qed - QLogic 4xxxx Ethernet Driver Core Module.
+ 
+ File: qed/qed_init_values_zipped-8.4.2.0.bin
+@@ -1459,424 +561,6 @@ Version: HuC API/APB ver 8.5.0 for Meteorlake
+ License: Redistributable. See LICENSE.i915 for details
+ --------------------------------------------------------------------------
+ 
+-Driver: nouveau - NVIDIA GPU driver
+-
+-File: nvidia/gk20a/fecs_data.bin
+-File: nvidia/gk20a/fecs_inst.bin
+-File: nvidia/gk20a/gpccs_data.bin
+-File: nvidia/gk20a/gpccs_inst.bin
+-File: nvidia/gk20a/sw_bundle_init.bin
+-File: nvidia/gk20a/sw_ctx.bin
+-File: nvidia/gk20a/sw_method_init.bin
+-File: nvidia/gk20a/sw_nonctx.bin
+-File: nvidia/gm200/acr/bl.bin
+-File: nvidia/gm200/acr/ucode_load.bin
+-File: nvidia/gm200/acr/ucode_unload.bin
+-File: nvidia/gm200/gr/fecs_bl.bin
+-File: nvidia/gm200/gr/fecs_data.bin
+-File: nvidia/gm200/gr/fecs_inst.bin
+-File: nvidia/gm200/gr/fecs_sig.bin
+-File: nvidia/gm200/gr/gpccs_bl.bin
+-File: nvidia/gm200/gr/gpccs_data.bin
+-File: nvidia/gm200/gr/gpccs_inst.bin
+-File: nvidia/gm200/gr/gpccs_sig.bin
+-File: nvidia/gm200/gr/sw_bundle_init.bin
+-File: nvidia/gm200/gr/sw_ctx.bin
+-File: nvidia/gm200/gr/sw_method_init.bin
+-File: nvidia/gm200/gr/sw_nonctx.bin
+-Link: nvidia/gm204/acr/bl.bin -> ../../gm200/acr/bl.bin
+-Link: nvidia/gm204/acr/ucode_load.bin -> ../../gm200/acr/ucode_load.bin
+-Link: nvidia/gm204/acr/ucode_unload.bin -> ../../gm200/acr/ucode_unload.bin
+-Link: nvidia/gm204/gr/fecs_bl.bin -> ../../gm200/gr/fecs_bl.bin
+-File: nvidia/gm204/gr/fecs_data.bin
+-Link: nvidia/gm204/gr/fecs_inst.bin -> ../../gm200/gr/fecs_inst.bin
+-File: nvidia/gm204/gr/fecs_sig.bin
+-Link: nvidia/gm204/gr/gpccs_bl.bin -> ../../gm200/gr/gpccs_bl.bin
+-File: nvidia/gm204/gr/gpccs_data.bin
+-Link: nvidia/gm204/gr/gpccs_inst.bin -> ../../gm200/gr/gpccs_inst.bin
+-File: nvidia/gm204/gr/gpccs_sig.bin
+-Link: nvidia/gm204/gr/sw_bundle_init.bin -> ../../gm200/gr/sw_bundle_init.bin
+-Link: nvidia/gm204/gr/sw_ctx.bin -> ../../gm200/gr/sw_ctx.bin
+-Link: nvidia/gm204/gr/sw_method_init.bin -> ../../gm200/gr/sw_method_init.bin
+-Link: nvidia/gm204/gr/sw_nonctx.bin -> ../../gm200/gr/sw_nonctx.bin
+-Link: nvidia/gm206/acr/bl.bin  -> ../../gm200/acr/bl.bin
+-File: nvidia/gm206/acr/ucode_load.bin
+-File: nvidia/gm206/acr/ucode_unload.bin
+-Link: nvidia/gm206/gr/fecs_bl.bin -> ../../gm200/gr/fecs_bl.bin
+-File: nvidia/gm206/gr/fecs_data.bin
+-Link: nvidia/gm206/gr/fecs_inst.bin -> ../../gm200/gr/fecs_inst.bin
+-File: nvidia/gm206/gr/fecs_sig.bin
+-Link: nvidia/gm206/gr/gpccs_bl.bin -> ../../gm200/gr/gpccs_bl.bin
+-File: nvidia/gm206/gr/gpccs_data.bin
+-Link: nvidia/gm206/gr/gpccs_inst.bin -> ../../gm200/gr/gpccs_inst.bin
+-File: nvidia/gm206/gr/gpccs_sig.bin
+-Link: nvidia/gm206/gr/sw_bundle_init.bin -> ../../gm200/gr/sw_bundle_init.bin
+-Link: nvidia/gm206/gr/sw_ctx.bin -> ../../gm200/gr/sw_ctx.bin
+-Link: nvidia/gm206/gr/sw_method_init.bin -> ../../gm200/gr/sw_method_init.bin
+-Link: nvidia/gm206/gr/sw_nonctx.bin -> ../../gm200/gr/sw_nonctx.bin
+-File: nvidia/gm20b/acr/bl.bin
+-File: nvidia/gm20b/acr/ucode_load.bin
+-File: nvidia/gm20b/gr/fecs_bl.bin
+-File: nvidia/gm20b/gr/fecs_data.bin
+-File: nvidia/gm20b/gr/fecs_inst.bin
+-File: nvidia/gm20b/gr/fecs_sig.bin
+-File: nvidia/gm20b/gr/gpccs_data.bin
+-File: nvidia/gm20b/gr/gpccs_inst.bin
+-File: nvidia/gm20b/gr/sw_bundle_init.bin
+-File: nvidia/gm20b/gr/sw_ctx.bin
+-Link: nvidia/gm20b/gr/sw_method_init.bin -> ../../gm200/gr/sw_method_init.bin
+-File: nvidia/gm20b/gr/sw_nonctx.bin
+-File: nvidia/gm20b/pmu/desc.bin
+-File: nvidia/gm20b/pmu/image.bin
+-File: nvidia/gm20b/pmu/sig.bin
+-File: nvidia/gp100/acr/bl.bin
+-File: nvidia/gp100/acr/ucode_load.bin
+-File: nvidia/gp100/acr/ucode_unload.bin
+-Link: nvidia/gp100/gr/fecs_bl.bin -> ../../gm200/gr/fecs_bl.bin
+-File: nvidia/gp100/gr/fecs_data.bin
+-File: nvidia/gp100/gr/fecs_inst.bin
+-File: nvidia/gp100/gr/fecs_sig.bin
+-Link: nvidia/gp100/gr/gpccs_bl.bin -> ../../gm200/gr/gpccs_bl.bin
+-File: nvidia/gp100/gr/gpccs_data.bin
+-File: nvidia/gp100/gr/gpccs_inst.bin
+-File: nvidia/gp100/gr/gpccs_sig.bin
+-File: nvidia/gp100/gr/sw_bundle_init.bin
+-File: nvidia/gp100/gr/sw_ctx.bin
+-File: nvidia/gp100/gr/sw_method_init.bin
+-File: nvidia/gp100/gr/sw_nonctx.bin
+-File: nvidia/gp102/acr/bl.bin
+-File: nvidia/gp102/acr/ucode_load.bin
+-File: nvidia/gp102/acr/ucode_unload.bin
+-File: nvidia/gp102/acr/unload_bl.bin
+-Link: nvidia/gp102/gr/fecs_bl.bin -> ../../gm200/gr/fecs_bl.bin
+-File: nvidia/gp102/gr/fecs_data.bin
+-File: nvidia/gp102/gr/fecs_inst.bin
+-File: nvidia/gp102/gr/fecs_sig.bin
+-Link: nvidia/gp102/gr/gpccs_bl.bin -> ../../gm200/gr/gpccs_bl.bin
+-File: nvidia/gp102/gr/gpccs_data.bin
+-File: nvidia/gp102/gr/gpccs_inst.bin
+-File: nvidia/gp102/gr/gpccs_sig.bin
+-File: nvidia/gp102/gr/sw_bundle_init.bin
+-File: nvidia/gp102/gr/sw_ctx.bin
+-File: nvidia/gp102/gr/sw_method_init.bin
+-File: nvidia/gp102/gr/sw_nonctx.bin
+-File: nvidia/gp102/nvdec/scrubber.bin
+-File: nvidia/gp102/sec2/desc.bin
+-File: nvidia/gp102/sec2/image.bin
+-File: nvidia/gp102/sec2/sig.bin
+-File: nvidia/gp102/sec2/desc-1.bin
+-File: nvidia/gp102/sec2/image-1.bin
+-File: nvidia/gp102/sec2/sig-1.bin
+-Link: nvidia/gp104/acr/bl.bin -> ../../gp102/acr/bl.bin
+-Link: nvidia/gp104/acr/ucode_load.bin -> ../../gp102/acr/ucode_load.bin
+-Link: nvidia/gp104/acr/ucode_unload.bin -> ../../gp102/acr/ucode_unload.bin
+-Link: nvidia/gp104/acr/unload_bl.bin -> ../../gp102/acr/unload_bl.bin
+-Link: nvidia/gp104/gr/fecs_bl.bin -> ../../gp102/gr/fecs_bl.bin
+-File: nvidia/gp104/gr/fecs_data.bin
+-File: nvidia/gp104/gr/fecs_inst.bin
+-File: nvidia/gp104/gr/fecs_sig.bin
+-Link: nvidia/gp104/gr/gpccs_bl.bin -> ../../gp102/gr/gpccs_bl.bin
+-File: nvidia/gp104/gr/gpccs_data.bin
+-File: nvidia/gp104/gr/gpccs_inst.bin
+-File: nvidia/gp104/gr/gpccs_sig.bin
+-Link: nvidia/gp104/gr/sw_bundle_init.bin -> ../../gp102/gr/sw_bundle_init.bin
+-Link: nvidia/gp104/gr/sw_ctx.bin -> ../../gp102/gr/sw_ctx.bin
+-Link: nvidia/gp104/gr/sw_method_init.bin -> ../../gp102/gr/sw_method_init.bin
+-Link: nvidia/gp104/gr/sw_nonctx.bin -> ../../gp102/gr/sw_nonctx.bin
+-Link: nvidia/gp104/nvdec/scrubber.bin -> ../../gp102/nvdec/scrubber.bin
+-Link: nvidia/gp104/sec2/desc.bin -> ../../gp102/sec2/desc.bin
+-Link: nvidia/gp104/sec2/image.bin -> ../../gp102/sec2/image.bin
+-Link: nvidia/gp104/sec2/sig.bin -> ../../gp102/sec2/sig.bin
+-Link: nvidia/gp104/sec2/desc-1.bin -> ../../gp102/sec2/desc-1.bin
+-Link: nvidia/gp104/sec2/image-1.bin -> ../../gp102/sec2/image-1.bin
+-Link: nvidia/gp104/sec2/sig-1.bin -> ../../gp102/sec2/sig-1.bin
+-Link: nvidia/gp106/acr/bl.bin -> ../../gp102/acr/bl.bin
+-Link: nvidia/gp106/acr/ucode_load.bin -> ../../gp102/acr/ucode_load.bin
+-Link: nvidia/gp106/acr/ucode_unload.bin -> ../../gp102/acr/ucode_unload.bin
+-Link: nvidia/gp106/acr/unload_bl.bin -> ../../gp102/acr/unload_bl.bin
+-Link: nvidia/gp106/gr/fecs_bl.bin -> ../../gp102/gr/fecs_bl.bin
+-File: nvidia/gp106/gr/fecs_data.bin
+-Link: nvidia/gp106/gr/fecs_inst.bin -> ../../gp102/gr/fecs_inst.bin
+-File: nvidia/gp106/gr/fecs_sig.bin
+-Link: nvidia/gp106/gr/gpccs_bl.bin -> ../../gp102/gr/gpccs_bl.bin
+-File: nvidia/gp106/gr/gpccs_data.bin
+-Link: nvidia/gp106/gr/gpccs_inst.bin -> ../../gp102/gr/gpccs_inst.bin
+-File: nvidia/gp106/gr/gpccs_sig.bin
+-Link: nvidia/gp106/gr/sw_bundle_init.bin -> ../../gp102/gr/sw_bundle_init.bin
+-Link: nvidia/gp106/gr/sw_ctx.bin -> ../../gp102/gr/sw_ctx.bin
+-Link: nvidia/gp106/gr/sw_method_init.bin -> ../../gp102/gr/sw_method_init.bin
+-Link: nvidia/gp106/gr/sw_nonctx.bin -> ../../gp102/gr/sw_nonctx.bin
+-Link: nvidia/gp106/nvdec/scrubber.bin -> ../../gp102/nvdec/scrubber.bin
+-Link: nvidia/gp106/sec2/desc.bin -> ../../gp102/sec2/desc.bin
+-Link: nvidia/gp106/sec2/image.bin -> ../../gp102/sec2/image.bin
+-Link: nvidia/gp106/sec2/sig.bin -> ../../gp102/sec2/sig.bin
+-Link: nvidia/gp106/sec2/desc-1.bin -> ../../gp102/sec2/desc-1.bin
+-Link: nvidia/gp106/sec2/image-1.bin -> ../../gp102/sec2/image-1.bin
+-Link: nvidia/gp106/sec2/sig-1.bin -> ../../gp102/sec2/sig-1.bin
+-Link: nvidia/gp107/acr/bl.bin -> ../../gp102/acr/bl.bin
+-Link: nvidia/gp107/acr/ucode_load.bin -> ../../gp102/acr/ucode_load.bin
+-Link: nvidia/gp107/acr/ucode_unload.bin -> ../../gp102/acr/ucode_unload.bin
+-Link: nvidia/gp107/acr/unload_bl.bin -> ../../gp102/acr/unload_bl.bin
+-File: nvidia/gp107/gr/fecs_bl.bin
+-File: nvidia/gp107/gr/fecs_data.bin
+-File: nvidia/gp107/gr/fecs_inst.bin
+-File: nvidia/gp107/gr/fecs_sig.bin
+-File: nvidia/gp107/gr/gpccs_bl.bin
+-File: nvidia/gp107/gr/gpccs_data.bin
+-File: nvidia/gp107/gr/gpccs_inst.bin
+-File: nvidia/gp107/gr/gpccs_sig.bin
+-Link: nvidia/gp107/gr/sw_bundle_init.bin -> ../../gp102/gr/sw_bundle_init.bin
+-File: nvidia/gp107/gr/sw_ctx.bin
+-Link: nvidia/gp107/gr/sw_method_init.bin -> ../../gp102/gr/sw_method_init.bin
+-File: nvidia/gp107/gr/sw_nonctx.bin
+-Link: nvidia/gp107/nvdec/scrubber.bin -> ../../gp102/nvdec/scrubber.bin
+-Link: nvidia/gp107/sec2/desc.bin -> ../../gp102/sec2/desc.bin
+-Link: nvidia/gp107/sec2/image.bin -> ../../gp102/sec2/image.bin
+-Link: nvidia/gp107/sec2/sig.bin -> ../../gp102/sec2/sig.bin
+-Link: nvidia/gp107/sec2/desc-1.bin -> ../../gp102/sec2/desc-1.bin
+-Link: nvidia/gp107/sec2/image-1.bin -> ../../gp102/sec2/image-1.bin
+-Link: nvidia/gp107/sec2/sig-1.bin -> ../../gp102/sec2/sig-1.bin
+-File: nvidia/gp10b/acr/bl.bin
+-File: nvidia/gp10b/acr/ucode_load.bin
+-File: nvidia/gp10b/gr/fecs_bl.bin
+-File: nvidia/gp10b/gr/fecs_data.bin
+-File: nvidia/gp10b/gr/fecs_inst.bin
+-File: nvidia/gp10b/gr/fecs_sig.bin
+-File: nvidia/gp10b/gr/gpccs_bl.bin
+-File: nvidia/gp10b/gr/gpccs_data.bin
+-File: nvidia/gp10b/gr/gpccs_inst.bin
+-File: nvidia/gp10b/gr/gpccs_sig.bin
+-File: nvidia/gp10b/gr/sw_bundle_init.bin
+-File: nvidia/gp10b/gr/sw_ctx.bin
+-File: nvidia/gp10b/gr/sw_method_init.bin
+-File: nvidia/gp10b/gr/sw_nonctx.bin
+-File: nvidia/gp10b/pmu/desc.bin
+-File: nvidia/gp10b/pmu/image.bin
+-File: nvidia/gp10b/pmu/sig.bin
+-Link: nvidia/gp108/acr/bl.bin -> ../../gp102/acr/bl.bin
+-Link: nvidia/gp108/acr/ucode_load.bin -> ../../gp102/acr/ucode_load.bin
+-Link: nvidia/gp108/acr/ucode_unload.bin -> ../../gp102/acr/ucode_unload.bin
+-Link: nvidia/gp108/acr/unload_bl.bin -> ../../gp102/acr/unload_bl.bin
+-File: nvidia/gp108/gr/fecs_bl.bin
+-File: nvidia/gp108/gr/fecs_data.bin
+-File: nvidia/gp108/gr/fecs_inst.bin
+-File: nvidia/gp108/gr/fecs_sig.bin
+-File: nvidia/gp108/gr/gpccs_bl.bin
+-File: nvidia/gp108/gr/gpccs_data.bin
+-File: nvidia/gp108/gr/gpccs_inst.bin
+-File: nvidia/gp108/gr/gpccs_sig.bin
+-File: nvidia/gp108/gr/sw_bundle_init.bin
+-File: nvidia/gp108/gr/sw_ctx.bin
+-File: nvidia/gp108/gr/sw_method_init.bin
+-File: nvidia/gp108/gr/sw_nonctx.bin
+-Link: nvidia/gp108/nvdec/scrubber.bin -> ../../gp102/nvdec/scrubber.bin
+-Link: nvidia/gp108/sec2/desc.bin -> ../../gp102/sec2/desc-1.bin
+-Link: nvidia/gp108/sec2/image.bin -> ../../gp102/sec2/image-1.bin
+-Link: nvidia/gp108/sec2/sig.bin -> ../../gp102/sec2/sig-1.bin
+-File: nvidia/gv100/acr/bl.bin
+-File: nvidia/gv100/acr/ucode_load.bin
+-File: nvidia/gv100/acr/ucode_unload.bin
+-File: nvidia/gv100/acr/unload_bl.bin
+-File: nvidia/gv100/gr/fecs_bl.bin
+-File: nvidia/gv100/gr/fecs_data.bin
+-File: nvidia/gv100/gr/fecs_inst.bin
+-File: nvidia/gv100/gr/fecs_sig.bin
+-File: nvidia/gv100/gr/gpccs_bl.bin
+-File: nvidia/gv100/gr/gpccs_data.bin
+-File: nvidia/gv100/gr/gpccs_inst.bin
+-File: nvidia/gv100/gr/gpccs_sig.bin
+-File: nvidia/gv100/gr/sw_bundle_init.bin
+-File: nvidia/gv100/gr/sw_ctx.bin
+-File: nvidia/gv100/gr/sw_method_init.bin
+-File: nvidia/gv100/gr/sw_nonctx.bin
+-File: nvidia/gv100/nvdec/scrubber.bin
+-File: nvidia/gv100/sec2/desc.bin
+-File: nvidia/gv100/sec2/image.bin
+-File: nvidia/gv100/sec2/sig.bin
+-File: nvidia/tu102/acr/bl.bin
+-File: nvidia/tu102/acr/ucode_ahesasc.bin
+-File: nvidia/tu102/acr/ucode_asb.bin
+-File: nvidia/tu102/acr/unload_bl.bin
+-File: nvidia/tu102/acr/ucode_unload.bin
+-File: nvidia/tu102/gr/fecs_bl.bin
+-File: nvidia/tu102/gr/fecs_data.bin
+-File: nvidia/tu102/gr/fecs_inst.bin
+-File: nvidia/tu102/gr/fecs_sig.bin
+-File: nvidia/tu102/gr/gpccs_bl.bin
+-File: nvidia/tu102/gr/gpccs_data.bin
+-File: nvidia/tu102/gr/gpccs_inst.bin
+-File: nvidia/tu102/gr/gpccs_sig.bin
+-File: nvidia/tu102/gr/sw_bundle_init.bin
+-File: nvidia/tu102/gr/sw_ctx.bin
+-File: nvidia/tu102/gr/sw_method_init.bin
+-File: nvidia/tu102/gr/sw_nonctx.bin
+-File: nvidia/tu102/gr/sw_veid_bundle_init.bin
+-File: nvidia/tu102/nvdec/scrubber.bin
+-File: nvidia/tu102/sec2/desc.bin
+-File: nvidia/tu102/sec2/image.bin
+-File: nvidia/tu102/sec2/sig.bin
+-Link: nvidia/tu104/acr/bl.bin -> ../../tu102/acr/bl.bin
+-Link: nvidia/tu104/acr/ucode_ahesasc.bin -> ../../tu102/acr/ucode_ahesasc.bin
+-Link: nvidia/tu104/acr/ucode_asb.bin -> ../../tu102/acr/ucode_asb.bin
+-Link: nvidia/tu104/acr/unload_bl.bin -> ../../tu102/acr/unload_bl.bin
+-Link: nvidia/tu104/acr/ucode_unload.bin -> ../../tu102/acr/ucode_unload.bin
+-Link: nvidia/tu104/gr/fecs_bl.bin -> ../../tu102/gr/fecs_bl.bin
+-File: nvidia/tu104/gr/fecs_data.bin
+-File: nvidia/tu104/gr/fecs_inst.bin
+-File: nvidia/tu104/gr/fecs_sig.bin
+-Link: nvidia/tu104/gr/gpccs_bl.bin -> ../../tu102/gr/gpccs_bl.bin
+-File: nvidia/tu104/gr/gpccs_data.bin
+-File: nvidia/tu104/gr/gpccs_inst.bin
+-File: nvidia/tu104/gr/gpccs_sig.bin
+-File: nvidia/tu104/gr/sw_bundle_init.bin
+-File: nvidia/tu104/gr/sw_ctx.bin
+-File: nvidia/tu104/gr/sw_method_init.bin
+-File: nvidia/tu104/gr/sw_nonctx.bin
+-File: nvidia/tu104/gr/sw_veid_bundle_init.bin
+-Link: nvidia/tu104/nvdec/scrubber.bin -> ../../tu102/nvdec/scrubber.bin
+-Link: nvidia/tu104/sec2/desc.bin -> ../../tu102/sec2/desc.bin
+-Link: nvidia/tu104/sec2/image.bin -> ../../tu102/sec2/image.bin
+-Link: nvidia/tu104/sec2/sig.bin -> ../../tu102/sec2/sig.bin
+-Link: nvidia/tu106/acr/bl.bin -> ../../tu102/acr/bl.bin
+-Link: nvidia/tu106/acr/ucode_ahesasc.bin -> ../../tu102/acr/ucode_ahesasc.bin
+-Link: nvidia/tu106/acr/ucode_asb.bin -> ../../tu102/acr/ucode_asb.bin
+-Link: nvidia/tu106/acr/unload_bl.bin -> ../../tu102/acr/unload_bl.bin
+-Link: nvidia/tu106/acr/ucode_unload.bin -> ../../tu102/acr/ucode_unload.bin
+-Link: nvidia/tu106/gr/fecs_bl.bin -> ../../tu102/gr/fecs_bl.bin
+-File: nvidia/tu106/gr/fecs_data.bin
+-File: nvidia/tu106/gr/fecs_inst.bin
+-File: nvidia/tu106/gr/fecs_sig.bin
+-Link: nvidia/tu106/gr/gpccs_bl.bin -> ../../tu102/gr/gpccs_bl.bin
+-File: nvidia/tu106/gr/gpccs_data.bin
+-File: nvidia/tu106/gr/gpccs_inst.bin
+-File: nvidia/tu106/gr/gpccs_sig.bin
+-File: nvidia/tu106/gr/sw_bundle_init.bin
+-File: nvidia/tu106/gr/sw_ctx.bin
+-File: nvidia/tu106/gr/sw_method_init.bin
+-File: nvidia/tu106/gr/sw_nonctx.bin
+-File: nvidia/tu106/gr/sw_veid_bundle_init.bin
+-Link: nvidia/tu106/nvdec/scrubber.bin -> ../../tu102/nvdec/scrubber.bin
+-Link: nvidia/tu106/sec2/desc.bin -> ../../tu102/sec2/desc.bin
+-Link: nvidia/tu106/sec2/image.bin -> ../../tu102/sec2/image.bin
+-Link: nvidia/tu106/sec2/sig.bin -> ../../tu102/sec2/sig.bin
+-File: nvidia/tu116/acr/bl.bin
+-File: nvidia/tu116/acr/ucode_ahesasc.bin
+-File: nvidia/tu116/acr/ucode_asb.bin
+-File: nvidia/tu116/acr/ucode_unload.bin
+-File: nvidia/tu116/acr/unload_bl.bin
+-File: nvidia/tu116/gr/fecs_bl.bin
+-File: nvidia/tu116/gr/fecs_data.bin
+-File: nvidia/tu116/gr/fecs_inst.bin
+-File: nvidia/tu116/gr/fecs_sig.bin
+-File: nvidia/tu116/gr/gpccs_bl.bin
+-File: nvidia/tu116/gr/gpccs_data.bin
+-File: nvidia/tu116/gr/gpccs_inst.bin
+-File: nvidia/tu116/gr/gpccs_sig.bin
+-File: nvidia/tu116/gr/sw_bundle_init.bin
+-File: nvidia/tu116/gr/sw_ctx.bin
+-File: nvidia/tu116/gr/sw_method_init.bin
+-File: nvidia/tu116/gr/sw_nonctx.bin
+-File: nvidia/tu116/gr/sw_veid_bundle_init.bin
+-File: nvidia/tu116/nvdec/scrubber.bin
+-File: nvidia/tu116/sec2/desc.bin
+-File: nvidia/tu116/sec2/image.bin
+-File: nvidia/tu116/sec2/sig.bin
+-Link: nvidia/tu117/acr/bl.bin -> ../../tu116/acr/bl.bin
+-Link: nvidia/tu117/acr/ucode_ahesasc.bin -> ../../tu116/acr/ucode_ahesasc.bin
+-Link: nvidia/tu117/acr/ucode_asb.bin -> ../../tu116/acr/ucode_asb.bin
+-Link: nvidia/tu117/acr/ucode_unload.bin -> ../../tu116/acr/ucode_unload.bin
+-Link: nvidia/tu117/acr/unload_bl.bin -> ../../tu116/acr/unload_bl.bin
+-Link: nvidia/tu117/gr/fecs_bl.bin -> ../../tu116/gr/fecs_bl.bin
+-File: nvidia/tu117/gr/fecs_data.bin
+-File: nvidia/tu117/gr/fecs_inst.bin
+-File: nvidia/tu117/gr/fecs_sig.bin
+-Link: nvidia/tu117/gr/gpccs_bl.bin -> ../../tu116/gr/gpccs_bl.bin
+-File: nvidia/tu117/gr/gpccs_data.bin
+-File: nvidia/tu117/gr/gpccs_inst.bin
+-File: nvidia/tu117/gr/gpccs_sig.bin
+-File: nvidia/tu117/gr/sw_bundle_init.bin
+-File: nvidia/tu117/gr/sw_ctx.bin
+-File: nvidia/tu117/gr/sw_method_init.bin
+-File: nvidia/tu117/gr/sw_nonctx.bin
+-File: nvidia/tu117/gr/sw_veid_bundle_init.bin
+-Link: nvidia/tu117/nvdec/scrubber.bin -> ../../tu116/nvdec/scrubber.bin
+-Link: nvidia/tu117/sec2/desc.bin -> ../../tu116/sec2/desc.bin
+-Link: nvidia/tu117/sec2/image.bin -> ../../tu116/sec2/image.bin
+-Link: nvidia/tu117/sec2/sig.bin -> ../../tu116/sec2/sig.bin
+-File: nvidia/ga102/acr/ucode_ahesasc.bin
+-File: nvidia/ga102/acr/ucode_asb.bin
+-File: nvidia/ga102/acr/ucode_unload.bin
+-File: nvidia/ga102/gr/fecs_bl.bin
+-File: nvidia/ga102/gr/fecs_sig.bin
+-File: nvidia/ga102/gr/gpccs_bl.bin
+-File: nvidia/ga102/gr/gpccs_sig.bin
+-File: nvidia/ga102/gr/NET_img.bin
+-File: nvidia/ga102/nvdec/scrubber.bin
+-File: nvidia/ga102/sec2/desc.bin
+-File: nvidia/ga102/sec2/hs_bl_sig.bin
+-File: nvidia/ga102/sec2/image.bin
+-File: nvidia/ga102/sec2/sig.bin
+-Link: nvidia/ga103/acr/ucode_ahesasc.bin -> ../../ga102/acr/ucode_ahesasc.bin
+-Link: nvidia/ga103/acr/ucode_asb.bin -> ../../ga102/acr/ucode_asb.bin
+-Link: nvidia/ga103/acr/ucode_unload.bin -> ../../ga102/acr/ucode_unload.bin
+-File: nvidia/ga103/gr/fecs_bl.bin
+-File: nvidia/ga103/gr/fecs_sig.bin
+-File: nvidia/ga103/gr/gpccs_bl.bin
+-File: nvidia/ga103/gr/gpccs_sig.bin
+-File: nvidia/ga103/gr/NET_img.bin
+-Link: nvidia/ga103/nvdec/scrubber.bin -> ../../ga102/nvdec/scrubber.bin
+-Link: nvidia/ga103/sec2/desc.bin -> ../../ga102/sec2/desc.bin
+-Link: nvidia/ga103/sec2/hs_bl_sig.bin -> ../../ga102/sec2/hs_bl_sig.bin
+-Link: nvidia/ga103/sec2/image.bin -> ../../ga102/sec2/image.bin
+-Link: nvidia/ga103/sec2/sig.bin -> ../../ga102/sec2/sig.bin
+-Link: nvidia/ga104/acr/ucode_ahesasc.bin -> ../../ga102/acr/ucode_ahesasc.bin
+-Link: nvidia/ga104/acr/ucode_asb.bin -> ../../ga102/acr/ucode_asb.bin
+-Link: nvidia/ga104/acr/ucode_unload.bin -> ../../ga102/acr/ucode_unload.bin
+-File: nvidia/ga104/gr/fecs_bl.bin
+-File: nvidia/ga104/gr/fecs_sig.bin
+-File: nvidia/ga104/gr/gpccs_bl.bin
+-File: nvidia/ga104/gr/gpccs_sig.bin
+-File: nvidia/ga104/gr/NET_img.bin
+-Link: nvidia/ga104/nvdec/scrubber.bin -> ../../ga102/nvdec/scrubber.bin
+-Link: nvidia/ga104/sec2/desc.bin -> ../../ga102/sec2/desc.bin
+-Link: nvidia/ga104/sec2/hs_bl_sig.bin -> ../../ga102/sec2/hs_bl_sig.bin
+-Link: nvidia/ga104/sec2/image.bin -> ../../ga102/sec2/image.bin
+-Link: nvidia/ga104/sec2/sig.bin -> ../../ga102/sec2/sig.bin
+-Link: nvidia/ga106/acr/ucode_ahesasc.bin -> ../../ga102/acr/ucode_ahesasc.bin
+-Link: nvidia/ga106/acr/ucode_asb.bin -> ../../ga102/acr/ucode_asb.bin
+-Link: nvidia/ga106/acr/ucode_unload.bin -> ../../ga102/acr/ucode_unload.bin
+-File: nvidia/ga106/gr/fecs_bl.bin
+-File: nvidia/ga106/gr/fecs_sig.bin
+-File: nvidia/ga106/gr/gpccs_bl.bin
+-File: nvidia/ga106/gr/gpccs_sig.bin
+-File: nvidia/ga106/gr/NET_img.bin
+-Link: nvidia/ga106/nvdec/scrubber.bin -> ../../ga102/nvdec/scrubber.bin
+-Link: nvidia/ga106/sec2/desc.bin -> ../../ga102/sec2/desc.bin
+-Link: nvidia/ga106/sec2/hs_bl_sig.bin -> ../../ga102/sec2/hs_bl_sig.bin
+-Link: nvidia/ga106/sec2/image.bin -> ../../ga102/sec2/image.bin
+-Link: nvidia/ga106/sec2/sig.bin -> ../../ga102/sec2/sig.bin
+-Link: nvidia/ga107/acr/ucode_ahesasc.bin -> ../../ga102/acr/ucode_ahesasc.bin
+-Link: nvidia/ga107/acr/ucode_asb.bin -> ../../ga102/acr/ucode_asb.bin
+-Link: nvidia/ga107/acr/ucode_unload.bin -> ../../ga102/acr/ucode_unload.bin
+-File: nvidia/ga107/gr/fecs_bl.bin
+-File: nvidia/ga107/gr/fecs_sig.bin
+-File: nvidia/ga107/gr/gpccs_bl.bin
+-File: nvidia/ga107/gr/gpccs_sig.bin
+-File: nvidia/ga107/gr/NET_img.bin
+-Link: nvidia/ga107/nvdec/scrubber.bin -> ../../ga102/nvdec/scrubber.bin
+-Link: nvidia/ga107/sec2/desc.bin -> ../../ga102/sec2/desc.bin
+-Link: nvidia/ga107/sec2/hs_bl_sig.bin -> ../../ga102/sec2/hs_bl_sig.bin
+-Link: nvidia/ga107/sec2/image.bin -> ../../ga102/sec2/image.bin
+-Link: nvidia/ga107/sec2/sig.bin -> ../../ga102/sec2/sig.bin
+-
+-File: nvidia/tu10x/typec/ccg_primary.cyacd
+-File: nvidia/tu10x/typec/ccg_secondary.cyacd
+-File: nvidia/tu10x/typec/ccg_boot.cyacd
+-
+-Licence: Redistributable. See LICENCE.nvidia for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: mtk_scp - MediaTek SCP System Control Processing Driver
+ 
+ File: mediatek/mt8183/scp.img
+@@ -1903,53 +587,6 @@ Licence: Redistributable. See LICENSE.sdma_firmware for details
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: adreno - Qualcomm Adreno GPU firmware
+-
+-File: qcom/a300_pfp.fw
+-Link: a300_pfp.fw -> qcom/a300_pfp.fw
+-File: qcom/a300_pm4.fw
+-Link: a300_pm4.fw -> qcom/a300_pm4.fw
+-File: qcom/a330_pfp.fw
+-File: qcom/a330_pm4.fw
+-File: qcom/a420_pfp.fw
+-File: qcom/a420_pm4.fw
+-File: qcom/a530_pfp.fw
+-File: qcom/a530_pm4.fw
+-File: qcom/a530v3_gpmu.fw2
+-File: qcom/apq8096/a530_zap.mbn
+-Link: qcom/a530_zap.mdt -> apq8096/a530_zap.mbn
+-File: qcom/a630_gmu.bin
+-File: qcom/a630_sqe.fw
+-File: qcom/sdm845/a630_zap.mbn
+-File: qcom/a650_gmu.bin
+-File: qcom/a650_sqe.fw
+-File: qcom/sm8250/a650_zap.mbn
+-File: qcom/a660_gmu.bin
+-File: qcom/a660_sqe.fw
+-File: qcom/leia_pfp_470.fw
+-File: qcom/leia_pm4_470.fw
+-File: qcom/sc8280xp/LENOVO/21BX/qcdxkmsuc8280.mbn
+-
+-Licence: Redistributable. See LICENSE.qcom and qcom/NOTICE.txt for details
+-
+-Binary files supplied originally from
+-https://developer.qualcomm.com/hardware/dragonboard-410c/tools
+-
+---------------------------------------------------------------------------
+-
+-Driver: adreno - Qualcomm Adreno GPU firmware
+-
+-File: qcom/yamato_pfp.fw
+-File: qcom/yamato_pm4.fw
+-
+-Licence: Redistributable, BSD-3-Clause licence, See LICENSE.qcom_yamato for details
+-
+-Binary files generated from header files in EfikaMX kernel sources. A prefix of
+-four zero bytes was prepended to make them work with the DRM MSM driver. See
+-https://github.com/genesi/linux-legacy/tree/master/drivers/mxc/amd-gpu
+-
+---------------------------------------------------------------------------
+-
+ Driver: mlxsw_spectrum - Mellanox Spectrum switch
+ 
+ File: mellanox/mlxsw_spectrum-13.1420.122.mfa2
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0009-linux-firmware-various-Remove-firmware-for-various-d.patch
+++ b/packages/linux-firmware/0009-linux-firmware-various-Remove-firmware-for-various-d.patch
@@ -1,0 +1,324 @@
+From aa70d48430741bc74b64f9ceb0df1348e7a0aa6d Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Wed, 26 Jul 2023 11:23:46 +0000
+Subject: [PATCH] linux-firmware: various: Remove firmware for various devices
+
+This patch is a catch all for any specialized hardware that did not
+losely fit into any of the other categories. Bottlerocket does not
+provide drivers for any of these devices, so there is no use in shipping
+firmware for them.
+
+The following list maps driver names as specified in WHENCE to kernel
+config options to allow for easy adding of firmware should driver
+enablement make that necessary.
+
+* dsp56k - CONFIG_ATARI_DSP56K
+* yam - CONFIG_YAM
+* mtk_scp - CONFIG_MTK_SCP
+* imx-sdma - CONFIG_IMX_SDMA
+* mlxsw_spectrum - CONFIG_MLXSW_SPECTRUM
+* prestera - CONFIG_PRESTERA
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENCE.Marvell       |  22 ------
+ LICENCE.mediatek      |   9 ---
+ LICENSE.sdma_firmware |  47 ------------
+ WHENCE                | 164 ------------------------------------------
+ 4 files changed, 242 deletions(-)
+ delete mode 100644 LICENCE.Marvell
+ delete mode 100644 LICENCE.mediatek
+ delete mode 100644 LICENSE.sdma_firmware
+
+diff --git a/LICENCE.Marvell b/LICENCE.Marvell
+deleted file mode 100644
+index fdf4cda..0000000
+--- a/LICENCE.Marvell
++++ /dev/null
+@@ -1,22 +0,0 @@
+-Copyright © 2019.  Marvell International Ltd.  All rights reserved.
+-
+-Redistribution and use in binary form is permitted provided that the following
+-conditions are met:
+-
+-1. Redistributions must reproduce the above copyright notice, this list of
+-conditions and the following disclaimer in the documentation and/or other
+-materials provided with the distribution.
+-
+-2. Redistribution and use shall be used only with Marvell silicon products.
+-Any other use, reproduction, modification, translation, or compilation of the
+-Software is prohibited.
+-
+-3. No reverse engineering, decompilation, or disassembly is permitted.
+-
+-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THIS SOFTWARE IS PROVIDED
+-“AS IS” WITHOUT WARRANTY OF ANY KIND, INCLUDING, WITHOUT LIMITATION, ANY EXPRESS
+-OR IMPLIED WARRANTIES OF MERCHANTABILITY, ACCURACY, FITNESS OR SUFFICIENCY FOR A
+-PARTICULAR PURPOSE, SATISFACTORY QUALITY, CORRESPONDENCE WITH DESCRIPTION, QUIET
+-ENJOYMENT OR NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS.
+-MARVELL, ITS AFFILIATES AND THEIR SUPPLIERS DISCLAIM ANY WARRANTY THAT THE
+-DELIVERABLES WILL OPERATE WITHOUT INTERRUPTION OR BE ERROR-FREE.
+diff --git a/LICENCE.mediatek b/LICENCE.mediatek
+deleted file mode 100644
+index 6886c61..0000000
+--- a/LICENCE.mediatek
++++ /dev/null
+@@ -1,9 +0,0 @@
+-MediaTek Inc. grants permission to use and redistribute aforementioned firmware
+-files for the use with devices containing MediaTek chipsets, but not as part of
+-the Linux kernel or in any other form which would require these files themselves
+-to be covered by the terms of the GNU General Public License or the GNU Lesser
+-General Public License.
+-
+-These firmware files are distributed in the hope that they will be useful, but
+-are provided WITHOUT ANY WARRANTY, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTY
+-OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+diff --git a/LICENSE.sdma_firmware b/LICENSE.sdma_firmware
+deleted file mode 100644
+index 0d3d562..0000000
+--- a/LICENSE.sdma_firmware
++++ /dev/null
+@@ -1,47 +0,0 @@
+-Copyright 2017, NXP
+-All rights reserved.
+-
+-Redistribution. Reproduction and redistribution in binary form, without
+-modification, for use solely in conjunction with a NXP
+-chipset, is permitted provided that the following conditions are met:
+-
+-  . Redistributions must reproduce the above copyright notice and the following
+-    disclaimer in the documentation and/or other materials provided with the
+-    distribution.
+-
+-  . Neither the name of NXP nor the names of its suppliers
+-    may be used to endorse or promote products derived from this Software
+-    without specific prior written permission.
+-
+-  . No reverse engineering, decompilation, or disassembly of this Software is
+-    permitted.
+-
+-Limited patent license. NXP (.Licensor.) grants you
+-(.Licensee.) a limited, worldwide, royalty-free, non-exclusive license under
+-the Patents to make, have made, use, import, offer to sell and sell the
+-Software. No hardware per se is licensed hereunder.
+-The term .Patents. as used in this agreement means only those patents or patent
+-applications owned solely and exclusively by Licensor as of the date of
+-Licensor.s submission of the Software and any patents deriving priority (i.e.,
+-having a first effective filing date) therefrom. The term .Software. as used in
+-this agreement means the firmware image submitted by Licensor, under the terms
+-of this license, to git://git.kernel.org/pub/scm/linux/kernel/git/firmware/
+-linux-firmware.git.
+-Notwithstanding anything to the contrary herein, Licensor does not grant and
+-Licensee does not receive, by virtue of this agreement or the Licensor's
+-submission of any Software, any license or other rights under any patent or
+-patent application owned by any affiliate of Licensor or any other entity
+-(other than Licensor), whether expressly, impliedly, by virtue of estoppel or
+-exhaustion, or otherwise.
+-
+-DISCLAIMER. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+diff --git a/WHENCE b/WHENCE
+index 3bb6523..748a81e 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -8,20 +8,6 @@ kernel.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: dsp56k - Atari DSP56k support
+-
+-File: dsp56k/bootstrap.bin
+-Source: dsp56k/bootstrap.asm
+-Source: dsp56k/Makefile
+-Source: dsp56k/concat-bootstrap.pl
+-
+-Licence: GPLv2 or later. See GPL-2 and GPL-3 for details.
+-
+-DSP56001 assembler, buildable with a56 from
+-http://www.zdomain.com/a56.html
+-
+---------------------------------------------------------------------------
+-
+ Driver: cxgb4 - Chelsio Terminator 4/5/6 1/10/25/40/100G Ethernet adapter
+ 
+ File: cxgb4/t4fw-1.14.4.0.bin
+@@ -69,18 +55,6 @@ Found in hex form in kernel source.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: yam - YAM driver for AX.25
+-
+-File: yam/1200.bin
+-File: yam/9600.bin
+-
+-Licence:
+- * (C) F6FBB 1998
+-
+-Found in hex form in kernel source.
+-
+---------------------------------------------------------------------------
+-
+ Driver: bnx2x: Broadcom Everest
+ 
+ File: bnx2x/bnx2x-e1-7.13.1.0.fw
+@@ -561,132 +535,6 @@ Version: HuC API/APB ver 8.5.0 for Meteorlake
+ License: Redistributable. See LICENSE.i915 for details
+ --------------------------------------------------------------------------
+ 
+-Driver: mtk_scp - MediaTek SCP System Control Processing Driver
+-
+-File: mediatek/mt8183/scp.img
+-Version: v2.0.13324
+-File: mediatek/mt8186/scp.img
+-Version: v0.0.9
+-File: mediatek/mt8192/scp.img
+-Version: v2.0.20536
+-File: mediatek/mt8195/scp.img
+-Version: v2.0.11966
+-
+-Licence: Redistributable. See LICENCE.mediatek for details.
+-
+---------------------------------------------------------------------------
+-
+-Driver: imx-sdma - support for i.MX SDMA driver
+-
+-File: imx/sdma/sdma-imx6q.bin
+-Version: 3.3
+-File: imx/sdma/sdma-imx7d.bin
+-Version: 4.2
+-
+-Licence: Redistributable. See LICENSE.sdma_firmware for details
+-
+---------------------------------------------------------------------------
+-
+-Driver: mlxsw_spectrum - Mellanox Spectrum switch
+-
+-File: mellanox/mlxsw_spectrum-13.1420.122.mfa2
+-File: mellanox/mlxsw_spectrum-13.1530.152.mfa2
+-File: mellanox/mlxsw_spectrum-13.1620.192.mfa2
+-File: mellanox/mlxsw_spectrum-13.1702.6.mfa2
+-File: mellanox/mlxsw_spectrum-13.1703.4.mfa2
+-File: mellanox/mlxsw_spectrum-13.1910.622.mfa2
+-File: mellanox/mlxsw_spectrum-13.2000.1122.mfa2
+-File: mellanox/mlxsw_spectrum-13.2000.1886.mfa2
+-File: mellanox/mlxsw_spectrum-13.2000.2308.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2000.2308.mfa2
+-File: mellanox/mlxsw_spectrum-13.2000.2714.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2000.2714.mfa2
+-File: mellanox/mlxsw_spectrum-13.2007.1168.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2007.1168.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2007.1168.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.1036.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.1036.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.1036.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.1310.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.1310.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.1310.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.1312.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.1312.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.1312.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.2018.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.2018.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.2018.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.2304.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.2304.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.2304.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.2406.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.2406.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.2406.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.2438.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.2438.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.2438.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.2946.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.2946.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.2946.mfa2
+-File: mellanox/mlxsw_spectrum-13.2008.3326.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2008.3326.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2008.3326.mfa2
+-File: mellanox/mlxsw_spectrum-13.2010.1006.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2010.1006.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2010.1006.mfa2
+-File: mellanox/lc_ini_bundle_2010_1006.bin
+-File: mellanox/mlxsw_spectrum-13.2010.1232.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2010.1232.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2010.1232.mfa2
+-File: mellanox/mlxsw_spectrum-13.2010.1406.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2010.1406.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2010.1406.mfa2
+-File: mellanox/mlxsw_spectrum-13.2010.1502.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2010.1502.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2010.1502.mfa2
+-File: mellanox/lc_ini_bundle_2010_1502.bin
+-File: mellanox/mlxsw_spectrum-13.2010.3020.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2010.3020.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2010.3020.mfa2
+-File: mellanox/lc_ini_bundle_2010_3020.bin
+-File: mellanox/mlxsw_spectrum-13.2010.3146.mfa2
+-File: mellanox/mlxsw_spectrum2-29.2010.3146.mfa2
+-File: mellanox/mlxsw_spectrum3-30.2010.3146.mfa2
+-File: mellanox/lc_ini_bundle_2010_3146.bin
+-
+-Licence:
+- Copyright (c) 2017-2020 Mellanox Technologies, Ltd. All rights reserved.
+-
+- Redistribution and use in source and binary forms, with or without
+- modification, are permitted provided that the following conditions are met:
+-
+- 1. Redistributions of source code must retain the above copyright
+-    notice, this list of conditions and the following disclaimer.
+- 2. Redistributions in binary form must reproduce the above copyright
+-    notice, this list of conditions and the following disclaimer in the
+-    documentation and/or other materials provided with the distribution.
+- 3. Neither the names of the copyright holders nor the names of its
+-    contributors may be used to endorse or promote products derived from
+-    this software without specific prior written permission.
+-
+- Alternatively, this software may be distributed under the terms of the
+- GNU General Public License ("GPL") version 2 as published by the Free
+- Software Foundation.
+-
+- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+- POSSIBILITY OF SUCH DAMAGE.
+-
+---------------------------------------------------------------------------
+-
+ Driver: ice - Intel(R) Ethernet Connection E800 Series
+ 
+ File: intel/ice/ddp/ice-1.3.30.0.pkg
+@@ -700,15 +548,3 @@ File: intel/ice/ddp-wireless_edge/ice_wireless_edge-1.3.10.0.pkg
+ License: Redistributable. See LICENSE.ice_enhanced for details
+ 
+ --------------------------------------------------------------------------
+-
+-Driver: prestera - Marvell driver for Prestera family ASIC devices
+-
+-File: mrvl/prestera/mvsw_prestera_fw-v2.0.img
+-File: mrvl/prestera/mvsw_prestera_fw-v3.0.img
+-File: mrvl/prestera/mvsw_prestera_fw-v4.0.img
+-File: mrvl/prestera/mvsw_prestera_fw-v4.1.img
+-File: mrvl/prestera/mvsw_prestera_fw_arm64-v4.1.img
+-
+-Licence: Redistributable. See LICENCE.Marvell for details.
+-
+-------------------------------------------------
+-- 
+2.40.1
+

--- a/packages/linux-firmware/0010-linux-firmware-amd-ucode-Remove-amd-microcode.patch
+++ b/packages/linux-firmware/0010-linux-firmware-amd-ucode-Remove-amd-microcode.patch
@@ -1,0 +1,122 @@
+From 820980a4ec6d39dcec84639fb4b7a80bb33f8a21 Mon Sep 17 00:00:00 2001
+From: Leonard Foerster <foersleo@amazon.com>
+Date: Wed, 26 Jul 2023 11:28:35 +0000
+Subject: [PATCH] linux-firmware: amd-ucode: Remove amd microcode
+
+Bottlerocket ships AMD microcode as part of the kernel packages already.
+There is no need to ship these microcode images twice.
+
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ LICENSE.amd-ucode | 64 -----------------------------------------------
+ WHENCE            | 23 -----------------
+ 2 files changed, 87 deletions(-)
+ delete mode 100644 LICENSE.amd-ucode
+
+diff --git a/LICENSE.amd-ucode b/LICENSE.amd-ucode
+deleted file mode 100644
+index ea47c57..0000000
+--- a/LICENSE.amd-ucode
++++ /dev/null
+@@ -1,64 +0,0 @@
+-Copyright (C) 2010-2022 Advanced Micro Devices, Inc., All rights reserved.
+-
+-Permission is hereby granted by Advanced Micro Devices, Inc. ("AMD"),
+-free of any license fees, to any person obtaining a copy of this
+-microcode in binary form (the "Software") ("You"), to install,
+-reproduce, copy and distribute copies of the Software and to permit
+-persons to whom the Software is provided to do the same, subject to
+-the following terms and conditions.  Your use of any portion of the
+-Software shall constitute Your acceptance of the following terms and
+-conditions. If You do not agree to the following terms and conditions,
+-do not use, retain or redistribute any portion of the Software.
+-
+-If You redistribute this Software, You must reproduce the above
+-copyright notice and this license with the Software.
+-Without specific, prior, written permission from AMD, You may not
+-reference AMD or AMD products in the promotion of any product derived
+-from or incorporating this Software in any manner that implies that
+-AMD endorses or has certified such product derived from or
+-incorporating this Software.
+-
+-You may not reverse engineer, decompile, or disassemble this Software
+-or any portion thereof.
+-
+-THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED
+-WARRANTY OF ANY KIND, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+-MERCHANTABILITY, NONINFRINGEMENT, TITLE, FITNESS FOR ANY PARTICULAR
+-PURPOSE, OR WARRANTIES ARISING FROM CONDUCT, COURSE OF DEALING, OR
+-USAGE OF TRADE. IN NO EVENT SHALL AMD OR ITS LICENSORS BE LIABLE FOR
+-ANY DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR
+-LOSS OF PROFITS, BUSINESS INTERRUPTION, OR LOSS OF DATA OR
+-INFORMATION) ARISING OUT OF AMD'S NEGLIGENCE, GROSS NEGLIGENCE, THE
+-USE OF OR INABILITY TO USE THE SOFTWARE, EVEN IF AMD HAS BEEN ADVISED
+-OF THE POSSIBILITY OF SUCH DAMAGES. BECAUSE SOME JURISDICTIONS
+-PROHIBIT THE EXCLUSION OR LIMITATION OF LIABILITY FOR CONSEQUENTIAL OR
+-INCIDENTAL DAMAGES OR THE EXCLUSION OF IMPLIED WARRANTIES, THE ABOVE
+-LIMITATION MAY NOT APPLY TO YOU.
+-
+-Without limiting the foregoing, the Software may implement third party
+-technologies for which You must obtain licenses from parties other
+-than AMD. You agree that AMD has not obtained or conveyed to You, and
+-that You shall be responsible for obtaining the rights to use and/or
+-distribute the applicable underlying intellectual property rights
+-related to the third party technologies. These third party
+-technologies are not licensed hereunder.
+-
+-If You use the Software (in whole or in part), You shall adhere to all
+-applicable U.S., European, and other export laws, including but not
+-limited to the U.S. Export Administration Regulations ("EAR"), (15
+-C.F.R. Sections 730 through 774), and E.U. Council Regulation (EC) No
+-1334/2000 of 22 June 2000. Further, pursuant to Section 740.6  of the
+-EAR, You hereby certify that, except pursuant to a license granted by
+-the United States Department of Commerce Bureau of Industry and
+-Security or as otherwise permitted pursuant to a License Exception
+-under the U.S. Export Administration Regulations ("EAR"), You will not
+-(1) export, re-export or release to a national of a country in Country
+-Groups D:1, E:1 or E:2 any restricted technology, software, or source
+-code You receive hereunder, or (2) export to Country Groups D:1, E:1
+-or E:2 the direct product of such technology or software, if such
+-foreign produced direct product is subject to national security
+-controls as identified on the Commerce Control List (currently found
+-in Supplement 1 to Part 774 of EAR). For the most current Country
+-Group listings, or for additional information about the EAR or Your
+-obligations under those regulations, please refer to the U.S. Bureau
+-of Industry and Security?s website at ttp://www.bis.doc.gov/.
+diff --git a/WHENCE b/WHENCE
+index 748a81e..5c19692 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -147,29 +147,6 @@ License: Redistributable.  See LICENCE.myri10ge_firmware for details.
+ 
+ --------------------------------------------------------------------------
+ 
+-Driver: microcode_amd - AMD CPU Microcode Update Driver for Linux
+-
+-File: amd-ucode/microcode_amd.bin
+-Raw: amd-ucode/microcode_amd.bin
+-Version: 2013-07-10
+-File: amd-ucode/microcode_amd_fam15h.bin
+-Raw: amd-ucode/microcode_amd_fam15h.bin
+-Version: 2018-05-24
+-File: amd-ucode/microcode_amd_fam16h.bin
+-Raw: amd-ucode/microcode_amd_fam16h.bin
+-Version: 2014-10-28
+-File: amd-ucode/microcode_amd_fam17h.bin
+-Raw: amd-ucode/microcode_amd_fam17h.bin
+-Version: 2023-04-13
+-File: amd-ucode/microcode_amd_fam19h.bin
+-Raw: amd-ucode/microcode_amd_fam19h.bin
+-Version: 2023-01-31
+-File: amd-ucode/README
+-
+-License: Redistributable. See LICENSE.amd-ucode for details
+-
+---------------------------------------------------------------------------
+-
+ Driver: i915 -- Intel Integrated Graphics driver
+ 
+ File: i915/skl_dmc_ver1_23.bin
+-- 
+2.40.1
+

--- a/packages/linux-firmware/Cargo.toml
+++ b/packages/linux-firmware/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "linux-firmware"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[package.metadata.build-package]
+package-name = "linux-firmware"
+
+[lib]
+path = "../packages.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-20230625.tar.xz"
+sha512 = "0e48aa7f63495485426d37491c7cb61843165625bd47f912c5d83628c6de871759f1a78be3af3d651f7c396bd87dff07e21ba7afc47896c1c143106d5f16d351"

--- a/packages/linux-firmware/linux-firmware.spec
+++ b/packages/linux-firmware/linux-firmware.spec
@@ -11,7 +11,16 @@ Name: %{_cross_os}linux-firmware
 Version: 20230625
 Release: 1%{?dist}
 Summary: Firmware files used by the Linux kernel
-License: GPL+ and GPLv2+ and MIT and Redistributable, no modification permitted
+# The following list of SPDX identifiers was constructed with help of scancode
+# tooling and has turned up the following licenses for different drivers by
+# checking the different LICENCE/LICENSE files and the licenses in WHENCE:
+# * BSD-Source-Code - myri10ge
+# * LicenseRef-scancode-chelsio-linux-firmware - cxgb4
+# * LicenseRef-scancode-qlogic-firmware - netxen_nic
+# * LicenseRef-scancode-intel - i915, ice
+# * LicenseRef-scancode-proprietary-license - bnx2x, qed
+# * LicenseRef-scancode-free-unknown - tg3
+License: GPL-1.0-or-later AND GPL-2.0-or-later AND BSD-Source-Code AND LicenseRef-scancode-chelsio-linux-firmware AND LicenseRef-scancode-qlogic-firmware AND LicenseRef-scancode-intel AND LicenseRef-scancode-proprietary-license AND LicenseRef-scancode-free-unknown
 URL: https://www.kernel.org/
 
 Source0: https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-%{version}.tar.xz

--- a/packages/linux-firmware/linux-firmware.spec
+++ b/packages/linux-firmware/linux-firmware.spec
@@ -16,6 +16,17 @@ URL: https://www.kernel.org/
 
 Source0: https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-%{version}.tar.xz
 
+Patch0001: 0001-linux-firmware-snd-remove-firmware-for-snd-audio-dev.patch
+Patch0002: 0002-linux-firmware-video-Remove-firmware-for-video-broad.patch
+Patch0003: 0003-linux-firmware-bt-wifi-Remove-firmware-for-Bluetooth.patch
+Patch0004: 0004-linux-firmware-scsi-Remove-firmware-for-SCSI-devices.patch
+Patch0005: 0005-linux-firmware-usb-remove-firmware-for-USB-Serial-PC.patch
+Patch0006: 0006-linux-firmware-ethernet-Remove-firmware-for-ethernet.patch
+Patch0007: 0007-linux-firmware-Remove-firmware-for-Accelarator-devic.patch
+Patch0008: 0008-linux-firmware-gpu-Remove-firmware-for-GPU-devices.patch
+Patch0009: 0009-linux-firmware-various-Remove-firmware-for-various-d.patch
+Patch0010: 0010-linux-firmware-amd-ucode-Remove-amd-microcode.patch
+
 %description
 %{summary}.
 

--- a/packages/linux-firmware/linux-firmware.spec
+++ b/packages/linux-firmware/linux-firmware.spec
@@ -1,0 +1,47 @@
+%global debug_package %{nil}
+
+%global fwdir %{_cross_libdir}/firmware
+
+# Many of the firmware files have specialized binary formats that are not supported
+# by the strip binary used in __spec_install_post macro. Work around build failures
+# by skipping striping.
+%global __strip /usr/bin/true
+
+Name: %{_cross_os}linux-firmware
+Version: 20230625
+Release: 1%{?dist}
+Summary: Firmware files used by the Linux kernel
+License: GPL+ and GPLv2+ and MIT and Redistributable, no modification permitted
+URL: https://www.kernel.org/
+
+Source0: https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-%{version}.tar.xz
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n linux-firmware-%{version} -p1
+
+%build
+
+%install
+mkdir -p %{buildroot}/%{fwdir}
+mkdir -p %{buildroot}/%{fwdir}/updates
+
+# Here we have potential to shave off some extra space by using `install-xz` of
+# `install-zst` to compress firmware images on disk. However, that functionality
+# relies on kernels being configured with `CONFIG_FW_LOADER_COMPRESS_[ZSTD|XZ]`
+# which we currently do not have.
+make DESTDIR=%{buildroot}/ FIRMWAREDIR=%{fwdir} install
+
+
+# Remove executable bits from random firmware
+pushd %{buildroot}/%{fwdir}
+find . -type f -executable -exec chmod -x {} \;
+popd
+
+%files
+%dir %{fwdir}
+%{fwdir}/*
+%license LICENCE.* LICENSE.* GPL* WHENCE
+%{_cross_attribution_file}

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -856,6 +856,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-firmware"
+version = "0.1.0"
+
+[[package]]
 name = "log4j2-hotpatch"
 version = "0.1.0"
 
@@ -889,6 +893,7 @@ dependencies = [
  "docker-proxy",
  "iputils",
  "kernel-6_1",
+ "linux-firmware",
  "login",
  "release",
  "strace",
@@ -902,6 +907,7 @@ dependencies = [
  "cni-plugins",
  "kernel-5_10",
  "kubernetes-1_23",
+ "linux-firmware",
  "release",
 ]
 
@@ -913,6 +919,7 @@ dependencies = [
  "cni-plugins",
  "kernel-5_15",
  "kubernetes-1_24",
+ "linux-firmware",
  "release",
 ]
 
@@ -924,6 +931,7 @@ dependencies = [
  "cni-plugins",
  "kernel-5_15",
  "kubernetes-1_25",
+ "linux-firmware",
  "release",
 ]
 
@@ -935,6 +943,7 @@ dependencies = [
  "cni-plugins",
  "kernel-5_15",
  "kubernetes-1_26",
+ "linux-firmware",
  "release",
 ]
 
@@ -946,6 +955,7 @@ dependencies = [
  "cni-plugins",
  "kernel-5_15",
  "kubernetes-1_27",
+ "linux-firmware",
  "release",
 ]
 

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
+    "linux-firmware",
 # docker
     "docker-cli",
     "docker-engine",
@@ -45,6 +46,7 @@ path = "../variants.rs"
 # core
 release = { path = "../../packages/release" }
 kernel-6_1 = { path = "../../packages/kernel-6.1" }
+linux-firmware = { path = "../../packages/linux-firmware" }
 # docker
 docker-cli = { path = "../../packages/docker-cli" }
 docker-engine = { path = "../../packages/docker-engine" }

--- a/variants/metal-k8s-1.23/Cargo.toml
+++ b/variants/metal-k8s-1.23/Cargo.toml
@@ -27,6 +27,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kernel-5.10",
+    "linux-firmware",
     "kubelet-1.23",
     "release",
 ]
@@ -38,5 +39,6 @@ path = "../variants.rs"
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_10 = { path = "../../packages/kernel-5.10" }
+linux-firmware = { path = "../../packages/linux-firmware" }
 kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
 release = { path = "../../packages/release" }

--- a/variants/metal-k8s-1.24/Cargo.toml
+++ b/variants/metal-k8s-1.24/Cargo.toml
@@ -27,6 +27,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kernel-5.15",
+    "linux-firmware",
     "kubelet-1.24",
     "release",
 ]
@@ -38,5 +39,6 @@ path = "../variants.rs"
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
+linux-firmware = { path = "../../packages/linux-firmware" }
 kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
 release = { path = "../../packages/release" }

--- a/variants/metal-k8s-1.25/Cargo.toml
+++ b/variants/metal-k8s-1.25/Cargo.toml
@@ -27,6 +27,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kernel-5.15",
+    "linux-firmware",
     "kubelet-1.25",
     "release",
 ]
@@ -38,5 +39,6 @@ path = "../variants.rs"
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
+linux-firmware = { path = "../../packages/linux-firmware" }
 kubernetes-1_25 = { path = "../../packages/kubernetes-1.25" }
 release = { path = "../../packages/release" }

--- a/variants/metal-k8s-1.26/Cargo.toml
+++ b/variants/metal-k8s-1.26/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kernel-5.15",
+    "linux-firmware",
     "kubelet-1.26",
     "release",
 ]
@@ -39,5 +40,6 @@ path = "../variants.rs"
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
+linux-firmware = { path = "../../packages/linux-firmware" }
 kubernetes-1_26 = { path = "../../packages/kubernetes-1.26" }
 release = { path = "../../packages/release" }

--- a/variants/metal-k8s-1.27/Cargo.toml
+++ b/variants/metal-k8s-1.27/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kernel-5.15",
+    "linux-firmware",
     "kubelet-1.27",
     "release",
 ]
@@ -39,5 +40,6 @@ path = "../variants.rs"
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }
+linux-firmware = { path = "../../packages/linux-firmware" }
 kubernetes-1_27 = { path = "../../packages/kubernetes-1.27" }
 release = { path = "../../packages/release" }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3246

**Description of changes:**

With introduction of Metal variants we opened up Bottlerocket to a wider variety of Hardware configurations. In the past we have added driver support for some server grade hardware, mostly in the 10G+ NIC realm. While adding the drivers, we overlooked that some of these devices may need firmware binaries to be available in order to update firmware and function with the driver version shipped with the kernel.

Add firmware from [linux-firmware](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/) to our metal variants for drivers we support in Bottlerocket. I have made an effort to cut down the list of binaries to only the ones we currently supply drivers for, as the linux-firmware package is quite large in full. I was able to cut the size of the installed size on disk down from 426 MB for the full package to 29 MB for the stripped down version carrying only the needed firmware.

We could strip the size on disk down even further when using compressed firmware images. Currently ZSTD and XZ compression are supported. While ZSTD does not change the size significantly XZ compression can further reduce the size from 29 MB (uncompressed) to 25 MB (xz compressed). However, doing that requires us to enable additional kernel config options `CONFIG_FW_LOADER_COMPRESS` and `CONFIG_FW_LOADER_COMPRESS_XZ`. That optimization can probably be part of a separate **commit.**

The resulting firmware package carries firmware for the following list of drivers and their corresponding config options we have configured for our metal kernels:

```
cxgb4 - CONFIG_CHELSIO_T4
tg3 - CONFIG_TIGON3
bnx2x - CONFIG_BNX2X
netxen_nic - CONFIG_NETXEN_NIC
qed - CONFIG_QED
myri10ge - CONFIG_MYRI10GE
i915 - CONFIG_DRM_I915
ice - CONFIG_ICE
```

**Testing done:**

I have done some build testing. Unfortunately assessing if all the firmware is in the correct place and can be reached by the drivers is beyond what I can do as I do not have access to these devices.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
