### PR TITLE
early-boot-config: prevent parsing empty user data

### DIFF
--- a/sources/api/early-boot-config/src/provider/aws.rs
+++ b/sources/api/early-boot-config/src/provider/aws.rs
@@ -33,6 +33,11 @@ impl AwsDataProvider {
             .context(error::DecompressionSnafu { what: "user data" })?;
         trace!("Received user data: {}", user_data_str);
 
+        // Return early to prevent parsing an empty string
+        if user_data_str.trim().is_empty() {
+            return Ok(None);
+        }
+
         let json = SettingsJson::from_toml_str(&user_data_str, "user data").context(
             error::SettingsToJSONSnafu {
                 from: "instance user data",


### PR DESCRIPTION
Now early-boot-config returns earlier, before it attempts to parse an empty user data string

**Issue number:**

Closes #1470

**Description of changes:**

`early-boot-config` fails to parse empty user data strings. With this change, the `user_data` function returns earlier, before attempting to deserialize it.

**Testing done:**
In `aws-ecs-1`, with empty user data, the instance boots:

```bash
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "8eb7c5fe-dirty",
    "pretty_name": "Bottlerocket OS 1.15.0 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.15.0"
  }
}
[root@admin]# journalctl -D /.bottlerocket/rootfs/var/log/journal/ -u early-boot-config.service
-- Logs begin at Fri 2023-09-08 00:27:03 UTC, end at Fri 2023-09-08 00:31:34 UTC. --
Sep 08 00:27:08 localhost systemd[1]: Starting Bottlerocket userdata configuration system...
Sep 08 00:27:09 localhost early-boot-config[1674]: 00:27:09 [INFO] early-boot-config started
Sep 08 00:27:09 localhost early-boot-config[1674]: 00:27:09 [INFO] Retrieving platform-specific data
Sep 08 00:27:09 localhost early-boot-config[1674]: 00:27:09 [WARN] No user data found via local file: /var/lib/bottlerocket/user-data.toml
Sep 08 00:27:09 localhost early-boot-config[1674]: 00:27:09 [INFO] Received dynamic/instance-identity/document
Sep 08 00:27:09 localhost early-boot-config[1674]: 00:27:09 [INFO] Received user-data
Sep 08 00:27:09 localhost early-boot-config[1674]: 00:27:09 [WARN] No user data found.
Sep 08 00:27:09 localhost early-boot-config[1674]: 00:27:09 [INFO] Sending instance identity document to API
Sep 08 00:27:09 localhost systemd[1]: Finished Bottlerocket userdata configuration system.
Sep 08 00:27:39 ip-XXX-YY-ZZ-WW.us-west-2.compute.internal systemd[1]: early-boot-config.service: Deactivated successfully.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
