### PR TITLE
netdog: Add none to bonds for deterministic MACs

### DIFF
--- a/sources/api/netdog/test_data/networkd/netdev/bond0.netdev
+++ b/sources/api/netdog/test_data/networkd/netdev/bond0.netdev
@@ -1,6 +1,7 @@
 [NetDev]
 Name=bond0
 Kind=bond
+MACAddress=none
 [Bond]
 Mode=active-backup
 MIIMonitorSec=100

--- a/sources/api/netdog/test_data/networkd/netdev/bond1.netdev
+++ b/sources/api/netdog/test_data/networkd/netdev/bond1.netdev
@@ -1,6 +1,7 @@
 [NetDev]
 Name=bond1
 Kind=bond
+MACAddress=none
 [Bond]
 Mode=active-backup
 ARPIntervalSec=200

--- a/sources/api/netdog/test_data/networkd/netdev/bond2.netdev
+++ b/sources/api/netdog/test_data/networkd/netdev/bond2.netdev
@@ -1,6 +1,7 @@
 [NetDev]
 Name=bond2
 Kind=bond
+MACAddress=none
 [Bond]
 Mode=active-backup
 MinLinks=2


### PR DESCRIPTION
**Issue number:**

Closes #3413

**Description of changes:**
`networkd` will generate a new MAC Address for bonds by default. If MACAddress is set to none, then it will use the lowest one found which is closer to the behavior of wicked. Future work can be added to allow a user to specify the MAC Address used for a bond but currently its hard coded to use the value of none.



**Testing done:**
Before the change, a random MAC Address is generated (b2:05:75:56:9c:34): 
```
bash-5.1# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: enp0s16: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc fq_codel master bond0 state UP group default qlen 1000
    link/ether b2:05:75:56:9c:34 brd ff:ff:ff:ff:ff:ff permaddr 52:54:00:12:34:56
3: enp0s17: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc fq_codel master bond0 state UP group default qlen 1000
    link/ether b2:05:75:56:9c:34 brd ff:ff:ff:ff:ff:ff permaddr 52:54:00:12:34:57
4: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether b2:05:75:56:9c:34 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 metric 1024 brd 10.0.2.255 scope global dynamic bond0
       valid_lft 86379sec preferred_lft 86379sec
    inet6 fec0::b005:75ff:fe56:9c34/64 scope site dynamic mngtmpaddr noprefixroute
       valid_lft 86381sec preferred_lft 14381sec
    inet6 fe80::b005:75ff:fe56:9c34/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:f4:91:8f:9c brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
```

After it ends up using one that is from the set of devices ( 52:54:00:12:34:56 and  52:54:00:12:34:57 ):
```
bash-5.1# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: enp0s16: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc fq_codel master bond0 state UP group default qlen 1000
    link/ether 52:54:00:12:34:57 brd ff:ff:ff:ff:ff:ff permaddr 52:54:00:12:34:56
3: enp0s17: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc fq_codel master bond0 state UP group default qlen 1000
    link/ether 52:54:00:12:34:57 brd ff:ff:ff:ff:ff:ff
4: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 52:54:00:12:34:57 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 metric 1024 brd 10.0.2.255 scope global dynamic bond0
       valid_lft 86198sec preferred_lft 86198sec
    inet6 fec0::5054:ff:fe12:3457/64 scope site dynamic mngtmpaddr noprefixroute
       valid_lft 86199sec preferred_lft 14199sec
    inet6 fe80::5054:ff:fe12:3457/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:b6:86:33:b0 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
