### PR TITLE
systemd: Update to latest stable patch version 252.18

### DIFF
--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://github.com/systemd/systemd-stable/releases"
 package-features = ["unified-cgroup-hierarchy"]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd-stable/archive/v252.13/systemd-stable-252.13.tar.gz"
-sha512 = "db96a49a8819abbd68606c4063b2f8ef56d2fa07a62733e82c31de12f8e6d33f40bc85d162edc56bd77b23904a017b3b7f7050d281613b78ac39d25c0f1f70ad"
+url = "https://github.com/systemd/systemd-stable/archive/v252.18/systemd-stable-252.18.tar.gz"
+sha512 = "0c8ec1aceb43a74693876e27b84df0973e879fca96960c32d28f365703ad6b2c193fce2038c169f0ad6f31e75bca19d880c6106d7737ce26e165f427957ba339"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,7 +2,7 @@
 %global __brp_check_rpaths %{nil}
 
 Name: %{_cross_os}systemd
-Version: 252.13
+Version: 252.18
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Updates systemd to the latest stable patch version in the 252 chain: `252.18`.



**Testing done:**
WIP

- [x] Ensure the build log contains no relevant warnings or warnings about patch offsets
- [x] Test spinning up large amounts (3k+) of pods in an ipv6-enabled cluster with systemd-networkd via `aws-k8s-1.28` to regression test the issue fixed in #3520 (instance loses ipv6 address because of timeout).  **Used 80 nodes and 5000 pods.**
- [x] Test launches at scale (2000 nodes) for multiple instance types and network backends (wicked / systemd-networkd), ensure nodes are schedule-able and run pods
  - [x] m5.large -> systemd-networkd
  - [x] m5.large -> wicked
  - [x] t3.medium -> systemd-networkd
  - [x] t3.medium -> wicked
  - [x] m6a.12xlarge -> systemd-networkd (could only get 800 of this instance type in my region)
  - [x] m6a.12xlarge -> wicked (same here)



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
