### PR TITLE
kernel-5.15, -6.1: drop i8042 modules from shared config

### DIFF
--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -119,23 +119,6 @@ CONFIG_DECOMPRESS_ZSTD=y
 # CONFIG_MODULE_COMPRESS_NONE is not set
 CONFIG_MODULE_COMPRESS_XZ=y
 
-# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
-# them before mounting the root device.
-CONFIG_SERIO_I8042=m
-CONFIG_KEYBOARD_ATKBD=m
-CONFIG_MOUSE_PS2=m
-# CONFIG_MOUSE_PS2_ALPS is not set
-# CONFIG_MOUSE_PS2_BYD is not set
-# CONFIG_MOUSE_PS2_LOGIPS2PP is not set
-# CONFIG_MOUSE_PS2_SYNAPTICS is not set
-# CONFIG_MOUSE_PS2_SYNAPTICS_SMBUS is not set
-# CONFIG_MOUSE_PS2_CYPRESS is not set
-# CONFIG_MOUSE_PS2_TRACKPOINT is not set
-# CONFIG_MOUSE_PS2_ELANTECH is not set
-# CONFIG_MOUSE_PS2_SENTELIC is not set
-# CONFIG_MOUSE_PS2_TOUCHKIT is not set
-# CONFIG_MOUSE_PS2_FOCALTECH is not set
-
 # Add virtio drivers for development setups running as guests in qemu
 CONFIG_VIRTIO_CONSOLE=m
 CONFIG_HW_RANDOM_VIRTIO=m

--- a/packages/kernel-5.15/config-bottlerocket-metal
+++ b/packages/kernel-5.15/config-bottlerocket-metal
@@ -126,3 +126,20 @@ CONFIG_SCSI_SMARTPQI=y
 
 # Support for virtio scsi boot devices for other cloud providers
 CONFIG_SCSI_VIRTIO=y
+
+# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
+# them before mounting the root device.
+CONFIG_SERIO_I8042=m
+CONFIG_KEYBOARD_ATKBD=m
+CONFIG_MOUSE_PS2=m
+# CONFIG_MOUSE_PS2_ALPS is not set
+# CONFIG_MOUSE_PS2_BYD is not set
+# CONFIG_MOUSE_PS2_LOGIPS2PP is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS_SMBUS is not set
+# CONFIG_MOUSE_PS2_CYPRESS is not set
+# CONFIG_MOUSE_PS2_TRACKPOINT is not set
+# CONFIG_MOUSE_PS2_ELANTECH is not set
+# CONFIG_MOUSE_PS2_SENTELIC is not set
+# CONFIG_MOUSE_PS2_TOUCHKIT is not set
+# CONFIG_MOUSE_PS2_FOCALTECH is not set

--- a/packages/kernel-5.15/config-bottlerocket-vmware
+++ b/packages/kernel-5.15/config-bottlerocket-vmware
@@ -1,0 +1,16 @@
+# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
+# them before mounting the root device.
+CONFIG_SERIO_I8042=m
+CONFIG_KEYBOARD_ATKBD=m
+CONFIG_MOUSE_PS2=m
+# CONFIG_MOUSE_PS2_ALPS is not set
+# CONFIG_MOUSE_PS2_BYD is not set
+# CONFIG_MOUSE_PS2_LOGIPS2PP is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS_SMBUS is not set
+# CONFIG_MOUSE_PS2_CYPRESS is not set
+# CONFIG_MOUSE_PS2_TRACKPOINT is not set
+# CONFIG_MOUSE_PS2_ELANTECH is not set
+# CONFIG_MOUSE_PS2_SENTELIC is not set
+# CONFIG_MOUSE_PS2_TOUCHKIT is not set
+# CONFIG_MOUSE_PS2_FOCALTECH is not set

--- a/packages/kernel-6.1/config-bottlerocket
+++ b/packages/kernel-6.1/config-bottlerocket
@@ -124,23 +124,6 @@ CONFIG_DECOMPRESS_ZSTD=y
 # CONFIG_MODULE_COMPRESS_NONE is not set
 CONFIG_MODULE_COMPRESS_XZ=y
 
-# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
-# them before mounting the root device.
-CONFIG_SERIO_I8042=m
-CONFIG_KEYBOARD_ATKBD=m
-CONFIG_MOUSE_PS2=m
-# CONFIG_MOUSE_PS2_ALPS is not set
-# CONFIG_MOUSE_PS2_BYD is not set
-# CONFIG_MOUSE_PS2_LOGIPS2PP is not set
-# CONFIG_MOUSE_PS2_SYNAPTICS is not set
-# CONFIG_MOUSE_PS2_SYNAPTICS_SMBUS is not set
-# CONFIG_MOUSE_PS2_CYPRESS is not set
-# CONFIG_MOUSE_PS2_TRACKPOINT is not set
-# CONFIG_MOUSE_PS2_ELANTECH is not set
-# CONFIG_MOUSE_PS2_SENTELIC is not set
-# CONFIG_MOUSE_PS2_TOUCHKIT is not set
-# CONFIG_MOUSE_PS2_FOCALTECH is not set
-
 # Add virtio drivers for development setups running as guests in qemu
 CONFIG_VIRTIO_CONSOLE=m
 CONFIG_HW_RANDOM_VIRTIO=m

--- a/packages/kernel-6.1/config-bottlerocket-metal
+++ b/packages/kernel-6.1/config-bottlerocket-metal
@@ -124,3 +124,20 @@ CONFIG_SCSI_SMARTPQI=y
 
 # Support for virtio scsi boot devices for other cloud providers
 CONFIG_SCSI_VIRTIO=y
+
+# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
+# them before mounting the root device.
+CONFIG_SERIO_I8042=m
+CONFIG_KEYBOARD_ATKBD=m
+CONFIG_MOUSE_PS2=m
+# CONFIG_MOUSE_PS2_ALPS is not set
+# CONFIG_MOUSE_PS2_BYD is not set
+# CONFIG_MOUSE_PS2_LOGIPS2PP is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS_SMBUS is not set
+# CONFIG_MOUSE_PS2_CYPRESS is not set
+# CONFIG_MOUSE_PS2_TRACKPOINT is not set
+# CONFIG_MOUSE_PS2_ELANTECH is not set
+# CONFIG_MOUSE_PS2_SENTELIC is not set
+# CONFIG_MOUSE_PS2_TOUCHKIT is not set
+# CONFIG_MOUSE_PS2_FOCALTECH is not set

--- a/packages/kernel-6.1/config-bottlerocket-vmware
+++ b/packages/kernel-6.1/config-bottlerocket-vmware
@@ -1,0 +1,16 @@
+# Load i8042 controller, keyboard, and mouse as modules, to avoid waiting for
+# them before mounting the root device.
+CONFIG_SERIO_I8042=m
+CONFIG_KEYBOARD_ATKBD=m
+CONFIG_MOUSE_PS2=m
+# CONFIG_MOUSE_PS2_ALPS is not set
+# CONFIG_MOUSE_PS2_BYD is not set
+# CONFIG_MOUSE_PS2_LOGIPS2PP is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS is not set
+# CONFIG_MOUSE_PS2_SYNAPTICS_SMBUS is not set
+# CONFIG_MOUSE_PS2_CYPRESS is not set
+# CONFIG_MOUSE_PS2_TRACKPOINT is not set
+# CONFIG_MOUSE_PS2_ELANTECH is not set
+# CONFIG_MOUSE_PS2_SENTELIC is not set
+# CONFIG_MOUSE_PS2_TOUCHKIT is not set
+# CONFIG_MOUSE_PS2_FOCALTECH is not set


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
This effectively removes i8042 hardware support from aws variants, matching the Amazon Linux upstream configuration for EC2.

i8042 is retained for vmware variants, where it's required for the interactive console to accept keyboard input, and for metal variants where it might also be useful in some environments.


**Testing done:**
Verified EC2 serial console connectivity:
- [x] kernel 6.1 / m6g.medium
- [x] kernel 6.1 / c5.large
- [x] kernel 5.15 / m6g.medium
- [x] kernel 5.15 / c5.large

Confirmed that only the aws kernel configs are affected:
```
./tools/diff-kernel-config \
  -a 7c8d340c -b 006afceb -o configs \
  -v aws-k8s-1.24 -v vmware-k8s-1.24 -v metal-k8s-1.24 \
  -v aws-k8s-1.28 -v vmware-k8s-1.28 -v metal-k8s-1.28

config-aarch64-aws-k8s-1.24-diff:        22 removed,   0 added,   3 changed
config-aarch64-aws-k8s-1.28-diff:        23 removed,   0 added,   3 changed
config-x86_64-aws-k8s-1.24-diff:         25 removed,   0 added,   3 changed
config-x86_64-aws-k8s-1.28-diff:         27 removed,   0 added,   3 changed
config-x86_64-metal-k8s-1.24-diff:        0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:        0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.24-diff:       0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:       0 removed,   0 added,   0 changed

==> configs/config-aarch64-aws-k8s-1.24-diff <==
-MOUSE_PS2_ALPS n
-MOUSE_PS2_BYD n
-MOUSE_PS2_CYPRESS n
-MOUSE_PS2_ELANTECH n
-MOUSE_PS2_FOCALTECH n
-MOUSE_PS2_LOGIPS2PP n
-MOUSE_PS2_SENTELIC n
-MOUSE_PS2_SYNAPTICS n
-MOUSE_PS2_SYNAPTICS_SMBUS n
-MOUSE_PS2_TOUCHKIT n
-MOUSE_PS2_TRACKPOINT n
-SERIO_ALTERA_PS2 n
-SERIO_AMBAKMI n
-SERIO_APBPS2 n
-SERIO_ARC_PS2 n
-SERIO_GPIO_PS2 n
-SERIO_LIBPS2 m
-SERIO_PCIPS2 n
-SERIO_PS2MULT n
-SERIO_RAW n
-SERIO_SERPORT m
-USERIO n
 KEYBOARD_ATKBD m -> n
 MOUSE_PS2 m -> n
 SERIO m -> n

==> configs/config-aarch64-aws-k8s-1.28-diff <==
-INPUT_VIVALDIFMAP m
-MOUSE_PS2_ALPS n
-MOUSE_PS2_BYD n
-MOUSE_PS2_CYPRESS n
-MOUSE_PS2_ELANTECH n
-MOUSE_PS2_FOCALTECH n
-MOUSE_PS2_LOGIPS2PP n
-MOUSE_PS2_SENTELIC n
-MOUSE_PS2_SYNAPTICS n
-MOUSE_PS2_SYNAPTICS_SMBUS n
-MOUSE_PS2_TOUCHKIT n
-MOUSE_PS2_TRACKPOINT n
-SERIO_ALTERA_PS2 n
-SERIO_AMBAKMI n
-SERIO_APBPS2 n
-SERIO_ARC_PS2 n
-SERIO_GPIO_PS2 n
-SERIO_LIBPS2 m
-SERIO_PCIPS2 n
-SERIO_PS2MULT n
-SERIO_RAW n
-SERIO_SERPORT m
-USERIO n
 KEYBOARD_ATKBD m -> n
 MOUSE_PS2 m -> n
 SERIO m -> n

==> configs/config-x86_64-aws-k8s-1.24-diff <==
-HYPERV_KEYBOARD m
-INPUT_IDEAPAD_SLIDEBAR n
-MOUSE_PS2_ALPS n
-MOUSE_PS2_BYD n
-MOUSE_PS2_CYPRESS n
-MOUSE_PS2_ELANTECH n
-MOUSE_PS2_FOCALTECH n
-MOUSE_PS2_LIFEBOOK y
-MOUSE_PS2_LOGIPS2PP n
-MOUSE_PS2_SENTELIC n
-MOUSE_PS2_SYNAPTICS n
-MOUSE_PS2_SYNAPTICS_SMBUS n
-MOUSE_PS2_TOUCHKIT n
-MOUSE_PS2_TRACKPOINT n
-MOUSE_PS2_VMMOUSE n
-SERIO_ALTERA_PS2 n
-SERIO_ARC_PS2 n
-SERIO_CT82C710 n
-SERIO_I8042 m
-SERIO_LIBPS2 m
-SERIO_PCIPS2 n
-SERIO_PS2MULT n
-SERIO_RAW n
-SERIO_SERPORT m
-USERIO n
 KEYBOARD_ATKBD m -> n
 MOUSE_PS2 m -> n
 SERIO m -> n

==> configs/config-x86_64-aws-k8s-1.28-diff <==
-ACER_WMI n
-HYPERV_KEYBOARD m
-INPUT_IDEAPAD_SLIDEBAR n
-INPUT_VIVALDIFMAP m
-MOUSE_PS2_ALPS n
-MOUSE_PS2_BYD n
-MOUSE_PS2_CYPRESS n
-MOUSE_PS2_ELANTECH n
-MOUSE_PS2_FOCALTECH n
-MOUSE_PS2_LIFEBOOK y
-MOUSE_PS2_LOGIPS2PP n
-MOUSE_PS2_SENTELIC n
-MOUSE_PS2_SYNAPTICS n
-MOUSE_PS2_SYNAPTICS_SMBUS n
-MOUSE_PS2_TOUCHKIT n
-MOUSE_PS2_TRACKPOINT n
-MOUSE_PS2_VMMOUSE n
-SERIO_ALTERA_PS2 n
-SERIO_ARC_PS2 n
-SERIO_CT82C710 n
-SERIO_I8042 m
-SERIO_LIBPS2 m
-SERIO_PCIPS2 n
-SERIO_PS2MULT n
-SERIO_RAW n
-SERIO_SERPORT m
-USERIO n
 KEYBOARD_ATKBD m -> n
 MOUSE_PS2 m -> n
 SERIO m -> n

==> configs/config-x86_64-metal-k8s-1.24-diff <==

==> configs/config-x86_64-metal-k8s-1.28-diff <==

==> configs/config-x86_64-vmware-k8s-1.24-diff <==

==> configs/config-x86_64-vmware-k8s-1.28-diff <==
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
