### PR TITLE
support non-standard DHCP Option 15 in EC2

### DIFF
--- a/packages/systemd/9013-sd-dhcp-lease-parse-multiple-domains-in-option-15.patch
+++ b/packages/systemd/9013-sd-dhcp-lease-parse-multiple-domains-in-option-15.patch
@@ -1,0 +1,131 @@
+From 4c79d11d6888944f251681003a7b8b41606e108b Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Sat, 2 Sep 2023 16:19:22 +0000
+Subject: [PATCH] sd-dhcp-lease: parse multiple domains in option 15
+
+Non-compliant DHCP servers may pass through multiple domain names in
+Option 15, separated by a space character. This is then normalized
+into "032" by systemd-networkd, which effectively synthesizes a new
+domain name that doesn't match any of the expected ones.
+
+DHCP also supports Option 119 which specifies a compression scheme to
+avoid repeating any shared suffixes of the domain names. This option
+doesn't support space-separated domains either, so working around the
+problem isn't as straightforward as treating an Option 15 payload as
+a 119 payload instead.
+
+Deal with this by splitting the Option 15 payload on spaces first,
+before normalizing the individual domain names. If multiple domains
+are found, use them as the list of search domains unless Option 119
+is also present.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ src/libsystemd-network/sd-dhcp-lease.c | 69 +++++++++++++++++++++-----
+ 1 file changed, 56 insertions(+), 13 deletions(-)
+
+diff --git a/src/libsystemd-network/sd-dhcp-lease.c b/src/libsystemd-network/sd-dhcp-lease.c
+index b14ad57..263e97e 100644
+--- a/src/libsystemd-network/sd-dhcp-lease.c
++++ b/src/libsystemd-network/sd-dhcp-lease.c
+@@ -401,34 +401,70 @@ static int lease_parse_string(const uint8_t *option, size_t len, char **ret) {
+         return 0;
+ }
+ 
+-static int lease_parse_domain(const uint8_t *option, size_t len, char **ret) {
+-        _cleanup_free_ char *name = NULL, *normalized = NULL;
++static int lease_parse_domain_list(const uint8_t *option, size_t len, char ***ret) {
++        _cleanup_free_ char *parsed = NULL;
++        _cleanup_strv_free_ char **names = NULL, **normalized_names = NULL;
+         int r;
+ 
+         assert(option);
+         assert(ret);
+ 
+-        r = lease_parse_string(option, len, &name);
++        r = lease_parse_string(option, len, &parsed);
+         if (r < 0)
+                 return r;
+-        if (!name) {
+-                *ret = mfree(*ret);
++
++        if (!parsed)
+                 return 0;
++
++        names = strv_split(parsed, " ");
++        if (!names)
++                return -ENOMEM;
++
++        STRV_FOREACH(name, names) {
++                _cleanup_free_ char *normalized = NULL;
++
++                r = dns_name_normalize(*name, 0, &normalized);
++                if (r < 0)
++                        return r;
++
++                if (is_localhost(normalized))
++                        return -EINVAL;
++
++                if (dns_name_is_root(normalized))
++                        return -EINVAL;
++
++                r = strv_extend(&normalized_names, normalized);
++                if (r < 0)
++                        return r;
+         }
+ 
+-        r = dns_name_normalize(name, 0, &normalized);
++        strv_free_and_replace(*ret, normalized_names);
++        return 0;
++}
++
++static int lease_parse_domain(const uint8_t *option, size_t len, char **ret) {
++        _cleanup_strv_free_ char **names = NULL;
++        size_t n;
++        int r;
++
++        assert(option);
++        assert(ret);
++
++        r = lease_parse_domain_list(option, len, &names);
+         if (r < 0)
+                 return r;
+ 
+-        if (is_localhost(normalized))
+-                return -EINVAL;
+-
+-        if (dns_name_is_root(normalized))
+-                return -EINVAL;
++        n = strv_length(names);
++        if (n == 0) {
++                *ret = mfree(*ret);
++                return 0;
++        }
+ 
+-        free_and_replace(*ret, normalized);
++        r = free_and_strdup(ret, names[0]);
++        if (r < 0)
++                return r;
+ 
+-        return 0;
++        return n;
+ }
+ 
+ static int lease_parse_in_addrs(const uint8_t *option, size_t len, struct in_addr **ret, size_t *n_ret) {
+@@ -725,6 +761,13 @@ int dhcp_lease_parse_options(uint8_t code, uint8_t len, const void *option, void
+                         return 0;
+                 }
+ 
++                if (r <= 1 || !strv_isempty(lease->search_domains))
++                        break;
++
++                r = lease_parse_domain_list(option, len, &lease->search_domains);
++                if (r < 0)
++                        log_debug_errno(r, "Failed to parse Domain Search List, ignoring: %m");
++
+                 break;
+ 
+         case SD_DHCP_OPTION_DOMAIN_SEARCH:
+-- 
+2.40.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -57,6 +57,10 @@ Patch9011: 9011-systemd-networkd-Conditionalize-hostnamed-timezoned-.patch
 # as a kernel command line parameter to override.
 Patch9012: 9012-core-mount-increase-mount-rate-limit-burst-to-25.patch
 
+# Local patch to work around a potentially non-compliant Option 15 in the DHCP
+# lease in EC2.
+Patch9013: 9013-sd-dhcp-lease-parse-multiple-domains-in-option-15.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
**Issue number:**

Fixes #3412

**Description of changes:**
EC2 VPCs have an associated DHCP option set which can include a field for domain name. This data is passed to instances via DHCP Option 15 in the lease.

For Linux distros not using systemd-networkd, such as older versions of Amazon Linux and older variants of Bottlerocket, the data from the option is written into `/etc/resolv.conf` as the "search" field, with essentially no validation or normalization. Separating domain names with a space character in the VPC's DHCP option set "just works" and causes host lookups to use all of the domains in the DNS search path.

However, systemd-networkd normalizes the Option 15 payload, replacing the space character with "032". While this results in a valid domain name, it doesn't match any of the ones that are present in the VPC's DHCP option set, and breaks this accidentally useful but non-standard functionality.

Ideally, any EC2 VPC DHCP option sets relying on this behavior would be modified to set only one domain name. Unfortunately, DHCP option sets are a VPC-wide setting, so the change can't be restricted to a subset of instances without creating a new VPC for those instances.

Alternatively, EC2 could detect when space-separated domain names are present in the DHCP option set, then use DHCP Option 15 for the first domain name and DHCP Option 119 for the full list.

In the meantime, carry a patch to cause systemd-networkd to do that instead: treat Option 15 as a potentially space-separated list of domain names; use the first such domain as the domain name; and use the full list for search domains unless Option 119 is provided.


**Testing done:**
No domain name in option set:
```
# /run/systemd/netif/leases/2
<no DOMAINNAME>
<no DOMAIN_SEARCH_LIST>

#/etc/resolv.conf
...
search .
```

One domain name in option set:
```
# /run/systemd/netif/leases/2
DOMAINNAME=us-west-2.compute.internal
<no DOMAIN_SEARCH_LIST>

# /etc/resolv.conf
search us-west-2.compute.internal
```

Two domain names in option set:
```
# /run/systemd/netif/leases/2
DOMAINNAME=us-west-2.compute.internal
DOMAIN_SEARCH_LIST=us-west-2.compute.internal cressey.org

# /etc/resolv.conf
search us-west-2.compute.internal cressey.org
```

253 characters' worth of domain names in option set:
```
# /run/systemd/netif/leases/2
DOMAINNAME=so-many.kubernetes-instances.dev.pets2.ec2.vpc.ben.cressey.org
DOMAIN_SEARCH_LIST=so-many.kubernetes-instances.dev.pets2.ec2.vpc.ben.cressey.org kubernetes-instances.dev.pets2.ec2.vpc.ben.cressey.org dev.pets2.ec2.vpc.ben.cressey.org pets2.ec2.vpc.ben.cressey.org ec2.vpc.ben.cressey.org vpc.ben.cressey.org ben.cressey.org cressey.org

# /etc/resolv.conf
...
search so-many.kubernetes-instances.dev.pets2.ec2.vpc.ben.cressey.org kubernetes-instances.dev.pets2.ec2.vpc.ben.cressey.org dev.pets2.ec2.vpc.ben.cressey.org pets2.ec2.vpc.ben.cressey.org ec2.vpc.ben.cressey.org vpc.ben.cressey.org ben.cressey.org cressey.org
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
