### PR TITLE
settings: add network settings extension

### DIFF
--- a/packages/settings-network/Cargo.toml
+++ b/packages/settings-network/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-network"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/network"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-network/settings-network.spec
+++ b/packages/settings-network/settings-network.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name network
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3649,6 +3649,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-network"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2631,6 +2631,7 @@ dependencies = [
  "settings-extension-container-registry",
  "settings-extension-kernel",
  "settings-extension-motd",
+ "settings-extension-network",
  "settings-extension-ntp",
  "settings-extension-updates",
  "toml 0.5.11",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -79,10 +79,11 @@ members = [
 
     "models",
 
+    "settings-extensions/container-registry",
     "settings-extensions/kernel",
     "settings-extensions/motd",
+    "settings-extensions/network",
     "settings-extensions/ntp",
-    "settings-extensions/container-registry",
     "settings-extensions/updates",
 
     "parse-datetime",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -18,10 +18,11 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 
 # settings extensions
+settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
+settings-extension-network = { path = "../settings-extensions/network", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
-settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-updates = { path = "../settings-extensions/updates", version = "0.1" }
 
 [build-dependencies]

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
+    HostContainer, MetricsSettings, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    ECSSettings, HostContainer, MetricsSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +16,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     ecs: ECSSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    ECSSettings, HostContainer, MetricsSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +16,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     ecs: ECSSettings,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    DnsSettings, ECSSettings, HostContainer, MetricsSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    DnsSettings, ECSSettings, HostContainer, MetricsSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/aws-k8s-1.29/mod.rs
+++ b/sources/models/src/aws-k8s-1.29/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
-    OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/metal-k8s-1.29/mod.rs
+++ b/sources/models/src/metal-k8s-1.29/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
-    OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -16,7 +16,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     boot: BootSettings,

--- a/sources/models/src/vmware-k8s-1.29/mod.rs
+++ b/sources/models/src/vmware-k8s-1.29/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +17,7 @@ struct Settings {
     host_containers: HashMap<Identifier, HostContainer>,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
-    network: NetworkSettings,
+    network: settings_extension_network::NetworkSettingsV1,
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     boot: BootSettings,

--- a/sources/settings-extensions/network/Cargo.toml
+++ b/sources/settings-extensions/network/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "settings-extension-network"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+snafu = "0.7"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/network/network.toml
+++ b/sources/settings-extensions/network/network.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/network/src/generate.rs
+++ b/sources/settings-extensions/network/src/generate.rs
@@ -1,0 +1,54 @@
+/// Generators for network settings
+use error::{ExecutionSnafu, GenerateError, InvalidHostnameSnafu};
+use modeled_types::ValidLinuxHostname;
+use snafu::ResultExt;
+use std::process::Command;
+
+pub fn generate_hostname() -> std::result::Result<ValidLinuxHostname, GenerateError> {
+    let ret = Command::new("netdog")
+        .arg("generate-hostname")
+        .output()
+        .context(ExecutionSnafu)?;
+
+    if !ret.status.success() {
+        Err(GenerateError::Failure {
+            message: String::from_utf8_lossy(&ret.stderr).to_string(),
+        })
+    } else {
+        let hostname = parse_stdout(String::from_utf8_lossy(&ret.stdout).to_string());
+        Ok(ValidLinuxHostname::try_from(hostname).context(InvalidHostnameSnafu)?)
+    }
+}
+
+fn parse_stdout(stdout: String) -> String {
+    // netdog gives us a response in the form of `"{hostname}"\n`, we should strip the whitespace
+    // and any quotations.
+    stdout.trim().trim_matches('"').to_string()
+}
+
+pub mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub))]
+    pub enum GenerateError {
+        #[snafu(display("Failed to run netdog command: {}", source))]
+        Execution { source: std::io::Error },
+        #[snafu(display("Generation failed: {}", message))]
+        Failure { message: String },
+        #[snafu(display("Generated invalid hostname: {}", source))]
+        InvalidHostname { source: modeled_types::error::Error },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_hostname() {
+        let stdout = String::from("\"foo.bar.com\"\n");
+        let hostname = parse_stdout(stdout);
+        assert_eq!(hostname, "foo.bar.com")
+    }
+}

--- a/sources/settings-extensions/network/src/lib.rs
+++ b/sources/settings-extensions/network/src/lib.rs
@@ -1,0 +1,131 @@
+/// The network settings will affect host service component's network behavior
+pub mod generate;
+
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use error::GenerateHostnameSnafu;
+use model_derive::model;
+use modeled_types::{EtcHostsEntries, SingleLineString, Url, ValidLinuxHostname};
+use snafu::ResultExt;
+
+#[model(impl_default = true)]
+struct NetworkSettingsV1 {
+    hostname: ValidLinuxHostname,
+    hosts: EtcHostsEntries,
+    https_proxy: Url,
+    // We allow some flexibility in NO_PROXY values because different services support different formats.
+    no_proxy: Vec<SingleLineString>,
+}
+
+type Result<T> = std::result::Result<T, error::Error>;
+
+impl SettingsModel for NetworkSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = error::Error;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Anything that parses as NetworkSettingsV1 is ok
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        let partial = existing_partial.unwrap_or_default();
+
+        Ok(GenerateResult::Complete(NetworkSettingsV1 {
+            hostname: Some(
+                partial
+                    .hostname
+                    .unwrap_or(generate::generate_hostname().context(GenerateHostnameSnafu)?),
+            ),
+            ..partial
+        }))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // This setting's field types handle validation during deserialization
+        Ok(())
+    }
+}
+
+mod error {
+    use super::generate;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub))]
+    pub enum Error {
+        #[snafu(display("Failed to generate hostname: {}", source))]
+        GenerateHostname {
+            source: generate::error::GenerateError,
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_serde_network() {
+        let test_json = r#"{
+            "hostname": "foo",
+            "hosts": [["127.0.0.1", ["localhost"]]],
+            "https-proxy": "https://example.net",
+            "no-proxy": ["foo"]
+        }"#;
+
+        let network: NetworkSettingsV1 = serde_json::from_str(test_json).unwrap();
+
+        assert_eq!(
+            network,
+            NetworkSettingsV1 {
+                hostname: Some(ValidLinuxHostname::try_from("foo").unwrap()),
+                hosts: Some(
+                    serde_json::from_str::<EtcHostsEntries>(r#"[["127.0.0.1", ["localhost"]]]"#)
+                        .unwrap()
+                ),
+                https_proxy: Some(Url::try_from("https://example.net").unwrap()),
+                no_proxy: Some(vec![SingleLineString::try_from("foo").unwrap()]),
+            }
+        );
+    }
+
+    #[test]
+    fn test_serde_network_invalid() {
+        // invalid hostname
+        let test_json = r#"{
+            "hostname": "$@%!"
+        }"#;
+        let err = serde_json::from_str::<NetworkSettingsV1>(test_json).unwrap_err();
+        // the "data" error type is returned from serde_json when the input is syntactically valid
+        // JSON, but the type of a field is incorrect.
+        assert!(err.is_data());
+
+        // invalid /etc/hosts entry
+        let test_json = r#"{
+            "hosts": [["not_an_ip", ["foo"]]]
+        }"#;
+        let err = serde_json::from_str::<NetworkSettingsV1>(test_json).unwrap_err();
+        assert!(err.is_data());
+
+        // invalid proxy
+        let test_json = r#"{
+            "https-proxy": "not a url"
+        }"#;
+        let err = serde_json::from_str::<NetworkSettingsV1>(test_json).unwrap_err();
+        assert!(err.is_data());
+
+        // invalid no-proxy
+        let test_json = r#"{
+            "no-proxy": ["two\nlines"]
+        }"#;
+        let err = serde_json::from_str::<NetworkSettingsV1>(test_json).unwrap_err();
+        assert!(err.is_data());
+    }
+}

--- a/sources/settings-extensions/network/src/main.rs
+++ b/sources/settings-extensions/network/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_network::NetworkSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("network")
+        .with_models(vec![BottlerocketSetting::<NetworkSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
**Issue number:**

Closes #3652 

**Description of changes:**

Creates a network settings extension

**Testing done:**

Unit testing, built `aws-dev` variant and packaged `settings-network` in it. Tested on an ec2 instance.

network settings worked as expected, and the setting extension generation returned as expected:

```
bash-5.1# /usr/libexec/settings/network proto1 generate --setting-version v1
{
  "Complete": {
    "hostname": "ip-{instance public ip}.us-west-2.compute.internal"
  }
}
```

(EDIT 1-18)

Also built and tested a `vmware-dev` image, and the extension worked as expected:

```
bash-5.1# /usr/libexec/settings/network proto1 generate --setting-version v1
{
  "Complete": {
    "hostname": "{vm ip address}"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
