### PR TITLE
Xfsprogs cli

### DIFF
--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -22,6 +22,7 @@ source-groups = [
     "driverdog",
     "cfsignal",
     "bloodhound",
+    "xfscli",
 ]
 package-features = [ "systemd-networkd" ]
 

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -90,6 +90,7 @@ Requires: %{_cross_os}shimpei
 Requires: %{_cross_os}signpost
 Requires: %{_cross_os}storewolf
 Requires: %{_cross_os}sundog
+Requires: %{_cross_os}xfscli
 Requires: %{_cross_os}thar-be-settings
 Requires: %{_cross_os}thar-be-updates
 Requires: %{_cross_os}updog
@@ -293,6 +294,11 @@ Summary: Compliance check framework
 %description -n %{_cross_os}bloodhound
 %{summary}.
 
+%package -n %{_cross_os}xfscli
+Summary: XFS progs cli
+%description -n %{_cross_os}xfscli
+%{summary}.
+
 %prep
 %setup -T -c
 %cargo_prep
@@ -352,6 +358,7 @@ echo "** Output from non-static builds:"
     -p certdog \
     -p shimpei \
     -p bloodhound \
+    -p xfscli \
     %{?with_ecs_runtime: -p ecs-settings-applier} \
     %{?with_aws_platform: -p shibaken -p cfsignal} \
     %{?with_aws_k8s_family: -p pluto} \
@@ -389,6 +396,14 @@ done
 %if %{with k8s_runtime}
 install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/kubernetes-checks %{buildroot}%{_cross_bindir}
 %endif
+install -d %{buildroot}%{_cross_sbindir}
+for p in \
+  xfs_admin xfs_info \
+; do
+  install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/${p} %{buildroot}%{_cross_sbindir}/
+done
+# Rename fsck_xfs binary to fsck.xfs
+install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/fsck_xfs %{buildroot}%{_cross_sbindir}/fsck.xfs
 
 # Add the bloodhound checker symlinks
 mkdir -p %{buildroot}%{_cross_libexecdir}/cis-checks/bottlerocket
@@ -666,6 +681,12 @@ install -p -m 0644 %{S:121} %{buildroot}%{_cross_unitdir}
 %{_cross_bindir}/bloodhound
 %{_cross_bindir}/bottlerocket-checks
 %{_cross_libexecdir}/cis-checks/bottlerocket
+
+%files -n %{_cross_os}xfscli
+%{_cross_sbindir}/xfs_admin
+%{_cross_sbindir}/xfs_info
+%{_cross_sbindir}/fsck.xfs
+
 %if %{with k8s_runtime}
 %{_cross_bindir}/kubernetes-checks
 %{_cross_libexecdir}/cis-checks/kubernetes

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4807,6 +4807,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xfscli"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "snafu",
+ "tempfile",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -103,7 +103,9 @@ members = [
 
     "constants",
 
-    "shimpei"
+    "shimpei",
+
+    "xfscli"
 ]
 
 [profile.release]

--- a/sources/xfscli/Cargo.toml
+++ b/sources/xfscli/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "xfscli"
+version = "0.1.0"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "xfs_info"
+
+[[bin]]
+name = "xfs_admin"
+
+[[bin]]
+name = "fsck_xfs"
+path = "src/bin/fsck_xfs/main.rs"
+
+[dependencies]
+argh = "0.1"
+tempfile = "3"
+snafu = "0.7"

--- a/sources/xfscli/src/bin/fsck_xfs/error.rs
+++ b/sources/xfscli/src/bin/fsck_xfs/error.rs
@@ -1,0 +1,107 @@
+use snafu::Snafu;
+use std::process::ExitCode;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[repr(i32)]
+pub enum Error {
+    // Errors to map the errors defined in
+    // https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/fsck/xfs_fsck.sh
+    #[snafu(display("xfs {} errror: {} was not found!", cli, command))]
+    CommandUnavailable { cli: String, command: String },
+
+    #[snafu(display("{} does not exist", target))]
+    DeviceNotFound { target: String },
+
+    #[snafu(display(
+        "xfs fsck errror: The filesystem log is dirty, mount it to recover \
+        the log. If that fails, refer to the section DIRTY LOGS in the \
+        xfs_repair manual page."
+    ))]
+    DirtyLogs,
+
+    #[snafu(display("Unable to create tempdir: {}", source))]
+    MakeDir { source: std::io::Error },
+
+    #[snafu(display("Unable to mount the directory to device"))]
+    Mount,
+
+    #[snafu(display("xfs fsck error: xfs_repair could not fix the filesystem."))]
+    RepairFailure,
+
+    #[snafu(display("xfs fsck errror: An unknown return code from xfs_repair {}", code))]
+    UnrecognizedExitCode { code: i32 },
+
+    // Diverted behaviour from script, we fail as error code 8
+    // as we do not have etc/fstab file so device is mandatory argument
+    #[snafu(display("Could not parse target block device",))]
+    ParseTarget,
+
+    // General errors
+    #[snafu(display("Failed to run '{}' successfully {}", command, source))]
+    CommandFailure {
+        command: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display(
+        "Could not delete the temporary mount dir created to repair xfs filesystem {}",
+        source
+    ))]
+    DeleteMountDirectory { source: std::io::Error },
+
+    #[snafu(display("Unable to find {} base name", target))]
+    FindBasename { target: String },
+
+    #[snafu(display("Unable to read /proc/cmdline file {}.", source))]
+    FileRead { source: std::io::Error },
+
+    #[snafu(display("Failed to parse '{}' output: {}", command, source))]
+    FromUtf8 {
+        command: String,
+        source: std::string::FromUtf8Error,
+    },
+
+    #[snafu(display("Unable to get path metadata"))]
+    PathMetadata { source: std::io::Error },
+
+    #[snafu(display("Unable to read {} from /proc/cmdline file.", param))]
+    ReadKernelParams { param: String },
+
+    #[snafu(display("Unable to get path of temporary dir."))]
+    TempDirPath,
+
+    #[snafu(display("Failed to run repair successfully. {}", source))]
+    RepairCommandExecution { source: xfscli::error::Error },
+}
+
+impl Error {
+    pub fn exit_code(&self) -> ExitCode {
+        match self {
+            // Return error codes as per script
+            Error::CommandUnavailable { .. } => ExitCode::from(4),
+            Error::DeviceNotFound { .. } => ExitCode::from(8),
+            Error::DirtyLogs => ExitCode::from(4),
+            Error::MakeDir { .. } => ExitCode::from(1),
+            Error::Mount => ExitCode::from(1),
+            Error::RepairFailure { .. } => ExitCode::from(4),
+            Error::UnrecognizedExitCode { .. } => ExitCode::from(4),
+
+            // Return 8 when device argument is not provided
+            Error::ParseTarget => ExitCode::from(8),
+
+            // Return 8 for general errors
+            Error::CommandFailure { .. } => ExitCode::from(8),
+            Error::DeleteMountDirectory { .. } => ExitCode::from(8),
+            Error::FindBasename { .. } => ExitCode::from(8),
+            Error::FileRead { .. } => ExitCode::from(8),
+            Error::FromUtf8 { .. } => ExitCode::from(8),
+            Error::PathMetadata { .. } => ExitCode::from(8),
+            Error::ReadKernelParams { .. } => ExitCode::from(8),
+            Error::RepairCommandExecution { .. } => ExitCode::from(8),
+            Error::TempDirPath => ExitCode::from(8),
+        }
+    }
+}

--- a/sources/xfscli/src/bin/fsck_xfs/main.rs
+++ b/sources/xfscli/src/bin/fsck_xfs/main.rs
@@ -1,0 +1,216 @@
+use snafu::{OptionExt, ResultExt};
+use std::os::unix::fs::FileTypeExt;
+use std::path::Path;
+use std::process::Command;
+use std::process::ExitCode;
+use std::{fs, str};
+
+use argh::FromArgs;
+
+use self::error::{Error, Result};
+use xfscli::{perform_xfs_repair, XfsRepairResponseCode, BLKID, MOUNT, UMOUNT};
+
+mod error;
+
+// This CLI is rewritten in Rust for fsck.xfs shell script
+// https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/fsck/xfs_fsck.sh
+// since there isn't a shell on Bottlerocket hosts.
+
+const REPAIR_MOUNT_DIR: &str = "/tmp/repair_mnt";
+struct KernelParams {
+    root: String,
+    root_flags: String,
+}
+
+/// check and repair a XFS file system
+#[derive(FromArgs)]
+struct Args {
+    /// auto repair the file system
+    #[argh(switch, short = 'a')]
+    auto_repair: bool,
+
+    /// auto check all file systems
+    #[argh(switch, short = 'A')]
+    auto_check: bool,
+
+    /// check the root filesystem as well when -A flag is set
+    #[argh(switch, short = 'p')]
+    check_root_fs: bool,
+
+    /// force repair filesystem
+    #[argh(switch, short = 'f')]
+    force: bool,
+
+    /// repair filesystem automatically
+    #[argh(switch, short = 'y')]
+    repair: bool,
+
+    /// mount-point | block-device
+    #[argh(positional)]
+    target: Option<String>,
+}
+
+fn main() -> ExitCode {
+    let args: Args = argh::from_env();
+    match run(args) {
+        Ok(exit_code) => exit_code,
+        Err(e) => {
+            eprintln!("{:?}", e);
+            e.exit_code()
+        }
+    }
+}
+
+fn run(args: Args) -> Result<ExitCode> {
+    let auto = args.auto_check || args.auto_repair || args.check_root_fs;
+    let force = args.force;
+    let repair = args.repair;
+
+    // This is diverted behavior from xfs shell script.
+    // In fsck no filesystems are specified on the command line,
+    // and the -A option is not specified,
+    // fsck will default to checking filesystems in /etc/fstab serially
+    // Hence device name is not a mandatory argument. But as there isn't a /etc/fstab
+    // file in Bottlerocket we have to specify the device.
+    let target = &args.target.as_ref().context(error::ParseTargetSnafu)?;
+
+    if !Path::new(target).exists() {
+        return Err(Error::DeviceNotFound {
+            target: target.to_string(),
+        });
+    }
+
+    if force {
+        // Preform xfs_repair
+        println!("Performing XFS repair..");
+        let mut repair_exit_code =
+            perform_xfs_repair(vec!["-e", target]).context(error::RepairCommandExecutionSnafu)?;
+
+        // Clear the log, mount and unmount the XFS file system
+        // before xfs_repair
+        if repair_exit_code == XfsRepairResponseCode::DirtyLogs && repair {
+            println!("Replaying log for {}", target);
+
+            // Using random directory (/tmp/repair_mntxxxx) instead of a targeted directory (/tmp/repair_mnt)
+            let mnt_dir = tempfile::Builder::new()
+                .prefix(REPAIR_MOUNT_DIR)
+                .tempdir()
+                .context(error::MakeDirSnafu)?;
+
+            let mnt_dir_path = mnt_dir.path().to_str().context(error::TempDirPathSnafu)?;
+
+            let kernel_params = get_root_and_rootflags(target)?;
+
+            let basename_dev = Path::new(target)
+                .file_name()
+                .context(error::FindBasenameSnafu {
+                    target: "device".to_string(),
+                })?;
+
+            let basename_root =
+                Path::new(&kernel_params.root)
+                    .file_name()
+                    .context(error::FindBasenameSnafu {
+                        target: "root".to_string(),
+                    })?;
+
+            let mut mount_args = vec![target.as_str(), mnt_dir_path];
+            if basename_dev == basename_root && !kernel_params.root_flags.is_empty() {
+                mount_args.push(kernel_params.root_flags.as_str());
+            }
+
+            let mount_status = Command::new(MOUNT).args(mount_args).status().context(
+                error::CommandFailureSnafu {
+                    command: "mount".to_string(),
+                },
+            )?;
+
+            if !mount_status.success() {
+                return Err(Error::Mount);
+            }
+
+            Command::new(UMOUNT).arg(mnt_dir_path).output().context(
+                error::CommandFailureSnafu {
+                    command: "umount".to_string(),
+                },
+            )?;
+
+            println!("Performing XFS repair again after cleaning the log..");
+            repair_exit_code = perform_xfs_repair(vec!["-e", target])
+                .context(error::RepairCommandExecutionSnafu)?;
+
+            mnt_dir.close().context(error::DeleteMountDirectorySnafu)?;
+        }
+
+        let metadata_repaired = match repair_exit_code {
+            XfsRepairResponseCode::Ok => Ok(false),
+            XfsRepairResponseCode::RepairFailure => Err(Error::RepairFailure),
+            XfsRepairResponseCode::DirtyLogs => Err(Error::DirtyLogs),
+            XfsRepairResponseCode::MetadataRepair => Ok(true),
+            XfsRepairResponseCode::CommandUnavailable => Err(Error::CommandUnavailable {
+                cli: "fsck".to_string(),
+                command: "xfs_repair".to_string(),
+            }),
+            XfsRepairResponseCode::Unknown(code) => Err(Error::UnrecognizedExitCode { code }),
+        }?;
+
+        return Ok(if metadata_repaired {
+            ExitCode::from(1)
+        } else {
+            ExitCode::SUCCESS
+        });
+    }
+
+    if auto {
+        println!("fsck.xfs : XFS file system.");
+    } else {
+        println!(
+            "If you wish to check the consistency of an XFS filesystem or \
+        repair a damaged filesystem, see xfs_repair(8)."
+        );
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+// Get the kernel parameters by reading /proc/cmdline file
+fn get_root_and_rootflags(target: &String) -> Result<KernelParams> {
+    let params = fs::read_to_string("/proc/cmdline").context(error::FileReadSnafu)?;
+    let mut root = String::new();
+    let mut root_flags = String::new();
+    for param in params.split(' ') {
+        if param.starts_with("root=") {
+            root = param
+                .strip_prefix("root=")
+                .context(error::ReadKernelParamsSnafu {
+                    param: "root".to_string(),
+                })?
+                .to_string();
+        }
+        if param.starts_with("rootflags=") {
+            root_flags.push_str("-o ");
+            root_flags.push_str(param.strip_prefix("rootflags=").context(
+                error::ReadKernelParamsSnafu {
+                    param: "rootflags".to_string(),
+                },
+            )?);
+        }
+    }
+    let path = Path::new(&root);
+    let metadata = path.metadata().context(error::PathMetadataSnafu)?;
+    let file_type = metadata.file_type();
+
+    if !file_type.is_block_device() {
+        let blkid_result = Command::new(BLKID)
+            .args(["-t", &root, "-o", target])
+            .output()
+            .context(error::CommandFailureSnafu {
+                command: "blkid".to_string(),
+            })?;
+        root = String::from_utf8(blkid_result.stdout).context(error::FromUtf8Snafu {
+            command: "blkid".to_string(),
+        })?;
+    };
+
+    Ok(KernelParams { root, root_flags })
+}

--- a/sources/xfscli/src/bin/xfs_admin.rs
+++ b/sources/xfscli/src/bin/xfs_admin.rs
@@ -1,0 +1,246 @@
+use snafu::{OptionExt, ResultExt};
+use std::process::Command;
+use std::process::ExitCode;
+use std::str;
+
+use argh::FromArgs;
+
+use xfscli::error::{self, Error, Result};
+use xfscli::{get_mount_point, perform_xfs_repair, query_xfs_db, XFS_IO};
+
+// This CLI is rewritten in Rust for xfs_admin shell script
+// https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/db/xfs_admin.sh
+// since there isn't a shell on Bottlerocket hosts.
+
+/// change parameters of an XFS filesystem
+#[derive(FromArgs)]
+struct Args {
+    /// enables unwritten extent support on a filesystem that is disabled
+    #[argh(switch, short = 'e')]
+    extent_flag: bool,
+
+    /// specifies that the filesystem image to be processed is stored in a regular file at device
+    #[argh(switch, short = 'f')]
+    filesystem_image: bool,
+
+    /// prints the current filesystem label
+    #[argh(switch, short = 'l')]
+    filesystem_label: bool,
+
+    /// prints the current filesystem UUID
+    #[argh(switch, short = 'u')]
+    filesystem_uuid: bool,
+
+    /// set the filesystem label to label
+    #[argh(option, short = 'L')]
+    label: Option<String>,
+
+    /// enable (1) or disable (0) lazy-counters in the filesystem
+    #[argh(option, short = 'c')]
+    lazy_counters: Option<usize>,
+
+    /// enables version 2 log format
+    #[argh(switch, short = 'j')]
+    log_version_2: bool,
+
+    /// filesystem's external log location
+    #[argh(option)]
+    log_location: Option<String>,
+
+    /// enable 32bit project identifier support
+    #[argh(switch, short = 'p')]
+    project_identifier_32_bit: bool,
+
+    /// specifies the device special file where the filesystem's realtime section resides
+    #[argh(option, short = 'r')]
+    realtime_device: Option<String>,
+
+    /// set the UUID of the filesystem to uuid
+    #[argh(option, short = 'U')]
+    uuid: Option<String>,
+
+    /// add or remove features on an existing V5 filesystem
+    #[argh(option, short = 'O')]
+    v5_feature: Option<String>,
+
+    /// prints the version number and exits.
+    #[argh(switch, short = 'V')]
+    version: bool,
+
+    /// block-device
+    #[argh(positional)]
+    device: Option<String>,
+}
+
+impl Args {
+    // Filesystem should not be mounted with args in this function
+    // For more reference check require_offline variable in
+    // https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/db/xfs_admin.sh
+    fn is_required_offline(&self) -> bool {
+        self.extent_flag
+            || self.filesystem_image
+            || self.log_version_2
+            || self.project_identifier_32_bit
+            || self.uuid.is_some()
+            || self.lazy_counters.is_some()
+            || self.v5_feature.is_some()
+            || self.realtime_device.is_some()
+    }
+}
+
+fn main() -> ExitCode {
+    let args: Args = argh::from_env();
+    match run(args) {
+        Ok(exit_code) => exit_code,
+        Err(e) => {
+            eprintln!("{}", e);
+            e.exit_code()
+        }
+    }
+}
+
+fn run(args: Args) -> Result<ExitCode> {
+    // Return the version for arg version as true
+    if args.version {
+        let xfs_db_response = query_xfs_db(vec!["-p", "xfs_admin", "-V"])?;
+        return Ok(ExitCode::from(xfs_db_response as u8));
+    }
+
+    let device = &args.device.as_ref().context(error::ParseTargetSnafu)?;
+
+    // Collect all the arguments for XFS_DB, XFS_IO and XFS_REPAIR commands
+    // by parsing the CLI inputs.
+    let mut db_opts: Vec<&str> = vec![];
+    let mut io_opts: Vec<&str> = vec![];
+    let mut repair_opts: Vec<&str> = vec![];
+
+    let lazycount_arg;
+    if let Some(lazy_counters) = &args.lazy_counters {
+        lazycount_arg = format!("lazycount={}", lazy_counters);
+        repair_opts.append(&mut vec!["-c", lazycount_arg.as_str()]);
+    }
+
+    if args.extent_flag {
+        db_opts.append(&mut vec!["-c", "version extflg"]);
+    }
+
+    if args.filesystem_image {
+        db_opts.push("-f");
+    }
+
+    if args.log_version_2 {
+        db_opts.append(&mut vec!["-c", "version log2"]);
+    }
+
+    if args.filesystem_label {
+        db_opts.append(&mut vec!["-r", "-c", "label"]);
+        io_opts.append(&mut vec!["-r", "-c", "label"]);
+    }
+
+    let label_arg_db;
+    let label_arg_io;
+    if let Some(label) = &args.label {
+        label_arg_db = format!("label {}", label);
+        db_opts.append(&mut vec!["-c", label_arg_db.as_str()]);
+
+        label_arg_io = match label.as_str() {
+            "--" => format!("label {}", label),
+            _ => {
+                format!("label -s {}", label)
+            }
+        };
+        io_opts.append(&mut vec!["-c", label_arg_io.as_str()]);
+    }
+
+    if let Some(v5_feature) = &args.v5_feature {
+        repair_opts.append(&mut vec!["-c", v5_feature.as_str()]);
+    }
+
+    if args.project_identifier_32_bit {
+        db_opts.append(&mut vec!["-c", "version projid32bit"]);
+    }
+
+    if args.filesystem_uuid {
+        db_opts.append(&mut vec!["-r", "-c", "uuid"]);
+        io_opts.append(&mut vec!["-r", "-c", "fsuuid"]);
+    }
+
+    let uuid_arg;
+    if let Some(uuid) = &args.uuid {
+        uuid_arg = format!("uuid {}", uuid);
+        db_opts.append(&mut vec!["-c", uuid_arg.as_str()]);
+    }
+
+    // Exit if filesystem is mounted and require offline for queried arguments
+    if let Ok(mpt) = get_mount_point(device) {
+        // filesystem is mounted
+        if args.is_required_offline() {
+            return Err(Error::MountedFilesystem { mount_point: mpt });
+        }
+
+        if !io_opts.is_empty() {
+            let mut xfs_io = Command::new(XFS_IO);
+            xfs_io.args(["-p", "xfs_admin"]);
+            xfs_io.args(io_opts);
+            xfs_io.arg(mpt.as_str().trim());
+
+            let xfs_io_result = xfs_io.output().context(error::CommandFailureSnafu {
+                command: "xfs_io".to_string(),
+            })?;
+
+            print!(
+                "{}",
+                String::from_utf8(xfs_io_result.stdout).context(error::FromUtf8Snafu {
+                    command: "xfs io".to_string(),
+                })?,
+            );
+            let xfs_io_result =
+                xfs_io_result
+                    .status
+                    .code()
+                    .context(error::ParseStatusCodeSnafu {
+                        command: "xfs_io".to_string(),
+                    })?;
+            return Ok(ExitCode::from(xfs_io_result as u8));
+        }
+    }
+
+    let mut status = 0;
+    if !db_opts.is_empty() {
+        let mut xfs_db_args = vec!["-x", "-p", "xfs_admin"];
+
+        let log_location_arg;
+        if let Some(log_location) = &args.log_location {
+            log_location_arg = format!("-l {}", log_location);
+            xfs_db_args.push(log_location_arg.as_str());
+        }
+
+        xfs_db_args.append(&mut db_opts);
+        xfs_db_args.push(device);
+
+        status = query_xfs_db(xfs_db_args)?;
+    }
+
+    if !repair_opts.is_empty() {
+        print!("Running xfs_repair to upgrade filesystem.");
+        let mut repair_args: Vec<&str> = vec![];
+
+        let log_location_arg;
+        if let Some(log_location) = &args.log_location {
+            log_location_arg = format!("-l {}", log_location);
+            repair_args.push(log_location_arg.as_str());
+        }
+
+        let realtime_device_arg;
+        if let Some(realtime_device) = &args.realtime_device {
+            realtime_device_arg = format!("-r {}", realtime_device);
+            repair_args.push(realtime_device_arg.as_str());
+        }
+
+        repair_args.append(&mut repair_opts);
+        repair_args.push(device.as_str());
+
+        status += perform_xfs_repair(repair_args)?.exit_code();
+    }
+    Ok(ExitCode::from(status as u8))
+}

--- a/sources/xfscli/src/bin/xfs_info.rs
+++ b/sources/xfscli/src/bin/xfs_info.rs
@@ -1,0 +1,53 @@
+use snafu::OptionExt;
+use std::process::ExitCode;
+use std::str;
+
+use argh::FromArgs;
+
+use xfscli::error::{self, Result};
+use xfscli::{get_mount_point, query_xfs_db, query_xfs_spaceman};
+
+// This CLI is rewritten in Rust for xfs_info shell script
+// https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/spaceman/xfs_info.sh
+// since there isn't a shell on Bottlerocket hosts.
+
+/// display XFS filesystem geometry information
+#[derive(FromArgs)]
+struct Args {
+    /// print the version
+    #[argh(switch, short = 'V')]
+    version: bool,
+
+    /// mount-point | block-device | file-image
+    #[argh(positional)]
+    target: Option<String>,
+}
+
+fn main() -> ExitCode {
+    let args: Args = argh::from_env();
+    match run(args) {
+        Ok(exit_code) => exit_code,
+        Err(e) => {
+            eprintln!("{}", e);
+            e.exit_code()
+        }
+    }
+}
+
+fn run(args: Args) -> Result<ExitCode> {
+    // Return the version for arg version as true
+    if args.version {
+        let xfs_spaceman_response = query_xfs_spaceman(vec!["-p", "xfs_info", "-V"])?;
+        return Ok(ExitCode::from(xfs_spaceman_response as u8));
+    }
+
+    let target = &args.target.as_ref().context(error::ParseTargetSnafu)?;
+
+    // Get info using XFS_SPACEMAN if mounted else from XFS_DB
+    let response = if let Ok(mpt) = get_mount_point(target) {
+        query_xfs_spaceman(vec!["-p", "xfs_info", "-c", "info", mpt.as_str().trim()])?
+    } else {
+        query_xfs_db(vec!["-p", "xfs_info", "-c", "info", target.as_str()])?
+    };
+    Ok(ExitCode::from(response as u8))
+}

--- a/sources/xfscli/src/error.rs
+++ b/sources/xfscli/src/error.rs
@@ -1,0 +1,46 @@
+use snafu::Snafu;
+use std::process::ExitCode;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[repr(i32)]
+pub enum Error {
+    #[snafu(display("Failed to run '{}' successfully {}", command, source))]
+    CommandFailure {
+        command: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Unable to find the mount point for device: {}", target))]
+    FindMount { target: String },
+
+    #[snafu(display("Failed to parse '{}' output: {}", command, source))]
+    FromUtf8 {
+        command: String,
+        source: std::string::FromUtf8Error,
+    },
+
+    #[snafu(display("{} filesystem is mounted", mount_point))]
+    MountedFilesystem { mount_point: String },
+
+    #[snafu(display("Failed to read '{}' status code", command))]
+    ParseStatusCode { command: String },
+
+    #[snafu(display("Could not parse target block device",))]
+    ParseTarget,
+}
+
+impl Error {
+    pub fn exit_code(&self) -> ExitCode {
+        match self {
+            Error::CommandFailure { .. } => ExitCode::from(8),
+            Error::FindMount { .. } => ExitCode::from(8),
+            Error::FromUtf8 { .. } => ExitCode::from(8),
+            Error::MountedFilesystem { .. } => ExitCode::from(2),
+            Error::ParseStatusCode { .. } => ExitCode::from(8),
+            Error::ParseTarget => ExitCode::from(2),
+        }
+    }
+}

--- a/sources/xfscli/src/lib.rs
+++ b/sources/xfscli/src/lib.rs
@@ -1,0 +1,142 @@
+use error::Result;
+use snafu::{OptionExt, ResultExt};
+use std::process::Command;
+
+pub mod error;
+pub static BLKID: &str = "/usr/sbin/blkid";
+pub static FINDMNT: &str = "/usr/bin/findmnt";
+pub static MOUNT: &str = "/usr/bin/mount";
+pub static UMOUNT: &str = "/usr/bin/umount";
+pub static XFS_DB: &str = "/usr/sbin/xfs_db";
+pub static XFS_IO: &str = "/usr/sbin/xfs_io";
+pub static XFS_REPAIR: &str = "/usr/sbin/xfs_repair";
+pub static XFS_SPACEMAN: &str = "/usr/sbin/xfs_spaceman";
+
+/// Check if target is mounted and return mount point
+pub fn get_mount_point(target: &String) -> Result<String> {
+    let mountpt = Command::new(FINDMNT)
+        .args(["-t", "xfs", "-f", "-n", "-o", "TARGET", target])
+        .output()
+        .context(error::CommandFailureSnafu {
+            command: "findmnt".to_string(),
+        })?;
+
+    // All errors will be interpreted as failure in finding the mount point
+    if mountpt.status.success() {
+        Ok(
+            String::from_utf8(mountpt.stdout).context(error::FromUtf8Snafu {
+                command: "mount point".to_string(),
+            })?,
+        )
+    } else {
+        Err(error::Error::FindMount {
+            target: String::from(target),
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub enum XfsRepairResponseCode {
+    CommandUnavailable,
+    DirtyLogs,
+    MetadataRepair,
+    Ok,
+    RepairFailure,
+    Unknown(i32),
+}
+
+impl XfsRepairResponseCode {
+    pub fn exit_code(self) -> i32 {
+        match self {
+            XfsRepairResponseCode::CommandUnavailable => 127,
+            XfsRepairResponseCode::DirtyLogs => 2,
+            XfsRepairResponseCode::MetadataRepair => 4,
+            XfsRepairResponseCode::Ok => 0,
+            XfsRepairResponseCode::RepairFailure => 1,
+            XfsRepairResponseCode::Unknown(code) => code,
+        }
+    }
+}
+
+impl From<i32> for XfsRepairResponseCode {
+    fn from(code: i32) -> Self {
+        match code {
+            0 => XfsRepairResponseCode::Ok,
+            1 => XfsRepairResponseCode::RepairFailure,
+            2 => XfsRepairResponseCode::DirtyLogs,
+            4 => XfsRepairResponseCode::MetadataRepair,
+            127 => XfsRepairResponseCode::CommandUnavailable,
+            code => XfsRepairResponseCode::Unknown(code),
+        }
+    }
+}
+
+/// Perform xfs_repair for the given arguments
+pub fn perform_xfs_repair(args: Vec<&str>) -> Result<XfsRepairResponseCode> {
+    let xfs_repair_result =
+        Command::new(XFS_REPAIR)
+            .args(args)
+            .status()
+            .context(error::CommandFailureSnafu {
+                command: "xfs_repair".to_string(),
+            })?;
+
+    let code = xfs_repair_result
+        .code()
+        .context(error::ParseStatusCodeSnafu {
+            command: "xfs_repair".to_string(),
+        })?;
+
+    Ok(XfsRepairResponseCode::from(code))
+}
+
+/// Query xfs db to get required information
+pub fn query_xfs_db(args: Vec<&str>) -> Result<i32> {
+    let xfs_db_result =
+        Command::new(XFS_DB)
+            .args(args)
+            .output()
+            .context(error::CommandFailureSnafu {
+                command: "xfs db".to_string(),
+            })?;
+
+    print!(
+        "{}",
+        String::from_utf8(xfs_db_result.stdout).context(error::FromUtf8Snafu {
+            command: "xfs db".to_string(),
+        })?
+    );
+
+    xfs_db_result
+        .status
+        .code()
+        .context(error::ParseStatusCodeSnafu {
+            command: "xfs_db".to_string(),
+        })
+}
+
+/// Query xfs spaceman to get xfs information
+pub fn query_xfs_spaceman(args: Vec<&str>) -> Result<i32> {
+    let xfs_spaceman_result =
+        Command::new(XFS_SPACEMAN)
+            .args(args)
+            .output()
+            .context(error::CommandFailureSnafu {
+                command: "xfs spaceman".to_string(),
+            })?;
+
+    print!(
+        "{}",
+        String::from_utf8(xfs_spaceman_result.stdout).context(error::FromUtf8Snafu {
+            command: "xfs spaceman".to_string(),
+        })?
+    );
+
+    xfs_spaceman_result
+        .status
+        .code()
+        .context(error::ParseStatusCodeSnafu {
+            command: "xfs_spaceman".to_string(),
+        })
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Completes parts of # [3272](https://github.com/bottlerocket-os/bottlerocket/issues/3272) 

**Description of changes:**
Rewrite xfs_info, xfs_admin and fsck.xfs cli for bottlerocket as Bottlerocket does not have a shell.
- xfs_info cli: This works for both mounted and unmounted target. It fetches data using
xfs_spaceman when the target is mounted and use xfs_db in case of
unmounted target.
Param "-t" for mtab is not included in this cli as
xfs_spaceman -p xfs_info -c "info" -t "$mtab" "${target}"
do not produce expected output. The cli can be used as:
     - xfs_info -V
     - xfs_info $target where target is mount_point or block_device
- xfs_admin cli : All the commands for xfs progs that are listed on
https://man7.org/linux/man-pages/man8/xfs_admin.8.html
can be executed using this CLI.
- fsck.xfs: We are keeping it open for interactive sesssion too, though it is
recommended to invoke xfs_repair for Normal administrative filesystem
repairs directly.

**Testing done:**

-  xfs_admin
- [x] xfs_admin -u $device - For unmounted device
```
sudo xfs_admin -u /dev/nvme3n1p1
UUID = 405fabf4-0e29-40e9-a291-61400aac4fbb
______________________________________________
cargo run --bin xfs_admin --  -u /dev/nvme3n1p1
UUID = 405fabf4-0e29-40e9-a291-61400aac4fbb
```
- [x]  xfs_admin -l /dev/nvme3n1p1 - For unmounted device
```
sudo xfs_admin -l /dev/nvme3n1p1
label = ""
______________________________________________
cargo run --bin xfs_admin --  -l /dev/nvme3n1p1
label = ""
```
- [x] xfs_admin -u $device - For mounted device
```
xfs_admin -u /dev/nvme1n1p1
UUID = 03837d91-7a4a-4d9e-ab0c-176502893af4
```
- [x]  xfs_admin -l /dev/nvme3n1p1 - For mounted device
```
xfs_admin -l /dev/nvme1n1p1
label = " "
```
- [x] xfs_admin -V
```
sudo xfs_admin -V
xfs_admin version 5.0.0
_____________________________________________
 cargo run --bin xfs_admin --  -V
xfs_admin version 5.0.0
``` 
- [x]  xfs_admin --  -e  $device
```
sudo xfs_admin -e /dev/nvme3n1p1
unwritten extents always enabled for v5 superblocks.
versionnum [0xbca5+0x18a] = V5,NLINK,DIRV2,ALIGN,LOGV2,EXTFLG,SECTOR,MOREBITS,ATTR2,LAZYSBCOUNT,PROJID32BIT,CRC,FTYPE,FINOBT,SPARSE_INODES,REFLINK
______________________________________________
cargo run --bin xfs_admin --  -e /dev/nvme3n1p1
unwritten extents always enabled for v5 superblocks.
versionnum [0xbca5+0x18a] = V5,NLINK,DIRV2,ALIGN,LOGV2,EXTFLG,SECTOR,MOREBITS,ATTR2,LAZYSBCOUNT,PROJID32BIT,CRC,FTYPE,FINOBT,SPARSE_INODES,REFLINK
```
- [x] xfs_admin -L new_label $device
```
sudo xfs_admin -L new_label /dev/nvme3n1p1
writing all SBs
new label = "new_label"
sudo xfs_admin -L -- /dev/nvme3n1p1
writing all SBs
new label = ""
_____________________________________________
cargo run --bin xfs_admin --  -L new_label /dev/nvme3n1p1
writing all SBs
new label = "new_label"
 cargo run --bin xfs_admin --  -L -- /dev/nvme3n1p1
writing all SBs
new label = ""

Mounted device
xfs_admin -L new_label /dev/nvme1n1p1
label = "new_label"
xfs_admin -L -- /dev/nvme1n1p1
label = " "
```
- [x] xfs_admin -c 1 -O inobtcount=1 $device
- [x] xfs_admin -f $device
- [x] xfs_admin -j $device
```
sudo xfs_admin -j /dev/nvme3n1p1
Version 2 logs always enabled for v5 superblocks.
versionnum [0xbca5+0x18a] = V5,NLINK,DIRV2,ALIGN,LOGV2,EXTFLG,SECTOR,MOREBITS,ATTR2,LAZYSBCOUNT,PROJID32BIT,CRC,FTYPE,FINOBT,SPARSE_INODES,REFLINK
________________________________________________
cargo run --bin xfs_admin --  -j /dev/nvme3n1p1
Version 2 logs always enabled for v5 superblocks.
versionnum [0xbca5+0x18a] = V5,NLINK,DIRV2,ALIGN,LOGV2,EXTFLG,SECTOR,MOREBITS,ATTR2,LAZYSBCOUNT,PROJID32BIT,CRC,FTYPE,FINOBT,SPARSE_INODES,REFLINK
```
- [x] xfs_admin -p $device
```
// Unmounted filesystem
sudo xfs_admin -p /dev/nvme3n1p1
xfs_admin: Cannot change projid32bit on v5 superblocks.
_________________________________________________
cargo run --bin xfs_admin --  -p /dev/nvme3n1p1
xfs_admin: Cannot change projid32bit on v5 superblocks

// Mounted filesystem
// Error message and error code is different because of xfs_progs version
sudo xfs_admin -p /dev/nvme0n1p1
xfs_admin: /dev/nvme0n1p1 contains a mounted filesystem
echo $?
1
__________________________________________________
cargo run --bin xfs_admin --  -p /dev/nvme0n1p1
filesystem is mounted /
echo $?
2
```
- [x] xfs_admin -U c1b9d5a2-f162-11cf-9ece-0020afc76f16 $device
```
xfs_admin -U c1b9d5a2-f162-11cf-9ece-0020afc76f16 /dev/nvme3n1p1
Clearing log and setting UUID
writing all SBs
new UUID = c1b9d5a2-f162-11cf-9ece-0020afc76f16
sudo xfs_admin -U 405fabf4-0e29-40e9-a291-61400aac4fbb /dev/nvme3n1p1
Clearing log and setting UUID
writing all SBs
new UUID = 405fabf4-0e29-40e9-a291-61400aac4fbb
__________________________________________________
cargo run --bin xfs_admin --  -U c1b9d5a2-f162-11cf-9ece-0020afc76f16 /dev/nvme3n1p1
Clearing log and setting UUID
writing all SBs
new UUID = c1b9d5a2-f162-11cf-9ece-0020afc76f16
cargo run --bin xfs_admin --  -U 405fabf4-0e29-40e9-a291-61400aac4fbb /dev/nvme3n1p1
Clearing log and setting UUID
writing all SBs
new UUID = 405fabf4-0e29-40e9-a291-61400aac4fbb
```
- [x] Fail when device is not provided
```
sudo xfs_admin -u
Usage: xfs_admin [-efjlpuV] [-c 0|1] [-L label] [-U uuid] device
echo $?
2
__________________________________________________
cargo run --bin xfs_admin --  -u
Couldn't parse target block-device
echo $?
2
```
- xfs_info
- [x] xfs_info  -V
```
sudo xfs_info  -V
xfs_info version 5.0.0
 echo $?
0
__________________________________________________
cargo run --bin xfs_info --  -V
xfs_info version 5.0.0
echo $?
0
```
- [x] Fail when device is not provided
```
sudo xfs_info 
Usage: xfs_info [-V] [-t mtab] [mountpoint|device|file]
echo $?
2
__________________________________________________
cargo run --bin xfs_info --
Couldn't parse target  mount-point | block-device | file-image
[ec2-user@ip-172-31-46-161 xfscli]$ echo $?
2
```
- [x] xfs_info $device
```
// Unmounted device
sudo xfs_info /dev/nvme3n1p1
meta-data=/dev/nvme3n1p1         isize=512    agcount=4, agsize=6553536 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=26214144, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=12799, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
________________________________________________________
cargo run --bin xfs_info --  /dev/nvme3n1p1
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `/home/ec2-user/bottlerocket/sources/target/debug/xfs_info /dev/nvme3n1p1`
meta-data=/dev/nvme3n1p1         isize=512    agcount=4, agsize=6553536 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=26214144, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=12799, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0

// Mounted device
findmnt /dev/nvme4n1p1
TARGET   SOURCE         FSTYPE
/volume2 /dev/nvme4n1p1 xfs 

xfs_info /dev/nvme4n1p1
meta-data=/dev/nvme4n1p1         isize=512    agcount=4, agsize=6553536 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=26214144, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=12799, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
_______________________________________________________
cargo run --bin xfs_info --  /dev/nvme4n1p1
meta-data=/dev/nvme4n1p1         isize=512    agcount=4, agsize=6553536 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=26214144, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=12799, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
```
- fsck.xfs
- [x] fsck.xfs  -a /dev/nvme3n1p1 -- Do nothing, successfully
```
sudo fsck.xfs  -a /dev/nvme3n1p1
/sbin/fsck.xfs: XFS file system.
echo $?
0
_________________________________________________
cargo run --bin fsck_xfs --  -a /dev/nvme3n1p1
xfs fsck : XFS file system.
echo $?
0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
