### PR TITLE
mask repart services via symlink

### DIFF
--- a/packages/release/prepare-local-fs.service
+++ b/packages/release/prepare-local-fs.service
@@ -17,7 +17,8 @@ ExecStart=/usr/lib/systemd/systemd-makefs ${DATA_PARTITION_FILESYSTEM} /dev/disk
 # Stop and mask the repart-data-* oneshots in case they're waiting on non-existent data partitions.
 # 'BOTTLEROCKET-DATA' already exists so we can move on.
 ExecStart=/usr/bin/systemctl stop repart-data-preferred repart-data-fallback --no-block
-ExecStart=/usr/bin/systemctl mask repart-data-preferred repart-data-fallback --no-block
+ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-preferred.service
+ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-fallback.service
 
 RemainAfterExit=true
 StandardError=journal+console


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
`systemctl mask` implies a daemon reload operation, which slows the boot. Create the symlinks to `/dev/null` by hand, and rely on later steps - such as applying settings - to trigger the daemon reload.


**Testing done:**
Before the change, systemd prints three "reloading" messages on each boot: for the repart unit masking; and when isolating `configured.target` and `multi-user.target`. After, it only prints two.

The units are still linked to `/dev/null` and reported as masked:
```
# ls -latr /etc/systemd/system/repart-data-*
lrwxrwxrwx. 1 root root 9 Aug 21 14:58 /etc/systemd/system/repart-data-preferred.service -> /dev/null
lrwxrwxrwx. 1 root root 9 Aug 21 14:58 /etc/systemd/system/repart-data-fallback.service -> /dev/null

# systemctl list-units --state=masked
  UNIT                          LOAD   ACTIVE   SUB  DESCRIPTION
● repart-data-fallback.service  masked inactive dead repart-data-fallback.service
● repart-data-preferred.service masked inactive dead repart-data-preferred.service
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
