### PR TITLE
firmware: Enable firmware compression to conserve some disk space

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket-metal
+++ b/packages/kernel-5.10/config-bottlerocket-metal
@@ -110,3 +110,6 @@ CONFIG_SCSI_VIRTIO=y
 # Intel Volume Management Device driver, to support boot disks in a separate
 # PCI domain.
 CONFIG_VMD=y
+
+# Support handling of compressed firmware
+CONFIG_FW_LOADER_COMPRESS=y

--- a/packages/kernel-5.15/config-bottlerocket-metal
+++ b/packages/kernel-5.15/config-bottlerocket-metal
@@ -147,3 +147,6 @@ CONFIG_MOUSE_PS2=m
 # Intel Volume Management Device driver, to support boot disks in a separate
 # PCI domain.
 CONFIG_VMD=y
+
+# Support handling of compressed firmware
+CONFIG_FW_LOADER_COMPRESS=y

--- a/packages/kernel-6.1/config-bottlerocket-metal
+++ b/packages/kernel-6.1/config-bottlerocket-metal
@@ -145,3 +145,7 @@ CONFIG_MOUSE_PS2=m
 # Intel Volume Management Device driver, to support boot disks in a separate
 # PCI domain.
 CONFIG_VMD=y
+
+# Support handling of compressed firmware
+CONFIG_FW_LOADER_COMPRESS=y
+CONFIG_FW_LOADER_COMPRESS_XZ=y

--- a/packages/linux-firmware/linux-firmware.spec
+++ b/packages/linux-firmware/linux-firmware.spec
@@ -48,17 +48,9 @@ Patch0010: 0010-linux-firmware-amd-ucode-Remove-amd-microcode.patch
 mkdir -p %{buildroot}/%{fwdir}
 mkdir -p %{buildroot}/%{fwdir}/updates
 
-# Here we have potential to shave off some extra space by using `install-xz` of
-# `install-zst` to compress firmware images on disk. However, that functionality
-# relies on kernels being configured with `CONFIG_FW_LOADER_COMPRESS_[ZSTD|XZ]`
-# which we currently do not have.
-make DESTDIR=%{buildroot}/ FIRMWAREDIR=%{fwdir} install
-
-
-# Remove executable bits from random firmware
-pushd %{buildroot}/%{fwdir}
-find . -type f -executable -exec chmod -x {} \;
-popd
+# Use xz compression for firmware files to reduce size on disk. This relies on
+# kernel support through FW_LOADER_COMPRESS (and FW_LOADER_COMPRESS_XZ for kernels >=5.19)
+make DESTDIR=%{buildroot}/ FIRMWAREDIR=%{fwdir} install-xz
 
 %files
 %dir %{fwdir}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3359 

**Description of changes:**

When we introduced the linux-firmware package in https://github.com/bottlerocket-os/bottlerocket/pull/3296, we did not enable
compression as we had not have the necessary support in our kernels enabled. This PR fixes this by enabling the necessary
config options. Before linux kernel series 5.19 the firmware compression code only supported XZ compression, hence we do
not need (and cant) select a specific compression algorithm. With 6.1 we need to additionally select XZ compression.

This change saves about 4mb in the package size, and even 36 mb in unpacked form:
```
$ ls -ahl before after
after:
total 25M
drwxr-xr-x. 3 fedora fedora 4.0K Sep  6 12:08 .
drwxr-xr-x. 4 fedora fedora 4.0K Sep  6 11:38 ..
-rw-r--r--. 1 fedora fedora  25M Sep  6 11:43 bottlerocket-linux-firmware-20230625-1.x86_64.rpm
drwxr-xr-x. 3 fedora fedora 4.0K Sep  6 12:08 x86_64-bottlerocket-linux-gnu

before:
total 29M
drwxr-xr-x. 3 fedora fedora 4.0K Sep  6 12:08 .
drwxr-xr-x. 4 fedora fedora 4.0K Sep  6 11:38 ..
-rw-r--r--. 1 fedora fedora  29M Sep  6 11:40 bottlerocket-linux-firmware-20230625-1.x86_64.rpm
drwxr-xr-x. 3 fedora fedora 4.0K Sep  6 12:08 x86_64-bottlerocket-linux-gnu
$ du -sh before/x86_64-bottlerocket-linux-gnu/
61M	before/x86_64-bottlerocket-linux-gnu/
$ du -sh after/x86_64-bottlerocket-linux-gnu/
25M	after/x86_64-bottlerocket-linux-gnu/
```

**Testing done:**

Proper testing for this is tricky, as we do not have access to any of the hardware this package includes.

Only the expected config changes are recorded for this patch:

```
$ cat configs_firmware_compression/diff-report 
==> configs_firmware_compression/config-aarch64-metal-dev-diff <==
 FW_LOADER_COMPRESS n -> y
+FW_LOADER_COMPRESS_XZ y
+FW_LOADER_COMPRESS_ZSTD n

==> configs_firmware_compression/config-x86_64-metal-dev-diff <==
 FW_LOADER_COMPRESS n -> y
+FW_LOADER_COMPRESS_XZ y
+FW_LOADER_COMPRESS_ZSTD n

==> configs_firmware_compression/config-x86_64-metal-k8s-1.23-diff <==
 FW_LOADER_COMPRESS n -> y

==> configs_firmware_compression/config-x86_64-metal-k8s-1.27-diff <==
 FW_LOADER_COMPRESS n -> y
```

Apart from that we can not really 
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
