### PR TITLE
Use `systemd-networkd` for `aws-ecs-2` and k8s 1.28 variants

### DIFF
--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -12,6 +12,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 xfs-data-partition = true
 uefi-secure-boot = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 kernel-parameters = [

--- a/variants/aws-ecs-2-nvidia/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia/Cargo.toml
@@ -10,6 +10,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
+systemd-networkd = true
 
 [package.metadata.build-variant.image-layout]
 os-image-size-gib = 4

--- a/variants/aws-ecs-2/Cargo.toml
+++ b/variants/aws-ecs-2/Cargo.toml
@@ -12,6 +12,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.28-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.28-nvidia/Cargo.toml
@@ -17,6 +17,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.28/Cargo.toml
+++ b/variants/aws-k8s-1.28/Cargo.toml
@@ -14,6 +14,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -15,6 +15,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 xfs-data-partition = true
 uefi-secure-boot = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/metal-k8s-1.28/Cargo.toml
+++ b/variants/metal-k8s-1.28/Cargo.toml
@@ -18,6 +18,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -15,6 +15,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 xfs-data-partition = true
 uefi-secure-boot = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"

--- a/variants/vmware-k8s-1.28/Cargo.toml
+++ b/variants/vmware-k8s-1.28/Cargo.toml
@@ -17,6 +17,7 @@ grub-set-private-var = true
 unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
+systemd-networkd = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"


### PR DESCRIPTION
**Issue number:**
Related to #2449 

**Description of changes:**
*Draft while testing is in progress*

This PR moves the `aws-ecs-2`, Kubernetes 1.28, and `*-dev` variants to `systemd-networkd` as the network backend.


**Testing done:**
WIP - will update as testing is completed

- [x] Build each of the variants
- [x] `aws-k8s-1.28` conformance testing in IPv6-only cluster 
```
{
"plugins": [
{
"plugin": "e2e",
"node": "global",
"status": "complete",
"result-status": "passed",
"result-counts": {
"passed": 384,
"skipped": 7007
},
```

- [x] `aws-k8s-1.28` conformance testing in IPv4 cluster 
```
 e2e   global   complete   passed   Passed:380, Failed:  0, Remaining:  0
```
- [x] `metal-k8s-1.28` conformance testing
```
e2e   complete   passed       1   Passed:380, Failed:  0, Remaining:  0
```
- [x] `vmware-k8s-1.28` conformance testing 
```
e2e   global   complete   passed   Passed:380, Failed:  0, Remaining:  0
```
- [x] `aws-ecs-2` internal ECS testing
- [x] Given custom (correct) DNS settings, instance continues to function properly in a cluster and proper interface/resolved configuration is set (set custom settings identical to what comes in via DHCP, observe the settings as `Global` via `resolvectl`.)
```
bash-5.1# cat /etc/systemd/resolved.conf.d/10-resolv.conf 
[Resolve]
DNS=192.168.0.2
Domains=us-west-2.compute.internal

bash-5.1# resolvectl 
Global
       Protocols: -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported
resolv.conf mode: stub
      DNS Servers 192.168.0.2
       DNS Domain us-west-2.compute.internal

Link 2 (eth0)
Current Scopes: none
     Protocols: -DefaultRoute +LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

bash-5.1# cat /etc/systemd/network/10-eth0.network.d/10-dns.conf 
[Network]
DNSDefaultRoute=false
[DHCPv4]
UseDNS=false
UseDomains=false
[DHCPv6]
UseDNS=false
UseDomains=false
[IPv6AcceptRA]
UseDNS=false
UseDomains=false
```
- [x] AWS - chain the Cilium CNI with AWS VPC CNI
- [x]  Scale out an IPv6 and IPv4 cluster to 3000 nodes and ensure they all join properly
```
$ kubectl get nodes | grep -w Ready | wc -l
3000
```
- [x] Ensure the system doesn't wait for an interface configured with DHCP and marked as `optional` via network config.  Ensure `RequiredForOnline=false`
```
[Match]
Name=eno3
[Link]
RequiredForOnline=false
[Network]
DHCP=ipv4
[DHCPv4]
UseMTU=true
```
- [x] Ensure the system doesn't wait for a protocol (IPv4/6) marked as `optional` via network config
```
[Match]
Name=eno1
[Link]
RequiredForOnline=true
RequiredFamilyForOnline=ipv4
[Network]
DHCP=yes
[DHCPv4]
UseMTU=true
[Ipv6AcceptRA]
UseMTU=true
```
- [x] Smoke test bonding on metal (See #3415  and #3426 for issues found during bond testing
- [x] Smoke test VLANs on metal
```
version = 3

[bond0]
kind = "bond"
mode = "active-backup"
interfaces = ["eno1" , "eno2"]
dhcp4 = true

[bond0.monitoring]
miimon-frequency-ms = 100
miimon-updelay-ms = 200
miimon-downdelay-ms = 200

[VLAN43]
kind = "vlan"
device = "bond0"
id = 43
dhcp4 = true
```
- [x] Test all versions (1-3) of network config work as expected
- [x] Test interfaces configured via MAC address work as expected
- [x] Ensure MTU is set identically (via DHCP) to `wicked` variants across various platforms

| Instance Type | systemd-networkd | wicked |
| --- | --- | --- |
| c5.large | 9001 | 9001|
| m6g.medium | 9001 | 9001|
| c3.large | 9001 | 9001|
| c1.xlarge | 9001 | 9001|
| vmware | 1500 | 1500 |

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
