### PR TITLE
selinux: Add `network_exec` label for systemd-networkd

### DIFF
--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -51,6 +51,7 @@
 (filecon "/.*/usr/sbin/chronyd" file clock_exec)
 (filecon "/.*/usr/sbin/wicked.*" file network_exec)
 (filecon "/.*/usr/libexec/wicked/bin/wicked.*" file network_exec)
+(filecon "/.*/usr/lib/systemd/systemd-networkd.*" file network_exec)
 (filecon "/.*/usr/bin/containerd.*" file runtime_exec)
 (filecon "/.*/usr/bin/docker.*" file runtime_exec)
 (filecon "/.*/usr/bin/host-ctr" file runtime_exec)


### PR DESCRIPTION
**Issue number:**
Related to #2449 

**Description of changes:**
This change adds the network_exec label to systemd-networkd and systemd-networkd-wait-online, which is what `wicked` currently has and which gives access to `/etc` and DBUS .


**Testing done:**
* Boot an `aws-k8s-1.24` variant as a sanity check; it comes up and joins the cluster properly.  No spurious AVC denial messages in the journal.
* Build an `aws-dev` variant with systemd-networkd enabled and ensure the right label is placed `systemd-networkd` and `systemd-networkd-wait-online`.  Also make sure no  AVC denial messages showed up in the journal.

```
bash-5.1# ls -lahZ /usr/lib/systemd/
...
-rwxr-xr-x.  1 root root system_u:object_r:network_exec_t:s0 2.7M Aug  2 21:12 systemd-networkd
-rwxr-xr-x.  1 root root system_u:object_r:network_exec_t:s0 314K Aug  2 21:12 systemd-networkd-wait-online
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
