### PR TITLE
docs: update links to point to the currently used issue labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Bottlerocket follows a few basic filename case conventions:
 
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on.
-As this repository uses GitHub issue [labels](https://github.com/bottlerocket-os/bottlerocket/labels), looking at any ['status/helpwelcome'](https://github.com/bottlerocket-os/bottlerocket/labels/status%2Fhelpwelcome) issues is a great place to start.
+As this repository uses GitHub issue [labels](https://github.com/bottlerocket-os/bottlerocket/labels), looking through issues labeled ['good first issue'](https://github.com/bottlerocket-os/bottlerocket/labels/good%20first%20issue) or ['help wanted'](https://github.com/bottlerocket-os/bottlerocket/labels/help%20wanted) is a great place to start.
 
 
 ## Code of Conduct


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

The label 'status/helpwelcome' referenced in CONTRIBUTING.md doesn't exist. Updated the docs to point to what looks to be the currently used labels ('help wanted' and 'good first issue')

**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
