### PR TITLE
kernel: Update to latest versions for series 5.10,5.15

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/bd5e8c34551ab8c3014f5992f3561dcdf6525a3ded7dddbd6e84028bedb222c6/kernel-5.10.199-190.747.amzn2.src.rpm"
-sha512 = "eafa55b9faa750ca594fb5b28a345c6f95f46edec74b17fa389111b8cb7d09d932a8add9fae1a5eb8daf10c27fa858d678bb6da4123ffab139056b92356525ac"
+url = "https://cdn.amazonlinux.com/blobstore/d56d799376346afd56ebe3eec4b500b23c6fd3954f66b65aa7c867848d17a950/kernel-5.10.201-191.748.amzn2.src.rpm"
+sha512 = "8d8715a1e06dbf7adbc1b5f80e99ec6b5d448c9aefd69f48f77fe6c80bd0e2668a963f85360fefd93ea979e2d2a5323d916301f2f59961e125a5fe6c8b38065f"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.199
+Version: 5.10.201
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/bd5e8c34551ab8c3014f5992f3561dcdf6525a3ded7dddbd6e84028bedb222c6/kernel-5.10.199-190.747.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/d56d799376346afd56ebe3eec4b500b23c6fd3954f66b65aa7c867848d17a950/kernel-5.10.201-191.748.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/920e6b84cc4b3dad00df2d1a77a63242a9338b4a11be7b2e4bfb2b32c92e5cf4/kernel-5.15.137-91.144.amzn2.src.rpm"
-sha512 = "10339ba4db07782fd0058043afd3b271ad9903755b4a1f3727190681d3fcac4253d7b022d251bd8864a5cb7e66c38fecd1b8092bf7de885b8fc34b28394ebdc1"
+url = "https://cdn.amazonlinux.com/blobstore/76d66a34d25e5ebc08dc424d9b03b0ecb44046eb05d95e47459447a5ab582cd2/kernel-5.15.139-93.147.amzn2.src.rpm"
+sha512 = "f63269b6466df01b5a6a3387091665cb8931090fa73d848f0d77a6729aa7241d04be77383e34a41bed575cd295bf722bd6668965d1f1147d9ca975ae04b53219"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.137
+Version: 5.15.139
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/920e6b84cc4b3dad00df2d1a77a63242a9338b4a11be7b2e4bfb2b32c92e5cf4/kernel-5.15.137-91.144.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/76d66a34d25e5ebc08dc424d9b03b0ecb44046eb05d95e47459447a5ab582cd2/kernel-5.15.139-93.147.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                              STATUS   ROLES    AGE   VERSION                INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-64-192.eu-central-1.compute.internal   Ready    <none>   63s   v1.23.17-eks-bbbebb8   192.168.64.192   3.68.32.100     Bottlerocket OS 1.16.1 (aws-k8s-1.23)   5.10.201         containerd://1.6.25+bottlerocket
ip-192-168-83-94.eu-central-1.compute.internal    Ready    <none>   87s   v1.26.11-eks-b93ee12   192.168.83.94    18.185.249.79   Bottlerocket OS 1.16.1 (aws-k8s-1.26)   5.15.139         containerd://1.6.25+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
10:34:59             e2e                                            global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
10:34:59    systemd-logs   ip-192-168-64-192.eu-central-1.compute.internal   complete   passed                                        
10:34:59    systemd-logs    ip-192-168-83-94.eu-central-1.compute.internal   complete   passed 
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:	  0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:	  0 removed,   0 added,   1 changed
config-x86_64-aws-k8s-1.23-diff:	  0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:	  2 removed,   1 added,   5 changed
config-x86_64-metal-k8s-1.26-diff:	  2 removed,   1 added,   5 changed
config-x86_64-vmware-k8s-1.26-diff:	  2 removed,   1 added,   5 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/foersleo/b056a6027c006be1615836e1161b4053).

All changes to the kernels config for 5.15 are related to bumping the number of CPUs that can be handled by the kernels. This is done by AL in order to enable environments with more than the previously set 512 possible CPUs (e.g. the new high-memory instance types announced at re:invent with 896 vCPUs).

**Terms of contribuation"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
