### PR TITLE
housekeeping: Remove redundant dependabot.yaml

### DIFF
--- a/dependabot.yaml
+++ b/dependabot.yaml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every month
-      interval: "monthly"


### PR DESCRIPTION
**Description of changes:**

We have more extensive dependabot configuration now in `.github/dependabot.yaml`, so this file is not needed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
