### PR TITLE
microcode: Update amd and intel ucode and remove indirection

### DIFF
--- a/packages/microcode/Cargo.toml
+++ b/packages/microcode/Cargo.toml
@@ -11,9 +11,9 @@ path = "../packages.rs"
 # Use latest-srpm-urls.sh to get these.
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.amazonlinux.com/blobstore/6d7f707779f6aff41c89bad00f7abe69dc70919cee29a8d3e5060f8070efe71d/linux-firmware-20200421-79.git78c0348.amzn2.src.rpm"
-sha512 = "d5a62eca6ddd7ff322574f17359681d03a733acc51c334127f291af5d5e39fcdf821c073ddcd977b2ca088cd95d35dc31db2001ca4c312a62dcbd4ea935434fd"
+url = "https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-20230804.tar.xz"
+sha512 = "b7fdffd49530223394a0896608a746395cbe9d1a3ca7e4e744bc8381e937845e085f08e2b56854a233426164072f4c365b281db2f0dbb47192a97a94ada8fae6"
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.amazonlinux.com/blobstore/76e8f9f15ec2b27c70aff3ca15a28df51790b25c73fc8dc1bf1f28a9069b15e8/microcode_ctl-2.1-47.amzn2.0.9.src.rpm"
-sha512 = "e1347139d1edbd52d2619d970ba0f03500ba7367d071bb30ab3d209e44b3ff63000fcaa681f7352c79f7d5d2f0753130161b42b0eab7aab97b5b4fc4bfaa1b3b"
+url = "https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-20230808.tar.gz"
+sha512 = "8316eb9d35b315e630c6c9fab1ba601b91e72cc42926ef14e7c2b77e7025d276ae06c143060f44cd1a873d3879c067d11ad82e1886c796e6be6bf466243ad85b"

--- a/packages/microcode/Cargo.toml
+++ b/packages/microcode/Cargo.toml
@@ -8,7 +8,7 @@ build = "../build.rs"
 [lib]
 path = "../packages.rs"
 
-# Use latest-srpm-urls.sh to get these.
+# Check the two upstream repositories for the latest releases
 
 [[package.metadata.build-package.external-files]]
 url = "https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-20230804.tar.xz"

--- a/packages/microcode/latest-srpm-urls.sh
+++ b/packages/microcode/latest-srpm-urls.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run --rm amazonlinux:2 sh -c 'yum install -q -y yum-utils && yumdownloader -q --source --urls linux-firmware microcode_ctl | grep ^http'

--- a/packages/microcode/microcode.spec
+++ b/packages/microcode/microcode.spec
@@ -3,8 +3,8 @@
 
 # These are specific to the upstream source RPM, and will likely need to be
 # updated for each new version.
-%global amd_ucode_archive linux-firmware-20200421.tar.gz
-%global intel_ucode_archive microcode-20210608-1-amzn.tgz
+%global amd_ucode_version 20230804
+%global intel_ucode_version 20230808
 
 Name: %{_cross_os}microcode
 Version: 0.0
@@ -18,9 +18,8 @@ License: LicenseRef-scancode-amd-linux-firmware-export AND LicenseRef-scancode-i
 # the subpackage definitions.
 URL: https://github.com/bottlerocket-os/bottlerocket/tree/develop/packages/microcode
 
-# We use Amazon Linux 2 as our upstream for microcode updates.
-Source0: https://cdn.amazonlinux.com/blobstore/6d7f707779f6aff41c89bad00f7abe69dc70919cee29a8d3e5060f8070efe71d/linux-firmware-20200421-79.git78c0348.amzn2.src.rpm
-Source1: https://cdn.amazonlinux.com/blobstore/76e8f9f15ec2b27c70aff3ca15a28df51790b25c73fc8dc1bf1f28a9069b15e8/microcode_ctl-2.1-47.amzn2.0.9.src.rpm
+Source0: https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-%{amd_ucode_version}.tar.xz
+Source1: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-%{intel_ucode_version}.tar.gz
 
 # Lets us install "microcode" to pull in the AMD and Intel updates.
 Requires: %{_cross_os}microcode-amd
@@ -75,11 +74,9 @@ Requires: %{_cross_os}microcode-intel-license
 %{summary}.
 
 %prep
-rpm2cpio %{SOURCE0} | cpio -iu %{amd_ucode_archive}
-rpm2cpio %{SOURCE1} | cpio -iu %{intel_ucode_archive}
 mkdir amd intel
-tar -C amd -xof %{amd_ucode_archive}
-tar -C intel -xof %{intel_ucode_archive}
+tar -C amd --strip-components=1 -xof %{SOURCE0}
+tar -C intel --strip-components=1 -xof %{SOURCE1}
 cp {amd/,}LICENSE.amd-ucode
 cp intel/intel-ucode-with-caveats/* intel/intel-ucode
 cp intel/license LICENSE.intel-ucode
@@ -110,6 +107,7 @@ install -p -m 0644 intel/intel-ucode/* %{buildroot}%{_cross_libdir}/firmware/int
 %dir %{_cross_libdir}/firmware
 %dir %{_cross_libdir}/firmware/intel-ucode
 %{_cross_libdir}/firmware/intel-ucode/??-??-??
+%exclude %{_cross_libdir}/firmware/intel-ucode/??-??-??_DUPLICATE
 
 %files intel-license
 %license LICENSE.intel-ucode LicenseRef-scancode-intel-mcu-2018


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** -

**Description of changes:**

```
Update microcode for Intel and AMD processors in face of recent
processor vulnerabilities. In the process cut out the indirection step
through Amazon Linux. They do not change the microcode between getting
it from upstream and us consuming it, so it is an extra step of
indirection.
```

There is one caveat to this change, and that is increased space needed in the images. Amazon Linux reduces the
provided Intel microcode down to the platforms it will encounter in EC2. We had carried that gap of not shipping
microcode for potential target platforms for a while now since we introduced metal variants and were in need to fix
that gap. However, now that we take the upstream Intel package completely we carry a lot more microcode binaries,
which leads to a quite steep increase in space needed (11M vs 235K for the intel microcode rpm size, see below).

But given that this is cutting out an indirection that can introduce additional head ache I think this is a worthwhile
tradeoff for closing the coverage gap. If we have to, we can later thin out the microcode we ship to not include super
binaries for obsolete technology or platforms that are unlikely to run Bottlerocket (Intel Atom platforms come to mind).

```
$ ls -ahl before/*x86*
-rw-r--r--. 1 fedora fedora 6.3K Aug 11 14:57 before/bottlerocket-microcode-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora  29K Aug 11 14:57 before/bottlerocket-microcode-amd-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora 9.1K Aug 11 14:57 before/bottlerocket-microcode-amd-license-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora 235K Aug 11 14:57 before/bottlerocket-microcode-intel-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora 8.2K Aug 11 14:57 before/bottlerocket-microcode-intel-license-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora 7.1K Aug 11 14:57 before/bottlerocket-microcode-licenses-0.0-1.x86_64.rpm
$ ls -ahl after/*x86*
-rw-r--r--. 1 fedora fedora 6.3K Aug 11 14:56 after/bottlerocket-microcode-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora  45K Aug 11 14:56 after/bottlerocket-microcode-amd-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora 9.2K Aug 11 14:56 after/bottlerocket-microcode-amd-license-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora  11M Aug 11 14:56 after/bottlerocket-microcode-intel-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora 8.2K Aug 11 14:56 after/bottlerocket-microcode-intel-license-0.0-1.x86_64.rpm
-rw-r--r--. 1 fedora fedora 7.1K Aug 11 14:56 after/bottlerocket-microcode-licenses-0.0-1.x86_64.rpm
```

**Testing done:**

Booted `aws-k8s-1.27` with the new microcode package on c5.metal host and checked microcode version. Expected according to [release notes](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20230808) is `05003604` (Search for Processor `CLX-SP` for that platform):

```
bash-5.1# grep microcode /proc/cpuinfo 
microcode	: 0x5003604
microcode	: 0x5003604
microcode	: 0x5003604
microcode	: 0x5003604
microcode	: 0x5003604
[...]
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
