### PR TITLE
remove IPVS module drop-in for kubelet

### DIFF
--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -44,7 +44,6 @@ Source14: credential-provider-config-yaml
 Source20: prestart-pull-pause-ctr.conf
 Source21: dockershim-symlink.conf
 Source22: make-kubelet-dirs.conf
-Source23: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -96,7 +95,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -133,7 +132,6 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
-%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env

--- a/packages/kubernetes-1.23/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.23/load-ipvs-modules.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
-After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -52,7 +52,6 @@ Source14: credential-provider-config-yaml
 Source20: prestart-pull-pause-ctr.conf
 Source21: dockershim-symlink.conf
 Source22: make-kubelet-dirs.conf
-Source23: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -104,7 +103,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -141,7 +140,6 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
-%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env

--- a/packages/kubernetes-1.24/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.24/load-ipvs-modules.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
-After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -52,7 +52,6 @@ Source14: credential-provider-config-yaml
 Source20: prestart-pull-pause-ctr.conf
 Source21: dockershim-symlink.conf
 Source22: make-kubelet-dirs.conf
-Source23: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -104,7 +103,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -141,7 +140,6 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
-%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env

--- a/packages/kubernetes-1.25/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.25/load-ipvs-modules.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
-After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -52,7 +52,6 @@ Source14: credential-provider-config-yaml
 Source20: prestart-pull-pause-ctr.conf
 Source21: dockershim-symlink.conf
 Source22: make-kubelet-dirs.conf
-Source23: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -104,7 +103,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -141,7 +140,6 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
-%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env

--- a/packages/kubernetes-1.26/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.26/load-ipvs-modules.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
-After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -52,7 +52,6 @@ Source14: credential-provider-config-yaml
 Source20: prestart-pull-pause-ctr.conf
 Source21: dockershim-symlink.conf
 Source22: make-kubelet-dirs.conf
-Source23: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -104,7 +103,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -141,7 +140,6 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
-%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env

--- a/packages/kubernetes-1.27/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.27/load-ipvs-modules.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
-After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -52,7 +52,6 @@ Source14: credential-provider-config-yaml
 Source20: prestart-pull-pause-ctr.conf
 Source21: dockershim-symlink.conf
 Source22: make-kubelet-dirs.conf
-Source23: load-ipvs-modules.conf
 
 Source1000: clarify.toml
 
@@ -106,7 +105,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
-install -p -m 0644 %{S:20} %{S:21} %{S:22} %{S:23} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
@@ -143,7 +142,6 @@ ln -rs \
 %dir %{_cross_unitdir}/kubelet.service.d
 %{_cross_unitdir}/kubelet.service.d/prestart-pull-pause-ctr.conf
 %{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
-%{_cross_unitdir}/kubelet.service.d/load-ipvs-modules.conf
 %{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env

--- a/packages/kubernetes-1.28/load-ipvs-modules.conf
+++ b/packages/kubernetes-1.28/load-ipvs-modules.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service
-After=modprobe@ip_vs_sh.service modprobe@ip_vs_rr.service modprobe@ip_vs_wrr.service


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Essentially reverts 7919d8923e82a8410e32d4465000f28ceca53344.

We added the proactive load of IPVS modules to allow `kube-proxy` to use the functionality even though its older `kmod` version couldn't handle zstd-compressed modules.

However, the zstd-compressed modules change was subsequently reverted because of widespread compatibility issues. So the proactive load is no longer necessary, and slightly delays `kubelet` start.


**Testing done:**
Put the kube-proxy EKS managed add-on into IPVS mode and verified that the scheduler kmods were automatically loaded.

```
{
	"mode": "ipvs",
	"ipvs": {
		"scheduler": "lc"
	}
}

[   25.697354] IPVS: Registered protocols (TCP, UDP, SCTP, AH, ESP)
[   25.697371] IPVS: Connection hash table configured (size=4096, memory=32Kbytes)
[   25.697413] IPVS: ipvs loaded.
[   25.702272] IPVS: [lc] scheduler registered
```

```
{
	"mode": "ipvs",
	"ipvs": {
		"scheduler": "wrr"
	}
}

[   18.671353] IPVS: Registered protocols (TCP, UDP, SCTP, AH, ESP)
[   18.671372] IPVS: Connection hash table configured (size=4096, memory=32Kbytes)
[   18.671415] IPVS: ipvs loaded.
[   18.676638] IPVS: [wrr] scheduler registered.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
