### PR TITLE
Update host containers for v1.18.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -256,4 +256,6 @@ version = "1.18.0"
     "migrate_v1.17.0_public-control-container-v0-7-6.lz4",
 ]
 "(1.17.0, 1.18.0)" = [
+    "migrate_v1.18.0_aws-admin-container-v0-11-3.lz4",
+    "migrate_v1.18.0_public-admin-container-v0-11-3.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -258,4 +258,6 @@ version = "1.18.0"
 "(1.17.0, 1.18.0)" = [
     "migrate_v1.18.0_aws-admin-container-v0-11-3.lz4",
     "migrate_v1.18.0_public-admin-container-v0-11-3.lz4",
+    "migrate_v1.18.0_aws-control-container-v0-7-7.lz4",
+    "migrate_v1.18.0_public-control-container-v0-7-7.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -592,6 +592,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-7"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +3128,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-6"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-7"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -534,6 +534,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-config"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,6 +3093,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-2"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-3"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -54,6 +54,8 @@ members = [
     "api/migration/migrations/v1.17.0/public-control-container-v0-7-6",
     "api/migration/migrations/v1.18.0/aws-admin-container-v0-11-3",
     "api/migration/migrations/v1.18.0/public-admin-container-v0-11-3",
+    "api/migration/migrations/v1.18.0/aws-control-container-v0-7-7",
+    "api/migration/migrations/v1.18.0/public-control-container-v0-7-7",
 
     "bloodhound",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -52,6 +52,8 @@ members = [
     "api/migration/migrations/v1.17.0/public-admin-container-v0-11-2",
     "api/migration/migrations/v1.17.0/aws-control-container-v0-7-6",
     "api/migration/migrations/v1.17.0/public-control-container-v0-7-6",
+    "api/migration/migrations/v1.18.0/aws-admin-container-v0-11-3",
+    "api/migration/migrations/v1.18.0/public-admin-container-v0-11-3",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.18.0/aws-admin-container-v0-11-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.18.0/aws-admin-container-v0-11-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-admin-container-v0-11-3"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.18.0/aws-admin-container-v0-11-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.18.0/aws-admin-container-v0-11-3/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.2'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.3'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.18.0/aws-control-container-v0-7-7/Cargo.toml
+++ b/sources/api/migration/migrations/v1.18.0/aws-control-container-v0-7-7/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aws-control-container-v0-7-7"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.18.0/aws-control-container-v0-7-7/src/main.rs
+++ b/sources/api/migration/migrations/v1.18.0/aws-control-container-v0-7-7/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.6'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.7'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.18.0/public-admin-container-v0-11-3/Cargo.toml
+++ b/sources/api/migration/migrations/v1.18.0/public-admin-container-v0-11-3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-admin-container-v0-11-3"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.18.0/public-admin-container-v0-11-3/src/main.rs
+++ b/sources/api/migration/migrations/v1.18.0/public-admin-container-v0-11-3/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.2";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.3";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.18.0/public-control-container-v0-7-7/Cargo.toml
+++ b/sources/api/migration/migrations/v1.18.0/public-control-container-v0-7-7/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "public-control-container-v0-7-7"
+version = "0.1.0"
+authors = ["Markus Boehme <markubo@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.18.0/public-control-container-v0-7-7/src/main.rs
+++ b/sources/api/migration/migrations/v1.18.0/public-control-container-v0-7-7/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.6";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.7";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.6'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.7'"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.2'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.3'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.2"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.3"
 
 [settings.host-containers.control]
 enabled = false

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.3"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.6"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.7"


### PR DESCRIPTION
**Issue number:**

Closes #3693 

**Description of changes:**

Update the admin and control host containers to the recently released version v0.11.3 and v0.7.7, respectively. Add migrations to point host container source settings to those new images for images that are upgraded in-place.

**Testing done:** Using a c6g.large (aarch64) EC2 instance with the aws-k8s-1.28 variant, I successfully tested the following scenarios:

* Bottlerocket v1.17.0 can be upgraded into Bottlerocket v1.18.0 and will use the new host container images.
* A system upgraded that way can be rolled back to Bottlerocket v1.17.0 and revert to using the old host container images.
* A freshly booted Bottlerocket v1.18.0 uses the new host container images.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
