### PR TITLE
3p packages update 1.15.0

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.815.0/amazon-ssm-agent-3.2.815.0.tar.gz"
-sha512 = "724b659f7141dc9c797288f109b35c2a516f08f843d472da0d44f1a04c5fbce30fd8df0cde95be355ca2a710b146c89e1ee3bb5905c297a90b3aaccf78d9da8b"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.1478.0/amazon-ssm-agent-3.2.1478.0.tar.gz"
+sha512 = "f9a4741784a861ab8319793d37baee57137aa2eb6a350df329d8dee0c00a97c6e639560eb0c17d4bb596ddc032ee36819fbc40b55f559c490a3eb214e9627ba1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -8,7 +8,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.2.815.0
+Version: 3.2.1478.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0

--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.8/aws-iam-authenticator-0.6.8.tar.gz"
-sha512 = "6e9f43852cdd3fb7d47ea70df5d108a0e235245b6db1a4f6406efffc329f5c940bf284c216e4bf20e83ff691b078652cee3fbae4c7c3da658ea3eef2ecab92b5"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.11/aws-iam-authenticator-0.6.11.tar.gz"
+sha512 = "6d78fbe95d6e36a7a3835b4df257e96fff3ab53fe4abd8ef525c24aebaf8727e2a6016107024bebe031b2e24295172190407ca892d1b3478329c62cdd9fe553f"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.6.8
+%global gover 0.6.11
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ca-certificates/Cargo.toml
+++ b/packages/ca-certificates/Cargo.toml
@@ -12,5 +12,5 @@ path = "../packages.rs"
 releases-url = "https://curl.se/docs/caextract.html"
 
 [[package.metadata.build-package.external-files]]
-url = "https://curl.haxx.se/ca/cacert-2023-01-10.pem"
-sha512 = "08cd35277bf2260cb3232d7a7ca3cce6b2bd58af9221922d2c6e9838a19c2f96d1ca6d77f3cc2a3ab611692f9fec939e9b21f67442282e867a487b0203ee0279"
+url = "https://curl.haxx.se/ca/cacert-2023-08-22.pem"
+sha512 = "26a6696b4b17a8d95a6baeaf0643e21789eae033a680c18ff7083d3dea70b908e12c6afeb39aee0025c4f65428d2c2944576893936818426c5030d7e150ef1c2"

--- a/packages/ca-certificates/ca-certificates.spec
+++ b/packages/ca-certificates/ca-certificates.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}ca-certificates
-Version: 2023.01.10
+Version: 2023.08.22
 Release: 1%{?dist}
 Summary: CA certificates extracted from Mozilla
 License: MPL-2.0
 # Note: You can see changes here:
 # https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
 URL: https://curl.haxx.se/docs/caextract.html
-Source0: https://curl.haxx.se/ca/cacert-2023-01-10.pem
+Source0: https://curl.haxx.se/ca/cacert-2023-08-22.pem
 Source1: ca-certificates-tmpfiles.conf
 
 %description

--- a/packages/chrony/Cargo.toml
+++ b/packages/chrony/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://download.tuxfamily.org/chrony"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download.tuxfamily.org/chrony/chrony-4.3.tar.gz"
-sha512 = "1394bac3ed684352fe89b7fef7da50e61f9f522abee807627ae1fc4c2dde891017bc8e5b13759fced028f3a1e875d5e4e5a4f85de65c63b5f83d0ca03bb4c5df"
+url = "https://download.tuxfamily.org/chrony/chrony-4.4.tar.gz"
+sha512 = "45e060eb0c5892552f28dc436429e5823409cc93533127af27b64d08ff9c769fdc72694272232114f5ca1884c2bc8b5e842fae7956dc457358e937bcd3dda4d7"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}chrony
-Version: 4.3
+Version: 4.4
 Release: 1%{?dist}
 Summary: A versatile implementation of the Network Time Protocol
 License: GPL-2.0-only

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containernetworking/plugins/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/plugins/archive/v1.2.0/plugins-1.2.0.tar.gz"
-sha512 = "fb6fb4f46ac1610b3721f5f3a6ddfb096cbf2e5d5b792306edca5351a3944d2f802170d83e5adec01420395bf64fc8a174ede61ac9b93b5ac6b938a4b48651e6"
+url = "https://github.com/containernetworking/plugins/archive/v1.3.0/plugins-1.3.0.tar.gz"
+sha512 = "87e186b3cd64f66280f5b2293dcdd1fc22cb8f51a248124fb622adc48a893348419ba4c29c4769dede4d9e60f2e9fea5d4198f10badb4ecd20a1551e0b344e10"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 %global gorepo plugins
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.2.0
+%global gover 1.3.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -55,6 +55,7 @@ install -p -m 0755 bin/* %{buildroot}%{_cross_libexecdir}/cni/bin
 %{_cross_libexecdir}/cni/bin/ptp
 %{_cross_libexecdir}/cni/bin/sbr
 %{_cross_libexecdir}/cni/bin/static
+%{_cross_libexecdir}/cni/bin/tap
 %{_cross_libexecdir}/cni/bin/tuning
 %{_cross_libexecdir}/cni/bin/vlan
 %{_cross_libexecdir}/cni/bin/vrf

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.20/containerd-1.6.20.tar.gz"
-sha512 = "dd9708c99d95773a78b0fcd77b388cb8a971d0d65502c8b86cbb3b29c48bac31366ae0603d7710a13c21c33adcd341cdec69dcb3c3a06a2d753c4c59f2549d75"
+url = "https://github.com/containerd/containerd/archive/v1.6.23/containerd-1.6.23.tar.gz"
+sha512 = "576ab87c07700054918ac8fa8e6c1f1ba971722ac7cad8f3d8ecccdb8cb162103fa826fa815f58f5f63d061b2a8dce8f2fbbee3def85cd4a4f8dbee124d2596a"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.20
+%global gover 1.6.23
 %global rpmver %{gover}
 %global gitrev 1e1ea6e986c6c86565bc33d52e34b81b3e2bc71f
 

--- a/packages/ecs-agent/0001-bottlerocket-default-filesystem-locations.patch
+++ b/packages/ecs-agent/0001-bottlerocket-default-filesystem-locations.patch
@@ -1,38 +1,27 @@
-From 09721aa67086fde4f3cfd05d13b7ba1c4b05d379 Mon Sep 17 00:00:00 2001
-From: Samuel Karp <skarp@amazon.com>
-Date: Wed, 8 Jul 2020 11:18:35 -0700
+From 3df68e0247900b32e096eefd7465fb5e836916d1 Mon Sep 17 00:00:00 2001
+From: Shikha Vyaghra <vyaghras@amazon.com>
+Date: Wed, 23 Aug 2023 21:09:50 +0000
 Subject: [PATCH] bottlerocket: default filesystem locations
 
+This patch was originally written by Samuel Karp <skarp@amazon.com>
+(09721aa67086fde4f3cfd05d13b7ba1c4b05d379). In this updated patch
+version all the settings that can be configured using config file,
+have been removed from the patch.
+
 Signed-off-by: Sean P. Kelly <seankell@amazon.com>
+Signed-off-by: Shikha Vyaghra <vyaghras@amazon.com>
 ---
- agent/config/config.go             | 6 +++---
- agent/config/config_unix.go        | 6 +++---
+ agent/config/config.go             | 2 +-
  agent/ecscni/plugin_linux.go       | 2 +-
  agent/ecscni/plugin_unsupported.go | 2 +-
  agent/utils/license.go             | 6 +++---
- 5 files changed, 11 insertions(+), 11 deletions(-)
+ 4 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/agent/config/config.go b/agent/config/config.go
-index 38f0d0f..acebb26 100644
+index 34339bd..0cf7426 100644
 --- a/agent/config/config.go
 +++ b/agent/config/config.go
-@@ -51,7 +51,7 @@ const (
- 	AgentPrometheusExpositionPort = 51680
- 
- 	// defaultConfigFileName is the default (json-formatted) config file
--	defaultConfigFileName = "/etc/ecs_container_agent/config.json"
-+	defaultConfigFileName = "/etc/ecs/ecs.config.json"
- 
- 	// DefaultClusterName is the name of the default cluster.
- 	DefaultClusterName = "default"
-@@ -118,13 +118,13 @@ const (
- 	minimumNumImagesToDeletePerCycle = 1
- 
- 	// defaultCNIPluginsPath is the default path where cni binaries are located
--	defaultCNIPluginsPath = "/amazon-ecs-cni-plugins"
-+	defaultCNIPluginsPath = "/usr/libexec/amazon-ecs-agent"
- 
- 	// DefaultMinSupportedCNIVersion denotes the minimum version of cni spec required
+@@ -122,7 +122,7 @@ const (
  	DefaultMinSupportedCNIVersion = "0.3.0"
  
  	// pauseContainerTarball is the path to the pause container tarball
@@ -41,37 +30,11 @@ index 38f0d0f..acebb26 100644
  
  	// DefaultTaskMetadataSteadyStateRate is set as 40. This is arrived from our benchmarking
  	// results where task endpoint can handle 4000 rps effectively. Here, 100 containers
-diff --git a/agent/config/config_unix.go b/agent/config/config_unix.go
-index 6c1254d..3adefaa 100644
---- a/agent/config/config_unix.go
-+++ b/agent/config/config_unix.go
-@@ -29,10 +29,10 @@ const (
- 	// AgentCredentialsAddress is used to serve the credentials for tasks.
- 	AgentCredentialsAddress = "" // this is left blank right now for net=bridge
- 	// defaultAuditLogFile specifies the default audit log filename
--	defaultCredentialsAuditLogFile = "/log/audit.log"
-+	defaultCredentialsAuditLogFile = "/var/log/ecs/audit.log"
- 
- 	// defaultRuntimeStatsLogFile stores the path where the golang runtime stats are periodically logged
--	defaultRuntimeStatsLogFile = `/log/agent-runtime-stats.log`
-+	defaultRuntimeStatsLogFile = `/var/log/ecs/agent-runtime-stats.log`
- 
- 	// DefaultTaskCgroupV1Prefix is default cgroup v1 prefix for ECS tasks
- 	DefaultTaskCgroupV1Prefix = "/ecs"
-@@ -63,7 +63,7 @@ func DefaultConfig() Config {
- 		DockerEndpoint:                      "unix:///var/run/docker.sock",
- 		ReservedPorts:                       []uint16{SSHPort, DockerReservedPort, DockerReservedSSLPort, AgentIntrospectionPort, AgentCredentialsPort},
- 		ReservedPortsUDP:                    []uint16{},
--		DataDir:                             "/data/",
-+		DataDir:                             "/var/lib/ecs/data",
- 		DataDirOnHost:                       "/var/lib/ecs",
- 		DisableMetrics:                      BooleanDefaultFalse{Value: ExplicitlyDisabled},
- 		ReservedMemory:                      0,
 diff --git a/agent/ecscni/plugin_linux.go b/agent/ecscni/plugin_linux.go
-index cb13d41..4acf042 100644
+index 0d3a940..3e76060 100644
 --- a/agent/ecscni/plugin_linux.go
 +++ b/agent/ecscni/plugin_linux.go
-@@ -33,7 +33,7 @@ import (
+@@ -34,7 +34,7 @@ import (
  const (
  	vpcCNIPluginInterfaceType = "vlan"
  	// vpcCNIPluginPath is the path of the cni plugin's log file.
@@ -81,7 +44,7 @@ index cb13d41..4acf042 100644
  
  // newCNIGuard returns a new instance of CNI guard for the CNI client.
 diff --git a/agent/ecscni/plugin_unsupported.go b/agent/ecscni/plugin_unsupported.go
-index e156b75..55d1a3c 100644
+index 05bc3cf..a34a823 100644
 --- a/agent/ecscni/plugin_unsupported.go
 +++ b/agent/ecscni/plugin_unsupported.go
 @@ -26,7 +26,7 @@ import (
@@ -106,7 +69,7 @@ index 6eccff6..324307c 100644
 -	thirdPartyFile = "THIRD-PARTY"
 +	licenseFile    = "/usr/share/licenses/ecs-agent/LICENSE"
 +	noticeFile     = "/usr/share/licenses/ecs-agent/NOTICE"
-+	thirdPartyFile = "/usr/share/licenses/ecs-agent/THIRD-PARTY"
++	thirdPartyFile = "/usr/share/licenses/ecs-agent/THIRD_PARTY.md"
  )
  
  var readFile = ioutil.ReadFile

--- a/packages/ecs-agent/0002-bottlerocket-remove-unsupported-capabilities.patch
+++ b/packages/ecs-agent/0002-bottlerocket-remove-unsupported-capabilities.patch
@@ -1,6 +1,6 @@
-From b84708cfb634e84ca0ef2ac95292ddc1b370b41f Mon Sep 17 00:00:00 2001
-From: Sean McGinnis <stmcg@amazon.com>
-Date: Tue, 21 Feb 2023 19:06:43 +0000
+From b681439606e39ff21d14742ba58f1ecaf8e7f73d Mon Sep 17 00:00:00 2001
+From: Shikha Vyaghra <vyaghras@amazon.com>
+Date: Wed, 23 Aug 2023 22:16:58 +0000
 Subject: [PATCH] bottlerocket: remove unsupported capabilities
 
 Signed-off-by: Sean McGinnis <stmcg@amazon.com>
@@ -10,10 +10,10 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/agent/app/agent_capability.go b/agent/app/agent_capability.go
-index 0f78c00..746d87a 100644
+index e02e612..7ff5993 100644
 --- a/agent/app/agent_capability.go
 +++ b/agent/app/agent_capability.go
-@@ -248,7 +248,7 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
+@@ -250,7 +250,7 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
  	capabilities = agent.appendAppMeshCapabilities(capabilities)
  
  	// support elastic inference in agent
@@ -22,15 +22,15 @@ index 0f78c00..746d87a 100644
  
  	// support aws router capabilities for fluentd
  	capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
-@@ -272,9 +272,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
- 	capabilities = agent.appendGMSACapabilities(capabilities)
+@@ -277,9 +277,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
+ 	capabilities = agent.appendGMSADomainlessCapabilities(capabilities)
  
  	// support efs auth on ecs capabilities
 -	for _, cap := range agent.cfg.VolumePluginCapabilities {
 -		capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
 -	}
 +	// for _, cap := range agent.cfg.VolumePluginCapabilities {
-+	// 	capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
++	//      capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
 +	// }
  
  	// support fsxWindowsFileServer on ecs capabilities

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.70.2/amazon-ecs-agent-1.70.2.tar.gz"
-sha512 = "1cfbe51d87f63958b2c86df41dd2d42c7b96924a42be9889f0b7d3a6874c6787e9e65e6d03f974dd6fb75de74868a78f937e47908032b96272770eac39646cbc"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.75.0/amazon-ecs-agent-1.75.0.tar.gz"
+sha512 = "25bbf1f24451bff8f2bac03a83bdee64186f07de466bdebafe1ff149995ca3c57320b13ced85843139369c4638367015600439aa317ee9875038436d0ec67e17"
 
 # The ECS agent repository includes two CNI plugins as git submodules.  git
 # archive does not include submodules, so the tarball above does not include
@@ -23,12 +23,12 @@ sha512 = "1cfbe51d87f63958b2c86df41dd2d42c7b96924a42be9889f0b7d3a6874c6787e9e65e
 # You can get the commit SHA for the submodules for a particular ecs-agent release here:
 # https://github.com/aws/amazon-ecs-agent/blob/ECS_AGENT_VERSION/agent/ecscni/plugin_test.go#L29-L34
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/db5864722987c34ba309e6e7a7628fd1ccad1520/amazon-ecs-cni-plugins.tar.gz"
-sha512 = "550681f5cd9bdf46dd1a3353b9d328217a4d1b8697633fb70c19a0e2ddd839fb08bc764b63b1c23bc77b0d1c125ee8fbb5de0ad55628b1449261e9700e486387"
+url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/53a8481891251e66e35847554d52a13fc7c4fd03/amazon-ecs-cni-plugins.tar.gz"
+sha512 = "e819c1aae509d19461999bf717d126b3e918b73dc6049e415c4911be6cb11159404bb45bb6c92cdfa16b5b30bb174731e972e3f2be44fa0b51bbc7a969049ab7"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/24d6bd87707d1b1801086fc507ebab8d32067412/amazon-vpc-cni-plugins.tar.gz"
-sha512 = "70ee8b238ba05528c89042b2cf3102c77bd71ea3a3fef6d7645f420842d82da1c2b3798022b02feec73253c130497b706ea24ae1088f53730baa415cdcfcd606"
+url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/a83b66349768e020487a00e31767fc2e6fc88136/amazon-vpc-cni-plugins.tar.gz"
+sha512 = "ace0d27938b0c47a1208cbc0a30fa70f306270cc66a0b40bdd58d6d7060c69c361c3edcd4cc1d87bdb0f2be839cd6244541c485b3a294c265c5fdf740b012238"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.70.2
+%global agent_gover 1.75.0
 
 # git rev-parse --short=8
 %global agent_gitrev 06008fa1
@@ -10,12 +10,12 @@
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
 %global ecscni_goimport %{ecscni_goproject}/%{ecscni_gorepo}
-%global ecscni_gitrev db5864722987c34ba309e6e7a7628fd1ccad1520
+%global ecscni_gitrev 53a8481891251e66e35847554d52a13fc7c4fd03
 
 %global vpccni_goproject github.com/aws
 %global vpccni_gorepo amazon-vpc-cni-plugins
 %global vpccni_goimport %{vpccni_goproject}/%{vpccni_gorepo}
-%global vpccni_gitrev 24d6bd87707d1b1801086fc507ebab8d32067412
+%global vpccni_gitrev a83b66349768e020487a00e31767fc2e6fc88136
 %global vpccni_gover 1.3
 
 # Construct reproducible tar archives
@@ -296,7 +296,7 @@ mv %{vpccni_gorepo}-%{vpccni_gitrev}/vendor go-vendor/%{vpccni_gorepo}
 # ├── LICENSE.amazon-ecs-cni-plugins
 # ├── LICENSE.amazon-vpc-cni-plugins
 # ├── NOTICE
-# ├── THIRD-PARTY
+# ├── THIRD_PARTY.md
 # └── vendor
 #     ├── amazon-ecs-agent
 #     │ └── ...
@@ -309,7 +309,7 @@ mv %{vpccni_gorepo}-%{vpccni_gitrev}/vendor go-vendor/%{vpccni_gorepo}
 %{_cross_attribution_vendor_dir}
 %license %{agent_gorepo}-%{agent_gover}/LICENSE
 %license %{agent_gorepo}-%{agent_gover}/NOTICE
-%license %{agent_gorepo}-%{agent_gover}/THIRD-PARTY
+%license %{agent_gorepo}-%{agent_gover}/ecs-agent/THIRD_PARTY.md
 %license %{ecscni_gorepo}-%{ecscni_gitrev}/LICENSE.%{ecscni_gorepo}
 %license %{vpccni_gorepo}-%{vpccni_gitrev}/LICENSE.%{vpccni_gorepo}
 

--- a/packages/ecs-agent/ecs.config
+++ b/packages/ecs-agent/ecs.config
@@ -1,5 +1,6 @@
 ECS_LOGFILE=/var/log/ecs/ecs-agent.log
 ECS_LOGLEVEL="{{settings.ecs.loglevel}}"
+ECS_AGENT_CONFIG_FILE_PATH="/etc/ecs/ecs.config.json"
 {{#if settings.container-registry.credentials~}}
 ECS_ENGINE_AUTH_TYPE=dockercfg
 ECS_ENGINE_AUTH_DATA='{

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/software/network/ethtool/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.2.tar.xz"
-sha512 = "ff1f14c7876163bef93ca48e22a3429f09b4bcb3e1d101ef297d9f226e3fc2d3c3f19faf5b85f54cb558479e4a408ef5356a2d12e7ba132cc4cadaf92effccaf"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.4.tar.xz"
+sha512 = "5e389564b41e9494df102f9fb703ae2d80ba38346d84ec6c89b024ec21c85eca9f58e88012290feaa88d3ce035d6f779913798b0ca177e8d0a08eff197eb6afd"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}ethtool
-Version: 6.2
+Version: 6.4
 Release: 1%{?dist}
 Summary: Settings tool for Ethernet NICs
 License: GPL-2.0-only AND GPL-2.0-or-later

--- a/packages/iproute/Cargo.toml
+++ b/packages/iproute/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "http://kernel.org/pub/linux/utils/net/iproute2"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.2.0.tar.xz"
-sha512 = "b24e0fdd0f51b8b78bc3bb681e3829af47d3011e93f3892289eb070b336709a6883728ecc7627ca37f6449720f8ed1349af321c0d04454894a7175b82f7de151"
+url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.4.0.tar.xz"
+sha512 = "42330be6e061302694ea301765ff8d3cbfaeca4b1d06e39778861e4390ed211c03cb2d41498190202b659f7f5647b1ca4857410ef8c16fd601a35e7162788d21"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iproute/iproute.spec
+++ b/packages/iproute/iproute.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}iproute
-Version: 6.2.0
+Version: 6.4.0
 Release: 1%{?dist}
 Summary: Tools for advanced IP routing and network device configuration
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-audit/audit-userspace/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-audit/audit-userspace/archive/v3.1/audit-userspace-3.1.tar.gz"
-sha512 = "c21be7da557a2f0f2576645db23626785955190599e1b417252424eaefa7284da8e2e915cf2599f28078ee507d83497eb6cbbdb1b1459a0fabd62e235b34e7b9"
+url = "https://github.com/linux-audit/audit-userspace/archive/v3.1.2/audit-userspace-3.1.2.tar.gz"
+sha512 = "d5b05686aedd6eaaced000778580bd3e96e38c020534038d6b1ee6de96dd7687c2f3a52a2ae75be8b93c173b286a56dbc92231906c68fda79b113dfcaad6da84"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libaudit
-Version: 3.1
+Version: 3.1.2
 Release: 1%{?dist}
 Summary: Library for the audit subsystem
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libca
 # Changelog can be found here: https://sites.google.com/site/fullycapable/release-notes-for-libcap
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.68.tar.gz"
-sha512 = "b5dbf42790114cb26d923f8a7f40a44fc1ac370eac6f7cfc0c0bfed870648e501f920295159c4ab906b7df66d662add04938b1fe9998dc403be81aec95234bf3"
+url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.69.tar.gz"
+sha512 = "75ee0fe8e1ac835f29cb76d233f731dcf126b73eed5229a130bbe4308a42441934d4e9cefeaaab45f774de2ed6859c752fbbfb9908e792f2f9f3d0f841e01aee"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.68
+Version: 2.69
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause

--- a/packages/libdbus/Cargo.toml
+++ b/packages/libdbus/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://dbus.freedesktop.org/releases/dbus"
 
 [[package.metadata.build-package.external-files]]
-url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.15.4.tar.xz"
-sha512 = "53a5b7161940c5d4432b902c3c0ac1f1965978e3791a640d1a71f2d819474b727497f7a13c95d7c5850baef659062f1434296a3f5e56701383cc573dfbf187ee"
+url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.15.6.tar.xz"
+sha512 = "8c2e207d98245d5f8d358e9824be9e8646af8147958e8bd56e18d478e8976e58a6645ee1aba62451fcc58443157e2a39c4a6ed9c2e440e7b6b05053d022f0113"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libdbus
-Version: 1.15.4
+Version: 1.15.6
 Release: 1%{?dist}
 Summary: Library for a message bus
 License: AFL-2.1 OR GPL-2.0-or-later

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://download.gnome.org/sources/glib"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.76/glib-2.76.0.tar.xz"
-sha512 = "812834ca6d840dd9c15c0689685d8bd96f4acd69a89213f807a75732d1aa5efadbed0e0073f05a56a09beb2d4f0be1b83a4642259682aac84302632da2d62370"
+url = "https://download.gnome.org/sources/glib/2.77/glib-2.77.2.tar.xz"
+sha512 = "0e2cf5178a7174b174480a795b1cbb2f1dbbea35899b7e4756937e426b6c39c20deb8488958403b78552674c4179e6fd63ea7fac2b746ac49a62046e27086111"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,11 +1,11 @@
 Name: %{_cross_os}libglib
-Version: 2.76.0
+Version: 2.77.2
 Release: 1%{?dist}
 Summary: The GLib libraries
 # glib2 is LGPL-2.1-only
 License: LGPL-2.1-only
 URL: https://www.gtk.org/
-Source0: https://download.gnome.org/sources/glib/2.76/glib-%{version}.tar.xz
+Source0: https://download.gnome.org/sources/glib/2.77/glib-%{version}.tar.xz
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libffi-devel

--- a/packages/libinih/Cargo.toml
+++ b/packages/libinih/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/benhoyt/inih/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/benhoyt/inih/archive/refs/tags/r56.tar.gz"
-path = "inih-r56.tar.gz"
-sha512 = "ff3e0910990f73e5b21fddc84737ab346279f201c86c7ad864c6cad9de5bde57c3e0a433b9b8f3585b7d86feaae2ea074185f92891dcadc98c274c1c0745d2d2"
+url = "https://github.com/benhoyt/inih/archive/refs/tags/r57.tar.gz"
+path = "inih-r57.tar.gz"
+sha512 = "9f758df876df54ed7e228fd82044f184eefbe47e806cd1e6d62e1b0ea28e2c08e67fa743042d73b4baef0b882480e6afe2e72878b175822eb2bdbb6d89c0e411"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libinih/libinih.spec
+++ b/packages/libinih/libinih.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libinih
-Version: 56
+Version: 57
 Release: 1%{?dist}
 Summary: Simple INI file parser library
 License: BSD-3-Clause

--- a/packages/liblzma/Cargo.toml
+++ b/packages/liblzma/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://tukaani.org/xz"
 
 [[package.metadata.build-package.external-files]]
-url = "https://tukaani.org/xz/xz-5.4.2.tar.xz"
-sha512 = "39163ee327743111968c4231fccc4ebbc1c77c96acf19afa8b1ca4153826a2c0d83b43111fa22b56139c03fc19c621d365fa0f80be1f3c3784fe7dd6f8fcfb68"
+url = "https://tukaani.org/xz/xz-5.4.4.tar.xz"
+sha512 = "2b233a924b82190ff15e970c5a4a59f1c53a0b39a96bde228c9dfc9b103b4a3e5888f5024da4834e180f6010620ff23caf9f7135a38724eb2c8d01bff7a9a9e1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/liblzma/liblzma.spec
+++ b/packages/liblzma/liblzma.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}liblzma
-Version: 5.4.2
+Version: 5.4.4
 Release: 1%{?dist}
 Summary: Library for XZ and LZMA compressed files
 URL: https://tukaani.org/xz

--- a/packages/libnftnl/Cargo.toml
+++ b/packages/libnftnl/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://netfilter.org/projects/libnftnl/files"
 
 [[package.metadata.build-package.external-files]]
-url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.2.5.tar.xz"
-sha512 = "576ccd0815063a6ef3095b5514c3d286b4450fad98fbf7a85cd537f66adf043e7e6295d4c84cc3cbfd18cf9a29576d15a88cc439a61a3e654841a27c71babea1"
+url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.2.6.tar.xz"
+sha512 = "0c8c369eec84b0c568f0067598bece6e3be9a0fbd977e443ae3b14a5a6d842a6086ceb5426a65f8c77204709655f148c1241193f1a928f8c12154a57e3548b34"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnftnl/libnftnl.spec
+++ b/packages/libnftnl/libnftnl.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnftnl
-Version: 1.2.5
+Version: 1.2.6
 Release: 1%{?dist}
 Summary: Library for nftables netlink
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.13.1/libnvidia-container-1.13.1.tar.gz"
-sha512 = "9961480bdccb62e008ee4ee50c66eebc9cf86bcee988bd1c97dd8351ee1a223b2532c27323667c391b693f0655c391dc95309a74600220e7d368604ab3e66925"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.13.5/libnvidia-container-1.13.5.tar.gz"
+sha512 = "00de15c2a0168b0c131eae21e10d186053be7f78021fe28785130ea541f1a592f44042697f01b3bf20717d9a93a85b34c7b510028adcc265cc0ac6f97be2bf0e"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/NVIDIA/nvidia-modprobe/archive/495.44/nvidia-modprobe-495.44.tar.gz"

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global nvidia_modprobe_version 495.44
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.13.1
+Version: 1.13.5
 Release: 1%{?dist}
 Summary: NVIDIA container runtime library
 # The COPYING and COPYING.LESSER files in the sources don't apply to libnvidia-container

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/besser82/libxcrypt/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.33/libxcrypt-4.4.33.tar.xz"
-sha512 = "b46d226a83d35b578381aa340e34cd77aea25a304aec3d00ba3d3acb6462e96824ff82ea930aaf2b87039dfffef4dab4b1774736d6b8a107cfb61e6cdb307b99"
+url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.36/libxcrypt-4.4.36.tar.xz"
+sha512 = "468560e6f90877540d22e32c867cbcf3786983a6fdae6ef86454f4b7f2bbaae1b6589d1af75cda73078fa8f6e91b1a32f8353f26d433246eef7be3e96d4ae1c7"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.33
+Version: 4.4.36
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/libz/Cargo.toml
+++ b/packages/libz/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://www.zlib.net"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.zlib.net/zlib-1.2.13.tar.xz"
-sha512 = "9e7ac71a1824855ae526506883e439456b74ac0b811d54e94f6908249ba8719bec4c8d7672903c5280658b26cb6b5e93ecaaafe5cdc2980c760fa196773f0725"
+url = "https://www.zlib.net/zlib-1.3.tar.xz"
+sha512 = "3868ac4da5842dd36c9dad794930675b9082ce15cbd099ddb79c0f6bd20a24aa8f33a123f378f26fe0ae02d91f31f2994dccaac565cedeaffed7b315e6ded2a2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libz/libz.spec
+++ b/packages/libz/libz.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libz
-Version: 1.2.13
+Version: 1.3
 Release: 1%{?dist}
 Summary: Library for zlib compression
 URL: https://www.zlib.net/

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.13.1/nvidia-container-toolkit-1.13.1.tar.gz"
-sha512 = "e0d9dbb06e2b8ef075a881f4414bfb4b1ab9f571d148a202fbf7c2a7b59447f199028d5d176196703dadcb04040a74a229f09062da24e615faa4c051d614e206"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.13.5/nvidia-container-toolkit-1.13.5.tar.gz"
+sha512 = "7266e779abf27f2bc1b7c801e5eb4720b82be22bed3ec90171e4f5499b2bc7376f1369e4931d4db55edc8f5fd5e44d5e817eb258ec39bf55f16424fe725188d6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.13.1
+%global gover 1.13.5
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.14.0/v0.14.0.tar.gz"
-path = "k8s-device-plugin-0.14.0.tar.gz"
-sha512 = "25fc1e5a6c772d30c916229376adc8f8af98877f5741d8f5841fafbf20dfa479e7f69c2da01c02ff47acef1b7e899b9b0cc8cb6e0c49d76c8750628574d302d5"
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.14.1/v0.14.1.tar.gz"
+path = "k8s-device-plugin-0.14.1.tar.gz"
+sha512 = "e00a3da18ae803669d566faf5b8e8c5fe57c36d85100255c0c7be42bcb9c40cb1f97afecea8cab8035f8e10182a8a63cf18e89c702d161ee8bbc16dddd760d19"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.14.0
+%global gover 0.14.1
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-k8s-device-plugin

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/vmware/open-vm-tools/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/vmware/open-vm-tools/releases/download/stable-12.2.0/open-vm-tools-12.2.0-21223074.tar.gz"
-sha512 = "d663d8ea455264cad7d3eaac16c5d08672e8e10f7a9171be40fff69e208ae697bc0e8af498c978d8de470ed273351b42c54994b2c552fdc05b828c80f4826b84"
+url = "https://github.com/vmware/open-vm-tools/releases/download/stable-12.2.5/open-vm-tools-12.2.5-21855600.tar.gz"
+sha512 = "72db3b88f61624d26e8ff7e37e4fc52ecd0bec0b6f076d935870c03312321c5e0b406d05eae7012872734a50626ed760dff2cf872e26ec18ebf200aff5ed12ef"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -1,7 +1,7 @@
-%global buildver 21223074
+%global buildver 21855600
 
 Name: %{_cross_os}open-vm-tools
-Version: 12.2.0
+Version: 12.2.5
 Release: 1%{?dist}
 Summary: Tools for VMware
 License: LGPL-2.1-or-later

--- a/packages/pigz/Cargo.toml
+++ b/packages/pigz/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://zlib.net/pigz/pigz-2.7.tar.gz"
-sha512 = "9f9f61de4a0307fc057dc4e31a98bd8d706d9e709ecde0be02a871534fddf6a1fe1321158aa72708603aaaece43f83d2423b127f7689b6219b23aea4f989e8f5"
+url = "https://zlib.net/pigz/pigz-2.8.tar.gz"
+sha512 = "ae3d9d593e1645d65f9ab77aa828600c9af4bb30d0a073da7ae3dd805e65b87efaf6a0efb980f2d0168e475ae506eba194547d6479956dabb9d88293a9078a7f"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/pigz/pigz.spec
+++ b/packages/pigz/pigz.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}pigz
-Version: 2.7
+Version: 2.8
 Release: 1%{?dist}
 Summary: pigz is a parallel implementation of gzip which utilizes multiple cores
 License: Zlib AND Apache-2.0

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.6/runc.tar.xz"
-path = "runc-v1.1.6.tar.xz"
-sha512 = "a5b799cb5a69f7251f81e5887a9269fb8fc6573b8a7d1b2e2436a0955feea982a34cf0bc62017534fdbc75e37fa70db4a06bdaecc6e67140fb094d06642a8440"
+url = "https://github.com/opencontainers/runc/releases/download/v1.1.9/runc.tar.xz"
+path = "runc-v1.1.9.tar.xz"
+sha512 = "e6fd1e7414929436f996358389eeb968db1304358029f0b845eb7d4afac4fa0d637e06ab0e564d680b825e2edb97b55cc154f32e4912d56697bbaf0923c1ec0d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -2,7 +2,7 @@
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
 %global commit 0f48801a0e21e3f0bc4e74643ead2a502df4818d
-%global gover 1.1.6
+%global gover 1.1.9
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.2/strace-6.2.tar.xz"
-sha512 = "56708faa3f73c0673c98a5b8b8fe35289ecf2870f4f775bcb7a6be59451ef84685564c0129aca15b576d851f8efa1ff760e27658b914d1f31adf4de3b1ad721f"
+url = "https://strace.io/files/6.4/strace-6.4.tar.xz"
+sha512 = "29f47195b2766dc0d2907aba2d561e87ec87939251d07fd82d22ffdd3c864944ab0c47eabd7b13272345dfc5dfae7ca435c94fd5ccc297dd46e0747c6d463e01"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 6.2
+Version: 6.4
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.1.tar.xz"
-sha512 = "07f11147f67dfc6c8bc766dfc83266054e6ede776feada0566b447d13276b6882ee85c6fe53e8d94a17c03332106fc0549deca3cf5f2e92dda554e9bc0551957"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.2.tar.xz"
+sha512 = "cebecdd62749d0aeea2c4faf7ad1606426eff03ef3b15cd9c2df1126f216a4ed546d8fc3218c649fa95944eb87a98bb6a7cdd0bea31057c481c5cf608ffc19a3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -1,5 +1,5 @@
-%global majorminor 2.38
-%global version %{majorminor}.1
+%global majorminor 2.39
+%global version %{majorminor}.2
 
 Name: %{_cross_os}util-linux
 Version: %{version}
@@ -234,6 +234,9 @@ done
 %exclude %{_cross_bindir}/wdctl
 %exclude %{_cross_bindir}/whereis
 %exclude %{_cross_bindir}/write
+%exclude %{_cross_bindir}/fadvise
+%exclude %{_cross_bindir}/pipesz
+%exclude %{_cross_bindir}/waitpid
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_bindir}/i386
 %exclude %{_cross_bindir}/x86_64
@@ -283,6 +286,7 @@ done
 %exclude %{_cross_sbindir}/vigr
 %exclude %{_cross_sbindir}/vipw
 %exclude %{_cross_sbindir}/zramctl
+%exclude %{_cross_sbindir}/blkpr
 
 %exclude %{_cross_bashdir}
 %exclude %{_cross_docdir}
@@ -299,7 +303,6 @@ done
 %dir %{_cross_includedir}/blkid
 %{_cross_includedir}/blkid/blkid.h
 %{_cross_pkgconfigdir}/blkid.pc
-%exclude %{_cross_libdir}/libblkid.la
 
 %files -n %{_cross_os}libfdisk
 %license %{_cross_licensedir}/libfdisk/COPYING.LGPL-2.1-or-later
@@ -312,7 +315,6 @@ done
 %dir %{_cross_includedir}/libfdisk
 %{_cross_includedir}/libfdisk/libfdisk.h
 %{_cross_pkgconfigdir}/fdisk.pc
-%exclude %{_cross_libdir}/libfdisk.la
 
 %files -n %{_cross_os}libmount
 %license %{_cross_licensedir}/libmount/COPYING.LGPL-2.1-or-later
@@ -325,7 +327,6 @@ done
 %dir %{_cross_includedir}/libmount
 %{_cross_includedir}/libmount/libmount.h
 %{_cross_pkgconfigdir}/mount.pc
-%exclude %{_cross_libdir}/libmount.la
 
 %files -n %{_cross_os}libsmartcols
 %license %{_cross_licensedir}/libsmartcols/COPYING.LGPL-2.1-or-later
@@ -338,7 +339,6 @@ done
 %dir %{_cross_includedir}/libsmartcols
 %{_cross_includedir}/libsmartcols/libsmartcols.h
 %{_cross_pkgconfigdir}/smartcols.pc
-%exclude %{_cross_libdir}/libsmartcols.la
 
 %files -n %{_cross_os}libuuid
 %license %{_cross_licensedir}/libuuid/COPYING.BSD-3-Clause
@@ -351,6 +351,5 @@ done
 %dir %{_cross_includedir}/uuid
 %{_cross_includedir}/uuid/uuid.h
 %{_cross_pkgconfigdir}/uuid.pc
-%exclude %{_cross_libdir}/libuuid.la
 
 %changelog

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.3.0.tar.xz"
-sha512 = "dbb3e77d0d9cf184a0e647b8231350401a7549a23a0bfd9121cf2a1b48e85f71d98329dff440fc6e984bcecfdcc2a72f0f27c4989560f3c55359f21f3fb434bb"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.4.0.tar.xz"
+sha512 = "831e7747640bc2964b182226d8bb6f637610b123aeec9b3cb97a5de5d5b65bde30c6b40ad2e78de6a5214e823dd75de3a2bdfddd8ab1638f5c7340a760c91b3f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}xfsprogs
-Version: 6.3.0
+Version: 6.4.0
 Release: 1%{?dist}
 Summary: Utilities for managing the XFS filesystem
 License: GPL-2.0-only AND LGPL-2.1-only

--- a/sources/api/ecs-settings-applier/src/ecs.rs
+++ b/sources/api/ecs-settings-applier/src/ecs.rs
@@ -82,6 +82,13 @@ struct ECSConfig {
     image_cleanup_delete_per_cycle: Option<i64>,
 
     image_cleanup_disabled: bool,
+
+    #[serde(rename = "CNIPluginsPath")]
+    cni_plugins_path: String,
+
+    credentials_audit_log_file: String,
+
+    data_dir: String,
 }
 
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
@@ -151,6 +158,9 @@ async fn run() -> Result<()> {
         metadata_service_burst: ecs.metadata_service_burst,
         image_cleanup_delete_per_cycle: ecs.image_cleanup_delete_per_cycle,
         image_cleanup_disabled: !ecs.image_cleanup_enabled.unwrap_or(true),
+        cni_plugins_path: "/usr/libexec/amazon-ecs-agent".to_string(),
+        credentials_audit_log_file: "/var/log/ecs/audit.log".to_string(),
+        data_dir: "/var/lib/ecs/data".to_string(),
         ..Default::default()
     };
     if let Some(os) = settings.os {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3170

**Description of changes:**
```
packages: update xfsprogs to 6.4.0
packages: update util-linux to 2.39.2
packages: update strace to 6.4
packages:update runc to 1.1.8
packages: update pigz to 2.8
packages: update open-vm-tools to  12.2.5
packages: update nvidia-k8s-device-plugin to 0.14.1
packages: update nvidia-container-toolkit to 1.13.5
packages: update libz to 1.3
packages: update libxcrypt to 4.4.36
packages: update libnvidia-container to 1.13.5
packages: update libnftnl to 1.2.6
packages: update liblzma to 5.4.4
packages: update libinih to 57
packages: update libglib to 2.77.0
packages: update libdbus to 1.15.6
packages: update libcap to 2.69
packages: update libaudit to 3.1.2
packages: update iproute to 6.4.0
packages: update ethtool to 6.4
packages: update ecs-agent to 1.75.0
packages: update containerd to 1.6.23
packages: update chrony to 4.4
packages: update cni-plugins to 1.3.0
packages: update ca-certificates to 2023-08-22
packages: update aws-iam-authenticator to 0.6.11 
packages: update amazon-ssm-agent to 3.2.1478.0
```
Regenerated ecs-agent patches that no longer cleanly apply.

Updates all third party packages except for the following:

binutils 2.38 -> 2.40 - bottlerocket-sdk has to move to 2.40 first.
docker related packages(docker-cli, docker-engine) 20.12.21 -> 20.12.23 - To sync with ECS-optimized AMI packaged docker version listed in [its version table](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-versions.html#ecs-ami-versions-linux).
wicked 0.6.68 -> 0.6.70 - See update wicked to 0.6.70+ https://github.com/bottlerocket-os/bottlerocket/issues/2591

**Testing done:**

- [x] aws-k8s-1.24 x86_64
```
Every 2.0s: testsys --kubeconfig /home/ec2-user/bottlerocket/testsys.kubeconfig status                                                                 Fri Aug 25 22:12:49 2023

 NAME                               TYPE               STATE                     PASSED          FAILED          SKIPPED   BUILD ID                LAST UPDATE
 x86-64-aws-k8s-124-quick           Test               passed                         1               0             6972   2a501be5-dirty          2023-08-25T22:11:14Z
 x86-64-aws-k8s-124                 Resource           completed                                                           2a501be5-dirty          2023-08-25T22:06:05Z
```
- [x] aws-k8s-1.24 aarch64
```
NAME                                TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID                LAST UPDATE
 aarch64-aws-k8s-124-quick           Test              passed                         1               0             6972   9767282d-dirty          2023-08-27T21:32:41Z
 aarch64-aws-k8s-124                 Resource          completed                                                           9767282d-dirty          2023-08-27T21:31:08Z


```
- [x] aws-k8s-1.24-nvidia x86_64
```
NAME                                      TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 x86-64-aws-k8s-124-nvidia-quick           Test              passed                         1               0             6972   9767282d          2023-08-26T17:05:04Z
 x86-64-aws-k8s-124-nvidia                 Resource          completed                                                           9767282d          2023-08-26T17:03:00Z
```
- [x] aws-k8s-1.24-nvidia aarch64
```
NAME                                      TYPE              STATE                   PASSED         FAILED         SKIPPED   BUILD ID               LAST UPDATE
 aarch64-aws-k8s-124-nvidia-quick          Test              passed                       1              0            6972   9767282d-dirty         2023-08-27T22:44:43Z
 aarch64-aws-k8s-124-nvidia                Resource          completed                                                       9767282d-dirty         2023-08-27T22:42:35Z
```
- [x] aws-k8s-1.27 x86_64
```
Every 2.0s: testsys --kubeconfig /home/ec2-user/bottlerocket/testsys.kubeconfig status                                                                 Fri Aug 25 23:28:12 2023

 NAME                               TYPE               STATE                       PASSED           FAILED           SKIPPED   BUILD ID           LAST UPDATE
 x86-64-aws-k8s-127-quick           Test               passed                           5                0              7206   9767282d           2023-08-25T23:25:52Z
 x86-64-aws-k8s-127                 Resource           completed                                                               9767282d           2023-08-25T23:24:16Z
```
- [x] aws-k8s-1.27 aarch64
```
NAME                                TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID                LAST UPDATE
 aarch64-aws-k8s-127-quick           Test              passed                         5               0             7206   9767282d-dirty          2023-08-27T22:08:13Z
 aarch64-aws-k8s-127                 Resource          completed                                                           9767282d-dirty          2023-08-27T22:06:44Z
```
- [x] aws-k8s-1.27-nvidia x86_64
```
Every 2.0s: testsys --kubeconfig /home/ec2-user/bottlerocket/testsys.kubeconfig status                                                                 Sat Aug 26 00:09:02 2023

 NAME                                      TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 x86-64-aws-k8s-127-nvidia-quick           Test              passed                         5               0             7206   9767282d          2023-08-26T00:07:23Z
 x86-64-aws-k8s-127-nvidia                 Resource          completed                                                           9767282d          2023-08-26T00:05:19Z
```
- [x] aws-k8s-1.27-nvidia aarch64
```
 NAME                                      TYPE              STATE                   PASSED         FAILED         SKIPPED   BUILD ID               LAST UPDATE
 aarch64-aws-k8s-127-nvidia-quick          Test              passed                       5              0            7206   9767282d-dirty         2023-08-27T23:16:35Z
 aarch64-aws-k8s-127-nvidia                Resource          completed                                                       9767282d-dirty         2023-08-27T23:14:26Z
```
- [x] aws-ecs-1 - Also internal suite of tests passes
```
NAME                              TYPE            STATE                     PASSED           FAILED           SKIPPED   BUILD ID                 LAST UPDATE
 x86-64-aws-ecs-1-quick            Test            passed                         1                0                 0   9767282d-dirty           2023-08-27T23:31:25Z
```
- [x] aws-ecs-1-nvidia 
```
NAME                                   TYPE              STATE                     PASSED          FAILED         SKIPPED   BUILD ID               LAST UPDATE
 x86-64-aws-ecs-1-nvidia-quick          Test              passed                         1               0               0   9767282d-dirty         2023-08-27T23:47:15Z
 x86-64-aws-ecs-1-nvidia                Resource          completed                                                          9767282d-dirty         2023-08-27T23:46:36Z
```
- [x] aws-ecs-2 
```
NAME                              TYPE            STATE                     PASSED           FAILED           SKIPPED   BUILD ID                 LAST UPDATE
 x86-64-aws-ecs-2-quick            Test            passed                         1                0                 0   9767282d-dirty           2023-08-27T23:59:20Z
```
- [x] aws-ecs-2-nvidia 
- [x] vmware-k8s-1.24, 
```
$ kubectl --kubeconfig br-eksa-124-eks-a-cluster.kubeconfig get nodes -o wide
NAME                                     STATUS   ROLES           AGE     VERSION                INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                                   KERNEL-VERSION   CONTAINER-RUNTIME
br-eksa-124-md-0-66869c5b6x4scxd-92r7m   Ready    <none>          4m26s   v1.24.16-eks-a483404   198.19.0.126     198.19.0.126     Bottlerocket OS 1.15.0 (vmware-k8s-1.24)   5.15.122         containerd://1.6.23+bottlerocket
br-eksa-124-md-0-66869c5b6x4scxd-wsjnw   Ready    <none>          4m28s   v1.24.16-eks-a483404   198.19.0.62      198.19.0.62      Bottlerocket OS 1.15.0 (vmware-k8s-1.24)   5.15.122         containerd://1.6.23+bottlerocket
br-eksa-124-xnpdw                        Ready    control-plane   6m10s   v1.24.16-eks-a483404   198.19.134.175   198.19.134.175   Bottlerocket OS 1.15.0 (vmware-k8s-1.24)   5.15.122         containerd://1.6.23+bottlerocket
br-eksa-124-zbcjv                        Ready    control-plane   4m40s   v1.24.16-eks-a483404   198.19.16.153    198.19.16.153    Bottlerocket OS 1.15.0 (vmware-k8s-1.24)   5.15.122         containerd://1.6.23+bottlerocket
```
- [x] metal-k8s-1.27, 
```
br@br-admin:~/1.14.3-release/baremetal/eksa-colo/br-127$ kubectl --kubeconfig br-127-eks-a-cluster.kubeconfig get nodes -o wide
NAME                                STATUS   ROLES           AGE     VERSION               INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                  KERNEL-VERSION   CONTAINER-RUNTIME
br-127-h76ff                        Ready    control-plane   10m     v1.27.4-eks-cedffd4   10.80.50.24   <none>        Bottlerocket OS 1.15.0 (metal-k8s-1.27)   5.15.122         containerd://1.6.23+bottlerocket
br-127-md-0-c6486db87xlw4cp-2pm9g   Ready    <none>          2m50s   v1.27.4-eks-cedffd4   10.80.50.27   <none>        Bottlerocket OS 1.15.0 (metal-k8s-1.27)   5.15.122         containerd://1.6.23+bottlerocket
br-127-md-0-c6486db87xlw4cp-jvnxv   Ready    <none>          2m53s   v1.27.4-eks-cedffd4   10.80.50.22   <none>        Bottlerocket OS 1.15.0 (metal-k8s-1.27)   5.15.122         containerd://1.6.23+bottlerocket
br@br-admin:~/1.14.3-release/baremetal/eksa-colo/br-127$ sonobuoy --kubeconfig br-127-eks-a-cluster.kubeconfig run --mode=quick --plugin=e2e --wait
...
...
18:17:58       e2e   global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
```
- [x] Testing ecs variants for the configuration changes done using config files instead of doing using patch
```
Third party patch change
bash-5.1# ls /usr/share/licenses/ecs-agent/
LICENSE                         NOTICE           vendor
LICENSE.amazon-ecs-cni-plugins  THIRD_PARTY.md
LICENSE.amazon-vpc-cni-plugins  attribution.txt

On develop
bash-5.1# ls /usr/share/licenses/ecs-agent/
LICENSE                         LICENSE.amazon-vpc-cni-plugins  THIRD-PARTY      vendor
LICENSE.amazon-ecs-cni-plugins  NOTICE                          attribution.txt


/etc/ecs/ecs.config.json
Third party patch change
bash-5.1# cat /etc/ecs/ecs.config.json
{"Cluster":"bottlerocket-ecs","InstanceAttributes":{"bottlerocket.variant":"aws-ecs-1"},"PrivilegedDisabled":true,"AvailableLoggingDrivers":["json-file","awslogs","none"],"WarmPoolsSupport":false,"ImagePullBehavior":0,"TaskIAMRoleEnabled":true,"TaskIAMRoleEnabledForNetworkHost":true,"SELinuxCapable":true,"OverrideAWSLogsExecutionRole":true,"TaskENIEnabled":true,"GPUSupportEnabled":false,"ImageCleanupDisabled":false,"CNIPluginsPath":"/usr/libexec/amazon-ecs-agent","CredentialsAuditLogFile":"/var/log/ecs/audit.log","RuntimeStatsLogFile":"/var/log/ecs/agent-runtime-stats.log"}bash-5.1#

Develop
bash-5.1# cat /etc/ecs/ecs.config.json
{"Cluster":"bottlerocket-ecs","InstanceAttributes":{"bottlerocket.variant":"aws-ecs-1"},"PrivilegedDisabled":true,"AvailableLoggingDrivers":["json-file","awslogs","none"],"WarmPoolsSupport":false,"ImagePullBehavior":0,"TaskIAMRoleEnabled":true,"TaskIAMRoleEnabledForNetworkHost":true,"SELinuxCapable":true,"OverrideAWSLogsExecutionRole":true,"TaskENIEnabled":true,"GPUSupportEnabled":false,"ImageCleanupDisabled":false}bash-5.1#


Develop 
bash-5.1# ls /usr/libexec/amazon-ecs-agent
aws-appmesh  ecs-bridge  ecs-eni  ecs-ipam  managed-agents  vpc-branch-eni

Third party patch change
bash-5.1# ls /usr/libexec/amazon-ecs-agent
aws-appmesh  ecs-bridge  ecs-eni  ecs-ipam  managed-agents  vpc-branch-eni

Develop 
bash-5.1# ls /usr/lib/amazon-ecs-agent/
amazon-ecs-pause.tar

Third party patch change
bash-5.1# ls /usr/lib/amazon-ecs-agent/
amazon-ecs-pause.tar

Third party patch change
bash-5.1# docker exec -it a1bd77837f1c bash
root@ip-172-31-4-216:/# curl http://169.254.170.2/v1/credentials
{"code":"NoIdInRequest","message":"CredentialsV1Request: No Credential ID in the request","HTTPErrorCode":400}root@ip-172-31-4-216:/#
root@ip-172-31-4-216:/#
root@ip-172-31-4-216:/#
root@ip-172-31-4-216:/# exit
exit
bash-5.1# ls /var/log/ecs
audit.log      ecs-agent.log.2023-08-24-19  ecs-cni-bridge-plugin.log  exec
ecs-agent.log  ecs-agent.log.2023-08-24-20  ecs-cni-eni-plugin.log
bash-5.1# cat /var/log/ecs/audit.log
2023-08-24T21:38:04Z 400 169.254.172.2:45808 "/v1/credentials" "curl/7.88.1" -
bash-5.1#  cat /var/log/ecs/audit.log

Develop
docker exec -it b69c1b7da909  bash
root@ip-172-31-6-77:/# curl $ECS_CONTAINER_METADATA_URI_V2
curl: try 'curl --help' or 'curl --manual' for more information
root@ip-172-31-6-77:/# curl $ECS_CONTAINER_METADATA_URI_V4/credentials
404 page not found
root@ip-172-31-6-77:/# echo  $ECS_CONTAINER_METADATA_URI_V4
http://169.254.170.2/v4/e78c9d20-3596-47bc-bec6-9898978d9628
root@ip-172-31-6-77:/# http://169.254.170.2/v1/e78c9d20-3596-47bc-bec6-9898978d9628
bash: http://169.254.170.2/v1/e78c9d20-3596-47bc-bec6-9898978d9628: No such file or directory
root@ip-172-31-6-77:/# curl http://169.254.170.2/v1/e78c9d20-3596-47bc-bec6-9898978d9628
404 page not found
root@ip-172-31-6-77:/# curl http://169.254.170.2/v1/credentials
{"code":"NoIdInRequest","message":"CredentialsV1Request: No Credential ID in the request","HTTPErrorCode":400}root@ip-172-31-6-77:/#
root@ip-172-31-6-77:/#
root@ip-172-31-6-77:/# exit
exit
bash-5.1# ls /var/log/ecs/
audit.log      ecs-agent.log.2023-08-24-20  ecs-cni-eni-plugin.log
ecs-agent.log  ecs-cni-bridge-plugin.log    exec
bash-5.1#  cat /var/log/ecs/audit.log
2023-08-24T21:37:12Z 400 169.254.172.2:40972 "/v1/credentials" "curl/7.88.1" -


Third party patch change
ls /usr/share/licenses/ecs-agent/
LICENSE                         LICENSE.amazon-vpc-cni-plugins  THIRD_PARTY.md   vendor
LICENSE.amazon-ecs-cni-plugins  NOTICE  

Develop 
ls /usr/share/licenses/ecs-agent/
LICENSE                         LICENSE.amazon-vpc-cni-plugins  THIRD-PARTY      vendor
LICENSE.amazon-ecs-cni-plugins  NOTICE                          attribution.txt
```
- [x] xfsprogs update and util-linux update
 -  With 10 GB /dev/xvdb
nvme1n1      259:1    0   10G  0 disk
nvme1n1p1  259:16   0   10G  0 part /.bottlerocket/rootfs/local
   - With 100 GB  /dev/xvdb
nvme1n1      259:1    0  100G  0 disk
nvme1n1p1  259:16   0   10G  0 part /var
- [x] Runc test
   - Ran a cron job to replicate the issues.
   - The kubelet memory usage holds at 2626 MB. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
