### PR TITLE
packages: update containerd to 1.6.24

### DIFF
--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.23/containerd-1.6.23.tar.gz"
-sha512 = "576ab87c07700054918ac8fa8e6c1f1ba971722ac7cad8f3d8ecccdb8cb162103fa826fa815f58f5f63d061b2a8dce8f2fbbee3def85cd4a4f8dbee124d2596a"
+url = "https://github.com/containerd/containerd/archive/v1.6.24/containerd-1.6.24.tar.gz"
+sha512 = "4c434514e5f0002063a254b89fb8ad06c7bd7a3a83954b0538367a2a343de51ca63113c384c53719127907e70c12fbcd36687b0adc737b1e42bee9f08505dee7"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.23
+%global gover 1.6.24
 %global rpmver %{gover}
 %global gitrev 1e1ea6e986c6c86565bc33d52e34b81b3e2bc71f
 


### PR DESCRIPTION
**Description of changes:**
Updates `containerd` to 1.6.24.


**Testing done:**
I built a k8s 1.28 variant and added it to an existing EKS cluster. Containerd journal looked good.

```
...
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.275890680Z" level=info msg=serving... address=/run/containerd/containerd.sock.ttrpc
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.275925903Z" level=info msg=serving... address=/run/containerd/containerd.sock
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.275976371Z" level=info msg="Start subscribing containerd event"
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.276004895Z" level=info msg="Start recovering state"
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.276058780Z" level=info msg="Start event monitor"
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.276067362Z" level=info msg="Start snapshots syncer"
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.276074323Z" level=info msg="Start cni network conf syncer for default"
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.276079773Z" level=info msg="Start streaming server"
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:28:50.276271396Z" level=info msg="containerd successfully booted in 0.035095s"
Oct 12 23:28:50 ip-192-168-87-241.us-west-2.compute.internal systemd[1]: Started containerd container runtime.
...
Oct 12 23:29:13 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:29:13.094697167Z" level=info msg="CreateContainer within sandbox \"ac7d1b2c93b24b33508ec98510fa55e363091512cee5adeeae42c51c5f7b61b6\" for &ContainerMetadata{Name:aws-eks-nodeagent,Attempt:0,} returns container id \"7b63f931b59525619d970f50df15578f764ba22891b03cca207dd462728bcfda\""
Oct 12 23:29:13 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:29:13.095056851Z" level=info msg="StartContainer for \"7b63f931b59525619d970f50df15578f764ba22891b03cca207dd462728bcfda\""
Oct 12 23:29:13 ip-192-168-87-241.us-west-2.compute.internal containerd[1602]: time="2023-10-12T23:29:13.202671286Z" level=info msg="StartContainer for \"7b63f931b59525619d970f50df15578f764ba22891b03cca207dd462728bcfda\" returns successfully"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
