### PR TITLE
settings: add updates settings extension

### DIFF
--- a/packages/settings-updates/Cargo.toml
+++ b/packages/settings-updates/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-updates"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/updates"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-updates/settings-updates.spec
+++ b/packages/settings-updates/settings-updates.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name updates
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1044,8 +1044,8 @@ dependencies = [
 name = "bork"
 version = "0.1.0"
 dependencies = [
- "rand",
  "serde_json",
+ "settings-extension-updates",
 ]
 
 [[package]]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2617,6 +2617,7 @@ dependencies = [
  "settings-extension-container-registry",
  "settings-extension-motd",
  "settings-extension-ntp",
+ "settings-extension-updates",
  "toml 0.5.11",
 ]
 

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3618,6 +3618,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-updates"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "rand",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "settings-extensions/motd",
     "settings-extensions/ntp",
     "settings-extensions/container-registry",
+    "settings-extensions/updates",
 
     "parse-datetime",
 

--- a/sources/api/bork/Cargo.toml
+++ b/sources/api/bork/Cargo.toml
@@ -9,5 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-rand = "0.8"
 serde_json = "1"
+
+# generation logic moved to updates settings extension
+settings-extension-updates = { path = "../../settings-extensions/updates", version = "0.1" }

--- a/sources/api/bork/src/main.rs
+++ b/sources/api/bork/src/main.rs
@@ -1,8 +1,5 @@
-use rand::{thread_rng, Rng};
-
 fn main() {
-    let mut rng = thread_rng();
-    let val = rng.gen_range(0..2048);
+    let val = settings_extension_updates::generate::generate_seed();
 
     // sundog expects JSON-serialized output so that many types can be represented, allowing the
     // API model to use more accurate types.

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.5"
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
+settings-extension-updates = { path = "../settings-extensions/updates", version = "0.1" }
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
     HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
-    UpdatesSettings,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +12,7 @@ use modeled_types::Identifier;
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
     motd: settings_extension_motd::MotdV1,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
     ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate, UpdatesSettings,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
     motd: settings_extension_motd::MotdV1,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
     ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate, UpdatesSettings,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
     motd: settings_extension_motd::MotdV1,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
     motd: settings_extension_motd::MotdV1,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
     motd: settings_extension_motd::MotdV1,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.28-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/aws-k8s-1.28/mod.rs
+++ b/sources/models/src/aws-k8s-1.28/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, OciHooks, PemCertificate, UpdatesSettings,
+    NetworkSettings, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -12,7 +12,7 @@ use modeled_types::Identifier;
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
     motd: settings_extension_motd::MotdV1,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/metal-k8s-1.28/mod.rs
+++ b/sources/models/src/metal-k8s-1.28/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, OciHooks, PemCertificate, UpdatesSettings,
+    NetworkSettings, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -12,7 +12,7 @@ use modeled_types::Identifier;
 #[model(rename = "settings", impl_default = true)]
 struct Settings {
     motd: settings_extension_motd::MotdV1,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/models/src/vmware-k8s-1.28/mod.rs
+++ b/sources/models/src/vmware-k8s-1.28/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
     HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate, UpdatesSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
-    updates: UpdatesSettings,
+    updates: settings_extension_updates::UpdatesSettingsV1,
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,

--- a/sources/settings-extensions/updates/Cargo.toml
+++ b/sources/settings-extensions/updates/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "settings-extension-updates"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/updates/src/generate.rs
+++ b/sources/settings-extensions/updates/src/generate.rs
@@ -1,0 +1,7 @@
+/// Generators for updates settings.
+use rand::{thread_rng, Rng};
+
+pub fn generate_seed() -> u32 {
+    let mut rng = thread_rng();
+    rng.gen_range(0..2048)
+}

--- a/sources/settings-extensions/updates/src/lib.rs
+++ b/sources/settings-extensions/updates/src/lib.rs
@@ -1,0 +1,94 @@
+/// The updates settings can be used to configure settings related to updates, e.g. the
+/// seed that determines in which wave the instance will update, etc.
+pub mod generate;
+
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::{FriendlyVersion, Url};
+use std::convert::Infallible;
+
+#[model(impl_default = true)]
+pub struct UpdatesSettingsV1 {
+    metadata_base_url: Url,
+    targets_base_url: Url,
+    seed: u32,
+    // Version to update to when updating via the API.
+    version_lock: FriendlyVersion,
+    ignore_waves: bool,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for UpdatesSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // allow anything that parses as UpdatesSettingsV1
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        let partial = existing_partial.unwrap_or_default();
+
+        Ok(GenerateResult::Complete(UpdatesSettingsV1 {
+            seed: Some(partial.seed.unwrap_or_else(generate::generate_seed)),
+            ..partial
+        }))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_updates() {
+        if let GenerateResult::Complete(generated_settings) =
+            UpdatesSettingsV1::generate(None, None).unwrap()
+        {
+            assert!(generated_settings.seed.unwrap() < 2048);
+            assert!(generated_settings.metadata_base_url.is_none());
+            assert!(generated_settings.targets_base_url.is_none());
+            assert!(generated_settings.version_lock.is_none());
+            assert!(generated_settings.ignore_waves.is_none());
+        } else {
+            panic!("generate() should return GenerateResult::Complete")
+        }
+    }
+
+    #[test]
+    fn test_serde_updates() {
+        let test_json = r#"{
+            "metadata-base-url": "https://example.net",
+            "targets-base-url": "https://example.net",
+            "seed": 1,
+            "version-lock": "latest",
+            "ignore-waves": false
+        }"#;
+
+        let updates: UpdatesSettingsV1 = serde_json::from_str(test_json).unwrap();
+
+        assert_eq!(
+            updates,
+            UpdatesSettingsV1 {
+                metadata_base_url: Some(Url::try_from("https://example.net").unwrap()),
+                targets_base_url: Some(Url::try_from("https://example.net").unwrap()),
+                seed: Some(1),
+                version_lock: Some(FriendlyVersion::try_from("latest").unwrap()),
+                ignore_waves: Some(false),
+            }
+        );
+    }
+}

--- a/sources/settings-extensions/updates/src/main.rs
+++ b/sources/settings-extensions/updates/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_updates::UpdatesSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("updates")
+        .with_models(vec![BottlerocketSetting::<UpdatesSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/sources/settings-extensions/updates/updates.toml
+++ b/sources/settings-extensions/updates/updates.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket/issues/3649

**Description of changes:**

Adds an settings extension for updates settings

**Testing done:**

- Built aws-dev with the settings extension package included, spun up an ec2 instance with the resulting AMI.

- Updates settings (including the seed generated by `bork`) looked as expected

- `/usr/libexec/settings/updates` worked as expected:

```
bash-5.1# /usr/libexec/settings/updates proto1 generate --setting-version v1
{
  "Complete": {
    "seed": 722
  }
}
bash-5.1# /usr/libexec/settings/updates proto1 set --setting-version v1 --value '{"seed": 24, "ignore-waves": true}'

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
