### PR TITLE
prairiedog: migrate to config file

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -276,4 +276,6 @@ version = "1.19.3"
     "migrate_v1.19.2_add-ecs-enable-container-metadata.lz4",
 ]
 "(1.19.2, 1.19.3)" = [
+    "migrate_v1.19.3_prairiedog-config-file-v0-1-0.lz4",
+    "migrate_v1.19.3_prairiedog-services-cfg-v0-1-0.lz4",
 ]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -32,6 +32,7 @@ Source12: 00-resolved.conf
 Source13: cis-checks-k8s-metadata-json
 %endif
 Source14: certdog-toml
+Source15: prairiedog-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -473,7 +474,7 @@ install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
@@ -682,6 +683,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %files -n %{_cross_os}prairiedog
 %{_cross_bindir}/prairiedog
 %{_cross_unitdir}/reboot-if-required.service
+%{_cross_templatedir}/prairiedog-toml
 
 %files -n %{_cross_os}certdog
 %{_cross_bindir}/certdog

--- a/packages/os/prairiedog-toml
+++ b/packages/os/prairiedog-toml
@@ -1,0 +1,20 @@
+[required-extensions]
+boot = "v1"
++++
+{{#if settings.boot}}
+{{#if settings.boot.reboot-to-reconcile}}
+reboot-to-reconcile = {{settings.boot.reboot-to-reconcile}}
+{{/if}}
+{{#if settings.boot.kernel}}
+[kernel]
+{{#each settings.boot.kernel}}
+"{{@key}}" = [ {{#each this}}"{{{this}}}",{{/each}} ]
+{{/each}}
+{{/if}}
+{{#if settings.boot.init}}
+[init]
+{{#each settings.boot.init}}
+"{{@key}}" = [ {{#each this}}"{{{this}}}",{{/each}} ]
+{{/each}}
+{{/if}}
+{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3108,14 +3108,29 @@ dependencies = [
  "generate-readme",
  "log",
  "maplit",
- "models",
+ "modeled-types",
  "nix",
  "schnauzer",
+ "serde",
  "serde_json",
  "signpost",
  "simplelog",
  "snafu",
- "tokio",
+ "toml 0.8.8",
+]
+
+[[package]]
+name = "prairiedog-config-file-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "prairiedog-services-cfg-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -64,6 +64,8 @@ members = [
     "api/migration/migrations/v1.19.2/certdog-config-file-v0-1-0",
     "api/migration/migrations/v1.19.2/certdog-service-cfg-v0-1-0",
     "api/migration/migrations/v1.19.2/add-ecs-enable-container-metadata",
+    "api/migration/migrations/v1.19.3/prairiedog-config-file-v0-1-0",
+    "api/migration/migrations/v1.19.3/prairiedog-services-cfg-v0-1-0",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.19.3/prairiedog-config-file-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/prairiedog-config-file-v0-1-0/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "prairiedog-config-file-v0-1-0"
+version = "0.1.0"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/prairiedog-config-file-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/prairiedog-config-file-v0-1-0/src/main.rs
@@ -1,0 +1,16 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "configuration-files.prairiedog-toml",
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.3/prairiedog-services-cfg-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/prairiedog-services-cfg-v0-1-0/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "prairiedog-services-cfg-v0-1-0"
+version = "0.1.0"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/prairiedog-services-cfg-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/prairiedog-services-cfg-v0-1-0/src/main.rs
@@ -1,0 +1,18 @@
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "services.bootconfig.configuration-files",
+        old_vals: &[],
+        new_vals: &["prairiedog-toml"],
+    }]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/prairiedog/Cargo.toml
+++ b/sources/api/prairiedog/Cargo.toml
@@ -14,13 +14,14 @@ bytes = "1"
 constants = { path = "../../constants", version = "0.1" }
 log = "0.4"
 nix = "0.26"
-models =  { path = "../../models", version = "0.1" }
+modeled-types = { path = "../../models/modeled-types", version = "0.1"}
 schnauzer = { path = "../schnauzer", version = "0.1" }
 signpost = { path = "../../updater/signpost", version = "0.1" }
 simplelog = "0.12"
 snafu = "0.7"
-serde_json = "1"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
+serde = { version = "1.0", features = ["derive"]}
+serde_json = "1.0"
+toml = "0.8"
 
 [dev-dependencies]
 maplit = "1"

--- a/sources/api/prairiedog/src/error.rs
+++ b/sources/api/prairiedog/src/error.rs
@@ -56,9 +56,6 @@ pub(super) enum Error {
         path: PathBuf,
     },
 
-    #[snafu(display("Failed to retrieve settings: {}", source))]
-    RetrieveSettings { source: schnauzer::v1::Error },
-
     #[snafu(display("Failed to convert usize to u32: {}", source))]
     UsizeToU32 { source: std::num::TryFromIntError },
 
@@ -68,11 +65,11 @@ pub(super) enum Error {
     #[snafu(display("Failed to write initrd image file: {}", source))]
     WriteInitrd { source: std::io::Error },
 
+    #[snafu(display("Error deserializing `BootSettings` from TOML: {}", source))]
+    InputToml { source: toml::de::Error },
+
     #[snafu(display("Error serializing `BootSettings` to JSON: {}", source))]
     OutputJson { source: serde_json::error::Error },
-
-    #[snafu(display("Failed to deserialize `BootSettings` from JSON value: {}", source))]
-    BootSettingsFromJsonValue { source: serde_json::error::Error },
 
     #[snafu(display(
         "Invalid boot config file, expected key-value, or key entries for each line"
@@ -80,17 +77,13 @@ pub(super) enum Error {
     InvalidBootConfig,
 
     #[snafu(display("Failed to parse boot config key: {}", source))]
-    ParseBootConfigKey {
-        source: model::modeled_types::error::Error,
-    },
+    ParseBootConfigKey { source: modeled_types::error::Error },
 
     #[snafu(display("Invalid boot config value '{}'. Boot config values may only contain ASCII printable characters except for delimiters such as ';', '\n', ',', '#', and '}}'", input))]
     InvalidBootConfigValue { input: String },
 
     #[snafu(display("Failed to parse boot config value: {}", source))]
-    ParseBootConfigValue {
-        source: model::modeled_types::error::Error,
-    },
+    ParseBootConfigValue { source: modeled_types::error::Error },
 
     #[snafu(display("Unsupported boot config key '{}'. `BootSettings` currently only supports boot configuration for 'kernel' and 'init'", key))]
     UnsupportedBootConfigKey { key: String },

--- a/sources/models/shared-defaults/boot.toml
+++ b/sources/models/shared-defaults/boot.toml
@@ -5,5 +5,9 @@ affected-services = ["bootconfig"]
 setting-generator = "/usr/bin/prairiedog generate-boot-settings"
 
 [services.bootconfig]
-configuration-files = []
+configuration-files = ["prairiedog-toml"]
 restart-commands = ["/usr/bin/prairiedog generate-boot-config"]
+
+[configuration-files.prairiedog-toml]
+path = "/etc/prairiedog.toml"
+template-path = "/usr/share/templates/prairiedog-toml"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #3622 

Closes #3622 

**Description of changes:**
* Migrates prairiedog from fetching BootSettings from settings api to fetching this from /etc/prairiedog.toml or config file provided by -c/--config-path
* Adds template prairiedog-toml and migration


**Testing done:**
Fully tested migration upgrade and the reboot logic for the reconcile works. Also made sure kernel settings synced to the file


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
