### PR TITLE
testsys: support for overriding EKS service endpoint

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -360,6 +360,9 @@ pub struct DeveloperConfig {
     pub keep_tests_running: Option<bool>,
     /// Use an alternate account for image lookup
     pub image_account_id: Option<String>,
+    /// Overrides the EKS service endpoint for TestSys agents gathering EKS cluster metadata
+    /// (only for pre-existing EKS clusters, does not apply to new EKS cluster creation)
+    pub eks_service_endpoint: Option<String>,
 }
 
 impl DeveloperConfig {
@@ -374,6 +377,7 @@ impl DeveloperConfig {
                 .or(other.bottlerocket_destruction_policy),
             keep_tests_running: self.keep_tests_running.or(other.keep_tests_running),
             image_account_id: self.image_account_id.or(other.image_account_id),
+            eks_service_endpoint: self.eks_service_endpoint.or(other.eks_service_endpoint),
         }
     }
 }

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -106,6 +106,14 @@ impl CrdCreator for AwsK8sCreator {
 
         let eks_crd = EksClusterConfig::builder()
             .creation_policy(CreationPolicy::IfNotExists)
+            .eks_service_endpoint(
+                cluster_input
+                    .crd_input
+                    .config
+                    .dev
+                    .eks_service_endpoint
+                    .clone(),
+            )
             .assume_role(cluster_input.crd_input.config.agent_role.clone())
             .config(config)
             .image(

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -207,7 +207,7 @@ pub(crate) async fn ec2_crd<'a>(
     // Add in the EKS specific configuration.
     if cluster_type == ClusterType::Eks {
         ec2_builder
-            .subnet_ids_template(cluster_name, "privateSubnetIds")
+            .subnet_ids_template(cluster_name, "publicSubnetIds")
             .endpoint_template(cluster_name, "endpoint")
             .certificate_template(cluster_name, "certificate")
             .cluster_dns_ip_template(cluster_name, "clusterDnsIp")
@@ -305,7 +305,7 @@ pub(crate) async fn ec2_karpenter_crd<'a>(
         )
         .cluster_name_template(cluster_name, "clusterName")
         .region_template(cluster_name, "region")
-        .subnet_ids_template(cluster_name, "privateSubnetIds")
+        .subnet_ids_template(cluster_name, "publicSubnetIds")
         .endpoint_template(cluster_name, "endpoint")
         .cluster_sg_template(cluster_name, "clustersharedSg")
         .device_mappings(device_mappings)


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**

Blocked until the next TestSys release. Drafting changes here ahead of time.

```
    testsys: support for overriding EKS service endpoint
    
    This adds the plumbing necessary to override the EKS service endpoint
    for the EKS cluster agent when it queries cluster metadata for
    populating information necessary to launch nodes into the cluster.
```

```
    testsys: launch nodes in public subnets by default 
    
    It's more likely for a test cluster to at least have one or more public
    subnets than it is for it to have at least one or more private subnet.
```


**Testing done:**
With a Test.toml that defines a custom test:
```
[aws-k8s.configuration.beta-quick]
test-type = "quick"
[aws-k8s.configuration.beta-quick.dev]
eks-service-endpoint = "https://my-beta-endpoint.aws"
``` 

Targetting an EKS cluster created in the beta EKS service endpoint:
```bash                                             
$ cargo make \
  -e TESTSYS_TEST=beta-quick \
  -e BUILDSYS_VARIANT=aws-k8s-1.28 \
  -e BUILDSYS_ARCH="x86_64" \
  -e TESTSYS_TEST_CONFIG_PATH=./Test.toml \
  -e TESTSYS_TARGET_CLUSTER_NAME=beta-x86-64-aws-k8s-128 \
  test
[cargo-make] INFO - cargo make 0.36.11
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: test
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
[cargo-make] INFO - Execute Command: "/home/fedora/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "test" "--project-path=/home/fedora/bottlerocket/Twoliter.toml" "--cargo-home=/home/fedora/bottlerocket/.cargo" "--"
[cargo-make][1] INFO - Build File: /tmp/.tmp8Ms00n/Makefile.toml
[cargo-make][1] INFO - Task: test
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: test-tools
[cargo-make][1] INFO - Running Task: test
[2023-09-11T21:50:41Z INFO  testsys::run] Successfully added 'beta-x86-64-aws-k8s-128'
[2023-09-11T21:50:41Z INFO  testsys::run] Successfully added 'beta-x86-64-aws-k8s-128-instances-nqzt'
[2023-09-11T21:50:41Z INFO  testsys::run] Successfully added 'beta-x86-64-aws-k8s-128-beta-quick'
[cargo-make][1] INFO - Build Done in 3.52 seconds.
[cargo-make] INFO - Build Done in 4.02 seconds.
...
$ cargo make   testsys status
[cargo-make] INFO - cargo make 0.36.11
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: testsys
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
[cargo-make] INFO - Execute Command: "/home/fedora/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "testsys" "--project-path=/home/fedora/bottlerocket/Twoliter.toml" "--cargo-home=/home/fedora/bottlerocket/.cargo" "--" "status"
[cargo-make][1] INFO - Build File: /tmp/.tmpzuih3S/Makefile.toml
[cargo-make][1] INFO - Task: testsys
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: test-tools
[cargo-make][1] INFO - Running Task: testsys
 NAME                                      TYPE       STATE       PASSED   FAILED   SKIPPED   BUILD ID   LAST UPDATE
 beta-x86-64-aws-k8s-128-beta-quick        Test       running          0        0         0   1c4a410d   2023-09-11T21:50:58Z
 beta-x86-64-aws-k8s-128                   Resource   completed                               1c4a410d   2023-09-11T21:50:44Z
 beta-x86-64-aws-k8s-128-instances-nqzt    Resource   completed                               1c4a410d   2023-09-11T21:50:52Z
[cargo-make][1] INFO - Build Done in 3.58 seconds.
[cargo-make] INFO - Build Done in 4.09 seconds.

```
The tests pass
```
$ cargo make testsys status
[cargo-make] INFO - cargo make 0.36.11
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: testsys
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
[cargo-make] INFO - Execute Command: "/home/fedora/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "testsys" "--project-path=/home/fedora/bottlerocket/Twoliter.toml" "--cargo-home=/home/fedora/bottlerocket/.cargo" "--" "status"
[cargo-make][1] INFO - Build File: /tmp/.tmp2tUogX/Makefile.toml
[cargo-make][1] INFO - Task: testsys
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: test-tools
[cargo-make][1] INFO - Running Task: testsys
 NAME                                  TYPE        STATE         PASSED    FAILED   SKIPPED   BUILD ID   LAST UPDATE          
 beta-x86-64-aws-k8s-128-beta-quick    Test        passed             5         0      7386   1c4a410d   2023-09-11T21:52:49Z 
 beta-x86-64-aws-k8s-128               Resource    completed                                  1c4a410d   2023-09-11T21:50:44Z 
[cargo-make][1] INFO - Build Done in 3.82 seconds.
[cargo-make] INFO - Build Done in 4.34 seconds.
```


For regular EKS clusters, the tests will work:
```bash
$ cargo make  testsys status                                                                                                                            
[cargo-make] INFO - cargo make 0.36.11                                                                                                                                                                                                                                                    
[cargo-make] INFO - Build File: Makefile.toml                                                                                                                                                                                                                                             
[cargo-make] INFO - Task: testsys                                                                                                            
[cargo-make] INFO - Profile: development                                                                                                     
[cargo-make] INFO - Running Task: install-twoliter                    
[cargo-make] INFO - Execute Command: "/home/fedora/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "testsys" "--project-path=/home/fedora/bottlerocket/Twoliter.toml" "--cargo-home=/home/fedora/bottlerocket/.cargo" "--" "status"                                            
[cargo-make][1] INFO - Build File: /tmp/.tmpecSYaq/Makefile.toml                                                                                                                                                                                                                          
[cargo-make][1] INFO - Task: testsys                                                                                                                                                                                                                                                      
[cargo-make][1] INFO - Profile: development                                                                                                                                                                                                                                               
[cargo-make][1] INFO - Running Task: setup                                                                                                                                                                                                                                                
[cargo-make][1] INFO - Running Task: fetch-sources                                                                                                                                                                                                                                        
[cargo-make][1] INFO - Running Task: test-tools                                                                                                                                                                                                                                           
[cargo-make][1] INFO - Running Task: testsys                                                                                                                                                                                                                                              
 NAME                                      TYPE        STATE         PASSED    FAILED   SKIPPED   BUILD ID   LAST UPDATE                                                                                                                                                                                                                                                                                                                    
 x86-64-aws-k8s-127-quick                  Test        running            4         0      7065   741d0aec   2023-09-11T21:28:17Z                                                                                                                                                                                                                                                                                                               
 x86-64-aws-k8s-127                        Resource    completed                                  741d0aec   2023-09-11T21:17:50Z 
 x86-64-aws-k8s-127-instances-ugxj         Resource    completed                                  741d0aec   2023-09-11T21:17:59Z 
[cargo-make][1] INFO - Build Done in 3.54 seconds.                    
[cargo-make] INFO - Build Done in 4.04 seconds.   
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
