### PR TITLE
buildsys: Add option to force upstream source usage for specific packages

### DIFF
--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -15,10 +15,12 @@ releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 [[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/470.161.03/NVIDIA-Linux-x86_64-470.161.03.run"
 sha512 = "26b1640f9427847b68233ffacf5c4a07e75ed9923429dfc9e5de3d7e5c1f109dfaf0fe0a0639cbd47f056784ed3e00e2e741d5c84532df79590a0c9ffa5ba625"
+force-upstream = true
 
 [[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/470.161.03/NVIDIA-Linux-aarch64-470.161.03.run"
 sha512 = "16e83c4d3ea66b2da07c43fca912c839e5feb9d42bee279b9de3476ffbd5e2314fddc83c1a38c198adb2d5ea6b4f2b00bb4a4c32d6fd0bfcdbccc392043f99ce"
+force-upstream = true
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -15,10 +15,12 @@ releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 [[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/515.86.01/NVIDIA-Linux-x86_64-515.86.01.run"
 sha512 = "9a31e14afc017e847f1208577f597c490adb63c256d6dff1a9eae56b65cf85374a604516b0be9da7a43e9af93b3c5aec47b2ffefd6b4050a4b7e55f348cf4e7b"
+force-upstream = true
 
 [[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/515.86.01/NVIDIA-Linux-aarch64-515.86.01.run"
 sha512 = "43161f86143b1558d1f558acf4a060f53f538ea20e6235f76be24916fe4a9c374869645c7abf39eba66f1c2ca35f5d2b04f199bd1341b7ee6c1fdc879cb3ef96"
+force-upstream = true
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -15,10 +15,12 @@ releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 [[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/535.54.03/NVIDIA-Linux-x86_64-535.54.03.run"
 sha512 = "45b72b34272d3df14b56136bb61537d00145d55734b72d58390af4694d96f03b2b49433beb4a5bede4d978442b707b08e05f2f31b2fcfd9453091e7f0b945cff"
+force-upstream = true
 
 [[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/535.54.03/NVIDIA-Linux-aarch64-535.54.03.run"
 sha512 = "57b06a6fa16838176866c364a8722c546084529ad91c57e979aca7750692127cab1485b5a44aee398c5494782ed987e82f66061aa39e802bc6eefa2b40a33bc3"
+force-upstream = true
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -65,7 +65,9 @@ impl LookasideCache {
             }
 
             // next check with upstream, if permitted
-            if std::env::var("BUILDSYS_UPSTREAM_SOURCE_FALLBACK") == Ok("true".to_string()) {
+            if f.force_upstream.unwrap_or(false)
+                || std::env::var("BUILDSYS_UPSTREAM_SOURCE_FALLBACK") == Ok("true".to_string())
+            {
                 println!("Fetching {:?} from upstream source", url_file_name);
                 Self::fetch_file(&f.url, &tmp, hash)?;
                 fs::rename(&tmp, path).context(error::ExternalFileRenameSnafu { path: &tmp })?;

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -566,6 +566,7 @@ pub struct ExternalFile {
     pub path: Option<PathBuf>,
     pub sha512: String,
     pub url: String,
+    pub force_upstream: Option<bool>,
     pub bundle_modules: Option<Vec<BundleModule>>,
     pub bundle_root_path: Option<PathBuf>,
     pub bundle_output_path: Option<PathBuf>,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** -

**Description of changes:**

When building packages and we do not find the appropriate source files in the look-aside cache
we do not check the upstream source by default. We can allow using upstream as a fallback through
setting `BUILDSYS_UPSTREAM_SOURCE_FALLBACK=true` in the environment.
However, for some packages (i.e. nvidia drivers) we will never vend a copy of the upstream sources
in the look-aside cache for licensing reasons. With the linux-firmware package (https://github.com/bottlerocket-os/bottlerocket/pull/3296) we will probably grow another package that falls into that category.
Add an optional setting for `external-files` to force the use of upstream sources to allow these packages
to not derail a build where we forget to set the appropriate environment variable. Select the always upstream
source lookup for all nvidia kmod packages.

**Testing done:**

Building the nvidia kmod packages without specifying `-e BUILDSYS_UPSTREAM_SOURCE_FALLBACK=true` works:

```
$ cargo make -e BUILDSYS_VARIANT=aws-k8s-1.26-nvidia -e PACKAGE=kmod-5_15-nvidia build-package
[...]
[cargo-make] INFO - Running Task: build-package
   Compiling kmod-5_15-nvidia v0.1.0 (/home/fedora/src/bottlerocket/packages/kmod-5.15-nvidia)
    Finished dev [optimized] target(s) in 1m 39s
[cargo-make] INFO - Build Done in 105.83 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
