### PR TITLE
Improve CIS SCTP kernel module check

### DIFF
--- a/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-checks/checks.rs
@@ -584,15 +584,17 @@ pub struct BR03030100Checker {}
 
 impl Checker for BR03030100Checker {
     fn execute(&self) -> CheckerResult {
-        let result = check_file_contains!(
-            PROC_MODULES_FILE,
-            &["sctp"],
-            "unable to parse modules to check for sctp",
-            "sctp is currently loaded"
-        );
+        let mut result = CheckerResult::default();
 
-        // Check if we need to continue
-        if result.status == CheckStatus::FAIL {
+        // Make sure sctp isn't already loaded
+        if let Ok(found) = look_for_word_in_file(PROC_MODULES_FILE, "sctp") {
+            if found {
+                result.error = "sctp is currently loaded".to_string();
+                result.status = CheckStatus::FAIL;
+                return result;
+            }
+        } else {
+            result.error = "unable to parse modules to check for sctp".to_string();
             return result;
         }
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The level 2 check 3.3.1 verifies the sctp kernel module is disabled. The current check for whether it was already loaded was not correct. There is a second check to make sure loading is also disabled. If the setting for loading is to not allow it, but the module is already laoded, the check does not return the expected output. So it would stillr eport failure, but it is less than ideal for reporting the actual issue.

This changes the check for whether the module is loaded to correctly identify if the module is loaded or not before checking whether the ability has been disabled.

**Testing done:**

With default settings:

```sh
bash-5.1# lsmod | grep sctp

bash-5.1# modprobe -n -v sctp
insmod /lib/modules/5.15.134/kernel/net/ipv4/udp_tunnel.ko.xz 
insmod /lib/modules/5.15.134/kernel/net/ipv6/ip6_udp_tunnel.ko.xz   

bash-5.1# apiclient report cis -l 2
...
[FAIL] 3.3.1     Ensure SCTP is disabled (Automatic)
...
```

With driver loaded:

```sh
bash-5.1# insmod /lib/modules/5.15.134/kernel/net/ipv4/udp_tunnel.ko.xz 
bash-5.1# insmod /lib/modules/5.15.134/kernel/net/ipv6/ip6_udp_tunnel.ko.xz 
bash-5.1# insmod /lib/modules/5.15.134/kernel/net/sctp/sctp.ko.xz 

bash-5.1# lsmod | grep sctp
sctp                  454656  6
ip6_udp_tunnel         16384  1 sctp
udp_tunnel             24576  1 sctp

bash-5.1# apiclient report cis -l 2
...
[FAIL] 3.3.1     Ensure SCTP is disabled (Automatic)
...
```

With driver loading disabled and after reboot so module could be unloaded:

```sh
bash-5.1# apiclient set kernel.modules.sctp.allowed=false
bash-5.1# reboot

bash-5.1# apiclient report cis -l 2
...
[PASS] 3.3.1     Ensure SCTP is disabled (Automatic)
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
