### PR TITLE
bloodhound: Fix journal file permission check

### DIFF
--- a/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
@@ -857,7 +857,13 @@ pub struct BR04010200Checker {}
 
 impl Checker for BR04010200Checker {
     fn execute(&self) -> CheckerResult {
-        let mut result = CheckerResult::default();
+        // Default the result to report success
+        let mut result = {
+            CheckerResult {
+                status: CheckStatus::PASS,
+                ..Default::default()
+            }
+        };
 
         // Recursively walk over all files in /var/log/journal and check perms
         for file in WalkDir::new("/var/log/journal")


### PR DESCRIPTION
**Issue number:**

Closes #3546 

**Description of changes:**

The Bottlerocket CIS check 4.1.2 would correctly report if there was a failing condition, but it missed changing the result from SKIP to PASS if there was no failure.

This updates the result for 4.1.2 so that it will correctly report success as long as there are no non-compliant journal file permissions.

**Testing done:**

Ran Bottlerocket CIS compliance report and verified 4.1.2 correctly report PASS:

```
[ssm-user@control]$ apiclient report cis
Benchmark name:  CIS Bottlerocket Benchmark
Version:         v1.0.0
Reference:       https://www.cisecurity.org/benchmark/bottlerocket
Benchmark level: 1
Start time:      2023-10-23T16:41:44.527568759Z

[SKIP] 1.2.1     Ensure software update repositories are configured (Manual)
[PASS] 1.3.1     Ensure dm-verity is configured (Automatic)
[PASS] 1.4.1     Ensure setuid programs do not create core dumps (Automatic)
[PASS] 1.4.2     Ensure address space layout randomization (ASLR) is enabled (Automatic)
[PASS] 1.4.3     Ensure unprivileged eBPF is disabled (Automatic)
[PASS] 1.5.1     Ensure SELinux is configured (Automatic)
[SKIP] 1.6       Ensure updates, patches, and additional security software are installed (Manual)
[PASS] 2.1.1.1   Ensure chrony is configured (Automatic)
[PASS] 3.2.5     Ensure broadcast ICMP requests are ignored (Automatic)
[PASS] 3.2.6     Ensure bogus ICMP responses are ignored (Automatic)
[PASS] 3.2.7     Ensure TCP SYN Cookies is enabled (Automatic)
[SKIP] 3.4.1.3   Ensure IPv4 outbound and established connections are configured (Manual)
[SKIP] 3.4.2.3   Ensure IPv6 outbound and established connections are configured (Manual)
[PASS] 4.1.1.1   Ensure journald is configured to write logs to persistent disk (Automatic)
[PASS] 4.1.2     Ensure permissions on journal files are configured (Automatic)

Passed:          11
Failed:          0
Skipped:         4
Total checks:    15

Compliance check result: PASS
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
