### PR TITLE
models: improve hygienics of model-derive macro

### DIFF
--- a/sources/models/model-derive/src/lib.rs
+++ b/sources/models/model-derive/src/lib.rs
@@ -123,9 +123,9 @@ impl VisitMut for ModelHelper {
         if !is_attr_set("derive", &node.attrs) {
             // Derive Default, if the user requested
             let attr = if self.impl_default {
-                parse_quote!(#[derive(Debug, Default, PartialEq, Serialize, Deserialize)])
+                parse_quote!(#[derive(Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)])
             } else {
-                parse_quote!(#[derive(Debug, PartialEq, Serialize, Deserialize)])
+                parse_quote!(#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)])
             };
             // Rust 1.52 added a legacy_derive_helpers warning (soon to be an error) that yells if
             // you use an attribute macro before the derive macro that introduces it.  We should

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/aws-k8s-1.28/mod.rs
+++ b/sources/models/src/aws-k8s-1.28/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use modeled_types::Identifier;
 
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/metal-k8s-1.28/mod.rs
+++ b/sources/models/src/metal-k8s-1.28/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/variant_mod.rs
+++ b/sources/models/src/variant_mod.rs
@@ -4,7 +4,6 @@
 use crate::{ConfigurationFiles, Services};
 use bottlerocket_release::BottlerocketRelease;
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 
 // We expose anything defined by the current variant.
 mod current;

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{

--- a/sources/models/src/vmware-k8s-1.28/mod.rs
+++ b/sources/models/src/vmware-k8s-1.28/mod.rs
@@ -1,5 +1,4 @@
 use model_derive::model;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{


### PR DESCRIPTION
**Description of changes:**
```
The #[model] macro assumed that Serialize and Deserialize were in scope.
This modifies it to explicitly refer to serde in the derive line.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
