### PR TITLE
Ignore 'aws-credential-types' in dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -33,6 +33,7 @@ updates:
     ignore:
       # For AWS SDK for Rust, we'll update when we bump tough/coldsnap
       - dependency-name: "aws-config"
+      - dependency-name: "aws-credential-types"
       - dependency-name: "aws-endpoint"
       - dependency-name: "aws-http"
       - dependency-name: "aws-hyper"


### PR DESCRIPTION
**Description of changes:**

We're going to gate all AWS SDK for Rust bumps using `tough` and `coldsnap`, but this one managed to slip through. (https://github.com/bottlerocket-os/bottlerocket/pull/3384)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
