### PR TITLE
systemd: stop building gpt-auto-generator to avoid remounting /boot

### DIFF
--- a/packages/systemd/9014-meson-make-gpt-auto-generator-selectable-at-build-ti.patch
+++ b/packages/systemd/9014-meson-make-gpt-auto-generator-selectable-at-build-ti.patch
@@ -1,0 +1,66 @@
+From 33a689a000d56444ed47803b2fbec4376814e633 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Thu, 9 Nov 2023 15:02:14 +0000
+Subject: [PATCH] meson: make gpt-auto-generator selectable at build-time
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ meson.build       | 21 ++++++++++++---------
+ meson_options.txt |  2 ++
+ 2 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 3bef553..16421ce 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1851,6 +1851,7 @@ foreach term : ['analyze',
+                 'efi',
+                 'environment-d',
+                 'firstboot',
++                'gpt-auto-generator',
+                 'gshadow',
+                 'hibernate',
+                 'hostnamed',
+@@ -2424,15 +2425,17 @@ if conf.get('ENABLE_HIBERNATE') == 1
+ endif
+ 
+ if conf.get('HAVE_BLKID') == 1
+-        executable(
+-                'systemd-gpt-auto-generator',
+-                'src/gpt-auto-generator/gpt-auto-generator.c',
+-                include_directories : includes,
+-                link_with : [libshared],
+-                dependencies : libblkid,
+-                install_rpath : rootpkglibdir,
+-                install : true,
+-                install_dir : systemgeneratordir)
++        if conf.get('ENABLE_GPT_AUTO_GENERATOR') == 1
++                executable(
++                        'systemd-gpt-auto-generator',
++                        'src/gpt-auto-generator/gpt-auto-generator.c',
++                        include_directories : includes,
++                        link_with : [libshared],
++                        dependencies : libblkid,
++                        install_rpath : rootpkglibdir,
++                        install : true,
++                        install_dir : systemgeneratordir)
++        endif
+ 
+         public_programs += executable(
+                 'systemd-dissect',
+diff --git a/meson_options.txt b/meson_options.txt
+index 26dfab5..2df5361 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -176,6 +176,8 @@ option('html', type : 'combo', choices : ['auto', 'true', 'false'],
+        description : 'build and install html pages')
+ option('translations', type : 'boolean', value : true,
+        description : 'build and install translations')
++option('gpt-auto-generator', type : 'boolean', value : true,
++       description : 'build and install systemd-gpt-auto-generator')
+ 
+ option('certificate-root', type : 'string', value : '/etc/ssl',
+        description : 'the prefix for TLS certificates')
+-- 
+2.40.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -70,6 +70,10 @@ Patch9012: 9012-core-mount-increase-mount-rate-limit-burst-to-25.patch
 # lease in EC2.
 Patch9013: 9013-sd-dhcp-lease-parse-multiple-domains-in-option-15.patch
 
+# Local patch that allows to deselect systemd-gpt-auto-generator. We deselect
+# it since prairiedog mounts /boot depending on the partition bank in use.
+Patch9014: 9014-meson-make-gpt-auto-generator-selectable-at-build-ti.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson
@@ -192,6 +196,7 @@ CONFIGURE_OPTS=(
  -Dman=false
  -Dhtml=false
  -Dtranslations=false
+ -Dgpt-auto-generator=false
  -Dlog-message-verification=false
 
  -Dcertificate-root='%{_cross_sysconfdir}/ssl'


### PR DESCRIPTION
**Issue number:**

Closes #3539

**Description of changes:**

Stop building `systemd-gpt-auto-generator`. That generator creates (auto)mount units based on partition GUIDs that interfere with prairiedog mounting the `BOTTLEROCKET-BOOT` partition at `/boot`. Please see the commit message for details.

**Testing done:**

Booting `metal-dev` on x86_64 via BIOS, waiting a few minutes, checking the contents of `/boot`.

* Without this change, the ESP is mounted at `/boot` eventually.
* With this change, the `BOTTLEROCKET-BOOT` partition identified by prairiedog remains mounted at `/boot`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
