### PR TITLE
packages: use force_disable_rpath macro instead of open coding it

### DIFF
--- a/packages/iptables/iptables.spec
+++ b/packages/iptables/iptables.spec
@@ -44,8 +44,7 @@ Requires: %{name}
   --disable-nfsynproxy \
   --disable-static \
 
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/libacl/libacl.spec
+++ b/packages/libacl/libacl.spec
@@ -27,8 +27,7 @@ Requires: %{name}
   --disable-nls \
   --disable-rpath \
 
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/libattr/libattr.spec
+++ b/packages/libattr/libattr.spec
@@ -22,8 +22,7 @@ Requires: %{name}
 
 %build
 %cross_configure
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -48,9 +48,7 @@ autoreconf -fi
   --without-python \
   --without-python3 \
 
-# "fix" rpath
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -35,8 +35,7 @@ Requires: %{name}
   --disable-systemd \
   --with-xml=expat \
 
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/libnl/libnl.spec
+++ b/packages/libnl/libnl.spec
@@ -29,8 +29,7 @@ autoreconf -fi
   --enable-static \
   --disable-cli \
 
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/libpcre/libpcre.spec
+++ b/packages/libpcre/libpcre.spec
@@ -39,8 +39,7 @@ Requires: %{name}
   --disable-pcre2test-libedit \
   --disable-pcre2test-libreadline \
 
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/libseccomp/libseccomp.spec
+++ b/packages/libseccomp/libseccomp.spec
@@ -23,9 +23,7 @@ Requires: %{name}
 %build
 %cross_configure
 
-# "fix" rpath
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/liburcu/liburcu.spec
+++ b/packages/liburcu/liburcu.spec
@@ -24,9 +24,7 @@ Requires: %{name}
 %build
 %cross_configure --disable-static
 
-# "fix" rpath
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -63,9 +63,7 @@ autoreconf -fi
   --without-xmlsec1 \
   --without-xmlsecurity \
 
-# "fix" rpath
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/procps/procps.spec
+++ b/packages/procps/procps.spec
@@ -33,8 +33,7 @@ Requires: %{name}
   --without-ncurses \
   --without-systemd \
 
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -130,8 +130,7 @@ cp Documentation/licenses/COPYING.* .
   --without-udev \
   --without-utempter \
 
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -84,9 +84,7 @@ autoreconf -fi
   --with-dbus-configdir=%{_cross_datadir}/dbus-1/system.d \
   --without-dbus-servicedir \
 
-# "fix" rpath
-sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+%force_disable_rpath
 
 %make_build
 


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:**

The `force_disable_rpath` macro was released with the Bottlerocket SDK v0.34.0 (https://github.com/bottlerocket-os/bottlerocket-sdk/pull/122) and expands to the rpath hack. Switch over all packages open coding it to actually make use of the macro.

Note that the util-linux and libacl packages use both the rpath hack and `--disable-rpath` in the invocation of the `configure` script. For those `--disable-rpath` does not actually prevent inclusion of an rpath into the actual executables. This commit only mechanically changes over to the use of the macro, and leaves fixing the incomplete handling of the option in those packages to another day.


**Testing done:**

All affected packages build. If the change weren't working, the build would fail due to `check-rpaths` complaining about the non-canonical rpaths.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
