### PR TITLE
twoliter install mkdir

### DIFF
--- a/tools/install-twoliter.sh
+++ b/tools/install-twoliter.sh
@@ -113,6 +113,7 @@ set -e
 
 workdir="$(mktemp -d)"
 on_exit "rm -rf ${workdir}"
+mkdir -p "${dir}"
 
 if [ "${reuse_existing}" = "true" ] ; then
    if [ -x "${dir}/twoliter" ] ; then
@@ -143,7 +144,6 @@ if [ "${allow_bin}" = "true" ] ; then
       cd "${workdir}"
       curl -sSL "${twoliter_release}/twoliter-${twoliter_target}.tar.xz" -o "twoliter.tar.xz"
       tar xf twoliter.tar.xz
-      mkdir -p "${dir}"
       mv "./twoliter-${twoliter_target}/twoliter" "${dir}"
       exit 0
       ;;


### PR DESCRIPTION

**Issue number:**

N/A

**Description of changes:**

Oops:

```
    build: make sure twoliter dir is created

    If the twoliter directory does not exist, make sure we create it
    regardless of which installation method is being used.
```

**Testing done:**

It fixed the problem.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
