### PR TITLE
tools/diff-kernel-config: various small improvements

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -31,7 +31,7 @@ bail() {
 
 usage() {
     cat <<EOF
-Usage: $0 -b GITREV_BEFORE -a GITREV_AFTER -o OUTPUT_DIR [-v VARIANT] [-h]
+Usage: $0 -b GITREV_BEFORE -a GITREV_AFTER -o OUTPUT_DIR [-v VARIANT] [-r] [-h]
 Compare kernel configurations before and after a series of commits.
 
     -a, --after         new Git revision to compare from
@@ -40,6 +40,8 @@ Compare kernel configurations before and after a series of commits.
                         be given multiple times (optional, defaults to this list:
                         'aws-k8s-1.23', 'metal-k8s-1.23', 'aws-dev', 'metal-dev')
     -o, --output-dir    path to the output directory; must not exist yet
+    -r, --resume        resume work on a previous invocation; check which parts
+                        already exist in OUTPUT_DIR and skip builds accordingly
     -h, --help          show this help text
 
 Example invocation:
@@ -84,6 +86,8 @@ while [[ $# -gt 0 ]]; do
             shift; variants+=( "$1" ) ;;
         -o|--output-dir)
             shift; output_dir=$1 ;;
+        -r|--resume)
+            shift; resume=1 ;;
         -h|--help)
             usage; exit 0 ;;
         *)
@@ -102,7 +106,7 @@ done
 readonly variants
 
 [[ -n ${output_dir} ]] || usage_error 'require -o|--output-dir'
-[[ -e ${output_dir} ]] && bail "Output directory '${output_dir}' exists already, not touching it"
+[[ -e ${output_dir} && ! -v resume ]] && bail "Output directory '${output_dir}' exists already, not touching it"
 readonly output_dir
 
 # Validate and resolve the given before and after Git revisions. Resolving
@@ -163,6 +167,12 @@ for state in after before; do
         kernel_versions+=( "${kver}" )
 
         for arch in "${arches[@]}"; do
+            config_path=${output_dir}/config-${arch}-${variant}-${state}
+
+            if [[ -v resume && -e ${config_path} ]]; then
+                echo "${config_path} already exists, skipping"
+                continue
+            fi
 
             debug_id="state=${state} arch=${arch} variant=${variant} kernel=${kver}"
 
@@ -212,7 +222,6 @@ for state in after before; do
             # Extract kernel config
             #
 
-            config_path=${output_dir}/config-${arch}-${variant}-${state}
             rpm2cpio "${kernel_rpm}" \
                 | cpio --quiet --extract --to-stdout ./boot/config >"${config_path}"
             [[ -s "${config_path}" ]] || bail "Failed to extract config for ${debug_id}"

--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -31,7 +31,7 @@ bail() {
 
 usage() {
     cat <<EOF
-Usage: $0 -b GITREV_BEFORE -a GITREV_AFTER -o OUTPUT_DIR [-k KERNEL_VERSION] [-h]
+Usage: $0 -b GITREV_BEFORE -a GITREV_AFTER -o OUTPUT_DIR [-v VARIANT] [-h]
 Compare kernel configurations before and after a series of commits.
 
     -a, --after         new Git revision to compare from

--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -206,7 +206,7 @@ for state in after before; do
                     ;;
             esac
 
-            kver_full=$(rpm --query --queryformat '%{VERSION}' "${kernel_rpm}")
+            kver_full=$(rpm --query --queryformat '%{VERSION}-%{RELEASE}' "${kernel_rpm}")
 
             #
             # Extract kernel config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** -

**Description of changes:**

Add three improvements (two minor, one bigger) to the diff-kernel-config tool.
The big interesting change enables the script to be resumed, which can save the time one would need for rebuilding things that already had been built successfully. This is particularly helpful when using the script for multiple variants where one variant may not build successfully, but others do. We can fix whatever fails that particular build and resume, keeping the state that finished successful previously.

**Testing done:**

I have used unpolished versions of these changes for previous kernel updates to cut down on time to redo builds.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
