### PR TITLE
Updated EKS-D to v1-26-eks-15

### DIFF
--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.26"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/12/artifacts/kubernetes/v1.26.6/kubernetes-src.tar.gz"
-sha512 = "dc318e8a4ad6985c0d347c30b5589a2e52b710ae1efd39b1a06a6fd276203c915b3656a0a7f28380abaf5a37540fdddd0a5c92a91df63f14d8ba55d7b83fbdc6"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/15/artifacts/kubernetes/v1.26.7/kubernetes-src.tar.gz"
+sha512 = "bd1a04b34766a052cc1f10a346a53c96aa5f0bfaace5264105600512135b07de23baa44985f91ad1849b2f56107ddc9d93ccaf486a4301d72ccefd3f03e541c8"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.26.6
+%global gover 1.26.7
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/12/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/15/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

* Updated EKS-D to `v1-26-eks-15`. Changes with this EKS-D version include an update to Kubernetes patch version from `v1.26.6` to `v1.26.7`, which is the latest release for this minor version.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
