### PR TITLE
schnauzer: add ca-west-1 to registry maps

### DIFF
--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -36,6 +36,7 @@ lazy_static! {
         m.insert("ap-southeast-3", "386774335080");
         m.insert("ap-southeast-4", "731751899352");
         m.insert("ca-central-1", "328549459982");
+        m.insert("ca-west-1", "253897149516");
         m.insert("cn-north-1", "183470599484");
         m.insert("cn-northwest-1", "183901325759");
         m.insert("eu-central-1", "328549459982");
@@ -82,6 +83,7 @@ lazy_static! {
         m.insert("ap-southeast-3", "296578399912");
         m.insert("ap-southeast-4", "491585149902");
         m.insert("ca-central-1", "602401143452");
+        m.insert("ca-west-1", "761377655185");
         m.insert("cn-north-1", "918309763551");
         m.insert("cn-northwest-1", "961992271922");
         m.insert("eu-central-1", "602401143452");

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -581,7 +581,6 @@ func cleanUp(containerdSocket string, namespace string, containerID string) erro
 // Referenced source: https://github.com/awslabs/amazon-ecr-containerd-resolver/blob/a5058cf091f4fc573813a032db37a9820952f1f9/ecr/ref.go#L70-L71
 func parseImageURISpecialRegions(input string) (ecr.ECRSpec, error) {
 	ecrRefPrefixMapping := map[string]string{
-		"il-central-1": "ecr.aws/arn:aws:ecr:il-central-1:",
 		"ca-west-1": "ecr.aws/arn:aws:ecr:ca-west-1:",
 	}
 	// Matching on account, region

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -582,6 +582,7 @@ func cleanUp(containerdSocket string, namespace string, containerID string) erro
 func parseImageURISpecialRegions(input string) (ecr.ECRSpec, error) {
 	ecrRefPrefixMapping := map[string]string{
 		"il-central-1": "ecr.aws/arn:aws:ecr:il-central-1:",
+		"ca-west-1": "ecr.aws/arn:aws:ecr:ca-west-1:",
 	}
 	// Matching on account, region
 	matches := ecrRegex.FindStringSubmatch(input)


### PR DESCRIPTION
**Description of changes:**

Adds **ca-west-1** to `schnauzer` and `host-ctr`.

Also removes **il-central-1** as a special region in `host-ctr`.

**Testing done:**

Launched AMI in **il-central-1** and connected to the control container.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
