### PR TITLE
allow fanotify permission events for trusted subjects in SELinux policy

### DIFF
--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -261,11 +261,12 @@
 ; successful, suppress this particular audit message.
 (dontaudit container_t any_t (file (relabelfrom)))
 
-; No components are allowed to block access to files by using
-; fanotify permission events. Fanotify only sends events for
-; accesses from within the mount namespace, so it's unlikely to
-; be useful for containers, and we don't use it in the host.
-(neverallow all_s global (files (block)))
+; Trusted components are allowed to block access to objects with
+; fanotify permission events.
+(allow trusted_s all_o (files (block)))
+
+; Untrusted components are not allowed to block any files.
+(neverallow untrusted_s global (files (block)))
 
 ; All subject labels can be used for files on /proc.
 (allow all_s proc_t (filesystem (associate)))


### PR DESCRIPTION
**Issue number:**
#3008

**Description of changes:**
fanotify supports permission events that allow the watching process to determine whether a file can be accessed, opened, or executed. If a process sets these event flags when marking a filesystem object, then SELinux allows us to deny that access. However, once the mark is set, the process is free to prevent any other process from accessing the watched files. These denials are not logged by the kernel and may not be logged at all, leading to failures that would be difficult to debug.

For that reason, the related actions are only allowed for "trusted" subjects. Since the host doesn't currently make use of fanotify, in practice this just means containers running with the "super_t" label. The goal is to enable vendors who are aware of the pitfalls to use this functionality in a way that does not interfere with the expected operation of the host.


**Testing done:**
Wrote a small fanotify program that sets the `FAN_ACCESS_PERM`, `FAN_OPEN_PERM`, and `FAN_OPEN_EXEC_PERM` flags when calling `fanotify_mark()`. Deployed it via a pod with different security options specified.

`super_t` and `CAP_SYS_ADMIN`:
```
❯ kubectl logs fanotify
Started monitoring directory '/'...
Received event in path '/' pid=0 (unknown):
	FAN_OPEN_PERM

(no SELinux denial)
```

`super_t` without `CAP_SYS_ADMIN`:
```
❯ kubectl logs fanotify
Couldn't setup new fanotify device: Operation not permitted
Couldn't initialize fanotify

(no SELinux denial)
```

`CAP_SYS_ADMIN` only:
```
❯ kubectl logs fanotify
Couldn't add monitor in directory '/': 'Permission denied'
Couldn't initialize fanotify

[  194.883816] audit: type=1400 audit(1697756135.516:9): avc:  denied  { watch_with_perm } for  pid=7017 comm="fanotify_exampl" path="/" dev="overlay" ino=42177191 scontext=system_u:system_r:container_t:s0:c675,c817 tcontext=system_u:object_r:data_t:s0:c675,c817 tclass=dir permissive=0
```

`privileged: true`:
```
❯ kubectl logs fanotify
Couldn't add monitor in directory '/': 'Permission denied'
Couldn't initialize fanotify

[  274.407493] audit: type=1400 audit(1697756215.046:12): avc:  denied  { watch_with_perm } for  pid=8444 comm="fanotify_exampl" path="/" dev="overlay" ino=25460084 scontext=system_u:system_r:control_t:s0-s0:c0.c1023 tcontext=system_u:object_r:data_t:s0:c209,c591 tclass=dir permissive=0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
