### PR TITLE
adds ecs-2 to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The following variants support ECS:
 
 * `aws-ecs-1`
 * `aws-ecs-1-nvidia`
+* `aws-ecs-2`
+* `aws-ecs-2-nvidia`
 
 We also have variants that are designed to be Kubernetes worker nodes in VMware:
 
@@ -337,7 +339,7 @@ If your user data is over the size limit of the platform (e.g. 16KiB for EC2) yo
 
 Here we'll describe each setting you can change.
 
-**Note:** You can see the default values (for any settings that are not generated at runtime) by looking in the `defaults.d` directory for a variant, for example [aws-ecs-1](sources/models/src/aws-ecs-1/defaults.d/).
+**Note:** You can see the default values (for any settings that are not generated at runtime) by looking in the `defaults.d` directory for a variant, for example [aws-ecs-2](sources/models/src/aws-ecs-2/defaults.d/).
 
 When you're sending settings to the API, or receiving settings from the API, they're in a structured JSON format.
 This allows modification of any number of keys at once.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # n/a

**Description of changes:**
I noticed that the variant list didn't have `ecs-2` (available since 1.15.0) and that we reference `ecs-1` as an example. Since `ecs-2` is the most recent, this PR makes it more prominent than `ecs-1`.


**Testing done:**

👁️ 👁️ 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
