### PR TITLE
build: allow skipping of twoliter install

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,6 +3,11 @@ skip_core_tasks = true
 
 [env]
 BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
+# The build tool, Twoliter, needs to be installed to run a Bottlerocket build.
+# If you need to build in an offline environment, first you should run `cargo
+# make fetch` in an online environment. Subsequently in the offline environment
+# you need to set this to true. `cargo make -e TWOLITER_SKIP_INSTALL=true build`
+TWOLITER_SKIP_INSTALL = "false"
 # TODO - replace with crates.io version when published
 TWOLITER_GIT = "https://github.com/bottlerocket-os/twoliter"
 TWOLITER_REV = "v0.0.2"
@@ -242,8 +247,15 @@ fi
 ] }
 
 [tasks.install-twoliter]
+script_runner = "bash"
 script = [
 '''
+if [ "${TWOLITER_SKIP_INSTALL}" = "true" ]; then
+   echo "TWOLITER_SKIP_INSTALL=${TWOLITER_SKIP_INSTALL}"
+   echo "Skipping Twoliter installation"
+   exit 0
+fi
+
 cargo install \
   --locked \
   --root "${TWOLITER_INSTALL_ROOT}" \


### PR DESCRIPTION


**Issue number:**

Amends #3342 

**Description of changes:**

The cargo install of Twoliter was causing a call out to the git repository even if Twoliter was already installed. This is a problem in intentionally offline environments.

Furthermore, in the future we plan to curl a binary release of Twoliter, which means we will need a way to skip the installation there as well.

This commit introduces a Makefile.toml variable
SKIP_TWOLITER_INSTALL which can be used to skip the installation of Twoliter when it has already been installed.


**Testing done:**



Try to install with `true` but without Twoliter installed. Fails as expected.

```
$ cargo make -e TWOLITER_SKIP_INSTALL=true fetch
[cargo-make] INFO - cargo make 0.36.13
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fetch
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
TWOLITER_SKIP_INSTALL=true
Skipping Twoliter installation
[cargo-make] INFO - Execute Command: "/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "fetch" "--project-path=/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/Twoliter.toml" "--cargo-home=/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/.cargo" "--"
[cargo-make] ERROR - Error while executing command, error: Os {
    code: 2,
    kind: NotFound,
    message: "No such file or directory",
}
[cargo-make] WARN - Build Failed.
FAIL: 1
```

Run fetch without skipping installation. Twoliter is installed.

```
$ cargo make fetch
[cargo-make] INFO - cargo make 0.36.13
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fetch
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
[cargo-make] INFO - Execute Command: "/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "fetch" "--project-path=/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/Twoliter.toml" "--cargo-home=/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/.cargo" "--"
[cargo-make][1] INFO - Build File: /tmp/.tmp5SnkTI/Makefile.toml
[cargo-make][1] INFO - Task: fetch
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: setup-build
[cargo-make][1] INFO - Running Task: fetch-sdk
v0.34.0: Pulling from bottlerocket/bottlerocket-sdk-x86_64
805c2f499150: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:e9756cbefdfa9b0d24f1482d430e6916558866c135f1c7e13dcc6cc8f6b66d17
Status: Downloaded newer image for public.ecr.aws/bottlerocket/bottlerocket-sdk-x86_64:v0.34.0
public.ecr.aws/bottlerocket/bottlerocket-sdk-x86_64:v0.34.0
[cargo-make][1] INFO - Running Task: fetch-toolchain
v0.34.0: Pulling from bottlerocket/bottlerocket-toolchain-x86_64
8076fd0b2319: Pull complete
Digest: sha256:a3346f199a90006adbf464550dc9fbba87c231ff2965a977d6507954328a1569
Status: Downloaded newer image for public.ecr.aws/bottlerocket/bottlerocket-toolchain-x86_64:v0.34.0
public.ecr.aws/bottlerocket/bottlerocket-toolchain-x86_64:v0.34.0
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: fetch-vendored
go: downloading github.com/aws/aws-sdk-go v1.44.332
go: downloading github.com/containerd/containerd v1.6.23
...
go: downloading golang.org/x/mod v0.12.0
[cargo-make][1] INFO - Build Done in 49.65 seconds.
[cargo-make] INFO - Build Done in 58.14 seconds.
```

Now try fetch again with skip install true:

```
$ cargo make -e TWOLITER_SKIP_INSTALL=true fetch
[cargo-make] INFO - cargo make 0.36.13
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fetch
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
TWOLITER_SKIP_INSTALL=true
Skipping Twoliter installation
[cargo-make] INFO - Execute Command: "/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "fetch" "--project-path=/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/Twoliter.toml" "--cargo-home=/home/ANT.AMAZON.COM/brigmatt/repos/bottlerocket/.cargo" "--"
[cargo-make][1] INFO - Build File: /tmp/.tmpQMRzKz/Makefile.toml
[cargo-make][1] INFO - Task: fetch
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: setup-build
[cargo-make][1] INFO - Running Task: fetch-sdk
[cargo-make][1] INFO - Running Task: fetch-toolchain
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: fetch-vendored
[cargo-make][1] INFO - Build Done in 2.77 seconds.
[cargo-make] INFO - Build Done in 3.09 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
