### PR TITLE
[1.14.x] Add empty migration for 1.14.3

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.14.2"
+version = "1.14.3"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -215,3 +215,4 @@ version = "1.14.2"
 "(1.14.1, 1.14.2)" = [
     "migrate_v1.14.2_ecs-images-cleanup.lz4",
 ]
+"(1.14.2, 1.14.3)" = []


### PR DESCRIPTION
**Description of changes:**

Adds an empty migration definition to Release.toml to allow for a 1.14.3 release.

(cherry picked from commit f0ba96abb4ca5401ffad673b24e3b7864a549e3e)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
