### PR TITLE
3p packages update 1.16.0

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.1478.0/amazon-ssm-agent-3.2.1478.0.tar.gz"
-sha512 = "f9a4741784a861ab8319793d37baee57137aa2eb6a350df329d8dee0c00a97c6e639560eb0c17d4bb596ddc032ee36819fbc40b55f559c490a3eb214e9627ba1"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.1630.0/amazon-ssm-agent-3.2.1630.0.tar.gz"
+sha512 = "5d5371ebeec66b5be6960f4c8669d595665ad3e27820a9e8cd8568f7a951d235116022aa5935a10ceecfe09f940d612b65381da42e6f817d62b59effe3293d8f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -8,7 +8,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.2.1478.0
+Version: 3.2.1630.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.0.4/rolesanywhere-credential-helper-v1.0.4.tar.gz"
-sha512 = "6dbc915808c299551adacbad85e6645c10a48ee77103c024beddd29c25215e0afdd1b57554b8be040fee7745ee3d4111e43aa238d0dba6d740868fa0c14009a8"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.1.1/rolesanywhere-credential-helper-v1.1.1.tar.gz"
+sha512 = "c60d62f8e946955d181577d1e2e5fe2ecb7a82ef0c4cc29fa98b6136b93e9bac9a91cffe3a98c063d7a3f07a956b02e1dd5a92160648b26bbee90aec52a15dca"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.0.4
+%global gover 1.1.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -29,7 +29,7 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 %set_cross_go_flags
 
-go build ${GOFLAGS} -buildmode=pie -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper cmd/aws_signing_helper/main.go
+go build ${GOFLAGS} -buildmode=pie -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper main.go
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/coreutils/Cargo.toml
+++ b/packages/coreutils/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://ftp.gnu.org/gnu/coreutils"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.3.tar.xz"
-sha512 = "242271f212a6860bdc6c8d7e5c4f85ce66c1b48ef781aca9daa56e0fe7c2b7809ef72b4392120219fe5b687637c83ce89ceef8bb35f6274f43f8f968a6901694"
+url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.4.tar.xz"
+sha512 = "7c55ee23b685a0462bbbd118b04d25278c902604a0dcf3bf4f8bf81faa0500dee5a7813cba6f586d676c98e520cafd420f16479619305e94ea6798d8437561f5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/coreutils/coreutils.spec
+++ b/packages/coreutils/coreutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}coreutils
-Version: 9.3
+Version: 9.4
 Release: 1%{?dist}
 Summary: A set of basic GNU tools
 License: GPL-3.0-or-later

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.75.0/amazon-ecs-agent-1.75.0.tar.gz"
-sha512 = "25bbf1f24451bff8f2bac03a83bdee64186f07de466bdebafe1ff149995ca3c57320b13ced85843139369c4638367015600439aa317ee9875038436d0ec67e17"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.77.0/amazon-ecs-agent-1.77.0.tar.gz"
+sha512 = "b8dfc61a570a2e195969185474dac942804592631cb9b94f2fc55605ed3ace8fb2a3c3ba785bd356488311bbfc600e9ac0c5c156a7dfafac25ddf4e10303f7eb"
 
 # The ECS agent repository includes two CNI plugins as git submodules.  git
 # archive does not include submodules, so the tarball above does not include
@@ -27,8 +27,8 @@ url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/53a8481891251e66e35
 sha512 = "e819c1aae509d19461999bf717d126b3e918b73dc6049e415c4911be6cb11159404bb45bb6c92cdfa16b5b30bb174731e972e3f2be44fa0b51bbc7a969049ab7"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/a83b66349768e020487a00e31767fc2e6fc88136/amazon-vpc-cni-plugins.tar.gz"
-sha512 = "ace0d27938b0c47a1208cbc0a30fa70f306270cc66a0b40bdd58d6d7060c69c361c3edcd4cc1d87bdb0f2be839cd6244541c485b3a294c265c5fdf740b012238"
+url = "https://github.com/aws/amazon-vpc-cni-plugins/archive/be5214353252f8315a1341f4df9ffbd8cf69000c/amazon-vpc-cni-plugins.tar.gz"
+sha512 = "b1aa61d0000ff732dae67213cea2eac49363c048416716e27f36b2b43f6227db8b15ead27c43c5fd623569a49572cb6b2149c86d69363f75cec4620ddc9ef47b"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.75.0
+%global agent_gover 1.77.0
 
 # git rev-parse --short=8
 %global agent_gitrev 06008fa1
@@ -15,7 +15,7 @@
 %global vpccni_goproject github.com/aws
 %global vpccni_gorepo amazon-vpc-cni-plugins
 %global vpccni_goimport %{vpccni_goproject}/%{vpccni_gorepo}
-%global vpccni_gitrev a83b66349768e020487a00e31767fc2e6fc88136
+%global vpccni_gitrev be5214353252f8315a1341f4df9ffbd8cf69000c
 %global vpccni_gover 1.3
 
 # Construct reproducible tar archives
@@ -227,18 +227,19 @@ cd "${BUILD_TOP}"
 LD_VPC_CNI_VERSION="-X github.com/aws/amazon-vpc-cni-plugins/version.Version=%{vpccni_gover}"
 VPC_CNI_HASH="%{vpccni_gitrev}"
 LD_VPC_CNI_SHORT_HASH="-X github.com/aws/amazon-vpc-cni-plugins/version.GitShortHash=${VPC_CNI_HASH::8}"
-go build -a \
+
+for p in \
+  vpc-branch-eni \
+  aws-appmesh \
+  vpc-eni \
+; do
+  go build -a \
   -buildmode=pie \
   -ldflags "${GOLDFLAGS} ${LD_VPC_CNI_VERSION} ${LD_VPC_CNI_SHORT_HASH} ${LD_VPC_CNI_PORCELAIN}" \
   -mod=vendor \
-  -o vpc-branch-eni \
-  ./plugins/vpc-branch-eni
-go build -a \
-  -buildmode=pie \
-  -ldflags "${GOLDFLAGS} ${LD_VPC_CNI_VERSION} ${LD_VPC_CNI_SHORT_HASH} ${LD_VPC_CNI_PORCELAIN}" \
-  -mod=vendor \
-  -o aws-appmesh \
-  ./plugins/aws-appmesh
+  -o ${p} \
+  ./plugins/${p}
+done
 
 %install
 install -D -p -m 0755 %{agent_gorepo}-%{agent_gover}/amazon-ecs-agent %{buildroot}%{_cross_bindir}/amazon-ecs-agent
@@ -248,6 +249,7 @@ install -D -p -m 0755 %{ecscni_gorepo}-%{ecscni_gitrev}/ecs-eni %{buildroot}%{_c
 install -D -p -m 0755 %{ecscni_gorepo}-%{ecscni_gitrev}/ecs-ipam %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent/ecs-ipam
 install -D -p -m 0755 %{vpccni_gorepo}-%{vpccni_gitrev}/vpc-branch-eni %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent/vpc-branch-eni
 install -D -p -m 0755 %{vpccni_gorepo}-%{vpccni_gitrev}/aws-appmesh %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent/aws-appmesh
+install -D -p -m 0755 %{vpccni_gorepo}-%{vpccni_gitrev}/vpc-eni %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent/vpc-eni
 
 install -d %{buildroot}%{_cross_unitdir}
 install -D -p -m 0644 %{S:101} %{S:200} %{buildroot}%{_cross_unitdir}
@@ -319,6 +321,7 @@ mv %{vpccni_gorepo}-%{vpccni_gitrev}/vendor go-vendor/%{vpccni_gorepo}
 %{_cross_libexecdir}/amazon-ecs-agent/ecs-ipam
 %{_cross_libexecdir}/amazon-ecs-agent/vpc-branch-eni
 %{_cross_libexecdir}/amazon-ecs-agent/aws-appmesh
+%{_cross_libexecdir}/amazon-ecs-agent/vpc-eni
 %{_cross_libexecdir}/amazon-ecs-agent/managed-agents
 %{_cross_unitdir}/ecs.service
 %{_cross_unitdir}/etc-ecs.mount

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/software/network/ethtool/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.4.tar.xz"
-sha512 = "5e389564b41e9494df102f9fb703ae2d80ba38346d84ec6c89b024ec21c85eca9f58e88012290feaa88d3ce035d6f779913798b0ca177e8d0a08eff197eb6afd"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.5.tar.xz"
+sha512 = "07994a20f34b1c1e72f9f855972d31d027968b53b278a5b46c5a2977be8d7152e6439c9719001101be85359876d9d932d2afb9561af9967e84d8a447a7d0c558"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}ethtool
-Version: 6.4
+Version: 6.5
 Release: 1%{?dist}
 Summary: Settings tool for Ethernet NICs
 License: GPL-2.0-only AND GPL-2.0-or-later

--- a/packages/kexec-tools/Cargo.toml
+++ b/packages/kexec-tools/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/linux/utils/kernel/kexec"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.26.tar.xz"
-sha512 = "afecb64f50a0a2e553712d7e6e4d48e0dc745e4140983a33a10cce931e6aeddaff9c4a3385fbaf7ab9ff7b3b905d932fbce1e0e37aa2c35d5c1e61277140dee9"
+url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.27.tar.xz"
+sha512 = "30b5ef7c2075dfd11fd1c3c33abe6b60673400257668d60145be08a2472356c7191a0810095da0fa32e327b9806a7578c73129ac0550d26c28ea6571c88c7b3c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kexec-tools/kexec-tools.spec
+++ b/packages/kexec-tools/kexec-tools.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kexec-tools
-Version: 2.0.26
+Version: 2.0.27
 Release: 1%{?dist}
 Summary: Linux tool to load kernels from the running system
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-30.tar.xz"
-sha512 = "e2cd34e600a72e44710760dfda9364b790b8352a99eafbd43e683e4a06f37e6b5c0b5d14e7c28070e30fc5fc6ceddedf7b97f3b6c2c5c2d91204fefd630b9a3e"
+url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-31.tar.xz"
+sha512 = "05ca70381808bec5f262b94db625662c385408988178a35e4aaf4960ee0716dc0cbfc327160ea4b61098d0c2130ab1b5142ea8156bea8e06ded7f4d288b6d085"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kmod/kmod.spec
+++ b/packages/kmod/kmod.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kmod
-Version: 30
+Version: 31
 Release: 1%{?dist}
 Summary: Tools for kernel module loading and unloading
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://download.gnome.org/sources/glib"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.77/glib-2.77.2.tar.xz"
-sha512 = "0e2cf5178a7174b174480a795b1cbb2f1dbbea35899b7e4756937e426b6c39c20deb8488958403b78552674c4179e6fd63ea7fac2b746ac49a62046e27086111"
+url = "https://download.gnome.org/sources/glib/2.78/glib-2.78.0.tar.xz"
+sha512 = "3d06890002f4b13f831c83fbb70cfce529f9750e30888619e4d6277116be15d106379a03143412cf4b2a289c0cbdbbc299ecf17284fbffc06c791ecf7556c765"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libglib
-Version: 2.77.2
+Version: 2.78.0
 Release: 1%{?dist}
 Summary: The GLib libraries
 # glib2 is LGPL-2.1-only

--- a/packages/libnl/Cargo.toml
+++ b/packages/libnl/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/thom311/libnl/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/thom311/libnl/archive/libnl3_7_0.tar.gz"
-sha512 = "86d9a5e9471495d29ab54377937dc662be693de40266d54c5b3690dbae627ed93b1ca9266b722d7e86c741e6f9ed6ea5129eb839e633f10ccc77e69dfd4f816a"
+url = "https://github.com/thom311/libnl/archive/libnl3_8_0.tar.gz"
+sha512 = "4e5e7187ecf6184ddfc38a95fdfe47efeb826f43f9f6546b5531780389ecf406f82f588275abea9970416b9fe8afa81527a7ddb771509f468ac5005774b0246c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnl/libnl.spec
+++ b/packages/libnl/libnl.spec
@@ -1,5 +1,5 @@
-%global rpmver 3.7.0
-%global srcver 3_7_0
+%global rpmver 3.8.0
+%global srcver 3_8_0
 
 Name: %{_cross_os}libnl
 Version: %{rpmver}

--- a/packages/libtirpc/Cargo.toml
+++ b/packages/libtirpc/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://sourceforge.net/projects/libtirpc/files/libtirpc/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.3.tar.bz2"
-sha512 = "df0781a74ff9ded2d3c4f5eb7e05496b9f58eac8060c02c68331dc14c4a00304dcd19f46836f5756fe0d9d27095fd463d42dd696fcdff891516711b7d63deabe"
+url = "https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.4.tar.bz2"
+sha512 = "004e61b5853717324790c46cda5ff227d525909f189194ae72a1ec8f476ca35d7f4c1f03c0fbc690c1696d60a212675b09246dbe627fdbf1a9a47f5664e82b00"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libtirpc/libtirpc.spec
+++ b/packages/libtirpc/libtirpc.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libtirpc
-Version: 1.3.3
+Version: 1.3.4
 Release: 1%{?dist}
 Summary: Library for RPC
 License: BSD-3-Clause

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.4/strace-6.4.tar.xz"
-sha512 = "29f47195b2766dc0d2907aba2d561e87ec87939251d07fd82d22ffdd3c864944ab0c47eabd7b13272345dfc5dfae7ca435c94fd5ccc297dd46e0747c6d463e01"
+url = "https://strace.io/files/6.5/strace-6.5.tar.xz"
+sha512 = "7edf7b00b5ad91be2df4e44b63df7f88376f3e6a8f078dfccf307a6a5003ad25d9cf233f2a32139e00fe399494ce6a8f67728bf9dfeb9bb5958ed08ce25e9e01"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 6.4
+Version: 6.5
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later


### PR DESCRIPTION
**Issue number:**

Closes #3470

**Description of changes:**
```
packages: update strace to 6.5
packages: update libtirpc to 1.3.4
packages: update libnl to 3.8.0
packages: update libglib to 2.78.0
packages: update kmod to 31
packages: update kexec-tools to 2.0.27
packages: update ethtool to 6.5
packages: update ecs-agent to 1.77.0
packages: update coreutils to 9.4
packages: update aws-signing-helper to 1.1.1
packages: update amazon-ssm-agent to 3.2.1630.0
```
Updates all third party packages except for the following:

binutils 2.38 -> 2.40 - bottlerocket-sdk has to move to 2.40 first.
docker related packages(docker-cli, docker-engine) 20.12.21 -> 20.12.23 - To sync with ECS-optimized AMI packaged docker version listed in [its version table](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-versions.html#ecs-ami-versions-linux).
wicked 0.6.68 -> 0.6.70 - See update wicked to 0.6.70+ https://github.com/bottlerocket-os/bottlerocket/issues/2591
Containerd 1.6.24 -> 1.7.* - See https://github.com/bottlerocket-os/bottlerocket/issues/1963

**Tasks**
- [x] Upload packages in look aside cache
 
**Testing done:**

- [x] aws-k8s-1.24 x86_64
```
NAME                               TYPE               STATE                      PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 x86-64-aws-k8s-124-quick           Test               passed                          1               0             6972   ca1cec36          2023-10-20T14:47:39Z
 x86-64-aws-k8s-124                 Resource           completed                                                            ca1cec36          2023-10-20T14:45:55Z
```
- [x] aws-k8s-1.24 aarch64
```
NAME                                TYPE               STATE                     PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 aarch64-aws-k8s-124-quick           Test               passed                         1               0             6972   ca1cec36          2023-10-20T17:40:14Z
 aarch64-aws-k8s-124                 Resource           completed                                                           ca1cec36          2023-10-20T17:38:06Z
```
- [x] aws-k8s-1.24-nvidia x86_64
```
NAME                                             TYPE             STATE                  PASSED        FAILED        SKIPPED   BUILD ID        LAST UPDATE
 x86-64-aws-k8s-124-nvidia-quick                  Test             passed                      1             0           6972   c824540f        2023-10-20T23:59:01Z
 x86-64-aws-k8s-124-nvidia                        Resource         completed                                                    c824540f        2023-10-20T23:56:23Z
 x86-64-aws-k8s-124-nvidia-instances-rwsi         Resource         running                                                      c824540f        2023-10-20T23:59:13Z
```
- [x] aws-k8s-1.24-nvidia aarch64
```
NAME                                             TYPE            STATE                 PASSED       FAILED       SKIPPED   BUILD ID             LAST UPDATE
 aarch64-aws-k8s-124-nvidia-quick                 Test            passed                     1            0          6972   ca1cec36-dirty	 2023-10-20T19:18:10Z
 aarch64-aws-k8s-124-nvidia                       Resource        completed                                                 ca1cec36-dirty	 2023-10-20T19:15:01Z
 aarch64-aws-k8s-124-nvidia-instances-odlp        Resource        running                                                   ca1cec36-dirty	 2023-10-20T19:18:21Z
```
- [x] aws-k8s-1.27 x86_64
```
NAME                                       TYPE              STATE                   PASSED         FAILED         SKIPPED   BUILD ID         LAST UPDATE
 x86-64-aws-k8s-127-quick                   Test              passed                       5              0            7206   ca1cec36         2023-10-20T15:33:52Z
 x86-64-aws-k8s-127                         Resource          completed                                                       ca1cec36         2023-10-20T15:32:16Z
 x86-64-aws-k8s-127-instances-poby          Resource          running                                                         ca1cec36         2023-10-20T15:34:03Z
```
- [x] aws-k8s-1.27 aarch64
```
aarch64-aws-k8s-127-quick               Test             passed                       5              0            7206   ca1cec36-dirty        2023-10-20T18:16:34Z
 aarch64-aws-k8s-127                     Resource         completed                                                       ca1cec36-dirty        2023-10-20T18:14:31Z

```
- [x] aws-k8s-1.27-nvidia x86_64
```
x86-64-aws-k8s-127-nvidia-quick         Test             passed                       5              0            7206   ca1cec36-dirty        2023-10-20T22:03:15Z
 x86-64-aws-k8s-127-nvidia               Resource         completed                                                       ca1cec36-dirty        2023-10-20T22:00:08Z
```
- [x] aws-k8s-1.27-nvidia aarch64
```
 NAME                                             TYPE            STATE                 PASSED       FAILED	  SKIPPED   BUILD ID             LAST UPDATE
 aarch64-aws-k8s-127-nvidia-quick                 Test            passed                     5            0          7206   ca1cec36-dirty	 2023-10-20T21:29:21Z
 aarch64-aws-k8s-127-nvidia                       Resource        completed                                                 ca1cec36-dirty	 2023-10-20T21:26:43Z
 aarch64-aws-k8s-127-nvidia-instances-oimv        Resource        completed                                                 ca1cec36-dirty	 2023-10-20T21:26:54Z
```
- [x] aws-ecs-1 - Internal suite of tests passes successfully.
```
NAME                                     TYPE              STATE                     PASSED         FAILED         SKIPPED   BUILD ID         LAST UPDATE
 x86-64-aws-ecs-1-quick                   Test              passed                         1              0               0   c824540f         2023-10-20T22:57:15Z
 x86-64-aws-ecs-1                         Resource          completed                                                         c824540f         2023-10-20T22:56:42Z
 x86-64-aws-ecs-1-instances-dsyo          Resource          completed                                                         c824540f         2023-10-20T22:56:52Z


```
- [x] aws-ecs-1-nvidia
```
 NAME                                           TYPE             STATE                   PASSED         FAILED        SKIPPED   BUILD ID        LAST UPDATE
 x86-64-aws-ecs-1-nvidia-quick                  Test             passed                       1              0              0   c824540f        2023-10-20T23:11:26Z
```
- [x] aws-ecs-2
```
 x86-64-aws-ecs-2-quick                  Test             passed                       1              0               0   c824540f              2023-10-20T22:45:56Z
 x86-64-aws-ecs-2                        Resource         completed                                                       c824540f              2023-10-20T22:45:18Z
```
- [x] aws-ecs-2-nvidia
```
x86-64-aws-ecs-2-nvidia-quick                  Test             passed                       1              0              0   c824540f        2023-10-20T23:23:46Z
 x86-64-aws-ecs-2-nvidia                        Resource         completed                                                      c824540f        2023-10-20T23:22:58Z
 x86-64-aws-ecs-2-nvidia-instances-pmpe         Resource         running                                                        c824540f        2023-10-20T23:23:57Z
```
- [x] vmware-k8s-1.26
```
 NAME                                  TYPE               STATE                   PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 x86-64-vmware-k8s-126-quick           Test               passed                       4               0             7068   c824540f          2023-10-23T21:19:40Z
 x86-64-vmware-k8s-126                 Resource           running                                                           c824540f          2023-10-23T21:20:00Z

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
