### PR TITLE
packages: Update open-vm-tools to 12.3.0

### DIFF
--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/vmware/open-vm-tools/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/vmware/open-vm-tools/releases/download/stable-12.2.5/open-vm-tools-12.2.5-21855600.tar.gz"
-sha512 = "72db3b88f61624d26e8ff7e37e4fc52ecd0bec0b6f076d935870c03312321c5e0b406d05eae7012872734a50626ed760dff2cf872e26ec18ebf200aff5ed12ef"
+url = "https://github.com/vmware/open-vm-tools/releases/download/stable-12.3.0/open-vm-tools-12.3.0-22234872.tar.gz"
+sha512 = "942be3c225d5724e236959dc0d422358b99d2844ed8f1c2d2ca06ea5959c12b1a5ac4fa47ee48c27d1c1291f6d783d1cf87303bf64b8117fd96f226ae4d632e5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -1,7 +1,7 @@
-%global buildver 21855600
+%global buildver 22234872
 
 Name: %{_cross_os}open-vm-tools
-Version: 12.2.5
+Version: 12.3.0
 Release: 1%{?dist}
 Summary: Tools for VMware
 License: LGPL-2.1-or-later


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This updates the `open-vm-tools` package to use the 12.3.0 release.

There are a lot of merged changes since the previous release [0], but most are called out as not being applicable for this package. The only significant change appears to be the commit to add addition x509 checks to the SAM token verification.

[0] https://github.com/vmware/open-vm-tools/compare/stable-12.2.5...stable-12.3.0
[1] https://github.com/vmware/open-vm-tools/commit/74b6d0d9000eda1a2c8f31c40c725fb0b8520b16

**Testing done:**

Built package with:

```sh
cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.28 -e BUILDSYS_ARCH=x86_64 -e PACKAGE=open-vm-tools build-package
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
