### PR TITLE
Host container update for v1.17.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -252,4 +252,6 @@ version = "1.17.0"
 "(1.16.1, 1.17.0)" = [
     "migrate_v1.17.0_aws-admin-container-v0-11-2.lz4",
     "migrate_v1.17.0_public-admin-container-v0-11-2.lz4",
+    "migrate_v1.17.0_aws-control-container-v0-7-6.lz4",
+    "migrate_v1.17.0_public-control-container-v0-7-6.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -250,4 +250,6 @@ version = "1.17.0"
     "migrate_v1.16.1_updog-network-affected.lz4",
 ]
 "(1.16.1, 1.17.0)" = [
+    "migrate_v1.17.0_aws-admin-container-v0-11-2.lz4",
+    "migrate_v1.17.0_public-admin-container-v0-11-2.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.16.1"
+version = "1.17.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -248,4 +248,6 @@ version = "1.16.1"
 ]
 "(1.16.0, 1.16.1)" = [
     "migrate_v1.16.1_updog-network-affected.lz4",
+]
+"(1.16.1, 1.17.0)" = [
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -578,6 +578,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-6"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,6 +3097,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-5"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-6"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -527,6 +527,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-config"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3062,6 +3069,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-1"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-2"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -50,6 +50,8 @@ members = [
     "api/migration/migrations/v1.16.1/updog-network-affected",
     "api/migration/migrations/v1.17.0/aws-admin-container-v0-11-2",
     "api/migration/migrations/v1.17.0/public-admin-container-v0-11-2",
+    "api/migration/migrations/v1.17.0/aws-control-container-v0-7-6",
+    "api/migration/migrations/v1.17.0/public-control-container-v0-7-6",
 
     "bloodhound",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -48,6 +48,8 @@ members = [
     "api/migration/migrations/v1.16.0/public-control-container-v0-7-5",
     "api/migration/migrations/v1.16.0/schnauzer-v2-generators",
     "api/migration/migrations/v1.16.1/updog-network-affected",
+    "api/migration/migrations/v1.17.0/aws-admin-container-v0-11-2",
+    "api/migration/migrations/v1.17.0/public-admin-container-v0-11-2",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.17.0/aws-admin-container-v0-11-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.17.0/aws-admin-container-v0-11-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-11-2"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.17.0/aws-admin-container-v0-11-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.17.0/aws-admin-container-v0-11-2/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.1'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.2'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.17.0/aws-control-container-v0-7-6/Cargo.toml
+++ b/sources/api/migration/migrations/v1.17.0/aws-control-container-v0-7-6/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-6"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.17.0/aws-control-container-v0-7-6/src/main.rs
+++ b/sources/api/migration/migrations/v1.17.0/aws-control-container-v0-7-6/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.5'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.6'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.17.0/public-admin-container-v0-11-2/Cargo.toml
+++ b/sources/api/migration/migrations/v1.17.0/public-admin-container-v0-11-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-11-2"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.17.0/public-admin-container-v0-11-2/src/main.rs
+++ b/sources/api/migration/migrations/v1.17.0/public-admin-container-v0-11-2/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.1";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.2";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.17.0/public-control-container-v0-7-6/Cargo.toml
+++ b/sources/api/migration/migrations/v1.17.0/public-control-container-v0-7-6/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-6"
+version = "0.1.0"
+authors = ["Patrick J.P. Culp <jpculp@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.17.0/public-control-container-v0-7-6/src/main.rs
+++ b/sources/api/migration/migrations/v1.17.0/public-control-container-v0-7-6/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.5";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.6";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.1'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.2'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.5'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.6'"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.2"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.5"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.6"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.1"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.2"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Description of changes:**

Update the default admin and control container images to [v0.11.2](https://github.com/bottlerocket-os/bottlerocket-admin-container/pull/89) and [v0.7.6](https://github.com/bottlerocket-os/bottlerocket-control-container/pull/52) respectively.


**Testing done:**

* [x] `cargo make check-migrations`
* [x] Verify upgrade/downgrade


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
