### PR TITLE
netdog: fix clippy for systemd

### DIFF
--- a/sources/api/netdog/src/networkd/config/netdev.rs
+++ b/sources/api/netdog/src/networkd/config/netdev.rs
@@ -135,7 +135,7 @@ enum NetDevMacAddress {
 impl Display for NetDevMacAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NetDevMacAddress::MacAddress(m) => write!(f, "{}", m.to_string()),
+            NetDevMacAddress::MacAddress(m) => write!(f, "{}", m),
             NetDevMacAddress::Nothing => write!(f, "none"),
         }
     }


### PR DESCRIPTION
Minor tidy commit to fix a clippy warning missed since its only in the systemd side of netdog.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
