### PR TITLE
Update host containers for v1.15.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -229,4 +229,6 @@ version = "1.15.0"
     "migrate_v1.15.0_oci-defaults-docker-setting-metadata.lz4",
     "migrate_v1.15.0_aws-admin-container-v0-11-0.lz4",
     "migrate_v1.15.0_public-admin-container-v0-11-0.lz4",
+    "migrate_v1.15.0_aws-control-container-v0-7-4.lz4",
+    "migrate_v1.15.0_public-control-container-v0-7-4.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -227,4 +227,6 @@ version = "1.15.0"
     "migrate_v1.15.0_seccomp-default-setting.lz4",
     "migrate_v1.15.0_oci-defaults-docker-setting.lz4",
     "migrate_v1.15.0_oci-defaults-docker-setting-metadata.lz4",
+    "migrate_v1.15.0_aws-admin-container-v0-11-0.lz4",
+    "migrate_v1.15.0_public-admin-container-v0-11-0.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -599,6 +599,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,6 +3105,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-4"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -527,6 +527,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-admin-container-v0-9-4"
 version = "0.1.0"
 dependencies = [
@@ -3049,6 +3056,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-10-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-0"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -64,6 +64,8 @@ members = [
     "api/migration/migrations/v1.15.0/oci-defaults-docker-setting-metadata",
     "api/migration/migrations/v1.15.0/aws-admin-container-v0-11-0",
     "api/migration/migrations/v1.15.0/public-admin-container-v0-11-0",
+    "api/migration/migrations/v1.15.0/aws-control-container-v0-7-4",
+    "api/migration/migrations/v1.15.0/public-control-container-v0-7-4",
 
     "bloodhound",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -62,6 +62,8 @@ members = [
     "api/migration/migrations/v1.15.0/seccomp-default-setting",
     "api/migration/migrations/v1.15.0/oci-defaults-docker-setting",
     "api/migration/migrations/v1.15.0/oci-defaults-docker-setting-metadata",
+    "api/migration/migrations/v1.15.0/aws-admin-container-v0-11-0",
+    "api/migration/migrations/v1.15.0/public-admin-container-v0-11-0",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.15.0/aws-admin-container-v0-11-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.15.0/aws-admin-container-v0-11-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-11-0"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.15.0/aws-admin-container-v0-11-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.15.0/aws-admin-container-v0-11-0/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.2";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.0";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.15.0/aws-control-container-v0-7-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.15.0/aws-control-container-v0-7-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-4"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.15.0/aws-control-container-v0-7-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.15.0/aws-control-container-v0-7-4/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.3";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.4";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.15.0/public-admin-container-v0-11-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.15.0/public-admin-container-v0-11-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-11-0"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.15.0/public-admin-container-v0-11-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.15.0/public-admin-container-v0-11-0/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.15.0/public-control-container-v0-7-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.15.0/public-control-container-v0-7-4/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-4"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.15.0/public-control-container-v0-7-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.15.0/public-control-container-v0-7-4/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -15,4 +15,4 @@ superpowered = false
 
 [metadata.settings.host-containers.control.source]
 setting-generator = "schnauzer settings.host-containers.control.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.3"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.4"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -4,7 +4,7 @@ superpowered = true
 
 [metadata.settings.host-containers.admin.source]
 setting-generator = "schnauzer settings.host-containers.admin.source"
-template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.10.2"
+template = "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.0"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Issue number:**
Closes #3173

**Description of changes:**
Update the default admin and control container images to [v0.11.0](https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/87) and [v0.7.4](https://github.com/bottlerocket-os/bottlerocket-control-container/pull/49) respectively.


**Testing done:**
* `cargo make check-migrations` works fine
* A v1.14.3 AMI can be upgraded to v1.15.0 and also downgraded. 
 The correct host container images are used in both versions




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
