### PR TITLE
[1.16.x] bloodhound: Improve chronyd active check

### DIFF
--- a/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
@@ -287,8 +287,8 @@ impl Checker for BR02010101Checker {
 
         check_output_contains!(
             SYSTEMCTL_CMD,
-            ["is-active", "chronyd"],
-            &["active"],
+            ["show", "--property", "ActiveState", "chronyd"],
+            &["ActiveState=active"],
             "unable to verify chronyd service enabled",
             "chronyd NTP service is not enabled"
         )


### PR DESCRIPTION
**Issue number:**

Closes #3551

**Description of changes:**

The existing check for chronyd is fine if the service is running and it properly recognizes the state. If the service is stopped or failed though, the check directs the user to perform a manual check due to the way the status is being checked. The "systemctl is-active" call returns a failure exit code, causing the check to fail to determine its state.

This changes the way the check is performed by calling "systemctl show --property ActiveState chronyd". This command will just report the state, and its exit status will be 0 as long as the state can be retrieved. It is not affected by what that state actually is. The string check of the output is also improved to explicitly look for the full ActiveState output.

(cherry picked from commit 9545a9fdd45ab4e5813801412434a7c394898e02)

**Testing done:**

See testing in [PR](https://github.com/bottlerocket-os/bottlerocket/pull/3552) to `develop`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
