### PR TITLE
testsys: Add support for gpu based ecs workloads

### DIFF
--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -222,6 +222,7 @@ pub(crate) fn workload_crd(region: &str, test_input: TestInput) -> Result<Test> 
         "testsys/type".to_string() => test_input.test_type.to_string(),
         "testsys/cluster".to_string() => cluster_resource_name.to_string(),
     });
+    let gpu = test_input.crd_input.variant.variant_flavor() == Some("nvidia");
     let plugins: Vec<_> = test_input
         .crd_input
         .config
@@ -230,7 +231,7 @@ pub(crate) fn workload_crd(region: &str, test_input: TestInput) -> Result<Test> 
         .map(|(name, image)| WorkloadTest {
             name: name.to_string(),
             image: image.to_string(),
-            ..Default::default()
+            gpu,
         })
         .collect();
     if plugins.is_empty() {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

This sets the `gpu` flag for all workload tests on `*-nvidia` variants to ensure they are run on gpus.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
