### PR TITLE
actions: Use latest cargo-make

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -25,8 +25,8 @@ runs:
         path: |
           .cargo
         key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('sources/Cargo.lock') }}
-    - run: cargo install --locked --version 0.36.0 cargo-make
+    - run: cargo install cargo-make
       shell: bash
     - if: ${{ inputs.perform-cache-cleanup }}
-      run: cargo install --locked --version 0.8.3 --no-default-features --features ci-autoclean cargo-cache
+      run: cargo install --no-default-features --features ci-autoclean cargo-cache
       shell: bash


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates the version of cargo-make used in the GitHub Action runs. This is only part of the workflow since things are delegated off to twoliter and the SDK, but we should keep the initial `cargo make` calls updated.

**Testing done:**

Local usage.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
