### PR TITLE
[1.16.x] Cherry-pick "don't specify hostname-override if cloudprovider is set to aws"

### DIFF
--- a/packages/kubernetes-1.23/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.23/kubelet-exec-start-conf
@@ -27,9 +27,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \

--- a/packages/kubernetes-1.24/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.24/kubelet-exec-start-conf
@@ -26,9 +26,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \

--- a/packages/kubernetes-1.25/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.25/kubelet-exec-start-conf
@@ -26,9 +26,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \

--- a/packages/kubernetes-1.26/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.26/kubelet-exec-start-conf
@@ -26,9 +26,11 @@ ExecStart=/usr/bin/kubelet \
     --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
 {{/if}}
 {{/if}}
+{{#unless (eq settings.kubernetes.cloud-provider "aws")}}
 {{#if settings.kubernetes.hostname-override}}
     --hostname-override {{settings.kubernetes.hostname-override}} \
 {{/if}}
+{{/unless}}
     --node-ip ${NODE_IP} \
     --node-labels "${NODE_LABELS}" \
     --register-with-taints "${NODE_TAINTS}" \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Addresses https://github.com/bottlerocket-os/bottlerocket/issues/3525

**Description of changes:**
Cherry-picks https://github.com/bottlerocket-os/bottlerocket/pull/3582


**Testing done:**
See https://github.com/bottlerocket-os/bottlerocket/pull/3582


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
