### PR TITLE
build: update twoliter to v0.0.4

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,7 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.0.3"
+TWOLITER_VERSION = "v0.0.4"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,
@@ -62,12 +62,6 @@ BUILDSYS_NAME = "bottlerocket"
 # If you're building a Bottlerocket remix, you'd want to set this to something like
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
-# SDK name used for building
-BUILDSYS_SDK_NAME="bottlerocket"
-# SDK version used for building
-BUILDSYS_SDK_VERSION="v0.34.1"
-# Site for fetching the SDK
-BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 
 # These can be overridden with -e to change configuration for pubsys (`cargo
 # make repo`).  In addition, you can set RELEASE_START_TIME to determine when
@@ -173,11 +167,6 @@ TESTSYS_TEST_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Test.toml"
 # on the command line.
 
 TWOLITER = "${TWOLITER_INSTALL_DIR}/twoliter"
-
-# Depends on ${BUILDSYS_ARCH}, ${BUILDSYS_REGISTRY}, ${BUILDSYS_SDK_NAME}, and
-# ${BUILDSYS_SDK_VERSION}.
-BUILDSYS_SDK_IMAGE = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME}-sdk-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
-BUILDSYS_TOOLCHAIN = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME}-toolchain-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
 
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_LIMIT_JOBS = "--jobs ${BUILDSYS_JOBS}"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,1 +1,11 @@
 schema-version = 1
+
+[sdk]
+registry = "public.ecr.aws/bottlerocket"
+name = "bottlerocket-sdk"
+version = "v0.34.1"
+
+[toolchain]
+registry = "public.ecr.aws/bottlerocket"
+name = "bottlerocket-toolchain"
+version = "v0.34.1"


### PR DESCRIPTION
TODO:

- [x] Aggregate additional Twoliter changes and release/use v0.0.4

**Issue number:**

https://github.com/bottlerocket-os/twoliter/issues/55

**Description of changes:**

Update Twoliter:
- Has testsys enhancements and fixes that we need
- Moves declaration of SDK to Twoliter.toml
- Makes it possible to turn on pubsys and testsys logging

**Testing done:**

- [x] `cargo make` works
- [x] `cargo make ami` works
- [x] `cargo make test --help` works

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
