### PR TITLE
settings: add ntp settings extension

### DIFF
--- a/packages/settings-ntp/Cargo.toml
+++ b/packages/settings-ntp/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-ntp"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/ntp"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-ntp/settings-ntp.spec
+++ b/packages/settings-ntp/settings-ntp.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name ntp
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3741,6 +3741,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-ntp"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+ "string_impls_for",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings-extension-motd",
+ "settings-extension-ntp",
  "toml 0.5.11",
 ]
 

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1755,6 +1755,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2339,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3746,11 +3776,11 @@ name = "settings-extension-ntp"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-settings-sdk",
+ "env_logger",
  "model-derive",
  "modeled-types",
  "serde",
  "serde_json",
- "string_impls_for",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -103,6 +103,7 @@ members = [
     "models",
 
     "settings-extensions/motd",
+    "settings-extensions/ntp",
 
     "parse-datetime",
 

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -19,6 +19,7 @@ toml = "0.5"
 
 # settings extensions
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
+settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KernelSettings, MetricsSettings, NetworkSettings, NtpSettings, OciHooks,
-    PemCertificate, RegistrySettings, UpdatesSettings,
+    HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
+    RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, NtpSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, NtpSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
+    UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
+    UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
+    UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/aws-k8s-1.28/mod.rs
+++ b/sources/models/src/aws-k8s-1.28/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, NtpSettings, OciDefaults, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
+    UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +15,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/metal-k8s-1.28/mod.rs
+++ b/sources/models/src/metal-k8s-1.28/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, NtpSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +15,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     boot: BootSettings,

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,

--- a/sources/models/src/vmware-k8s-1.28/mod.rs
+++ b/sources/models/src/vmware-k8s-1.28/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    NtpSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     updates: UpdatesSettings,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
-    ntp: NtpSettings,
+    ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: KernelSettings,
     aws: AwsSettings,

--- a/sources/settings-extensions/ntp/Cargo.toml
+++ b/sources/settings-extensions/ntp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-ntp"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+string_impls_for = { version = "0.1", path = "../../models/string_impls_for" }
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.1"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/ntp/Cargo.toml
+++ b/sources/settings-extensions/ntp/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
+env_logger = "0.10"
 modeled-types = { path = "../../models/modeled-types", version = "0.1" }
 model-derive = { path = "../../models/model-derive", version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-string_impls_for = { version = "0.1", path = "../../models/string_impls_for" }
 
 [dependencies.bottlerocket-settings-sdk]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"

--- a/sources/settings-extensions/ntp/ntp.toml
+++ b/sources/settings-extensions/ntp/ntp.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/ntp/src/lib.rs
+++ b/sources/settings-extensions/ntp/src/lib.rs
@@ -1,8 +1,8 @@
 /// The ntp settings can be used to specify time servers with which to synchronize the instance's
 /// clock.
 use bottlerocket_settings_sdk::{GenerateResult, LinearlyMigrateable, NoMigration, SettingsModel};
-use modeled_types::Url;
 use model_derive::model;
+use modeled_types::Url;
 use std::convert::Infallible;
 
 #[model(impl_default = true)]
@@ -23,8 +23,7 @@ impl SettingsModel for NtpSettingsV1 {
     }
 
     fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
-        // TODO: add additional validation -- legal for this to be set to any URL or do we need to
-        // check that it is a valid time server?
+        // Anything that parses as a list of URLs is ok
         Ok(())
     }
 
@@ -38,8 +37,7 @@ impl SettingsModel for NtpSettingsV1 {
     }
 
     fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
-        // TODO: add additional validation -- legal for this to be set to any URL or do we need to
-        // check that it is a valid time server?
+        // Anything that parses as a list of URLs is ok
         Ok(())
     }
 }

--- a/sources/settings-extensions/ntp/src/lib.rs
+++ b/sources/settings-extensions/ntp/src/lib.rs
@@ -1,0 +1,90 @@
+/// The ntp settings can be used to specify time servers with which to synchronize the instance's
+/// clock.
+use bottlerocket_settings_sdk::{GenerateResult, LinearlyMigrateable, NoMigration, SettingsModel};
+use modeled_types::Url;
+use model_derive::model;
+use std::convert::Infallible;
+
+#[model(impl_default = true)]
+pub struct NtpSettingsV1 {
+    time_servers: Vec<Url>,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for NtpSettingsV1 {
+    /// the `model` macro makes every field of the `NtpSettingsV1` struct an `Option`, so we can use
+    /// the type as its own `PartialKind`.
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // TODO: add additional validation -- legal for this to be set to any URL or do we need to
+        // check that it is a valid time server?
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // TODO: add additional validation -- legal for this to be set to any URL or do we need to
+        // check that it is a valid time server?
+        Ok(())
+    }
+}
+
+impl LinearlyMigrateable for NtpSettingsV1 {
+    type ForwardMigrationTarget = NoMigration;
+    type BackwardMigrationTarget = NoMigration;
+
+    fn migrate_forward(&self) -> Result<Self::ForwardMigrationTarget> {
+        NoMigration::no_defined_migration()
+    }
+
+    fn migrate_backward(&self) -> Result<Self::BackwardMigrationTarget> {
+        NoMigration::no_defined_migration()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_ntp_settings() {
+        assert_eq!(
+            NtpSettingsV1::generate(None, None),
+            Ok(GenerateResult::Complete(NtpSettingsV1 {
+                time_servers: None
+            }))
+        )
+    }
+
+    #[test]
+    fn test_serde_ntp() {
+        let test_json = r#"{"time-servers":["https://example.net","http://www.example.com"]}"#;
+
+        let ntp: NtpSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            ntp.time_servers.clone().unwrap(),
+            vec!(
+                Url::try_from("https://example.net").unwrap(),
+                Url::try_from("http://www.example.com").unwrap(),
+            )
+        );
+
+        let results = serde_json::to_string(&ntp).unwrap();
+        assert_eq!(results, test_json);
+    }
+}

--- a/sources/settings-extensions/ntp/src/main.rs
+++ b/sources/settings-extensions/ntp/src/main.rs
@@ -3,6 +3,8 @@ use settings_extension_ntp::NtpSettingsV1;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    env_logger::init();
+
     match LinearMigratorExtensionBuilder::with_name("ntp")
         .with_models(vec![BottlerocketSetting::<NtpSettingsV1>::model()])
         .build()

--- a/sources/settings-extensions/ntp/src/main.rs
+++ b/sources/settings-extensions/ntp/src/main.rs
@@ -1,0 +1,16 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, LinearMigratorExtensionBuilder};
+use settings_extension_ntp::NtpSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match LinearMigratorExtensionBuilder::with_name("ntp")
+        .with_models(vec![BottlerocketSetting::<NtpSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Implements a settings extension for NTP settings using the `bottlerocket-settings-sdk`.

Because it uses the SDK, this will create a settings binary which can be installed on a variant via the `settings-ntp` package. But for now, we are only using the settings model from the extension.

**Testing done:**

- ran a build of `aws-dev` on an ec2 instance and checked that the NTP settings were set correctly on boot and would update `/etc/chrony.conf` when set to a new value
- included the settings extension binary on a build of `aws-dev`, and made sure the binary gave the expected responses.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
