### PR TITLE
kernel: enable Intel VMD driver for metal variants

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket-metal
+++ b/packages/kernel-5.10/config-bottlerocket-metal
@@ -106,3 +106,7 @@ CONFIG_SCSI_SMARTPQI=y
 
 # Support for virtio scsi boot devices for other cloud providers
 CONFIG_SCSI_VIRTIO=y
+
+# Intel Volume Management Device driver, to support boot disks in a separate
+# PCI domain.
+CONFIG_VMD=y

--- a/packages/kernel-5.15/config-bottlerocket-metal
+++ b/packages/kernel-5.15/config-bottlerocket-metal
@@ -143,3 +143,7 @@ CONFIG_MOUSE_PS2=m
 # CONFIG_MOUSE_PS2_SENTELIC is not set
 # CONFIG_MOUSE_PS2_TOUCHKIT is not set
 # CONFIG_MOUSE_PS2_FOCALTECH is not set
+
+# Intel Volume Management Device driver, to support boot disks in a separate
+# PCI domain.
+CONFIG_VMD=y

--- a/packages/kernel-6.1/config-bottlerocket-metal
+++ b/packages/kernel-6.1/config-bottlerocket-metal
@@ -141,3 +141,7 @@ CONFIG_MOUSE_PS2=m
 # CONFIG_MOUSE_PS2_SENTELIC is not set
 # CONFIG_MOUSE_PS2_TOUCHKIT is not set
 # CONFIG_MOUSE_PS2_FOCALTECH is not set
+
+# Intel Volume Management Device driver, to support boot disks in a separate
+# PCI domain.
+CONFIG_VMD=y


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** Enabling the Intel Volume Management Device driver for metal variants lets Bottlerocket boot on hosts that have a root disk in a separate PCI domain.

**Testing done:** A Siemens SIMATIC IPC BX-39A with an NVMe drive failed to boot without this, being unable to discover the partitions needed to assemble the dm-verity root. With this change the drive was found and the host booted.

`diff-kernel-config`:

```
config-aarch64-aws-dev-diff:              0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.23-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.27-diff:         0 removed,   0 added,   0 changed
config-aarch64-metal-dev-diff:            0 removed,   0 added,   0 changed
config-x86_64-aws-dev-diff:               0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.27-diff:          0 removed,   0 added,   0 changed
config-x86_64-metal-dev-diff:             0 removed,   0 added,   1 changed
config-x86_64-metal-k8s-1.23-diff:        0 removed,   0 added,   1 changed
config-x86_64-metal-k8s-1.27-diff:        0 removed,   0 added,   1 changed
```

```
[...removed variants without changes...]
==> /home/fedora/kernel-diff-vmd/config-x86_64-metal-dev-diff <==
 VMD n -> y

==> /home/fedora/kernel-diff-vmd/config-x86_64-metal-k8s-1.23-diff <==
 VMD n -> y

==> /home/fedora/kernel-diff-vmd/config-x86_64-metal-k8s-1.27-diff <==
 VMD n -> y
```




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
