### PR TITLE
maintenance: Add convenience script to check for upstream releases

### DIFF
--- a/packages/linux-firmware/latest-upstream-tags.sh
+++ b/packages/linux-firmware/latest-upstream-tags.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Latest upstream tag for linux-firmware:"
+git ls-remote --tags --refs https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git | tail -1

--- a/packages/microcode/latest-upstream-tags.sh
+++ b/packages/microcode/latest-upstream-tags.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Latest upstream tag for Intel ucode (microcode-ctl):"
+git ls-remote --tags --refs https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git | tail -1
+
+echo "Latest upstream tag for AMD ucode (linux-firmware):"
+git ls-remote --tags --refs https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git | tail -1


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a

**Description of changes:**

For packages we base on Amazon Linux we have convenience scripts to check for the latest released version of the Amazon Linux package (e.g. [`latest-srpm-url.sh` in `kernel-6.1`](https://github.com/bottlerocket-os/bottlerocket/blob/develop/packages/kernel-6.1/latest-srpm-url.sh)). These scripts help ease the process of updating packages.

This patch series introduces convenience scripts for packages `microcode` and `linux-firmware` that act in the same spirit of easing package updates by checking for the latest release upstream.

Maybe this can act as a pilot to get similar scripts for more upstream packages.


**Testing done:**

Running the two new scripts provides the expected latest release tags for all affected upstream packages:

```
$ ./packages/linux-firmware/latest-upstream-tags.sh 
Latest upstream tag for linux-firmware:
c92d9798064e8bcc62690ab75e0cf2b83eabad54	refs/tags/20230804

$ ./packages/microcode/latest-upstream-tags.sh 
Latest upstream tag for Intel ucode (microcode-ctl):
6788bb07eb5f9e9b83c31ea1364150fe898f450a	refs/tags/microcode-20230808
Latest upstream tag for AMD ucode (linux-firmware):
c92d9798064e8bcc62690ab75e0cf2b83eabad54	refs/tags/20230804
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
