### PR TITLE
certdog: change certdog to use a generated certdog.toml file

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -270,4 +270,7 @@ version = "1.19.2"
     "migrate_v1.19.1_aws-control-container-v0-7-8.lz4",
     "migrate_v1.19.1_public-control-container-v0-7-8.lz4",
 ]
-"(1.19.1, 1.19.2)" = []
+"(1.19.1, 1.19.2)" = [
+    "migrate_v1.19.2_certdog-config-file-v0-1-0.lz4",
+    "migrate_v1.19.2_certdog-service-cfg-v0-1-0.lz4",
+]

--- a/packages/os/certdog-toml
+++ b/packages/os/certdog-toml
@@ -1,0 +1,10 @@
+[required-extensions]
+pki = "v1"
++++
+{{#if settings.pki}}
+{{#each settings.pki}}
+["{{@key}}"]
+trusted = {{this.trusted}}
+data = "{{this.data}}"
+{{/each}}
+{{/if}}

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -31,6 +31,7 @@ Source12: 00-resolved.conf
 %if %{with k8s_runtime}
 Source13: cis-checks-k8s-metadata-json
 %endif
+Source14: certdog-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -472,7 +473,7 @@ install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
@@ -684,6 +685,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
 %files -n %{_cross_os}certdog
 %{_cross_bindir}/certdog
+%{_cross_templatedir}/certdog-toml
 
 %files -n %{_cross_os}bootstrap-containers
 %{_cross_bindir}/bootstrap-containers

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1262,7 +1262,22 @@ dependencies = [
  "snafu",
  "tempfile",
  "tokio",
+ "toml 0.8.8",
  "x509-parser",
+]
+
+[[package]]
+name = "certdog-config-file-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "certdog-service-cfg-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -61,6 +61,8 @@ members = [
     "api/migration/migrations/v1.19.1/public-admin-container-v0-11-4",
     "api/migration/migrations/v1.19.1/aws-control-container-v0-7-8",
     "api/migration/migrations/v1.19.1/public-control-container-v0-7-8",
+    "api/migration/migrations/v1.19.2/certdog-config-file-v0-1-0",
+    "api/migration/migrations/v1.19.2/certdog-service-cfg-v0-1-0",
 
     "bloodhound",
 

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
 tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
+toml = "0.8"
 x509-parser = "0.15"
 
 [dev-dependencies]

--- a/sources/api/migration/migrations/v1.19.2/certdog-config-file-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.2/certdog-config-file-v0-1-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "certdog-config-file-v0-1-0"
+version = "0.1.0"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.2/certdog-config-file-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.2/certdog-config-file-v0-1-0/src/main.rs
@@ -1,0 +1,17 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// Add settings for the new certdog-toml config file
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "configuration-files.certdog-toml",
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.2/certdog-service-cfg-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.2/certdog-service-cfg-v0-1-0/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "certdog-service-cfg-v0-1-0"
+version = "0.1.0"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.2/certdog-service-cfg-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.2/certdog-service-cfg-v0-1-0/src/main.rs
@@ -1,0 +1,19 @@
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// Add settings for the new certdog-toml config file
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "services.pki.configuration-files",
+        old_vals: &[],
+        new_vals: &["certdog-toml"],
+    }]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -162,7 +162,7 @@ affected-services = ["bootstrap-containers"]
 # Certdog
 
 [services.pki]
-configuration-files = []
+configuration-files = ["certdog-toml"]
 restart-commands = ["/usr/bin/certdog"]
 
 # DNS
@@ -176,3 +176,7 @@ restart-commands = ["netdog write-resolv-conf"]
 [configuration-files.netdog-toml]
 path = "/etc/netdog.toml"
 template-path = "/usr/share/templates/netdog-toml"
+
+[configuration-files.certdog-toml]
+path = "/etc/certdog.toml"
+template-path = "/usr/share/templates/certdog-toml"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #3623 

Closes #3623 

**Description of changes:**
Changed certdog binary to accept an argument -c instead of -s that defaults to the location /etc/certdog.toml. This toml file will be generated by schnauzer from settings.pki. Certdog now will read the custom certificates from this generated template instead of calling back to the settings api.

**Testing done:**
Tested via ecs using the aws-ecs-2 variant and verified that the file is generated correctly and certdog runs with no errors


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
