### PR TITLE
shared-defaults: add missing updog to list of network-affected services

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -246,3 +246,6 @@ version = "1.16.0"
     "migrate_v1.16.0_public-control-container-v0-7-5.lz4",
     "migrate_v1.16.0_schnauzer-v2-generators.lz4",
 ]
+"(1.16.0, 1.16.1)" = [
+    "migrate_v1.16.1_updog-network-affected.lz4",
+]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4535,6 +4535,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "updog-network-affected"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "api/migration/migrations/v1.16.0/aws-control-container-v0-7-5",
     "api/migration/migrations/v1.16.0/public-control-container-v0-7-5",
     "api/migration/migrations/v1.16.0/schnauzer-v2-generators",
+    "api/migration/migrations/v1.16.1/updog-network-affected",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.16.1/updog-network-affected/Cargo.toml
+++ b/sources/api/migration/migrations/v1.16.1/updog-network-affected/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "updog-network-affected"
+version = "0.1.0"
+authors = ["Erikson Tung <etung@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.16.1/updog-network-affected/src/main.rs
+++ b/sources/api/migration/migrations/v1.16.1/updog-network-affected/src/main.rs
@@ -1,0 +1,81 @@
+use migration_helpers::common_migrations::{
+    MetadataListReplacement, ReplaceMetadataListsMigration,
+};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the 'affected-services' list metadata for 'settings.network' to include
+/// updog. The metadata list need to be restored to the prior value on downgrade and
+/// updated to include updog on upgrades.
+/// We're trying to match old values for different variants.
+fn run() -> Result<()> {
+    migrate(ReplaceMetadataListsMigration(vec![
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &["containerd", "host-containerd", "host-containers"],
+            new_vals: &["containerd", "host-containerd", "host-containers", "updog"],
+        },
+        // For K8S variants
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &[
+                "containerd",
+                "kubernetes",
+                "host-containerd",
+                "host-containers",
+            ],
+            new_vals: &[
+                "containerd",
+                "kubernetes",
+                "host-containerd",
+                "host-containers",
+                "updog",
+            ],
+        },
+        // For the ECS variants
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &[
+                "containerd",
+                "docker",
+                "ecs",
+                "host-containerd",
+                "host-containers",
+            ],
+            new_vals: &[
+                "containerd",
+                "docker",
+                "ecs",
+                "host-containerd",
+                "host-containers",
+                "updog",
+            ],
+        },
+        // For *-dev variants
+        MetadataListReplacement {
+            setting: "settings.network",
+            metadata: "affected-services",
+            old_vals: &["containerd", "docker", "host-containerd", "host-containers"],
+            new_vals: &[
+                "containerd",
+                "docker",
+                "host-containerd",
+                "host-containers",
+                "updog",
+            ],
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -78,7 +78,7 @@ path = "/etc/network/proxy.env"
 template-path = "/usr/share/templates/proxy-env"
 
 [metadata.settings.network]
-affected-services = ["containerd", "host-containerd", "host-containers"]
+affected-services = ["containerd", "host-containerd", "host-containers", "updog"]
 
 [metadata.settings.network.hostname]
 affected-services = ["hostname", "hosts"]

--- a/sources/models/shared-defaults/ecs.toml
+++ b/sources/models/shared-defaults/ecs.toml
@@ -22,7 +22,7 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-containers"]
+affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-containers", "updog"]
 
 # Image registry credentials
 [metadata.settings.container-registry.credentials]

--- a/sources/models/shared-defaults/kubernetes-aws.toml
+++ b/sources/models/shared-defaults/kubernetes-aws.toml
@@ -20,7 +20,7 @@ affected-services = ["kubernetes", "containerd"]
 service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kubelet"]
 
 [metadata.settings.network]
-affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers"]
+affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers", "updog"]
 
 [services.autoscaling-warm-pool]
 configuration-files = ["warm-pool-wait-toml"]

--- a/sources/models/shared-defaults/kubernetes-metal.toml
+++ b/sources/models/shared-defaults/kubernetes-metal.toml
@@ -16,4 +16,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kube
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers"]
+affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers", "updog"]

--- a/sources/models/shared-defaults/kubernetes-vmware.toml
+++ b/sources/models/shared-defaults/kubernetes-vmware.toml
@@ -16,4 +16,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kube
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers"]
+affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers", "updog"]

--- a/sources/models/src/aws-dev/defaults.d/50-aws-dev.toml
+++ b/sources/models/src/aws-dev/defaults.d/50-aws-dev.toml
@@ -5,4 +5,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd", "host-containers"]
+affected-services = ["containerd", "docker", "host-containerd", "host-containers", "updog"]

--- a/sources/models/src/metal-dev/defaults.d/50-metal-dev.toml
+++ b/sources/models/src/metal-dev/defaults.d/50-metal-dev.toml
@@ -5,4 +5,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd", "host-containers"]
+affected-services = ["containerd", "docker", "host-containerd", "host-containers", "updog"]

--- a/sources/models/src/vmware-dev/defaults.d/50-vmware-dev.toml
+++ b/sources/models/src/vmware-dev/defaults.d/50-vmware-dev.toml
@@ -5,4 +5,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd", "host-containers"]
+affected-services = ["containerd", "docker", "host-containerd", "host-containers", "updog"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Resolves https://github.com/bottlerocket-os/bottlerocket/issues/3577

**Description of changes:**
For aws-* variants, we need to regenerate updog's config when the network proxy setting changes.


**Testing done:**
Before updating network.no-proxy setting
```bash
[root@admin]# sudo sheltie                                                                                                                                                                                        
bash-5.1# cat /etc/updog.toml 
metadata_base_url = "https://updates.bottlerocket.aws/2020-07-07/aws-k8s-1.28/x86_64/"
targets_base_url = "https://updates.bottlerocket.aws/targets/"
seed = 492
version_lock = "latest"
ignore_waves = true
```
After:
```bash
bash-5.1# apiclient set -j '{"settings": {"network":{"no-proxy": ["testing"]}}}' 
bash-5.1# cat /etc/updog.toml 
metadata_base_url = "https://updates.bottlerocket.aws/2020-07-07/aws-k8s-1.28/x86_64/"
targets_base_url = "https://updates.bottlerocket.aws/targets/"
seed = 492
version_lock = "latest"
ignore_waves = true
no_proxy=["testing"]

```

Migration tested:
On 1.16.0
```
bash-5.1# cat /var/lib/bottlerocket/datastore/current/live/settings/network.affected-services 
["containerd","kubernetes","host-containerd","host-containers"]
```
After upgrade to 1.16.1:
```
bash-5.1# cat /var/lib/bottlerocket/datastore/current/live/settings/network.affected-services 
["containerd","kubernetes","host-containerd","host-containers","updog"]
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
