### PR TITLE
Updated EKS-D to v1-24-eks-23

### DIFF
--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.24"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/20/artifacts/kubernetes/v1.24.15/kubernetes-src.tar.gz"
-sha512 = "6b116aadba6d83cf92b0ecf4c454e51e1eaba669b13a1d067a4a0ff65762d0e97c94afefb46073592befe39b24848a0d7271648a1729345f6be0edb442dcb67d"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/23/artifacts/kubernetes/v1.24.16/kubernetes-src.tar.gz"
+sha512 = "e3b3f5a6708c77419b7ba8fd9a9bbb2a1ca3df7f198a7f80246a09473ff7b80b7dc750637d635d4d7f2f7bf301324b22df08ee0e3cd35d83be8d8ca5ebeabb5c"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.24.15
+%global gover 1.24.16
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/20/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/23/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

* Updated EKS-D to `v1-24-eks-23`. Changes with this EKS-D version include an update to Kubernetes patch version from `v1.24.15` to `v1.24.16`, which is the latest release for this minor version.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
