### PR TITLE
pluto: handle auth info in https_proxy

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3175,6 +3175,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-rustls",
+ "url",
 ]
 
 [[package]]

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -31,6 +31,7 @@ snafu = "0.7"
 tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 tokio-retry = "0.3"
 tokio-rustls = "0.23"
+url = "2"
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket/issues/3525

**Description of changes:**
```
    pluto: handle auth info in https_proxy
    
    Need to parse out auth info in `https_proxy` and set to proxy header.
```


**Testing done:**
Unit tests pass.

Set up my own tiny proxy host and launched new Bottlerocket host with the following settings:
```toml
[settings.network]
https-proxy = "http://user:pass@my_proxy:9898"
```

The boot succeeds, pluto successfully fetches instance information through AWS EC2 API.
In cloudtrail, i can see the source of the DescribeInstance event as being my proxy:
```
{
    "userIdentity": {
        "type": "AssumedRole",
        "principalId": ".....i-0d2d921de0b0a9aad",
        "arn": "..../i-0d2d921de0b0a9aad",
...
    "eventTime": "2023-12-05T23:51:56Z",
    "eventSource": "ec2.amazonaws.com",
    "eventName": "DescribeInstances",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "<my_proxy_url>",
    "userAgent": "aws-sdk-rust/0.55.3 os/linux lang/rust/1.73.0",
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
