### PR TITLE
certdog: change certdog to parse generated certdog.toml file

### DIFF
--- a/packages/os/certdog-toml
+++ b/packages/os/certdog-toml
@@ -1,0 +1,11 @@
+[required-extensions]
+std = { version = "v1", helpers = ["default"]}
+pki = "v1"
++++
+{{#if settings.pki}}
+{{#each settings.pki}}
+[{{@key}}]
+trusted = {{this.trusted}}
+data = "{{this.data}}"
+{{/each}}
+{{/if}}

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -55,6 +55,7 @@ Source121: disable-udp-offload.service
 Source122: has-boot-ever-succeeded.service
 Source123: run-netdog.mount
 Source124: write-network-status.service
+Source125: certdog-toml
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -472,7 +473,7 @@ install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:125} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
@@ -684,6 +685,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
 %files -n %{_cross_os}certdog
 %{_cross_bindir}/certdog
+%{_cross_templatedir}/certdog-toml
 
 %files -n %{_cross_os}bootstrap-containers
 %{_cross_bindir}/bootstrap-containers

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1227,6 +1227,7 @@ dependencies = [
  "snafu",
  "tempfile",
  "tokio",
+ "toml 0.8.8",
  "x509-parser",
 ]
 

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
 tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
+toml = "0.8"
 x509-parser = "0.15"
 
 [dev-dependencies]

--- a/sources/api/certdog/src/main.rs
+++ b/sources/api/certdog/src/main.rs
@@ -19,7 +19,10 @@ use std::path::Path;
 use std::process;
 
 use model::modeled_types::Identifier;
+use model::PemCertificate;
 
+// Default location of the config file
+const DEFAULT_CONFIG_FILE: &str = "/etc/certdog.toml";
 // Read from the source in `/usr/share/factory` not the copy in `/etc`
 const DEFAULT_SOURCE_BUNDLE: &str = "/usr/share/factory/etc/pki/tls/certs/ca-bundle.crt";
 // This file is first created with tmpfilesd configurations
@@ -36,9 +39,9 @@ struct Args {
     #[argh(option, default = "LevelFilter::Info", short = 'l')]
     /// log-level trace|debug|info|warn|error
     log_level: LevelFilter,
-    #[argh(option, default = "constants::API_SOCKET.to_string()", short = 's')]
-    /// socket-path path to apiserver socket
-    socket_path: String,
+    #[argh(option, default = "DEFAULT_CONFIG_FILE.to_string()", short = 'c')]
+    /// config-path path to apiserver socket
+    config_path: String,
     #[argh(option, default = "DEFAULT_TRUSTED_STORE.to_string()", short = 't')]
     /// trusted-store path to the trusted store
     trusted_store: String,
@@ -54,29 +57,26 @@ struct CertBundle {
 
 /// Query the API for the certificate bundles, returns a tuple with trusted
 /// and distrusted PEM certificates
-async fn get_certificate_bundles<P>(socket_path: P) -> Result<CertBundle>
+async fn get_certificate_bundles<P>(config_path: P) -> Result<CertBundle>
 where
     P: AsRef<Path>,
 {
-    debug!("Querying the API for settings");
+    debug!("Loading certdog configuration");
+    if config_path.as_ref().exists() {
+        let config_str = fs::read_to_string(config_path.as_ref())
+            .context(error::ConfigReadSnafu { config: config_path.as_ref().to_str().unwrap() })?;
+        let pki: HashMap<Identifier, PemCertificate> = toml::from_str(config_str.as_str())
+            .context(error::ConfigDeserializationSnafu { config: config_path.as_ref().to_str().unwrap() })?;
 
-    let method = "GET";
-    let uri = constants::API_SETTINGS_URI;
-    let (_code, response_body) = apiclient::raw_request(&socket_path, uri, method, None)
-        .await
-        .context(error::APIRequestSnafu { method, uri })?;
-
-    // Build a Settings struct from the response string
-    debug!("Deserializing response");
-    let settings: model::Settings =
-        serde_json::from_str(&response_body).context(error::ResponseJsonSnafu { uri })?;
-
-    split_bundles(settings.pki.unwrap_or_default())
+        split_bundles(pki)
+    } else {
+        split_bundles(HashMap::new())
+    }
 }
 
 /// Returns a tuple with two lists, for trusted and distrusted certificates
 fn split_bundles(
-    certificates_bundle: HashMap<Identifier, model::PemCertificate>,
+    certificates_bundle: HashMap<Identifier, PemCertificate>,
 ) -> Result<CertBundle> {
     let mut trusted_certs: Vec<x509_parser::pem::Pem> = Vec::new();
     let mut distrusted_certs: Vec<x509_parser::pem::Pem> = Vec::new();
@@ -210,7 +210,7 @@ async fn run() -> Result<()> {
     SimpleLogger::init(args.log_level, LogConfig::default()).context(error::LoggerSnafu)?;
 
     info!("certdog started");
-    let certificate_bundles = get_certificate_bundles(&args.socket_path).await?;
+    let certificate_bundles = get_certificate_bundles(&args.config_path).await?;
     info!("Got certificate bundles from API");
     update_trusted_store(certificate_bundles, args.trusted_store, args.source_bundle)?;
     info!("Updated trusted store");
@@ -244,6 +244,20 @@ mod error {
             uri: String,
             #[snafu(source(from(apiclient::Error, Box::new)))]
             source: Box<apiclient::Error>,
+        },
+
+        #[snafu(display("Error reading data from configuration at {}: {}", config, source))]
+        ConfigReadError {
+            config: String,
+            #[snafu(source(from(std::io::Error, Box::new)))]
+            source: Box<std::io::Error>,
+        },
+
+        #[snafu(display("Error deserializing pki from configuration at {}: {}", config, source))]
+        ConfigDeserializationError {
+            config: String,
+            #[snafu(source(from(toml::de::Error, Box::new)))]
+            source: Box<toml::de::Error>,
         },
 
         #[snafu(display("Unable to decode base64 from certificate '{}': {}", name, source))]

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -162,8 +162,11 @@ affected-services = ["bootstrap-containers"]
 # Certdog
 
 [services.pki]
-configuration-files = []
+configuration-files = ["certdog-toml"]
 restart-commands = ["/usr/bin/certdog"]
+
+[metadata.settings.pki]
+affected-services = ["pki"]
 
 # DNS
 [metadata.settings.dns]
@@ -176,3 +179,7 @@ restart-commands = ["netdog write-resolv-conf"]
 [configuration-files.netdog-toml]
 path = "/etc/netdog.toml"
 template-path = "/usr/share/templates/netdog-toml"
+
+[configuration-files.certdog-toml]
+path = "/etc/certdog.toml"
+template-path = "/usr/share/templates/certdog-toml"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #3623

Closes #3623 

**Description of changes:**
Changed certdog binary to accept an argument -c <config-path> instead of -s <socket-api> that defaults to the location /etc/certdog.toml. This toml file will be generated by schnauzer from settings.pki. Certdog now will read the custom certificates from this generated template instead of calling back to the settings api.


**Testing done:**
Tested via ecs using the aws-ecs-2 variant and verified that the file is generated correctly and certdog runs with no errors


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
