### PR TITLE
fix cargo install twoliter

### DIFF
--- a/tools/install-twoliter.sh
+++ b/tools/install-twoliter.sh
@@ -146,7 +146,8 @@ else
 fi
 
 if [ "${from_source}" = "true" ] ; then
-   cargo install \
+   cargo +nightly install \
+     -Z bindeps \
      --locked \
      --root "${workdir}" \
      --git "${repo}" \


### PR DESCRIPTION

**Issue number:**

N/A

**Description of changes:**

Unfortunately the cargo install command does not seem to respect the rust-toolchain.toml and .cargo/config.toml settings when installing from a git reference.

https://github.com/rust-lang/cargo/issues/11036

We need to fix this by adding +nightly and specifying -Z bindeps in the cargo install command for twoliter.

**Testing done:**

Git install works with this fix but doesn't work without it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
