### PR TITLE
kernel: Update to latest versions for series 6.1

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/64195460250d20bac796e24a69da55beb4bdd09fb3ed41f8d4c9ef984bd35f7c/kernel-6.1.61-85.141.amzn2023.src.rpm"
-sha512 = "94871ce78edf9475b3e4ccef44292172dc4a59f7cf00e0c765b5be4688d7c8e46fdd2a6152cc6006c9f191fcbc1377e3a40dd81896dc9971741c814bbf36799f"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/5880ce1298c2bb541461845a29b2787036b8d18aff0f0bc308117a5f9990057e/kernel-6.1.66-91.160.amzn2023.src.rpm"
+sha512 = "4a2b52e6fc8045a5bdf3f7a4a8080623206352e2921d9cf899e367c9102a806dc1135985863cb5efc43c4a757971404e88abdea9c78dcb55cb64e204f97dc232"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.61
+Version: 6.1.66
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/64195460250d20bac796e24a69da55beb4bdd09fb3ed41f8d4c9ef984bd35f7c/kernel-6.1.61-85.141.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/5880ce1298c2bb541461845a29b2787036b8d18aff0f0bc308117a5f9990057e/kernel-6.1.66-91.160.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                              STATUS   ROLES    AGE   VERSION               INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-80-245.eu-central-1.compute.internal   Ready    <none>   38s   v1.28.4-eks-d91a302   192.168.80.245   3.69.250.7    Bottlerocket OS 1.17.0 (aws-k8s-1.28)   6.1.66           containerd://1.6.25+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
14:33:58             e2e                                            global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
14:33:58    systemd-logs   ip-192-168-80-245.eu-central-1.compute.internal   complete   passed                                        
14:33:58 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.28-diff:         0 removed,   0 added,   2 changed
config-x86_64-aws-k8s-1.28-diff:          4 removed,   1 added,   6 changed
config-x86_64-metal-k8s-1.28-diff:        4 removed,   1 added,   6 changed
config-x86_64-vmware-k8s-1.28-diff:       4 removed,   1 added,   6 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/foersleo/fc86502ea0b118b19ac32e862c21c3d4).

The changes to the configs are:

* Bumping the number of CPUs that can be handled by the kernels. This is done by AL in order to enable environments with more than the previously set 512 possible CPUs (e.g. the new high-memory instance types announced at re:invent with 896 vCPUs). Same was picked up for 5.15 kernels in https://github.com/bottlerocket-os/bottlerocket/pull/3643
* Removal of not needed DRM drivers for virtual box and some drm helpers, pulling in only the necessary helpers through `DRM_SIMPLEDRM`, as we already do since https://github.com/bottlerocket-os/bottlerocket/pull/3203

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license