### PR TITLE
actions: Do not continue on error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,13 +42,13 @@ jobs:
     runs-on:
       group: bottlerocket
       labels: bottlerocket_ubuntu-latest_32-core
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       matrix:
         variant: ${{ fromJson(needs.list-variants.outputs.variants) }}
         arch: [x86_64, aarch64]
         exclude: ${{ fromJson(needs.list-variants.outputs.aarch-enemies) }}
-      fail-fast: false
+      fail-fast: true
     name: "Build ${{ matrix.variant }}-${{ matrix.arch }}"
     steps:
       - name: Random delay


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

We've set the `fail-fast` setting in the GitHub Action that runs on every PR to `false`. This means that even if one of the variants encounters an error, all other variants will continue to run.

This is useful in getting data if a failure only impacts one specific variant, but in some cases this means that we will run X number of jobs for all variants that have no chance of succeeding, resulting in a waste of Action runner resources.

There are times when we hit failures due to intermittent network or other issues, but there are also times where there are things like packages being added that have not been put in the lookaside cache. In either case, someone will need to look at the failure and determine what went wrong. For those intermittent failures, it's easy enough to trigger the actions to run again. But if there is a change required to the code or something that is not just an intermittent failure, this would allow the necessary actions to take place before wasting any more resources.

This also flips `continue-on-error` from `true` to `false`. Similar to `fail-fast`, `continue-on-error` allows subsequent steps to run even if a previous step has failed. While this may provide some useful data, it can also cause unnecessary processing time for something that will not pass.

**Testing done:**

Just reading docs, will see how this works in practice and adjust as needed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
