### PR TITLE
selinux-policy: remove unused entry

### DIFF
--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -55,7 +55,6 @@
 (filecon "/.*/usr/bin/containerd.*" file runtime_exec)
 (filecon "/.*/usr/bin/docker.*" file runtime_exec)
 (filecon "/.*/usr/bin/host-ctr" file runtime_exec)
-(filecon "/.*/usr/sbin/runc" file runtime_exec)
 (filecon "/.*/usr/bin/shibaken" file api_exec)
 
 ; Label local storage mounts.

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -34,7 +34,7 @@
 (roletype object_r bus_exec_t)
 (context bus_exec (system_u object_r bus_exec_t s0))
 
-; Executable files for container runtimes such as /usr/sbin/runc.
+; Executable files for container runtimes such as /usr/bin/containerd.
 (type runtime_exec_t)
 (roletype object_r runtime_exec_t)
 (context runtime_exec (system_u object_r runtime_exec_t s0))


### PR DESCRIPTION
We don't invoke `runc` directly but rather through `host-ctr`, `containerd`, or `docker` so this line isn't doing anything. This cleans up the line to be more clear that we don't actually need this rule. In fact, it was pointing to a different location than where `runc` resides.

**Testing done:**
Built an aws-k8s-1.28 image and confirmed it could launch host containers and orchestrated containers.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
