### PR TITLE
Host container update for v1.16.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -240,5 +240,7 @@ version = "1.16.0"
     "migrate_v1.16.0_kernel-modules-autoload-files.lz4",
     "migrate_v1.16.0_kernel-modules-autoload-restart.lz4",
     "migrate_v1.16.0_kernel-modules-autoload-settings.lz4",
+    "migrate_v1.16.0_aws-admin-container-v0-11-1.lz4",
+    "migrate_v1.16.0_public-admin-container-v0-11-1.lz4",
     "migrate_v1.16.0_schnauzer-v2-generators.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -242,5 +242,7 @@ version = "1.16.0"
     "migrate_v1.16.0_kernel-modules-autoload-settings.lz4",
     "migrate_v1.16.0_aws-admin-container-v0-11-1.lz4",
     "migrate_v1.16.0_public-admin-container-v0-11-1.lz4",
+    "migrate_v1.16.0_aws-control-container-v0-7-5.lz4",
+    "migrate_v1.16.0_public-control-container-v0-7-5.lz4",
     "migrate_v1.16.0_schnauzer-v2-generators.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -559,6 +559,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-admin-container-v0-9-4"
 version = "0.1.0"
 dependencies = [
@@ -3113,6 +3120,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-1"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -638,6 +638,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-5"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,6 +3176,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-5"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -73,6 +73,8 @@ members = [
     "api/migration/migrations/v1.16.0/kernel-modules-autoload-files",
     "api/migration/migrations/v1.16.0/kernel-modules-autoload-restart",
     "api/migration/migrations/v1.16.0/kernel-modules-autoload-settings",
+    "api/migration/migrations/v1.16.0/aws-admin-container-v0-11-1",
+    "api/migration/migrations/v1.16.0/public-admin-container-v0-11-1",
     "api/migration/migrations/v1.16.0/schnauzer-v2-generators",
 
     "bloodhound",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -75,6 +75,8 @@ members = [
     "api/migration/migrations/v1.16.0/kernel-modules-autoload-settings",
     "api/migration/migrations/v1.16.0/aws-admin-container-v0-11-1",
     "api/migration/migrations/v1.16.0/public-admin-container-v0-11-1",
+    "api/migration/migrations/v1.16.0/aws-control-container-v0-7-5",
+    "api/migration/migrations/v1.16.0/public-control-container-v0-7-5",
     "api/migration/migrations/v1.16.0/schnauzer-v2-generators",
 
     "bloodhound",

--- a/sources/api/migration/migrations/v1.16.0/aws-admin-container-v0-11-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.16.0/aws-admin-container-v0-11-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-11-1"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.16.0/aws-admin-container-v0-11-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.16.0/aws-admin-container-v0-11-1/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.0";
+const NEW_ADMIN_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.1";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.admin.source",
+        old_template: OLD_ADMIN_CTR_TEMPLATE,
+        new_template: NEW_ADMIN_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.16.0/aws-control-container-v0-7-5/Cargo.toml
+++ b/sources/api/migration/migrations/v1.16.0/aws-control-container-v0-7-5/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-5"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.16.0/aws-control-container-v0-7-5/src/main.rs
+++ b/sources/api/migration/migrations/v1.16.0/aws-control-container-v0-7-5/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceTemplateMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.4";
+const NEW_CONTROL_CTR_TEMPLATE: &str =
+    "{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.5";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceTemplateMigration {
+        setting: "settings.host-containers.control.source",
+        old_template: OLD_CONTROL_CTR_TEMPLATE,
+        new_template: NEW_CONTROL_CTR_TEMPLATE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.16.0/public-admin-container-v0-11-1/Cargo.toml
+++ b/sources/api/migration/migrations/v1.16.0/public-admin-container-v0-11-1/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-11-1"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.16.0/public-admin-container-v0-11-1/src/main.rs
+++ b/sources/api/migration/migrations/v1.16.0/public-admin-container-v0-11-1/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.1";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.16.0/public-control-container-v0-7-5/Cargo.toml
+++ b/sources/api/migration/migrations/v1.16.0/public-control-container-v0-7-5/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-5"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.16.0/public-control-container-v0-7-5/src/main.rs
+++ b/sources/api/migration/migrations/v1.16.0/public-control-container-v0-7-5/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.5";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.16.0/schnauzer-v2-generators/src/main.rs
+++ b/sources/api/migration/migrations/v1.16.0/schnauzer-v2-generators/src/main.rs
@@ -14,13 +14,13 @@ fn build_metadata_migrations() -> Vec<MetadataReplacement> {
                 setting: "settings.host-containers.admin.source",
                 metadata: "setting-generator",
                 old_val: "schnauzer settings.host-containers.admin.source",
-                new_val: "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.0'",
+                new_val: "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.1'",
             },
             MetadataReplacement {
                 setting: "settings.host-containers.control.source",
                 metadata: "setting-generator",
                 old_val: "schnauzer settings.host-containers.control.source",
-                new_val: "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.4'",
+                new_val: "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.5'",
             },
             MetadataReplacement {
                 setting: "settings.updates.metadata-base-url",

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.0'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.1'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.4'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.5'"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.1"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.5"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.1"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Issue number:**

Closes #3473

**Description of changes:**
Update the default admin and control container images to [v0.11.1](https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/88) and [v0.7.5](https://github.com/bottlerocket-os/bottlerocket-control-container/pull/51) respectively.


**Testing done:**
* [x] `cargo make check-migrations` works fine
* [x] A v1.15.1 AMI can be upgraded to v1.16.0 and also downgraded. 
 The correct host container images are used in both versions



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
