### PR TITLE
[1.15.x] Updates to prepare for the 1.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# v1.15.1 (2023-10-9)
+
+## OS Changes
+
+* Allow older ext4 snapshot volumes to be mounted in newer variants that default to xfs ([#3499])
+* Update `apiclient` Rust dependencies ([#3491])
+* Update `pluto` Rust dependencies ([#3439])
+* Patch glibc to address CVE-2023-4806, CVE-2023-4911, and CVE-2023-5156 ([#3501])
+* Update open-vm-tools to 12.3.0 to address CVE-2023-20900 ([#3500])
+
+## Build Changes
+
+* Update `twoliter` to v0.0.4 ([#3480])
+
+[#3439]: https://github.com/bottlerocket-os/bottlerocket/pull/3439
+[#3480]: https://github.com/bottlerocket-os/bottlerocket/pull/3480
+[#3491]: https://github.com/bottlerocket-os/bottlerocket/pull/3491
+[#3499]: https://github.com/bottlerocket-os/bottlerocket/pull/3499
+[#3500]: https://github.com/bottlerocket-os/bottlerocket/pull/3500
+[#3501]: https://github.com/bottlerocket-os/bottlerocket/pull/3501
+
 # v1.15.0 (2023-09-18)
 
 ## Major Features

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.15.0"
+version = "1.15.1"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -234,3 +234,4 @@ version = "1.15.0"
     "migrate_v1.15.0_log4j-hotpatch-enabled-metadata.lz4",
     "migrate_v1.15.0_deprecate-log4j-hotpatch-enabled.lz4",
 ]
+"(1.15.0, 1.15.1)" = []


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds the 1.15.0->1.15.1 migration step to Release.toml and adds the included 1.15.1 changes to the CHANGELOG.

Cherry-pick drops the 1.16.0 migrations and updates the version value to 1.15.1.

(cherry picked from commit 86039f12df44c7419849aa40ddcc50a4be749781)

**Testing done:**

Testing in `develop`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
