### PR TITLE
start-local-vm: allow resizing the extracted images before boot

### DIFF
--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -54,6 +54,7 @@ usage: ${0##*/} [--arch BUILDSYS_ARCH] [--variant BUILDSYS_VARIANT]
                       [--force-extract]
                       [--inject-file LOCAL_PATH[:IMAGE_PATH]]...
                       [--firmware-code PATH] [--firmware-vars PATH]
+                      [--os-image-size SIZE] [--data-image-size SIZE]
 
 Launch a local virtual machine from a Bottlerocket image.
 
@@ -82,6 +83,8 @@ Options:
                         private partition will be lost
     --firmware-code     override the default firmware executable file
     --firmware-vars     override the initial firmware variable storage file
+    --os-image-size     resize the OS disk image to the given size (e.g. 4096M)
+    --data-image-size   resize the data disk image to the given size (e.g. 20G)
     --help              shows this usage text
 
 By default, the virtual machine's port 22 (SSH) will be exposed via the local
@@ -147,6 +150,12 @@ parse_args() {
             --firmware-vars)
                 shift; firmware_vars=$1
                 ;;
+            --os-image-size)
+                shift; os_image_size=$1
+                ;;
+            --data-image-size)
+                shift; data_image_size=$1
+                ;;
             *)
                 usage_error "unknown option '$1'" ;;
         esac
@@ -193,6 +202,20 @@ prepare_raw_images() {
     else
         # Missing data image is fine. This variant may not be a split build.
         readonly data_image=
+    fi
+
+    if [[ -n ${os_image_size} ]]; then
+        truncate --no-create --size "${os_image_size}" "${os_image}" \
+            || bail "Failed to resize OS image '${os_image}'."
+    fi
+
+    if [[ -n ${data_image_size} ]]; then
+        if [[ -e ${data_image} ]]; then
+            truncate --no-create --size "${data_image_size}" "${data_image}" \
+                || bail "Failed to resize data image '${data_image}'."
+        else
+            >&2 echo "Ignoring option --data-image-size ${data_image_size} since no data image was found."
+        fi
     fi
 }
 

--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -4,7 +4,7 @@
 #
 # Common error handling
 #
-#
+
 exit_trap_cmds=()
 
 on_exit() {
@@ -49,8 +49,11 @@ show_usage() {
     echo "\
 usage: ${0##*/} [--arch BUILDSYS_ARCH] [--variant BUILDSYS_VARIANT]
                       [--host-port-forwards HOST_PORT_FWDS]
+                      [--product-name NAME]
                       [--vm-memory VM_MEMORY] [--vm-cpus VM_CPUS]
+                      [--force-extract]
                       [--inject-file LOCAL_PATH[:IMAGE_PATH]]...
+                      [--firmware-code PATH] [--firmware-vars PATH]
 
 Launch a local virtual machine from a Bottlerocket image.
 
@@ -61,10 +64,9 @@ Options:
                         BUILDSYS_ARCH environment variable is set)
     --variant           Bottlerocket variant to run (may be omitted if the
                         BUILDSYS_VARIANT environment variable is set)
-    --product-name
-                        product name used for file and directory naming used when
-                        building with the "-e BUILDSYS_NAME" option; may be omitted if the
-                        BUILDSYS_NAME environment variable is set. Otherwise default is bottlerocket if not defined or empty
+    --product-name      short product name used as prefix for file and directory
+                        names (defaults to the BUILDSYS_NAME environment variable
+                        or 'bottlerocket' when that is unset)
     --host-port-forwards
                         list of host ports to forward to the VM; HOST_PORT_FWDS
                         must be a valid QEMU port forwarding specifier (default
@@ -196,7 +198,7 @@ prepare_raw_images() {
 
 prepare_firmware() {
     # Create local copies of the edk2 firmware variable storage, to help with
-    # faciliate Secure Boot testing where custom variables are needed for both
+    # facilitate Secure Boot testing where custom variables are needed for both
     # architectures, but can't safely be reused across QEMU invocations. Also
     # set reasonable defaults for both firmware files, if nothing more specific
     # was requested.

--- a/tools/start-local-vm
+++ b/tools/start-local-vm
@@ -35,7 +35,7 @@ vm_cpus=4
 force_extract=
 declare -A extra_files=()
 
-boot_image=
+os_image=
 data_image=
 
 
@@ -177,12 +177,12 @@ extract_image() {
 
 prepare_raw_images() {
     local -r image_dir=build/images/${arch}-${variant}/latest
-    local -r compressed_boot_image=${image_dir}/${product_name}-${variant}-${arch}.img.lz4
+    local -r compressed_os_image=${image_dir}/${product_name}-${variant}-${arch}.img.lz4
     local -r compressed_data_image=${image_dir}/${product_name}-${variant}-${arch}-data.img.lz4
 
-    if [[ -e ${compressed_boot_image} ]]; then
-        readonly boot_image=${compressed_boot_image%*.lz4}
-        extract_image "${compressed_boot_image}" "${boot_image}"
+    if [[ -e ${compressed_os_image} ]]; then
+        readonly os_image=${compressed_os_image%*.lz4}
+        extract_image "${compressed_os_image}" "${os_image}"
     else
         bail 'Boot image not found. Did the last build fail?'
     fi
@@ -261,10 +261,10 @@ inject_files() {
     # absence of actual hardware, assume a traditional sector size of 512 bytes.
     local private_first_sector private_last_sector
     read -r private_first_sector private_last_sector < <(
-        fdisk --list-details "${boot_image}" \
+        fdisk --list-details "${os_image}" \
             | awk '/BOTTLEROCKET-PRIVATE/ { print $2, $3 }')
     if [[ -z ${private_first_sector} ]] || [[ -z ${private_last_sector} ]]; then
-        bail "Failed to find the private partition in '${boot_image}'."
+        bail "Failed to find the private partition in '${os_image}'."
     fi
     local private_size_mib=$(( (private_last_sector - private_first_sector + 1) * 512 / 1024 / 1024 ))
 
@@ -279,11 +279,11 @@ inject_files() {
     done
 
     if ! mkfs.ext4 -d "${private_mount}" "${private_image}" "${private_size_mib}M" \
-    || ! dd if="${private_image}" of="${boot_image}" conv=notrunc bs=512 seek="${private_first_sector}"
+    || ! dd if="${private_image}" of="${os_image}" conv=notrunc bs=512 seek="${private_first_sector}"
     then
         rm -f "${private_image}"
         rm -rf "${private_mount}"
-        bail "Failed to inject files into '${boot_image}'."
+        bail "Failed to inject files into '${os_image}'."
     fi
 }
 
@@ -296,7 +296,7 @@ launch_vm() {
         -m "${vm_mem}"
         -drive if=pflash,format=raw,unit=0,file="${firmware_code}",readonly=on
         -drive if=pflash,format=raw,unit=1,file="${firmware_vars}"
-        -drive index=0,if=virtio,format=raw,file="${boot_image}"
+        -drive index=0,if=virtio,format=raw,file="${os_image}"
     )
 
     # Plug the virtual primary NIC in as BDF 00:10.0 so udev will give it a


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:** Sometimes it is helpful to not go with the default image sizes for testing purposes--in practice, this would mean testing with bigger images. Introduce the `--boot-image-size` and `--data-image-size` options to `start-local-vm` that allow for resizing the respective images after they have been extracted, but before they are booted.

**Testing done:**

Without `--boot-image-size`, the regular metal-dev disk image size is used:

```
bash-5.1# df -h /local
Filesystem      Size  Used Avail Use% Mounted on
/dev/vda13      961M  657M  305M  69% /local
```

With `--boot-image-size 20G`, the boot disk image is resized to 20 GiB before boot, and Bottlerocket extends the data partition accordingly:

```
bash-5.1# df -h /local
Filesystem      Size  Used Avail Use% Mounted on
/dev/vda13       18G  781M   18G   5% /local
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
