### PR TITLE
Security fixes for container packages

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.1630.0/amazon-ssm-agent-3.2.1630.0.tar.gz"
-sha512 = "5d5371ebeec66b5be6960f4c8669d595665ad3e27820a9e8cd8568f7a951d235116022aa5935a10ceecfe09f940d612b65381da42e6f817d62b59effe3293d8f"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.1798.0/amazon-ssm-agent-3.2.1798.0.tar.gz"
+sha512 = "17110456172ac4de07f7c0963a629aff800fb2db2111d0f5eb7f78a93490ed50706925774c156c51d3c58684992be3a92df00667274297ea6c147d85602cbf84"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -8,7 +8,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.2.1630.0
+Version: 3.2.1798.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.24/containerd-1.6.24.tar.gz"
-sha512 = "4c434514e5f0002063a254b89fb8ad06c7bd7a3a83954b0538367a2a343de51ca63113c384c53719127907e70c12fbcd36687b0adc737b1e42bee9f08505dee7"
+url = "https://github.com/containerd/containerd/archive/v1.6.25/containerd-1.6.25.tar.gz"
+sha512 = "5d225e1d0f9682c5831b1b2b8397cea69e6bc10ab8ee2fe5e79a0077fb2d4f3f81456de5c8e4483c63bcc25b342c9e69a9649da4420753ca376c002ca7e5b017"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.24
+%global gover 1.6.25
 %global rpmver %{gover}
 %global gitrev 1e1ea6e986c6c86565bc33d52e34b81b3e2bc71f
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.77.0/amazon-ecs-agent-1.77.0.tar.gz"
-sha512 = "b8dfc61a570a2e195969185474dac942804592631cb9b94f2fc55605ed3ace8fb2a3c3ba785bd356488311bbfc600e9ac0c5c156a7dfafac25ddf4e10303f7eb"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.79.1/amazon-ecs-agent-1.79.1.tar.gz"
+sha512 = "7ad4e370fbefdf19bc2ac90e4bca80eba25ddd46e3b86d95cdf4288f36ffb01bbae7b4cc98f85392f47a6e1d68b21f02921a24058e6d07946cae43457cfd393f"
 
 # The ECS agent repository includes two CNI plugins as git submodules.  git
 # archive does not include submodules, so the tarball above does not include

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.77.0
+%global agent_gover 1.79.1
 
 # git rev-parse --short=8
 %global agent_gitrev 06008fa1

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.25"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/25/artifacts/kubernetes/v1.25.15/kubernetes-src.tar.gz"
-sha512 = "3f2a65892394dbf8e56c3ea1a4d01f760b6781ae22cf2cb73cf9ff026989625ba66d4398f52e1a27666bc722559ca9c88ac8d6c7611902c979a1efd7e0771c6d"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/27/artifacts/kubernetes/v1.25.16/kubernetes-src.tar.gz"
+sha512 = "e3a7b21e6fe07e31d42a4c8b917679b1d3d7f3d0020d5085b592fdb776228e786bbe458cce94d6cf1d7c8bd85142ba02bbfb71b89047f99f8e82a5e9f62dd477"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.25.15
+%global gover 1.25.16
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/25/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/27/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.26"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/21/artifacts/kubernetes/v1.26.10/kubernetes-src.tar.gz"
-sha512 = "fd045d732d5cb0a1ef360dfb62a603331d8b898c1ef58c9c55246200eb38ff944aba69b6eaf8044680206cd1833f46a4ee53c677e2f58aeacc344b0f255bb3be"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/23/artifacts/kubernetes/v1.26.11/kubernetes-src.tar.gz"
+sha512 = "7790ef617fbd30a1f264a4af19d6ccd0a81a6b3abfafe75aa9584948211c1e16a0d4f8910cb9b3edfc77407932bd879215fc0084fbfc5e65b090369e05378790"
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.26.10
+%global gover 1.26.11
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/21/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/23/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.27"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/15/artifacts/kubernetes/v1.27.7/kubernetes-src.tar.gz"
-sha512 = "bd48e9a287d9edb0b8573bbe00911a7e1297a7a3f4cae491e2cd4831add5e1e4c57ad3ee6f9f4102490ec89437d5b89410874380b771553f1c3d34d47720b034"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/17/artifacts/kubernetes/v1.27.8/kubernetes-src.tar.gz"
+sha512 = "d09335d7d171c0a1d6e7a85dfbbfedd6732c89f56c617f4c54555429339ab3ce2a6008e8a0583b71d26cf46df3ebd8bf9b46344f4b1f7d43d6ec381b37f300cf"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.7
+%global gover 1.27.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/15/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/17/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/8/artifacts/kubernetes/v1.28.3/kubernetes-src.tar.gz"
-sha512 = "25a7c7cc48ef865662b449ac2e6f5e85d380eed4f97498815b0ad80b30857f4868883110534ee412d434d04906aa16e7f2f33cd03bd2aaa83ac5624c01d95d6c"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/10/artifacts/kubernetes/v1.28.4/kubernetes-src.tar.gz"
+sha512 = "663762465cf0a926651b4996f59fa20d31cc0dc2a0d7b8aeb6cd7ad465b154fc330a5b51e92c1a5d6ae80af2cb3789e8b99b68524a4c58d03d298c6ff4e29b32"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.28.3
+%global gover 1.28.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/8/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/10/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.14.1/v0.14.1.tar.gz"
-path = "k8s-device-plugin-0.14.1.tar.gz"
-sha512 = "e00a3da18ae803669d566faf5b8e8c5fe57c36d85100255c0c7be42bcb9c40cb1f97afecea8cab8035f8e10182a8a63cf18e89c702d161ee8bbc16dddd760d19"
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.14.3/v0.14.3.tar.gz"
+path = "k8s-device-plugin-0.14.3.tar.gz"
+sha512 = "cd60ca6b87df8d0a4a34a95284253a7129b6fb617e6df639a92c312919f36343584472f148fac95c47c54dbbb883b2e1c8e564c6921c2a6b3e49819fb27f1f85"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.14.1
+%global gover 0.14.3
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-k8s-device-plugin

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.9/runc.tar.xz"
-path = "runc-v1.1.9.tar.xz"
-sha512 = "e6fd1e7414929436f996358389eeb968db1304358029f0b845eb7d4afac4fa0d637e06ab0e564d680b825e2edb97b55cc154f32e4912d56697bbaf0923c1ec0d"
+url = "https://github.com/opencontainers/runc/releases/download/v1.1.10/runc.tar.xz"
+path = "runc-v1.1.10.tar.xz"
+sha512 = "bf25d5222b560428daab58d887fd867a7e4c5703004eae9dbc1a082d55ac5db961ed8e5a2ff5dafe6d6350e59afd1053b98a6fc0e8a281758b706cf9144860d3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -2,7 +2,7 @@
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
 %global commit 0f48801a0e21e3f0bc4e74643ead2a502df4818d
-%global gover 1.1.9
+%global gover 1.1.10
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```
packages: update kubernetes -1.28 to 1.28.4
packages: update kubernetes 1.27 to 1.27.8
packages: update kubernetes-1.26 to 1.26.11
packages: update kubernetes-1.25 to 1.25.16
packages: update runc to 1.1.10
packages: update nvidia-k8s-device-plugin to 0.14.3
packages: update ecs-agent to 1.79.1
packages: update containerd to 1.6.25
packages: update amazon-ssm-agent to 3.2.1798.0
```

The update for nvidia-kubernetes-device-plugin mitigates: CVE-2023-3978, CVE-2023-44487, CVE-2023-39325, GHSA-m425-mq94-257g, CVE-2023-44487.

The update for ecs-agent mitigates: GHSA-m425-mq94-257g, CVE-2023-3978, CVE-2023-44487, CVE-2023-39325.
The update for containerd mitigates: CVE-2023-3978, CVE-2023-44487, CVE-2023-39325
The update for amazon-ssm-agent  mitigates:  CVE-2023-3978, CVE-2023-44487, CVE-2023-39325.

**Testing done:**
- [x] aws-k8s-1.27 x86_64
```
NAME                                       TYPE              STATE                     PASSED          FAILED         SKIPPED   BUILD ID         LAST UPDATE
 x86-64-aws-k8s-127-quick                   Test              passed                         5               0            7206   92cbb22f         2023-12-05T16:29:37Z
 x86-64-aws-k8s-127                         Resource          completed                                                          92cbb22f         2023-12-05T16:27:25Z
 x86-64-aws-k8s-127-instances-mlhv          Resource          completed                                                          92cbb22f         2023-12-05T16:27:34Z
```
- [x] aws-k8s-1.24 aarch64
```
NAME                                TYPE               STATE                       PASSED           FAILED          SKIPPED   BUILD ID          LAST UPDATE
 aarch64-aws-k8s-124-quick           Test               passed                           1                0             6972   92cbb22f          2023-12-05T17:30:53Z
 aarch64-aws-k8s-124                 Resource           completed                                                              92cbb22f          2023-12-05T17:28:54Z
```
- [x] aws-k8s-1.27-nvidia x86_64
```
x86-64-aws-k8s-127-nvidia-quick                  Test             passed                       5              0            7206   5b28082c         2023-12-05T23:34:43Z
 x86-64-aws-k8s-127-nvidia                        Resource         completed                                                       5b28082c         2023-12-05T23:32:08Z
 x86-64-aws-k8s-127-nvidia-instances-wumo         Resource         completed                                                       5b28082c         2023-12-05T23:32:16Z
```
- [x] aws-k8s-1.27-nvidia aarch64
```
aarch64-aws-k8s-127-nvidia-quick                  Test             passed                       5              0            7206   5b28082c         2023-12-05T23:59:01Z
 aarch64-aws-k8s-127-nvidia                        Resource         completed                                                       5b28082c         2023-12-05T23:56:57Z
 aarch64-aws-k8s-127-nvidia-instances-yjle         Resource         running                                                         5b28082c         2023-12-05T23:59:11Z
```
- [x] aws-ecs-1 
```
 NAME                                     TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 x86-64-aws-ecs-1-quick                   Test              passed                         1               0                0   92cbb22f          2023-12-05T17:47:28Z
 x86-64-aws-ecs-1                         Resource          completed                                                           92cbb22f          2023-12-05T17:46:56Z
```
- [x] aws-ecs-1-nvidia
```
 x86-64-aws-ecs-1-nvidia-quick                     Test             passed                       1              0               0   5b28082c         2023-12-05T23:45:58Z
 x86-64-aws-ecs-1-nvidia                           Resource         completed                                                       5b28082c         2023-12-05T23:45:10Z
 x86-64-aws-ecs-1-nvidia-instances-sdgu            Resource         running                                                         5b28082c         2023-12-05T23:46:07Z
``` 
- [x] aws-ecs-2 
```
NAME                                     TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 x86-64-aws-ecs-2-quick                   Test              passed                         1               0                0   92cbb22f          2023-12-05T17:58:14Z
 x86-64-aws-ecs-2                         Resource          completed                                                           92cbb22f          2023-12-05T17:57:36Z
```
- [x] aws-ecs-2-nvidia 
```
x86-64-aws-ecs-2-nvidia-quick                     Test             passed                       1              0               0   5b28082c         2023-12-05T23:47:59Z
 x86-64-aws-ecs-2-nvidia                           Resource         completed                                                       5b28082c         2023-12-05T23:47:07Z
 x86-64-aws-ecs-2-nvidia-instances-zjhi            Resource         completed                                                       5b28082c         2023-12-05T23:47:19Z
```
- [x] Runc test




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
