### PR TITLE
skip reinstillation of twoliter from source

### DIFF
--- a/tools/install-twoliter.sh
+++ b/tools/install-twoliter.sh
@@ -110,6 +110,10 @@ on_exit "rm -rf ${workdir}"
 
 if [ "${reuse_existing}" = "true" ] ; then
    if [ -x "${dir}/twoliter" ] ; then
+      if [ "${allow_bin}" != "true" ]; then
+        echo "Twoliter binary found and --allow-binary-install is false. Skipping install."
+        exit 0
+      fi
       version_output="$("${dir}/twoliter" --version)"
       found_version=v$(echo $version_output | awk '{print $2}')
       echo "Found twoliter ${found_version} installed."


### PR DESCRIPTION


**Issue number:**

Closes #3478 

**Description of changes:**

When we are testing changes to Twoliter, we need to install from git. In that case the sha is not going to match the version output from Twoliter --version. This means that we have to rebuild and install Twoliter each time we call cargo make. It takes 10 minutes to compile Twoliter.

Fix this such that TWOLITER_ALLOW_BINARY_INSTALL=false skips checking the version when any `twoliter` is installed.

**Testing done:**

Used this locally and it fixed the problem.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
