### PR TITLE
pluto: remove unnecessary auth header in hyper-proxy 

### DIFF
--- a/sources/api/pluto/src/hyper_proxy/mod.rs
+++ b/sources/api/pluto/src/hyper_proxy/mod.rs
@@ -126,15 +126,12 @@ impl Proxy {
 
     /// Set `Proxy` authorization
     pub fn set_authorization<C: Credentials + Clone>(&mut self, credentials: Authorization<C>) {
+        // In pluto, we use custom intercept for HTTPS traffic we might proxy based on the no proxy specification.
         match self.intercept {
-            Intercept::Https => {
+            Intercept::Custom(_) | Intercept::Https => {
                 self.headers.typed_insert(ProxyAuthorization(credentials.0));
             }
-            _ => {
-                self.headers
-                    .typed_insert(Authorization(credentials.0.clone()));
-                self.headers.typed_insert(ProxyAuthorization(credentials.0));
-            }
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
We should only need the proxy auth header to talk to the proxy when proxying.



**Testing done:**
Launched instance with `https_proxy` setting:
```toml
[settings.network]
https-proxy = "http://user:pass@proxy:port"
```
Cloudtrail shows the describe instance originating from pluto going through my proxy:
```
    "eventTime": "2023-12-08T04:09:29Z",
    "eventSource": "ec2.amazonaws.com",
    "eventName": "DescribeInstances",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "my_proxy",
    "userAgent": "aws-sdk-rust/0.55.3 os/linux lang/rust/1.74.0",
```

Without the https_proxy setting, the source of the event is my instance public IP as expected:
```
    "eventSource": "ec2.amazonaws.com",
    "eventName": "DescribeInstances",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "my_instance_pub_ip",
    "userAgent": "aws-sdk-rust/0.55.3 os/linux lang/rust/1.74.0",
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
