### PR TITLE
Updated EKS-D to v1-27-eks-9

### DIFF
--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.27"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/6/artifacts/kubernetes/v1.27.3/kubernetes-src.tar.gz"
-sha512 = "308fffed3f390d7abfe4abc9b83f859169121b0a05e7da46bc718cc0508cee746de58b82b05316801457cbf85e91d6a66fd57d3f915b41a3888ced4a0b07d7d6"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/9/artifacts/kubernetes/v1.27.4/kubernetes-src.tar.gz"
+sha512 = "184b1c4863ef3606f0d36f8535f0b5b3ecddb05e35f6815e41862dca1cbe2297600d85657bb89aaacebf9507e49fd67dcf9af99aa1b01042a4e10bf8991702f6"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.3
+%global gover 1.27.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/6/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
* Updated EKS-D to `v1-27-eks-9`. Changes with this EKS-D version include an update to Kubernetes patch version from `v1.27.3` to `v1.27.4`, which is the latest release for this minor version.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
