### PR TITLE
add patch to increase systemd mount rate limit

### DIFF
--- a/packages/systemd/9012-core-mount-increase-mount-rate-limit-burst-to-25.patch
+++ b/packages/systemd/9012-core-mount-increase-mount-rate-limit-burst-to-25.patch
@@ -1,0 +1,29 @@
+From 1f8d86a74c09738eb000aacec6bbd74360177796 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 31 Aug 2023 19:14:13 +0000
+Subject: [PATCH] core/mount: increase mount rate limit burst to 25
+
+On systems where many mounts are set up on boot, the default rate
+limit is too low and leads to several stalls.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ src/core/mount.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/mount.c b/src/core/mount.c
+index d82092a..7ba009b 100644
+--- a/src/core/mount.c
++++ b/src/core/mount.c
+@@ -1928,7 +1928,7 @@ static void mount_enumerate(Manager *m) {
+         mnt_init_debug(0);
+ 
+         if (!m->mount_monitor) {
+-                unsigned mount_rate_limit_burst = 5;
++                unsigned mount_rate_limit_burst = 25;
+                 int fd;
+ 
+                 m->mount_monitor = mnt_new_monitor();
+-- 
+2.40.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -52,6 +52,11 @@ Patch9010: 9010-units-keep-modprobe-service-units-running.patch
 # DBUS services not used in Bottlerocket
 Patch9011: 9011-systemd-networkd-Conditionalize-hostnamed-timezoned-.patch
 
+# Local patch to adjust the default mount rate limit to 25 per second.
+# Carried as a patch so that SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST can be used
+# as a kernel command line parameter to override.
+Patch9012: 9012-core-mount-increase-mount-rate-limit-burst-to-25.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Bottlerocket includes a lot of mount units, and the 5 mounts per second rate limit leads to several throttles during the boot process. The higher rate limit eliminates this, speeding up the boot by up to one second.

Setting `SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST` in the environment can also change the rate limit, but this must be done on the kernel command line. If we set it there by default, then it can't be tuned by system administrators using `settings.boot.kernel-parameters`.


**Testing done:**
Added a second patch to warn about rate limit events. The burst limit of 25 mounts per second eliminates the rate limit warnings, where lower values like 20 mounts per second did not.

```
From d8222f3d5baf9897cc0503a70c5c756f847fad7f Mon Sep 17 00:00:00 2001
From: Ben Cressey <bcressey@amazon.com>
Date: Sun, 20 Aug 2023 05:05:11 +0000
Subject: [PATCH] test rate limit

Signed-off-by: Ben Cressey <bcressey@amazon.com>
---
 src/libsystemd/sd-event/sd-event.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/src/libsystemd/sd-event/sd-event.c b/src/libsystemd/sd-event/sd-event.c
index aee2ed5..a025a98 100644
--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -3020,7 +3020,7 @@ static int event_source_leave_ratelimit(sd_event_source *s, bool run_callback) {
         event_source_pp_prioq_reshuffle(s);
         ratelimit_reset(&s->rate_limit);

-        log_debug("Event source %p (%s) left rate limit state.", s, strna(s->description));
+        log_emergency("Event source %p (%s) left rate limit state.", s, strna(s->description));

         if (run_callback && s->ratelimit_expire_callback) {
                 s->dispatching = true;
--
2.40.1
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
