### PR TITLE
tools/diff-kernel-config: Write summary to file

### DIFF
--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -270,7 +270,7 @@ for config_diff in "${output_dir}"/config-*-diff; do
         / -> / { changed += 1 }
         END    { printf \"${config_base}:\t%3d removed, %3d added, %3d changed\n\", removed, added, changed }
     " "${config_diff}"
-done | sort -V
+done | sort -V | tee "${output_dir}"/diff-summary
 echo
 
 # Generate combined report of changes


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** n/a

**Description of changes:**

```
tools/diff-kernel-config: Write summary to file

Write out the overview of config changes to a file in addition to
showing it on the console. This can come in handy when using this script
as part of other automation to recall that information in a final bigger
report. An example application could be automatic composition of PR
cover letters.
```

**Testing done:**

Ran the script with the change and checked that it indeed produces the extra file in the correct location:

```
$ ./tools/diff-kernel-config -a v1.16.1 -b v1.16.0 -v aws-dev -v metal-dev -o config_test
[...]

config-aarch64-aws-dev-diff:	  0 removed,   1 added,   0 changed
config-aarch64-metal-dev-diff:	  0 removed,   1 added,   0 changed
config-x86_64-aws-dev-diff:	  0 removed,   0 added,   1 changed
config-x86_64-metal-dev-diff:	  0 removed,   0 added,   1 changed

A full report has been placed in 'config_test/diff-report'
A tabular report in csv-format has been placed in 'config_test/diff-table'
[fedora@ip-10-1-118-193 bottlerocket]$ cat config_test/diff-summary 
config-aarch64-aws-dev-diff:	  0 removed,   1 added,   0 changed
config-aarch64-metal-dev-diff:	  0 removed,   1 added,   0 changed
config-x86_64-aws-dev-diff:	  0 removed,   0 added,   1 changed
config-x86_64-metal-dev-diff:	  0 removed,   0 added,   1 changed
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
