### PR TITLE
[docs]: add container details on settings.kubernetes.pod-pids-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,8 @@ The following settings are optional and allow you to further configure your clus
   It can be very difficult to recover from configuration errors.
   Use the memory reservation information from `kubectl describe node` and make sure you understand the Kubernetes documentation related to the [memory manager](https://kubernetes.io/docs/tasks/administer-cluster/memory-manager/) and how to [reserve compute resources for system daemons](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/).
 
-* `settings.kubernetes.pod-pids-limit`: The maximum number of processes per pod.
+* `settings.kubernetes.pod-pids-limit`: The maximum number of processes per pod applied to the cgroup slice of the pod. Container slices have their own maximum number of processes. The maximum number of processes per container defaults to [DefaultsTasksMax](https://www.freedesktop.org/software/systemd/man/latest/systemd-system.conf.html#DefaultTasksMax=) of systemd:
+    > Defaults to 15% of the minimum of kernel.pid_max=, kernel.threads-max= and root cgroup pids.max.
 * `settings.kubernetes.provider-id`: This sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node.
 * `settings.kubernetes.registry-burst`: The maximum size of bursty pulls.
 * `settings.kubernetes.registry-qps`: The registry pull QPS.


### PR DESCRIPTION
**Description of changes:**
Add details to the description of the Kubernetes setting `settings.kubernetes.pod-pids-limit`. When the `pod-pids-limit` setting is applied and checked via `cat /sys/fs/cgroup/pids.max` from inside a pod it is not reflected, but instead has another default value not specified from bottlerocket. Mentioning this in the documentation saves one a long investigation where the value is coming from.


**Testing done:**
Applied the `settings.kubernetes.pod-pids-limit` via user data and checked that value from within the admin container via `systemctl show <pod-slice> | grep TasksMax` as well as on the container slice via `systemctl show <pod-slice> | grep DefaultTasksMax`. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
