### PR TITLE
configure systemd-networkd to ignore foreign routes and rules

### DIFF
--- a/packages/release/release-systemd-networkd.conf
+++ b/packages/release/release-systemd-networkd.conf
@@ -1,0 +1,4 @@
+# Do not clobber any routes or rules added by CNI.
+[Network]
+ManageForeignRoutes=no
+ManageForeignRoutingPolicyRules=no

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -9,6 +9,7 @@ License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
 
 Source11: nsswitch.conf
+Source95: release-systemd-networkd.conf
 Source96: release-repart-local.conf
 Source97: release-sysctl.conf
 Source98: release-systemd-system.conf
@@ -124,6 +125,9 @@ Requires: %{_cross_os}xfsprogs
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -p -m 0644 %{S:11} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 
+install -d %{buildroot}%{_cross_libdir}/systemd/networkd.conf.d
+install -p -m 0644 %{S:95} %{buildroot}%{_cross_libdir}/systemd/networkd.conf.d/80-release.conf
+
 install -d %{buildroot}%{_cross_libdir}/repart.d/
 install -p -m 0644 %{S:96} %{buildroot}%{_cross_libdir}/repart.d/80-local.conf
 
@@ -199,8 +203,9 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_libdir}/os-release
 %dir %{_cross_libdir}/repart.d
 %{_cross_libdir}/repart.d/80-local.conf
-%{_cross_libdir}/systemd/system.conf.d/80-release.conf
 %{_cross_libdir}/systemd/network/80-release.link
+%{_cross_libdir}/systemd/networkd.conf.d/80-release.conf
+%{_cross_libdir}/systemd/system.conf.d/80-release.conf
 %{_cross_unitdir}/configured.target
 %{_cross_unitdir}/preconfigured.target
 %{_cross_unitdir}/multi-user.target


### PR DESCRIPTION
**Issue number:**
Fixes #3436

**Description of changes:**
Configure `systemd-networkd` to ignore foreign routes and rules. Otherwise, it may unexpectedly delete any IP routes and rules added by CNI solutions, which could break container networking.


**Testing done:**
With `SYSTEMD_LOG_LEVEL=debug` set in the `systemd-networkd` environment.

Before, I see the behavior in the related issue.

After:
```
# systemctl restart systemd-networkd

# journalctl | grep systemd-networkd | grep -E '(Remembering|Removing|Forgetting)'
Sep 08 20:44:57 ip-10-0-85-67.us-west-2.compute.internal systemd-networkd[1036]: eth0: Removing DHCPv6 address (configured): 2600:1f14:ae2:f103:1d45:b2fb:1f61:3045/128 (valid for 6min 54s, preferred for 1min 44s), flags: no-prefixroute, scope: global
Sep 08 20:44:57 ip-10-0-85-67.us-west-2.compute.internal systemd-networkd[7446]: eth0: Removing foreign address (configured,marked): 10.0.85.67/20 (valid forever, preferred forever), flags: permanent, scope: global
Sep 08 20:44:58 ip-10-0-85-67.us-west-2.compute.internal systemd-networkd[7446]: eth0: Forgetting foreign address (n/a): 10.0.85.67/20 (valid forever, preferred forever), flags: permanent, scope: global

# ip rule show && echo && ip route show
0:	from all lookup local
512:	from all to 10.0.84.82 lookup main
512:	from all to 10.0.84.116 lookup main
512:	from all to 10.0.80.34 lookup main
512:	from all to 10.0.81.197 lookup main
512:	from all to 10.0.95.247 lookup main
512:	from all to 10.0.82.192 lookup main
1024:	from all fwmark 0x80/0x80 lookup main
1536:	from 10.0.81.197 lookup 2
32766:	from all lookup main
32767:	from all lookup default

default via 10.0.80.1 dev eth0 proto dhcp src 10.0.85.67 metric 1024
10.0.0.2 via 10.0.80.1 dev eth0 proto dhcp src 10.0.85.67 metric 1024
10.0.80.0/20 dev eth0 proto kernel scope link src 10.0.85.67 metric 1024
10.0.80.1 dev eth0 proto dhcp scope link src 10.0.85.67 metric 1024
10.0.80.34 dev eni6acc9569775 scope link
10.0.81.197 dev eni7dbcb7169d9 scope link
10.0.82.192 dev enidbb501e1ff2 scope link
10.0.84.82 dev enie837592a360 scope link
10.0.84.116 dev eni7ea3d14dff3 scope link
10.0.95.247 dev eni53c8adaa1b5 scope link
169.254.169.123 via 10.0.80.1 dev eth0 proto dhcp src 10.0.85.67 metric 1024
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
