### PR TITLE
read additional local files in early-boot-config

### DIFF
--- a/sources/api/early-boot-config/src/provider/metal.rs
+++ b/sources/api/early-boot-config/src/provider/metal.rs
@@ -4,7 +4,7 @@
 use super::{PlatformDataProvider, SettingsJson};
 use async_trait::async_trait;
 
-use crate::provider::local_file::{local_file_user_data, USER_DATA_FILE};
+use crate::provider::local_file;
 
 pub(crate) struct MetalDataProvider;
 
@@ -15,9 +15,33 @@ impl PlatformDataProvider for MetalDataProvider {
     ) -> std::result::Result<Vec<SettingsJson>, Box<dyn std::error::Error>> {
         let mut output = Vec::new();
 
-        match local_file_user_data()? {
+        // First read from any site-local defaults. It's unlikely that this file will exist, since
+        // for bare metal provisioning these settings could just be written to the main user data
+        // file, but this is consistent with other platforms.
+        match local_file::user_data_defaults()? {
             Some(s) => output.push(s),
-            None => warn!("No user data found via local file: {}", USER_DATA_FILE),
+            None => info!(
+                "No user data found via site defaults file: {}",
+                local_file::USER_DATA_DEFAULTS_FILE
+            ),
+        }
+
+        // This is the main file where we expect settings, so warn if they're not found.
+        match local_file::user_data()? {
+            Some(s) => output.push(s),
+            None => warn!(
+                "No user data found via local file: {}",
+                local_file::USER_DATA_FILE
+            ),
+        }
+
+        // Finally, apply any site-local overrides.
+        match local_file::user_data_overrides()? {
+            Some(s) => output.push(s),
+            None => info!(
+                "No user data found via site overrides file: {}",
+                local_file::USER_DATA_OVERRIDES_FILE
+            ),
         }
 
         Ok(output)


### PR DESCRIPTION
**Issue number:**

Closes #3360

**Description of changes:**
This adds two new sources of user-data settings for all platforms:
* `/local/user-data-defaults.toml`
* `/local/user-data-overrides.toml`

The defaults are applied before any other source of user-data, while the overrides are applied after. This allows sites to customize the initial and final state for settings entirely through modifications to the BOTTLEROCKET-DATA filesystem.

Bottlerocket makes relatively few assumptions about that filesystem, and it's intended to be modified by site-specific workflows such as caching container images, so this is a natural fit.


**Testing done:**
aws-dev with no defaults or overrides:
```
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [INFO] early-boot-config started
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [INFO] Retrieving platform-specific data
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [INFO] No user data found via site defaults file: /local/user-data-defaults.toml
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [INFO] No user data found via local file: /var/lib/bottlerocket/user-data.toml
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [INFO] Received dynamic/instance-identity/document
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [WARN] No user data found.
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [INFO] No user data found via site overrides file: /local/user-data-overrides.toml
Sep 01 18:59:55 localhost early-boot-config[1034]: 18:59:55 [INFO] Sending instance identity document to API
```

aws-dev with defaults and overrides:
```
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] early-boot-config started
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] Retrieving platform-specific data
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] '/local/user-data-defaults.toml' exists, using it
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] No user data found via local file: /var/lib/bottlerocket/user-data.toml
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] Received dynamic/instance-identity/document
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [WARN] No user data found.
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] '/local/user-data-overrides.toml' exists, using it
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] Sending user data to API
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] Sending instance identity document to API
Sep 01 19:08:45 localhost early-boot-config[1029]: 19:08:45 [INFO] Sending user data to API
```

metal-dev with no defaults or overrides:
```
Sep 01 20:24:18 localhost early-boot-config[1105]: 20:24:18 [INFO] early-boot-config started
Sep 01 20:24:18 localhost early-boot-config[1105]: 20:24:18 [INFO] Retrieving platform-specific data
Sep 01 20:24:18 localhost early-boot-config[1105]: 20:24:18 [INFO] No user data found via site defaults file: /local/user-data-defaults.toml
Sep 01 20:24:18 localhost early-boot-config[1105]: 20:24:18 [WARN] No user data found via local file: /var/lib/bottlerocket/user-data.toml
Sep 01 20:24:18 localhost early-boot-config[1105]: 20:24:18 [INFO] No user data found via site overrides file: /local/user-data-overrides.toml
```

metal-dev with defaults and overrides:
```
Sep 01 20:11:43 localhost early-boot-config[1102]: 20:11:43 [INFO] early-boot-config started
Sep 01 20:11:43 localhost early-boot-config[1102]: 20:11:43 [INFO] Retrieving platform-specific data
Sep 01 20:11:43 localhost early-boot-config[1102]: 20:11:43 [INFO] '/local/user-data-defaults.toml' exists, using it
Sep 01 20:11:43 localhost early-boot-config[1102]: 20:11:43 [WARN] No user data found via local file: /var/lib/bottlerocket/user-data.toml
Sep 01 20:11:43 localhost early-boot-config[1102]: 20:11:43 [INFO] '/local/user-data-overrides.toml' exists, using it
Sep 01 20:11:43 localhost early-boot-config[1102]: 20:11:43 [INFO] Sending user data to API
Sep 01 20:11:43 localhost early-boot-config[1102]: 20:11:43 [INFO] Sending user data to API
```

(vmware-dev had similar output for both cases on the graphical console.)

Verified the interaction between defaults and overrides:
```
bash-5.1# cat /local/user-data-{defaults,overrides}.toml
[settings.host-containers.custom]
source = "public.ecr.aws/bottlerocket/bottlerocket-custom:v0.0.0"
enabled = true

[settings]
motd = "sup"

[settings.host-containers.custom]
user-data = "SEVZCg=="
enabled = false

bash-5.1# apiclient get settings.host-containers.custom settings.motd
{
  "settings": {
    "host-containers": {
      "custom": {
        "enabled": false,
        "source": "public.ecr.aws/bottlerocket/bottlerocket-custom:v0.0.0",
        "user-data": "SEVZCg=="
      }
    },
    "motd": "sup"
  }
}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
