### PR TITLE
settings: add `container-registry` settings extension

### DIFF
--- a/packages/settings-container-registry/Cargo.toml
+++ b/packages/settings-container-registry/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-container-registry"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/container-registry"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-container-registry/settings-container-registry.spec
+++ b/packages/settings-container-registry/settings-container-registry.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name container-registry
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1048,8 +1048,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-sdk"
-version = "0.1.0-alpha.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-sdk-v0.1.0-alpha.1#6a7e2915f1ac3f70e839b8394256bc59f86f626e"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-sdk-v0.1.0-alpha.2#7a138e9de9d99944fbedc6a35c4d08607e459b24"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1062,7 +1062,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-sdk-v0.1.0-alpha.1#6a7e2915f1ac3f70e839b8394256bc59f86f626e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-sdk-v0.1.0-alpha.2#7a138e9de9d99944fbedc6a35c4d08607e459b24"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
@@ -3565,6 +3565,18 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-ntp"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-registry"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-settings-sdk",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2600,6 +2600,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "settings-extension-container-registry",
  "settings-extension-motd",
  "settings-extension-ntp",
  "toml 0.5.11",
@@ -3554,17 +3555,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "settings-extension-motd"
-version = "0.1.0"
-dependencies = [
- "bottlerocket-settings-sdk",
- "serde",
- "serde_json",
- "string_impls_for",
-]
-
-[[package]]
-name = "settings-extension-ntp"
+name = "settings-extension-container-registry"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-settings-sdk",
@@ -3576,7 +3567,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "settings-extension-registry"
+name = "settings-extension-motd"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "serde",
+ "serde_json",
+ "string_impls_for",
+]
+
+[[package]]
+name = "settings-extension-ntp"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-settings-sdk",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -73,6 +73,7 @@ members = [
 
     "settings-extensions/motd",
     "settings-extensions/ntp",
+    "settings-extensions/container-registry",
 
     "parse-datetime",
 

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -20,6 +20,7 @@ toml = "0.5"
 # settings extensions
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
+settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
     HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
-    RegistrySettings, UpdatesSettings,
+    UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -23,7 +23,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
     ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -23,7 +23,7 @@ struct Settings {
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
     ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -23,7 +23,7 @@ struct Settings {
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/aws-k8s-1.28/mod.rs
+++ b/sources/models/src/aws-k8s-1.28/mod.rs
@@ -1,8 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, RegistrySettings,
-    UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: OciHooks,
     dns: DnsSettings,
 }

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     dns: DnsSettings,

--- a/sources/models/src/metal-k8s-1.28/mod.rs
+++ b/sources/models/src/metal-k8s-1.28/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     aws: AwsSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     dns: DnsSettings,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    NetworkSettings, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: OciHooks,
     dns: DnsSettings,
 }

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     dns: DnsSettings,

--- a/sources/models/src/vmware-k8s-1.28/mod.rs
+++ b/sources/models/src/vmware-k8s-1.28/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, RegistrySettings, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
-    container_registry: RegistrySettings,
+    container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: OciHooks,
     dns: DnsSettings,

--- a/sources/settings-extensions/container-registry/Cargo.toml
+++ b/sources/settings-extensions/container-registry/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
-name = "settings-extension-motd"
+name = "settings-extension-container-registry"
 version = "0.1.0"
-authors = ["Sean P. Kelly <seankell@amazon.com>"]
+authors = ["Sam Berning <bernings@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"
 publish = false
 
 [dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-string_impls_for = { version = "0.1", path = "../../models/string_impls_for" }
 
 [dependencies.bottlerocket-settings-sdk]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"

--- a/sources/settings-extensions/container-registry/container-registry.toml
+++ b/sources/settings-extensions/container-registry/container-registry.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/container-registry/src/de.rs
+++ b/sources/settings-extensions/container-registry/src/de.rs
@@ -1,0 +1,47 @@
+use crate::RegistryMirrorV1;
+use serde::de::value::SeqAccessDeserializer;
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::fmt::Formatter;
+
+// Our standard representation of registry mirrors is a `Vec` of `RegistryMirror`; for backward compatibility, we also allow a `HashMap` of registry to endpoints.
+pub(crate) fn deserialize_mirrors<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<RegistryMirrorV1>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct TableOrArray;
+
+    impl<'de> Visitor<'de> for TableOrArray {
+        type Value = Option<Vec<RegistryMirrorV1>>;
+
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("TOML array or TOML table")
+        }
+
+        fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            Ok(Some(Deserialize::deserialize(SeqAccessDeserializer::new(
+                seq,
+            ))?))
+        }
+
+        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut vec = Vec::new();
+            while let Some((k, v)) = map.next_entry()? {
+                vec.push(RegistryMirrorV1 {
+                    registry: Some(k),
+                    endpoint: Some(v),
+                });
+            }
+            Ok(Some(vec))
+        }
+    }
+    deserializer.deserialize_any(TableOrArray)
+}

--- a/sources/settings-extensions/container-registry/src/lib.rs
+++ b/sources/settings-extensions/container-registry/src/lib.rs
@@ -1,0 +1,129 @@
+/// The container-registry settings can be used to configure settings related to container
+/// registries, including credentials for logging into a registry, or mirrors to use when
+/// pulling from a registry.
+mod de;
+
+use crate::de::deserialize_mirrors;
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::{SingleLineString, Url, ValidBase64};
+use std::convert::Infallible;
+
+#[model(impl_default = true)]
+struct RegistryMirrorV1 {
+    registry: SingleLineString,
+    endpoint: Vec<Url>,
+}
+
+#[model(impl_default = true)]
+struct RegistryCredentialV1 {
+    registry: SingleLineString,
+    username: SingleLineString,
+    password: SingleLineString,
+    // This is the base64 encoding of "username:password"
+    auth: ValidBase64,
+    identitytoken: SingleLineString,
+}
+
+#[model(impl_default = true)]
+struct RegistrySettingsV1 {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_mirrors"
+    )]
+    mirrors: Vec<RegistryMirrorV1>,
+    #[serde(alias = "creds", default, skip_serializing_if = "Option::is_none")]
+    credentials: Vec<RegistryCredentialV1>,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for RegistrySettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(
+        _current_value: Option<Self>,
+        _target: Self,
+    ) -> std::result::Result<(), Self::ErrorKind> {
+        // Anything that correctly deserializes to RegistrySettingsV1 is ok
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(
+        _value: Self,
+        _validated_settings: Option<serde_json::Value>,
+    ) -> std::result::Result<(), Self::ErrorKind> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_container_registry_settings() {
+        assert_eq!(
+            RegistrySettingsV1::generate(None, None),
+            Ok(GenerateResult::Complete(RegistrySettingsV1 {
+                mirrors: None,
+                credentials: None,
+            }))
+        )
+    }
+
+    #[test]
+    fn test_serde_container_registry_with_mirrors() {
+        let test_json =
+            r#"{"mirrors": [{"registry": "foo", "endpoint": ["https://example.net"]}]}"#;
+
+        let container_registry: RegistrySettingsV1 = serde_json::from_str(test_json).unwrap();
+        let mirrors = container_registry.mirrors.unwrap();
+
+        assert_eq!(mirrors.len(), 1);
+        assert_eq!(
+            mirrors[0].registry.clone().unwrap(),
+            SingleLineString::try_from("foo").unwrap(),
+        );
+        assert_eq!(
+            mirrors[0].endpoint.clone().unwrap(),
+            vec!(Url::try_from("https://example.net").unwrap()),
+        );
+    }
+
+    #[test]
+    fn test_serde_container_registry_with_credentials() {
+        let test_json = r#"{"credentials": [{"registry": "foo", "auth": "Ym90dGxlcm9ja2V0"}]}"#;
+
+        let container_registry: RegistrySettingsV1 = serde_json::from_str(test_json).unwrap();
+        let credentials = container_registry.credentials.unwrap();
+
+        assert_eq!(credentials.len(), 1);
+        assert_eq!(
+            credentials[0].registry.clone().unwrap(),
+            SingleLineString::try_from("foo").unwrap(),
+        );
+        assert_eq!(
+            credentials[0].auth.clone().unwrap(),
+            ValidBase64::try_from("Ym90dGxlcm9ja2V0").unwrap(),
+        );
+        assert!(credentials[0].username.is_none());
+        assert!(credentials[0].password.is_none());
+        assert!(credentials[0].identitytoken.is_none());
+    }
+}

--- a/sources/settings-extensions/container-registry/src/main.rs
+++ b/sources/settings-extensions/container-registry/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_container_registry::RegistrySettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("container-registry")
+        .with_models(vec![BottlerocketSetting::<RegistrySettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/sources/settings-extensions/ntp/Cargo.toml
+++ b/sources/settings-extensions/ntp/Cargo.toml
@@ -15,5 +15,5 @@ serde_json = "1"
 
 [dependencies.bottlerocket-settings-sdk]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-sdk-v0.1.0-alpha.1"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
 version = "0.1.0-alpha"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** 

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/3658

**Description of changes:**

Ports `container-registry` settings to a settings extension. Creates a basic binary for the extension and a package that can install it.

**Testing done:**

- built `aws-dev` variant with the `settings-container-registry` package included
- checked that the expected defaults (none in this case) were set
- made changes to the setting with `apiclient set -j '{"container-registry": {"mirrors": [{"registry": "foo", "endpoint": ["bar"]}]}'`
- validated that the settings extension binary at `/usr/libexec/settings/container-registry` worked as expected

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
