### PR TITLE
Update NVIDIA drivers to latest versions

### DIFF
--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -13,13 +13,13 @@ package-name = "kmod-5.10-nvidia"
 releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/470.161.03/NVIDIA-Linux-x86_64-470.161.03.run"
-sha512 = "26b1640f9427847b68233ffacf5c4a07e75ed9923429dfc9e5de3d7e5c1f109dfaf0fe0a0639cbd47f056784ed3e00e2e741d5c84532df79590a0c9ffa5ba625"
+url = "https://us.download.nvidia.com/tesla/470.223.02/NVIDIA-Linux-x86_64-470.223.02.run"
+sha512 = "66e470343b6f0c04703c81169cd03674be06b5315db738cab64308ec073b5bf5b87508b58ac8b6288d10e95307072d99e874e7884207a323a3dd08887bbc8750"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/470.161.03/NVIDIA-Linux-aarch64-470.161.03.run"
-sha512 = "16e83c4d3ea66b2da07c43fca912c839e5feb9d42bee279b9de3476ffbd5e2314fddc83c1a38c198adb2d5ea6b4f2b00bb4a4c32d6fd0bfcdbccc392043f99ce"
+url = "https://us.download.nvidia.com/tesla/470.223.02/NVIDIA-Linux-aarch64-470.223.02.run"
+sha512 = "c22eab4ec6aa1868bbe55200ba74187939571ae78645c333fe05d544869c54b84d63e26f5c4f922bbe4e768da1f394d15d0b85cacbd4bbbc2b1dfd5074734a02"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -1,4 +1,4 @@
-%global tesla_470 470.161.03
+%global tesla_470 470.223.02
 %global tesla_470_libdir %{_cross_libdir}/nvidia/tesla/%{tesla_470}
 %global tesla_470_bindir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -13,13 +13,13 @@ package-name = "kmod-5.15-nvidia"
 releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/515.86.01/NVIDIA-Linux-x86_64-515.86.01.run"
-sha512 = "9a31e14afc017e847f1208577f597c490adb63c256d6dff1a9eae56b65cf85374a604516b0be9da7a43e9af93b3c5aec47b2ffefd6b4050a4b7e55f348cf4e7b"
+url = "https://us.download.nvidia.com/tesla/535.129.03/NVIDIA-Linux-x86_64-535.129.03.run"
+sha512 = "3d7142658fe836e1debf7786857bdb293490ef33351e9b7d39face245fe8596b0f46052b86fae08350fcda1e2a9fd68d7309b94e107d1b016bd529d8fc37e31f"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/515.86.01/NVIDIA-Linux-aarch64-515.86.01.run"
-sha512 = "43161f86143b1558d1f558acf4a060f53f538ea20e6235f76be24916fe4a9c374869645c7abf39eba66f1c2ca35f5d2b04f199bd1341b7ee6c1fdc879cb3ef96"
+url = "https://us.download.nvidia.com/tesla/535.129.03/NVIDIA-Linux-aarch64-535.129.03.run"
+sha512 = "706de7e53b81f909d8bc6a12a39c594754a164c49f5d23c7939dc3abcfc04f5d5b12b7d65762ae574582149a098f06ee5fe95be4f8ad1056a3307a6ce93f3c00"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -1,9 +1,16 @@
-%global tesla_515 515.86.01
-%global tesla_515_libdir %{_cross_libdir}/nvidia/tesla/%{tesla_515}
-%global tesla_515_bindir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
-%global tesla_515_firmwaredir %{_cross_libdir}/firmware/nvidia/%{tesla_515}
+%global tesla_major 535
+%global tesla_minor 129
+%global tesla_patch 03
+%global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)
 %global license_file %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml path nvidia -p ./licenses)
+
+# With the split of the firmware binary from firmware/gsp.bin to firmware/gsp_ga10x.bin
+# and firmware/gsp_tu10x.bin the file format changed from executable to relocatable.
+# The __spec_install_post macro will by default try to strip all binary files.
+# Unfortunately the strip used is not compatible with the new file format.
+# Redefine strip, so that these firmware binaries do not derail the build.
+%global __strip /usr/bin/true
 
 Name: %{_cross_os}kmod-5.15-nvidia
 Version: 1.0.0
@@ -15,15 +22,15 @@ License: Apache-2.0 OR MIT
 URL: http://www.nvidia.com/
 
 # NVIDIA .run scripts from 0 to 199
-Source0: https://us.download.nvidia.com/tesla/%{tesla_515}/NVIDIA-Linux-x86_64-%{tesla_515}.run
-Source1: https://us.download.nvidia.com/tesla/%{tesla_515}/NVIDIA-Linux-aarch64-%{tesla_515}.run
+Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
+Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
 Source202: nvidia-dependencies-modules-load.conf
 
 # NVIDIA tesla conf files from 300 to 399
-Source300: nvidia-tesla-tmpfiles.conf.in
+Source300: nvidia-tesla-tmpfiles.conf
 Source301: nvidia-tesla-build-config.toml.in
 Source302: nvidia-tesla-path.env.in
 Source303: nvidia-ld.so.conf.in
@@ -34,25 +41,25 @@ BuildRequires: %{_cross_os}kernel-5.15-archive
 %description
 %{summary}.
 
-%package tesla-515
-Summary: NVIDIA 515 Tesla driver
-Version: %{tesla_515}
+%package tesla-%{tesla_major}
+Summary: NVIDIA %{tesla_major} Tesla driver
+Version: %{tesla_ver}
 License: %{spdx_id}
 Requires: %{name}
 
-%description tesla-515
+%description tesla-%{tesla_major}
 %{summary}
 
 %prep
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
-sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_515}.run -x
+sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
 
 %build
-pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_515}/kernel
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel
 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
@@ -94,81 +101,80 @@ install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_libdir}/modules-load.d
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
-# Begin NVIDIA tesla 515
-pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_515}
+# Begin NVIDIA tesla driver
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
 # We install bins and libs in a versioned directory to prevent collisions with future drivers versions
-install -d %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
-install -d %{buildroot}%{tesla_515_libdir}
-install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install -d %{buildroot}%{_cross_factorydir}/nvidia/tesla/%{tesla_515}
+install -d %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -d %{buildroot}%{_cross_libdir}/nvidia/tesla
+install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
+install -d %{buildroot}%{_cross_factorydir}/nvidia/tesla
 
-sed -e 's|__NVIDIA_VERSION__|%{tesla_515}|' %{S:300} > nvidia-tesla-%{tesla_515}.conf
-install -m 0644 nvidia-tesla-%{tesla_515}.conf %{buildroot}%{_cross_tmpfilesdir}/
-sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/|' %{S:301} > \
-  nvidia-tesla-%{tesla_515}.toml
-install -m 0644 nvidia-tesla-%{tesla_515}.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+install -m 0644 %{S:300} %{buildroot}%{_cross_tmpfilesdir}/nvidia-tesla.conf
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/tesla/module-objects.d/|' %{S:301} > \
+  nvidia-tesla.toml
+install -m 0644 nvidia-tesla.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
 # Install nvidia-path environment file, will be used as a drop-in for containerd.service since
 # libnvidia-container locates and mounts helper binaries into the containers from either
 # `PATH` or `NVIDIA_PATH`
-sed -e 's|__NVIDIA_BINDIR__|%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}|' %{S:302} > nvidia-path.env
-install -m 0644 nvidia-path.env %{buildroot}%{_cross_factorydir}/nvidia/tesla/%{tesla_515}
-# We need to add `_cross_libdir/tesla_515` to the paths loaded by the ldconfig service
+sed -e 's|__NVIDIA_BINDIR__|%{_cross_libexecdir}/nvidia/tesla/bin|' %{S:302} > nvidia-path.env
+install -m 0644 nvidia-path.env %{buildroot}%{_cross_factorydir}/nvidia/tesla
+# We need to add `_cross_libdir` to the paths loaded by the ldconfig service
 # because libnvidia-container uses the `ldcache` file created by the service, to locate and mount the
 # libraries into the containers
-sed -e 's|__LIBDIR__|%{_cross_libdir}|' %{S:303} | sed -e 's|__NVIDIA_VERSION__|%{tesla_515}|' \
-  > nvidia-tesla-%{tesla_515}.conf
-install -m 0644 nvidia-tesla-%{tesla_515}.conf %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/
+sed -e 's|__LIBDIR__|%{_cross_libdir}|' %{S:303} > nvidia-tesla.conf
+install -m 0644 nvidia-tesla.conf %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/
 
 # driver
-install kernel/nvidia.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install kernel/nvidia/nv-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install kernel/nvidia/nv-kernel.o_binary %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nv-kernel.o
+install kernel/nvidia.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
+install kernel/nvidia/nv-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
+install kernel/nvidia/nv-kernel.o_binary %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d/nv-kernel.o
 
 # uvm
-install kernel/nvidia-uvm.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install kernel/nvidia-uvm.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
+install kernel/nvidia-uvm.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
+install kernel/nvidia-uvm.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
 
 # modeset
-install kernel/nvidia-modeset.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install kernel/nvidia-modeset/nv-modeset-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install kernel/nvidia-modeset/nv-modeset-kernel.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
+install kernel/nvidia-modeset.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
+install kernel/nvidia-modeset/nv-modeset-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
+install kernel/nvidia-modeset/nv-modeset-kernel.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
 
 # peermem
-install kernel/nvidia-peermem.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install kernel/nvidia-peermem/nvidia-peermem.o %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
+install kernel/nvidia-peermem.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
+install kernel/nvidia-peermem/nvidia-peermem.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
 
 # drm
-install kernel/nvidia-drm.mod.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-install kernel/nvidia-drm.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
+install kernel/nvidia-drm.mod.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/module-objects.d
+install kernel/nvidia-drm.o %{buildroot}/%{_cross_datadir}/nvidia/tesla/module-objects.d
 
 # Binaries
-install -m 755 nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
-install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
-install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
-install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
+install -m 755 nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 %if "%{_cross_arch}" == "x86_64"
-install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
+install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 %endif
 
 # We install all the libraries, and filter them out in the 'files' section, so we can catch
 # when new libraries are added
-install -m 755 *.so* %{buildroot}/%{tesla_515_libdir}/
+install -m 755 *.so* %{buildroot}/%{_cross_libdir}/nvidia/tesla/
 
 # This library has the same SONAME as libEGL.so.1.1.0, this will cause collisions while
 # the symlinks are created. For now, we only symlink libEGL.so.1.1.0.
-EXCLUDED_LIBS="libEGL.so.%{tesla_515}"
+EXCLUDED_LIBS="libEGL.so.%{tesla_ver}"
 
 for lib in $(find . -maxdepth 1 -type f -name 'lib*.so.*' -printf '%%P\n'); do
   [[ "${EXCLUDED_LIBS}" =~ "${lib}" ]] && continue
   soname="$(%{_cross_target}-readelf -d "${lib}" | awk '/SONAME/{print $5}' | tr -d '[]')"
   [ -n "${soname}" ] || continue
   [ "${lib}" == "${soname}" ] && continue
-  ln -s "${lib}" %{buildroot}/%{tesla_515_libdir}/"${soname}"
+  ln -s "${lib}" %{buildroot}/%{_cross_libdir}/nvidia/tesla/"${soname}"
 done
 
 # Include the firmware file for GSP support
-install -d %{buildroot}%{tesla_515_firmwaredir}
-install -p -m 0644 firmware/gsp.bin %{buildroot}%{tesla_515_firmwaredir}
+install -d %{buildroot}%{_cross_libdir}/firmware/nvidia/%{tesla_ver}
+install -p -m 0644 firmware/gsp_ga10x.bin %{buildroot}%{_cross_libdir}/firmware/nvidia/%{tesla_ver}
+install -p -m 0644 firmware/gsp_tu10x.bin %{buildroot}%{_cross_libdir}/firmware/nvidia/%{tesla_ver}
 
 popd
 
@@ -183,141 +189,146 @@ popd
 %{_cross_libdir}/systemd/system/
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
-%files tesla-515
+%files tesla-%{tesla_major}
 %license %{license_file}
-%dir %{_cross_datadir}/nvidia/tesla/%{tesla_515}
-%dir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}
-%dir %{tesla_515_libdir}
-%dir %{tesla_515_firmwaredir}
-%dir %{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d
-%dir %{_cross_factorydir}/nvidia/tesla/%{tesla_515}
+%dir %{_cross_datadir}/nvidia/tesla
+%dir %{_cross_libexecdir}/nvidia/tesla/bin
+%dir %{_cross_libdir}/nvidia/tesla
+%dir %{_cross_libdir}/firmware/nvidia/%{tesla_ver}
+%dir %{_cross_datadir}/nvidia/tesla/module-objects.d
+%dir %{_cross_factorydir}/nvidia/tesla
 
 # Binaries
-%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}/nvidia-debugdump
-%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}/nvidia-smi
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-debugdump
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-smi
 
 # Configuration files
-%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla-%{tesla_515}.toml
-%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/nvidia-tesla-%{tesla_515}.conf
-%{_cross_factorydir}/nvidia/tesla/%{tesla_515}/nvidia-path.env
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla.toml
+%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/nvidia-tesla.conf
+%{_cross_factorydir}/nvidia/tesla/nvidia-path.env
 
 # driver
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia.mod.o
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nv-interface.o
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nv-kernel.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia.mod.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nv-interface.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nv-kernel.o
 
 # uvm
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia-uvm.mod.o
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia-uvm.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-uvm.mod.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-uvm.o
 
 # modeset
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nv-modeset-interface.o
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nv-modeset-kernel.o
-%{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia-modeset.mod.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nv-modeset-interface.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nv-modeset-kernel.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-modeset.mod.o
 
 # tmpfiles
-%{_cross_tmpfilesdir}/nvidia-tesla-%{tesla_515}.conf
+%{_cross_tmpfilesdir}/nvidia-tesla.conf
 
 # We only install the libraries required by all the DRIVER_CAPABILITIES, described here:
 # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
 
 # Utility libs
-%{tesla_515_libdir}/libnvidia-ml.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-ml.so.1
-%{tesla_515_libdir}/libnvidia-cfg.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-cfg.so.1
-%{tesla_515_libdir}/libnvidia-nvvm.so.4
-%{tesla_515_libdir}/libnvidia-nvvm.so.%{tesla_515}
+%{_cross_libdir}/nvidia/tesla/libnvidia-api.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-ml.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-ml.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-cfg.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-cfg.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-nvvm.so.4
+%{_cross_libdir}/nvidia/tesla/libnvidia-nvvm.so.%{tesla_ver}
 
 # Compute libs
-%{tesla_515_libdir}/libcuda.so.%{tesla_515}
-%{tesla_515_libdir}/libcuda.so.1
-%{tesla_515_libdir}/libnvidia-opencl.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-opencl.so.1
-%{tesla_515_libdir}/libnvidia-ptxjitcompiler.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-ptxjitcompiler.so.1
-%{tesla_515_libdir}/libnvidia-allocator.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-allocator.so.1
-%{tesla_515_libdir}/libOpenCL.so.1.0.0
-%{tesla_515_libdir}/libOpenCL.so.1
+%{_cross_libdir}/nvidia/tesla/libcuda.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libcuda.so.1
+%{_cross_libdir}/nvidia/tesla/libcudadebugger.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libcudadebugger.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-opencl.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-opencl.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-ptxjitcompiler.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-ptxjitcompiler.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-allocator.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-allocator.so.1
+%{_cross_libdir}/nvidia/tesla/libOpenCL.so.1.0.0
+%{_cross_libdir}/nvidia/tesla/libOpenCL.so.1
 %if "%{_cross_arch}" == "x86_64"
-%{tesla_515_libdir}/libnvidia-compiler.so.%{tesla_515}
+%{_cross_libdir}/nvidia/tesla/libnvidia-pkcs11.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-pkcs11-openssl3.so.%{tesla_ver}
 %endif
 
 # Video libs
-%{tesla_515_libdir}/libvdpau_nvidia.so.%{tesla_515}
-%{tesla_515_libdir}/libvdpau_nvidia.so.1
-%{tesla_515_libdir}/libnvidia-encode.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-encode.so.1
-%{tesla_515_libdir}/libnvidia-opticalflow.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-opticalflow.so.1
-%{tesla_515_libdir}/libnvcuvid.so.%{tesla_515}
-%{tesla_515_libdir}/libnvcuvid.so.1
+%{_cross_libdir}/nvidia/tesla/libvdpau_nvidia.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libvdpau_nvidia.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-encode.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-encode.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-opticalflow.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-opticalflow.so.1
+%{_cross_libdir}/nvidia/tesla/libnvcuvid.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvcuvid.so.1
 
 # Graphics libs
-%{tesla_515_libdir}/libnvidia-eglcore.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-glcore.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-tls.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-glsi.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-rtcore.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-fbc.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-fbc.so.1
-%{tesla_515_libdir}/libnvoptix.so.%{tesla_515}
-%{tesla_515_libdir}/libnvoptix.so.1
-%{tesla_515_libdir}/libnvidia-vulkan-producer.so.%{tesla_515}
+%{_cross_libdir}/nvidia/tesla/libnvidia-eglcore.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-glcore.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-tls.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-glsi.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-rtcore.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-fbc.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-fbc.so.1
+%{_cross_libdir}/nvidia/tesla/libnvoptix.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvoptix.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-vulkan-producer.so.%{tesla_ver}
 
 # Graphics GLVND libs
-%{tesla_515_libdir}/libnvidia-glvkspirv.so.%{tesla_515}
-%{tesla_515_libdir}/libGLX_nvidia.so.%{tesla_515}
-%{tesla_515_libdir}/libGLX_nvidia.so.0
-%{tesla_515_libdir}/libEGL_nvidia.so.%{tesla_515}
-%{tesla_515_libdir}/libEGL_nvidia.so.0
-%{tesla_515_libdir}/libGLESv2_nvidia.so.%{tesla_515}
-%{tesla_515_libdir}/libGLESv2_nvidia.so.2
-%{tesla_515_libdir}/libGLESv1_CM_nvidia.so.%{tesla_515}
-%{tesla_515_libdir}/libGLESv1_CM_nvidia.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-glvkspirv.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libGLX_nvidia.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libGLX_nvidia.so.0
+%{_cross_libdir}/nvidia/tesla/libEGL_nvidia.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libEGL_nvidia.so.0
+%{_cross_libdir}/nvidia/tesla/libGLESv2_nvidia.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libGLESv2_nvidia.so.2
+%{_cross_libdir}/nvidia/tesla/libGLESv1_CM_nvidia.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libGLESv1_CM_nvidia.so.1
 
 # Graphics compat
-%{tesla_515_libdir}/libEGL.so.1.1.0
-%{tesla_515_libdir}/libEGL.so.1
-%{tesla_515_libdir}/libEGL.so.%{tesla_515}
-%{tesla_515_libdir}/libGL.so.1.7.0
-%{tesla_515_libdir}/libGL.so.1
-%{tesla_515_libdir}/libGLESv1_CM.so.1.2.0
-%{tesla_515_libdir}/libGLESv1_CM.so.1
-%{tesla_515_libdir}/libGLESv2.so.2.1.0
-%{tesla_515_libdir}/libGLESv2.so.2
+%{_cross_libdir}/nvidia/tesla/libEGL.so.1.1.0
+%{_cross_libdir}/nvidia/tesla/libEGL.so.1
+%{_cross_libdir}/nvidia/tesla/libEGL.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libGL.so.1.7.0
+%{_cross_libdir}/nvidia/tesla/libGL.so.1
+%{_cross_libdir}/nvidia/tesla/libGLESv1_CM.so.1.2.0
+%{_cross_libdir}/nvidia/tesla/libGLESv1_CM.so.1
+%{_cross_libdir}/nvidia/tesla/libGLESv2.so.2.1.0
+%{_cross_libdir}/nvidia/tesla/libGLESv2.so.2
 
 # NGX
-%{tesla_515_libdir}/libnvidia-ngx.so.%{tesla_515}
-%{tesla_515_libdir}/libnvidia-ngx.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-ngx.so.%{tesla_ver}
+%{_cross_libdir}/nvidia/tesla/libnvidia-ngx.so.1
 
 # Firmware
-%{tesla_515_firmwaredir}/gsp.bin
+%{_cross_libdir}/firmware/nvidia/%{tesla_ver}/gsp_ga10x.bin
+%{_cross_libdir}/firmware/nvidia/%{tesla_ver}/gsp_tu10x.bin
 
 # Neither nvidia-peermem nor nvidia-drm are included in driver container images, we exclude them
 # for now, and we will add them if requested
-%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia-peermem.mod.o
-%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia-peermem.o
-%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia-drm.mod.o
-%exclude %{_cross_datadir}/nvidia/tesla/%{tesla_515}/module-objects.d/nvidia-drm.o
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}/nvidia-cuda-mps-control
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}/nvidia-cuda-mps-server
+%exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-peermem.mod.o
+%exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-peermem.o
+%exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.mod.o
+%exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.o
+%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
+%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
 %if "%{_cross_arch}" == "x86_64"
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_515}/nvidia-ngx-updater
+%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-ngx-updater
 %endif
 
 # None of these libraries are required by libnvidia-container, so they
 # won't be used by a containerized workload
-%exclude %{tesla_515_libdir}/libGLX.so.0
-%exclude %{tesla_515_libdir}/libGLdispatch.so.0
-%exclude %{tesla_515_libdir}/libOpenGL.so.0
-%exclude %{tesla_515_libdir}/libglxserver_nvidia.so.%{tesla_515}
-%exclude %{tesla_515_libdir}/libnvidia-gtk2.so.%{tesla_515}
-%exclude %{tesla_515_libdir}/libnvidia-gtk3.so.%{tesla_515}
-%exclude %{tesla_515_libdir}/nvidia_drv.so
-%exclude %{tesla_515_libdir}/libnvidia-egl-wayland.so.1
-%exclude %{tesla_515_libdir}/libnvidia-egl-gbm.so.1
-%exclude %{tesla_515_libdir}/libnvidia-egl-gbm.so.1.1.0
-%exclude %{tesla_515_libdir}/libnvidia-egl-wayland.so.1.1.9
-%exclude %{tesla_515_libdir}/libnvidia-wayland-client.so.%{tesla_515}
+%exclude %{_cross_libdir}/nvidia/tesla/libGLX.so.0
+%exclude %{_cross_libdir}/nvidia/tesla/libGLdispatch.so.0
+%exclude %{_cross_libdir}/nvidia/tesla/libOpenGL.so.0
+%exclude %{_cross_libdir}/nvidia/tesla/libglxserver_nvidia.so.%{tesla_ver}
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-gtk2.so.%{tesla_ver}
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-gtk3.so.%{tesla_ver}
+%exclude %{_cross_libdir}/nvidia/tesla/nvidia_drv.so
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.0
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.11
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-wayland-client.so.%{tesla_ver}

--- a/packages/kmod-5.15-nvidia/nvidia-ld.so.conf.in
+++ b/packages/kmod-5.15-nvidia/nvidia-ld.so.conf.in
@@ -1,1 +1,1 @@
-__LIBDIR__/nvidia/tesla/__NVIDIA_VERSION__/
+__LIBDIR__/nvidia/tesla/

--- a/packages/kmod-5.15-nvidia/nvidia-tesla-tmpfiles.conf
+++ b/packages/kmod-5.15-nvidia/nvidia-tesla-tmpfiles.conf
@@ -1,0 +1,3 @@
+C /etc/drivers/nvidia-tesla.toml
+C /etc/containerd/nvidia.env - - - - /usr/share/factory/nvidia/tesla/nvidia-path.env
+C /etc/ld.so.conf.d/nvidia-tesla.conf

--- a/packages/kmod-5.15-nvidia/nvidia-tesla-tmpfiles.conf.in
+++ b/packages/kmod-5.15-nvidia/nvidia-tesla-tmpfiles.conf.in
@@ -1,3 +1,0 @@
-C /etc/drivers/nvidia-tesla-__NVIDIA_VERSION__.toml
-C /etc/containerd/nvidia.env - - - - /usr/share/factory/nvidia/tesla/__NVIDIA_VERSION__/nvidia-path.env
-C /etc/ld.so.conf.d/nvidia-tesla-__NVIDIA_VERSION__.conf

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -13,13 +13,13 @@ package-name = "kmod-6.1-nvidia"
 releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.54.03/NVIDIA-Linux-x86_64-535.54.03.run"
-sha512 = "45b72b34272d3df14b56136bb61537d00145d55734b72d58390af4694d96f03b2b49433beb4a5bede4d978442b707b08e05f2f31b2fcfd9453091e7f0b945cff"
+url = "https://us.download.nvidia.com/tesla/535.129.03/NVIDIA-Linux-x86_64-535.129.03.run"
+sha512 = "3d7142658fe836e1debf7786857bdb293490ef33351e9b7d39face245fe8596b0f46052b86fae08350fcda1e2a9fd68d7309b94e107d1b016bd529d8fc37e31f"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.54.03/NVIDIA-Linux-aarch64-535.54.03.run"
-sha512 = "57b06a6fa16838176866c364a8722c546084529ad91c57e979aca7750692127cab1485b5a44aee398c5494782ed987e82f66061aa39e802bc6eefa2b40a33bc3"
+url = "https://us.download.nvidia.com/tesla/535.129.03/NVIDIA-Linux-aarch64-535.129.03.run"
+sha512 = "706de7e53b81f909d8bc6a12a39c594754a164c49f5d23c7939dc3abcfc04f5d5b12b7d65762ae574582149a098f06ee5fe95be4f8ad1056a3307a6ce93f3c00"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -1,5 +1,5 @@
 %global tesla_major 535
-%global tesla_minor 54
+%global tesla_minor 129
 %global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)

--- a/variants/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.24-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     "release",
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
-    "kmod-5.15-nvidia-tesla-515",
+    "kmod-5.15-nvidia-tesla-535",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.25-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.25-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     "release",
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
-    "kmod-5.15-nvidia-tesla-515",
+    "kmod-5.15-nvidia-tesla-535",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.26-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.26-nvidia/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     "release",
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
-    "kmod-5.15-nvidia-tesla-515",
+    "kmod-5.15-nvidia-tesla-535",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.27-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.27-nvidia/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     "release",
     "nvidia-container-toolkit",
     "nvidia-k8s-device-plugin",
-    "kmod-5.15-nvidia-tesla-515",
+    "kmod-5.15-nvidia-tesla-535",
 ]
 kernel-parameters = [
     "console=tty0",


### PR DESCRIPTION
**Description of changes:**
This updates the `kmod-5.10-nvidia` driver to `470.223.02`. It also updates the `kmod-6.1-nvidia` to `535.129.03`. 

This moves the `kmod-5.15-nvidia` driver from `515.86.01` to `535.129.03`. This is a version change but should keep compatibility the same between versions. The R515 driver is not receiving updates but the R535 series is so this gets the 5.15 kernel onto a support NVIDIA release. I also moved the logic to be more consistent with the 6.1 specfile so it should be easier to maintain moving forward since they are the same version now.


**Testing done:**
I built `aws-k8s-1.23-nvidia` for both x86_64 and aarch64 and ran an NVIDIA smoke test to confirm the driver is the correct version and CUDA tests pass.
```
=========================================
  Running sample UnifiedMemoryPerf
=========================================

GPU Device 0: "Ampere" with compute capability 8.6

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.225   0.346   0.339   0.016   0.035   0.023   0.039   0.027
16        0.220   0.350   0.489   0.030   0.050   0.042   0.054   0.041
64        0.303   0.345   0.763   0.099   0.103   0.097   0.097   0.080
256       0.650   0.693   1.223   0.533   0.320   0.301   0.278   0.269
1024      1.914   1.808   2.609   3.297   1.257   1.197   1.077   1.065
4096      7.026   6.497   9.518  23.412   5.214   5.192   5.130   5.089
16384    28.230  26.428  38.636 171.469  22.902  22.896  22.693  22.786

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA A10G"
  CUDA Driver Version / Runtime Version          11.4 / 11.4
  CUDA Capability Major/Minor version number:    8.6
  Total amount of global memory:                 22732 MBytes (23836098560 bytes)
  (080) Multiprocessors, (128) CUDA Cores/MP:    10240 CUDA Cores
  GPU Max Clock rate:                            1710 MHz (1.71 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              384-bit
  L2 Cache Size:                                 6291456 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
 Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 30
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 11.4, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Ampere" with compute capability 8.6

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 2424.89 GFlop/s, Time= 1.730 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm
=========================================

Initializing...
GPU Device 0: "Ampere" with compute capability 8.6

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 1.569792 ms
TOPS: 87.55

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Ampere" with compute capability 8.6
33554432 elements
numThreads: 768
numBlocks: 80

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.319910 ms
Bandwidth:    419.548255 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.020576
65536 elements scanned in 0.020576 ms -> 3185.069824 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.034550 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.022528 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.097824 ms
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Ampere" with compute capability 8.6

Launching normVecByDotProductAWBarrier kernel with numBlocks = 160 blockSize = 640
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================
simpleAtomicIntrinsics starting...
GPU Device 0: "Ampere" with compute capability 8.6

Processing time: 49.575001 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Ampere" with compute capability 8.6

> GPU device has 80 Multi-Processors, SM 8.6 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Ampere" with compute capability 8.6

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```

 I built `aws-k8s-1.25-nvidia` for both x86_64 and aarch64 and ran an NVIDIA smoke test to confirm the driver is the correct version and CUDA tests pass.

```
=========================================
  Running sample UnifiedMemoryPerf
=========================================

GPU Device 0: "Ampere" with compute capability 8.6

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.221   0.265   0.315   0.015   0.035   0.026   0.039   0.027
16        0.222   0.300   0.440   0.030   0.052   0.041   0.054   0.039
64        0.317   0.416   0.748   0.104   0.104   0.097   0.098   0.080
256       0.609   0.700   1.346   0.549   0.319   0.302   0.279   0.269
1024      1.913   1.808   2.649   3.211   1.233   1.183   1.085   1.072
4096      6.938   6.292   9.559  23.400   5.251   5.189   5.181   5.158
16384    28.252  26.533  38.924 171.785  22.978  23.022  22.837  22.779

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA A10G"
  CUDA Driver Version / Runtime Version          11.4 / 11.4
  CUDA Capability Major/Minor version number:    8.6
  Total amount of global memory:                 22732 MBytes (23836098560 bytes)
  (080) Multiprocessors, (128) CUDA Cores/MP:    10240 CUDA Cores
  GPU Max Clock rate:                            1710 MHz (1.71 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              384-bit
  L2 Cache Size:                                 6291456 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 30
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 11.4, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Ampere" with compute capability 8.6

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 2421.28 GFlop/s, Time= 1.732 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm
=========================================

Initializing...
GPU Device 0: "Ampere" with compute capability 8.6

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 1.552544 ms
TOPS: 88.52

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Ampere" with compute capability 8.6
33554432 elements
numThreads: 768
numBlocks: 80

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.320270 ms
Bandwidth:    419.076879 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.020352
65536 elements scanned in 0.020352 ms -> 3220.125732 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.034430 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.022528 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.098912 ms
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Ampere" with compute capability 8.6

Launching normVecByDotProductAWBarrier kernel with numBlocks = 160 blockSize = 640
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Ampere" with compute capability 8.6

Processing time: 50.570000 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Ampere" with compute capability 8.6

> GPU device has 80 Multi-Processors, SM 8.6 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Ampere" with compute capability 8.6

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```

I built `aws-k8s-1.28-nvidia` for both x86_64 and aarch64 and ran an NVIDIA smoke test to confirm the driver is the correct version and CUDA tests pass.
```
=========================================
  Running sample UnifiedMemoryPerf
=========================================

GPU Device 0: "Ampere" with compute capability 8.6

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.205   0.207   0.336   0.016   0.035   0.027   0.039   0.026
16        0.203   0.240   0.534   0.030   0.050   0.041   0.058   0.047
64        0.274   0.333   0.818   0.099   0.103   0.103   0.097   0.083
256       0.585   0.729   1.310   0.533   0.326   0.313   0.278   0.267
1024      1.926   1.735   2.678   3.224   1.262   1.199   1.074   1.061
4096      7.042   6.478  10.198  23.464   5.415   5.251   5.256   5.200
16384    28.501  26.929  41.092 171.894  23.940  23.803  23.217  23.082

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA A10G"
  CUDA Driver Version / Runtime Version          12.2 / 11.4
  CUDA Capability Major/Minor version number:    8.6
  Total amount of global memory:                 22516 MBytes (23609475072 bytes)
  (080) Multiprocessors, (128) CUDA Cores/MP:    10240 CUDA Cores
  GPU Max Clock rate:                            1710 MHz (1.71 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              384-bit
  L2 Cache Size:                                 6291456 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 30
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Ampere" with compute capability 8.6

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 2423.10 GFlop/s, Time= 1.731 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm

Initializing...
GPU Device 0: "Ampere" with compute capability 8.6

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 1.533952 ms
TOPS: 89.60

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Ampere" with compute capability 8.6

33554432 elements
numThreads: 768
numBlocks: 80

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.320290 ms
Bandwidth:    419.050636 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.029824
65536 elements scanned in 0.029824 ms -> 2197.424805 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.034250 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.022528 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.098848 ms
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Ampere" with compute capability 8.6

Launching normVecByDotProductAWBarrier kernel with numBlocks = 160 blockSize = 640
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Ampere" with compute capability 8.6

Processing time: 105.277000 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Ampere" with compute capability 8.6

> GPU device has 80 Multi-Processors, SM 8.6 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

4         0.150   0.181   0.318   0.020   0.035   0.029   0.039   0.029
16        0.171   0.210   0.474   0.044   0.057   0.046   0.065   0.065
64        0.335   0.331   0.704   0.134   0.144   0.130   0.144   0.129
256       0.845   0.784   1.229   0.736   0.534   0.513   0.489   0.481
1024      3.017   2.739   3.431   4.909   2.175   2.072   1.936   1.922
4096     11.294  10.206  13.448  35.243   8.757   8.638   8.580   8.563
16384    50.923  47.695  60.364 284.228  42.594  42.477  42.318  42.409

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA T4G"
  CUDA Driver Version / Runtime Version          12.2 / 11.4
  CUDA Capability Major/Minor version number:    7.5
  Total amount of global memory:                 14931 MBytes (15655829504 bytes)
  (040) Multiprocessors, (064) CUDA Cores/MP:    2560 CUDA Cores
  GPU Max Clock rate:                            1590 MHz (1.59 GHz)
  Memory Clock rate:                             5001 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        65536 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1024
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 3 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 31
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Turing" with compute capability 7.5

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 336.99 GFlop/s, Time= 12.446 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm
=========================================

Initializing...
GPU Device 0: "Turing" with compute capability 7.5

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 5.089152 ms
TOPS: 27.01

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Turing" with compute capability 7.5

33554432 elements
numThreads: 1024
numBlocks: 40

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.892860 ms
Bandwidth:    150.323455 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Computing Simple Sum test
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.024672
65536 elements scanned in 0.024672 ms -> 2656.290527 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.053420 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.051264 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.120640 ms
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Turing" with compute capability 7.5

Launching normVecByDotProductAWBarrier kernel with numBlocks = 40 blockSize = 1024
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Turing" with compute capability 7.5

Processing time: 127.449997 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Turing" with compute capability 7.5

> GPU device has 40 Multi-Processors, SM 7.5 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Turing" with compute capability 7.5

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
