### PR TITLE
rpm2img: create XFS partition on boot

### DIFF
--- a/tools/rpm2img
+++ b/tools/rpm2img
@@ -637,20 +637,9 @@ mkfs_data() {
   offset="${3:?}"
   # Create an XFS filesystem if requested
   if [ "${XFS_DATA_PARTITION}" == "yes" ] ; then
-    echo "writing XFS filesystem for DATA"
+    echo "writing blank partition for DATA"
     # Create a file to write the filesystem to first
     dd if=/dev/zero of="${BOTTLEROCKET_DATA}" bs=1M count=${size%?}
-    # block size of 4096, directory block size of 16384
-    # enable inotbtcount, bigtime, and reflink
-    # use an internal log with starting size of 64m
-    # use the minimal 2 Allocation groups, this still overprovisions when expanded
-    # set strip units of 512k and sectsize to make EBS volumes align
-    mkfs.xfs \
-      -b size=4096 -n size=16384 \
-      -m inobtcount=1,bigtime=1,reflink=1 \
-      -l internal,size=64m \
-      -d agcount=2,su=512k,sw=1,sectsize=4096 \
-      -f "${BOTTLEROCKET_DATA}"
   else
     # default to ext4
     echo "writing ext4 filesystem for DATA"


### PR DESCRIPTION
**Description of changes:**
XFS reads information from the device on mkfs. This results in an optimized filesystem for the particular situation. Boot time is slightly better as well since the IO from mkfs is less than growfs.

Having a prepared XFS partition with no data can result in similar problems as https://github.com/bottlerocket-os/bottlerocket/commit/ac0caccfd309501aaee7b2254fd5fd7a0df15b2e where data read in from an encrypted EBS volume returns random garbage which makes the filesystem appear corrupted. Having no filesystem sidesteps this problem.

**Testing done:**
Built an `aws-dev` image and checked XFS info:
```
bash-5.1# xfs_spaceman -c info /local
meta-data=/dev/nvme1n1p1         isize=512    agcount=4, agsize=1310592 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=0
data     =                       bsize=4096   blocks=5242368, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=16384, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0

```
Booting with an encrypted snapshot works with this empty partition vs getting the following error on boot otherwise:
```
[  OK  ] Finished Prepare Local Filesystem (/local).
         Mounting Local Directory (/local)...

[FAILED] Failed to mount Local Directory (/local).
See 'systemctl status local.mount' for details.

[DEPEND] Dependency failed for Mnt Directory (/mnt).
``` 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
