### PR TITLE
avoid unmerged-usr taint for newer systemd

### DIFF
--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -34,11 +34,13 @@ mkdir -p %{buildroot}/media/cdrom
 mkdir -p %{buildroot}/root/.aws
 
 ln -s .%{_cross_prefix} %{buildroot}%{_prefix}
-ln -s .%{_cross_bindir} %{buildroot}/bin
-ln -s .%{_cross_sbindir} %{buildroot}/sbin
 ln -s .%{_cross_libdir} %{buildroot}/lib
 ln -s .%{_cross_libdir} %{buildroot}/lib64
 ln -s lib %{buildroot}%{_cross_prefix}/lib64
+
+# Avoid "unmerged-usr" taint by linking to sys-root via `/usr`.
+ln -s .%{_bindir} %{buildroot}/bin
+ln -s .%{_sbindir} %{buildroot}/sbin
 
 %files
 %dir %{_cross_rootdir}


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
systemd 252 expects these symlinks; otherwise, it sets the taint for "unmerged-usr".


**Testing done:**
Before the change, the taint is listed when the system is in a degraded state:
```
# systemctl status
● ip-10-0-60-129.us-west-2.compute.internal
    State: degraded
    Units: 314 loaded (incl. loaded aliases)
     Jobs: 0 queued
   Failed: 2 units
    Since: Mon 2023-08-21 22:30:39 UTC; 1min 13s ago
  systemd: 252
  Tainted: unmerged-usr
```

After, it is not listed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
