### PR TITLE
bloodhound: Handle chronyd is-active failures

### DIFF
--- a/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
@@ -287,8 +287,8 @@ impl Checker for BR02010101Checker {
 
         check_output_contains!(
             SYSTEMCTL_CMD,
-            ["is-active", "chronyd"],
-            &["active"],
+            ["show", "--property", "ActiveState", "chronyd"],
+            &["ActiveState=active"],
             "unable to verify chronyd service enabled",
             "chronyd NTP service is not enabled"
         )


### PR DESCRIPTION
**Issue number:**

Closes #3551 

**Description of changes:**

Bottlerocket CIS Benchmark control 2.1.1.1 verifies time sync is enabled. For our check for chronyd service status, we run `systemctl is-active chronyd` to verify its active state.

The `systemctl is-active` command doesn't just report the state string though. If the service is not active, the return code from running this command is a 3 and the command execution from rust therefore does not report success.

This changes the way the check is performed by calling `systemctl show --property ActiveState chronyd`. This command will just report the state, and its exit status will be 0 as long as the state can be retrieved. It is not affected by what that state actually is. The string check of the output is also improved to explicitly look for the full `ActiveState` output.

**Testing done:**

Built and deployed instance prefix. Ran:

```sh
systemctl stop chronyd
apiclient report cis
```

Noted the 2.1.1.1 check reported `SKIP`, indicating manual checking was required.

Built and deployed instance with this fix included. Ran:

```sh
systemctl stop chronyd
apiclient report cis
```

Verified check now reported as `FAIL`. Then ran:

```sh
systemctl start chronyd
apiclient report cis
```

Verified reported `PASS` with service running.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
