### PR TITLE
Patch Docker host header fix for Go 1.20.6+ changes

### DIFF
--- a/packages/docker-cli/0001-non-tcp-host-header.patch
+++ b/packages/docker-cli/0001-non-tcp-host-header.patch
@@ -1,0 +1,121 @@
+From c85efebc0c9321fecc536485b47857dbcbe34ddf Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 12 Jul 2023 15:07:59 +0200
+Subject: [PATCH 1/2] pkg/plugins: use a dummy hostname for local connections
+
+For local communications (npipe://, unix://), the hostname is not used,
+but we need valid and meaningful hostname.
+
+The current code used the socket path as hostname, which gets rejected by
+go1.20.6 and go1.19.11 because of a security fix for [CVE-2023-29406 ][1],
+which was implemented in  https://go.dev/issue/60374.
+
+Prior versions go Go would clean the host header, and strip slashes in the
+process, but go1.20.6 and go1.19.11 no longer do, and reject the host
+header.
+
+Before this patch, tests would fail on go1.20.6:
+
+    === FAIL: pkg/authorization TestAuthZRequestPlugin (15.01s)
+    time="2023-07-12T12:53:45Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 1s"
+    time="2023-07-12T12:53:46Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 2s"
+    time="2023-07-12T12:53:48Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 4s"
+    time="2023-07-12T12:53:52Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 8s"
+        authz_unix_test.go:82: Failed to authorize request Post "http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq": http: invalid Host header
+
+[1]: https://github.com/advisories/GHSA-f8f7-69v5-w4vx
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+
+---
+ .../github.com/docker/docker/client/client.go | 30 +++++++++++++++++++
+ .../github.com/docker/docker/client/hijack.go |  6 +++-
+ .../docker/docker/client/request.go           | 10 +++----
+ 3 files changed, 39 insertions(+), 7 deletions(-)
+
+diff --git a/vendor/github.com/docker/docker/client/client.go b/vendor/github.com/docker/docker/client/client.go
+index 9b2b2eaeb8..5bf699d88d 100644
+--- a/vendor/github.com/docker/docker/client/client.go
++++ b/vendor/github.com/docker/docker/client/client.go
+@@ -57,6 +57,36 @@ import (
+ 	"github.com/pkg/errors"
+ )
+ 
++// DummyHost is a hostname used for local communication.
++//
++// It acts as a valid formatted hostname for local connections (such as "unix://"
++// or "npipe://") which do not require a hostname. It should never be resolved,
++// but uses the special-purpose ".localhost" TLD (as defined in [RFC 2606, Section 2]
++// and [RFC 6761, Section 6.3]).
++//
++// [RFC 7230, Section 5.4] defines that an empty header must be used for such
++// cases:
++//
++//	If the authority component is missing or undefined for the target URI,
++//	then a client MUST send a Host header field with an empty field-value.
++//
++// However, [Go stdlib] enforces the semantics of HTTP(S) over TCP, does not
++// allow an empty header to be used, and requires req.URL.Scheme to be either
++// "http" or "https".
++//
++// For further details, refer to:
++//
++//   - https://github.com/docker/engine-api/issues/189
++//   - https://github.com/golang/go/issues/13624
++//   - https://github.com/golang/go/issues/61076
++//   - https://github.com/moby/moby/issues/45935
++//
++// [RFC 2606, Section 2]: https://www.rfc-editor.org/rfc/rfc2606.html#section-2
++// [RFC 6761, Section 6.3]: https://www.rfc-editor.org/rfc/rfc6761#section-6.3
++// [RFC 7230, Section 5.4]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
++// [Go stdlib]: https://github.com/golang/go/blob/6244b1946bc2101b01955468f1be502dbadd6807/src/net/http/transport.go#L558-L569
++const DummyHost = "api.moby.localhost"
++
+ // ErrRedirect is the error returned by checkRedirect when the request is non-GET.
+ var ErrRedirect = errors.New("unexpected redirect in response")
+ 
+diff --git a/vendor/github.com/docker/docker/client/hijack.go b/vendor/github.com/docker/docker/client/hijack.go
+index e1dc49ef0f..b8fac0be7e 100644
+--- a/vendor/github.com/docker/docker/client/hijack.go
++++ b/vendor/github.com/docker/docker/client/hijack.go
+@@ -62,7 +62,11 @@ func fallbackDial(proto, addr string, tlsConfig *tls.Config) (net.Conn, error) {
+ }
+ 
+ func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto string) (net.Conn, error) {
+-	req.Host = cli.addr
++	req.URL.Host = cli.addr
++	if cli.proto == "unix" || cli.proto == "npipe" {
++		// Override host header for non-tcp connections.
++		req.Host = DummyHost
++	}
+ 	req.Header.Set("Connection", "Upgrade")
+ 	req.Header.Set("Upgrade", proto)
+ 
+diff --git a/vendor/github.com/docker/docker/client/request.go b/vendor/github.com/docker/docker/client/request.go
+index 7f54b1dd80..3fc99056d0 100644
+--- a/vendor/github.com/docker/docker/client/request.go
++++ b/vendor/github.com/docker/docker/client/request.go
+@@ -89,16 +89,14 @@ func (cli *Client) buildRequest(method, path string, body io.Reader, headers hea
+ 		return nil, err
+ 	}
+ 	req = cli.addHeaders(req, headers)
++	req.URL.Scheme = cli.scheme
++	req.URL.Host = cli.addr
+ 
+ 	if cli.proto == "unix" || cli.proto == "npipe" {
+-		// For local communications, it doesn't matter what the host is. We just
+-		// need a valid and meaningful host name. (See #189)
+-		req.Host = "docker"
++		// Override host header for non-tcp connections.
++		req.Host = DummyHost
+ 	}
+ 
+-	req.URL.Host = cli.addr
+-	req.URL.Scheme = cli.scheme
+-
+ 	if expectedPayload && req.Header.Get("Content-Type") == "" {
+ 		req.Header.Set("Content-Type", "text/plain")
+ 	}
+-- 
+2.34.1
+

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -19,6 +19,9 @@ URL: https://%{goimport}
 Source0: https://%{goimport}/archive/v%{gover}/cli-%{gover}.tar.gz
 Source1000: clarify.toml
 
+# Backport to fix host header issue when compiling with Go 1.20.6 or later
+Patch0001: 0001-non-tcp-host-header.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 

--- a/packages/docker-engine/0001-non-tcp-host-header.patch
+++ b/packages/docker-engine/0001-non-tcp-host-header.patch
@@ -1,0 +1,225 @@
+From f8325087eabcc4eba7f6685f17260384f81857b2 Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 12 Jul 2023 15:07:59 +0200
+Subject: [PATCH 1/2] pkg/plugins: use a dummy hostname for local connections
+
+For local communications (npipe://, unix://), the hostname is not used,
+but we need valid and meaningful hostname.
+
+The current code used the socket path as hostname, which gets rejected by
+go1.20.6 and go1.19.11 because of a security fix for [CVE-2023-29406 ][1],
+which was implemented in  https://go.dev/issue/60374.
+
+Prior versions go Go would clean the host header, and strip slashes in the
+process, but go1.20.6 and go1.19.11 no longer do, and reject the host
+header.
+
+Before this patch, tests would fail on go1.20.6:
+
+    === FAIL: pkg/authorization TestAuthZRequestPlugin (15.01s)
+    time="2023-07-12T12:53:45Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 1s"
+    time="2023-07-12T12:53:46Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 2s"
+    time="2023-07-12T12:53:48Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 4s"
+    time="2023-07-12T12:53:52Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 8s"
+        authz_unix_test.go:82: Failed to authorize request Post "http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq": http: invalid Host header
+
+[1]: https://github.com/advisories/GHSA-f8f7-69v5-w4vx
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+---
+ pkg/plugins/client.go | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/pkg/plugins/client.go b/pkg/plugins/client.go
+index 0353305358..5ea2ad75d9 100644
+--- a/pkg/plugins/client.go
++++ b/pkg/plugins/client.go
+@@ -19,6 +19,12 @@ import (
+ 
+ const (
+ 	defaultTimeOut = 30
++
++	// dummyHost is a hostname used for local communication.
++	//
++	// For local communications (npipe://, unix://), the hostname is not used,
++	// but we need valid and meaningful hostname.
++	dummyHost = "plugin.moby.localhost"
+ )
+ 
+ func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transport, error) {
+@@ -45,8 +51,12 @@ func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transpor
+ 		return nil, err
+ 	}
+ 	scheme := httpScheme(u)
+-
+-	return transport.NewHTTPTransport(tr, scheme, socket), nil
++	hostName := u.Host
++	if hostName == "" || u.Scheme == "unix" || u.Scheme == "npipe" {
++		// Override host header for non-tcp connections.
++		hostName = dummyHost
++	}
++	return transport.NewHTTPTransport(tr, scheme, hostName), nil
+ }
+ 
+ // NewClient creates a new plugin client (http).
+-- 
+2.34.1
+
+
+From f441f3d9a846589b5979fe9c30b4783974bc90ad Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 12 Jul 2023 14:15:38 +0200
+Subject: [PATCH 2/2] client: define a "dummy" hostname to use for local
+ connections
+
+For local communications (npipe://, unix://), the hostname is not used,
+but we need valid and meaningful hostname.
+
+The current code used the client's `addr` as hostname in some cases, which
+could contain the path for the unix-socket (`/var/run/docker.sock`), which
+gets rejected by go1.20.6 and go1.19.11 because of a security fix for
+[CVE-2023-29406 ][1], which was implemented in  https://go.dev/issue/60374.
+
+Prior versions go Go would clean the host header, and strip slashes in the
+process, but go1.20.6 and go1.19.11 no longer do, and reject the host
+header.
+
+This patch introduces a `DummyHost` const, and uses this dummy host for
+cases where we don't need an actual hostname.
+
+Before this patch (using go1.20.6):
+
+    make GO_VERSION=1.20.6 TEST_FILTER=TestAttach test-integration
+    === RUN   TestAttachWithTTY
+        attach_test.go:46: assertion failed: error is not nil: http: invalid Host header
+    --- FAIL: TestAttachWithTTY (0.11s)
+    === RUN   TestAttachWithoutTTy
+        attach_test.go:46: assertion failed: error is not nil: http: invalid Host header
+    --- FAIL: TestAttachWithoutTTy (0.02s)
+    FAIL
+
+With this patch applied:
+
+    make GO_VERSION=1.20.6 TEST_FILTER=TestAttach test-integration
+    INFO: Testing against a local daemon
+    === RUN   TestAttachWithTTY
+    --- PASS: TestAttachWithTTY (0.12s)
+    === RUN   TestAttachWithoutTTy
+    --- PASS: TestAttachWithoutTTy (0.02s)
+    PASS
+
+[1]: https://github.com/advisories/GHSA-f8f7-69v5-w4vx
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+---
+ client/client.go       | 30 ++++++++++++++++++++++++++++++
+ client/hijack.go       |  6 +++++-
+ client/request.go      | 10 ++++------
+ client/request_test.go |  4 ++--
+ 4 files changed, 41 insertions(+), 9 deletions(-)
+
+diff --git a/client/client.go b/client/client.go
+index 9b2b2eaeb8..5bf699d88d 100644
+--- a/client/client.go
++++ b/client/client.go
+@@ -57,6 +57,36 @@ import (
+ 	"github.com/pkg/errors"
+ )
+ 
++// DummyHost is a hostname used for local communication.
++//
++// It acts as a valid formatted hostname for local connections (such as "unix://"
++// or "npipe://") which do not require a hostname. It should never be resolved,
++// but uses the special-purpose ".localhost" TLD (as defined in [RFC 2606, Section 2]
++// and [RFC 6761, Section 6.3]).
++//
++// [RFC 7230, Section 5.4] defines that an empty header must be used for such
++// cases:
++//
++//	If the authority component is missing or undefined for the target URI,
++//	then a client MUST send a Host header field with an empty field-value.
++//
++// However, [Go stdlib] enforces the semantics of HTTP(S) over TCP, does not
++// allow an empty header to be used, and requires req.URL.Scheme to be either
++// "http" or "https".
++//
++// For further details, refer to:
++//
++//   - https://github.com/docker/engine-api/issues/189
++//   - https://github.com/golang/go/issues/13624
++//   - https://github.com/golang/go/issues/61076
++//   - https://github.com/moby/moby/issues/45935
++//
++// [RFC 2606, Section 2]: https://www.rfc-editor.org/rfc/rfc2606.html#section-2
++// [RFC 6761, Section 6.3]: https://www.rfc-editor.org/rfc/rfc6761#section-6.3
++// [RFC 7230, Section 5.4]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
++// [Go stdlib]: https://github.com/golang/go/blob/6244b1946bc2101b01955468f1be502dbadd6807/src/net/http/transport.go#L558-L569
++const DummyHost = "api.moby.localhost"
++
+ // ErrRedirect is the error returned by checkRedirect when the request is non-GET.
+ var ErrRedirect = errors.New("unexpected redirect in response")
+ 
+diff --git a/client/hijack.go b/client/hijack.go
+index e1dc49ef0f..b8fac0be7e 100644
+--- a/client/hijack.go
++++ b/client/hijack.go
+@@ -62,7 +62,11 @@ func fallbackDial(proto, addr string, tlsConfig *tls.Config) (net.Conn, error) {
+ }
+ 
+ func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto string) (net.Conn, error) {
+-	req.Host = cli.addr
++	req.URL.Host = cli.addr
++	if cli.proto == "unix" || cli.proto == "npipe" {
++		// Override host header for non-tcp connections.
++		req.Host = DummyHost
++	}
+ 	req.Header.Set("Connection", "Upgrade")
+ 	req.Header.Set("Upgrade", proto)
+ 
+diff --git a/client/request.go b/client/request.go
+index 7f54b1dd80..3fc99056d0 100644
+--- a/client/request.go
++++ b/client/request.go
+@@ -89,16 +89,14 @@ func (cli *Client) buildRequest(method, path string, body io.Reader, headers hea
+ 		return nil, err
+ 	}
+ 	req = cli.addHeaders(req, headers)
++	req.URL.Scheme = cli.scheme
++	req.URL.Host = cli.addr
+ 
+ 	if cli.proto == "unix" || cli.proto == "npipe" {
+-		// For local communications, it doesn't matter what the host is. We just
+-		// need a valid and meaningful host name. (See #189)
+-		req.Host = "docker"
++		// Override host header for non-tcp connections.
++		req.Host = DummyHost
+ 	}
+ 
+-	req.URL.Host = cli.addr
+-	req.URL.Scheme = cli.scheme
+-
+ 	if expectedPayload && req.Header.Get("Content-Type") == "" {
+ 		req.Header.Set("Content-Type", "text/plain")
+ 	}
+diff --git a/client/request_test.go b/client/request_test.go
+index e07c0ebcab..248c201b7c 100644
+--- a/client/request_test.go
++++ b/client/request_test.go
+@@ -27,12 +27,12 @@ func TestSetHostHeader(t *testing.T) {
+ 	}{
+ 		{
+ 			"unix:///var/run/docker.sock",
+-			"docker",
++			DummyHost,
+ 			"/var/run/docker.sock",
+ 		},
+ 		{
+ 			"npipe:////./pipe/docker_engine",
+-			"docker",
++			DummyHost,
+ 			"//./pipe/docker_engine",
+ 		},
+ 		{
+-- 
+2.34.1
+

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -29,6 +29,9 @@ Source100: prepare-var-lib-docker.service
 
 Source1000: clarify.toml
 
+# Backport to fix host header issue when compiling with Go 1.20.6 or later
+Patch0001: 0001-non-tcp-host-header.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libseccomp-devel


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Starting with Go 1.20.6, there was a security fix that changed the behavior when making local socket connections. It now requires a valid host header to be present, causing an error when connecting. This has since been [fixed upstream](https://github.com/moby/moby/issues/45935), but only in the newer versions of Docker.

This change backports the fix to our version of docker-engine and docker-cli.

**Testing done:**

Prior to applying this change, troubleshooting with the `docker` CLI on the console would give the error:

```sh
bash-5.1# docker run -it --rm --name testing fedora bash
http: invalid Host header
```

After applying, able to successfully using `docker` to run a container:

```sh
bash-5.1# docker run --rm -it fedora bash
[root@0f253dcfff6a /]#
```

Full ECS testing run by @arnaldo2792 and passed (thanks!!)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
