### PR TITLE
chore: specify feature resolver="1" in all rust workspaces

### DIFF
--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "1"
 members = [
     "api/apiserver",
     "api/apiclient",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "1"
 members = [
     "infrasys",
     "buildsys",

--- a/variants/Cargo.toml
+++ b/variants/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "1"
 members = [
     "aws-dev",
     "aws-ecs-1",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```

    chore: specify feature resolver="1" in all rust workspaces
    
    This gets rid of a warning that comes with rust 1.72.0. This does not
    impact any of our workspaces since we've always been defaulted to using
    resolver version 1. We can't use resolver v2 yet since that breaks the
    'cargo make build-package' task.
    
    See rust-lang/cargo#10112 for more details.
```


**Testing done:**
`cargo make build-package` works. The cargo warnings about feature resolver version mismatch is gone.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
