### PR TITLE
apiclient: update tungstenite to v0.20.1

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -327,6 +327,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 name = "apiclient"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.2",
  "constants",
  "datastore",
  "futures",
@@ -1023,15 +1024,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1490,20 +1482,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -1988,7 +1971,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2826,12 +2809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,19 +3562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3605,7 +3569,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3616,7 +3580,7 @@ checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4117,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.16.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -4247,18 +4211,18 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.16.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+base64 = "0.21"
 constants = { path = "../../constants", version = "0.1" }
 datastore = { path = "../datastore", version = "0.1" }
 futures = { version = "0.3", default-features = false }
@@ -31,7 +32,7 @@ signal-hook = "0.3"
 simplelog = "0.12"
 snafu = { version = "0.7", features = ["futures"] }
 tokio = { version = "~1.25", default-features = false, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
-tokio-tungstenite = { version = "0.16", default-features = false, features = ["connect"] }
+tokio-tungstenite = { version = "0.20", default-features = false, features = ["connect"] }
 toml = "0.5"
 unindent = "0.1"
 url = "2"

--- a/sources/api/apiclient/src/exec.rs
+++ b/sources/api/apiclient/src/exec.rs
@@ -313,6 +313,11 @@ impl ReadFromServer {
                                 }
                             }
                         }
+                        // The API server doesn't use frames, but still logging out a
+                        // warning in case a message of this type is received
+                        Message::Frame(_) => {
+                            warn!("Received an unexpected frame message");
+                        }
                     }
                     Ok(())
                 }

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -65,8 +65,6 @@ skip = [
 ]
 
 skip-tree = [
-    # tungstenite is using an older sha-1
-    { name = "tungstenite", version = "=0.16" },
     # windows-sys is not a direct dependency. mio and schannel
     # are using different versions of windows-sys. we skip the
     # dependency tree because windows-sys has many sub-crates
@@ -78,7 +76,10 @@ skip-tree = [
     # serde_yaml actually uses a newer hashbrown dependency,
     # but several crates in the graph pull in an older one, so skip for now
     # until they can be updated
-    { name = "hashbrown", version = "=0.13.2" }
+    { name = "hashbrown", version = "=0.13.2" },
+    # tungstenite uses a newer version of base64, but many of the
+    # first party crates are still in this version
+    { name = "base64", version = "=0.13.1" }
 ]
 
 [sources]


### PR DESCRIPTION
**Description of changes:**

Newer versions of `tungstenite` implemented the v13 version of the Web Sockets protocol (described in [rfc6455]). In this version, new headers are required in the upgrade request. With this update, now the upgrade request sent by `apiclient` include the missing headers.

In the same version, the 'frame' message was added. Neither `apiserver` nor `apiclient` send this type of message, so they are ignored by `apiclient`.

I found the required headers [here]. For the values I followed the RFC:

> The request MUST contain a |Host| header field whose value contains /host/ plus optionally ":" followed by /port/ (when not using the default port).

> The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword

> The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.

>The request MUST include a header field with the name |Sec-WebSocket-Key|.  The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]).  The nonce MUST be selected randomly for each connection.

> The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13.

[rfc6455]: https://www.rfc-editor.org/rfc/rfc6455
[here]: https://github.com/snapview/tungstenite-rs/blob/8b3ecd3cc0008145ab4bc8d0657c39d09db8c7e2/src/handshake/client.rs#L115 


**Testing done:**
I built the `aws-ecs-1` and `aws-ecs-2` variants, and confirmed I could exec commands through the admin container:

```bash
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "14d6c7d1",
    "pretty_name": "Bottlerocket OS 1.16.0 (aws-ecs-2)",
    "variant_id": "aws-ecs-2",
    "version_id": "1.16.0"
  }
}
[ssm-user@control]$ apiclient exec admin sheltie cat /etc/os-release
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.16.0 (aws-ecs-2)"
PRETTY_NAME="Bottlerocket OS 1.16.0 (aws-ecs-2)"
VARIANT_ID=aws-ecs-2
VERSION_ID=1.16.0
BUILD_ID=14d6c7d1
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
DOCUMENTATION_URL="https://bottlerocket.dev"
```

I also confirmed that I can enter the admin container:

```bash
[ssm-user@control]$ enter-admin-container
Confirming admin container is enabled...
Waiting for admin container to start...
Entering admin container
          Welcome to Bottlerocket's admin container!
    ╱╲
   ╱┄┄╲   This container provides access to the Bottlerocket host
   │▗▖│   filesystems (see /.bottlerocket/rootfs) and contains common
  ╱│  │╲  tools for inspection and troubleshooting.  It is based on
  │╰╮╭╯│  Amazon Linux 2, and most things are in the same places you
    ╹╹    would find them on an AL2 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[root@admin]#

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
