### PR TITLE
kernel: Cherry-pick fix for CVE-2023-20588 ("DIV0")

### DIFF
--- a/packages/kernel-5.10/5011-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
+++ b/packages/kernel-5.10/5011-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
@@ -1,0 +1,48 @@
+From d573bee81157742dfb6710646d365bcd37a0f92c Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Sat, 8 Jul 2023 10:21:35 +0200
+Subject: [PATCH] x86/bugs: Increase the x86 bugs vector size to two u32s
+
+Upstream commit: 0e52740ffd10c6c316837c6c128f460f1aaba1ea
+
+There was never a doubt in my mind that they would not fit into a single
+u32 eventually.
+
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 073a28a9b50662991e7d6956c2cf2fc5d54f28cd)
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ arch/x86/include/asm/cpufeatures.h       | 2 +-
+ tools/arch/x86/include/asm/cpufeatures.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
+index 0b0b9453b19f..9b06e142bad1 100644
+--- a/arch/x86/include/asm/cpufeatures.h
++++ b/arch/x86/include/asm/cpufeatures.h
+@@ -14,7 +14,7 @@
+  * Defines x86 CPU feature bits
+  */
+ #define NCAPINTS			19	   /* N 32-bit words worth of info */
+-#define NBUGINTS			1	   /* N 32-bit bug flags */
++#define NBUGINTS			2	   /* N 32-bit bug flags */
+ 
+ /*
+  * Note: If the comment begins with a quoted string, that string is used
+diff --git a/tools/arch/x86/include/asm/cpufeatures.h b/tools/arch/x86/include/asm/cpufeatures.h
+index 54ba20492ad1..51a8fdb487c7 100644
+--- a/tools/arch/x86/include/asm/cpufeatures.h
++++ b/tools/arch/x86/include/asm/cpufeatures.h
+@@ -14,7 +14,7 @@
+  * Defines x86 CPU feature bits
+  */
+ #define NCAPINTS			19	   /* N 32-bit words worth of info */
+-#define NBUGINTS			1	   /* N 32-bit bug flags */
++#define NBUGINTS			2	   /* N 32-bit bug flags */
+ 
+ /*
+  * Note: If the comment begins with a quoted string, that string is used
+-- 
+2.40.1
+

--- a/packages/kernel-5.10/5012-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
+++ b/packages/kernel-5.10/5012-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
@@ -1,0 +1,111 @@
+From 188ef20eb7f347966659092d75051f0cd4b572bf Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Sat, 5 Aug 2023 00:06:43 +0200
+Subject: [PATCH] x86/CPU/AMD: Do not leak quotient data after a division by 0
+
+commit 77245f1c3c6495521f6a3af082696ee2f8ce3921 upstream.
+
+Under certain circumstances, an integer division by 0 which faults, can
+leave stale quotient data from a previous division operation on Zen1
+microarchitectures.
+
+Do a dummy division 0/1 before returning from the #DE exception handler
+in order to avoid any leaks of potentially sensitive data.
+
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Cc: <stable@kernel.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit b6fc2fbf89089ecfb8eb9a89a7fc91d444f4fec7)
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ arch/x86/include/asm/cpufeatures.h |  2 ++
+ arch/x86/include/asm/processor.h   |  2 ++
+ arch/x86/kernel/cpu/amd.c          | 19 +++++++++++++++++++
+ arch/x86/kernel/traps.c            |  2 ++
+ 4 files changed, 25 insertions(+)
+
+diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
+index 9b06e142bad1..630196281a48 100644
+--- a/arch/x86/include/asm/cpufeatures.h
++++ b/arch/x86/include/asm/cpufeatures.h
+@@ -435,4 +435,6 @@
+ #define X86_BUG_RAS_POISONING		X86_BUG(29) /* CPU is affected by RAS poisoning */
+ #define X86_BUG_GDS			X86_BUG(30) /* CPU is affected by Gather Data Sampling */
+ 
++/* BUG word 2 */
++#define X86_BUG_DIV0			X86_BUG(1*32 + 1) /* AMD DIV0 speculation bug */
+ #endif /* _ASM_X86_CPUFEATURES_H */
+diff --git a/arch/x86/include/asm/processor.h b/arch/x86/include/asm/processor.h
+index 12714134f5eb..f20dc0c73cae 100644
+--- a/arch/x86/include/asm/processor.h
++++ b/arch/x86/include/asm/processor.h
+@@ -810,9 +810,11 @@ DECLARE_PER_CPU(u64, msr_misc_features_shadow);
+ #ifdef CONFIG_CPU_SUP_AMD
+ extern u16 amd_get_nb_id(int cpu);
+ extern u32 amd_get_nodes_per_socket(void);
++extern void amd_clear_divider(void);
+ #else
+ static inline u16 amd_get_nb_id(int cpu)		{ return 0; }
+ static inline u32 amd_get_nodes_per_socket(void)	{ return 0; }
++static inline void amd_clear_divider(void)		{ }
+ #endif
+ 
+ static inline uint32_t hypervisor_cpuid_base(const char *sig, uint32_t leaves)
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index 3d99a823ffac..842357ee7724 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -76,6 +76,10 @@ static const int amd_zenbleed[] =
+ 			   AMD_MODEL_RANGE(0x17, 0x60, 0x0, 0x7f, 0xf),
+ 			   AMD_MODEL_RANGE(0x17, 0xa0, 0x0, 0xaf, 0xf));
+ 
++static const int amd_div0[] =
++	AMD_LEGACY_ERRATUM(AMD_MODEL_RANGE(0x17, 0x00, 0x0, 0x2f, 0xf),
++			   AMD_MODEL_RANGE(0x17, 0x50, 0x0, 0x5f, 0xf));
++
+ static bool cpu_has_amd_erratum(struct cpuinfo_x86 *cpu, const int *erratum)
+ {
+ 	int osvw_id = *erratum++;
+@@ -1168,6 +1172,11 @@ static void init_amd(struct cpuinfo_x86 *c)
+ 	check_null_seg_clears_base(c);
+ 
+ 	zenbleed_check(c);
++
++	if (cpu_has_amd_erratum(c, amd_div0)) {
++		pr_notice_once("AMD Zen1 DIV0 bug detected. Disable SMT for full protection.\n");
++		setup_force_cpu_bug(X86_BUG_DIV0);
++	}
+ }
+ 
+ #ifdef CONFIG_X86_32
+@@ -1293,3 +1302,13 @@ void amd_check_microcode(void)
+ {
+ 	on_each_cpu(zenbleed_check_cpu, NULL, 1);
+ }
++
++/*
++ * Issue a DIV 0/1 insn to clear any division data from previous DIV
++ * operations.
++ */
++void noinstr amd_clear_divider(void)
++{
++	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
++		     :: "a" (0), "d" (0), "r" (1));
++}
+diff --git a/arch/x86/kernel/traps.c b/arch/x86/kernel/traps.c
+index 3780c728345c..d8142b5738ac 100644
+--- a/arch/x86/kernel/traps.c
++++ b/arch/x86/kernel/traps.c
+@@ -198,6 +198,8 @@ DEFINE_IDTENTRY(exc_divide_error)
+ {
+ 	do_error_trap(regs, 0, "divide error", X86_TRAP_DE, SIGFPE,
+ 		      FPE_INTDIV, error_get_trap_addr(regs));
++
++	amd_clear_divider();
+ }
+ 
+ DEFINE_IDTENTRY(exc_overflow)
+-- 
+2.40.1
+

--- a/packages/kernel-5.10/5013-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
+++ b/packages/kernel-5.10/5013-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
@@ -1,0 +1,83 @@
+From ea19dbd49d7dcdfa1a807ce1ea48164f10129113 Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Fri, 11 Aug 2023 23:38:24 +0200
+Subject: [PATCH] x86/CPU/AMD: Fix the DIV(0) initial fix attempt
+
+commit f58d6fbcb7c848b7f2469be339bc571f2e9d245b upstream.
+
+Initially, it was thought that doing an innocuous division in the #DE
+handler would take care to prevent any leaking of old data from the
+divider but by the time the fault is raised, the speculation has already
+advanced too far and such data could already have been used by younger
+operations.
+
+Therefore, do the innocuous division on every exit to userspace so that
+userspace doesn't see any potentially old data from integer divisions in
+kernel space.
+
+Do the same before VMRUN too, to protect host data from leaking into the
+guest too.
+
+Fixes: 77245f1c3c64 ("x86/CPU/AMD: Do not leak quotient data after a division by 0")
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Cc: <stable@kernel.org>
+Link: https://lore.kernel.org/r/20230811213824.10025-1-bp@alien8.de
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 69712baf249570a1419e75dc1a103a44e375b2cd)
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ arch/x86/include/asm/entry-common.h | 1 +
+ arch/x86/kernel/cpu/amd.c           | 1 +
+ arch/x86/kernel/traps.c             | 2 --
+ arch/x86/kvm/svm/svm.c              | 1 +
+ 4 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/entry-common.h b/arch/x86/include/asm/entry-common.h
+index 4a382fb6a9ef..5443851d3aa6 100644
+--- a/arch/x86/include/asm/entry-common.h
++++ b/arch/x86/include/asm/entry-common.h
+@@ -78,6 +78,7 @@ static inline void arch_exit_to_user_mode_prepare(struct pt_regs *regs,
+ static __always_inline void arch_exit_to_user_mode(void)
+ {
+ 	mds_user_clear_cpu_buffers();
++	amd_clear_divider();
+ }
+ #define arch_exit_to_user_mode arch_exit_to_user_mode
+ 
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index 842357ee7724..64e97f243441 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -1312,3 +1312,4 @@ void noinstr amd_clear_divider(void)
+ 	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
+ 		     :: "a" (0), "d" (0), "r" (1));
+ }
++EXPORT_SYMBOL_GPL(amd_clear_divider);
+diff --git a/arch/x86/kernel/traps.c b/arch/x86/kernel/traps.c
+index d8142b5738ac..3780c728345c 100644
+--- a/arch/x86/kernel/traps.c
++++ b/arch/x86/kernel/traps.c
+@@ -198,8 +198,6 @@ DEFINE_IDTENTRY(exc_divide_error)
+ {
+ 	do_error_trap(regs, 0, "divide error", X86_TRAP_DE, SIGFPE,
+ 		      FPE_INTDIV, error_get_trap_addr(regs));
+-
+-	amd_clear_divider();
+ }
+ 
+ DEFINE_IDTENTRY(exc_overflow)
+diff --git a/arch/x86/kvm/svm/svm.c b/arch/x86/kvm/svm/svm.c
+index 5ddc75ade8f0..d0a1c0420c92 100644
+--- a/arch/x86/kvm/svm/svm.c
++++ b/arch/x86/kvm/svm/svm.c
+@@ -3381,6 +3381,7 @@ static void svm_flush_tlb_gva(struct kvm_vcpu *vcpu, gva_t gva)
+ 
+ static void svm_prepare_guest_switch(struct kvm_vcpu *vcpu)
+ {
++	amd_clear_divider();
+ }
+ 
+ static inline void sync_cr8_to_lapic(struct kvm_vcpu *vcpu)
+-- 
+2.40.1
+

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -29,6 +29,12 @@ Patch2001: 2001-kbuild-add-support-for-zstd-compressed-modules.patch
 Patch5001: 5001-x86-cpu-amd-Move-the-errata-checking-functionality-u.patch
 Patch5002: 5002-x86-cpu-amd-Add-a-Zenbleed-fix.patch
 
+# Cherry-picked fixes for CVE-2023-20588 ("DIV0"). Can be dropped when moving
+# upstream to 5.10.192 or later.
+Patch5011: 5011-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
+Patch5012: 5012-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
+Patch5013: 5013-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname

--- a/packages/kernel-5.15/5001-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
+++ b/packages/kernel-5.15/5001-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
@@ -1,0 +1,48 @@
+From 40f837f02c448b37fb8967e5c50878c8a4e9459a Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Sat, 8 Jul 2023 10:21:35 +0200
+Subject: [PATCH] x86/bugs: Increase the x86 bugs vector size to two u32s
+
+Upstream commit: 0e52740ffd10c6c316837c6c128f460f1aaba1ea
+
+There was never a doubt in my mind that they would not fit into a single
+u32 eventually.
+
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 236dd7133394bfe30275191e3aefcc6b3b09962b)
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ arch/x86/include/asm/cpufeatures.h       | 2 +-
+ tools/arch/x86/include/asm/cpufeatures.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
+index ad6984f941f7..3800d0ec048d 100644
+--- a/arch/x86/include/asm/cpufeatures.h
++++ b/arch/x86/include/asm/cpufeatures.h
+@@ -14,7 +14,7 @@
+  * Defines x86 CPU feature bits
+  */
+ #define NCAPINTS			20	   /* N 32-bit words worth of info */
+-#define NBUGINTS			1	   /* N 32-bit bug flags */
++#define NBUGINTS			2	   /* N 32-bit bug flags */
+ 
+ /*
+  * Note: If the comment begins with a quoted string, that string is used
+diff --git a/tools/arch/x86/include/asm/cpufeatures.h b/tools/arch/x86/include/asm/cpufeatures.h
+index 3781a7f489ef..da6d66e1fbb1 100644
+--- a/tools/arch/x86/include/asm/cpufeatures.h
++++ b/tools/arch/x86/include/asm/cpufeatures.h
+@@ -14,7 +14,7 @@
+  * Defines x86 CPU feature bits
+  */
+ #define NCAPINTS			20	   /* N 32-bit words worth of info */
+-#define NBUGINTS			1	   /* N 32-bit bug flags */
++#define NBUGINTS			2	   /* N 32-bit bug flags */
+ 
+ /*
+  * Note: If the comment begins with a quoted string, that string is used
+-- 
+2.40.1
+

--- a/packages/kernel-5.15/5002-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
+++ b/packages/kernel-5.15/5002-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
@@ -1,0 +1,111 @@
+From 7292d6bb18710a2c1f283f77f3f69196536bdc2b Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Sat, 5 Aug 2023 00:06:43 +0200
+Subject: [PATCH] x86/CPU/AMD: Do not leak quotient data after a division by 0
+
+commit 77245f1c3c6495521f6a3af082696ee2f8ce3921 upstream.
+
+Under certain circumstances, an integer division by 0 which faults, can
+leave stale quotient data from a previous division operation on Zen1
+microarchitectures.
+
+Do a dummy division 0/1 before returning from the #DE exception handler
+in order to avoid any leaks of potentially sensitive data.
+
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Cc: <stable@kernel.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit a74878207b02060c5feaf88b5566208ed08eb78d)
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ arch/x86/include/asm/cpufeatures.h |  2 ++
+ arch/x86/include/asm/processor.h   |  2 ++
+ arch/x86/kernel/cpu/amd.c          | 19 +++++++++++++++++++
+ arch/x86/kernel/traps.c            |  2 ++
+ 4 files changed, 25 insertions(+)
+
+diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
+index 3800d0ec048d..8d64a1e26589 100644
+--- a/arch/x86/include/asm/cpufeatures.h
++++ b/arch/x86/include/asm/cpufeatures.h
+@@ -454,4 +454,6 @@
+ #define X86_BUG_RAS_POISONING		X86_BUG(29) /* CPU is affected by RAS poisoning */
+ #define X86_BUG_GDS			X86_BUG(30) /* CPU is affected by Gather Data Sampling */
+ 
++/* BUG word 2 */
++#define X86_BUG_DIV0			X86_BUG(1*32 + 1) /* AMD DIV0 speculation bug */
+ #endif /* _ASM_X86_CPUFEATURES_H */
+diff --git a/arch/x86/include/asm/processor.h b/arch/x86/include/asm/processor.h
+index 3e3bd5b7d5db..aeef8a6c2088 100644
+--- a/arch/x86/include/asm/processor.h
++++ b/arch/x86/include/asm/processor.h
+@@ -803,9 +803,11 @@ extern u16 get_llc_id(unsigned int cpu);
+ #ifdef CONFIG_CPU_SUP_AMD
+ extern u32 amd_get_nodes_per_socket(void);
+ extern u32 amd_get_highest_perf(void);
++extern void amd_clear_divider(void);
+ #else
+ static inline u32 amd_get_nodes_per_socket(void)	{ return 0; }
+ static inline u32 amd_get_highest_perf(void)		{ return 0; }
++static inline void amd_clear_divider(void)		{ }
+ #endif
+ 
+ static inline uint32_t hypervisor_cpuid_base(const char *sig, uint32_t leaves)
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index 3daceadf5d1f..892eb16a9ea2 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -75,6 +75,10 @@ static const int amd_zenbleed[] =
+ 			   AMD_MODEL_RANGE(0x17, 0x60, 0x0, 0x7f, 0xf),
+ 			   AMD_MODEL_RANGE(0x17, 0xa0, 0x0, 0xaf, 0xf));
+ 
++static const int amd_div0[] =
++	AMD_LEGACY_ERRATUM(AMD_MODEL_RANGE(0x17, 0x00, 0x0, 0x2f, 0xf),
++			   AMD_MODEL_RANGE(0x17, 0x50, 0x0, 0x5f, 0xf));
++
+ static bool cpu_has_amd_erratum(struct cpuinfo_x86 *cpu, const int *erratum)
+ {
+ 	int osvw_id = *erratum++;
+@@ -1140,6 +1144,11 @@ static void init_amd(struct cpuinfo_x86 *c)
+ 	check_null_seg_clears_base(c);
+ 
+ 	zenbleed_check(c);
++
++	if (cpu_has_amd_erratum(c, amd_div0)) {
++		pr_notice_once("AMD Zen1 DIV0 bug detected. Disable SMT for full protection.\n");
++		setup_force_cpu_bug(X86_BUG_DIV0);
++	}
+ }
+ 
+ #ifdef CONFIG_X86_32
+@@ -1281,3 +1290,13 @@ void amd_check_microcode(void)
+ {
+ 	on_each_cpu(zenbleed_check_cpu, NULL, 1);
+ }
++
++/*
++ * Issue a DIV 0/1 insn to clear any division data from previous DIV
++ * operations.
++ */
++void noinstr amd_clear_divider(void)
++{
++	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
++		     :: "a" (0), "d" (0), "r" (1));
++}
+diff --git a/arch/x86/kernel/traps.c b/arch/x86/kernel/traps.c
+index ca47080e3774..3361d32d090f 100644
+--- a/arch/x86/kernel/traps.c
++++ b/arch/x86/kernel/traps.c
+@@ -202,6 +202,8 @@ DEFINE_IDTENTRY(exc_divide_error)
+ {
+ 	do_error_trap(regs, 0, "divide error", X86_TRAP_DE, SIGFPE,
+ 		      FPE_INTDIV, error_get_trap_addr(regs));
++
++	amd_clear_divider();
+ }
+ 
+ DEFINE_IDTENTRY(exc_overflow)
+-- 
+2.40.1
+

--- a/packages/kernel-5.15/5003-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
+++ b/packages/kernel-5.15/5003-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
@@ -1,0 +1,82 @@
+From 1524872707f69fe6bea94d26238e8f6d9302b5d6 Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Fri, 11 Aug 2023 23:38:24 +0200
+Subject: [PATCH] x86/CPU/AMD: Fix the DIV(0) initial fix attempt
+
+commit f58d6fbcb7c848b7f2469be339bc571f2e9d245b upstream.
+
+Initially, it was thought that doing an innocuous division in the #DE
+handler would take care to prevent any leaking of old data from the
+divider but by the time the fault is raised, the speculation has already
+advanced too far and such data could already have been used by younger
+operations.
+
+Therefore, do the innocuous division on every exit to userspace so that
+userspace doesn't see any potentially old data from integer divisions in
+kernel space.
+
+Do the same before VMRUN too, to protect host data from leaking into the
+guest too.
+
+Fixes: 77245f1c3c64 ("x86/CPU/AMD: Do not leak quotient data after a division by 0")
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Cc: <stable@kernel.org>
+Link: https://lore.kernel.org/r/20230811213824.10025-1-bp@alien8.de
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ arch/x86/include/asm/entry-common.h | 1 +
+ arch/x86/kernel/cpu/amd.c           | 1 +
+ arch/x86/kernel/traps.c             | 2 --
+ arch/x86/kvm/svm/svm.c              | 2 ++
+ 4 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/entry-common.h b/arch/x86/include/asm/entry-common.h
+index 43184640b579..a12fdf01dc26 100644
+--- a/arch/x86/include/asm/entry-common.h
++++ b/arch/x86/include/asm/entry-common.h
+@@ -92,6 +92,7 @@ static inline void arch_exit_to_user_mode_prepare(struct pt_regs *regs,
+ static __always_inline void arch_exit_to_user_mode(void)
+ {
+ 	mds_user_clear_cpu_buffers();
++	amd_clear_divider();
+ }
+ #define arch_exit_to_user_mode arch_exit_to_user_mode
+ 
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index 892eb16a9ea2..f485e6c3ae90 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -1300,3 +1300,4 @@ void noinstr amd_clear_divider(void)
+ 	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
+ 		     :: "a" (0), "d" (0), "r" (1));
+ }
++EXPORT_SYMBOL_GPL(amd_clear_divider);
+diff --git a/arch/x86/kernel/traps.c b/arch/x86/kernel/traps.c
+index 3361d32d090f..ca47080e3774 100644
+--- a/arch/x86/kernel/traps.c
++++ b/arch/x86/kernel/traps.c
+@@ -202,8 +202,6 @@ DEFINE_IDTENTRY(exc_divide_error)
+ {
+ 	do_error_trap(regs, 0, "divide error", X86_TRAP_DE, SIGFPE,
+ 		      FPE_INTDIV, error_get_trap_addr(regs));
+-
+-	amd_clear_divider();
+ }
+ 
+ DEFINE_IDTENTRY(exc_overflow)
+diff --git a/arch/x86/kvm/svm/svm.c b/arch/x86/kvm/svm/svm.c
+index 0611dac70c25..944a08cc3b6b 100644
+--- a/arch/x86/kvm/svm/svm.c
++++ b/arch/x86/kvm/svm/svm.c
+@@ -1452,6 +1452,8 @@ static void svm_prepare_guest_switch(struct kvm_vcpu *vcpu)
+ 	struct vcpu_svm *svm = to_svm(vcpu);
+ 	struct svm_cpu_data *sd = per_cpu(svm_data, vcpu->cpu);
+ 
++	amd_clear_divider();
++
+ 	if (sev_es_guest(vcpu->kvm))
+ 		sev_es_unmap_ghcb(svm);
+ 
+-- 
+2.40.1
+

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -22,6 +22,12 @@ Patch1003: 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
 # Increase default of sysctl net.unix.max_dgram_qlen to 512.
 Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 
+# Cherry-picked fixes for CVE-2023-20588 ("DIV0"). Can be dropped when moving
+# upstream to 5.15.128 or later.
+Patch5001: 5001-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
+Patch5002: 5002-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
+Patch5003: 5003-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname

--- a/packages/kernel-6.1/5001-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
+++ b/packages/kernel-6.1/5001-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
@@ -1,0 +1,48 @@
+From 3bf59e709af08ffd0e321755b5699942474c1962 Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Sat, 8 Jul 2023 10:21:35 +0200
+Subject: [PATCH] x86/bugs: Increase the x86 bugs vector size to two u32s
+
+Upstream commit: 0e52740ffd10c6c316837c6c128f460f1aaba1ea
+
+There was never a doubt in my mind that they would not fit into a single
+u32 eventually.
+
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit dfede4cb8ef732039b7a479d260bd89d3b474f14)
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ arch/x86/include/asm/cpufeatures.h       | 2 +-
+ tools/arch/x86/include/asm/cpufeatures.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
+index b69f948be454..32221013c45d 100644
+--- a/arch/x86/include/asm/cpufeatures.h
++++ b/arch/x86/include/asm/cpufeatures.h
+@@ -14,7 +14,7 @@
+  * Defines x86 CPU feature bits
+  */
+ #define NCAPINTS			20	   /* N 32-bit words worth of info */
+-#define NBUGINTS			1	   /* N 32-bit bug flags */
++#define NBUGINTS			2	   /* N 32-bit bug flags */
+ 
+ /*
+  * Note: If the comment begins with a quoted string, that string is used
+diff --git a/tools/arch/x86/include/asm/cpufeatures.h b/tools/arch/x86/include/asm/cpufeatures.h
+index b71f4f2ecdd5..9ecc62861194 100644
+--- a/tools/arch/x86/include/asm/cpufeatures.h
++++ b/tools/arch/x86/include/asm/cpufeatures.h
+@@ -14,7 +14,7 @@
+  * Defines x86 CPU feature bits
+  */
+ #define NCAPINTS			20	   /* N 32-bit words worth of info */
+-#define NBUGINTS			1	   /* N 32-bit bug flags */
++#define NBUGINTS			2	   /* N 32-bit bug flags */
+ 
+ /*
+  * Note: If the comment begins with a quoted string, that string is used
+-- 
+2.40.1
+

--- a/packages/kernel-6.1/5002-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
+++ b/packages/kernel-6.1/5002-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
@@ -1,0 +1,111 @@
+From 35131bf2a0cc0d522f294c21be7d9c2a88c06035 Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Sat, 5 Aug 2023 00:06:43 +0200
+Subject: [PATCH] x86/CPU/AMD: Do not leak quotient data after a division by 0
+
+commit 77245f1c3c6495521f6a3af082696ee2f8ce3921 upstream.
+
+Under certain circumstances, an integer division by 0 which faults, can
+leave stale quotient data from a previous division operation on Zen1
+microarchitectures.
+
+Do a dummy division 0/1 before returning from the #DE exception handler
+in order to avoid any leaks of potentially sensitive data.
+
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Cc: <stable@kernel.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit f2615bb47be4f53be92c81a6a8aa286c92ef04d9)
+Signed-off-by: Leonard Foerster <foersleo@amazon.com>
+---
+ arch/x86/include/asm/cpufeatures.h |  2 ++
+ arch/x86/include/asm/processor.h   |  2 ++
+ arch/x86/kernel/cpu/amd.c          | 19 +++++++++++++++++++
+ arch/x86/kernel/traps.c            |  2 ++
+ 4 files changed, 25 insertions(+)
+
+diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
+index 32221013c45d..e2d980757511 100644
+--- a/arch/x86/include/asm/cpufeatures.h
++++ b/arch/x86/include/asm/cpufeatures.h
+@@ -467,4 +467,6 @@
+ #define X86_BUG_RAS_POISONING		X86_BUG(30) /* CPU is affected by RAS poisoning */
+ #define X86_BUG_GDS			X86_BUG(31) /* CPU is affected by Gather Data Sampling */
+ 
++/* BUG word 2 */
++#define X86_BUG_DIV0			X86_BUG(1*32 + 1) /* AMD DIV0 speculation bug */
+ #endif /* _ASM_X86_CPUFEATURES_H */
+diff --git a/arch/x86/include/asm/processor.h b/arch/x86/include/asm/processor.h
+index d8277eec1bcd..7dc733062313 100644
+--- a/arch/x86/include/asm/processor.h
++++ b/arch/x86/include/asm/processor.h
+@@ -800,9 +800,11 @@ extern u16 get_llc_id(unsigned int cpu);
+ #ifdef CONFIG_CPU_SUP_AMD
+ extern u32 amd_get_nodes_per_socket(void);
+ extern u32 amd_get_highest_perf(void);
++extern void amd_clear_divider(void);
+ #else
+ static inline u32 amd_get_nodes_per_socket(void)	{ return 0; }
+ static inline u32 amd_get_highest_perf(void)		{ return 0; }
++static inline void amd_clear_divider(void)		{ }
+ #endif
+ 
+ #define for_each_possible_hypervisor_cpuid_base(function) \
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index 7f4eb8b027cc..7a93bb12302d 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -75,6 +75,10 @@ static const int amd_zenbleed[] =
+ 			   AMD_MODEL_RANGE(0x17, 0x60, 0x0, 0x7f, 0xf),
+ 			   AMD_MODEL_RANGE(0x17, 0xa0, 0x0, 0xaf, 0xf));
+ 
++static const int amd_div0[] =
++	AMD_LEGACY_ERRATUM(AMD_MODEL_RANGE(0x17, 0x00, 0x0, 0x2f, 0xf),
++			   AMD_MODEL_RANGE(0x17, 0x50, 0x0, 0x5f, 0xf));
++
+ static bool cpu_has_amd_erratum(struct cpuinfo_x86 *cpu, const int *erratum)
+ {
+ 	int osvw_id = *erratum++;
+@@ -1115,6 +1119,11 @@ static void init_amd(struct cpuinfo_x86 *c)
+ 	check_null_seg_clears_base(c);
+ 
+ 	zenbleed_check(c);
++
++	if (cpu_has_amd_erratum(c, amd_div0)) {
++		pr_notice_once("AMD Zen1 DIV0 bug detected. Disable SMT for full protection.\n");
++		setup_force_cpu_bug(X86_BUG_DIV0);
++	}
+ }
+ 
+ #ifdef CONFIG_X86_32
+@@ -1256,3 +1265,13 @@ void amd_check_microcode(void)
+ {
+ 	on_each_cpu(zenbleed_check_cpu, NULL, 1);
+ }
++
++/*
++ * Issue a DIV 0/1 insn to clear any division data from previous DIV
++ * operations.
++ */
++void noinstr amd_clear_divider(void)
++{
++	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
++		     :: "a" (0), "d" (0), "r" (1));
++}
+diff --git a/arch/x86/kernel/traps.c b/arch/x86/kernel/traps.c
+index d3fdec706f1d..80b719ff60ed 100644
+--- a/arch/x86/kernel/traps.c
++++ b/arch/x86/kernel/traps.c
+@@ -206,6 +206,8 @@ DEFINE_IDTENTRY(exc_divide_error)
+ {
+ 	do_error_trap(regs, 0, "divide error", X86_TRAP_DE, SIGFPE,
+ 		      FPE_INTDIV, error_get_trap_addr(regs));
++
++	amd_clear_divider();
+ }
+ 
+ DEFINE_IDTENTRY(exc_overflow)
+-- 
+2.40.1
+

--- a/packages/kernel-6.1/5003-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
+++ b/packages/kernel-6.1/5003-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
@@ -1,0 +1,82 @@
+From 20eb241125391039b9a7248b82e8e6c892522931 Mon Sep 17 00:00:00 2001
+From: "Borislav Petkov (AMD)" <bp@alien8.de>
+Date: Fri, 11 Aug 2023 23:38:24 +0200
+Subject: [PATCH] x86/CPU/AMD: Fix the DIV(0) initial fix attempt
+
+commit f58d6fbcb7c848b7f2469be339bc571f2e9d245b upstream.
+
+Initially, it was thought that doing an innocuous division in the #DE
+handler would take care to prevent any leaking of old data from the
+divider but by the time the fault is raised, the speculation has already
+advanced too far and such data could already have been used by younger
+operations.
+
+Therefore, do the innocuous division on every exit to userspace so that
+userspace doesn't see any potentially old data from integer divisions in
+kernel space.
+
+Do the same before VMRUN too, to protect host data from leaking into the
+guest too.
+
+Fixes: 77245f1c3c64 ("x86/CPU/AMD: Do not leak quotient data after a division by 0")
+Signed-off-by: Borislav Petkov (AMD) <bp@alien8.de>
+Cc: <stable@kernel.org>
+Link: https://lore.kernel.org/r/20230811213824.10025-1-bp@alien8.de
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ arch/x86/include/asm/entry-common.h | 1 +
+ arch/x86/kernel/cpu/amd.c           | 1 +
+ arch/x86/kernel/traps.c             | 2 --
+ arch/x86/kvm/svm/svm.c              | 2 ++
+ 4 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/entry-common.h b/arch/x86/include/asm/entry-common.h
+index 674ed46d3ced..11203a9fe0a8 100644
+--- a/arch/x86/include/asm/entry-common.h
++++ b/arch/x86/include/asm/entry-common.h
+@@ -92,6 +92,7 @@ static inline void arch_exit_to_user_mode_prepare(struct pt_regs *regs,
+ static __always_inline void arch_exit_to_user_mode(void)
+ {
+ 	mds_user_clear_cpu_buffers();
++	amd_clear_divider();
+ }
+ #define arch_exit_to_user_mode arch_exit_to_user_mode
+ 
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index 7a93bb12302d..b76e85f8cdb8 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -1275,3 +1275,4 @@ void noinstr amd_clear_divider(void)
+ 	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
+ 		     :: "a" (0), "d" (0), "r" (1));
+ }
++EXPORT_SYMBOL_GPL(amd_clear_divider);
+diff --git a/arch/x86/kernel/traps.c b/arch/x86/kernel/traps.c
+index 80b719ff60ed..d3fdec706f1d 100644
+--- a/arch/x86/kernel/traps.c
++++ b/arch/x86/kernel/traps.c
+@@ -206,8 +206,6 @@ DEFINE_IDTENTRY(exc_divide_error)
+ {
+ 	do_error_trap(regs, 0, "divide error", X86_TRAP_DE, SIGFPE,
+ 		      FPE_INTDIV, error_get_trap_addr(regs));
+-
+-	amd_clear_divider();
+ }
+ 
+ DEFINE_IDTENTRY(exc_overflow)
+diff --git a/arch/x86/kvm/svm/svm.c b/arch/x86/kvm/svm/svm.c
+index fc1649b5931a..9d549826b23f 100644
+--- a/arch/x86/kvm/svm/svm.c
++++ b/arch/x86/kvm/svm/svm.c
+@@ -3940,6 +3940,8 @@ static noinstr void svm_vcpu_enter_exit(struct kvm_vcpu *vcpu, bool spec_ctrl_in
+ 
+ 	guest_state_enter_irqoff();
+ 
++	amd_clear_divider();
++
+ 	if (sev_es_guest(vcpu->kvm))
+ 		__svm_sev_es_vcpu_run(svm, spec_ctrl_intercepted);
+ 	else
+-- 
+2.40.1
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -25,6 +25,12 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 # options for nvidia are instead included through DRM_SIMPLE
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 
+# Cherry-picked fixes for CVE-2023-20588 ("DIV0"). Can be dropped when moving
+# upstream to 6.1.48 or later
+Patch5001: 5001-x86-bugs-Increase-the-x86-bugs-vector-size-to-two-u3.patch
+Patch5002: 5002-x86-CPU-AMD-Do-not-leak-quotient-data-after-a-divisi.patch
+Patch5003: 5003-x86-CPU-AMD-Fix-the-DIV-0-initial-fix-attempt.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a

**Description of changes:**

Cherry-pick the software mitigation for CVE-2023-20588 ("DIV0") from the latest upstream stable kernel releases. Kept in separate commits to aid updating the individual kernel series as Bottlerocket's Amazon Linux upstream releases them. This also picks up a required augmentation of the x86 bugs vector to two words.

**Testing done:**

I have done some light build testing. Still need to do proper validation of the fix on appropriate instances.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
