### PR TITLE
Actions: prebuild common packages to cache for full builds

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         path: |
           ~/.cargo
-        key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}
+        key: ${{ hashFiles('.github/**/*.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}
     - uses: actions/cache@v3
       # Cache first-party code dependencies
       with:

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,11 +6,25 @@ inputs:
     required: false
     default: false
     type: boolean
+  read-only-cache:
+    description: "Whether to update the cache (false) or not (true)"
+    required: false
+    default: false
+    type: boolean
+  cache-arch:
+    description: "The platform architecture for this cache"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
     - run: |
         echo "OS_ARCH=`uname -m`" >> $GITHUB_ENV
+        if [[ "${{ inputs.cache-arch }}" == "" ]]; then
+          echo "CACHE_ARCH=`uname -m`" >> $GITHUB_ENV
+        else
+          echo "CACHE_ARCH=${{ inputs.cache-arch }}" >> $GITHUB_ENV
+        fi
         sudo apt -y install build-essential openssl libssl-dev pkg-config liblz4-tool
       shell: bash
     - uses: actions/cache@v3
@@ -18,13 +32,45 @@ runs:
       with:
         path: |
           ~/.cargo
-        key: ${{ hashFiles('.github/**/*.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}
+        key: home-cargo-${{ env.CACHE_ARCH }}-${{ hashFiles('.github/**/*.yml') }}
+      if: ${{ inputs.read-only-cache != 'true' }}
     - uses: actions/cache@v3
       # Cache first-party code dependencies
       with:
         path: |
           .cargo
-        key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('sources/Cargo.lock') }}
+        key: cargo-${{ env.CACHE_ARCH }}-${{ hashFiles('.github/**/*.yml') }}${{ hashFiles('sources/Cargo.lock') }}
+      if: ${{ inputs.read-only-cache != 'true' }}
+    - uses: actions/cache@v3
+      # Cache build artifacts in 'variants/target/' to reduce rebuilds
+      with:
+        path: |
+          variants/target
+          build
+        key: target-${{ env.CACHE_ARCH }}-${{ hashFiles('.github/**/*.yml') }}${{ hashFiles('packages/**/Cargo.toml', 'packages/**/*.spec') }}
+      if: ${{ inputs.read-only-cache != 'true' }}
+    - uses: actions/cache/restore@v3
+      # Cache `cargo-make`, `cargo-cache`, `cargo-sweep`
+      with:
+        path: |
+          ~/.cargo
+        key: home-cargo-${{ env.CACHE_ARCH }}-${{ hashFiles('.github/**/*.yml') }}
+      if: ${{ inputs.read-only-cache == 'true' }}
+    - uses: actions/cache/restore@v3
+      # Cache first-party code dependencies
+      with:
+        path: |
+          .cargo
+        key: cargo-${{ env.CACHE_ARCH }}-${{ hashFiles('.github/**/*.yml') }}${{ hashFiles('sources/Cargo.lock') }}
+      if: ${{ inputs.read-only-cache == 'true' }}
+    - uses: actions/cache/restore@v3
+      # Cache build artifacts in 'variants/target/' to reduce rebuilds
+      with:
+        path: |
+          variants/target
+          build
+        key: target-${{ env.CACHE_ARCH }}-${{ hashFiles('.github/**/*.yml') }}${{ hashFiles('packages/**/Cargo.toml', 'packages/**/*.spec') }}
+      if: ${{ inputs.read-only-cache == 'true' }}
     - run: cargo install cargo-make
       shell: bash
     - if: ${{ inputs.perform-cache-cleanup }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,37 @@ jobs:
       - uses: ./.github/actions/list-variants
         id: get-variants
 
-  build:
+  package-prep:
     needs: list-variants
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_32-core
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+      fail-fast: false
+    name: "Prebuild ${{ matrix.arch }} packages"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Preflight step to set up the runner
+        uses: ./.github/actions/setup-node
+        with:
+          cache-arch: ${{ matrix.arch }}
+      # Build some of the most common packages so later builds pick them up from the cache and don't rebuild
+      # TODO: Make some of this dynamic like we do with discovering variants
+      - run: |
+          cargo make -e BUILDSYS_ARCH=${{ matrix.arch }} -e PACKAGE=kernel-5_10 build-package
+        shell: bash
+      - run: |
+          cargo make -e BUILDSYS_ARCH=${{ matrix.arch }} -e PACKAGE=kernel-5_15 build-package
+        shell: bash
+      - run: |
+          cargo make -e BUILDSYS_ARCH=${{ matrix.arch }} -e PACKAGE=kernel-6_1 build-package
+        shell: bash
+
+  build:
+    needs: [list-variants, package-prep]
     runs-on:
       group: bottlerocket
       labels: bottlerocket_ubuntu-latest_32-core
@@ -59,6 +88,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Preflight step to set up the runner
         uses: ./.github/actions/setup-node
+        with:
+          read-only-cache: true
+          cache-arch: ${{ matrix.arch }}
       - if: contains(matrix.variant, 'nvidia')
         run: |
           cat <<-EOF > Licenses.toml


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This builds some of the common packages in a step before the normal full build. The build output from these package builds will be captured in the cache, so later on when there are multiple variants being built that all use the same packages, it should be able to get the artifacts from the cache and perform an incremental build rather than each building the same package repeatedly.

**Testing done:**

Observing CI run to make sure it is behaving as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
