### PR TITLE
Update Kubernetes CIS benchmark to 1.8.0

### DIFF
--- a/packages/os/cis-checks-k8s-metadata-json
+++ b/packages/os/cis-checks-k8s-metadata-json
@@ -1,5 +1,5 @@
 {
     "name": "CIS Kubernetes Benchmark (Worker Node)",
-    "version": "v1.7.1",
+    "version": "v1.8.0",
     "url": "https://www.cisecurity.org/benchmark/kubernetes"
 }


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

An updated Kuberntes CIS benchmark was published in September 2023. This only included updates to the control plane components of Kubernetes. Since the Bottlerocket CIS checking only evaluates worker node controls (section 4.x.x of the benchmark), nothing changes with our checks between 1.7.1 and 1.8.0.

This updates the checker metadata to reflect evaluation against the latest 1.8.0 benchmark. No other changes are needed.

**Testing done:**

Built and verified `apiclient report cis-k8s` reflects the new benchmark version number.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
