### PR TITLE
kernel: update to 5.10.196, 5.15.133 and 6.1.55

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/4cbf281b8513ad2257aae8ad983a75fd76cb9c613fe7025822f0f16879cb2e2b/kernel-5.10.192-182.736.amzn2.src.rpm"
-sha512 = "8c1885a9f3a7c00d55b5c1bdadc5d95f1f64b321eabb602d69ce78706ce7f7241022cb094f161aebeebac74d4a08479c07d4a3db7bacb2896cf10ede962de3ec"
+url = "https://cdn.amazonlinux.com/blobstore/2e0b99966781510902082be83f28d36844f9f84a1cc9c31f08550a5d7b632e14/kernel-5.10.196-185.743.amzn2.src.rpm"
+sha512 = "579684744ae32d79ea6b40cee223613541d0d82db9f760528d043999d6f96c6d9656e01e403f1f8a434b0ee1ea2c5bb637afe97a74339b6a7cba752da48c2b14"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.192
+Version: 5.10.196
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/4cbf281b8513ad2257aae8ad983a75fd76cb9c613fe7025822f0f16879cb2e2b/kernel-5.10.192-182.736.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/2e0b99966781510902082be83f28d36844f9f84a1cc9c31f08550a5d7b632e14/kernel-5.10.196-185.743.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/d301b89106ee983f8cd5cd0b4d6b4111ea97b7e51ca2892a6d9bbec4eaf18c4f/kernel-5.15.128-80.144.amzn2.src.rpm"
-sha512 = "ac8fce4c8f293dd123e64ec6f3cf553e2d9b0462de5b48e0caebeecb1091a6d72dde35571264da1ed05984845778e758552636faf42d89ac6af41feec1f8b5da"
+url = "https://cdn.amazonlinux.com/blobstore/2856e0e792b1a49369693e4b0e4246700fdf5094b2f5f953569e74d7b99e8f0e/kernel-5.15.133-86.144.amzn2.src.rpm"
+sha512 = "5d0ffb542f8c7caebc0bf61e91c9a65b2fd2c17df91d1ec3e4536f9f1fd1b56e7150391513e9d95eab179975e07f5a6ffd543dc0edaa103f4cf18e023b8ca2f1"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.128
+Version: 5.15.133
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/d301b89106ee983f8cd5cd0b4d6b4111ea97b7e51ca2892a6d9bbec4eaf18c4f/kernel-5.15.128-80.144.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/2856e0e792b1a49369693e4b0e4246700fdf5094b2f5f953569e74d7b99e8f0e/kernel-5.15.133-86.144.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/b7fd4bb92caacd373bbd4cf41dca8c29736bf229c08ef80c59bb6063654d058b/kernel-6.1.49-69.116.amzn2023.src.rpm"
-sha512 = "d9ccbf828b0466a226a6bf42e9d8a4482b4acea1bd27f6ba28a823d481d6357688a1594b457a6b8735b611d4d370b2aeb1382726ae694bb03f7aa1cf9ee7a9c2"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/b857edbf6e8d7c005d0e6e25d052548bb4a1113e504b6d2f50357998d94f9d07/kernel-6.1.55-75.123.amzn2023.src.rpm"
+sha512 = "b87a14ab06804d1574a5a9b91df0749be4e22af5531a45b1bd2933656f92ac3688ea36adb06dd440234eb82f2c6139351a0efa1efa95259d151f91b3c242b67d"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.49
+Version: 6.1.55
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/b7fd4bb92caacd373bbd4cf41dca8c29736bf229c08ef80c59bb6063654d058b/kernel-6.1.49-69.116.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/b857edbf6e8d7c005d0e6e25d052548bb4a1113e504b6d2f50357998d94f9d07/kernel-6.1.55-75.123.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a

**Description of changes:**

Update kernels to latest AL kernels available in the repositories.


**Testing done:**

Sonobuoy quick test results show basic functionality:

```
> kubectl get nodes -o wide
NAME                                              STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP    OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-0-136.eu-central-1.compute.internal    Ready    <none>   118s    v1.26.7-eks-7ea2e3a    192.168.0.136    3.68.197.237   Bottlerocket OS 1.16.0 (aws-k8s-1.26)   5.15.133         containerd://1.6.23+bottlerocket
ip-192-168-48-50.eu-central-1.compute.internal    Ready    <none>   63s     v1.28.1-eks-f0272c7    192.168.48.50    3.79.206.226   Bottlerocket OS 1.16.0 (aws-k8s-1.28)   6.1.55           containerd://1.6.23+bottlerocket
ip-192-168-58-103.eu-central-1.compute.internal   Ready    <none>   2m31s   v1.23.17-eks-bbbebb8   192.168.58.103   3.79.154.135   Bottlerocket OS 1.16.0 (aws-k8s-1.23)   5.10.196         containerd://1.6.23+bottlerocket
> sonobuoy run --mode=quick --wait
[...]
16:07:30             e2e                                            global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
16:07:30    systemd-logs    ip-192-168-0-136.eu-central-1.compute.internal   complete   passed                                        
16:07:30    systemd-logs    ip-192-168-48-50.eu-central-1.compute.internal   complete   passed                                        
16:07:30    systemd-logs   ip-192-168-58-103.eu-central-1.compute.internal   complete   passed                                        
16:07:30 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Config diff reports some minor changes:

```
config-aarch64-aws-dev-diff:      2 removed,   0 added,   1 changed
config-aarch64-aws-k8s-1.23-diff:         0 removed,   0 added,   1 changed
config-aarch64-aws-k8s-1.26-diff:         2 removed,   0 added,   2 changed
config-aarch64-metal-dev-diff:    2 removed,   0 added,   1 changed
config-x86_64-aws-dev-diff:       2 removed,   0 added,   1 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   0 added,   1 changed
config-x86_64-aws-k8s-1.26-diff:          2 removed,   0 added,   2 changed
config-x86_64-metal-dev-diff:     2 removed,   0 added,   1 changed
config-x86_64-metal-k8s-1.23-diff:        0 removed,   0 added,   1 changed
config-x86_64-metal-k8s-1.26-diff:        2 removed,   0 added,   2 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/foersleo/665a22a4527ff5dc0598631de854ec64)

Summary of the changes:

* Upstream retirement of net sched rsvp clasifier (`NET_CLS_RSVP` and `NET_CLS_RSVP6`) through [5.15.133](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=08569c92f7f339de21b7a68d43d6795fc0aa24f2) and [v6.1.55](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=[b93aeb6352b0229e3c5ca5ca4ff015b015aff33c](https://kernel.dance/#b93aeb6352b0229e3c5ca5ca4ff015b015aff33c)). (The corresponding change for the 5.10 series landed only in 5.10.197 and will thus be part of the next update once available through AL).
* Inclusion of `DM_LOG_WRITES` as a module. This module is mostly for testing and debugging and was enabled by AL per customer request. I am not quite sure if we should remove it. It probably will not find any users on Bottlerocket and removing it would help keep the images small, but increase the delta in our kernel configs.
* Setting `EFI_VARS_PSTORE_DEFAULT_DISABLE` on 5.15 to align AL kernels to a uniform bahvior - no concerns here.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
