### PR TITLE
pluto: retry on empty private-dns-name from EC2

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3048,6 +3048,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "tokio-retry",
 ]
 
 [[package]]

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -26,6 +26,7 @@ aws-smithy-types = "0.55"
 serde_json = "1"
 snafu = "0.7"
 tokio = { version = "~1.25", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio-retry = "0.3"
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Resolves https://github.com/bottlerocket-os/bottlerocket/issues/3363

**Description of changes:**
```
    pluto: retry on empty private-dns-name from EC2
    
    Use fibonacci backoff on requests to EC2 for fetching the private DNS
    name of the instance. Retry on both API failures and on when the private
    DNS name is empty.

```


**Testing done:**
Instance comes up fine. Directly calling pluto works:
On an instance where hostname is resource-based in the subnet:
```
bash-5.1# pluto private-dns-name
"i-088c99da0374c92a5.us-west-2.compute.internal"
```

On an instance where hostname is IP based:
```
bash-5.1# pluto private-dns-name
"ip-192-168-21-104.us-west-2.compute.internal"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
