### PR TITLE
build: twoliter skip version check

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,7 +4,17 @@ skip_core_tasks = true
 [env]
 BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 
-# Skip installing Twoliter if it is already installed its version
+# For binary installation, this should be a released version (prefixed with a v,
+# for example v0.1.0). For the git sourcecode installation method, this can be
+# any git rev, e.g. a tag, sha, or branch name.
+TWOLITER_VERSION = "v0.0.3"
+
+# For binary installation, this is the GitHub repository that has binary release artifacts attached
+# to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,
+# this is any URI that can be used in a git clone command.
+TWOLITER_REPO = "https://github.com/bottlerocket-os/twoliter"
+
+# Skip installing Twoliter if it is already installed and its version
 # matches the requested version.
 TWOLITER_REUSE_EXISTING_INSTALL="true"
 
@@ -15,18 +25,12 @@ TWOLITER_ALLOW_BINARY_INSTALL="true"
 # Allow Twoliter to be installed by building from sourcecode.
 TWOLITER_ALLOW_SOURCE_INSTALL="true"
 
+# If you know the version string returned by Twoliter will not match TWOLITER_VERSION (e.g. when you
+# are testing changes to Twoliter itself), set this to true to prevent re-installation.
+TWOLITER_SKIP_VERSION_CHECK="false"
+
 # Where Twoliter will be installed.
 TWOLITER_INSTALL_DIR = "${BUILDSYS_ROOT_DIR}/tools/twoliter"
-
-# For binary installation, this should be a released version (prefixed with a v,
-# for example v0.1.0). For the git sourcecode installation method, this can be
-# any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.0.3"
-
-# For binary installation, this is the GitHub repository that has binary release artifacts attached
-# to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,
-# this is any URI that can be used in a git clone command.
-TWOLITER_REPO = "https://github.com/bottlerocket-os/twoliter"
 
 # The logging verbosity for Twoliter: error, warn, info, debug, trace
 TWOLITER_LOG_LEVEL = "info"
@@ -282,6 +286,10 @@ fi
 
 if [ "${TWOLITER_ALLOW_SOURCE_INSTALL}" = "true" ]; then
    flags+=("--allow-from-source")
+fi
+
+if [ "${TWOLITER_SKIP_VERSION_CHECK}" = "true" ]; then
+   flags+=("--skip-version-check")
 fi
 
 "${BUILDSYS_TOOLS_DIR}/install-twoliter.sh" \

--- a/tools/install-twoliter.sh
+++ b/tools/install-twoliter.sh
@@ -45,6 +45,10 @@ Usage: $0 -r GIT_REPO -v TWOLITER_VERSION -d INSTALL_DIR [-e REUSE_EXISTING] [-b
     -s, --allow-from-source       we will install from source using cargo install pointed to a git
                                   repo and rev when binary install is either not allowed or not
                                   possible
+    -k, --skip-version-check      do not check to see if the installed version matches the one that
+                                  is requested by the --version argument. twoliter will not be
+                                  installed when the binary is present, regardless of what version
+                                  it is.
     -h, --help                    show this help text
 
 Example invocation:
@@ -95,6 +99,8 @@ while [[ $# -gt 0 ]]; do
             allow_bin="true" ;;
         -s|--allow-from-source)
             from_source="true" ;;
+        -k|--skip-version-check)
+            skip_version_check="true" ;;
         -h|--help)
             usage; exit 0 ;;
         *)
@@ -110,13 +116,13 @@ on_exit "rm -rf ${workdir}"
 
 if [ "${reuse_existing}" = "true" ] ; then
    if [ -x "${dir}/twoliter" ] ; then
-      if [ "${allow_bin}" != "true" ]; then
-        echo "Twoliter binary found and --allow-binary-install is false. Skipping install."
+      if [ "${skip_version_check}" = "true" ]; then
+        echo "Twoliter binary found and --skip-version-check is true. Skipping install."
         exit 0
       fi
       version_output="$("${dir}/twoliter" --version)"
       found_version=v$(echo $version_output | awk '{print $2}')
-      echo "Found twoliter ${found_version} installed."
+      echo "Found Twoliter ${found_version} installed."
       if [ "${found_version}" = "${version}" ] ; then
          echo "Skipping installation."
          exit 0
@@ -131,7 +137,7 @@ if [ "${allow_bin}" = "true" ] ; then
    host_kernel="${host_kernel,,}"
    case "${host_kernel}-${host_arch}" in
       linux-x86_64 | linux-aarch64)
-      echo "Installing twoliter from binary release."
+      echo "Installing Twoliter from binary release."
       twoliter_release="${repo}/releases/download/${version}"
       twoliter_target="${host_arch}-unknown-${host_kernel}-musl"
       cd "${workdir}"
@@ -146,10 +152,11 @@ if [ "${allow_bin}" = "true" ] ; then
       ;;
    esac
 else
-   echo "Skipped installing twoliter ${version} from pre-built binaries."
+   echo "Skipping binary installation of twoliter ${version} because --allow-binary-install was not set."
 fi
 
 if [ "${from_source}" = "true" ] ; then
+   echo "Installing Twoliter version ${version} from source"
    cargo +nightly install \
      -Z bindeps \
      --locked \


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Improves #3479 

**Description of changes:**

Improves the method by which we can avoid re-installing from source when we are testing changes to Twoliter.

**Testing done:**

I ran this command twice and both times it took 365 seconds to install Twoliter: `cargo make -e TWOLITER_VERSION=09734ab -e TWOLITER_ALLOW_BINARY_INSTALL=false unit-tests`

I then ran this and the re-installation did not take place: `cargo make -e TWOLITER_VERSION=09734ab -e TWOLITER_ALLOW_BINARY_INSTALL=false -e TWOLITER_SKIP_VERSION_CHECK=true unit-tests`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
