### PR TITLE
3p packages updates for 1.17.0

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.11/aws-iam-authenticator-0.6.11.tar.gz"
-sha512 = "6d78fbe95d6e36a7a3835b4df257e96fff3ab53fe4abd8ef525c24aebaf8727e2a6016107024bebe031b2e24295172190407ca892d1b3478329c62cdd9fe553f"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.13/aws-iam-authenticator-0.6.13.tar.gz"
+sha512 = "deb7692c5e3d87fd9b6f3e44c916a08604fb6fbb23ba1cbd5611e87b0aca9f4380525641fb5ac7e4d7d9f82223bc73d7d5d6c1295e56de351a011c38a252e5f5"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.6.11
+%global gover 0.6.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/bash/Cargo.toml
+++ b/packages/bash/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://ftp.gnu.org/gnu/bash"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz"
-sha512 = "a32a343b6dde9a18eb6217602655f72c4098b0d90f04cf4e686fb21b81fc4ef26ade30f7226929fbb7c207cde34617dbad2c44f6103161d1141122bb31dc6c80"
+url = "https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz"
+sha512 = "68af0b6b04b6825a3cb294ed8e1061d14d51d786aa7fb1c88d2848257409122f308ef4b8006ed401e2897aabe2adf6837074cea6f3a0523077308e45f49319fd"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/bash/bash.spec
+++ b/packages/bash/bash.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}bash
-Version: 5.1.16
+Version: 5.2.21
 Release: 1%{?dist}
 Summary: The GNU Bourne Again shell
 License: GPL-3.0-or-later

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containernetworking/plugins/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/plugins/archive/v1.3.0/plugins-1.3.0.tar.gz"
-sha512 = "87e186b3cd64f66280f5b2293dcdd1fc22cb8f51a248124fb622adc48a893348419ba4c29c4769dede4d9e60f2e9fea5d4198f10badb4ecd20a1551e0b344e10"
+url = "https://github.com/containernetworking/plugins/archive/v1.4.0/plugins-1.4.0.tar.gz"
+sha512 = "d812663fb58cfa2bfe35dd70940586d47f11feddd35a86ea7639197b022f9c0e0f487679e2e968eebf1f80b8b1d9cfbd0fe99d80590ae60a8128fa393d713e0b"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 %global gorepo plugins
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.3.0
+%global gover 1.4.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/software/network/ethtool/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.5.tar.xz"
-sha512 = "07994a20f34b1c1e72f9f855972d31d027968b53b278a5b46c5a2977be8d7152e6439c9719001101be85359876d9d932d2afb9561af9967e84d8a447a7d0c558"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.6.tar.xz"
+sha512 = "1e7eae3abe59e6af4bce0ebedd0a7ea84d1b0adc7693a0f03021c4096677096a022fdae521ac02413f9db46ee232b89dd2015a116845aa6ca7686fdda50a5b21"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}ethtool
-Version: 6.5
+Version: 6.6
 Release: 1%{?dist}
 Summary: Settings tool for Ethernet NICs
 License: GPL-2.0-only AND GPL-2.0-or-later

--- a/packages/libelf/Cargo.toml
+++ b/packages/libelf/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://sourceware.org/elfutils/ftp/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/elfutils/ftp/0.189/elfutils-0.189.tar.bz2"
-sha512 = "93a877e34db93e5498581d0ab2d702b08c0d87e4cafd9cec9d6636dfa85a168095c305c11583a5b0fb79374dd93bc8d0e9ce6016e6c172764bcea12861605b71"
+url = "https://sourceware.org/elfutils/ftp/0.190/elfutils-0.190.tar.bz2"
+sha512 = "9c4f5328097e028286c42f29e39dc3d80914b656cdfbbe05b639e91bc787ae8ae64dd4d69a6e317ce30c01648ded10281b86a51e718295f4c589df1225a48102"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libelf/libelf.spec
+++ b/packages/libelf/libelf.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libelf
-Version: 0.189
+Version: 0.190
 Release: 1%{?dist}
 Summary: Library for ELF files
 License: GPL-2.0-or-later OR LGPL-3.0-or-later

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://download.gnome.org/sources/glib"
 
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.78/glib-2.78.0.tar.xz"
-sha512 = "3d06890002f4b13f831c83fbb70cfce529f9750e30888619e4d6277116be15d106379a03143412cf4b2a289c0cbdbbc299ecf17284fbffc06c791ecf7556c765"
+url = "https://download.gnome.org/sources/glib/2.78/glib-2.78.2.tar.xz"
+sha512 = "d09d25977c2121e68e6215c29d672330b88b4d11e1c34b81b658225ae3e63226c64ce91d3093b9718bef62be0d549b3e46f0177560fb0585c5bfb21de45d1c83"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,11 +1,11 @@
 Name: %{_cross_os}libglib
-Version: 2.78.0
+Version: 2.78.2
 Release: 1%{?dist}
 Summary: The GLib libraries
 # glib2 is LGPL-2.1-only
 License: LGPL-2.1-only
 URL: https://www.gtk.org/
-Source0: https://download.gnome.org/sources/glib/2.77/glib-%{version}.tar.xz
+Source0: https://download.gnome.org/sources/glib/2.78/glib-%{version}.tar.xz
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libffi-devel

--- a/packages/liblzma/Cargo.toml
+++ b/packages/liblzma/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://tukaani.org/xz"
 
 [[package.metadata.build-package.external-files]]
-url = "https://tukaani.org/xz/xz-5.4.4.tar.xz"
-sha512 = "2b233a924b82190ff15e970c5a4a59f1c53a0b39a96bde228c9dfc9b103b4a3e5888f5024da4834e180f6010620ff23caf9f7135a38724eb2c8d01bff7a9a9e1"
+url = "https://tukaani.org/xz/xz-5.4.5.tar.xz"
+sha512 = "5cbc3b5bb35a9f5773ad657788fe77013471e3b621c5a8149deb7389d48535926e5bed103456fcfe5ecb044b236b1055b03938a6cc877cfc749372b899fc79e5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/liblzma/liblzma.spec
+++ b/packages/liblzma/liblzma.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}liblzma
-Version: 5.4.4
+Version: 5.4.5
 Release: 1%{?dist}
 Summary: Library for XZ and LZMA compressed files
 URL: https://tukaani.org/xz

--- a/packages/libnl/Cargo.toml
+++ b/packages/libnl/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/thom311/libnl/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/thom311/libnl/archive/libnl3_8_0.tar.gz"
-sha512 = "4e5e7187ecf6184ddfc38a95fdfe47efeb826f43f9f6546b5531780389ecf406f82f588275abea9970416b9fe8afa81527a7ddb771509f468ac5005774b0246c"
+url = "https://github.com/thom311/libnl/archive/libnl3_9_0.tar.gz"
+sha512 = "7182752ccd3663f14fc7bce20d134c42e54b8305b67e44e509027aab0150a5ef056f373332d22f87386a827f8ca8b7bdaf2bd5d410982210d28ec071f31ccc73"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnl/libnl.spec
+++ b/packages/libnl/libnl.spec
@@ -1,5 +1,5 @@
-%global rpmver 3.8.0
-%global srcver 3_8_0
+%global rpmver 3.9.0
+%global srcver 3_9_0
 
 Name: %{_cross_os}libnl
 Version: %{rpmver}

--- a/packages/libseccomp/Cargo.toml
+++ b/packages/libseccomp/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/seccomp/libseccomp/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/seccomp/libseccomp/releases/download/v2.5.4/libseccomp-2.5.4.tar.gz"
-sha512 = "92650bd7d1d48b383f402a536b97a017fd0f6ad1234daf4b938d01c92e8d134a01d2f2dd45fd9e2d025d7556bd1386ec360402145a87f20580c85949d62cea0e"
+url = "https://github.com/seccomp/libseccomp/releases/download/v2.5.5/libseccomp-2.5.5.tar.gz"
+sha512 = "f630e7a7e53a21b7ccb4d3e7b37616b89aeceba916677c8e3032830411d77a14c2d74dcf594cd193b1acc11f52595072e28316dc44300e54083d5d7b314a38da"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libseccomp/libseccomp.spec
+++ b/packages/libseccomp/libseccomp.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libseccomp
-Version: 2.5.4
+Version: 2.5.5
 Release: 1%{?dist}
 Summary: Library for enhanced seccomp
 License: LGPL-2.1-only

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/makedumpfile/makedumpfile/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.3/makedumpfile-1.7.3.tar.gz"
-sha512 = "a8e2ef5fdb45e6ed57c8b63f242d989bf1a66746ff665aefb7a52fc5d6d73b71171a08de1dc080ab31130938e2caea414929a5b64be9ee7443cf646c35ce3822"
+url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.4/makedumpfile-1.7.4.tar.gz"
+sha512 = "6c3455b711bd4e120173ee07fcc5ff708ae6d34eaee0f4c135eca7ee0e0475b4d391429c23cf68e848b156ee3edeab956e693a390d67ccc634c43224c7129a96"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/makedumpfile/makedumpfile.spec
+++ b/packages/makedumpfile/makedumpfile.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}makedumpfile
-Version: 1.7.3
+Version: 1.7.4
 Release: 1%{?dist}
 Summary: Tool to create dumps from kernel memory images
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.5/strace-6.5.tar.xz"
-sha512 = "7edf7b00b5ad91be2df4e44b63df7f88376f3e6a8f078dfccf307a6a5003ad25d9cf233f2a32139e00fe399494ce6a8f67728bf9dfeb9bb5958ed08ce25e9e01"
+url = "https://strace.io/files/6.6/strace-6.6.tar.xz"
+sha512 = "77ea45c72e513f6c07026cd9b2cc1a84696a5a35cdd3b06dd4a360fb9f9196958e3f6133b4a9c91e091c24066ba29e0330b6459d18a9c390caae2dba97ab399b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 6.5
+Version: 6.6
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```
packages: update strace to 6.6
packages: update makedumpfile to 1.7.4
packages: update libseccomp to 2.5.5 
packages: update libnl to 3_9_0
packages: update liblzma to 5.4.5
packages: update libglib to 2.78.2
packages: update libelf to 0.190 
packages: update ethtool to 6.6
packages: update cni-plugins to 1.4.0 
packages: update bash to 5.2.21
packages: update aws-iam-authenticator to 0.6.13
```

**Testing done:**

- [x] aws-k8s-1.27 x86_64
```
x86-64-aws-k8s-127-quick                  Test              passed                         5               0             7206   b5a1f1f0          2023-12-06T13:41:22Z
 x86-64-aws-k8s-127                        Resource          completed                                                           b5a1f1f0          2023-12-06T13:39:53Z
 x86-64-aws-k8s-127-nvidia                 Resource          completed                                                           b5a1f1f0          2023-12-06T06:44:32Z
```
- [x] aws-k8s-1.27 aarch64
```
aarch64-aws-k8s-127-quick                   Test              passed                         5               0             7206   03f1e61f         2023-12-06T14:32:44Z
 aarch64-aws-k8s-127                         Resource          completed                                                           03f1e61f         2023-12-06T14:30:39Z
 aarch64-aws-k8s-127-instances-ujqq          Resource          completed                                                           03f1e61f         2023-12-06T14:30:46Z
```
- [x] aws-k8s-1.27-nvidia x86_64
```
x86-64-aws-k8s-127-nvidia-quick                  Test             passed                       5              0            7206   b5a1f1f0         2023-12-06T06:46:37Z
 x86-64-aws-k8s-127-nvidia                        Resource         completed                                                       b5a1f1f0         2023-12-06T06:44:32Z
```
- [x] aws-k8s-1.27-nvidia aarch64
```
 NAME                                      TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID          LAST UPDATE
 aarch64-aws-k8s-127-nvidia-quick          Test              passed                         5               0             7206   03f1e61f          2023-12-06T16:00:46Z
 aarch64-aws-k8s-127-nvidia                Resource          completed                                                           03f1e61f          2023-12-06T15:58:38Z
```
- [x] aws-ecs-1 
```
x86-64-aws-ecs-1-quick                    Test              passed                         1               0                0   03f1e61f          2023-12-06T13:49:00Z
 x86-64-aws-ecs-1                          Resource          completed                                                           03f1e61f          2023-12-06T13:48:28Z
```
- [x] aws-ecs-1-nvidia
```
NAME                                     TYPE            STATE                    PASSED           FAILED           SKIPPED   BUILD ID           LAST UPDATE
 x86-64-aws-ecs-1-nvidia-quick            Test            passed                        1                0                 0   03f1e61f           2023-12-06T16:24:17Z
```
- [x] aws-ecs-2-nvidia
```
NAME                                     TYPE            STATE                    PASSED           FAILED           SKIPPED   BUILD ID           LAST UPDATE
 x86-64-aws-ecs-2-nvidia-quick            Test            passed                        1                0                 0   03f1e61f           2023-12-06T17:09:01Z
```
- [x] aws-ecs-2
```
NAME                               TYPE            STATE                      PASSED            FAILED            SKIPPED   BUILD ID            LAST UPDATE
 x86-64-aws-ecs-2-quick             Test            passed                          1                 0                  0   03f1e61f            2023-12-06T17:27:35Z
```
- [x] vmware-k8s-1.26




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
