### PR TITLE
 kernel: update to 5.10.197 and 5.15.134

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/2e0b99966781510902082be83f28d36844f9f84a1cc9c31f08550a5d7b632e14/kernel-5.10.196-185.743.amzn2.src.rpm"
-sha512 = "579684744ae32d79ea6b40cee223613541d0d82db9f760528d043999d6f96c6d9656e01e403f1f8a434b0ee1ea2c5bb637afe97a74339b6a7cba752da48c2b14"
+url = "https://cdn.amazonlinux.com/blobstore/9f9ded8eec13c7cacb468496c899e93063db7800ad20b12d07c1fee60e05eb33/kernel-5.10.197-186.748.amzn2.src.rpm"
+sha512 = "c5986ab33ef52cfe61a67e29db2856072cb68c525c69dc0be14efbba58ad7df9f9989ddad27ebd722088d6f01b58875b49bf1aed06901e3d9966c0fed95ba722"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.196
+Version: 5.10.197
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/2e0b99966781510902082be83f28d36844f9f84a1cc9c31f08550a5d7b632e14/kernel-5.10.196-185.743.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/9f9ded8eec13c7cacb468496c899e93063db7800ad20b12d07c1fee60e05eb33/kernel-5.10.197-186.748.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/2856e0e792b1a49369693e4b0e4246700fdf5094b2f5f953569e74d7b99e8f0e/kernel-5.15.133-86.144.amzn2.src.rpm"
-sha512 = "5d0ffb542f8c7caebc0bf61e91c9a65b2fd2c17df91d1ec3e4536f9f1fd1b56e7150391513e9d95eab179975e07f5a6ffd543dc0edaa103f4cf18e023b8ca2f1"
+url = "https://cdn.amazonlinux.com/blobstore/418a9aab17cff76bb9577affa1df20b27fa223168e2fafef62510de157e1957d/kernel-5.15.134-87.145.amzn2.src.rpm"
+sha512 = "fdc386b82928c7a29bbdbf0ff0c55e22a36f03d725aedfe8d6d309628e79484d2743ec00322713009fb2a56c49e1c20f3938fef7075215c76028b00f3149bdad"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.133
+Version: 5.15.134
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/2856e0e792b1a49369693e4b0e4246700fdf5094b2f5f953569e74d7b99e8f0e/kernel-5.15.133-86.144.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/418a9aab17cff76bb9577affa1df20b27fa223168e2fafef62510de157e1957d/kernel-5.15.134-87.145.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a

**Description of changes:**

Update kernels to latest AL kernels available in the repositories. No newer 6.1 kernel available at this time.

**Testing done:**

Sonobuoy quick test results show basic functionality:

```
]> kubectl get nodes -o wide
NAME                                              STATUS   ROLES    AGE   VERSION                INTERNAL-IP      EXTERNAL-IP    OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-65-146.eu-central-1.compute.internal   Ready    <none>   60s   v1.23.17-eks-bbbebb8   192.168.65.146   3.71.36.89     Bottlerocket OS 1.16.0 (aws-k8s-1.23)   5.10.197         containerd://1.6.24+bottlerocket
ip-192-168-74-10.eu-central-1.compute.internal    Ready    <none>   33s   v1.26.7-eks-7ea2e3a    192.168.74.10    18.157.85.44   Bottlerocket OS 1.16.0 (aws-k8s-1.26)   5.15.134         containerd://1.6.24+bottlerocket
]> sonobuoy run --mode=quick --wait
[...]
17:02:40             e2e                                            global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
17:02:40    systemd-logs   ip-192-168-65-146.eu-central-1.compute.internal   complete   passed                                        
17:02:40    systemd-logs    ip-192-168-74-10.eu-central-1.compute.internal   complete   passed
```

Config diff reports some minor changes:
```
config-aarch64-aws-k8s-1.23-diff:         2 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:         0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          2 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:        0 removed,   0 added,   0 changed
```
The full diff-report can be found on [Gist](https://gist.github.com/foersleo/ef052f35b66fb9ba8bf297d76d397036)

Summary of the changes:

* Upstream retirement of net sched rsvp clasifier (`NET_CLS_RSVP` and `NET_CLS_RSVP6`) through [5.10.197](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8db844077ec9912d75952c80d76da71fc2412852)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
