### PR TITLE
kernel: Update to latest versions for series 5.10, 5.15, 6.1

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/5c8155b74bb2980fed073710617014a21ad836d9b6aa2c1d39e9168289236fde/kernel-5.10.198-187.748.amzn2.src.rpm"
-sha512 = "ae931ec40f8edd7cf76dfc10e7f6e8719cf680e3aa4b65a4efaf37b3075b36d71f01cb28fa59f0e7a73eba7a41f6e0b753bd1eed2fda66563e7d6f2ac36394d5"
+url = "https://cdn.amazonlinux.com/blobstore/bd5e8c34551ab8c3014f5992f3561dcdf6525a3ded7dddbd6e84028bedb222c6/kernel-5.10.199-190.747.amzn2.src.rpm"
+sha512 = "eafa55b9faa750ca594fb5b28a345c6f95f46edec74b17fa389111b8cb7d09d932a8add9fae1a5eb8daf10c27fa858d678bb6da4123ffab139056b92356525ac"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.198
+Version: 5.10.199
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/5c8155b74bb2980fed073710617014a21ad836d9b6aa2c1d39e9168289236fde/kernel-5.10.198-187.748.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/bd5e8c34551ab8c3014f5992f3561dcdf6525a3ded7dddbd6e84028bedb222c6/kernel-5.10.199-190.747.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/8bbf53203badda16f39f6dabe8974acac6f4b3d0dcf96378a434a32c897da379/kernel-5.15.136-90.144.amzn2.src.rpm"
-sha512 = "5f1cf5c446a96805f54f8e38a32d779782e510af0c4efe5015d07d3d5606216410939f883c7769f9faede67d77e4d9fc3a2ba4a9251a150417ce1a2283304066"
+url = "https://cdn.amazonlinux.com/blobstore/920e6b84cc4b3dad00df2d1a77a63242a9338b4a11be7b2e4bfb2b32c92e5cf4/kernel-5.15.137-91.144.amzn2.src.rpm"
+sha512 = "10339ba4db07782fd0058043afd3b271ad9903755b4a1f3727190681d3fcac4253d7b022d251bd8864a5cb7e66c38fecd1b8092bf7de885b8fc34b28394ebdc1"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.136
+Version: 5.15.137
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/8bbf53203badda16f39f6dabe8974acac6f4b3d0dcf96378a434a32c897da379/kernel-5.15.136-90.144.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/920e6b84cc4b3dad00df2d1a77a63242a9338b4a11be7b2e4bfb2b32c92e5cf4/kernel-5.15.137-91.144.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/7f6b70d0766761e79bb6dae9a840ac4fb6ca95c78dad994ea97abac37dd2a061/kernel-6.1.59-84.139.amzn2023.src.rpm"
-sha512 = "9e5c3dab3583742254775c82710007360da8d1a0b252f2acb9096788f6ed33d04599ef61bffc489f78540a4f8194440e79aa3e9ff25ae3be802973ade868bfb1"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/64195460250d20bac796e24a69da55beb4bdd09fb3ed41f8d4c9ef984bd35f7c/kernel-6.1.61-85.141.amzn2023.src.rpm"
+sha512 = "94871ce78edf9475b3e4ccef44292172dc4a59f7cf00e0c765b5be4688d7c8e46fdd2a6152cc6006c9f191fcbc1377e3a40dd81896dc9971741c814bbf36799f"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.59
+Version: 6.1.61
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/7f6b70d0766761e79bb6dae9a840ac4fb6ca95c78dad994ea97abac37dd2a061/kernel-6.1.59-84.139.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/64195460250d20bac796e24a69da55beb4bdd09fb3ed41f8d4c9ef984bd35f7c/kernel-6.1.61-85.141.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels avaulable in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                             STATUS   ROLES    AGE   VERSION               INTERNAL-IP     EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-26-55.eu-central-1.compute.internal   Ready    <none>   18s   v1.28.3-eks-e7a04cd   192.168.26.55   18.197.52.207   Bottlerocket OS 1.16.1 (aws-k8s-1.28)   6.1.61           containerd://1.6.24+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
16:27:39    systemd-logs   ip-192-168-26-55.eu-central-1.compute.internal   complete                                                 
16:27:59             e2e                                           global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
16:27:59    systemd-logs   ip-192-168-26-55.eu-central-1.compute.internal   complete   passed                                        
16:27:59 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by :

```
config-aarch64-aws-k8s-1.23-diff:	  0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:	  0 removed,   0 added,   1 changed
config-x86_64-aws-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/foersleo/e3ee8d0ee04fd8a1a013d079aaa54360).

**Terms of contribuation"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apacke License, version 2.0, and the MIT license.
