### PR TITLE
chore: use char for single char replace pattern

### DIFF
--- a/sources/api/netdog/src/cli/generate_hostname.rs
+++ b/sources/api/netdog/src/cli/generate_hostname.rs
@@ -55,7 +55,7 @@ pub(crate) async fn run() -> Result<()> {
         hostname
     }
     // If no hostname has been determined we return the IP address of the host, replacing invalid ipv6 chars.
-    .unwrap_or(ip_string.replace(":", "-"));
+    .unwrap_or(ip_string.replace(':', "-"));
 
     // sundog expects JSON-serialized output
     print_json(hostname)


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

check-clippy is [failing](https://github.com/bottlerocket-os/bottlerocket/actions/runs/6883446106/job/18724040643?pr=3595) on #3595 and [others](https://github.com/bottlerocket-os/bottlerocket/actions/runs/6880269855/job/18714097682?pr=3598) due to an unrelated change:

```
error: single-character string constant used as pattern
  --> api/netdog/src/cli/generate_hostname.rs:58:34
   |
58 |     .unwrap_or(ip_string.replace(":", "-"));
   |                                  ^^^ help: try using a `char` instead: `':'`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern
   = note: `-D clippy::single-char-pattern` implied by `-D warnings`
```

This PR updates the type of the pattern to make clippy happy.

**Testing done:**

```
cargo make -e BUILDSYS_VARIANT=aws-dev check-clippy
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
