### PR TITLE
Correct the SPDX grammar for xfsprogs and oci-add-hooks packages

### DIFF
--- a/packages/oci-add-hooks/oci-add-hooks.spec
+++ b/packages/oci-add-hooks/oci-add-hooks.spec
@@ -9,7 +9,7 @@ Name: %{_cross_os}oci-add-hooks
 Version: 1.0.0
 Release: 1%{?dist}
 Summary: OCI runtime wrapper that injects OCI hooks
-License: Apache-2.0 and MIT
+License: Apache-2.0 AND MIT
 URL: https://github.com/awslabs/oci-add-hooks
 Source0: %{gorepo}-%{shortrev}.tar.gz
 Source1: bundled-%{gorepo}-%{shortrev}.tar.gz

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -2,7 +2,7 @@ Name: %{_cross_os}xfsprogs
 Version: 6.3.0
 Release: 1%{?dist}
 Summary: Utilities for managing the XFS filesystem
-License: GPL-2.0-only and LGPL-2.1-only
+License: GPL-2.0-only AND LGPL-2.1-only
 URL: https://xfs.wiki.kernel.org
 Source0: http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-%{version}.tar.xz
 Patch1: 0001-libxfs-do-not-try-to-run-the-crc32selftest.patch


### PR DESCRIPTION

**Description of changes:** This PR corrects the usage of `and` in our licenses for `xfsprogs` and `oci-add-hooks` to use proper SPDX  grammar. These now use `AND` which is correct.


**Testing done:** N/A its a License only change and only improves the grammar, doesn't change the licenses.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
