### PR TITLE
packages: Update kubelet config resolvConf setting for k8s 1.28

### DIFF
--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -122,7 +122,7 @@ imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent
 {{#if settings.kubernetes.provider-id}}
 providerID: {{settings.kubernetes.provider-id}}
 {{/if}}
-resolvConf: "/etc/resolv.conf"
+resolvConf: "/run/netdog/resolv.conf"
 hairpinMode: hairpin-veth
 readOnlyPort: 0
 cgroupDriver: systemd


### PR DESCRIPTION
**Issue number:**
Related to #2449 and #3394 

**Description of changes:**

This commit changes the kubelet config's `resolveConf` setting to point
to the common path `/run/netdog/resolv.conf`.  This path is symlinked to the "real" resolv.conf depending on the network backend being used.


**Testing done:**
* Build and run the image and confirm the kubelet config is correct
```
bash-5.1# cat /etc/kubernetes/kubelet/config | grep resolv    
resolvConf: "/run/netdog/resolv.conf"
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
