### PR TITLE
kernel: update to latest version for series 5.10, 5.15, 6.1

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/d56d799376346afd56ebe3eec4b500b23c6fd3954f66b65aa7c867848d17a950/kernel-5.10.201-191.748.amzn2.src.rpm"
-sha512 = "8d8715a1e06dbf7adbc1b5f80e99ec6b5d448c9aefd69f48f77fe6c80bd0e2668a963f85360fefd93ea979e2d2a5323d916301f2f59961e125a5fe6c8b38065f"
+url = "https://cdn.amazonlinux.com/blobstore/9feb6cecf780648ffd492525552ba31ce039667031f7ff32ff8a8802145f4827/kernel-5.10.205-195.804.amzn2.src.rpm"
+sha512 = "409ddcfcd2f29ab7e7cff8d38ea00fbbd2f2960e4eeffbb4031997921becc797b7e29a66c3869b70e362530d2ed30b747472dbee229f21f9499e3d90f40a880e"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -154,6 +154,11 @@ CONFIG_EXT4_USE_FOR_EXT2=y
 
 # Disable obsolete NIC drivers
 # CONFIG_QLGE is not set
+# CONFIG_MLX4_CORE is not set
+# CONFIG_MLX4_EN is not set
+# CONFIG_MLX4_INFINIBAND is not set
+# CONFIG_MLXSW_CORE is not set
+# CONFIG_MLXFW is not set
 
 # Disable unused qdiscs
 #   - sch_cake targets home routers and residential links
@@ -171,3 +176,4 @@ CONFIG_SCSI_SMARTPQI=m
 
 # Disable AL port of BBR2 congestion algorithm
 # CONFIG_TCP_CONG_BBR2 is not set
+

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.201
+Version: 5.10.205
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/d56d799376346afd56ebe3eec4b500b23c6fd3954f66b65aa7c867848d17a950/kernel-5.10.201-191.748.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/9feb6cecf780648ffd492525552ba31ce039667031f7ff32ff8a8802145f4827/kernel-5.10.205-195.804.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/5001-kallsyms-Make-module_kallsyms_on_each_symbol-general.patch
+++ b/packages/kernel-5.15/5001-kallsyms-Make-module_kallsyms_on_each_symbol-general.patch
@@ -1,0 +1,73 @@
+From 5d5e377de988002f0db05c90ef39010503c61cee Mon Sep 17 00:00:00 2001
+From: Jiri Olsa <jolsa@kernel.org>
+Date: Tue, 25 Oct 2022 15:41:41 +0200
+Subject: [PATCH] kallsyms: Make module_kallsyms_on_each_symbol generally
+ available
+
+commit 73feb8d5fa3b755bb51077c0aabfb6aa556fd498 upstream.
+
+Making module_kallsyms_on_each_symbol generally available, so it
+can be used outside CONFIG_LIVEPATCH option in following changes.
+
+Rather than adding another ifdef option let's make the function
+generally available (when CONFIG_KALLSYMS and CONFIG_MODULES
+options are defined).
+
+Cc: Christoph Hellwig <hch@lst.de>
+Acked-by: Song Liu <song@kernel.org>
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Link: https://lore.kernel.org/r/20221025134148.3300700-2-jolsa@kernel.org
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Stable-dep-of: 926fe783c8a6 ("tracing/kprobes: Fix symbol counting logic by looking at modules as well")
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ include/linux/module.h | 9 +++++++++
+ kernel/module.c        | 2 --
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/include/linux/module.h b/include/linux/module.h
+index c9f1200b2312..701c150485b2 100644
+--- a/include/linux/module.h
++++ b/include/linux/module.h
+@@ -867,8 +867,17 @@ static inline bool module_sig_ok(struct module *module)
+ }
+ #endif	/* CONFIG_MODULE_SIG */
+ 
++#if defined(CONFIG_MODULES) && defined(CONFIG_KALLSYMS)
+ int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
+ 					     struct module *, unsigned long),
+ 				   void *data);
++#else
++static inline int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
++						 struct module *, unsigned long),
++						 void *data)
++{
++	return -EOPNOTSUPP;
++}
++#endif  /* CONFIG_MODULES && CONFIG_KALLSYMS */
+ 
+ #endif /* _LINUX_MODULE_H */
+diff --git a/kernel/module.c b/kernel/module.c
+index 3c90840133c0..ba9f2bb57889 100644
+--- a/kernel/module.c
++++ b/kernel/module.c
+@@ -4482,7 +4482,6 @@ unsigned long module_kallsyms_lookup_name(const char *name)
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_LIVEPATCH
+ int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
+ 					     struct module *, unsigned long),
+ 				   void *data)
+@@ -4514,7 +4513,6 @@ int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
+ 	mutex_unlock(&module_mutex);
+ 	return ret;
+ }
+-#endif /* CONFIG_LIVEPATCH */
+ #endif /* CONFIG_KALLSYMS */
+ 
+ static void cfi_init(struct module *mod)
+-- 
+2.40.1
+

--- a/packages/kernel-5.15/5002-tracing-kprobes-Fix-symbol-counting-logic-by-looking.patch
+++ b/packages/kernel-5.15/5002-tracing-kprobes-Fix-symbol-counting-logic-by-looking.patch
@@ -1,0 +1,49 @@
+From 7bc06ef49649ff064c6bc3825e047c500eea141a Mon Sep 17 00:00:00 2001
+From: Andrii Nakryiko <andrii@kernel.org>
+Date: Fri, 27 Oct 2023 16:31:26 -0700
+Subject: [PATCH] tracing/kprobes: Fix symbol counting logic by looking at
+ modules as well
+
+commit 926fe783c8a64b33997fec405cf1af3e61aed441 upstream.
+
+Recent changes to count number of matching symbols when creating
+a kprobe event failed to take into account kernel modules. As such, it
+breaks kprobes on kernel module symbols, by assuming there is no match.
+
+Fix this my calling module_kallsyms_on_each_symbol() in addition to
+kallsyms_on_each_match_symbol() to perform a proper counting.
+
+Link: https://lore.kernel.org/all/20231027233126.2073148-1-andrii@kernel.org/
+
+Cc: Francis Laniel <flaniel@linux.microsoft.com>
+Cc: stable@vger.kernel.org
+Cc: Masami Hiramatsu <mhiramat@kernel.org>
+Cc: Steven Rostedt <rostedt@goodmis.org>
+Fixes: b022f0c7e404 ("tracing/kprobes: Return EADDRNOTAVAIL when func matches several symbols")
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Song Liu <song@kernel.org>
+Signed-off-by: Masami Hiramatsu (Google) <mhiramat@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Hao Wei Tee <angelsl@in04.sg>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ kernel/trace/trace_kprobe.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/kernel/trace/trace_kprobe.c b/kernel/trace/trace_kprobe.c
+index 1c565db2de7b..21aef22a8489 100644
+--- a/kernel/trace/trace_kprobe.c
++++ b/kernel/trace/trace_kprobe.c
+@@ -735,6 +735,8 @@ static unsigned int number_of_same_symbols(char *func_name)
+ 
+ 	kallsyms_on_each_symbol(count_symbols, &args);
+ 
++	module_kallsyms_on_each_symbol(count_symbols, &args);
++
+ 	return args.count;
+ }
+ 
+-- 
+2.40.1
+

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/76d66a34d25e5ebc08dc424d9b03b0ecb44046eb05d95e47459447a5ab582cd2/kernel-5.15.139-93.147.amzn2.src.rpm"
-sha512 = "f63269b6466df01b5a6a3387091665cb8931090fa73d848f0d77a6729aa7241d04be77383e34a41bed575cd295bf722bd6668965d1f1147d9ca975ae04b53219"
+url = "https://cdn.amazonlinux.com/blobstore/ee035f7e9f6cfe0e00a4c32b3f7d9170e85ca9e9f5cc5026b601b532343b260d/kernel-5.15.145-95.156.amzn2.src.rpm"
+sha512 = "372738cd8139c6904a047e9298373ee60dc64a5776a624399615ad13736fc21cd9ab70bccee4a0aa12fcdbbf3fd2b1d01a9d8bf4ad6c4b9063f0404c904db250"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -22,6 +22,10 @@ Patch1003: 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
 # Increase default of sysctl net.unix.max_dgram_qlen to 512.
 Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 
+# Backport fix for #3691. Needs to be upstreamed to 5.15 stable series.
+Patch5001: 5001-kallsyms-Make-module_kallsyms_on_each_symbol-general.patch
+Patch5002: 5002-tracing-kprobes-Fix-symbol-counting-logic-by-looking.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.139
+Version: 5.15.145
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/76d66a34d25e5ebc08dc424d9b03b0ecb44046eb05d95e47459447a5ab582cd2/kernel-5.15.139-93.147.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/ee035f7e9f6cfe0e00a4c32b3f7d9170e85ca9e9f5cc5026b601b532343b260d/kernel-5.15.145-95.156.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/5880ce1298c2bb541461845a29b2787036b8d18aff0f0bc308117a5f9990057e/kernel-6.1.66-91.160.amzn2023.src.rpm"
-sha512 = "4a2b52e6fc8045a5bdf3f7a4a8080623206352e2921d9cf899e367c9102a806dc1135985863cb5efc43c4a757971404e88abdea9c78dcb55cb64e204f97dc232"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/f0517376e35e75defefac98e867091249abdcbad3d0958d58d19c0db26a8d0c7/kernel-6.1.66-93.164.amzn2023.src.rpm"
+sha512 = "215330abf659fd459d79bee3cd1c7beb6075a08f3eacd484ce1836169e436ea6b98462e9e5bd6d1ccb79474b1b5c54f21f3e5643fc47fac954ae84701c32a00c"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/5880ce1298c2bb541461845a29b2787036b8d18aff0f0bc308117a5f9990057e/kernel-6.1.66-91.160.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/f0517376e35e75defefac98e867091249abdcbad3d0958d58d19c0db26a8d0c7/kernel-6.1.66-93.164.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories. Massage the configuration for the 5.10 kernel to be closer to the state we had before the update. Add a fix for #3691 to the 5.15 series, since its update picks up the buggy commit (this is a downstream backport since none is publicly available yet; to be upstreamed; backport could be simplified a bit compared to #3699 due to the existing backport of the bug already bringing enough helpers).

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                              STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-71-140.eu-central-1.compute.internal   Ready    <none>   9m47s   v1.23.17-eks-ea94ec3   192.168.71.140   18.185.22.137   Bottlerocket OS 1.18.0 (aws-k8s-1.23)   5.10.205         containerd://1.6.26+bottlerocket
ip-192-168-77-109.eu-central-1.compute.internal   Ready    <none>   101s    v1.28.4-eks-d91a302    192.168.77.109   3.126.118.175   Bottlerocket OS 1.18.0 (aws-k8s-1.28)   6.1.66           containerd://1.6.26+bottlerocket
ip-192-168-87-213.eu-central-1.compute.internal   Ready    <none>   5m27s   v1.26.11-eks-b93ee12   192.168.87.213   3.71.78.190     Bottlerocket OS 1.18.0 (aws-k8s-1.26)   5.15.145         containerd://1.6.26+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
17:32:57    systemd-logs   ip-192-168-71-140.eu-central-1.compute.internal   complete   passed                                        
17:32:57    systemd-logs   ip-192-168-77-109.eu-central-1.compute.internal   complete   passed                                        
17:32:57    systemd-logs   ip-192-168-87-213.eu-central-1.compute.internal   complete   passed                                        
17:32:57             e2e                                            global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
17:32:57 Sonobuoy plugins have completed. Preparing results for download.
17:33:17 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:        15 removed,   0 added,   4 changed
config-aarch64-aws-k8s-1.26-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.28-diff:         0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:          0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:        0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:        0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.26-diff:       0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:       0 removed,   0 added,   0 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/markusboehme/68a7c15f5756a0203a9081f32b914b7c).

The changed configuration in the 5.10 kernel on aarch64 boils down to two groups:

* `DRM_QXL`: Removed the driver for a virtualized GPU used in remote desktop scenarios. It's no longer supported by Amazon Linux. Nothing of value is lost for Bottlerocket's scenario.
* `MLX4` and friends: Dropping the drivers for 4th gen Mellanox NICs. Those are only relevant in bare metal scenarios. Amazon Linux enabled those drivers for x86_64 as well (they were already enabled for aarch64) to reach parity. However, for Bottlerocket the reverse makes more sense: We don't support aarch64 on bare metal (and not with the 5.10 kernel), and ship drivers for the 5th gen Mellanox NICs instead.

The backport for #3691 I tested via aws-k8s-1.27 on x86_64. I verified that probes can be placed on symbols defined in loadable modules (via qualified and unqualified names, using `nf_nat_packet` and `nf_nat:nf_nat_packet`, respectively), and that ambiguous probe definitions are still rejected (using `kzalloc`):

```
bash-5.1# uname -r
5.15.145
bash-5.1# cd /sys/kernel/tracing/              
bash-5.1# > kprobe_events
bash-5.1# echo 'p nf_nat_packet' >>kprobe_events
bash-5.1# echo 'p kzalloc' >>kprobe_events      
bash: echo: write error: Address not available
bash-5.1# grep -wc kzalloc /proc/kallsyms 
8
bash-5.1# cat kprobe_events  
p:kprobes/p_nf_nat_packet_0 nf_nat_packet
```

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
