### PR TITLE
README: add additional commentary on data volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,9 @@ Bottlerocket operates with two default storage volumes.
 * The root device, holds the active and passive [partition sets](#updates-1).
   It also contains the bootloader, the dm-verity hash tree for verifying the [immutable root filesystem](SECURITY_FEATURES.md#immutable-rootfs-backed-by-dm-verity), and the data store for the Bottlerocket API.
 * The data device is used as persistent storage for container images, container orchestration, [host-containers](#Custom-host-containers), and [bootstrap containers](#Bootstrap-containers-settings).
+  The operating system does not typically make changes to this volume during regular updates, though changes to upstream software such as containerd or kubelet could result in changes to their stored data.
+  This device (mounted to `/local` on the host) can be used for application storage for orchestrated workloads; however, we recommend using an additional volume if possible for such cases.
+  See [this section of the Security Guidance documentation](./SECURITY_GUIDANCE.md#limit-access-to-system-mounts) for more information.
 
 On boot Bottlerocket will increase the data partition size to use all of the data device.
 If you increase the size of the device, you can reboot Bottlerocket to extend the data partition.


### PR DESCRIPTION
**Description of changes:**
This updates the README to add additional clarification on usage Bottlerocket's data volume.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
