### PR TITLE
variants: add aws-iam-authenticator to metal variants

### DIFF
--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
 name = "metal-k8s-1_23"
 version = "0.1.0"
 dependencies = [
+ "aws-iam-authenticator",
  "cni",
  "cni-plugins",
  "kernel-5_10",
@@ -909,6 +910,7 @@ dependencies = [
 name = "metal-k8s-1_24"
 version = "0.1.0"
 dependencies = [
+ "aws-iam-authenticator",
  "cni",
  "cni-plugins",
  "kernel-5_15",
@@ -920,6 +922,7 @@ dependencies = [
 name = "metal-k8s-1_25"
 version = "0.1.0"
 dependencies = [
+ "aws-iam-authenticator",
  "cni",
  "cni-plugins",
  "kernel-5_15",
@@ -931,6 +934,7 @@ dependencies = [
 name = "metal-k8s-1_26"
 version = "0.1.0"
 dependencies = [
+ "aws-iam-authenticator",
  "cni",
  "cni-plugins",
  "kernel-5_15",
@@ -942,6 +946,7 @@ dependencies = [
 name = "metal-k8s-1_27"
 version = "0.1.0"
 dependencies = [
+ "aws-iam-authenticator",
  "cni",
  "cni-plugins",
  "kernel-5_15",

--- a/variants/metal-k8s-1.23/Cargo.toml
+++ b/variants/metal-k8s-1.23/Cargo.toml
@@ -24,6 +24,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M"
 ]
 included-packages = [
+    "aws-iam-authenticator",
     "cni",
     "cni-plugins",
     "kernel-5.10",
@@ -35,6 +36,7 @@ included-packages = [
 path = "../variants.rs"
 
 [build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_10 = { path = "../../packages/kernel-5.10" }

--- a/variants/metal-k8s-1.24/Cargo.toml
+++ b/variants/metal-k8s-1.24/Cargo.toml
@@ -24,6 +24,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M"
 ]
 included-packages = [
+    "aws-iam-authenticator",
     "cni",
     "cni-plugins",
     "kernel-5.15",
@@ -35,6 +36,7 @@ included-packages = [
 path = "../variants.rs"
 
 [build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }

--- a/variants/metal-k8s-1.25/Cargo.toml
+++ b/variants/metal-k8s-1.25/Cargo.toml
@@ -24,6 +24,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M"
 ]
 included-packages = [
+    "aws-iam-authenticator",
     "cni",
     "cni-plugins",
     "kernel-5.15",
@@ -35,6 +36,7 @@ included-packages = [
 path = "../variants.rs"
 
 [build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }

--- a/variants/metal-k8s-1.26/Cargo.toml
+++ b/variants/metal-k8s-1.26/Cargo.toml
@@ -25,6 +25,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M"
 ]
 included-packages = [
+    "aws-iam-authenticator",
     "cni",
     "cni-plugins",
     "kernel-5.15",
@@ -36,6 +37,7 @@ included-packages = [
 path = "../variants.rs"
 
 [build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }

--- a/variants/metal-k8s-1.27/Cargo.toml
+++ b/variants/metal-k8s-1.27/Cargo.toml
@@ -25,6 +25,7 @@ kernel-parameters = [
     "crashkernel=2G-:256M"
 ]
 included-packages = [
+    "aws-iam-authenticator",
     "cni",
     "cni-plugins",
     "kernel-5.15",
@@ -36,6 +37,7 @@ included-packages = [
 path = "../variants.rs"
 
 [build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
 cni = { path = "../../packages/cni" }
 cni-plugins = { path = "../../packages/cni-plugins" }
 kernel-5_15 = { path = "../../packages/kernel-5.15" }


### PR DESCRIPTION
**Issue number:**

Closes # [2823](https://github.com/bottlerocket-os/bottlerocket/issues/2823)

**Description of changes:**
AWS IAM Authentication can be set in metal variants right now but the binary is not included in the image causing it to fail. This adds the binary to the variants so that one can use AWS IAM Authentication instead of TLS.

**Testing done:**
Built a metal-k8s-1.23 image and confirmed the binary prints out usage:
```
/usr/bin/aws-iam-authenticator
A tool to authenticate to Kubernetes using AWS IAM credentials

Usage:
  aws-iam-authenticator [command]

Available Commands:
  add         add IAM entity to an existing aws-auth configmap
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  init        Pre-generate certificate, private key, and kubeconfig files for the server.
  server      Run a webhook validation server suitable that validates tokens using AWS IAM
  token       Authenticate using AWS IAM and get token for Kubernetes
  verify      Verify a token for debugging purpose
  version     Version will output the current build information

Flags:
  -i, --cluster-id ID                 Specify the cluster ID, a unique-per-cluster identifier for your aws-iam-authenticator installation.
  -c, --config filename               Load configuration from filename
      --feature-gates mapStringBool   A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                      AllAlpha=true|false (ALPHA - default=false)
                                      AllBeta=true|false (BETA - default=false)
  1 variants: add aws-iam-authenticator to metal variants
                                      ConfiguredInitDirectories=true|false (ALPHA - default=false)
                                      IAMIdentityMappingCRD=true|false (ALPHA - default=false)
  -h, --help                          help for aws-iam-authenticator
  -l, --log-format string             Specify log format to use when logging to stderr [text or json] (default "text")

Use "aws-iam-authenticator [command] --help" for more information about a command.
```
I don't have a cluster for metal where I could test that it works as intended but it should function the same as the aws variants today.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
