### PR TITLE
Update packages for http v2x/net CVE

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -17,6 +17,26 @@ package-name = "kubernetes-1.23"
 url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/28/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
 sha512 = "31fd414bebe6ec71682c65256373a99467f558340739739df3f332d6bf1cfef2a2c0b39b337f3f0ed56ae72a4ae083f4fdbe6ad8e964b86c2c9e144aa1f748ab"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0026-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch"
+sha512 = "0406fad037a41750310bcc7e75dceaa65cb6d9ffd8e324541068d25074386ff5fbfdb3e6b4d429704e692a39624377483ecd8ed7fcc16d54ba68d81c97d5d270"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0027-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch"
+sha512 = "d36a581ec2b4622da52d25e942fc063c7fcccbba08ee3c9d0dd52366ca6cd80300ced9c807ef786544b83e7d1dddcf88e24b478a4a4f32e864e9e8edaea8940d"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0028-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch"
+sha512 = "b9a87cc4d8d37af308ef0d65cf270b120da6b75aeeed4011f14a2a62e194b0ef509df687d1f7c75e4656606b7e9d7fff4162d3277d1150e3df27d8fca14c83fe"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0029-EKS-PATCH-Add-ephemeralcontainer-to-imagepolicy-secu.patch"
+sha512 = "3b68bc637648a1fff3f2acdbe370689f09c74b465ac1124d62bb99deefb691eb15f88fae4cf4da66c67fca6888513134b5012e5f48cd58f6632360465d8e38cb"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0030-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch"
+sha512 = "66bcd6602e974e237c083fafc24e68b88a0010db1e2fe30c1ea41ef3c112d94c639ae87c3f7cc9a0142d823ea44cce2aa71476ca01bf2efc1ad3f00454df627f"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -47,6 +47,13 @@ Source22: make-kubelet-dirs.conf
 
 Source1000: clarify.toml
 
+# Additional patches on top of last 1.23 point release
+Patch0001: 0026-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch
+Patch0002: 0027-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch
+Patch0003: 0028-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch
+Patch0004: 0029-EKS-PATCH-Add-ephemeralcontainer-to-imagepolicy-secu.patch
+Patch0005: 0030-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch
+
 BuildRequires: git
 BuildRequires: rsync
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.24"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/23/artifacts/kubernetes/v1.24.16/kubernetes-src.tar.gz"
-sha512 = "e3b3f5a6708c77419b7ba8fd9a9bbb2a1ca3df7f198a7f80246a09473ff7b80b7dc750637d635d4d7f2f7bf301324b22df08ee0e3cd35d83be8d8ca5ebeabb5c"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/29/artifacts/kubernetes/v1.24.17/kubernetes-src.tar.gz"
+sha512 = "cfdecfb3cdae51f8484eb611f3946c3ffbb708d701ee3a4723498f1164a455a1a8a9ebd61cf195cd5532edcf16e6bf3d6e554142b679f3d0c425e685e32b26da"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.24.16
+%global gover 1.24.17
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/23/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/29/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.25"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/19/artifacts/kubernetes/v1.25.12/kubernetes-src.tar.gz"
-sha512 = "fe107da955502c8a71cc20f662765d725186a1a77dba49bd3eb5204a7414f7dbf9ab05b45d99672a6d9a5b098b434518562d9f8df5fe21f03b9d5fc8de8ae665"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/25/artifacts/kubernetes/v1.25.15/kubernetes-src.tar.gz"
+sha512 = "3f2a65892394dbf8e56c3ea1a4d01f760b6781ae22cf2cb73cf9ff026989625ba66d4398f52e1a27666bc722559ca9c88ac8d6c7611902c979a1efd7e0771c6d"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.25.12
+%global gover 1.25.15
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/19/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/25/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.26"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/15/artifacts/kubernetes/v1.26.7/kubernetes-src.tar.gz"
-sha512 = "bd1a04b34766a052cc1f10a346a53c96aa5f0bfaace5264105600512135b07de23baa44985f91ad1849b2f56107ddc9d93ccaf486a4301d72ccefd3f03e541c8"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/21/artifacts/kubernetes/v1.26.10/kubernetes-src.tar.gz"
+sha512 = "fd045d732d5cb0a1ef360dfb62a603331d8b898c1ef58c9c55246200eb38ff944aba69b6eaf8044680206cd1833f46a4ee53c677e2f58aeacc344b0f255bb3be"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.26.7
+%global gover 1.26.10
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/15/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/21/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.27"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/9/artifacts/kubernetes/v1.27.4/kubernetes-src.tar.gz"
-sha512 = "184b1c4863ef3606f0d36f8535f0b5b3ecddb05e35f6815e41862dca1cbe2297600d85657bb89aaacebf9507e49fd67dcf9af99aa1b01042a4e10bf8991702f6"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/15/artifacts/kubernetes/v1.27.7/kubernetes-src.tar.gz"
+sha512 = "bd48e9a287d9edb0b8573bbe00911a7e1297a7a3f4cae491e2cd4831add5e1e4c57ad3ee6f9f4102490ec89437d5b89410874380b771553f1c3d34d47720b034"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.4
+%global gover 1.27.7
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/15/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/4/artifacts/kubernetes/v1.28.1/kubernetes-src.tar.gz"
-sha512 = "b65c9144cc2af9a4311a14912a5e338f12b661e8efee0c04fa79f1d09967507c5b6cf7657c909bd5bbd5d5126b1fea238f940a8cd678af04ca841197b30df36d"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/8/artifacts/kubernetes/v1.28.3/kubernetes-src.tar.gz"
+sha512 = "25a7c7cc48ef865662b449ac2e6f5e85d380eed4f97498815b0ad80b30857f4868883110534ee412d434d04906aa16e7f2f33cd03bd2aaa83ac5624c01d95d6c"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.28.1
+%global gover 1.28.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/2/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/8/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
This update is required to mitigate HTTP V2 x/net (CVE-2023-39325) in Kubernetes packages
```
packages: Add patches for CVE-2023-39325 
packages: update kubernetes 1.24 to 1.24.17 
packages: update kubernetes 1.25 to 1.25.15 
packages: update kubernetes 1.26 to 1.26.10 
packages: update kubernetes 1.27 to 1.27.7 
packages: update kubernetes 1.28 to 1.28.3
```
**Testing done:**
- [x] aws-k8s-1.23 
```
 NAME                               TYPE               STATE                       PASSED           FAILED           SKIPPED   BUILD ID          LAST UPDATE
 x86-64-aws-k8s-123-quick           Test               passed                           1                0              7051   9c505403          2023-11-08T15:22:58Z
 x86-64-aws-k8s-123                 Resource           completed                                                               9c505403          2023-11-08T15:17:02Z


```
- [x] aws-k8s-1.24 
```
NAME                                       TYPE              STATE                     PASSED          FAILED         SKIPPED   BUILD ID         LAST UPDATE
 x86-64-aws-k8s-124-quick                   Test              passed                         1               0            6972   9c505403         2023-11-08T07:45:51Z
 x86-64-aws-k8s-124                         Resource          completed                                                          9c505403         2023-11-08T07:43:35Z
```
- [x] aws-k8s-1.25 
```
 NAME                                       TYPE              STATE                     PASSED          FAILED         SKIPPED   BUILD ID         LAST UPDATE
 x86-64-aws-k8s-125-quick                   Test              passed                         4               0            7065   9c505403         2023-11-08T15:59:15Z
 x86-64-aws-k8s-125                         Resource          completed                                                          9c505403         2023-11-08T15:57:38Z
```
- [x] aws-k8s-1.26 
```
 NAME                                       TYPE              STATE                     PASSED          FAILED         SKIPPED   BUILD ID         LAST UPDATE
 x86-64-aws-k8s-126-quick                   Test              passed                         4               0            7068   9c505403         2023-11-08T16:37:06Z
 x86-64-aws-k8s-126                         Resource          completed                                                          9c505403         2023-11-08T16:32:33Z
```
- [x] aws-k8s-1.27 
```
NAME                                       TYPE              STATE                     PASSED          FAILED         SKIPPED   BUILD ID         LAST UPDATE
 x86-64-aws-k8s-127-quick                   Test              passed                         5               0            7206   9c505403         2023-11-08T18:14:05Z
 x86-64-aws-k8s-127                         Resource          completed                                                          9c505403         2023-11-08T18:10:26Z
 x86-64-aws-k8s-127-instances-obyp          Resource          running                                                            9c505403         2023-11-08T18:14:16Z


```
- [x] aws-k8s-1.28 : Nodes join the cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
