### PR TITLE
nvidia-variants: fix deleted NVIDIA char devices

### DIFF
--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -16,6 +16,7 @@ Source0: https://%{goimport}/archive/v%{gover}/nvidia-container-toolkit-%{gover}
 Source1: nvidia-container-toolkit-config.toml
 Source2: nvidia-container-toolkit-tmpfiles.conf
 Source3: nvidia-oci-hooks-json
+Source4: nvidia-gpu-devices.rules
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container
@@ -31,24 +32,30 @@ Requires: %{_cross_os}shimpei
 %build
 %cross_go_configure %{goimport}
 go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime-hook ./cmd/nvidia-container-runtime-hook
+go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o nvidia-ctk ./cmd/nvidia-ctk
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_templatedir}
+install -d %{buildroot}%{_cross_udevrulesdir}
 install -d %{buildroot}%{_cross_datadir}/nvidia-container-toolkit
 install -d %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime
 install -p -m 0755 nvidia-container-runtime-hook %{buildroot}%{_cross_bindir}/
+install -p -m 0755 nvidia-ctk %{buildroot}%{_cross_bindir}/
 install -m 0644 %{S:1} %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime/config.toml
 install -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit.conf
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-oci-hooks-json
+install -p -m 0644 %{S:4} %{buildroot}%{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules
 ln -s shimpei %{buildroot}%{_cross_bindir}/nvidia-oci
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_bindir}/nvidia-container-runtime-hook
+%{_cross_bindir}/nvidia-ctk
 %{_cross_bindir}/nvidia-oci
 %{_cross_templatedir}/nvidia-oci-hooks-json
 %{_cross_factorydir}/etc/nvidia-container-runtime/config.toml
 %{_cross_tmpfilesdir}/nvidia-container-toolkit.conf
+%{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules

--- a/packages/nvidia-container-toolkit/nvidia-gpu-devices.rules
+++ b/packages/nvidia-container-toolkit/nvidia-gpu-devices.rules
@@ -1,0 +1,2 @@
+# This will create /dev/char symlinks to all device nodes
+ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/usr/bin/nvidia-ctk system create-dev-char-symlinks --create-all"

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
@@ -6,7 +6,7 @@ After=kubelet.service
 Wants=kubelet.service
 
 [Service]
-ExecStart=/usr/bin/nvidia-device-plugin
+ExecStart=/usr/bin/nvidia-device-plugin --pass-device-specs=true
 Type=simple
 TimeoutSec=0
 RestartSec=2


### PR DESCRIPTION
**Issue number:**

Closes #3072

**Description of changes:**

After some time, or by executing `systemctl daemon-reload`, the NVIDIA char devices are deleted from the containers, and tools like `nvidia-smi` stop working. In #3072, it was suggested that the issue should be gone if systemd `240` was used in conjunction with runc >= `1.1.7`. I built Bottlerocket from the tip of develop (since now we include systemd `252` and runc `1.1.9`) to confirm if the problem was fixed, but it wasn't. I even tried with a variant with cgroups v2 enabled, since according to [this comment], that could fix the problem, but it didn't.

I followed what was suggested in [this NOTICE], specifically, the steps under “For K8s environments”, which include:

- Create a `udev` rule that calls `nvidia-ctx` to create the char devices
- Per [this suggestion], pass `pass-device-specs` to the NVIDIA device plugin

According to the NVIDIA device plugin documentation, `pass-device-specs` “exists for the sole purpose of allowing the device plugin to interoperate with the CPUManager in Kubernetes. Setting this flag also requires one to deploy the daemonset with elevated privileges, so only do so if you know you need to interoperate with the CPUManager.”

We don't deploy the NVIDIA device plugin as a daemonset, rather it is executed as a system service. Thus, the service doesn't need additional privileges to work with the new flag.

[this comment]: https://github.com/NVIDIA/nvidia-docker/issues/1671#issuecomment-1236824748 
[this NOTICE]: https://github.com/NVIDIA/nvidia-docker/issues/1730
[this suggestion]: https://github.com/NVIDIA/nvidia-docker/issues/1671#issuecomment-1532305701

**Testing done:**

- In `aws-k8s-1.27`, I deployed a pod with one GPU, executed `systemctl daemon-reload`, and confirmed that `nvidia-smi` from the pod still worked
- In `aws-k8s-1.28`, I deployed a pod with one GPU, executed `systemctl daemon-reload`, and confirmed that `nvidia-smi` from the pod still worked

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
