### PR TITLE
glibc: Update to latest set of patches

### DIFF
--- a/packages/glibc/0020-getaddrinfo-Fix-use-after-free-in-getcanonname-CVE-2.patch
+++ b/packages/glibc/0020-getaddrinfo-Fix-use-after-free-in-getcanonname-CVE-2.patch
@@ -1,0 +1,338 @@
+From 00ae4f10b504bc4564e9f22f00907093f1ab9338 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Fri, 15 Sep 2023 13:51:12 -0400
+Subject: [PATCH] getaddrinfo: Fix use after free in getcanonname
+ (CVE-2023-4806)
+
+When an NSS plugin only implements the _gethostbyname2_r and
+_getcanonname_r callbacks, getaddrinfo could use memory that was freed
+during tmpbuf resizing, through h_name in a previous query response.
+
+The backing store for res->at->name when doing a query with
+gethostbyname3_r or gethostbyname2_r is tmpbuf, which is reallocated in
+gethosts during the query.  For AF_INET6 lookup with AI_ALL |
+AI_V4MAPPED, gethosts gets called twice, once for a v6 lookup and second
+for a v4 lookup.  In this case, if the first call reallocates tmpbuf
+enough number of times, resulting in a malloc, th->h_name (that
+res->at->name refers to) ends up on a heap allocated storage in tmpbuf.
+Now if the second call to gethosts also causes the plugin callback to
+return NSS_STATUS_TRYAGAIN, tmpbuf will get freed, resulting in a UAF
+reference in res->at->name.  This then gets dereferenced in the
+getcanonname_r plugin call, resulting in the use after free.
+
+Fix this by copying h_name over and freeing it at the end.  This
+resolves BZ #30843, which is assigned CVE-2023-4806.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit 973fe93a5675c42798b2161c6f29c01b0e243994)
+---
+ nss/Makefile                                  | 15 ++++-
+ nss/nss_test_gai_hv2_canonname.c              | 56 +++++++++++++++++
+ nss/tst-nss-gai-hv2-canonname.c               | 63 +++++++++++++++++++
+ nss/tst-nss-gai-hv2-canonname.h               |  1 +
+ .../postclean.req                             |  0
+ .../tst-nss-gai-hv2-canonname.script          |  2 +
+ sysdeps/posix/getaddrinfo.c                   | 25 +++++---
+ 7 files changed, 152 insertions(+), 10 deletions(-)
+ create mode 100644 nss/nss_test_gai_hv2_canonname.c
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.c
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.h
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.root/postclean.req
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script
+
+diff --git a/nss/Makefile b/nss/Makefile
+index 06fcdc450f..8a5126ecf3 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -82,6 +82,7 @@ tests-container := \
+   tst-nss-test3 \
+   tst-reload1 \
+   tst-reload2 \
++  tst-nss-gai-hv2-canonname \
+ # tests-container
+ 
+ # Tests which need libdl
+@@ -145,7 +146,8 @@ libnss_compat-inhibit-o	= $(filter-out .os,$(object-suffixes))
+ ifeq ($(build-static-nss),yes)
+ tests-static		+= tst-nss-static
+ endif
+-extra-test-objs		+= nss_test1.os nss_test2.os nss_test_errno.os
++extra-test-objs		+= nss_test1.os nss_test2.os nss_test_errno.os \
++			   nss_test_gai_hv2_canonname.os
+ 
+ include ../Rules
+ 
+@@ -180,12 +182,16 @@ rtld-tests-LDFLAGS += -Wl,--dynamic-list=nss_test.ver
+ libof-nss_test1 = extramodules
+ libof-nss_test2 = extramodules
+ libof-nss_test_errno = extramodules
++libof-nss_test_gai_hv2_canonname = extramodules
+ $(objpfx)/libnss_test1.so: $(objpfx)nss_test1.os $(link-libc-deps)
+ 	$(build-module)
+ $(objpfx)/libnss_test2.so: $(objpfx)nss_test2.os $(link-libc-deps)
+ 	$(build-module)
+ $(objpfx)/libnss_test_errno.so: $(objpfx)nss_test_errno.os $(link-libc-deps)
+ 	$(build-module)
++$(objpfx)/libnss_test_gai_hv2_canonname.so: \
++  $(objpfx)nss_test_gai_hv2_canonname.os $(link-libc-deps)
++	$(build-module)
+ $(objpfx)nss_test2.os : nss_test1.c
+ # Use the nss_files suffix for these objects as well.
+ $(objpfx)/libnss_test1.so$(libnss_files.so-version): $(objpfx)/libnss_test1.so
+@@ -195,10 +201,14 @@ $(objpfx)/libnss_test2.so$(libnss_files.so-version): $(objpfx)/libnss_test2.so
+ $(objpfx)/libnss_test_errno.so$(libnss_files.so-version): \
+   $(objpfx)/libnss_test_errno.so
+ 	$(make-link)
++$(objpfx)/libnss_test_gai_hv2_canonname.so$(libnss_files.so-version): \
++  $(objpfx)/libnss_test_gai_hv2_canonname.so
++	$(make-link)
+ $(patsubst %,$(objpfx)%.out,$(tests) $(tests-container)) : \
+ 	$(objpfx)/libnss_test1.so$(libnss_files.so-version) \
+ 	$(objpfx)/libnss_test2.so$(libnss_files.so-version) \
+-	$(objpfx)/libnss_test_errno.so$(libnss_files.so-version)
++	$(objpfx)/libnss_test_errno.so$(libnss_files.so-version) \
++	$(objpfx)/libnss_test_gai_hv2_canonname.so$(libnss_files.so-version)
+ 
+ ifeq (yes,$(have-thread-library))
+ $(objpfx)tst-cancel-getpwuid_r: $(shared-thread-library)
+@@ -215,3 +225,4 @@ LDFLAGS-tst-nss-test3 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test4 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test5 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test_errno = -Wl,--disable-new-dtags
++LDFLAGS-tst-nss-test_gai_hv2_canonname = -Wl,--disable-new-dtags
+diff --git a/nss/nss_test_gai_hv2_canonname.c b/nss/nss_test_gai_hv2_canonname.c
+new file mode 100644
+index 0000000000..4439c83c9f
+--- /dev/null
++++ b/nss/nss_test_gai_hv2_canonname.c
+@@ -0,0 +1,56 @@
++/* NSS service provider that only provides gethostbyname2_r.
++   Copyright The GNU Toolchain Authors.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <nss.h>
++#include <stdlib.h>
++#include <string.h>
++#include "nss/tst-nss-gai-hv2-canonname.h"
++
++/* Catch misnamed and functions.  */
++#pragma GCC diagnostic error "-Wmissing-prototypes"
++NSS_DECLARE_MODULE_FUNCTIONS (test_gai_hv2_canonname)
++
++extern enum nss_status _nss_files_gethostbyname2_r (const char *, int,
++						    struct hostent *, char *,
++						    size_t, int *, int *);
++
++enum nss_status
++_nss_test_gai_hv2_canonname_gethostbyname2_r (const char *name, int af,
++					      struct hostent *result,
++					      char *buffer, size_t buflen,
++					      int *errnop, int *herrnop)
++{
++  return _nss_files_gethostbyname2_r (name, af, result, buffer, buflen, errnop,
++				      herrnop);
++}
++
++enum nss_status
++_nss_test_gai_hv2_canonname_getcanonname_r (const char *name, char *buffer,
++					    size_t buflen, char **result,
++					    int *errnop, int *h_errnop)
++{
++  /* We expect QUERYNAME, which is a small enough string that it shouldn't fail
++     the test.  */
++  if (memcmp (QUERYNAME, name, sizeof (QUERYNAME))
++      || buflen < sizeof (QUERYNAME))
++    abort ();
++
++  strncpy (buffer, name, buflen);
++  *result = buffer;
++  return NSS_STATUS_SUCCESS;
++}
+diff --git a/nss/tst-nss-gai-hv2-canonname.c b/nss/tst-nss-gai-hv2-canonname.c
+new file mode 100644
+index 0000000000..d5f10c07d6
+--- /dev/null
++++ b/nss/tst-nss-gai-hv2-canonname.c
+@@ -0,0 +1,63 @@
++/* Test NSS query path for plugins that only implement gethostbyname2
++   (#30843).
++   Copyright The GNU Toolchain Authors.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <nss.h>
++#include <netdb.h>
++#include <stdlib.h>
++#include <string.h>
++#include <support/check.h>
++#include <support/xstdio.h>
++#include "nss/tst-nss-gai-hv2-canonname.h"
++
++#define PREPARE do_prepare
++
++static void do_prepare (int a, char **av)
++{
++  FILE *hosts = xfopen ("/etc/hosts", "w");
++  for (unsigned i = 2; i < 255; i++)
++    {
++      fprintf (hosts, "ff01::ff02:ff03:%u:2\ttest.example.com\n", i);
++      fprintf (hosts, "192.168.0.%u\ttest.example.com\n", i);
++    }
++  xfclose (hosts);
++}
++
++static int
++do_test (void)
++{
++  __nss_configure_lookup ("hosts", "test_gai_hv2_canonname");
++
++  struct addrinfo hints = {};
++  struct addrinfo *result = NULL;
++
++  hints.ai_family = AF_INET6;
++  hints.ai_flags = AI_ALL | AI_V4MAPPED | AI_CANONNAME;
++
++  int ret = getaddrinfo (QUERYNAME, NULL, &hints, &result);
++
++  if (ret != 0)
++    FAIL_EXIT1 ("getaddrinfo failed: %s\n", gai_strerror (ret));
++
++  TEST_COMPARE_STRING (result->ai_canonname, QUERYNAME);
++
++  freeaddrinfo(result);
++  return 0;
++}
++
++#include <support/test-driver.c>
+diff --git a/nss/tst-nss-gai-hv2-canonname.h b/nss/tst-nss-gai-hv2-canonname.h
+new file mode 100644
+index 0000000000..14f2a9cb08
+--- /dev/null
++++ b/nss/tst-nss-gai-hv2-canonname.h
+@@ -0,0 +1 @@
++#define QUERYNAME "test.example.com"
+diff --git a/nss/tst-nss-gai-hv2-canonname.root/postclean.req b/nss/tst-nss-gai-hv2-canonname.root/postclean.req
+new file mode 100644
+index 0000000000..e69de29bb2
+diff --git a/nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script b/nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script
+new file mode 100644
+index 0000000000..31848b4a28
+--- /dev/null
++++ b/nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script
+@@ -0,0 +1,2 @@
++cp $B/nss/libnss_test_gai_hv2_canonname.so $L/libnss_test_gai_hv2_canonname.so.2
++su
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 0356b622be..b2236b105c 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -120,6 +120,7 @@ struct gaih_result
+ {
+   struct gaih_addrtuple *at;
+   char *canon;
++  char *h_name;
+   bool free_at;
+   bool got_ipv6;
+ };
+@@ -165,6 +166,7 @@ gaih_result_reset (struct gaih_result *res)
+   if (res->free_at)
+     free (res->at);
+   free (res->canon);
++  free (res->h_name);
+   memset (res, 0, sizeof (*res));
+ }
+ 
+@@ -203,9 +205,8 @@ gaih_inet_serv (const char *servicename, const struct gaih_typeproto *tp,
+   return 0;
+ }
+ 
+-/* Convert struct hostent to a list of struct gaih_addrtuple objects.  h_name
+-   is not copied, and the struct hostent object must not be deallocated
+-   prematurely.  The new addresses are appended to the tuple array in RES.  */
++/* Convert struct hostent to a list of struct gaih_addrtuple objects.  The new
++   addresses are appended to the tuple array in RES.  */
+ static bool
+ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+ 				   struct hostent *h, struct gaih_result *res)
+@@ -238,6 +239,15 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+   res->at = array;
+   res->free_at = true;
+ 
++  /* Duplicate h_name because it may get reclaimed when the underlying storage
++     is freed.  */
++  if (res->h_name == NULL)
++    {
++      res->h_name = __strdup (h->h_name);
++      if (res->h_name == NULL)
++	return false;
++    }
++
+   /* Update the next pointers on reallocation.  */
+   for (size_t i = 0; i < old; i++)
+     array[i].next = array + i + 1;
+@@ -262,7 +272,6 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+ 	}
+       array[i].next = array + i + 1;
+     }
+-  array[0].name = h->h_name;
+   array[count - 1].next = NULL;
+ 
+   return true;
+@@ -324,15 +333,15 @@ gethosts (nss_gethostbyname3_r fct, int family, const char *name,
+    memory allocation failure.  The returned string is allocated on the
+    heap; the caller has to free it.  */
+ static char *
+-getcanonname (nss_action_list nip, struct gaih_addrtuple *at, const char *name)
++getcanonname (nss_action_list nip, const char *hname, const char *name)
+ {
+   nss_getcanonname_r *cfct = __nss_lookup_function (nip, "getcanonname_r");
+   char *s = (char *) name;
+   if (cfct != NULL)
+     {
+       char buf[256];
+-      if (DL_CALL_FCT (cfct, (at->name ?: name, buf, sizeof (buf),
+-			      &s, &errno, &h_errno)) != NSS_STATUS_SUCCESS)
++      if (DL_CALL_FCT (cfct, (hname ?: name, buf, sizeof (buf), &s, &errno,
++			      &h_errno)) != NSS_STATUS_SUCCESS)
+ 	/* If the canonical name cannot be determined, use the passed
+ 	   string.  */
+ 	s = (char *) name;
+@@ -771,7 +780,7 @@ get_nss_addresses (const char *name, const struct addrinfo *req,
+ 		  if ((req->ai_flags & AI_CANONNAME) != 0
+ 		      && res->canon == NULL)
+ 		    {
+-		      char *canonbuf = getcanonname (nip, res->at, name);
++		      char *canonbuf = getcanonname (nip, res->h_name, name);
+ 		      if (canonbuf == NULL)
+ 			{
+ 			  __resolv_context_put (res_ctx);
+-- 
+2.42.0
+

--- a/packages/glibc/0021-iconv-restore-verbosity-with-unrecognized-encoding-n.patch
+++ b/packages/glibc/0021-iconv-restore-verbosity-with-unrecognized-encoding-n.patch
@@ -1,0 +1,32 @@
+From 63250e9c571314b6daa2c949ea0af335ee766751 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Tue, 1 Aug 2023 17:01:37 +0200
+Subject: [PATCH] iconv: restore verbosity with unrecognized encoding names
+ (bug 30694)
+
+Commit 91927b7c76 ("Rewrite iconv option parsing [BZ #19519]") changed the
+iconv program to call __gconv_open directly instead of the iconv_open
+wrapper, but the former does not set errno.  Update the caller to
+interpret the return codes like iconv_open does.
+
+(cherry picked from commit fc72b6d7d818ab2868920af956d1542d03342a4d)
+---
+ iconv/iconv_prog.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iconv/iconv_prog.c b/iconv/iconv_prog.c
+index bee898c63c..cf32cf9b44 100644
+--- a/iconv/iconv_prog.c
++++ b/iconv/iconv_prog.c
+@@ -187,7 +187,7 @@ main (int argc, char *argv[])
+ 
+       if (res != __GCONV_OK)
+ 	{
+-	  if (errno == EINVAL)
++	  if (res == __GCONV_NOCONV || res == __GCONV_NODB)
+ 	    {
+ 	      /* Try to be nice with the user and tell her which of the
+ 		 two encoding names is wrong.  This is possible because
+-- 
+2.42.0
+

--- a/packages/glibc/0022-string-Fix-tester-build-with-fortify-enable-with-gcc.patch
+++ b/packages/glibc/0022-string-Fix-tester-build-with-fortify-enable-with-gcc.patch
@@ -1,0 +1,49 @@
+From d94461bb86ba176b9390c0015bb612a528e22d95 Mon Sep 17 00:00:00 2001
+From: Mahesh Bodapati <bmahi496@linux.ibm.com>
+Date: Fri, 11 Aug 2023 10:38:25 -0500
+Subject: [PATCH] string: Fix tester build with fortify enable with gcc < 12
+
+When building with fortify enabled, GCC < 12 issues a warning on the
+fortify strncat wrapper might overflow the destination buffer (the
+failure is tied to -Werror).
+
+Checked on ppc64 and x86_64.
+Reviewed-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+
+(cherry picked from commit f1c7ed0859a45929136836341741c7cd70f428cb)
+---
+ string/tester.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/string/tester.c b/string/tester.c
+index f7d4bac5a8..824cf315ff 100644
+--- a/string/tester.c
++++ b/string/tester.c
+@@ -34,6 +34,14 @@
+ DIAG_IGNORE_NEEDS_COMMENT (8, "-Wstringop-truncation");
+ #endif
+ 
++/* When building with fortify enabled, GCC < 12 issues a warning on the
++   fortify strncat wrapper might overflow the destination buffer (the
++   failure is tied to -Werror).
++   Triggered by strncat fortify wrapper when it is enabled.  */
++#if __GNUC_PREREQ (11, 0)
++DIAG_IGNORE_NEEDS_COMMENT (11, "-Wstringop-overread");
++#endif
++
+ #include <errno.h>
+ #include <stdint.h>
+ #include <stdio.h>
+@@ -52,9 +60,6 @@ DIAG_IGNORE_NEEDS_COMMENT (5.0, "-Wmemset-transposed-args");
+ DIAG_IGNORE_NEEDS_COMMENT (9, "-Wrestrict");
+ DIAG_IGNORE_NEEDS_COMMENT (7, "-Wstringop-overflow=");
+ #endif
+-#if __GNUC_PREREQ (11, 0)
+-DIAG_IGNORE_NEEDS_COMMENT (11, "-Wstringop-overread");
+-#endif
+ 
+ 
+ #define	STREQ(a, b)	(strcmp((a), (b)) == 0)
+-- 
+2.42.0
+

--- a/packages/glibc/0023-manual-jobs.texi-Add-missing-item-EPERM-for-getpgid.patch
+++ b/packages/glibc/0023-manual-jobs.texi-Add-missing-item-EPERM-for-getpgid.patch
@@ -1,0 +1,30 @@
+From 0e1ef6779a90bc0f8a05bc367796df2793deecaa Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Thu, 24 Aug 2023 21:36:34 +0200
+Subject: [PATCH] manual/jobs.texi: Add missing @item EPERM for getpgid
+
+The missing @item makes it look like errno will be set to ESRCH
+if a cross-session getpgid is not permitted.
+
+Found by ulfvonbelow on irc.
+
+(cherry picked from commit 5a21cefd5abab1b99eda1fbf84204a9bf41662ab)
+---
+ manual/job.texi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/manual/job.texi b/manual/job.texi
+index 42cb9fb26d..8157f13a1c 100644
+--- a/manual/job.texi
++++ b/manual/job.texi
+@@ -1133,6 +1133,7 @@ following @code{errno} error conditions are defined for this function:
+ @table @code
+ @item ESRCH
+ There is no process with the given process ID @var{pid}.
++@item EPERM
+ The calling process and the process specified by @var{pid} are in
+ different sessions, and the implementation doesn't allow to access the
+ process group ID of the process with ID @var{pid} from the calling
+-- 
+2.42.0
+

--- a/packages/glibc/0024-Fix-leak-in-getaddrinfo-introduced-by-the-fix-for-CV.patch
+++ b/packages/glibc/0024-Fix-leak-in-getaddrinfo-introduced-by-the-fix-for-CV.patch
@@ -1,0 +1,98 @@
+From 5ee59ca371b99984232d7584fe2b1a758b4421d3 Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@amadeus.com>
+Date: Mon, 25 Sep 2023 01:21:51 +0100
+Subject: [PATCH] Fix leak in getaddrinfo introduced by the fix for
+ CVE-2023-4806 [BZ #30843]
+
+This patch fixes a very recently added leak in getaddrinfo.
+
+This was assigned CVE-2023-5156.
+
+Resolves: BZ #30884
+Related: BZ #30842
+
+Reviewed-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit ec6b95c3303c700eb89eebeda2d7264cc184a796)
+---
+ nss/Makefile                    | 20 ++++++++++++++++++++
+ nss/tst-nss-gai-hv2-canonname.c |  3 +++
+ sysdeps/posix/getaddrinfo.c     |  4 +---
+ 3 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/nss/Makefile b/nss/Makefile
+index 8a5126ecf3..668ba34b18 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -149,6 +149,15 @@ endif
+ extra-test-objs		+= nss_test1.os nss_test2.os nss_test_errno.os \
+ 			   nss_test_gai_hv2_canonname.os
+ 
++ifeq ($(run-built-tests),yes)
++ifneq (no,$(PERL))
++tests-special += $(objpfx)mtrace-tst-nss-gai-hv2-canonname.out
++endif
++endif
++
++generated += mtrace-tst-nss-gai-hv2-canonname.out \
++		tst-nss-gai-hv2-canonname.mtrace
++
+ include ../Rules
+ 
+ ifeq (yes,$(have-selinux))
+@@ -217,6 +226,17 @@ endif
+ $(objpfx)tst-nss-files-alias-leak.out: $(objpfx)/libnss_files.so
+ $(objpfx)tst-nss-files-alias-truncated.out: $(objpfx)/libnss_files.so
+ 
++tst-nss-gai-hv2-canonname-ENV = \
++		MALLOC_TRACE=$(objpfx)tst-nss-gai-hv2-canonname.mtrace \
++		LD_PRELOAD=$(common-objpfx)/malloc/libc_malloc_debug.so
++$(objpfx)mtrace-tst-nss-gai-hv2-canonname.out: \
++  $(objpfx)tst-nss-gai-hv2-canonname.out
++	{ test -r $(objpfx)tst-nss-gai-hv2-canonname.mtrace \
++	|| ( echo "tst-nss-gai-hv2-canonname.mtrace does not exist"; exit 77; ) \
++	&& $(common-objpfx)malloc/mtrace \
++	$(objpfx)tst-nss-gai-hv2-canonname.mtrace; } > $@; \
++	$(evaluate-test)
++
+ # Disable DT_RUNPATH on NSS tests so that the glibc internal NSS
+ # functions can load testing NSS modules via DT_RPATH.
+ LDFLAGS-tst-nss-test1 = -Wl,--disable-new-dtags
+diff --git a/nss/tst-nss-gai-hv2-canonname.c b/nss/tst-nss-gai-hv2-canonname.c
+index d5f10c07d6..7db53cf09d 100644
+--- a/nss/tst-nss-gai-hv2-canonname.c
++++ b/nss/tst-nss-gai-hv2-canonname.c
+@@ -21,6 +21,7 @@
+ #include <netdb.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <mcheck.h>
+ #include <support/check.h>
+ #include <support/xstdio.h>
+ #include "nss/tst-nss-gai-hv2-canonname.h"
+@@ -41,6 +42,8 @@ static void do_prepare (int a, char **av)
+ static int
+ do_test (void)
+ {
++  mtrace ();
++
+   __nss_configure_lookup ("hosts", "test_gai_hv2_canonname");
+ 
+   struct addrinfo hints = {};
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index b2236b105c..13082305d3 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -1196,9 +1196,7 @@ free_and_return:
+   if (malloc_name)
+     free ((char *) name);
+   free (addrmem);
+-  if (res.free_at)
+-    free (res.at);
+-  free (res.canon);
++  gaih_result_reset (&res);
+ 
+   return result;
+ }
+-- 
+2.42.0
+

--- a/packages/glibc/0025-Document-CVE-2023-4806-and-CVE-2023-5156-in-NEWS.patch
+++ b/packages/glibc/0025-Document-CVE-2023-4806-and-CVE-2023-5156-in-NEWS.patch
@@ -1,0 +1,36 @@
+From f6445dc94da185b3d1ee283f0ca0a34c4e1986cc Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 26 Sep 2023 07:38:07 -0400
+Subject: [PATCH] Document CVE-2023-4806 and CVE-2023-5156 in NEWS
+
+These are tracked in BZ #30884 and BZ #30843.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit fd134feba35fa839018965733b34d28a09a075dd)
+---
+ NEWS | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/NEWS b/NEWS
+index dfee278a9c..f1b1b0a3b4 100644
+--- a/NEWS
++++ b/NEWS
+@@ -15,6 +15,15 @@ Security related changes:
+   2048 bytes, getaddrinfo may potentially disclose stack contents via
+   the returned address data, or crash.
+ 
++  CVE-2023-4806: When an NSS plugin only implements the
++  _gethostbyname2_r and _getcanonname_r callbacks, getaddrinfo could use
++  memory that was freed during buffer resizing, potentially causing a
++  crash or read or write to arbitrary memory.
++
++  CVE-2023-5156: The fix for CVE-2023-4806 introduced a memory leak when
++  an application calls getaddrinfo for AF_INET6 with AI_CANONNAME,
++  AI_ALL and AI_V4MAPPED flags set.
++
+ The following bugs are resolved with this release:
+ 
+   [30723] posix_memalign repeatedly scans long bin lists
+-- 
+2.42.0
+

--- a/packages/glibc/0026-Propagate-GLIBC_TUNABLES-in-setxid-binaries.patch
+++ b/packages/glibc/0026-Propagate-GLIBC_TUNABLES-in-setxid-binaries.patch
@@ -1,0 +1,32 @@
+From 73e3fcd1a552783e66ff1f65c5f322e2f17a81d1 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 13:25:40 -0400
+Subject: [PATCH] Propagate GLIBC_TUNABLES in setxid binaries
+
+GLIBC_TUNABLES scrubbing happens earlier than envvar scrubbing and some
+tunables are required to propagate past setxid boundary, like their
+env_alias.  Rely on tunable scrubbing to clean out GLIBC_TUNABLES like
+before, restoring behaviour in glibc 2.37 and earlier.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 0d5f9ea97f1b39f2a855756078771673a68497e1)
+---
+ sysdeps/generic/unsecvars.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/sysdeps/generic/unsecvars.h b/sysdeps/generic/unsecvars.h
+index 81397fb90b..8278c50a84 100644
+--- a/sysdeps/generic/unsecvars.h
++++ b/sysdeps/generic/unsecvars.h
+@@ -4,7 +4,6 @@
+ #define UNSECURE_ENVVARS \
+   "GCONV_PATH\0"							      \
+   "GETCONF_DIR\0"							      \
+-  "GLIBC_TUNABLES\0"							      \
+   "HOSTALIASES\0"							      \
+   "LD_AUDIT\0"								      \
+   "LD_DEBUG\0"								      \
+-- 
+2.42.0
+

--- a/packages/glibc/0027-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
+++ b/packages/glibc/0027-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
@@ -1,0 +1,173 @@
+From 750a45a783906a19591fb8ff6b7841470f1f5701 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 18:39:32 -0400
+Subject: [PATCH] tunables: Terminate if end of input is reached
+ (CVE-2023-4911)
+
+The string parsing routine may end up writing beyond bounds of tunestr
+if the input tunable string is malformed, of the form name=name=val.
+This gets processed twice, first as name=name=val and next as name=val,
+resulting in tunestr being name=name=val:name=val, thus overflowing
+tunestr.
+
+Terminate the parsing loop at the first instance itself so that tunestr
+does not overflow.
+
+This also fixes up tst-env-setuid-tunables to actually handle failures
+correct and add new tests to validate the fix for this CVE.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa)
+---
+ NEWS                          |  5 +++++
+ elf/dl-tunables.c             | 17 +++++++++-------
+ elf/tst-env-setuid-tunables.c | 37 +++++++++++++++++++++++++++--------
+ 3 files changed, 44 insertions(+), 15 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index f1b1b0a3b4..bfcd46efa9 100644
+--- a/NEWS
++++ b/NEWS
+@@ -24,6 +24,11 @@ Security related changes:
+   an application calls getaddrinfo for AF_INET6 with AI_CANONNAME,
+   AI_ALL and AI_V4MAPPED flags set.
+ 
++  CVE-2023-4911: If a tunable of the form NAME=NAME=VAL is passed in the
++  environment of a setuid program and NAME is valid, it may result in a
++  buffer overflow, which could be exploited to achieve escalated
++  privileges.  This flaw was introduced in glibc 2.34.
++
+ The following bugs are resolved with this release:
+ 
+   [30723] posix_memalign repeatedly scans long bin lists
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 62b7332d95..cae67efa0a 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -180,11 +180,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -244,9 +240,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ 
+ /* Enable the glibc.malloc.check tunable in SETUID/SETGID programs only when
+diff --git a/elf/tst-env-setuid-tunables.c b/elf/tst-env-setuid-tunables.c
+index 7dfb0e073a..f0b92c97e7 100644
+--- a/elf/tst-env-setuid-tunables.c
++++ b/elf/tst-env-setuid-tunables.c
+@@ -50,6 +50,8 @@ const char *teststrings[] =
+   "glibc.malloc.perturb=0x800:not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
+   "glibc.not_valid.check=2:glibc.malloc.mmap_threshold=4096",
+   "not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.check=2",
+   "glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096:glibc.malloc.check=2",
+   "glibc.malloc.check=4:glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096",
+   ":glibc.malloc.garbage=2:glibc.malloc.check=1",
+@@ -68,6 +70,8 @@ const char *resultstrings[] =
+   "glibc.malloc.perturb=0x800:glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "",
+   "",
+   "",
+   "",
+@@ -81,11 +85,18 @@ test_child (int off)
+ {
+   const char *val = getenv ("GLIBC_TUNABLES");
+ 
++  printf ("    [%d] GLIBC_TUNABLES is %s\n", off, val);
++  fflush (stdout);
+   if (val != NULL && strcmp (val, resultstrings[off]) == 0)
+     return 0;
+ 
+   if (val != NULL)
+-    printf ("[%d] Unexpected GLIBC_TUNABLES VALUE %s\n", off, val);
++    printf ("    [%d] Unexpected GLIBC_TUNABLES VALUE %s, expected %s\n",
++	    off, val, resultstrings[off]);
++  else
++    printf ("    [%d] GLIBC_TUNABLES environment variable absent\n", off);
++
++  fflush (stdout);
+ 
+   return 1;
+ }
+@@ -106,21 +117,26 @@ do_test (int argc, char **argv)
+       if (ret != 0)
+ 	exit (1);
+ 
+-      exit (EXIT_SUCCESS);
++      /* Special return code to make sure that the child executed all the way
++	 through.  */
++      exit (42);
+     }
+   else
+     {
+-      int ret = 0;
+-
+       /* Spawn tests.  */
+       for (int i = 0; i < array_length (teststrings); i++)
+ 	{
+ 	  char buf[INT_BUFSIZE_BOUND (int)];
+ 
+-	  printf ("Spawned test for %s (%d)\n", teststrings[i], i);
++	  printf ("[%d] Spawned test for %s\n", i, teststrings[i]);
+ 	  snprintf (buf, sizeof (buf), "%d\n", i);
++	  fflush (stdout);
+ 	  if (setenv ("GLIBC_TUNABLES", teststrings[i], 1) != 0)
+-	    exit (1);
++	    {
++	      printf ("    [%d] Failed to set GLIBC_TUNABLES: %m", i);
++	      support_record_failure ();
++	      continue;
++	    }
+ 
+ 	  int status = support_capture_subprogram_self_sgid (buf);
+ 
+@@ -128,9 +144,14 @@ do_test (int argc, char **argv)
+ 	  if (WEXITSTATUS (status) == EXIT_UNSUPPORTED)
+ 	    return EXIT_UNSUPPORTED;
+ 
+-	  ret |= status;
++	  if (WEXITSTATUS (status) != 42)
++	    {
++	      printf ("    [%d] child failed with status %d\n", i,
++		      WEXITSTATUS (status));
++	      support_record_failure ();
++	    }
+ 	}
+-      return ret;
++      return 0;
+     }
+ }
+ 
+-- 
+2.42.0
+

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -38,6 +38,14 @@ Patch0016: 0016-elf-Remove-unused-l_text_end-field-from-struct-link_.patch
 Patch0017: 0017-elf-Move-l_init_called_next-to-old-place-of-l_text_e.patch
 Patch0018: 0018-NEWS-Add-the-2.38.1-bug-list.patch
 Patch0019: 0019-CVE-2023-4527-Stack-read-overflow-with-large-TCP-res.patch
+Patch0020: 0020-getaddrinfo-Fix-use-after-free-in-getcanonname-CVE-2.patch
+Patch0021: 0021-iconv-restore-verbosity-with-unrecognized-encoding-n.patch
+Patch0022: 0022-string-Fix-tester-build-with-fortify-enable-with-gcc.patch
+Patch0023: 0023-manual-jobs.texi-Add-missing-item-EPERM-for-getpgid.patch
+Patch0024: 0024-Fix-leak-in-getaddrinfo-introduced-by-the-fix-for-CV.patch
+Patch0025: 0025-Document-CVE-2023-4806-and-CVE-2023-5156-in-NEWS.patch
+Patch0026: 0026-Propagate-GLIBC_TUNABLES-in-setxid-binaries.patch
+Patch0027: 0027-tunables-Terminate-if-end-of-input-is-reached-CVE-20.patch
 
 # Fedora patches
 Patch1001: glibc-cs-path.patch


### PR DESCRIPTION
**Description of changes:**
Takes the latest updates for glibc which include several CVE fixes (CVE-2023-4806, CVE-2023-5156, and CVE-2023-4911)


**Testing done:**
Built an aws-k8s-1.28 and lauched it as part of a cluster. It came up and connected. I hopped on and spot tested that things work.

```
bash-5.1#  journalctl -p 3 -xb
bash-5.1#
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
