### PR TITLE
Include systemd-logind for inhibit functionality

### DIFF
--- a/packages/systemd/systemd-tmpfiles.conf
+++ b/packages/systemd/systemd-tmpfiles.conf
@@ -3,4 +3,6 @@ d /run/lock 0755 root root -
 L /var/lock - - - - /run/lock
 Z /var/lib/systemd 0755 root root -
 z /var/lib/systemd/random-seed 600 root root -
+R /var/lib/systemd/linger
+D /var/lib/systemd/linger 0700 root root -
 d /etc/sysctl.d 0700 root root -

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -137,7 +137,7 @@ CONFIGURE_OPTS=(
  -Dcoredump=false
  -Dpstore=true
  -Doomd=false
- -Dlogind=false
+ -Dlogind=true
  -Dhostnamed=false
  -Dlocaled=false
  -Dmachined=false
@@ -301,6 +301,7 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_bindir}/systemd-detect-virt
 %{_cross_bindir}/systemd-escape
 %{_cross_bindir}/systemd-id128
+%{_cross_bindir}/systemd-inhibit
 %{_cross_bindir}/systemd-machine-id-setup
 %{_cross_bindir}/systemd-mount
 %{_cross_bindir}/systemd-notify
@@ -315,6 +316,7 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_bindir}/systemd-tty-ask-password-agent
 %{_cross_bindir}/systemd-umount
 %{_cross_bindir}/udevadm
+%{_cross_bindir}/loginctl
 
 %{_cross_sbindir}/halt
 %{_cross_sbindir}/init
@@ -338,11 +340,17 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_libdir}/udev/*
 %exclude %{_cross_libdir}/tmpfiles.d/systemd-network.conf
 %exclude %{_cross_libdir}/sysusers.d/systemd-network.conf
+%exclude %{_cross_libdir}/systemd/system/dbus-org.freedesktop.login1.service
 %exclude %{_cross_libdir}/systemd/systemd-networkd
 %exclude %{_cross_libdir}/systemd/systemd-networkd-wait-online
+%exclude %{_cross_libdir}/systemd/systemd-user-runtime-dir
 %exclude %{_cross_libdir}/systemd/system/systemd-networkd.service
 %exclude %{_cross_libdir}/systemd/system/systemd-networkd-wait-online.service
 %exclude %{_cross_libdir}/systemd/system/systemd-networkd.socket
+%exclude %{_cross_libdir}/pam.d/systemd-user
+%exclude %{_cross_libdir}/udev/rules.d/70-uaccess.rules
+%exclude %{_cross_libdir}/udev/rules.d/71-seat.rules
+%exclude %{_cross_libdir}/udev/rules.d/73-seat-late.rules
 
 %{_cross_tmpfilesdir}/*
 %exclude %{_cross_tmpfilesdir}/x11.conf
@@ -355,6 +363,7 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_datadir}/dbus-1/*
 %exclude %{_cross_datadir}/polkit-1
 %exclude %{_cross_datadir}/dbus-1/system-services/org.freedesktop.network1.service
+%exclude %{_cross_datadir}/dbus-1/system-services/org.freedesktop.login1.service
 %exclude %{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
 
 %dir %{_cross_factorydir}
@@ -364,6 +373,7 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d/other
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d/system-auth
+%exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d/systemd-user
 
 %exclude %{_cross_docdir}
 


### PR DESCRIPTION
**Issue number:**

Closes #3305 

**Description of changes:**

Settings were added for kubelet to be configured with pod shutdown grace policy settings. This feature allows kubelet to hold off a system shutdown until it has had a chance to terminate and migrate pod workloads cleanly.

Unfortunately, it was missed when these settings were added that the mechanism kubelet uses internally for this is to use systemd-inhibit that is part of systemd-logind. Without the systemd-logind functionality included in Bottlerocket, the attempt to start processes with inhibit protection would fail and shutdown calls would be immediate.

This adds systemd-logind to the systemd build process to enable this functionality, excluding things like PAM and its CLI since those are not needed for our inhibit requirements.

**Testing done:**

Checked initial inhibit list:

```sh
bash-5.1# systemd-inhibit --list
No inhibitors.
```

Configured Kubernetes graceful shutdown periods:

```sh
bash-5.1# apiclient apply <<EOF
> [settings.kubernetes]
> shutdown-grace-period = "15m"          
> shutdown-grace-period-for-critical-pods = "10m"
> EOF
```

Checked `kubelet` service status and checked logs to verify the node shutdown manager picked up settings without any errors:

```
Jul 31 17:58:22 ip-192-168-93-85.us-east-2.compute.internal kubelet[1179]: I0731 17:58:22.212698    1179 nodeshutdown_manager_linux.go:137] "Creating node shutdown manager
" shutdownGracePeriodRequested="15m0s" shutdownGracePeriodCriticalPods="10m0s" shutdownGracePeriodByPodPriority=[{Priority:0 ShutdownGracePeriodSeconds:300} {Priority:2000
000000 ShutdownGracePeriodSeconds:600}]
```

Listed inhibited processes again and verified kubelet shows up:

```sh
bash-5.1# systemd-inhibit --list                                                                                                             
WHO     UID USER PID  COMM    WHAT     WHY                                        MODE
kubelet 0   root 4356 kubelet shutdown Kubelet needs time to handle node shutdown delay

1 inhibitors listed.
```

Rebooted one of the nodes and made sure there were no errors reported.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
