### PR TITLE
testsys: Add support for EKS-A release manifest url for metal and VMware testing

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -363,6 +363,8 @@ pub struct DeveloperConfig {
     /// Overrides the EKS service endpoint for TestSys agents gathering EKS cluster metadata
     /// (only for pre-existing EKS clusters, does not apply to new EKS cluster creation)
     pub eks_service_endpoint: Option<String>,
+    /// A manifest containing the EKS Anywhere binary that should be used for cluster provisioning
+    pub eks_a_release_manifest_url: Option<String>,
 }
 
 impl DeveloperConfig {
@@ -378,6 +380,9 @@ impl DeveloperConfig {
             keep_tests_running: self.keep_tests_running.or(other.keep_tests_running),
             image_account_id: self.image_account_id.or(other.image_account_id),
             eks_service_endpoint: self.eks_service_endpoint.or(other.eks_service_endpoint),
+            eks_a_release_manifest_url: self
+                .eks_a_release_manifest_url
+                .or(other.eks_a_release_manifest_url),
         }
     }
 }

--- a/tools/testsys/src/metal_k8s.rs
+++ b/tools/testsys/src/metal_k8s.rs
@@ -115,6 +115,14 @@ impl CrdCreator for MetalK8sCreator {
                         what: "A cluster config is required for Bare Metal testing",
                     })?,
             ))
+            .eks_a_release_manifest_url(
+                cluster_input
+                    .crd_input
+                    .config
+                    .dev
+                    .eks_a_release_manifest_url
+                    .clone(),
+            )
             .set_conflicts_with(Some(existing_clusters))
             .destruction_policy(
                 cluster_input

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -120,6 +120,14 @@ impl CrdCreator for VmwareK8sCreator {
             .vcenter_resource_pool(&self.datacenter.resource_pool)
             .vcenter_workload_folder(&self.datacenter.folder)
             .mgmt_cluster_kubeconfig_base64(&self.encoded_mgmt_cluster_kubeconfig)
+            .eks_a_release_manifest_url(
+                cluster_input
+                    .crd_input
+                    .config
+                    .dev
+                    .eks_a_release_manifest_url
+                    .clone(),
+            )
             .set_conflicts_with(Some(existing_clusters))
             .destruction_policy(
                 cluster_input


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
Adds support for passing the EKS-A manifest release URL to the metal/vsphere cluster agents.

Waiting for next TestSys release to merge

**Testing done:**

With a dev configuration in Test.toml for 'quick' tests:
```
[vmware-k8s.configuration.quick.dev]
eks-a-release-manifest-url = "https://blah.cloudfront.net/baremetal/eksctl-anywhere-manifest.yaml"
```
Then kicking off vmware k8s tests:
```
$ cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.27 -e BUILDSYS_ARCH=x86_64 test --mgmt-cluster-kubeconfig=./mgmt-eks-a-cluster.kubeconfig                                                                                                                                                   
[cargo-make] INFO - cargo make 0.36.11                                                                                                                                                                                                                                                    
[cargo-make] INFO - Build File: Makefile.toml                                                                                                                                                                                                                                             
[cargo-make] INFO - Task: test                                                                                                                                                                                                                                                            
[cargo-make] INFO - Profile: development                                                                                                                                                                                                                                                  
[cargo-make] INFO - Running Task: install-twoliter                                                                                                                                                                                                                                        
[cargo-make] INFO - Execute Command: "/home/fedora/bottlerocket/tools/bin/twoliter" "--log-level=info" "make" "test" "--project-path=/home/fedora/bottlerocket/Twoliter.toml" "--cargo-home=/home/fedora/bottlerocket/.cargo" "--" "--mgmt-cluster-kubeconfig=./mgmt-eks-a-cluster.kubecon
fig"                                                                                                                                                                                                                                                                                      
[cargo-make][1] INFO - Build File: /tmp/.tmpBDzCrO/Makefile.toml                                                                                                                                                                                                                          
[cargo-make][1] INFO - Task: test                                                                                                                                                                                                                                                         
[cargo-make][1] INFO - Profile: development                                                                                                                                                                                                                                               
[cargo-make][1] INFO - Running Task: setup                                                                                                                                                                                                                                                
[cargo-make][1] INFO - Running Task: fetch-sources                                                                                                                                                                                                                                        
[cargo-make][1] INFO - Running Task: test-tools                                                                                                                                                                                                                                           
[cargo-make][1] INFO - Running Task: test                                                                                                                                                                                                                                                 
[2023-09-13T02:42:27Z INFO  testsys::run] Creating vSphere secret, 'vspherecreds'                                                                                                                                                                                                         
[2023-09-13T02:42:27Z INFO  testsys::run] vSphere credentials file not found, will attempt to use environment                                                                                                                                                                             
[2023-09-13T02:42:27Z INFO  testsys::run] Successfully added 'x86-64-vmware-k8s-127-vms-vwck'                                                
[2023-09-13T02:42:27Z INFO  testsys::run] Successfully added 'x86-64-vmware-k8s-127-quick'                                                                                                                                                                                                
[cargo-make][1] INFO - Build Done in 3.59 seconds.                                                                                                                                                                                                                                        
[cargo-make] INFO - Build Done in 4.09 seconds.                                                  
```
The cluster creation step finishes successfully:
```
$ kubectl --kubeconfig testsys.kubeconfig get resources -A                                                                                                                                                                                                                                
NAMESPACE   NAME                             DESTRUCTIONPOLICY   CREATIONSTATE   DESTRUCTIONSTATE                                                                                                                                                                                         
testsys     x86-64-vmware-k8s-127            onTestSuccess       completed       unknown                                                                                                                                                                                                  
testsys     x86-64-vmware-k8s-127-vms-vwck   onTestSuccess       running         unknown
$ kubectl --kubeconfig testsys.kubeconfig logs -f x86-64-vmware-ka587cf56-de17-4050-a673-ee9bf146bc0c-creati2m9zp -n testsys                                                                                                                                                              
[2023-09-13T02:40:38Z INFO  resource_agent::agent] Initializing Agent                                                                                                                                                                                                                     
[2023-09-13T02:40:38Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Getting vSphere secret                                                                                                                                                                      
[2023-09-13T02:40:38Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating working directory                                                                                                                                                                  
[2023-09-13T02:40:38Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Checking existing cluster                                                                                                                                                                   
[2023-09-13T02:40:38Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creation policy is 'IfNotExists' and cluster 'x86-64-vmware-k8s-127' does not exist: creating cluster                                                                                       
[2023-09-13T02:40:38Z INFO  bottlerocket_agents::clusters] Using EKS-A release manifest 'https://blah.cloudfront.net/baremetal/eksctl-anywhere-manifest.yaml'                                                                                                                   
[2023-09-13T02:40:38Z INFO  bottlerocket_agents::clusters] Fetching EKS-A binary archive from 'https://blah.cloudfront.net/baremetal/eksctl-anywhere-linux-amd64.tar.gz'                                                                                                        
[2023-09-13T02:40:40Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating cluster                                                                                                                                                                            
[2023-09-13T02:40:40Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Downloading OVA 'bottlerocket-vmware-k8s-1.27-x86_64-v1.15.0.ova'                                                                                                                           
[2023-09-13T02:40:44Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Importing OVA and creating a VM template out of it                                                                                                                                          
[2023-09-13T02:40:57Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Tagging VM template                                                                                                                                                                         
2023-09-13T02:41:53.593Z        V4      Reading bundles manifest        {"url": "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml"}                                                                                                                       
2023-09-13T02:41:53.638Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2                                                                                                                                                           
2023-09-13T02:41:53.638Z        V1      SSHUsername is not set or is empty for VSphereMachineConfig, using default     {"c": "x86-64-vmware-k8s-127-node", "user": "ec2-user"}                                                                                                            
2023-09-13T02:41:53.693Z        V2      Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.17.1-eks-a-v0.0.0-dev-build.7550"}                                                                                                                           
2023-09-13T02:41:59.534Z        V3      Initializing long running container     {"name": "eksa_1694572913693196773", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.17.1-eks-a-v0.0.0-dev-build.7550"}                                                                       
2023-09-13T02:42:02.124Z        V4      Task start      {"task_name": "setup-validate"}                                                                                                                                                                                                   
2023-09-13T02:42:02.124Z        V0      Performing setup and validations                                                                                                                                                                                                                  
2023-09-13T02:42:02.140Z        V0      ✅ Connected to server                                                                
...
[2023-09-13T02:47:30Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Scaling default NodeGroup machinedeployments replicas to 0                                                                                                                                  
machinedeployment.cluster.x-k8s.io/x86-64-vmware-k8s-127-md-0 scaled                                                                         
[2023-09-13T02:47:30Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Cluster created                                
[2023-09-13T02:47:30Z INFO  resource_agent::agent] Resource action succeeded. 
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
