### PR TITLE
Only limit concurrency while building RPMs

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -143,7 +143,8 @@ BUILDSYS_SDK_IMAGE = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME
 BUILDSYS_TOOLCHAIN = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME}-toolchain-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
 
 # Depends on ${BUILDSYS_JOBS}.
-CARGO_MAKE_CARGO_ARGS = "--jobs ${BUILDSYS_JOBS} --offline --locked"
+CARGO_MAKE_CARGO_LIMIT_JOBS = "--jobs ${BUILDSYS_JOBS}"
+CARGO_MAKE_CARGO_ARGS = "--offline --locked"
 
 # Depends on ${BUILDSYS_ARCH} and ${BUILDSYS_VARIANT}.
 BUILDSYS_OUTPUT_DIR = "${BUILDSYS_IMAGES_DIR}/${BUILDSYS_ARCH}-${BUILDSYS_VARIANT}"
@@ -838,6 +839,7 @@ export CARGO_TARGET_DIR=${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}
 cargo build \
   ${CARGO_BUILD_ARGS} \
   ${CARGO_MAKE_CARGO_ARGS} \
+  ${CARGO_MAKE_CARGO_LIMIT_JOBS} \
   --manifest-path "variants/Cargo.toml" \
   --package "${PACKAGE}"
 '''
@@ -864,6 +866,7 @@ rm -rf "${BUILDSYS_OUTPUT_DIR}/latest"
 cargo build \
   ${CARGO_BUILD_ARGS} \
   ${CARGO_MAKE_CARGO_ARGS} \
+  ${CARGO_MAKE_CARGO_LIMIT_JOBS} \
   --manifest-path variants/${BUILDSYS_VARIANT}/Cargo.toml
 ln -snf "${BUILDSYS_VERSION_FULL}" "${BUILDSYS_OUTPUT_DIR}/latest"
 '''
@@ -940,7 +943,6 @@ dependencies = [
 script = [
 '''
 cargo install \
-  --jobs ${BUILDSYS_JOBS} \
   --locked \
   --root tools \
   --quiet \


### PR DESCRIPTION
**Description of changes:**
cargo make build-variant and build-package typically run several RPM builds concurrently, and those allow for their own levels of parallelism. 8 concurrent jobs (though unscientifically decided) still seems like a reasonable limitation there.

On the other hand, the rest of the build commands mostly focus on building a directory of rust sources. It shouldn't be a problem to let cargo use as many cores as it needs for those.


**Testing done:**
This seems to make `cargo make tuftool` and `cargo make publish-setup` faster when you don't have any of their dependencies' builds cached.

On my (admittedly beefy) machine:

Without change:
* `cargo make tuftool` 152 seconds
* `cargo make publish-setup-tools` 60 seconds

With change:
* `cargo make tuftool` 131 seconds
* `cargo make publish-setup-tools` 38.72 seconds


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
