### PR TITLE
Updated EKS-D to v1-23-eks-28

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/27/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
-sha512 = "10588a77eca51bc05745d4ec26a01963252ef1c509ebf6d80cc73284d3364fc5b345d978ad888c39acaa228857b9c494dea26c31b654c8be2a74a0f5d2c9155d"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/28/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
+sha512 = "31fd414bebe6ec71682c65256373a99467f558340739739df3f332d6bf1cfef2a2c0b39b337f3f0ed56ae72a4ae083f4fdbe6ad8e964b86c2c9e144aa1f748ab"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -24,7 +24,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/27/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/28/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

* Updated EKS-D to `v1-23-eks-28`. Changes with this EKS-D version include a new [patch](https://github.com/aws/eks-distro/blob/main/projects/kubernetes/kubernetes/1-23/patches/0022-EKS-PATCH-Bump-1.23-runc-version-to-1.1.6.patch) to fix CVE-2023-27561 and CVE-2023-28642. This patch is not included in EKS-D v1.24+ because the changes made by the patch are already part of the upstream Kubernetes patch versions that the latest EKS-D releases use.
* There is no update to the Kubernetes patch version in this EKS-D release because it is already using the latest version of v1.23.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
