### PR TITLE
[1.14.x] Update host containers for v1.14.3

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -215,4 +215,7 @@ version = "1.14.3"
 "(1.14.1, 1.14.2)" = [
     "migrate_v1.14.2_ecs-images-cleanup.lz4",
 ]
-"(1.14.2, 1.14.3)" = []
+"(1.14.2, 1.14.3)" = [
+    "migrate_v1.14.3_aws-admin-container-v0-10-2.lz4",
+    "migrate_v1.14.3_public-admin-container-v0-10-2.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -218,4 +218,6 @@ version = "1.14.3"
 "(1.14.2, 1.14.3)" = [
     "migrate_v1.14.3_aws-admin-container-v0-10-2.lz4",
     "migrate_v1.14.3_public-admin-container-v0-10-2.lz4",
+    "migrate_v1.14.3_aws-control-container-v0-7-3.lz4",
+    "migrate_v1.14.3_public-control-container-v0-7-3.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -569,6 +569,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,6 +3075,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-3"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -505,6 +505,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-10-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-admin-container-v0-9-4"
 version = "0.1.0"
 dependencies = [
@@ -3026,6 +3033,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-10-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-10-2"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -55,6 +55,8 @@ members = [
     "api/migration/migrations/v1.14.2/ecs-images-cleanup",
     "api/migration/migrations/v1.14.3/aws-admin-container-v0-10-2",
     "api/migration/migrations/v1.14.3/public-admin-container-v0-10-2",
+    "api/migration/migrations/v1.14.3/aws-control-container-v0-7-3",
+    "api/migration/migrations/v1.14.3/public-control-container-v0-7-3",
 
     "bottlerocket-release",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -53,6 +53,8 @@ members = [
     "api/migration/migrations/v1.14.0/aws-control-container-v0-7-2",
     "api/migration/migrations/v1.14.0/public-control-container-v0-7-2",
     "api/migration/migrations/v1.14.2/ecs-images-cleanup",
+    "api/migration/migrations/v1.14.3/aws-admin-container-v0-10-2",
+    "api/migration/migrations/v1.14.3/public-admin-container-v0-10-2",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.14.3/aws-admin-container-v0-10-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.3/aws-admin-container-v0-10-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-10-2"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.3/aws-admin-container-v0-10-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.3/aws-admin-container-v0-10-2/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.1";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.2";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.14.3/aws-control-container-v0-7-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.3/aws-control-container-v0-7-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-3"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.3/aws-control-container-v0-7-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.3/aws-control-container-v0-7-3/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.2";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.3";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.14.3/public-admin-container-v0-10-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.3/public-admin-container-v0-10-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-10-2"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.3/public-admin-container-v0-10-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.3/public-admin-container-v0-10-2/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.14.3/public-control-container-v0-7-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.14.3/public-control-container-v0-7-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-3"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.14.3/public-control-container-v0-7-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.14.3/public-control-container-v0-7-3/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.3"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.1"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.2"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** Cherry-pick of #3307. A minor context change was needed in https://github.com/bottlerocket-os/bottlerocket/commit/71c67396d560009ac3b6c67f68976e04b0428733 to remove the unnecessary migration change from 1.14.3 to 1.15.0.


**Testing done:**

* `cargo make check-migrations`: all good (i.e. no obvious mistakes)
* `cargo make`: worked (i.e. TOML isn't broken, migrations do compile)
* An instance booting using a v1.14.3 AMI has the new host container images configured by default.
* A v1.14.2 AMI can be upgraded to v1.14.3 and then uses the new host container images.
* An updated v1.14.3 can be rolled back to v1.14.2 and then uses the old host container images.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
