### PR TITLE
docs: updates QUICKSTART-LOCAL to use a newer admin container

### DIFF
--- a/QUICKSTART-LOCAL.md
+++ b/QUICKSTART-LOCAL.md
@@ -72,8 +72,9 @@ ADMIN_USER_DATA="$(echo '{"ssh": {"authorized-keys": ["'"${PUBKEY}"'"]}}' | base
 cat <<EOF >>user-data.toml
 [settings.host-containers.admin]
 enabled = true
+superpowered = true
 user-data = "${ADMIN_USER_DATA}"
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.0"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.1"
 EOF
 ```
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

I was following along on the `QUICKSTART-LOCAL.md` guide, and I needed to make a few changes in order to get the admin container working:

- For `v0.9.0` and above of the admin container, it must be set as `superpowered` for SSH access to work
- The `metal-dev` variant now uses cgroupsv2, requiring `v0.10.0+` of the admin container

**Testing done:**

Followed the guide

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
