### PR TITLE
readme: possible values for OCI-defaults rlimits

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,9 +752,9 @@ capability | setting | default value
 
 ##### OCI Defaults: Resource Limits
 
-Each of the `resource-limits` settings below contain two numeric fields: `hard-limit` and `soft-limit`, which are **32-bit unsigned integers**.
+Each of the `resource-limits` settings below contain two fields: `hard-limit` and `soft-limit`.
 
-Please see the [`getrlimit` linux manpage](https://man7.org/linux/man-pages/man7/capabilities.7.html) for meanings of `hard-limit` and `soft-limit`.
+Please see the [`getrlimit` linux manpage](https://man7.org/linux/man-pages/man2/getrlimit.2.html) for meanings of `hard-limit` and `soft-limit`.
 
 The full list of resource limits that can be configured in Bottlerocket are:
 <table>


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
- Update possible values of OCI defaults resource limits.
-  Update getrlimit link in readme


**Testing done:**
NA


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
