### PR TITLE
release: Remove explicit Type for Local Filesystem

### DIFF
--- a/packages/release/local.mount
+++ b/packages/release/local.mount
@@ -7,12 +7,11 @@ After=prepare-local-fs.service
 Requires=prepare-local-fs.service
 
 [Mount]
-EnvironmentFile=/usr/share/bottlerocket/image-features.env
 What=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
 Where=/local
-Type=${DATA_PARTITION_FILESYSTEM}
 # "noexec" omitted to allow containers and migrations to run
 Options=defaults,nosuid,nodev,noatime,private
+StandardError=journal+console
 
 [Install]
 WantedBy=preconfigured.target


### PR DESCRIPTION
**Issue number:** #3497

**Description of changes:**
The filesystem will mount without specifying a specific type when defining a systemd Mount. This allows any filesystem that the OS can mount to be used as a filesystem for /local. Before this change, the boot would fail if the /local filesystem didn't match the one specified in /usr/share/bottlerocket/image-features.env


**Testing done:**
Attaching an `ext4` filesystem to an aws-k8s-1.28 variant which has XFS specified as its data partition would result in failures to boot similar to the issue described in #3497. 
```
K  ] Listening on Journal Socket (/dev/log).
[  OK  ] Listening on Journal Socket.
[  OK  ] Listening on Network Service Netlink Socket.
[  OK  ] Listening on udev Control Socket.
[  OK  ] Listening on udev Kernel Socket.
         Mounting Huge Pages File System...
         Mounting POSIX Message Queue File System...
         Mounting CNI Configuration Directory (/etc/cni)...
         Mounting Kernel Debug File System...
         Mounting Kernel Trace File System...
         Mounting Temporary Directory /tmp...
         Starting Load audit rules...
         Starting Checks and marks if boot has ever succeeded before...
         Starting Create List of Static Device Nodes...
         Starting Load Kernel Module configfs...
         Starting Load Kernel Module efi_pstore...
         Starting Load Kernel Module fuse...
         Starting Copy SELinux policy files...
         Starting Journal Service...
         Starting Load Kernel Modules...
         Starting Generate network units from Kernel command line...
         Starting Remount Root and Kernel File Systems...
         Starting Coldplug All udev Devices...
[  OK  ] Finished Load audit rules.
[  OK  ] Finished Create List of Static Device Nodes.
[  OK  ] Finished Load Kernel Module configfs.
[  OK  ] Finished Load Kernel Module efi_pstore.
         Mounting Kernel Configuration File System...
[  OK  ] Finished Generate network units from Kernel command line.
[  OK  ] Finished Remount Root and Kernel File Systems.
         Starting Create System Users...
[  OK  ] Finished Load Kernel Module fuse.
         Mounting FUSE Control File System...
[  OK  ] Started Journal Service.
[  OK  ] Mounted Huge Pages File System.
[  OK  ] Mounted POSIX Message Queue File System.
[  OK  ] Mounted CNI Configuration Directory (/etc/cni).
[  OK  ] Mounted Kernel Debug File System.
[  OK  ] Mounted Kernel Trace File System.
[  OK  ] Mounted Temporary Directory /tmp.
[  OK  ] Mounted Kernel Configuration File System.
[  OK  ] Mounted FUSE Control File System.
[  OK  ] Finished Coldplug All udev Devices.
[  OK  ] Finished Checks and marks if boot has ever succeeded before.
[  OK  ] Finished Create System Users.
         Starting Create Static Device Nodes in /dev...
[  OK  ] Finished Copy SELinux policy files.
         Mounting Containerd Configuration Directory (/etc/containerd)...
         Mounting Host containers Configuratâ¦irectory (/etc/host-containers)...
         Mounting Kubernetes PKI private dirâ¦y (/etc/kubernetes/pki/private)...
         Mounting AWS configuration directory (/root/.aws)...
         Mounting Ephemeral netdog configuration directory...
[  OK  ] Mounted Containerd Configuration Directory (/etc/containerd).
[  OK  ] Mounted Host containers Configuratiâ¦ Directory (/etc/host-containers).
[  OK  ] Mounted Kubernetes PKI private direâ¦ory (/etc/kubernetes/pki/private).
[  OK  ] Mounted AWS configuration directory (/root/.aws).
[  OK  ] Mounted Ephemeral netdog configuration directory.
[  OK  ] Finished Create Static Device Nodes in /dev.
[  OK  ] Reached target Preparation for Local File Systems.
         Starting Rule-based Manager for Device Events and Files...
[  OK  ] Finished Load Kernel Modules.
         Starting Apply Kernel Variables...
[  OK  ] Started Rule-based Manager for Device Events and Files.
[  OK  ] Found device Amazon Elastic Block Store 13.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-PRIVATE.
[  OK  ] Finished Apply Kernel Variables.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-DATA.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-DATA.
         Starting Prepare Local Filesystem (/local)...
[  OK  ] Finished Prepare Local Filesystem (/local).
         Mounting Local Directory (/local)...
[    7.748873] mount[1328]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
[FAILED] Failed to mount Local Directory (/local).
See 'systemctl status local.mount' for details.
[    7.750765] mount[1328]:        dmesg(1) may have more information after failed mount system call.
[DEPEND] Dependency failed for Var Directory (/var).
[DEPEND] Dependency failed for Mask Local Var Directory (/local/var).
[DEPEND] Dependency failed for Kernel Development Sources (Read-Write).
[DEPEND] Dependency failed for D-Bus System Message Bus.
[DEPEND] Dependency failed for Prepare Var Directory (/var).
[DEPEND] Dependency failed for Platform Persistent Storage Archival.
[DEPEND] Dependency failed for Flush Journal to Persistent Storage.
[DEPEND] Dependency failed for Kernel Modules (Read-Write).
[DEPEND] Dependency failed for Private Directory (/var/lib/bottlerocket).
[DEPEND] Dependency failed for Prepare Kubelet Directory (/var/lib/kubelet).
[DEPEND] Dependency failed for Prepare Contaâ¦d Directory (/var/lib/containerd).
[DEPEND] Dependency failed for Kernel Development Sources (Read-Only).
[DEPEND] Dependency failed for Network Name Resolution.
[DEPEND] Dependency failed for Load/Save Random Seed.
[DEPEND] Dependency failed for Basic System.
[DEPEND] Dependency failed for Bottlerocket initial configuration complete.
[DEPEND] Dependency failed for Isolates configured.target.
[DEPEND] Dependency failed for CNI Plugin Directory (/opt/cni/bin).
[DEPEND] Dependency failed for Mnt Directory (/mnt).
[DEPEND] Dependency failed for Mask Local Mnt Directory (/local/mnt).
[DEPEND] Dependency failed for Opt Directory (/opt).
[DEPEND] Dependency failed for Mask Local Opt Directory (/local/opt).
[DEPEND] Dependency failed for Prepare Opt Directory (/opt).
[DEPEND] Dependency failed for Resize Data Partition.
[  OK  ] Reached target First Boot Complete.
[  OK  ] Reached target Local File Systems.
[  OK  ] Reached target Host and Network Name Lookups.
         Mounting License files...
         Starting Commit a transient machine-id on disk...
         Starting Create Volatile Files and Directories...
[  OK  ] Finished Commit a transient machine-id on disk.
[  OK  ] Finished Create Volatile Files and Directories.
         Starting Rebuild Dynamic Linker Cache...
[  OK  ] Mounted License files.
[  OK  ] Finished Rebuild Dynamic Linker Cache.
         Starting Update is Completed...
[  OK  ] Finished Update is Completed.
[  OK  ] Reached target System Initialization.
[  OK  ] Started Scheduled Metricdog Pings.
[  OK  ] Started Daily Cleanup of Temporary Directories.
[  OK  ] Reached target Timer Units.
[  OK  ] Listening on D-Bus System Message Bus Socket.
[  OK  ] Reached target Socket Units.
         Starting ACPI event daemon...
         Starting Generate network configuration...
         Starting Call signpost to mark the â¦r all required targets are met....
         Starting Bottlerocket data store migrator...
[  OK  ] Started ACPI event daemon.
[  OK  ] Finished Call signpost to mark the â¦ter all required targets are met..
         Starting Prepare Boot Directory (/boot)...
[    9.080198] migrator[1366]: Data store does not exist at given path, exiting (/var/lib/bottlerocket/datastore/current)
[  OK  ] Finished Bottlerocket data store migrator.
         Starting Datastore creator...
[    9.261725] storewolf[1383]: Unable to create datastore: Unable to create directory at '/var/lib/bottlerocket/datastore': Read-only file system (os error 30)
[FAILED] Failed to start Datastore creator.
See 'systemctl status storewolf.service' for details.
[DEPEND] Dependency failed for Applies settings to create config files.
[DEPEND] Dependency failed for Sets the hostname.
[DEPEND] Dependency failed for Send signal to CloudFormation Stack.
[DEPEND] Dependency failed for Bottlerocket API server.
[DEPEND] Dependency failed for Bottlerocket userdata configuration system.
[DEPEND] Dependency failed for User-specified setting generators.
[  OK  ] Finished Prepare Boot Directory (/boot).
         Starting Disable kexec load syscalls...
[    9.492573] netdog[1363]: Failed to write primary interface to '/var/lib/netdog/primary_interface': No such file or directory (os error 2)
[FAILED] Failed to start Generate network configuration.
See 'systemctl status generate-network-config.service' for details.
[DEPEND] Dependency failed for Preparation for Network.
         Starting Network Configuration...
[  OK  ] Finished Disable kexec load syscalls.
         Mounting Local Directory (/local)...
[  OK  ] Started Network Configuration.
[  OK  ] Reached target Network.
         Starting Wait for Network to be Configured...
[    9.864772] mount[1392]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
[    9.866748] mount[1392]:        dmesg(1) may have more information after failed mount system call.
[FAILED] Failed to mount Local Directory (/local).
See 'systemctl status local.mount' for details.
[DEPEND] Dependency failed for Var Directory (/var).
[DEPEND] Dependency failed for Mask Local Var Directory (/local/var).
[DEPEND] Dependency failed for D-Bus System Message Bus.
[DEPEND] Dependency failed for Prepare Var Directory (/var).
[DEPEND] Dependency failed for Mnt Directory (/mnt).
[DEPEND] Dependency failed for Mask Local Mnt Directory (/local/mnt).
[DEPEND] Dependency failed for Opt Directory (/opt).
[DEPEND] Dependency failed for Mask Local Opt Directory (/local/opt).
[DEPEND] Dependency failed for Prepare Opt Directory (/opt).
         Mounting Local Directory (/local)...
[    9.882391] mount[1399]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
[FAILED] Failed to mount Local Directory (/local).
See 'systemctl status local.mount' for details.
[DEPEND] Dependency failed for Var Directory (/var).
[    9.887664] mount[1399]:        dmesg(1) may have more information after failed mount system call.
[DEPEND] Dependency failed for Mask Local Var Directory (/local/var).
[DEPEND] Dependency failed for D-Bus System Message Bus.
[DEPEND] Dependency failed for Prepare Var Directory (/var).
[DEPEND] Dependency failed for Mnt Directory (/mnt).
[DEPEND] Dependency failed for Mask Local Mnt Directory (/local/mnt).
[DEPEND] Dependency failed for Opt Directory (/opt).
[DEPEND] Dependency failed for Mask Local Opt Directory (/local/opt).
[DEPEND] Dependency failed for Prepare Opt Directory (/opt).
         Mounting Local Directory (/local)...
[    9.904539] mount[1405]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
[    9.907559] mount[1405]:        dmesg(1) may have more information after failed mount system call.
[FAILED] Failed to mount Local Directory (/local).
See 'systemctl status local.mount' for details.
[DEPEND] Dependency failed for Var Directory (/var).
[DEPEND] Dependency failed for Mask Local Var Directory (/local/var).
[DEPEND] Dependency failed for D-Bus System Message Bus.
[DEPEND] Dependency failed for Prepare Var Directory (/var).
[DEPEND] Dependency failed for Mnt Directory (/mnt).
[DEPEND] Dependency failed for Mask Local Mnt Directory (/local/mnt).
[DEPEND] Dependency failed for Opt Directory (/opt).
[DEPEND] Dependency failed for Mask Local Opt Directory (/local/opt).
[DEPEND] Dependency failed for Prepare Opt Directory (/opt).
         Mounting Local Directory (/local)...
[    9.926960] mount[1411]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
[    9.930085] mount[1411]:        dmesg(1) may have more information after failed mount system call.
[FAILED] Failed to mount Local Directory (/local).
...
[DEPEND] Dependency failed for Var Directory (/var).
[DEPEND] Dependency failed for Mask Local Var Directory (/local/var).
[DEPEND] Dependency failed for D-Bus System Message Bus.
[DEPEND] Dependency failed for Prepare Var Directory (/var).
[DEPEND] Dependency failed for Mnt Directory (/mnt).
[DEPEND] Dependency failed for Mask Local Mnt Directory (/local/mnt).
[DEPEND] Dependency failed for Opt Directory (/opt).
[DEPEND] Dependency failed for Mask Local Opt Directory (/local/opt).
[DEPEND] Dependency failed for Prepare Opt Directory (/opt).
[FAILED] Failed to mount Local Directory (/local).
See 'systemctl status local.mount' for details.
[DEPEND] Dependency failed for Var Directory (/var).
[DEPEND] Dependency failed for Mask Local Var Directory (/local/var).
[**    ] A start job is running for Wait forâ¦e Configured (1min 58s / no limit)
M
[K[***   ] A start job is running for Wait forâ¦e Configured (1min 58s / no limit)
M
[K[ ***  ] A start job is running for Wait forâ¦e Configured (1min 59s / no limit)
M
[K[  *** ] A start job is running for Wait forâ¦e Configured (1min 59s / no limit)
M
[K[   ***] A start job is running for Wait forâ¦to be Configured (2min / no limit)
M
[K[    **] A start job is running for Wait forâ¦to be Configured (2min / no limit)
M
[K[     *] A start job is running for Wait forâ¦be Configured (2min 1s / no limit)
M
[K         Mounting Local Directory (/local)...
[K[  OK  ] Stopped ACPI event daemon.
         Starting ACPI event daemon...
[  OK  ] Started ACPI event daemon.
[  127.344708] mount[1579]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
[FAILED] Failed to mount Local Directory (/local).
[  127.346591] mount[1579]:        dmesg(1) may have more information after failed mount system call.
See 'systemctl status local.mount' for details.
[DEPEND] Dependency failed for Var Directory (/var).
[DEPEND] Dependency failed for Mask Local Var Directory (/local/var).
[DEPEND] Dependency failed for Prepare Var Directory (/var).
[DEPEND] Dependency failed for Mnt Directory (/mnt).
[DEPEND] Dependency failed for Mask Local Mnt Directory (/local/mnt).
[DEPEND] Dependency failed for Opt Directory (/opt).
[DEPEND] Dependency failed for Mask Local Opt Directory (/local/opt).
[DEPEND] Dependency failed for Prepare Opt Directory (/opt).
[    **] A start job is running for Wait forâ¦be Configured (2min 3s / no limit)
M
[K[   ***] A start job is running for Wait forâ¦be Configured (2min 4s / no limit)
M
[K[FAILED] Failed to start Wait for Network to be Configured.
[KSee 'systemctl status systemd-networkd-wait-online.service' for details.
         Starting Write network status...
[  130.092427] netdog[1587]: Unable to read '/var/lib/netdog/primary_mac_address': No such file or directory (os error 2)
[FAILED] Failed to start Write network status.
See 'systemctl status write-network-status.service' for details.
[  OK  ] Reached target Network is Online.
[  132.843285] mount[1590]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
[  132.845624] mount[1590]:        dmesg(1) may have more information after failed mount system call.
[  224.343391] mount[1726]: mount: /local: wrong fs type, bad option, bad superblock on /dev/nvme1n1p1, missing codepage or helper program, or other error.
....
```


Without this line, the boot proceeds without issue:

```
[root@admin]# sheltie

bash-5.1# mount | grep local
/dev/nvme1n1p1 on /local type ext4 (rw,nosuid,nodev,noatime,seclabel)
/dev/dm-0 on /local/mnt type ext4 (ro,nosuid,nodev,noexec,relatime,seclabel,stripe=1024)
/dev/dm-0 on /local/opt type ext4 (ro,nosuid,nodev,noexec,relatime,seclabel,stripe=1024)
/dev/dm-0 on /local/var type ext4 (ro,nosuid,nodev,noexec,relatime,seclabel,stripe=1024)

bash-5.1# journalctl -u local.mount
Oct 02 21:34:49 localhost systemd[1]: Mounting Local Directory (/local)...
Oct 02 21:34:51 localhost systemd[1]: Mounted Local Directory (/local).

bash-5.1# cat /usr/share/bottlerocket/image-features.env
DATA_PARTITION_FILESYSTEM=xfs
```

Booting with XFS works just as well:
```
[  OK  ] Found device Amazon Elastic Block Store 13.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-PRIVATE.
[  OK  ] Found device Amazon Elastic Block Store 1.
         Starting Repart preferred data partition...
[  OK  ] Finished Repart preferred data partition.
[  OK  ] Found device Amazon Elastic Block Store BOTTLEROCKET-DATA.
         Starting Prepare Local Filesystem (/local)...
[  OK  ] Stopped Repart preferred data partition.
[  OK  ] Finished Prepare Local Filesystem (/local).
         Mounting Local Directory (/local)...
[  OK  ] Mounted Local Directory (/local).
         Mounting Mnt Directory (/mnt)...
         Mounting Opt Directory (/opt)...
         Mounting Var Directory (/var)...
         Starting Resize Data Partition...
[  OK  ] Mounted Mnt Directory (/mnt).
[  OK  ] Mounted Opt Directory (/opt).
[  OK  ] Mounted Var Directory (/var).
         Mounting Private Directory (/var/lib/bottlerocket)...
         Starting Mask Local Mnt Directory (/local/mnt)...
         Starting Mask Local Opt Directory (/local/opt)...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
