### PR TITLE
trivial: Add entries to `.mailmap` file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,3 +7,28 @@ Tom Kirchner <tjk@amazon.com> <tjkirch@users.noreply.github.com>
 Zac Mrowicki <mrowicki@amazon.com>
 Zac Mrowicki <mrowicki@amazon.com> <zmrowicki@hotmail.com>
 Mahdi Chaker <mmchaker@amazon.com> M <mchaker@users.noreply.github.com>
+Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Arnaldo Garcia Rincon <agarrcia@amazon.com> <asgar.2792@gmail.com>
+Ben Cressey <bcressey@amazon.com> <ben@cressey.org>
+Erikson Tung <etung@amazon.com>
+Jacob Vallejo <jakeev@amazon.com> <jake@jahkeup.com>
+John McBride <jpmmcb@amazon.com> <jpmmcbride@gmail.com>
+Kyle J. Davis <halldirector@gmail.com> <kyledvs@amazon.com>
+Markus Boehme <markubo@amazon.com> <markusboehme@users.noreply.github.com>
+Matthew James Briggs <brigmatt@amazon.com>
+Matthew James Briggs <brigmatt@amazon.com> <6260372+webern@users.noreply.github.com>
+Matthew James Briggs <brigmatt@amazon.com> <matthew.james.briggs@gmail.com>
+Matthew James Briggs <brigmatt@amazon.com> Matt Briggs <mjb@bitflip.software>
+Matthew Yeazel <yeazelm@amazon.com> <67169369+yeazelm@users.noreply.github.com>
+Matthias Sterckx <msterckx@amazon.com>
+Samuel Karp <skarp@amazon.com> <samuelkarp@users.noreply.github.com>
+Sanika Shah <shasanik@amazon.com> <sanikashah1110@gmail.com>
+Sean Kelly <seankell@amazon.com> <sean.kelly.2992@gmail.com>
+Sean McGinnis <stmcg@amazon.com> <sean.mcginnis@gmail.com>
+Sean P. Kelly <seankell@amazon.com> <sean.kelly.2992@gmail.com>
+Shailesh Gothi <gothisg@amazon.com> <shaileshgothiece@gmail.com>
+Tianhao Geng <tianhg@amazon.com> <gthao313@gmail.com>
+Tianhao Geng <tianhg@amazon.com> <45469883+gthao313@users.noreply.github.com>
+Ethan Pullen <pullenep@amazon.com>
+Ethan Pullen <pullenep@amazon.com> <ecpullen@aol.com>
+Shikha Vyaghra <vyaghras@amazon.com> <107685805+vyaghras@users.noreply.github.com>


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

I've generally not been a fan of maintaining a mailmap file, but looking at the output called out in #192 with `git shortlog -se`, I could see this being useful if we ever try to pull some metrics on the project git activity.

This adds a few entries for some of the user duplication seen in the output from that command.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
