### PR TITLE
dependabot: Remove /tools configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,21 +26,3 @@ updates:
     labels:
       - "area/dependencies"
     open-pull-requests-limit: 0
-
-  # Enable updates for the `tools` dependencies
-  - package-ecosystem: "cargo"
-    directory: "/tools"
-    ignore:
-      # For AWS SDK for Rust, we'll update when we bump tough/coldsnap
-      - dependency-name: "aws-config"
-      - dependency-name: "aws-credential-types"
-      - dependency-name: "aws-endpoint"
-      - dependency-name: "aws-http"
-      - dependency-name: "aws-hyper"
-      - dependency-name: "aws-sig*"
-      - dependency-name: "aws-sdk*"
-      - dependency-name: "aws-smithy*"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "area/dependencies"


### PR DESCRIPTION
The tools directory is being removed in the very near future as things move over to twoliter. Dependencies will be updated there, so any updates now are questionable since they add to the churn as we try to live migrate over to the new location.

This removes the tools-specific configuration from the dependabot config to try to reduce the noise.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
