### PR TITLE
Fix rust 1.72.0 lints/warnings

### DIFF
--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "api/apiserver",
     "api/apiclient",

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -170,8 +170,7 @@ fn parse_metadata_toml(md_toml_val: toml::Value) -> Result<Vec<model::Metadata>>
     // Start at the root of the tree.
     let mut to_process = vec![(Vec::new(), md_toml_val)];
 
-    while !to_process.is_empty() {
-        let (mut path, toml_value) = to_process.pop().unwrap();
+    while let Some((mut path, toml_value)) = to_process.pop() {
         trace!("Current metadata table path: {:#?}", &path);
 
         match toml_value {

--- a/sources/models/scalar-derive/src/lib.rs
+++ b/sources/models/scalar-derive/src/lib.rs
@@ -437,7 +437,7 @@ impl StructInfo {
             }
         );
 
-        stream.append_all(impls.into_iter());
+        stream.append_all(impls);
 
         // Generate code that is only applicable if the inner type can be treated like a String.
         if self.as_ref_str {
@@ -481,7 +481,7 @@ impl StructInfo {
                     }
                 }
             );
-            stream.append_all(code.into_iter());
+            stream.append_all(code);
         }
 
         // If the inner type is String, then we already have this implemented. If not, we can add
@@ -494,7 +494,7 @@ impl StructInfo {
                     }
                 }
             );
-            stream.append_all(code.into_iter());
+            stream.append_all(code);
         }
     }
 }
@@ -594,7 +594,7 @@ fn write_string_impls_for_enum(name: &str, ast: &mut TokenStream2) {
         }
     );
 
-    ast.append_all(impls.into_iter());
+    ast.append_all(impls);
 }
 
 /// Make sure all variants of the enum are empty of data. Otherwise we can't represent this enum

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "infrasys",
     "buildsys",

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -48,7 +48,7 @@ const GO_MOD_DOCKER_SCRIPT_NAME: &str = "docker-go-script.sh";
 // buildsys is executed from the context of many different package directories,
 // managing a temporary file via this Rust module prevents having to acquire the
 // path of some static script file on the host system.
-const GO_MOD_SCRIPT_TMPL: &str = r###"#!/bin/bash
+const GO_MOD_SCRIPT_TMPL: &str = r#".#!/bin/bash
 
 set -e
 
@@ -68,7 +68,7 @@ popd
 tar czf __OUTPUT__ "${targetdir}"/vendor
 rm -rf "${targetdir}"
 touch -r __LOCAL_FILE_NAME__ __OUTPUT__
-"###;
+"#;
 
 impl GoMod {
     pub(crate) fn vendor(

--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -281,7 +281,7 @@ fn merge_parameters(
     source_parameters
         .into_iter()
         // Process the `set_parameters` second so that they overwrite existing values.
-        .chain(set_parameters.clone().into_iter())
+        .chain(set_parameters.clone())
         .for_each(|(ssm_key, ssm_value)| {
             combined_parameters
                 // The `entry()` API demands that we clone

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -514,7 +514,7 @@ pub(crate) async fn modify_regional_images(
                 info!("Modified permissions of image {} in {}", image_id, region);
 
                 // Set the `public` and `launch_permissions` fields for the Image object
-                let mut image = images.get_mut(&Region::new(region.clone())).ok_or(
+                let image = images.get_mut(&Region::new(region.clone())).ok_or(
                     error::Error::MissingRegion {
                         region: region.clone(),
                     },

--- a/variants/Cargo.toml
+++ b/variants/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "aws-dev",
     "aws-ecs-1",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**
Preemptively address newly activated lints and warnings in rust 1.72.0

```
    sources: fix 1.72.0 clippy warnings
```

```
    tools: fix 1.72.0 clippy warnings
```

```
    chore: explicity set cargo feature resolver version to 2
    
    This gets rid of a warning that comes with rust 1.72.0. This does not
    impact any of our existing crates since they're all on edition 2021.
    
    See https://github.com/rust-lang/cargo/issues/10112

```


**Testing done:**
`cargo clippy` returns no warnings across sources/tools workspaces.
Unit tests pass


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
