### PR TITLE
k8s: update eni-max-pods mapping for latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
       - '**.tpl'
       # Sample config files and OpenAPI docs
       - '**.yaml'
+      # Other files that don't affect the build
+      - 'packages/os/eni-max-pods'
 
 concurrency:
   group: ${{ github.ref }}

--- a/packages/os/eni-max-pods
+++ b/packages/os/eni-max-pods
@@ -212,6 +212,8 @@ c7i.48xlarge 737
 c7i.4xlarge 234
 c7i.8xlarge 234
 c7i.large 29
+c7i.metal-24xl 737
+c7i.metal-48xl 737
 c7i.xlarge 58
 cr1.8xlarge 234
 d2.2xlarge 58
@@ -229,6 +231,7 @@ d3en.6xlarge 58
 d3en.8xlarge 78
 d3en.xlarge 10
 dl1.24xlarge 737
+dl2q.24xlarge 737
 f1.16xlarge 394
 f1.2xlarge 58
 f1.4xlarge 234
@@ -301,7 +304,9 @@ i4g.4xlarge 234
 i4g.8xlarge 234
 i4g.large 29
 i4g.xlarge 58
+i4i.12xlarge 234
 i4i.16xlarge 737
+i4i.24xlarge 437
 i4i.2xlarge 58
 i4i.32xlarge 737
 i4i.4xlarge 234
@@ -516,8 +521,11 @@ m7i.48xlarge 737
 m7i.4xlarge 234
 m7i.8xlarge 234
 m7i.large 29
+m7i.metal-24xl 737
+m7i.metal-48xl 737
 m7i.xlarge 58
 mac1.metal 234
+mac2-m2.metal 234
 mac2-m2pro.metal 234
 mac2.metal 234
 p2.16xlarge 234
@@ -708,6 +716,8 @@ r7i.48xlarge 737
 r7i.4xlarge 234
 r7i.8xlarge 234
 r7i.large 29
+r7i.metal-24xl 737
+r7i.metal-48xl 737
 r7i.xlarge 58
 r7iz.12xlarge 234
 r7iz.16xlarge 737
@@ -716,6 +726,8 @@ r7iz.32xlarge 737
 r7iz.4xlarge 234
 r7iz.8xlarge 234
 r7iz.large 29
+r7iz.metal-16xl 737
+r7iz.metal-32xl 737
 r7iz.xlarge 58
 t1.micro 4
 t2.2xlarge 44


### PR DESCRIPTION
**Issue number:**

Closes #3694

**Description of changes:**

This pulls in the new instance types to the eni-max-pods mapping file. It adds the max pod values for a new set of published instance types.

Generated content by using the [update script](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/gen_vpc_ip_limits.go).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
