### PR TITLE
Migrate to schnauzer v2 for configuration file templates

### DIFF
--- a/packages/chrony/chrony-conf
+++ b/packages/chrony/chrony-conf
@@ -1,3 +1,6 @@
+[required-extensions]
+ntp = "v1"
++++
 {{#each settings.ntp.time-servers}}
 pool {{this}} iburst
 {{/each}}

--- a/packages/containerd/containerd-config-toml_basic
+++ b/packages/containerd/containerd-config-toml_basic
@@ -1,3 +1,4 @@
++++
 version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"

--- a/packages/containerd/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd/containerd-config-toml_k8s_containerd_sock
@@ -1,3 +1,9 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array"]}
++++
 version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"

--- a/packages/containerd/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -1,3 +1,9 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array"]}
++++
 version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"

--- a/packages/containerd/containerd-cri-base-json
+++ b/packages/containerd/containerd-cri-base-json
@@ -1,3 +1,6 @@
+[required-extensions]
+oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
++++
 {
     "ociVersion": "1.0.2-dev",
     "process": {

--- a/packages/docker-engine/daemon-json
+++ b/packages/docker-engine/daemon-json
@@ -1,3 +1,8 @@
+[required-extensions]
+container-registry = "v1"
+oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
+std = { version = "v1", helpers = ["join_array"] }
++++
 {
   "log-driver": "journald",
   "live-restore": true,

--- a/packages/docker-engine/daemon-nvidia-json
+++ b/packages/docker-engine/daemon-nvidia-json
@@ -1,3 +1,8 @@
+[required-extensions]
+container-registry = "v1"
+oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
+std = { version = "v1", helpers = ["join_array"] }
++++
 {
   "log-driver": "journald",
   "live-restore": true,

--- a/packages/ecs-agent/ecs.config
+++ b/packages/ecs-agent/ecs.config
@@ -1,3 +1,7 @@
+[required-extensions]
+container-registry = "v1"
+ecs = "v1"
++++
 ECS_LOGFILE=/var/log/ecs/ecs-agent.log
 ECS_LOGLEVEL="{{settings.ecs.loglevel}}"
 {{#if settings.container-registry.credentials~}}

--- a/packages/kubernetes-1.23/credential-provider-config-yaml
+++ b/packages/kubernetes-1.23/credential-provider-config-yaml
@@ -1,3 +1,8 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes  = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
 apiVersion: kubelet.config.k8s.io/v1alpha1
 kind: CredentialProviderConfig
 providers:

--- a/packages/kubernetes-1.23/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.23/kubelet-bootstrap-kubeconfig
@@ -1,3 +1,6 @@
+[required-extensions]
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 ---
 kind: KubeletConfiguration

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["default"] }
++++
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/packages/kubernetes-1.23/kubelet-env
+++ b/packages/kubernetes-1.23/kubelet-env
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
 NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.23/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.23/kubelet-exec-start-conf
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = "v1"
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 [Service]
 ExecStart=

--- a/packages/kubernetes-1.23/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.23/kubelet-exec-start-conf
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled"] }
+std = { version = "v1", helpers = ["default"] }
++++
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \

--- a/packages/kubernetes-1.23/kubelet-kubeconfig
+++ b/packages/kubernetes-1.23/kubelet-kubeconfig
@@ -1,3 +1,7 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.23/kubelet-server-crt
+++ b/packages/kubernetes-1.23/kubelet-server-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-certificate~}}
 {{base64_decode settings.kubernetes.server-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.23/kubelet-server-key
+++ b/packages/kubernetes-1.23/kubelet-server-key
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-key~}}
 {{base64_decode settings.kubernetes.server-key}}
 {{~/if~}}

--- a/packages/kubernetes-1.23/kubernetes-ca-crt
+++ b/packages/kubernetes-1.23/kubernetes-ca-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.24/credential-provider-config-yaml
+++ b/packages/kubernetes-1.24/credential-provider-config-yaml
@@ -1,3 +1,8 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes  = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: CredentialProviderConfig
 providers:

--- a/packages/kubernetes-1.24/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.24/kubelet-bootstrap-kubeconfig
@@ -1,3 +1,6 @@
+[required-extensions]
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 ---
 kind: KubeletConfiguration

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["default"] }
++++
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/packages/kubernetes-1.24/kubelet-env
+++ b/packages/kubernetes-1.24/kubelet-env
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
 NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.24/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.24/kubelet-exec-start-conf
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = "v1"
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 [Service]
 ExecStart=

--- a/packages/kubernetes-1.24/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.24/kubelet-exec-start-conf
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled"] }
+std = { version = "v1", helpers = ["default"] }
++++
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \

--- a/packages/kubernetes-1.24/kubelet-kubeconfig
+++ b/packages/kubernetes-1.24/kubelet-kubeconfig
@@ -1,3 +1,7 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.24/kubelet-server-crt
+++ b/packages/kubernetes-1.24/kubelet-server-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-certificate~}}
 {{base64_decode settings.kubernetes.server-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.24/kubelet-server-key
+++ b/packages/kubernetes-1.24/kubelet-server-key
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-key~}}
 {{base64_decode settings.kubernetes.server-key}}
 {{~/if~}}

--- a/packages/kubernetes-1.24/kubernetes-ca-crt
+++ b/packages/kubernetes-1.24/kubernetes-ca-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.25/credential-provider-config-yaml
+++ b/packages/kubernetes-1.25/credential-provider-config-yaml
@@ -1,3 +1,8 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes  = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: CredentialProviderConfig
 providers:

--- a/packages/kubernetes-1.25/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.25/kubelet-bootstrap-kubeconfig
@@ -1,3 +1,6 @@
+[required-extensions]
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 ---
 kind: KubeletConfiguration

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["default"] }
++++
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/packages/kubernetes-1.25/kubelet-env
+++ b/packages/kubernetes-1.25/kubelet-env
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
 NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.25/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.25/kubelet-exec-start-conf
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = "v1"
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 [Service]
 ExecStart=

--- a/packages/kubernetes-1.25/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.25/kubelet-exec-start-conf
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled"] }
+std = { version = "v1", helpers = ["default"] }
++++
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \

--- a/packages/kubernetes-1.25/kubelet-kubeconfig
+++ b/packages/kubernetes-1.25/kubelet-kubeconfig
@@ -1,3 +1,7 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.25/kubelet-server-crt
+++ b/packages/kubernetes-1.25/kubelet-server-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-certificate~}}
 {{base64_decode settings.kubernetes.server-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.25/kubelet-server-key
+++ b/packages/kubernetes-1.25/kubelet-server-key
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-key~}}
 {{base64_decode settings.kubernetes.server-key}}
 {{~/if~}}

--- a/packages/kubernetes-1.25/kubernetes-ca-crt
+++ b/packages/kubernetes-1.25/kubernetes-ca-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.26/credential-provider-config-yaml
+++ b/packages/kubernetes-1.26/credential-provider-config-yaml
@@ -1,3 +1,8 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes  = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
 apiVersion: kubelet.config.k8s.io/v1
 kind: CredentialProviderConfig
 providers:

--- a/packages/kubernetes-1.26/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.26/kubelet-bootstrap-kubeconfig
@@ -1,3 +1,6 @@
+[required-extensions]
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 ---
 kind: KubeletConfiguration

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["default"] }
++++
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/packages/kubernetes-1.26/kubelet-env
+++ b/packages/kubernetes-1.26/kubelet-env
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
 NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.26/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.26/kubelet-exec-start-conf
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = "v1"
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 [Service]
 ExecStart=

--- a/packages/kubernetes-1.26/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.26/kubelet-exec-start-conf
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled"] }
+std = { version = "v1", helpers = ["default"] }
++++
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \

--- a/packages/kubernetes-1.26/kubelet-kubeconfig
+++ b/packages/kubernetes-1.26/kubelet-kubeconfig
@@ -1,3 +1,7 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.26/kubelet-server-crt
+++ b/packages/kubernetes-1.26/kubelet-server-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-certificate~}}
 {{base64_decode settings.kubernetes.server-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.26/kubelet-server-key
+++ b/packages/kubernetes-1.26/kubelet-server-key
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-key~}}
 {{base64_decode settings.kubernetes.server-key}}
 {{~/if~}}

--- a/packages/kubernetes-1.26/kubernetes-ca-crt
+++ b/packages/kubernetes-1.26/kubernetes-ca-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.27/credential-provider-config-yaml
+++ b/packages/kubernetes-1.27/credential-provider-config-yaml
@@ -1,3 +1,8 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes  = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
 apiVersion: kubelet.config.k8s.io/v1
 kind: CredentialProviderConfig
 providers:

--- a/packages/kubernetes-1.27/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.27/kubelet-bootstrap-kubeconfig
@@ -1,3 +1,6 @@
+[required-extensions]
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 ---
 kind: KubeletConfiguration

--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled", "kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["default"] }
++++
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/packages/kubernetes-1.27/kubelet-env
+++ b/packages/kubernetes-1.27/kubelet-env
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
 NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.27/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.27/kubelet-exec-start-conf
@@ -1,6 +1,6 @@
 [required-extensions]
-kubernetes = { version = "v1", helpers = ["any_enabled"] }
-std = { version = "v1", helpers = ["default"] }
+kubernetes = "v1"
+std = { version = "v1", helpers = ["any_enabled", "default"] }
 +++
 [Service]
 ExecStart=

--- a/packages/kubernetes-1.27/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.27/kubelet-exec-start-conf
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["any_enabled"] }
+std = { version = "v1", helpers = ["default"] }
++++
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet \

--- a/packages/kubernetes-1.27/kubelet-kubeconfig
+++ b/packages/kubernetes-1.27/kubelet-kubeconfig
@@ -1,3 +1,7 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes = "v1"
++++
 ---
 apiVersion: v1
 kind: Config

--- a/packages/kubernetes-1.27/kubelet-server-crt
+++ b/packages/kubernetes-1.27/kubelet-server-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-certificate~}}
 {{base64_decode settings.kubernetes.server-certificate}}
 {{~/if~}}

--- a/packages/kubernetes-1.27/kubelet-server-key
+++ b/packages/kubernetes-1.27/kubelet-server-key
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.server-key~}}
 {{base64_decode settings.kubernetes.server-key}}
 {{~/if~}}

--- a/packages/kubernetes-1.27/kubernetes-ca-crt
+++ b/packages/kubernetes-1.27/kubernetes-ca-crt
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.kubernetes.cluster-certificate~}}
 {{base64_decode settings.kubernetes.cluster-certificate}}
 {{~/if~}}

--- a/packages/nvidia-container-toolkit/nvidia-oci-hooks-json
+++ b/packages/nvidia-container-toolkit/nvidia-oci-hooks-json
@@ -1,3 +1,6 @@
+[required-extensions]
+oci-hooks = "v1"
++++
 {
   "hooks": {
     "prestart": [

--- a/packages/os/cfsignal-toml
+++ b/packages/os/cfsignal-toml
@@ -1,3 +1,6 @@
+[required-extensions]
+cloudformation = "v1"
++++
 should_signal = {{settings.cloudformation.should-signal}}
 stack_name = "{{settings.cloudformation.stack-name}}"
 logical_resource_id = "{{settings.cloudformation.logical-resource-id}}"

--- a/packages/os/host-ctr-toml
+++ b/packages/os/host-ctr-toml
@@ -1,3 +1,7 @@
+[required-extensions]
+container-registry = "v1"
+std = { version = "v1", helpers = ["join_array"] }
++++
 {{#if settings.container-registry.mirrors}}
 {{#each settings.container-registry.mirrors}}
 [mirrors."{{registry}}"]

--- a/packages/os/metricdog-toml
+++ b/packages/os/metricdog-toml
@@ -1,3 +1,9 @@
+[required-extensions]
+aws = "v1"
+metrics = "v1"
+std = { version = "v1", helpers = ["join_array"] }
+updates = "v1"
++++
 metrics_url = "{{settings.metrics.metrics-url}}"
 send_metrics = {{settings.metrics.send-metrics}}
 service_checks = [{{join_array ", " settings.metrics.service-checks}}]

--- a/packages/os/oci-default-hooks-json
+++ b/packages/os/oci-default-hooks-json
@@ -1,3 +1,6 @@
+[required-extensions]
+oci-hooks = "v1"
++++
 {
   "hooks": {
     "prestart": [

--- a/packages/os/updog-toml
+++ b/packages/os/updog-toml
@@ -1,3 +1,8 @@
+[required-extensions]
+network = "v1"
+std = { version = "v1", helpers = ["join_array"] }
+updates = "v1"
++++
 metadata_base_url = "{{settings.updates.metadata-base-url}}"
 targets_base_url = "{{settings.updates.targets-base-url}}"
 seed = {{settings.updates.seed}}

--- a/packages/os/warm-pool-wait-toml
+++ b/packages/os/warm-pool-wait-toml
@@ -1,2 +1,5 @@
+[required-extensions]
+autoscaling = "v1"
++++
 should_wait = {{settings.autoscaling.should-wait}}
 marker_path = "/var/lib/bottlerocket/warm-pool-wait.ran"

--- a/packages/release/aws-config
+++ b/packages/release/aws-config
@@ -1,3 +1,7 @@
+[required-extensions]
+aws = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.aws.config~}}
 {{base64_decode settings.aws.config}}
 {{~/if~}}

--- a/packages/release/aws-credentials
+++ b/packages/release/aws-credentials
@@ -1,3 +1,7 @@
+[required-extensions]
+aws = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
 {{~#if settings.aws.credentials~}}
 {{base64_decode settings.aws.credentials}}
 {{~/if~}}

--- a/packages/release/hostname-env
+++ b/packages/release/hostname-env
@@ -1,1 +1,4 @@
+[required-extensions]
+network = "v1"
++++
 HOSTNAME={{settings.network.hostname}}

--- a/packages/release/hosts.template
+++ b/packages/release/hosts.template
@@ -1,3 +1,6 @@
+[required-extensions]
+network = { version = "v1", helpers = ["localhost_aliases", "etc_hosts_entries"] }
++++
 127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4 {{localhost_aliases "ipv4" settings.network.hostname settings.network.hosts}}
 ::1 localhost localhost.localdomain localhost6 localhost6.localdomain6 {{localhost_aliases "ipv6" settings.network.hostname settings.network.hosts}}
 

--- a/packages/release/modprobe-conf.template
+++ b/packages/release/modprobe-conf.template
@@ -1,3 +1,6 @@
+[required-extensions]
+kernel = "v1"
++++
 {{#if settings.kernel.modules}}
 {{#each settings.kernel.modules}}
 {{#unless this.allowed }}

--- a/packages/release/motd.template
+++ b/packages/release/motd.template
@@ -1,1 +1,4 @@
+[required-extensions]
+motd = "v1"
++++
 {{ settings.motd }}

--- a/packages/release/netdog.template
+++ b/packages/release/netdog.template
@@ -1,3 +1,7 @@
+[required-extensions]
+dns = "v1"
+std = { version = "v1", helpers = ["join_array"] }
++++
 {{#if settings.dns.name-servers}}
 name-servers = [{{join_array ", " settings.dns.name-servers }}]
 {{/if}}

--- a/packages/release/proxy-env
+++ b/packages/release/proxy-env
@@ -1,3 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+network = { version = "v1", helpers = ["host"] }
++++
 {{#if settings.network.https-proxy}}
 HTTPS_PROXY={{settings.network.https-proxy}}
 https_proxy={{settings.network.https-proxy}}

--- a/sources/api/schnauzer/src/bin/schnauzer-v2/clirequirements.rs
+++ b/sources/api/schnauzer/src/bin/schnauzer-v2/clirequirements.rs
@@ -90,6 +90,7 @@ impl FromStr for CLIExtensionRequirement {
             name,
             version,
             helpers,
+            ..Default::default()
         }))
     }
 }
@@ -109,6 +110,7 @@ mod test {
                     name: "extension".to_string(),
                     version: "version".to_string(),
                     helpers: vec!["helper1".to_string()],
+                    ..Default::default()
                 },
             ),
             (
@@ -117,6 +119,7 @@ mod test {
                     name: "myextension".to_string(),
                     version: "v1".to_string(),
                     helpers: vec![],
+                    ..Default::default()
                 },
             ),
             (
@@ -125,6 +128,7 @@ mod test {
                     name: "extension".to_string(),
                     version: "version".to_string(),
                     helpers: vec![],
+                    ..Default::default()
                 },
             ),
             (
@@ -136,6 +140,7 @@ mod test {
                         .into_iter()
                         .map(String::from)
                         .collect(),
+                    ..Default::default()
                 },
             ),
             (
@@ -144,6 +149,7 @@ mod test {
                     name: "weird-extension".to_string(),
                     version: "but_valid1.23".to_string(),
                     helpers: vec!["1", "2", "3"].into_iter().map(String::from).collect(),
+                    ..Default::default()
                 },
             ),
             (
@@ -152,6 +158,7 @@ mod test {
                     name: "empty-helpers".to_string(),
                     version: "version".to_string(),
                     helpers: vec![],
+                    ..Default::default()
                 },
             ),
         ];

--- a/sources/api/schnauzer/src/v2/import/helpers.rs
+++ b/sources/api/schnauzer/src/v2/import/helpers.rs
@@ -271,6 +271,7 @@ mod test {
                 name: setting_name.to_string(),
                 version: version.to_string(),
                 helpers: helpers.iter().map(|s| s.to_string()).collect(),
+                ..Default::default()
             };
             assert!(StaticHelperResolver::ensure_helpers_exist(&extension_requirement).is_err());
         }
@@ -286,6 +287,7 @@ mod test {
                 name: setting_name.to_string(),
                 version: version.to_string(),
                 helpers: helpers.iter().map(|s| s.to_string()).collect(),
+                ..Default::default()
             };
             assert!(StaticHelperResolver::ensure_helpers_exist(&extension_requirement).is_ok());
         }

--- a/sources/api/schnauzer/src/v2/import/helpers.rs
+++ b/sources/api/schnauzer/src/v2/import/helpers.rs
@@ -41,7 +41,6 @@ fn all_helpers() -> HashMap<ExtensionName, HashMap<HelperName, Box<dyn HelperDef
             "join_node_taints" => helper!(handlebars_helpers::join_node_taints),
             "kube_reserve_cpu" => helper!(handlebars_helpers::kube_reserve_cpu),
             "kube_reserve_memory" => helper!(handlebars_helpers::kube_reserve_memory),
-            "any_enabled" => helper!(handlebars_helpers::any_enabled),
             "pause-prefix" => helper!(handlebars_helpers::pause_prefix),
         },
 
@@ -62,6 +61,7 @@ fn all_helpers() -> HashMap<ExtensionName, HashMap<HelperName, Box<dyn HelperDef
 
         // globally helpful helpers will be included in a null extension called "std"
         "std" => hashmap! {
+            "any_enabled" => helper!(handlebars_helpers::any_enabled),
             "base64_decode" => helper!(handlebars_helpers::base64_decode),
             "default" => helper!(handlebars_helpers::default),
             "join_array" => helper!(handlebars_helpers::join_array),
@@ -257,7 +257,7 @@ mod test {
         let success_cases = &[
             ("network", "v1", vec!["host"]),
             ("empty-helpers-succeeds", "v1", vec![]),
-            ("kubernetes", "v1", vec!["any_enabled", "pause-prefix"]),
+            ("kubernetes", "v1", vec!["pause-prefix"]),
         ];
 
         for (setting_name, version, helpers) in fail_cases.into_iter() {
@@ -309,7 +309,6 @@ mod test {
                     "join_node_taints",
                     "kube_reserve_cpu",
                     "kube_reserve_memory",
-                    "any_enabled",
                     "pause-prefix",
                 ],
             ),

--- a/sources/api/schnauzer/src/v2/import/helpers.rs
+++ b/sources/api/schnauzer/src/v2/import/helpers.rs
@@ -5,7 +5,7 @@
 use super::as_std_err;
 use crate::{helpers as handlebars_helpers, v2::ExtensionRequirement};
 use async_trait::async_trait;
-use handlebars::{Handlebars, HelperDef};
+use handlebars::{Handlebars, HelperDef, ScopedJson};
 use maplit::hashmap;
 use snafu::{ensure, OptionExt};
 use std::collections::{HashMap, HashSet};
@@ -187,11 +187,39 @@ impl SettingExtensionTemplateHelper {
             helper_name,
         }
     }
+
+    fn get_helper(&self) -> std::result::Result<Box<dyn HelperDef>, handlebars::RenderError> {
+        let mut available_helpers = all_helpers();
+        let referenced_helper = available_helpers
+            .get_mut(self.setting_extension.as_str())
+            .ok_or(handlebars::RenderError::new(format!(
+                "Requested setting extension '{}' not found",
+                self.setting_extension
+            )))?
+            .remove(self.helper_name.as_str())
+            .ok_or(handlebars::RenderError::new(format!(
+                "Requested helper '{}' not found",
+                self.helper_name
+            )))?;
+        Ok(referenced_helper)
+    }
 }
 
 // The `HelperDef` implementation for `SettingExtensionTemplateHelper` currently just invokes the already-defined
 // global helper. This is a temporary workaround until settings extensions are merged into Bottlerocket.
 impl HelperDef for SettingExtensionTemplateHelper {
+    // `call_inner` is used in cases where `handlebars` tries to compose helpers
+    fn call_inner<'reg: 'rc, 'rc>(
+        &self,
+        h: &handlebars::Helper<'reg, 'rc>,
+        r: &'reg Handlebars<'reg>,
+        ctx: &'rc handlebars::Context,
+        rc: &mut handlebars::RenderContext<'reg, 'rc>,
+    ) -> std::result::Result<ScopedJson<'reg, 'rc>, handlebars::RenderError> {
+        self.get_helper()?.call_inner(h, r, ctx, rc)
+    }
+
+    // `call` is used in cases where `handlebars` tries to render helper output
     fn call<'reg: 'rc, 'rc>(
         &self,
         h: &handlebars::Helper<'reg, 'rc>,
@@ -200,19 +228,7 @@ impl HelperDef for SettingExtensionTemplateHelper {
         rc: &mut handlebars::RenderContext<'reg, 'rc>,
         out: &mut dyn handlebars::Output,
     ) -> handlebars::HelperResult {
-        let available_helpers = all_helpers();
-        let referenced_helper = available_helpers
-            .get(self.setting_extension.as_str())
-            .ok_or(handlebars::RenderError::new(format!(
-                "Requested setting extension '{}' not found",
-                self.setting_extension
-            )))?
-            .get(self.helper_name.as_str())
-            .ok_or(handlebars::RenderError::new(format!(
-                "Requested helper '{}' not found",
-                self.helper_name
-            )))?;
-        referenced_helper.call(h, r, ctx, rc, out)
+        self.get_helper()?.call(h, r, ctx, rc, out)
     }
 }
 

--- a/sources/api/schnauzer/src/v2/template.rs
+++ b/sources/api/schnauzer/src/v2/template.rs
@@ -45,8 +45,8 @@ type HelperName = String;
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TemplateFrontmatter {
-    #[serde(rename = "required-extensions")]
-    required_extensions: Option<HashMap<ExtensionName, TemplateExtensionRequirements>>,
+    #[serde(rename = "required-extensions", default)]
+    required_extensions: HashMap<ExtensionName, TemplateExtensionRequirements>,
 }
 
 /// Template extension requirements can be specified in two ways, similar to Cargo.toml:
@@ -65,7 +65,7 @@ impl From<ExtensionRequirement> for TemplateExtensionRequirements {
     fn from(requirement: ExtensionRequirement) -> Self {
         Self::VersionAndHelpers(DetailedTemplateExtensionRequirements {
             version: requirement.version,
-            helpers: (!requirement.helpers.is_empty()).then_some(requirement.helpers),
+            helpers: requirement.helpers,
             optional: requirement.optional,
         })
     }
@@ -76,7 +76,8 @@ impl From<ExtensionRequirement> for TemplateExtensionRequirements {
 #[serde(deny_unknown_fields)]
 struct DetailedTemplateExtensionRequirements {
     version: ExtensionVersion,
-    helpers: Option<Vec<HelperName>>,
+    #[serde(default)]
+    helpers: Vec<HelperName>,
     #[serde(default)]
     optional: bool,
 }
@@ -85,9 +86,7 @@ impl TemplateFrontmatter {
     /// Returns the name, version of each setting and the associated helpers required by this template.
     pub fn extension_requirements(&self) -> impl Iterator<Item = ExtensionRequirement> + '_ {
         self.required_extensions
-            .as_ref()
-            .map(|requirements| Box::new(requirements.iter()) as Box<dyn Iterator<Item = _> + Send>)
-            .unwrap_or_else(|| Box::new(std::iter::empty()) as Box<dyn Iterator<Item = _> + Send>)
+            .iter()
             .map(|(extension_name, extension_requirements)| {
                 ExtensionRequirement::from_template_requirements(
                     extension_name,
@@ -138,17 +137,15 @@ impl TryFrom<Vec<ExtensionRequirement>> for TemplateFrontmatter {
     type Error = Error;
 
     fn try_from(extension_requirements: Vec<ExtensionRequirement>) -> Result<Self> {
-        let required_extensions = (!extension_requirements.is_empty()).then(|| {
-            extension_requirements
-                .into_iter()
-                .map(|extension_requirement| {
-                    (
-                        extension_requirement.name.clone(),
-                        extension_requirement.into(),
-                    )
-                })
-                .collect()
-        });
+        let required_extensions = extension_requirements
+            .into_iter()
+            .map(|extension_requirement| {
+                (
+                    extension_requirement.name.clone(),
+                    extension_requirement.into(),
+                )
+            })
+            .collect();
 
         let frontmatter = Self {
             required_extensions,
@@ -182,7 +179,7 @@ impl ExtensionRequirement {
                 ExtensionRequirement {
                     name: extension_name.clone(),
                     version: extension_requirements.version.clone(),
-                    helpers: extension_requirements.helpers.clone().unwrap_or_default(),
+                    helpers: extension_requirements.helpers.clone(),
                     optional: extension_requirements.optional,
                 }
             }

--- a/sources/api/schnauzer/src/v2/template.rs
+++ b/sources/api/schnauzer/src/v2/template.rs
@@ -66,6 +66,7 @@ impl From<ExtensionRequirement> for TemplateExtensionRequirements {
         Self::VersionAndHelpers(DetailedTemplateExtensionRequirements {
             version: requirement.version,
             helpers: (!requirement.helpers.is_empty()).then_some(requirement.helpers),
+            optional: requirement.optional,
         })
     }
 }
@@ -76,6 +77,8 @@ impl From<ExtensionRequirement> for TemplateExtensionRequirements {
 struct DetailedTemplateExtensionRequirements {
     version: ExtensionVersion,
     helpers: Option<Vec<HelperName>>,
+    #[serde(default)]
+    optional: bool,
 }
 
 impl TemplateFrontmatter {
@@ -161,6 +164,7 @@ pub struct ExtensionRequirement {
     pub name: ExtensionName,
     pub version: ExtensionVersion,
     pub helpers: Vec<HelperName>,
+    pub optional: bool,
 }
 
 impl ExtensionRequirement {
@@ -172,13 +176,14 @@ impl ExtensionRequirement {
             TemplateExtensionRequirements::Version(version) => ExtensionRequirement {
                 name: extension_name.clone(),
                 version: version.clone(),
-                helpers: vec![],
+                ..Default::default()
             },
             TemplateExtensionRequirements::VersionAndHelpers(extension_requirements) => {
                 ExtensionRequirement {
                     name: extension_name.clone(),
                     version: extension_requirements.version.clone(),
                     helpers: extension_requirements.helpers.clone().unwrap_or_default(),
+                    optional: extension_requirements.optional,
                 }
             }
         }

--- a/sources/api/schnauzer/tests/v2_parse_success_templates.rs
+++ b/sources/api/schnauzer/tests/v2_parse_success_templates.rs
@@ -135,6 +135,7 @@ fn succeeds_04_comments() {
             name: "labrador".to_string(),
             version: "v1".to_string(),
             helpers: vec!["woof".to_string()],
+            ..Default::default()
         },
     };
     let expected_body = "# comments are included in template\n{{ woof }}\n".to_string();
@@ -163,10 +164,12 @@ fn succeeds_05_unambiguous_delims() {
             name: "beagle".to_string(),
             version: "+++\n".to_string(),
             helpers: vec![],
+            ..Default::default()
         }, ExtensionRequirement {
             name: "std".to_string(),
             version: "v1".to_string(),
             helpers: vec!["join_map".to_string()],
+            ..Default::default()
         }
     };
     let expected_body = r#"{{ join_map "=" "," "fail-if-missing" settings.beagle }}
@@ -219,11 +222,13 @@ fn succeeds_07_aws_config() {
             name: "aws".to_string(),
             version: "v1".to_string(),
             helpers: vec![],
+            ..Default::default()
         },
         ExtensionRequirement {
             name: "std".to_string(),
             version: "v1".to_string(),
             helpers: vec!["base64_decode".to_string()],
+            ..Default::default()
         },
     };
     let expected_body =

--- a/sources/api/thar-be-settings/src/error.rs
+++ b/sources/api/thar-be-settings/src/error.rs
@@ -50,8 +50,8 @@ pub enum Error {
     #[snafu(display("Configuration file '{}' failed to render: {}", template, source))]
     TemplateRender {
         template: String,
-        #[snafu(source(from(handlebars::RenderError, Box::new)))]
-        source: Box<handlebars::RenderError>,
+        #[snafu(source(from(schnauzer::RenderError, Box::new)))]
+        source: Box<schnauzer::RenderError>,
     },
 
     #[snafu(display("Error sending {} to {}: {}", method, uri, source))]


### PR DESCRIPTION
**NOTE** This is against the `ootb-settings-extension` feature branch.
---

**Issue number:**
#3133

**Description of changes:**
* Adds support for "optional" settings extensions in templates. This lets us e.g. use AWS settings if the extension is installed, but not otherwise. Right now, the implementation does nothing because there's no concept of a setting being present or not.
* Uses the new schnauzer v2 rendering library in `thar-be-settings`, and changes all current templates to the new format
* Simplify schnauzer implementation by moving some `Option` types to have a `serde(default)`.

Existing templates were found by checking for all files installed into `%{_cross_templatedir}`.


**Testing done:**
* [x] All built-in test suites pass
* [x] Booted and checked logs/behavior of a k8s and ecs variant
* [x] Fuzz testing (I'm generating a corpus of settings objects and asserting that the old template system produces the same results as the new one)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
