### PR TITLE
chore: fix libzstd spec source URL

### DIFF
--- a/packages/libzstd/libzstd.spec
+++ b/packages/libzstd/libzstd.spec
@@ -4,7 +4,7 @@ Release: 1%{?dist}
 Summary: Library for Zstandard compression
 License: BSD-3-Clause AND GPL-2.0-only
 URL: https://github.com/facebook/zstd/
-Source0: https://github.com/faceboot/zstd/releases/download/v%{version}/zstd-%{version}.tar.gz
+Source0: https://github.com/facebook/zstd/releases/download/v%{version}/zstd-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 
 %description


### PR DESCRIPTION


**Issue number:**

n/a

**Description of changes:**

in playing around w/ package and package sources in bottlerocket, I noticed some 404s. Some were due to the issue outlined in #2831 regarding GitHub's switch away from generated archives, with this typo being an easy outlier to quickly fix.


**Testing done:**

n/a typo fix

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
