### PR TITLE
Revert "release: consult resolved for host lookups"

### DIFF
--- a/packages/release/nsswitch.conf
+++ b/packages/release/nsswitch.conf
@@ -1,4 +1,4 @@
 passwd: files
 group: files
 shadow: files
-hosts: files resolve [!UNAVAIL=return] dns
+hosts: files dns


### PR DESCRIPTION
**Issue number:**
Fixes #3457

**Description of changes:**
```    
    This reverts commit dfbf90b8615d237f6ccf774ba8af847cae2c4ae8.
    
    Go's netgo resolver doesn't understand the "resolve" directive in
    nsswitch.conf, so it falls back to cgo, which uses glibc to look up
    hosts.  The glibc lookup behaves differently in certain cases, such as
    multiple records for the same host in `/etc/hosts`.  Avoid the behavior
    change by using the previous order.  This still results in queries going
    through systemd-resolved, just not via the nss plugin.
```

**Testing done:**
Before the change:
```
bash-5.1# resolvectl statistics
DNSSEC supported by current servers: no

Transactions             
Current Transactions: 0
  Total Transactions: 756
                         
Cache                    
  Current Cache Size: 2
          Cache Hits: 305
        Cache Misses: 451
                         
DNSSEC Verdicts          
              Secure: 0
            Insecure: 0
               Bogus: 0
       Indeterminate: 0
```

After the change:
```
bash-5.1# resolvectl statistics
DNSSEC supported by current servers: no

Transactions             
Current Transactions: 0
  Total Transactions: 236
                         
Cache                    
  Current Cache Size: 10
          Cache Hits: 144
        Cache Misses: 92
                         
DNSSEC Verdicts          
              Secure: 0
            Insecure: 0
               Bogus: 0
       Indeterminate: 0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
