### PR TITLE
Change nightly GitHub Action to run weekly

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,12 +2,12 @@
 # to try to catch errors close to their introduction due to yanked Go modules. These
 # could otherwise be covered up by caching and not discovered until much later when
 # bypassing the main cache.
-name: Nightly
+name: Weekly
 on:
   schedule:
-    # Run once a day at 02:15 UTC. Randomly chosen as a "quiet" time for this to run.
+    # Run Monday at 02:15 UTC. Randomly chosen as a "quiet" time for this to run.
     # See syntax for format details: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
-    - cron: '15 2 * * *'
+    - cron: '15 2 * * 1'
 
 env:
   # When Go packages are built, buildsys will vendor in dependent Go code for


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The nightly job was added to help catch cases where yanked Go modules would be found right away by using the GOPROXY=direct setting to bypass any caching.

This has been in place for a few months, and so far the only failures seen have been due to Docker repo throttling (too many requests). Since this job runs every variant in the repo, it is a relatively expensive job to be running every night.

This switches the job from nightly to weekly. This will still give an early warning in case of any yanked modules, but will limit the amount of overall runtime that is usually unnecessary.

**Testing done:**

None, will observe in Action runs and adjust as needed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
