### PR TITLE
packages: update open vm tools to 12.3.5

### DIFF
--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/vmware/open-vm-tools/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/vmware/open-vm-tools/releases/download/stable-12.3.0/open-vm-tools-12.3.0-22234872.tar.gz"
-sha512 = "942be3c225d5724e236959dc0d422358b99d2844ed8f1c2d2ca06ea5959c12b1a5ac4fa47ee48c27d1c1291f6d783d1cf87303bf64b8117fd96f226ae4d632e5"
+url = "https://github.com/vmware/open-vm-tools/releases/download/stable-12.3.5/open-vm-tools-12.3.5-22544099.tar.gz"
+sha512 = "7a81d929ea4871b8af0af0fa3dc62a821ac4286235255103f1bcf014e3b04b5bbbfa178a9328a16d67cfd595c4ce726dc9e195adbe21ec5c68a4d1abb1561ff6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -1,7 +1,7 @@
-%global buildver 22234872
+%global buildver 22544099
 
 Name: %{_cross_os}open-vm-tools
-Version: 12.3.0
+Version: 12.3.5
 Release: 1%{?dist}
 Summary: Tools for VMware
 License: LGPL-2.1-or-later


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
The update is required because of following reasons: 
- This open vm tools release resolves CVE-2023-34058. For more information on this vulnerability and its impact on VMware products, see https://www.vmware.com/security/advisories/VMSA-2023-0024.html.
- This open vm tools release resolves CVE-2023-34059 which only affects open-vm-tools.

**Testing done:**
- [x] vmware-k8s-1.26
```
 NAME                                    TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 x86-64-vmware-k8s-126-quick             Test              passed                         4               0             7068   ecd53f5d          2023-10-30T19:28:24Z
 x86-64-vmware-k8s-126                   Resource          completed                                                           ecd53f5d          2023-10-30T19:24:57Z
 x86-64-vmware-k8s-126-vms-uies          Resource          running                                                             ecd53f5d          2023-10-30T19:28:33Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
