### PR TITLE
netdog: Add BindCarrier to bond network files

### DIFF
--- a/sources/api/netdog/src/networkd/config/network.rs
+++ b/sources/api/netdog/src/networkd/config/network.rs
@@ -73,6 +73,8 @@ struct NetworkSection {
     vlan: Vec<InterfaceName>,
     #[systemd(entry = "KeepConfiguration")]
     keep_configuration: Option<KeepConfiguration>,
+    #[systemd(entry = "BindCarrier")]
+    bind_carrier: Vec<InterfaceName>,
 }
 
 #[derive(Debug, Default, SystemdUnitSection)]
@@ -376,6 +378,11 @@ impl NetworkBuilder<Bond> {
             network,
             spooky: PhantomData,
         }
+    }
+
+    /// Bind workers to bond for carrier detection
+    pub(crate) fn with_bind_carrier(&mut self, interfaces: Vec<InterfaceName>) {
+        self.network.network_mut().bind_carrier = interfaces;
     }
 }
 
@@ -697,6 +704,7 @@ mod tests {
         if let Some(r) = bond.routes {
             network.with_routes(r)
         }
+        network.with_bind_carrier(bond.interfaces);
         network.build()
     }
 

--- a/sources/api/netdog/src/networkd/devices/bond.rs
+++ b/sources/api/netdog/src/networkd/devices/bond.rs
@@ -83,6 +83,8 @@ impl NetworkFileCreator for NetworkDBond {
         maybe_add_some!(network, with_static_config, static6);
         maybe_add_some!(network, with_routes, routes);
 
+        network.with_bind_carrier(interfaces.clone());
+
         // Attach VLANs to this interface, if any
         if let Some(vlans) = vlans.get(name) {
             network.with_vlans(vlans.to_vec())

--- a/sources/api/netdog/test_data/networkd/network/bond0.network
+++ b/sources/api/netdog/test_data/networkd/network/bond0.network
@@ -5,5 +5,7 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+BindCarrier=eno51
+BindCarrier=eno52
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/bond0.network
+++ b/sources/api/netdog/test_data/networkd/network/bond0.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+KeepConfiguration=dhcp
 BindCarrier=eno51
 BindCarrier=eno52
 [DHCPv4]

--- a/sources/api/netdog/test_data/networkd/network/bond1.network
+++ b/sources/api/netdog/test_data/networkd/network/bond1.network
@@ -5,5 +5,7 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+BindCarrier=eno53
+BindCarrier=eno54
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/bond1.network
+++ b/sources/api/netdog/test_data/networkd/network/bond1.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+KeepConfiguration=dhcp
 BindCarrier=eno53
 BindCarrier=eno54
 [DHCPv4]

--- a/sources/api/netdog/test_data/networkd/network/bond2.network
+++ b/sources/api/netdog/test_data/networkd/network/bond2.network
@@ -5,5 +5,8 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv6
+BindCarrier=eno55
+BindCarrier=eno56
+BindCarrier=eno57
 [IPv6AcceptRA]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/bond2.network
+++ b/sources/api/netdog/test_data/networkd/network/bond2.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv6
+KeepConfiguration=dhcp
 BindCarrier=eno55
 BindCarrier=eno56
 BindCarrier=eno57

--- a/sources/api/netdog/test_data/networkd/network/eno1-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno1-ra.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 [Network]
 DHCP=ipv4
 IPv6AcceptRA=true
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [DHCPv6]

--- a/sources/api/netdog/test_data/networkd/network/eno1.network
+++ b/sources/api/netdog/test_data/networkd/network/eno1.network
@@ -4,5 +4,6 @@ Name=eno1
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno10-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno10-ra.network
@@ -5,6 +5,7 @@ RequiredForOnline=false
 [Network]
 DHCP=ipv6
 IPv6AcceptRA=true
+KeepConfiguration=dhcp
 [DHCPv6]
 WithoutRA=solicit
 [IPv6AcceptRA]

--- a/sources/api/netdog/test_data/networkd/network/eno10.network
+++ b/sources/api/netdog/test_data/networkd/network/eno10.network
@@ -4,5 +4,6 @@ Name=eno10
 RequiredForOnline=false
 [Network]
 DHCP=ipv6
+KeepConfiguration=dhcp
 [IPv6AcceptRA]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno1001.network
+++ b/sources/api/netdog/test_data/networkd/network/eno1001.network
@@ -5,5 +5,6 @@ RequiredForOnline=true
 [Network]
 DHCP=ipv4
 VLAN=vlancfgdev
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno18.network
+++ b/sources/api/netdog/test_data/networkd/network/eno18.network
@@ -6,5 +6,6 @@ RequiredForOnline=true
 Address=10.0.0.10/24
 Address=11.0.0.11/24
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno19.network
+++ b/sources/api/netdog/test_data/networkd/network/eno19.network
@@ -6,5 +6,6 @@ RequiredForOnline=true
 Address=3001:f00f:f00f::2/64
 Address=3001:f00f:f00f::3/64
 DHCP=ipv6
+KeepConfiguration=dhcp
 [IPv6AcceptRA]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno2-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno2-ra.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 [Network]
 DHCP=ipv6
 IPv6AcceptRA=true
+KeepConfiguration=dhcp
 [DHCPv6]
 WithoutRA=solicit
 [IPv6AcceptRA]

--- a/sources/api/netdog/test_data/networkd/network/eno2.network
+++ b/sources/api/netdog/test_data/networkd/network/eno2.network
@@ -4,5 +4,6 @@ Name=eno2
 RequiredForOnline=true
 [Network]
 DHCP=ipv6
+KeepConfiguration=dhcp
 [IPv6AcceptRA]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno3.network
+++ b/sources/api/netdog/test_data/networkd/network/eno3.network
@@ -5,5 +5,6 @@ RequiredForOnline=true
 RequiredFamilyForOnline=ipv4
 [Network]
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno4.network
+++ b/sources/api/netdog/test_data/networkd/network/eno4.network
@@ -5,5 +5,6 @@ RequiredForOnline=true
 RequiredFamilyForOnline=ipv6
 [Network]
 DHCP=ipv6
+KeepConfiguration=dhcp
 [IPv6AcceptRA]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno5-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno5-ra.network
@@ -6,6 +6,7 @@ RequiredFamilyForOnline=both
 [Network]
 DHCP=yes
 IPv6AcceptRA=true
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [DHCPv6]

--- a/sources/api/netdog/test_data/networkd/network/eno5.network
+++ b/sources/api/netdog/test_data/networkd/network/eno5.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 RequiredFamilyForOnline=both
 [Network]
 DHCP=yes
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [IPv6AcceptRA]

--- a/sources/api/netdog/test_data/networkd/network/eno6.network
+++ b/sources/api/netdog/test_data/networkd/network/eno6.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 RequiredFamilyForOnline=ipv4
 [Network]
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 RouteMetric=100
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/eno7-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno7-ra.network
@@ -6,6 +6,7 @@ RequiredFamilyForOnline=ipv4
 [Network]
 DHCP=yes
 IPv6AcceptRA=true
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [DHCPv6]

--- a/sources/api/netdog/test_data/networkd/network/eno7.network
+++ b/sources/api/netdog/test_data/networkd/network/eno7.network
@@ -5,6 +5,7 @@ RequiredForOnline=true
 RequiredFamilyForOnline=ipv4
 [Network]
 DHCP=yes
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [IPv6AcceptRA]

--- a/sources/api/netdog/test_data/networkd/network/eno8-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno8-ra.network
@@ -5,6 +5,7 @@ RequiredForOnline=false
 [Network]
 DHCP=yes
 IPv6AcceptRA=true
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [DHCPv6]

--- a/sources/api/netdog/test_data/networkd/network/eno8.network
+++ b/sources/api/netdog/test_data/networkd/network/eno8.network
@@ -4,6 +4,7 @@ Name=eno8
 RequiredForOnline=false
 [Network]
 DHCP=yes
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [IPv6AcceptRA]

--- a/sources/api/netdog/test_data/networkd/network/eno9-ra.network
+++ b/sources/api/netdog/test_data/networkd/network/eno9-ra.network
@@ -5,6 +5,7 @@ RequiredForOnline=false
 [Network]
 DHCP=ipv4
 IPv6AcceptRA=true
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true
 [DHCPv6]

--- a/sources/api/netdog/test_data/networkd/network/eno9.network
+++ b/sources/api/netdog/test_data/networkd/network/eno9.network
@@ -4,5 +4,6 @@ Name=eno9
 RequiredForOnline=false
 [Network]
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/f874a4d53264.network
+++ b/sources/api/netdog/test_data/networkd/network/f874a4d53264.network
@@ -4,5 +4,6 @@ PermanentMACAddress=f8:74:a4:d5:32:64
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/f874a4d53265.network
+++ b/sources/api/netdog/test_data/networkd/network/f874a4d53265.network
@@ -4,5 +4,6 @@ PermanentMACAddress=f8:74:a4:d5:32:65
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/f874a4d53266.network
+++ b/sources/api/netdog/test_data/networkd/network/f874a4d53266.network
@@ -4,5 +4,6 @@ PermanentMACAddress=f8:74:a4:d5:32:66
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/myvlan.network
+++ b/sources/api/netdog/test_data/networkd/network/myvlan.network
@@ -5,5 +5,6 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/api/netdog/test_data/networkd/network/vlancfgdev.network
+++ b/sources/api/netdog/test_data/networkd/network/vlancfgdev.network
@@ -5,5 +5,6 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true


### PR DESCRIPTION

**Issue number:**

Closes #3425

**Description of changes:**
networkd will lose track of carrier for worker devices in a bond when bringing it up. This causes a delay in the bond becoming routable while the devices re-establish carrier status. This change adds BindCarrier to bond .network files which ensures networkd brings up the bond if at least one link has carrier.


**Testing done:**
This produces quicker boots and the bonds become routable quickly as expected:

```
[    2.816654] bond0: (slave enp0s17): Enslaving as a backup interface with an up link
[    2.817785] bond0: (slave enp0s16): Enslaving as a backup interface with an up link
[    3.055789] bond0: (slave enp0s17): link status definitely up, 0 Mbps full duplex
[    3.057791] bond0: (slave enp0s17): making interface the new active one
[    3.060579] bond0: active interface up!
[    3.061597] IPv6: ADDRCONF(NETDEV_CHANGE): bond0: link becomes ready
[    5.561715] ACPI: bus type drm_connector registered
[    6.076869] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
[    6.080478] Bridge firewalling registered
[    6.242966] Initializing XFRM netlink socket
[    6.618105] fbcon: Taking over console
[    6.619157] Console: switching to colour frame buffer device 160x50
[  207.715645] bond0: (slave enp0s16): link status definitely up, 0 Mbps full duplex
[  207.717310] bond0: (slave enp0s16): making interface the new active one
```
The backstop message still appears, but the network is useable well before this (fetched immediately after my `metal-dev` instance booted and provided a login prompt:
```
bash-5.1# networkctl
IDX LINK    TYPE     OPERATIONAL SETUP
  1 lo      loopback carrier     unmanaged
  2 enp0s16 ether    enslaved    configured
  3 enp0s17 ether    enslaved    configured
  4 bond0   bond     routable    configured
  5 docker0 bridge   no-carrier  unmanaged

5 links listed.
```

Tests were also updated to ensure this change shows up in the resulting configurations.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
