### PR TITLE
Fix for invalid chars when returning IPv6 hostname

### DIFF
--- a/sources/api/netdog/src/cli/generate_hostname.rs
+++ b/sources/api/netdog/src/cli/generate_hostname.rs
@@ -54,8 +54,8 @@ pub(crate) async fn run() -> Result<()> {
     } else {
         hostname
     }
-    // If no hostname has been determined we return the IP address of the host.
-    .unwrap_or(ip_string);
+    // If no hostname has been determined we return the IP address of the host, replacing invalid ipv6 chars.
+    .unwrap_or(ip_string.replace(":", "-"));
 
     // sundog expects JSON-serialized output
     print_json(hostname)


### PR DESCRIPTION
**Issue number:**

Closes #3571 

**Description of changes:**
Netdog will return an IPv6 address string in some corner cases.  Replace colons with dashes to ensure the string will validate as ValidLinuxHostname.


**Testing done:**
Validated locally when no valid IPv4 is assigned by `systemd-networkd` _but_ a valid IPv6 is assigned when `systemd-networkd-wait-online.service` times out that the string netdog returns can be validated as ValidLinuxHostname

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.