### PR TITLE
kubelet: don't specify hostname-override if cloudprovider is set to aws

### DIFF
--- a/packages/kubernetes-1.23/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.23/kubelet-exec-start-conf
@@ -27,9 +27,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \

--- a/packages/kubernetes-1.24/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.24/kubelet-exec-start-conf
@@ -26,9 +26,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \

--- a/packages/kubernetes-1.25/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.25/kubelet-exec-start-conf
@@ -26,9 +26,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \

--- a/packages/kubernetes-1.26/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.26/kubelet-exec-start-conf
@@ -26,9 +26,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Provides workaround for https://github.com/bottlerocket-os/bottlerocket/issues/3525

**Description of changes:**
This is only applicable to <1.27 kubelet since 1.27 removes the aws in-tree cloud provider.


**Testing done:**
Set cloud-provider to aws, `hostname-override` goes away.
```
bash-5.1# apiclient set kubernetes.cloud-provider=aws
bash-5.1# cat /etc/systemd/system/kubelet.service.d/exec-start.conf 
[Service]
ExecStart=
ExecStart=/usr/bin/kubelet \
    --cloud-provider aws \
    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
    --config /etc/kubernetes/kubelet/config \
    --container-runtime=remote \
    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
    --containerd=/run/containerd/containerd.sock \
    --root-dir /var/lib/kubelet \
    --cert-dir /var/lib/kubelet/pki \
    --node-ip ${NODE_IP} \
    --node-labels "${NODE_LABELS}" \
    --register-with-taints "${NODE_TAINTS}" \
    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
