### PR TITLE
Migrate corndog to use its own config file

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -282,4 +282,6 @@ version = "1.19.3"
     "migrate_v1.19.3_thar-be-updates-affected-services-v0-1-0.lz4",
     "migrate_v1.19.3_host-containers-config-file-v0-1-0.lz4",
     "migrate_v1.19.3_host-containers-config-list-v0-1-0.lz4",
+    "migrate_v1.19.3_corndog-config-file-v0-1-0.lz4",
+    "migrate_v1.19.3_corndog-services-cfg-v0-1-0.lz4",
 ]

--- a/packages/os/corndog-toml
+++ b/packages/os/corndog-toml
@@ -1,0 +1,12 @@
+[required-extensions]
+kernel = "v1"
++++
+{{#if settings.kernel.lockdown}}
+lockdown = "{{{settings.kernel.lockdown}}}"
+{{/if}}
+{{#if settings.kernel.sysctl}}
+[sysctl]
+{{#each settings.kernel.sysctl}}
+"{{@key}}" = "{{{this}}}"
+{{/each}}
+{{/if}}

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -34,6 +34,7 @@ Source13: cis-checks-k8s-metadata-json
 Source14: certdog-toml
 Source15: prairiedog-toml
 Source16: thar-be-updates-toml
+Source17: corndog-toml
 Source19: host-containers-toml
 
 # 1xx sources: systemd units
@@ -476,7 +477,7 @@ install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{S:16} %{S:19} \
+install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{S:16} %{S:17} %{S:19} \
   %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
@@ -569,6 +570,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
 %files -n %{_cross_os}corndog
 %{_cross_bindir}/corndog
+%{_cross_templatedir}/corndog-toml
 
 %files -n %{_cross_os}sundog
 %{_cross_bindir}/sundog

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1400,16 +1400,28 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 name = "corndog"
 version = "0.1.0"
 dependencies = [
- "apiclient",
- "constants",
  "generate-readme",
- "http",
  "log",
- "models",
+ "modeled-types",
+ "serde",
  "serde_json",
  "simplelog",
  "snafu",
- "tokio",
+ "toml 0.8.8",
+]
+
+[[package]]
+name = "corndog-config-file-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "corndog-services-cfg-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -70,6 +70,8 @@ members = [
     "api/migration/migrations/v1.19.3/thar-be-updates-affected-services-v0-1-0",
     "api/migration/migrations/v1.19.3/host-containers-config-file-v0-1-0",
     "api/migration/migrations/v1.19.3/host-containers-config-list-v0-1-0",
+    "api/migration/migrations/v1.19.3/corndog-config-file-v0-1-0",
+    "api/migration/migrations/v1.19.3/corndog-services-cfg-v0-1-0",
 
     "bloodhound",
 
@@ -113,7 +115,7 @@ members = [
 
     "shimpei",
 
-    "xfscli"
+    "xfscli",
 ]
 
 [profile.release]

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -10,15 +10,13 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
-constants = { path = "../../constants", version = "0.1" }
-http = "0.2"
 log = "0.4"
-models = { path = "../../models", version = "0.1" }
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+serde = { version = "1.0", features = ["derive"]}
 serde_json = "1"
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+toml = "0.8"
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/migration/migrations/v1.19.3/corndog-config-file-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/corndog-config-file-v0-1-0/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "corndog-config-file-v0-1-0"
+version = "0.1.0"
+edition = "2021"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/corndog-config-file-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/corndog-config-file-v0-1-0/src/main.rs
@@ -1,0 +1,16 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "configuration-files.corndog-toml",
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.3/corndog-services-cfg-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/corndog-services-cfg-v0-1-0/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "corndog-services-cfg-v0-1-0"
+version = "0.1.0"
+edition = "2021"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/corndog-services-cfg-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/corndog-services-cfg-v0-1-0/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![
+        ListReplacement {
+            setting: "services.sysctl.configuration-files",
+            old_vals: &[],
+            new_vals: &["corndog-toml"],
+        },
+        ListReplacement {
+            setting: "services.lockdown.configuration-files",
+            old_vals: &[],
+            new_vals: &["corndog-toml"],
+        },
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -134,7 +134,7 @@ affected-services = ["ntp"]
 # Kernel
 
 [services.sysctl]
-configuration-files = []
+configuration-files = ["corndog-toml"]
 restart-commands = ["/usr/bin/corndog sysctl"]
 
 [metadata.settings.kernel.sysctl]
@@ -156,11 +156,15 @@ template-path = "/usr/share/templates/modules-load"
 affected-services = ["kernel-modules"]
 
 [services.lockdown]
-configuration-files = []
+configuration-files = ["corndog-toml"]
 restart-commands = ["/usr/bin/corndog lockdown"]
 
 [metadata.settings.kernel.lockdown]
 affected-services = ["lockdown"]
+
+[configuration-files.corndog-toml]
+path = "/etc/corndog.toml"
+template-path = "/usr/share/templates/corndog-toml"
 
 # Bootstrap Containers
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #3624 

Closes #3624 

**Description of changes:**
Migrated corndog to read its settings from /etc/corndog.toml which is generated
Added corndog-toml template
Added migrations to ensure configuration file is seen both by services.sysctl and services.lockdown


**Testing done:**

- [x] Ran `cargo +nightly udeps` to ensure all unused dependencies have been removed
- [x] Pass the settings on first boot via userdata. Verify config.
- [x] cat /etc/os-release record your build ID include commit sha, record this
- [x] Use apiclient to update relevant settings at runtime. Verify config was updated correctly.
- [x] Downgrade to older version. 
  - [x] verify connectivity
  - [x] cat /etc/os-release to verify lower version
  - [x] verify that migrations have changed the metadata/settings as expected (i.e. they are gone from the datastore, or lists have been changed back)
- [x] Upgrade to newer version.
  - [x] verify connectivity
  - [x] cat /etc/os-release to verify version
  - [x] verify config file

<details>
<summary>Test Report</summary>

### Test Report:

**Initial_Build_ID.Output**

```json
{
  "os": {
    "arch": "aarch64",
    "build_id": "f6cd87be",
    "pretty_name": "Bottlerocket OS 1.19.3 (aws-ecs-2)",
    "variant_id": "aws-ecs-2",
    "version_id": "1.19.3"
  }
}
```

**Initial_Config.Output**

```toml
lockdown = "integrity"
[sysctl]
"net.ipv4.conf.default.arp_accept" = "0"

```

configuration-files.corndog-toml

```json
{
  "configuration-files": {
    "corndog-toml": {
      "path": "/etc/corndog.toml",
      "template-path": "/usr/share/templates/corndog-toml"
    }
  }
}
```

services.sysctl

```json
{
  "services": {
    "sysctl": {
      "configuration-files": [
        "corndog-toml"
      ],
      "restart-commands": [
        "/usr/bin/corndog sysctl"
      ]
    }
  }
}
```

**Downgrade.Output**

```json
{
  "active_partition": {
    "image": {
      "arch": "aarch64",
      "variant": "aws-ecs-2",
      "version": "1.19.3"
    },
    "next_to_boot": true
  },
  "available_updates": [
    "1.19.3",
    "1.19.2"
  ],
  "chosen_update": {
    "arch": "aarch64",
    "variant": "aws-ecs-2",
    "version": "1.19.2"
  },
  "most_recent_command": {
    "cmd_status": "Success",
    "cmd_type": "refresh",
    "exit_status": 0,
    "stderr": "",
    "timestamp": "2024-03-06T22:22:43.101239840Z"
  },
  "staging_partition": null,
  "update_state": "Available"
}
```

```
22:22:41 [INFO] Refreshing updates...
22:22:43 [INFO] Downloading and applying update to disk...
22:22:48 [INFO] Still waiting for updated status, will wait up to 594.5s longer...
22:22:53 [INFO] Still waiting for updated status, will wait up to 589.5s longer...
22:22:58 [INFO] Still waiting for updated status, will wait up to 584.5s longer...
22:23:02 [INFO] Setting the update active so it will apply on the next reboot...
22:23:03 [INFO] Rebooting, goodbye...
```

**Downgrade_Build_ID.Output**

```json
{
  "os": {
    "arch": "aarch64",
    "build_id": "29cc92cc",
    "pretty_name": "Bottlerocket OS 1.19.2 (aws-ecs-2)",
    "variant_id": "aws-ecs-2",
    "version_id": "1.19.2"
  }
}
```

**Downgrade_Config.Output**

```
cat: /etc/corndog.toml: No such file or directory
```

configuration-files.corndog-toml

```
{}
```

services.sysctl

```json
{
  "services": {
    "sysctl": {
      "configuration-files": [],
      "restart-commands": [
        "/usr/bin/corndog sysctl"
      ]
    }
  }
}
```

**Upgrade.Output**

```json
{
  "active_partition": {
    "image": {
      "arch": "aarch64",
      "variant": "aws-ecs-2",
      "version": "1.19.2"
    },
    "next_to_boot": true
  },
  "available_updates": [
    "1.19.3",
    "1.19.2"
  ],
  "chosen_update": {
    "arch": "aarch64",
    "variant": "aws-ecs-2",
    "version": "1.19.3"
  },
  "most_recent_command": {
    "cmd_status": "Success",
    "cmd_type": "refresh",
    "exit_status": 0,
    "stderr": "",
    "timestamp": "2024-03-06T22:25:12.736397Z"
  },
  "staging_partition": null,
  "update_state": "Available"
}
```

```
22:25:11 [INFO] Refreshing updates...
22:25:12 [INFO] Downloading and applying update to disk...
22:25:17 [INFO] Still waiting for updated status, will wait up to 594.5s longer...
22:25:22 [INFO] Still waiting for updated status, will wait up to 589.5s longer...
22:25:27 [INFO] Still waiting for updated status, will wait up to 584.5s longer...
22:25:31 [INFO] Setting the update active so it will apply on the next reboot...
22:25:32 [INFO] Rebooting, goodbye...
```

**Upgrade_Build_ID.Output**

```json
{
  "os": {
    "arch": "aarch64",
    "build_id": "f6cd87be",
    "pretty_name": "Bottlerocket OS 1.19.3 (aws-ecs-2)",
    "variant_id": "aws-ecs-2",
    "version_id": "1.19.3"
  }
}
```

**Upgrade_Config.Output**

```toml
lockdown = "integrity"
[sysctl]
"net.ipv4.conf.default.arp_accept" = "0"
```

configuration-files.corndog-toml

```json
{
  "configuration-files": {
    "corndog-toml": {
      "path": "/etc/corndog.toml",
      "template-path": "/usr/share/templates/corndog-toml"
    }
  }
}
```

services.sysctl

```json
{
  "services": {
    "sysctl": {
      "configuration-files": [
        "corndog-toml"
      ],
      "restart-commands": [
        "/usr/bin/corndog sysctl"
      ]
    }
  }
}
```

**Change_Settings.Output**

```bash
apiclient set --json '{"kernel": {"sysctl": {"net.ipv4.conf.default.arp_accept": "1"}}}'
```

```toml
lockdown = "integrity"
[sysctl]
"net.ipv4.conf.default.arp_accept" = "1"

```

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
