### PR TITLE
kernel-6.1: cherry-pick fix for creating kprobes using unqualified names

### DIFF
--- a/packages/kernel-6.1/5001-kallsyms-Make-module_kallsyms_on_each_symbol-general.patch
+++ b/packages/kernel-6.1/5001-kallsyms-Make-module_kallsyms_on_each_symbol-general.patch
@@ -1,0 +1,68 @@
+From beb3f3e7170b7ee99803d941a07a9a249e381fa6 Mon Sep 17 00:00:00 2001
+From: Jiri Olsa <jolsa@kernel.org>
+Date: Tue, 25 Oct 2022 15:41:41 +0200
+Subject: [PATCH] kallsyms: Make module_kallsyms_on_each_symbol generally
+ available
+
+commit 73feb8d5fa3b755bb51077c0aabfb6aa556fd498 upstream.
+
+Making module_kallsyms_on_each_symbol generally available, so it
+can be used outside CONFIG_LIVEPATCH option in following changes.
+
+Rather than adding another ifdef option let's make the function
+generally available (when CONFIG_KALLSYMS and CONFIG_MODULES
+options are defined).
+
+Cc: Christoph Hellwig <hch@lst.de>
+Acked-by: Song Liu <song@kernel.org>
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Link: https://lore.kernel.org/r/20221025134148.3300700-2-jolsa@kernel.org
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ include/linux/module.h   | 9 +++++++++
+ kernel/module/kallsyms.c | 2 --
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/include/linux/module.h b/include/linux/module.h
+index ec61fb53979a9..35876e89eb93f 100644
+--- a/include/linux/module.h
++++ b/include/linux/module.h
+@@ -879,8 +879,17 @@ static inline bool module_sig_ok(struct module *module)
+ }
+ #endif	/* CONFIG_MODULE_SIG */
+ 
++#if defined(CONFIG_MODULES) && defined(CONFIG_KALLSYMS)
+ int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
+ 					     struct module *, unsigned long),
+ 				   void *data);
++#else
++static inline int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
++						 struct module *, unsigned long),
++						 void *data)
++{
++	return -EOPNOTSUPP;
++}
++#endif  /* CONFIG_MODULES && CONFIG_KALLSYMS */
+ 
+ #endif /* _LINUX_MODULE_H */
+diff --git a/kernel/module/kallsyms.c b/kernel/module/kallsyms.c
+index f5c5c9175333d..4523f99b03589 100644
+--- a/kernel/module/kallsyms.c
++++ b/kernel/module/kallsyms.c
+@@ -494,7 +494,6 @@ unsigned long module_kallsyms_lookup_name(const char *name)
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_LIVEPATCH
+ int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
+ 					     struct module *, unsigned long),
+ 				   void *data)
+@@ -531,4 +530,3 @@ int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
+ 	mutex_unlock(&module_mutex);
+ 	return ret;
+ }
+-#endif /* CONFIG_LIVEPATCH */
+-- 
+2.25.1
+

--- a/packages/kernel-6.1/5002-tracing-kprobes-Fix-symbol-counting-logic-by-looking.patch
+++ b/packages/kernel-6.1/5002-tracing-kprobes-Fix-symbol-counting-logic-by-looking.patch
@@ -1,0 +1,75 @@
+From abbcb10d6691e6f98838753c216c92ecd560a59a Mon Sep 17 00:00:00 2001
+From: Andrii Nakryiko <andrii@kernel.org>
+Date: Fri, 27 Oct 2023 16:31:26 -0700
+Subject: [PATCH] tracing/kprobes: Fix symbol counting logic by looking at
+ modules as well
+
+commit 926fe783c8a64b33997fec405cf1af3e61aed441 upstream.
+
+Recent changes to count number of matching symbols when creating
+a kprobe event failed to take into account kernel modules. As such, it
+breaks kprobes on kernel module symbols, by assuming there is no match.
+
+Fix this my calling module_kallsyms_on_each_symbol() in addition to
+kallsyms_on_each_match_symbol() to perform a proper counting.
+
+Link: https://lore.kernel.org/all/20231027233126.2073148-1-andrii@kernel.org/
+
+Cc: Francis Laniel <flaniel@linux.microsoft.com>
+Cc: stable@vger.kernel.org
+Cc: Masami Hiramatsu <mhiramat@kernel.org>
+Cc: Steven Rostedt <rostedt@goodmis.org>
+Fixes: b022f0c7e404 ("tracing/kprobes: Return EADDRNOTAVAIL when func matches several symbols")
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Song Liu <song@kernel.org>
+Signed-off-by: Masami Hiramatsu (Google) <mhiramat@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Hao Wei Tee <angelsl@in04.sg>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ kernel/trace/trace_kprobe.c | 25 +++++++++++++++++++++----
+ 1 file changed, 21 insertions(+), 4 deletions(-)
+
+diff --git a/kernel/trace/trace_kprobe.c b/kernel/trace/trace_kprobe.c
+index a34a4fcdab7b1..e3993d19687db 100644
+--- a/kernel/trace/trace_kprobe.c
++++ b/kernel/trace/trace_kprobe.c
+@@ -714,14 +714,31 @@ static int count_symbols(void *data, unsigned long unused)
+ 	return 0;
+ }
+ 
++struct sym_count_ctx {
++	unsigned int count;
++	const char *name;
++};
++
++static int count_mod_symbols(void *data, const char *name,
++			     struct module *module, unsigned long unused)
++{
++	struct sym_count_ctx *ctx = data;
++
++	if (strcmp(name, ctx->name) == 0)
++		ctx->count++;
++
++	return 0;
++}
++
+ static unsigned int number_of_same_symbols(char *func_name)
+ {
+-	unsigned int count;
++	struct sym_count_ctx ctx = { .count = 0, .name = func_name };
++
++	kallsyms_on_each_match_symbol(count_symbols, func_name, &ctx.count);
+ 
+-	count = 0;
+-	kallsyms_on_each_match_symbol(count_symbols, func_name, &count);
++	module_kallsyms_on_each_symbol(count_mod_symbols, &ctx);
+ 
+-	return count;
++	return ctx.count;
+ }
+ 
+ static int __trace_kprobe_create(int argc, const char *argv[])
+-- 
+2.25.1
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -25,6 +25,10 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 # options for nvidia are instead included through DRM_SIMPLE
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 
+# Cherry-pick fix for #3691. Can be dropped after rebasing to 6.1.71 or later.
+Patch5001: 5001-kallsyms-Make-module_kallsyms_on_each_symbol-general.patch
+Patch5002: 5002-tracing-kprobes-Fix-symbol-counting-logic-by-looking.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname


### PR DESCRIPTION
**Issue number:**

Closes #3691

**Description of changes:** Commit b022f0c7e404 ("tracing/kprobes: Return EADDRNOTAVAIL when func matches several symbols") in the upstream kernel introduced a regression where kprobes cannot be created on functions residing in loadable modules if the probe location is identified by an unqualified function name.

The faulty commit was backported e.g. to kernel 6.1.60. The backported fix is on track to be released in kernel 6.1.71. Cherry-pick the fix until 6.1.71 is released and our upstream catches up to it.

While the faulty commit was backported to the 5.15 series as well, the backport has not hit our upstream yet. There is nothing to be done for our other kernel packages (but to be vigilant about not picking up a release with the faulty backport in the near future).

**Testing done:** On the host:

```
bash-5.2# cd /sys/kernel/debug/tracing/
bash-5.2# echo 'p nf_nat_packet' >kprobe_events 
bash-5.2# cat kprobe_events
p:kprobes/p_nf_nat_packet_0 nf_nat_packet
```

The probe has been successfully created even though the name is unqualified and the probed function resides in a loadable module. Creating the kprobe (line 2) previously failed during symbol lookup (see #3691).


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
