### PR TITLE
settings: implement motd settings extension

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1225,7 +1225,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8245dd5f576a41c3b76247b54c15b0e43139ceeb4f732033e15be7c005176"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1474,8 +1474,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1493,14 +1503,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2590,10 +2625,10 @@ dependencies = [
 name = "model-derive"
 version = "0.1.0"
 dependencies = [
- "darling",
+ "darling 0.20.3",
  "generate-readme",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3440,14 +3475,14 @@ dependencies = [
 name = "scalar-derive"
 version = "0.1.0"
 dependencies = [
- "darling",
+ "darling 0.20.3",
  "generate-readme",
  "proc-macro2",
  "quote",
  "scalar",
  "serde",
  "serde_plain",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3935,11 +3970,11 @@ dependencies = [
 name = "systemd-derive"
 version = "0.1.0"
 dependencies = [
- "darling",
+ "darling 0.20.3",
  "generate-readme",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "model-derive",
+ "motd",
  "rand",
  "regex",
  "scalar",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1135,6 +1135,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bottlerocket-settings-sdk"
+version = "0.1.0-alpha.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-sdk-v0.1.0-alpha.0#efd1ebeed2f8cbe84b99eabf3df0251285ed8a81"
+dependencies = [
+ "bottlerocket-template-helper",
+ "clap",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
+name = "bottlerocket-template-helper"
+version = "0.1.0-alpha.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-sdk-v0.1.0-alpha.0#efd1ebeed2f8cbe84b99eabf3df0251285ed8a81"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "bottlerocket-variant"
 version = "0.1.0"
 dependencies = [
@@ -2656,6 +2681,15 @@ dependencies = [
  "toml 0.5.11",
  "url",
  "x509-parser",
+]
+
+[[package]]
+name = "motd"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -101,6 +101,8 @@ members = [
 
     "models",
 
+    "models/settings-extensions/motd",
+
     "parse-datetime",
 
     "retry-read",

--- a/sources/api/netdog/systemd-derive/Cargo.toml
+++ b/sources/api/netdog/systemd-derive/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-darling = { version = "0.14", default-features = false }
+darling = { version = "0.20", default-features = false }
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", default-features = false, features = ["derive"] }
+syn = { version = "2", default-features = false, features = ["derive"] }
 
 [build-dependencies]
 generate-readme = { path = "../../../generate-readme", version = "0.1" }

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -58,7 +58,11 @@ wildcards = "deny"
 
 deny = [
     { name = "structopt" },
-    { name = "clap", wrappers = [ "cargo-readme" ] },
+
+    # The bottlerocket-settings-sdk uses clap, but plans to migrate to argh
+    # We will provide an exception until the following is resolved:
+    # https://github.com/bottlerocket-os/bottlerocket-settings-sdk/issues/23
+    { name = "clap", wrappers = [ "cargo-readme", "bottlerocket-settings-sdk" ] },
 ]
 
 skip = [
@@ -89,3 +93,10 @@ skip-tree = [
 # Deny crates from unknown registries or git repositories.
 unknown-registry = "deny"
 unknown-git = "deny"
+
+allow-git = [
+    # The settings SDK is currently provided as a git dependency,
+    # We will allow it as an exception until the following is resolved:
+    # https://github.com/bottlerocket-os/bottlerocket-settings-sdk/issues/18
+    "https://github.com/bottlerocket-os/bottlerocket-settings-sdk",
+]

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -81,6 +81,8 @@ skip-tree = [
     { name = "windows-sys" },
     # httptest uses an older version of bstr
     { name = "httptest", version = "=0.15.4" },
+    # schnauzer uses cached, which uses an older version of darling
+    { name = "darling", version = "=0.14.4" },
 ]
 
 [sources]

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -28,6 +28,9 @@ toml = "0.5"
 x509-parser = "0.15"
 url = "2"
 
+# settings extensions
+motd = { path = "./settings-extensions/motd", version = "0.1" }
+
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/models/model-derive/Cargo.toml
+++ b/sources/models/model-derive/Cargo.toml
@@ -14,9 +14,9 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-darling = "0.14"
+darling = "0.20"
 quote = "1"
-syn = { version = "1", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
+syn = { version = "2", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/models/scalar-derive/Cargo.toml
+++ b/sources/models/scalar-derive/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-darling = "0.14"
+darling = "0.20"
 proc-macro2 = "1"
 quote = "1"
 scalar = { path = "../scalar", version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_plain = "1"
-syn = { version = "1", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
+syn = { version = "2", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
 
 [build-dependencies]
 generate-readme = { path = "../../generate-readme", version = "0.1" }

--- a/sources/models/settings-extensions/motd/Cargo.toml
+++ b/sources/models/settings-extensions/motd/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "motd"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.0"
+version = "0.1.0-alpha"

--- a/sources/models/settings-extensions/motd/motd.toml
+++ b/sources/models/settings-extensions/motd/motd.toml
@@ -1,0 +1,14 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+
+[v1]
+    [v1.validation.cross-validates]
+
+    [v1.templating]
+        helpers = []
+
+    [v1.generation.requires]

--- a/sources/models/settings-extensions/motd/src/lib.rs
+++ b/sources/models/settings-extensions/motd/src/lib.rs
@@ -1,0 +1,65 @@
+/// The motd setting is used to set the "message of the day" that is shown to users when logging
+/// into the Bottlerocket control container.
+use bottlerocket_settings_sdk::{GenerateResult, LinearlyMigrateable, NoMigration, SettingsModel};
+use serde::{Deserialize, Serialize};
+use std::convert::Infallible;
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct MotdV1(pub Option<String>);
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for MotdV1 {
+    /// We only have one value, so there's no such thing as a partial
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Allow anything that parses as MotdV1
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or(MotdV1::default()),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // No need to do any additional validation, any MotdV1 is acceptable
+        Ok(())
+    }
+}
+
+impl LinearlyMigrateable for MotdV1 {
+    type ForwardMigrationTarget = NoMigration;
+    type BackwardMigrationTarget = NoMigration;
+
+    fn migrate_forward(&self) -> Result<Self::ForwardMigrationTarget> {
+        NoMigration::no_defined_migration()
+    }
+
+    fn migrate_backward(&self) -> Result<Self::BackwardMigrationTarget> {
+        NoMigration::no_defined_migration()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_motd() {
+        assert!(matches!(
+            MotdV1::generate(None, None),
+            Ok(GenerateResult::Complete(MotdV1(None)))
+        ))
+    }
+}

--- a/sources/models/settings-extensions/motd/src/main.rs
+++ b/sources/models/settings-extensions/motd/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, LinearMigratorExtensionBuilder};
+use motd::MotdV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match LinearMigratorExtensionBuilder::with_name("motd")
+        .with_models(vec![BottlerocketSetting::<MotdV1>::model()])
+        .build()
+    {
+        Ok(extension) => {
+            extension.run()
+        }
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/aws-k8s-1.28/mod.rs
+++ b/sources/models/src/aws-k8s-1.28/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/metal-k8s-1.28/mod.rs
+++ b/sources/models/src/metal-k8s-1.28/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,

--- a/sources/models/src/vmware-k8s-1.28/mod.rs
+++ b/sources/models/src/vmware-k8s-1.28/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 // that uses its name in serialization; internal structures use the field name that points to it
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
-    motd: String,
+    motd: motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,


### PR DESCRIPTION
**Description of changes:**
This uses the `bottlerocket-settings-sdk` to add the first Bottlerocket settings extension for the `motd` setting.

The binary exists now, but we are currently just pulling in the crate as a library into the monolithic models until we can replace more of the settings with extensions.

RPMs to install the setting will be provided at a later time.

**Testing done:**
* Launched a aws-k8s-1.2{5,6,7} Bottlerocket images and checked `settings.motd`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
