### PR TITLE
tough async

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -492,6 +492,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1873,7 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1883,6 +1895,17 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2626,7 +2649,10 @@ name = "migrator"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-release",
+ "bytes",
  "chrono",
+ "futures",
+ "futures-core",
  "generate-readme",
  "log",
  "lz4",
@@ -2638,7 +2664,9 @@ dependencies = [
  "snafu",
  "storewolf",
  "tempfile",
- "tough",
+ "tokio",
+ "tokio-util",
+ "tough 0.15.0",
  "update_metadata",
  "url",
 ]
@@ -3045,6 +3073,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
+dependencies = [
+ "base64 0.21.4",
+ "serde",
+]
+
+[[package]]
 name = "pentacle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,10 +3453,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -4318,6 +4358,7 @@ checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4381,7 +4422,7 @@ dependencies = [
  "log",
  "olpc-cjson",
  "path-absolutize",
- "pem",
+ "pem 1.1.1",
  "percent-encoding",
  "reqwest",
  "ring",
@@ -4390,6 +4431,40 @@ dependencies = [
  "serde_plain",
  "snafu",
  "tempfile",
+ "untrusted",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "tough"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16dc5f42fc7ce7cb51eebc7a6ef91f4d69a6d41bb13f34a09674ec47e454d9b"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "dyn-clone",
+ "futures",
+ "futures-core",
+ "globset",
+ "hex",
+ "log",
+ "olpc-cjson",
+ "pem 3.0.2",
+ "percent-encoding",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "typed-path",
  "untrusted",
  "url",
  "walkdir",
@@ -4479,6 +4554,12 @@ dependencies = [
  "url",
  "utf-8",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb9d13b8242894ff21f9990082b90a6410a43dcc6029ac4227a1467853ba781"
 
 [[package]]
 name = "typenum"
@@ -4572,7 +4653,7 @@ dependencies = [
  "snafu",
  "tempfile",
  "toml 0.5.11",
- "tough",
+ "tough 0.14.0",
  "update_metadata",
  "url",
 ]
@@ -4729,6 +4810,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "tough 0.15.0",
+ "tough",
  "update_metadata",
  "url",
 ]
@@ -3044,33 +3044,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "path-absolutize"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
-dependencies = [
- "path-dedot",
-]
-
-[[package]]
-name = "path-dedot"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
 
 [[package]]
 name = "pem"
@@ -4411,33 +4384,6 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda3efa9005cf9c1966984c3b9a44c3f37b7ed2c95ba338d6ad51bba70e989a0"
-dependencies = [
- "chrono",
- "dyn-clone",
- "globset",
- "hex",
- "log",
- "olpc-cjson",
- "path-absolutize",
- "pem 1.1.1",
- "percent-encoding",
- "reqwest",
- "ring",
- "serde",
- "serde_json",
- "serde_plain",
- "snafu",
- "tempfile",
- "untrusted",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "tough"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16dc5f42fc7ce7cb51eebc7a6ef91f4d69a6d41bb13f34a09674ec47e454d9b"
@@ -4453,7 +4399,7 @@ dependencies = [
  "hex",
  "log",
  "olpc-cjson",
- "pem 3.0.2",
+ "pem",
  "percent-encoding",
  "reqwest",
  "ring",
@@ -4638,8 +4584,12 @@ name = "updog"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "async-trait",
  "bottlerocket-release",
+ "bytes",
  "chrono",
+ "futures",
+ "futures-core",
  "log",
  "lz4",
  "models",
@@ -4652,8 +4602,10 @@ dependencies = [
  "simplelog",
  "snafu",
  "tempfile",
+ "tokio",
+ "tokio-util",
  "toml 0.5.11",
- "tough 0.14.0",
+ "tough",
  "update_metadata",
  "url",
 ]

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -11,6 +11,9 @@ exclude = ["README.md"]
 
 [dependencies]
 bottlerocket-release = { path = "../../../bottlerocket-release", version = "0.1" }
+bytes = "1"
+futures = "0.3"
+futures-core = "0.3"
 log = "0.4"
 lz4 = "1"
 nix = "0.26"
@@ -19,7 +22,9 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 semver = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tough = "0.14"
+tokio = { version = "~1.32", default-features = false, features = ["fs", "macros", "rt-multi-thread"] }  # LTS
+tokio-util = { version = "0.7", features = ["compat", "io-util"] }
+tough = { version = "0.15", features = ["http"] }
 update_metadata = { path = "../../../updater/update_metadata", version = "0.1" }
 url = "2"
 

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -9,9 +9,13 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
+async-trait = "0.1"
 argh = "0.1"
 bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
+bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+futures = "0.3"
+futures-core = "0.3"
 log = "0.4"
 lz4 = "1"
 semver = "1"
@@ -21,8 +25,10 @@ serde_plain = "1"
 signpost = { path = "../signpost", version = "0.1" }
 simplelog = "0.12"
 snafu = "0.7"
+tokio = { version = "~1.32", default-features = false, features = ["fs", "macros", "process", "rt-multi-thread"] }  # LTS
+tokio-util = { version = "0.7", features = ["compat", "io-util"] }
 toml = "0.5"
-tough = { version = "0.14", features = ["http"] }
+tough = { version = "0.15", features = ["http"] }
 update_metadata = { path = "../update_metadata", version = "0.1" }
 url = "2"
 signal-hook = "0.3"


### PR DESCRIPTION
**Issue number:**

- Closes #3559 
- Related https://github.com/awslabs/tough/pull/687
- Related https://github.com/bottlerocket-os/twoliter/pull/98

**Description of changes:**

Use `tough` in its `async` incarnation.

**Testing done:**

- [x] Before the PR landed 
  - [x] Run an image
  - [x] Downgrade with migrations
  - [x] Upgrade with migrations
 - [x] Repeat the above once we have a released version of `tough` with these changes. 

Note: during the re-test, when I looked at migrator's jounral entries I saw some errors on downgrade. This is was v1.15.1 which was built from the tag (and thus not running the new async code).

```
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.1_updog-network-affected.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_schnauzer-v2-generators.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_public-control-container-v0-7-5.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_aws-control-container-v0-7-5.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [ERROR] Migration stderr: 'settings.host-containers.control.source' has no 'template' key in metadata
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_public-admin-container-v0-11-1.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_aws-admin-container-v0-11-1.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [ERROR] Migration stderr: 'settings.host-containers.admin.source' has no 'template' key in metadata
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-settings.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-restart.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-files.lz4'
Nov 29 19:33:13 localhost migrator[941]: 19:33:13 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-configs.lz4'
```

On upgrade (running the new async code) I did not see these errors. For the purposes of these PRs, the testing shows that migrator is working correctly. Someone may want to look into the host container migrations on downgrade to see what's up.

```
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-configs.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-files.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-restart.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_kernel-modules-autoload-settings.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_aws-admin-container-v0-11-1.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_public-admin-container-v0-11-1.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_aws-control-container-v0-7-5.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_public-control-container-v0-7-5.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.0_schnauzer-v2-generators.lz4'
Nov 29 22:58:47 localhost migrator[942]: 22:58:47 [INFO] Running migration 'migrate_v1.16.1_updog-network-affected.lz4'
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
