### PR TITLE
systemd-sysusers: change execution order

### DIFF
--- a/packages/systemd/systemd-sysusers.conf
+++ b/packages/systemd/systemd-sysusers.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=selinux-policy-files.service

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -13,6 +13,7 @@ Source2: systemd-modules-load.conf
 Source3: journald.conf
 Source4: issue
 Source5: systemd-journald.conf
+Source6: systemd-sysusers.conf
 
 # Backport of upstream patches that make the netlink default timeout
 # configurable.  Bottlerocket carries this patch and configures the timeout in
@@ -301,6 +302,9 @@ install -p -m 0644 %{S:3} %{buildroot}%{_cross_libdir}/systemd/journald.conf.d/j
 
 install -d %{buildroot}%{_cross_unitdir}/systemd-journald.service.d
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_unitdir}/systemd-journald.service.d/systemd-journald.conf
+
+install -d %{buildroot}%{_cross_unitdir}/systemd-sysusers.service.d
+install -p -m 0644 %{S:6} %{buildroot}%{_cross_unitdir}/systemd-sysusers.service.d/systemd-sysusers.conf
 
 # Remove all stock network configurations, as they can interfere
 # with container networking by attempting to manage veth devices.


### PR DESCRIPTION
**Description of changes:**

`systemd-sysusers` might run while the `/etc` `tmpfs` filesystem is still being set up, which results on failures on the service when it tries to read SELinux configuration files. With this change, `systemd-sysusers` is forced to run after the required SELinux configuration files are in place.


**Testing done:**

- I confirmed `systemd-sysusers` runs after `selinux-policy-files`. 
- There weren't any new warnings when I ran `journalctl -p4`. 
- `systemctl status` shows the system is `running` 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
