### PR TITLE
tools: fix clippy warnings

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -207,9 +207,7 @@ impl VariantBuilder {
         );
         args.build_arg(
             "KERNEL_PARAMETERS",
-            kernel_parameters
-                .map(|v| v.join(" "))
-                .unwrap_or_else(|| "".to_string()),
+            kernel_parameters.map(|v| v.join(" ")).unwrap_or_default(),
         );
 
         if let Some(image_features) = image_features {

--- a/tools/pubsys/src/aws/ssm/template.rs
+++ b/tools/pubsys/src/aws/ssm/template.rs
@@ -196,7 +196,7 @@ impl From<&Vec<RenderedParameter>> for RenderedParametersMap {
         for parameter in parameters.iter() {
             parameter_map
                 .entry(parameter.ssm_key.region.to_string())
-                .or_insert(HashMap::new())
+                .or_default()
                 .insert(
                     parameter.ssm_key.name.to_owned(),
                     parameter.value.to_owned(),

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -486,7 +486,7 @@ pub(crate) trait CrdCreator: Sync {
                             .additional_fields(&test_type.to_string())
                             .into_iter()
                             // Add the image id in case it is needed for cluster creation
-                            .chain(Some(("image-id".to_string(), image_id.clone())).into_iter())
+                            .chain(Some(("image-id".to_string(), image_id.clone())))
                             .collect::<BTreeMap<String, String>>(),
                     )?,
                     hardware_csv: &crd_input


### PR DESCRIPTION


**Issue number:**

~~Looks like #1776 maybe didn't include the tools workspace. This is fine, Twoliter's CI will check for these when the code moves over.~~

Edit: maybe it's just because of a newer version of cargo.

**Description of changes:**

Fix Clippy warnings in the tools workspace.

**Testing done:**

None

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
