### PR TITLE
packages: update CGO_LDFLAGS for NVIDIA Go packages

### DIFF
--- a/packages/ecs-gpu-init/ecs-gpu-init.spec
+++ b/packages/ecs-gpu-init/ecs-gpu-init.spec
@@ -21,7 +21,7 @@ cp -r %{_builddir}/sources/%{workspace_name}/* .
 %set_cross_go_flags
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host
-export CGO_LDFLAGS="-Wl,-z,relro"
+export CGO_LDFLAGS="-Wl,-z,relro,-export-dynamic"
 go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o ecs-gpu-init ./cmd/ecs-gpu-init
 
 %install

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -27,7 +27,7 @@ BuildRequires: %{_cross_os}glibc-devel
 %cross_go_configure %{goimport}
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host
-export CGO_LDFLAGS="-Wl,-z,relro"
+export CGO_LDFLAGS="-Wl,-z,relro,-export-dynamic"
 go build -ldflags="${GOLDFLAGS}" -o nvidia-device-plugin ./cmd/nvidia-device-plugin/
 
 %install


### PR DESCRIPTION
**Description of changes:**
The way that Go 1.21 builds dynamicaly linked binaries changed from 1.20 and before. This doesn't export all the symbols and can result in a panic when dynamically loaded. Adding in -export-dynamic to the CGO_FLAGS tells the compiler to export all the symbols which provides the needed lookups for these binaries.

**Testing done:**
I used the SDK and toolchain versions 0.36.0 which has the Go 1.21.5 SDK. These result in images that boot properly.

Before the change it fails to boot:
```
....
[  OK  ] Finished Applies settings to create config files.
[  OK  ] Started Send signal to CloudFormation Stack.
         Starting Sets the hostname...
[  OK  ] Finished Sets the hostname.
[   23.120577] 
[  OK  ] Finished Load additional kernel modules.
         Starting Initialize ECS GPU config...
[   23.255503] ecs-gpu-init[1712]: /usr/bin/ecs-gpu-init: error while loading shared libraries: unexpected PLT reloc type 0x00
[FAILED] Failed to start Initialize ECS GPU config.
See 'systemctl status ecs-gpu-init.service' for details.
[DEPEND] Dependency failed for Bottlerocket initial configuration complete.
[DEPEND] Dependency failed for Isolates configured.target.
```

After the change boot succeeds and the gpu smoke tests pass:
```
....
[  OK  ] Reached target Remote File Systems.
         Starting containerd container runtime...
[  OK  ] Started Host container: control.
         Starting Load Kernel Module drm...
         Starting Reboot system if needed fo…guration changes to take effect...
         Starting Send boot success...
[  OK  ] Started containerd container runtime.
[  OK  ] Finished Load Kernel Module drm.
[  OK  ] Finished Reboot system if needed fo…figuration changes to take effect.
         Starting docker engine...
         Starting User Login Management...
[  OK  ] Finished Isolates multi-user.target.
[  OK  ] Started User Login Management.
[  OK  ] Finished Send boot success.
[  OK  ] Started docker engine.
         Starting Amazon Elastic Container Service - container agent...
[  OK  ] Started Amazon Elastic Container Service - container agent.
[  OK  ] Reached target Multi-User System.
```
Test results for an `aws-ecs-2-nvidia` build I did with these changes:
```
=========================================
--
Running sample UnifiedMemoryPerf
=========================================
GPU Device 0: "Turing" with compute capability 7.5
Running ........................................................
Overall Time For matrixMultiplyPerf
Printing Average of 20 measurements in (ms)
Size_KB	 UMhint	UMhntAs	 UMeasy	  0Copy	MemCopy	CpAsync	CpHpglk	CpPglAs
4	  0.155	  0.181	  0.322	  0.017	  0.034	  0.029	  0.036	  0.028
16	  0.177	  0.210	  0.430	  0.041	  0.063	  0.054	  0.065	  0.058
64	  0.314	  0.338	  0.816	  0.134	  0.173	  0.159	  0.134	  0.127
256	  0.837	  0.785	  1.384	  0.756	  0.618	  0.580	  0.478	  0.473
1024	  3.342	  3.259	  4.291	  5.223	  2.531	  2.322	  1.925	  1.909
4096	 13.061	 14.214	 14.973	 36.177	 10.520	 10.547	  9.580	  9.691
16384	 58.133	 60.597	 67.500	317.627	 49.452	 49.358	 46.741	 46.709
NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
=========================================
Running sample deviceQuery
=========================================
./deviceQuery Starting...
CUDA Device Query (Runtime API) version (CUDART static linking)
Detected 1 CUDA Capable device(s)
Device 0: "Tesla T4"
CUDA Driver Version / Runtime Version          12.2 / 11.4
CUDA Capability Major/Minor version number:    7.5
Total amount of global memory:                 14931 MBytes (15655829504 bytes)
(040) Multiprocessors, (064) CUDA Cores/MP:    2560 CUDA Cores
GPU Max Clock rate:                            1590 MHz (1.59 GHz)
Memory Clock rate:                             5001 Mhz
Memory Bus Width:                              256-bit
L2 Cache Size:                                 4194304 bytes
Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
Total amount of constant memory:               65536 bytes
Total amount of shared memory per block:       49152 bytes
Total shared memory per multiprocessor:        65536 bytes
Total number of registers available per block: 65536
Warp size:                                     32
Maximum number of threads per multiprocessor:  1024
Maximum number of threads per block:           1024
Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
Maximum memory pitch:                          2147483647 bytes
Texture alignment:                             512 bytes
Concurrent copy and kernel execution:          Yes with 3 copy engine(s)
Run time limit on kernels:                     No
Integrated GPU sharing Host Memory:            No
Support host page-locked memory mapping:       Yes
Alignment requirement for Surfaces:            Yes
Device has ECC support:                        Enabled
Device supports Unified Addressing (UVA):      Yes
Device supports Managed Memory:                Yes
Device supports Compute Preemption:            Yes
Supports Cooperative Kernel Launch:            Yes
Supports MultiDevice Co-op Kernel Launch:      Yes
Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 30
Compute Mode:
< Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >
deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS
=========================================
Running sample globalToShmemAsyncCopy
=========================================
[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Turing" with compute capability 7.5
MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 322.35 GFlop/s, Time= 13.012 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS
NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
=========================================
Running sample immaTensorCoreGemm
=========================================
Initializing...
GPU Device 0: "Turing" with compute capability 7.5
M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 4.001376 ms
TOPS: 34.35
=========================================
Running sample reductionMultiBlockCG
=========================================
reductionMultiBlockCG Starting...
GPU Device 0: "Turing" with compute capability 7.5
33554432 elements
numThreads: 1024
numBlocks: 40
Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 1.440640 ms
Bandwidth:    93.165358 GB/s
GPU result = 1.992401361465
CPU result = 1.992401361465
=========================================
Running sample shfl_scan
=========================================
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5
> Detected Compute SM 7.5 hardware with 40 multi-processors
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5
> Detected Compute SM 7.5 hardware with 40 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.039456
65536 elements scanned in 0.039456 ms -> 1660.989624 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.030530 ms
Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.051712 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.138880 ms
CheckSum: 2073600, (expect 1920x1080=2073600)
=========================================
Running sample simpleAWBarrier
=========================================
./simpleAWBarrier starting...
GPU Device 0: "Turing" with compute capability 7.5
Launching normVecByDotProductAWBarrier kernel with numBlocks = 40 blockSize = 1024
Result = PASSED
./simpleAWBarrier completed, returned OK
=========================================
Running sample simpleAtomicIntrinsics
=========================================
simpleAtomicIntrinsics starting...
GPU Device 0: "Turing" with compute capability 7.5
Processing time: 175.352997 (ms)
simpleAtomicIntrinsics completed, returned OK
=========================================
Running sample simpleVoteIntrinsics
=========================================
[simpleVoteIntrinsics]
GPU Device 0: "Turing" with compute capability 7.5
> GPU device has 40 Multi-Processors, SM 7.5 compute capabilities
[VOTE Kernel Test 1/3]
Running <<Vote.Any>> kernel1 ...
OK
[VOTE Kernel Test 2/3]
Running <<Vote.All>> kernel2 ...
OK
[VOTE Kernel Test 3/3]
Running <<Vote.Any>> kernel3 ...
OK
Shutting down...
=========================================
Running sample vectorAdd
=========================================
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
=========================================
Running sample warpAggregatedAtomicsCG
=========================================
GPU Device 0: "Turing" with compute capability 7.5
CPU max matches GPU max
Warp Aggregated Atomics PASSED


```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
