### PR TITLE
Fine-tune the Ordering for the atomic usages

### DIFF
--- a/sources/api/apiclient/src/exec.rs
+++ b/sources/api/apiclient/src/exec.rs
@@ -306,10 +306,10 @@ impl ReadFromServer {
                                     );
                                     capacity
                                         .max_messages_outstanding
-                                        .store(new.max_messages_outstanding, Ordering::SeqCst);
+                                        .store(new.max_messages_outstanding, Ordering::Relaxed);
                                     capacity
                                         .messages_written
-                                        .store(new.messages_written, Ordering::SeqCst);
+                                        .store(new.messages_written, Ordering::Relaxed);
                                 }
                             }
                         }
@@ -473,8 +473,8 @@ impl ReadFromUser {
     fn wait_for_capacity(messages_read: u64, capacity: &Arc<AtomicCapacity>) -> Result<()> {
         let mut waited = 0u64;
         loop {
-            let max_outstanding = capacity.max_messages_outstanding.load(Ordering::SeqCst);
-            let messages_written = capacity.messages_written.load(Ordering::SeqCst);
+            let max_outstanding = capacity.max_messages_outstanding.load(Ordering::Relaxed);
+            let messages_written = capacity.messages_written.load(Ordering::Relaxed);
 
             // Check how many messages are currently waiting to be written; read - written.
             // If the server has written more than we've read, something is quite wrong!


### PR DESCRIPTION
https://github.com/bottlerocket-os/bottlerocket/blob/147a019a57f3575b04669277da033c5b0c67b30e/sources/api/apiclient/src/exec.rs#L307-L311
https://github.com/bottlerocket-os/bottlerocket/blob/147a019a57f3575b04669277da033c5b0c67b30e/sources/api/apiclient/src/exec.rs#L476-L477

Here, `max_messages_outstanding` and `messages_written` are simply used as markers in a multithreaded context and do not synchronize with other locals. Therefore, I think using `Relaxed` ordering should be adequate to ensure the program's correctness.