### PR TITLE
Updated EKS-D to v1-25-eks-19

### DIFF
--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.25"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/16/artifacts/kubernetes/v1.25.11/kubernetes-src.tar.gz"
-sha512 = "75ddd4f18680c5c9127b2f023b3f15235fe8f81c4e2d720745ba58a786ba8031a8233ededa348768d3a8cae86d79716a5d68dd51f4ff119ce4b259396e83406f"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/19/artifacts/kubernetes/v1.25.12/kubernetes-src.tar.gz"
+sha512 = "fe107da955502c8a71cc20f662765d725186a1a77dba49bd3eb5204a7414f7dbf9ab05b45d99672a6d9a5b098b434518562d9f8df5fe21f03b9d5fc8de8ae665"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.25.11
+%global gover 1.25.12
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/16/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/19/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

* Updated EKS-D to `v1-25-eks-19`. Changes with this EKS-D version include an update to Kubernetes patch version from `v1.25.11` to `v1.25.12`, which is the latest release for this minor version.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
