### PR TITLE
kernel: Update to 5.10.198, 5.15.136, and 6.1.59

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/9f9ded8eec13c7cacb468496c899e93063db7800ad20b12d07c1fee60e05eb33/kernel-5.10.197-186.748.amzn2.src.rpm"
-sha512 = "c5986ab33ef52cfe61a67e29db2856072cb68c525c69dc0be14efbba58ad7df9f9989ddad27ebd722088d6f01b58875b49bf1aed06901e3d9966c0fed95ba722"
+url = "https://cdn.amazonlinux.com/blobstore/5c8155b74bb2980fed073710617014a21ad836d9b6aa2c1d39e9168289236fde/kernel-5.10.198-187.748.amzn2.src.rpm"
+sha512 = "ae931ec40f8edd7cf76dfc10e7f6e8719cf680e3aa4b65a4efaf37b3075b36d71f01cb28fa59f0e7a73eba7a41f6e0b753bd1eed2fda66563e7d6f2ac36394d5"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.197
+Version: 5.10.198
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/9f9ded8eec13c7cacb468496c899e93063db7800ad20b12d07c1fee60e05eb33/kernel-5.10.197-186.748.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/5c8155b74bb2980fed073710617014a21ad836d9b6aa2c1d39e9168289236fde/kernel-5.10.198-187.748.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/418a9aab17cff76bb9577affa1df20b27fa223168e2fafef62510de157e1957d/kernel-5.15.134-87.145.amzn2.src.rpm"
-sha512 = "fdc386b82928c7a29bbdbf0ff0c55e22a36f03d725aedfe8d6d309628e79484d2743ec00322713009fb2a56c49e1c20f3938fef7075215c76028b00f3149bdad"
+url = "https://cdn.amazonlinux.com/blobstore/8bbf53203badda16f39f6dabe8974acac6f4b3d0dcf96378a434a32c897da379/kernel-5.15.136-90.144.amzn2.src.rpm"
+sha512 = "5f1cf5c446a96805f54f8e38a32d779782e510af0c4efe5015d07d3d5606216410939f883c7769f9faede67d77e4d9fc3a2ba4a9251a150417ce1a2283304066"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.134
+Version: 5.15.136
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/418a9aab17cff76bb9577affa1df20b27fa223168e2fafef62510de157e1957d/kernel-5.15.134-87.145.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/8bbf53203badda16f39f6dabe8974acac6f4b3d0dcf96378a434a32c897da379/kernel-5.15.136-90.144.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/b857edbf6e8d7c005d0e6e25d052548bb4a1113e504b6d2f50357998d94f9d07/kernel-6.1.55-75.123.amzn2023.src.rpm"
-sha512 = "b87a14ab06804d1574a5a9b91df0749be4e22af5531a45b1bd2933656f92ac3688ea36adb06dd440234eb82f2c6139351a0efa1efa95259d151f91b3c242b67d"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/4c8745cd575d4358f74f7088fcfb66ec0026d3cf812356255425847141782ab4/kernel-6.1.56-82.125.amzn2023.src.rpm"
+sha512 = "6b152f9e2e14b99fb7a88a45cb369db330165355e679a536e182bcf3c53cf23a1e3dd46703971dc32d34f757aaabacbc8fed6eaf57bfe6b3ac68ec0c4b1a31c0"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/4c8745cd575d4358f74f7088fcfb66ec0026d3cf812356255425847141782ab4/kernel-6.1.56-82.125.amzn2023.src.rpm"
-sha512 = "6b152f9e2e14b99fb7a88a45cb369db330165355e679a536e182bcf3c53cf23a1e3dd46703971dc32d34f757aaabacbc8fed6eaf57bfe6b3ac68ec0c4b1a31c0"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/7f6b70d0766761e79bb6dae9a840ac4fb6ca95c78dad994ea97abac37dd2a061/kernel-6.1.59-84.139.amzn2023.src.rpm"
+sha512 = "9e5c3dab3583742254775c82710007360da8d1a0b252f2acb9096788f6ed33d04599ef61bffc489f78540a4f8194440e79aa3e9ff25ae3be802973ade868bfb1"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/config-bottlerocket
+++ b/packages/kernel-6.1/config-bottlerocket
@@ -193,3 +193,14 @@ CONFIG_ISCSI_TARGET=m
 
 # Disable DAMON subsystem. We currently do not have a good use-case for DAMON.
 # CONFIG_DAMON is not set
+
+# Disable unnecessary keyboard and mouse drivers.
+# CONFIG_MOUSE_PS2 is not set
+# CONFIG_SERIO is not set
+# CONFIG_KEYBOARD_ATKBD is not set
+
+# Disable unnecessary framebuffer/drm drivers
+# CONFIG_DRM_BOCHS is not set
+# CONFIG_DRM_SIMPLEDRM is not set
+# CONFIG_SYSFB_SIMPLEFB is not set
+

--- a/packages/kernel-6.1/config-bottlerocket-metal
+++ b/packages/kernel-6.1/config-bottlerocket-metal
@@ -141,6 +141,7 @@ CONFIG_MOUSE_PS2=m
 # CONFIG_MOUSE_PS2_SENTELIC is not set
 # CONFIG_MOUSE_PS2_TOUCHKIT is not set
 # CONFIG_MOUSE_PS2_FOCALTECH is not set
+# CONFIG_MOUSE_PS2_VMMOUSE is not set
 
 # Intel Volume Management Device driver, to support boot disks in a separate
 # PCI domain.

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.55
+Version: 6.1.56
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/b857edbf6e8d7c005d0e6e25d052548bb4a1113e504b6d2f50357998d94f9d07/kernel-6.1.55-75.123.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/4c8745cd575d4358f74f7088fcfb66ec0026d3cf812356255425847141782ab4/kernel-6.1.56-82.125.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.56
+Version: 6.1.59
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/4c8745cd575d4358f74f7088fcfb66ec0026d3cf812356255425847141782ab4/kernel-6.1.56-82.125.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/7f6b70d0766761e79bb6dae9a840ac4fb6ca95c78dad994ea97abac37dd2a061/kernel-6.1.59-84.139.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a

**Description of changes:**

Update kernels to latest AL kernels available in the repositories. Drop drivers for AT keyboard, PS2 Mouse and basic framebuffer devices as they are not needed on all variants. We carry the necessary drivers already in metal and vmware variants.

**Testing done:**

Validated basic functionality through sonobouy quick test:

```
> kubectl get nodes -o wide
NAME                                             STATUS   ROLES    AGE     VERSION                INTERNAL-IP     EXTERNAL-IP      OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-1-119.eu-central-1.compute.internal   Ready    <none>   105s    v1.28.1-eks-f0272c7    192.168.1.119   3.70.205.210     Bottlerocket OS 1.16.0 (aws-k8s-1.28)   6.1.59           containerd://1.6.24+bottlerocket
ip-192-168-19-53.eu-central-1.compute.internal   Ready    <none>   2m27s   v1.26.7-eks-7ea2e3a    192.168.19.53   18.196.241.205   Bottlerocket OS 1.16.0 (aws-k8s-1.26)   5.15.136         containerd://1.6.24+bottlerocket
ip-192-168-35-78.eu-central-1.compute.internal   Ready    <none>   3m      v1.23.17-eks-bbbebb8   192.168.35.78   3.75.217.248     Bottlerocket OS 1.16.0 (aws-k8s-1.23)   5.10.198         containerd://1.6.24+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
16:42:41             e2e                                           global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
16:42:41    systemd-logs   ip-192-168-1-119.eu-central-1.compute.internal   complete   passed                                        
16:42:41    systemd-logs   ip-192-168-19-53.eu-central-1.compute.internal   complete   passed                                        
16:42:41    systemd-logs   ip-192-168-35-78.eu-central-1.compute.internal   complete   passed
```

Config diff reports some changes:

```
config-aarch64-aws-dev-diff:	  0 removed,   1 added,   0 changed
config-aarch64-aws-k8s-1.23-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:         0 removed,   9 added,   3 changed
config-aarch64-metal-dev-diff:	  0 removed,   1 added,   0 changed
config-x86_64-aws-dev-diff:	  0 removed,   0 added,   1 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          0 removed,  10 added,   3 changed
config-x86_64-metal-dev-diff:	  0 removed,   0 added,   1 changed
config-x86_64-metal-k8s-1.26-diff:        0 removed,  10 added,   3 changed
```
The full diff-report can be found on [Gist](https://gist.github.com/foersleo/c5432dde79e084cdb2af6c238c2d65bf)

* 6.1:
  * `ARM64_ERRATUM_2966298` was added on aarch64 to mitigate a speculative execution leak on some Cortex A520 processors.
  * `DEBUG_PREEMPT y -> n` debug option was disabled as it has some performance impact and is not fit for production use-cases.
* 5.15:
  * A set of options around `PTP` and `PPS` were enabled as a dependency for ENA drivers to use the hardware clock. These options are enabled on other kernels already and were added for parity.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
