### PR TITLE
thar-be-updates: migrate to use configuration file

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -278,4 +278,6 @@ version = "1.19.3"
 "(1.19.2, 1.19.3)" = [
     "migrate_v1.19.3_prairiedog-config-file-v0-1-0.lz4",
     "migrate_v1.19.3_prairiedog-services-cfg-v0-1-0.lz4",
+    "migrate_v1.19.3_thar-be-updates-config-file-v0-1-0.lz4",
+    "migrate_v1.19.3_thar-be-updates-affected-services-v0-1-0.lz4",
 ]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -33,6 +33,7 @@ Source13: cis-checks-k8s-metadata-json
 %endif
 Source14: certdog-toml
 Source15: prairiedog-toml
+Source16: thar-be-updates-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -474,7 +475,7 @@ install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{S:16} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
@@ -585,6 +586,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %files -n %{_cross_os}thar-be-updates
 %{_cross_bindir}/thar-be-updates
 %{_cross_tmpfilesdir}/thar-be-updates.conf
+%{_cross_templatedir}/thar-be-updates-toml
 
 %files -n %{_cross_os}host-containers
 %{_cross_bindir}/host-containers

--- a/packages/os/thar-be-updates-toml
+++ b/packages/os/thar-be-updates-toml
@@ -1,0 +1,5 @@
+[required-extensions]
+updates = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
+version-lock = "{{{default "latest" settings.updates.version-lock}}}"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4094,15 +4094,12 @@ dependencies = [
 name = "thar-be-updates"
 version = "0.1.0"
 dependencies = [
- "apiclient",
  "bottlerocket-release",
  "chrono",
- "constants",
  "fs2",
  "generate-readme",
- "http",
  "log",
- "models",
+ "modeled-types",
  "nix",
  "num-derive",
  "num-traits",
@@ -4114,8 +4111,22 @@ dependencies = [
  "simplelog",
  "snafu",
  "tempfile",
- "tokio",
+ "toml 0.8.8",
  "update_metadata",
+]
+
+[[package]]
+name = "thar-be-updates-affected-services-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "thar-be-updates-config-file-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -66,6 +66,8 @@ members = [
     "api/migration/migrations/v1.19.2/add-ecs-enable-container-metadata",
     "api/migration/migrations/v1.19.3/prairiedog-config-file-v0-1-0",
     "api/migration/migrations/v1.19.3/prairiedog-services-cfg-v0-1-0",
+    "api/migration/migrations/v1.19.3/thar-be-updates-config-file-v0-1-0",
+    "api/migration/migrations/v1.19.3/thar-be-updates-affected-services-v0-1-0",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.19.3/thar-be-updates-affected-services-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/thar-be-updates-affected-services-v0-1-0/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "thar-be-updates-affected-services-v0-1-0"
+version = "0.1.0"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/thar-be-updates-affected-services-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/thar-be-updates-affected-services-v0-1-0/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::{
+    MetadataListReplacement, ReplaceMetadataListsMigration,
+};
+use migration_helpers::{migrate, Result};
+use std::process;
+fn run() -> Result<()> {
+    migrate(ReplaceMetadataListsMigration(vec![
+        MetadataListReplacement {
+            setting: "settings.updates",
+            metadata: "affected-services",
+            old_vals: &["updog"],
+            new_vals: &["updog", "thar-be-updates"],
+        },
+    ]))
+}
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.3/thar-be-updates-config-file-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/thar-be-updates-config-file-v0-1-0/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "thar-be-updates-config-file-v0-1-0"
+version = "0.1.0"
+edition = "2021"
+authors = ["Jarrett Tierney <jmt@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/thar-be-updates-config-file-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/thar-be-updates-config-file-v0-1-0/src/main.rs
@@ -1,0 +1,17 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "configuration-files.thar-be-updates-toml",
+        "services.thar-be-updates",
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -10,14 +10,11 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
-constants = { path = "../../constants", version = "0.1" }
 bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
 chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
 fs2 = "0.4"
-http = "0.2"
 log = "0.4"
-models = { path = "../../models", version = "0.1" }
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
 nix = "0.26"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -29,7 +26,7 @@ signpost = { path = "../../updater/signpost", version = "0.1" }
 simplelog = "0.12"
 snafu = "0.7"
 tempfile = "3"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+toml = "0.8"
 update_metadata = { path = "../../updater/update_metadata", version = "0.1" }
 
 [build-dependencies]

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -46,16 +46,24 @@ restart-commands = ["/bin/systemctl try-restart host-containerd.service"]
 version-lock = "latest"
 ignore-waves = false
 
+[services.thar-be-updates]
+configuration-files = ["thar-be-updates-toml"]
+restart-commands = []
+
 [services.updog]
 configuration-files = ["updog-toml"]
 restart-commands = []
+
+[configuration-files.thar-be-updates-toml]
+path = "/etc/thar-be-updates.toml"
+template-path = "/usr/share/templates/thar-be-updates-toml"
 
 [configuration-files.updog-toml]
 path = "/etc/updog.toml"
 template-path = "/usr/share/templates/updog-toml"
 
 [metadata.settings.updates]
-affected-services = ["updog"]
+affected-services = ["updog", "thar-be-updates"]
 seed.setting-generator = "bork seed"
 
 # HostContainers


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #3625 

Closes #3625 

**Description of changes:**

This change migrates the thar-be-updates tool to utilize a configuration file at /etc/thar-be-updates.toml instead of calling back to the settings api.

log:
* migration and template
* migrate thar-be-updates tool to read settings from a config file


**Testing done:**
Tested update from 1.18.0 -> 1.18.1 and ensured settings get populated appropriately

- [x] Ran `cargo +nightly udeps` to ensure all unused dependencies have been removed
- [x] Pass the settings on first boot via userdata. Verify config.

<details>
<summary>Test Results</summary>

**User Data**

```toml
[settings.updates]
ignore-waves = true
metadata-base-url = "https://d160pk1ajy78su.cloudfront.net/tough-async/live/metadata/aws-ecs-2/aarch64"
targets-base-url = "https://d160pk1ajy78su.cloudfront.net/tough-async/live/targets"
```

**Generated Config**

```toml
version-lock = "latest"
```

</details>

- [x] cat /etc/os-release record your build ID include commit sha, record this

| Version | os-release |
| - | - | 
| 1.19.2 | BUILD_ID=29cc92cc |
| 1.19.3 | BUILD_ID=01c5e345 |

- [x] Use apiclient to update relevant settings at runtime. Verify config was updated correctly.

<details>
<summary>Test Info</summary>

**Command Run**

```apiclient set settings.updates.version-lock="1.19.3"```

**Resulting Config File**

```toml
version-lock = "1.19.3"
```
</details>

- [x] Downgrade to older version. 
  - [x] verify connectivity
  - [x] cat /etc/os-release to verify lower version
  - [x] verify that migrations have changed the metadata/settings as expected (i.e. they are gone from the datastore, or lists have been changed back)

<details>
<summary>Test Info</summary>

**/etc/os-release upon downgrade**

```
VERSION_ID=1.19.2
BUILD_ID=29cc92cc
```

**Migrations**

```
apiclient get configuration-files.thar-be-updates-toml
{}
```

```
apiclient get services.thar-be-updates
{}
```

```
cat var/lib/bottlerocket/datastore/current/live/settings/updates.affected-services
["updog"]
```

</details>

- [x] Upgrade to newer version.
  - [x] verify connectivity
  - [x] cat /etc/os-release to verify version
  - [x] verify config file

<details>
<summary>Test Info</summary>

**/etc/os-release upon upgrade**

```
VERSION_ID=1.19.3
BUILD_ID=01c5e345
```

**Config File**

```toml
version-lock = "latest"
```

**Migrations**

```
apiclient get configuration-files.thar-be-updates-toml
{
  "configuration-files": {
    "thar-be-updates-toml": {
      "path": "/etc/thar-be-updates.toml",
      "template-path": "/usr/share/templates/thar-be-updates-toml"
    }
  }
}
```

```
apiclient get services.thar-be-updates
{
  "services": {
    "thar-be-updates": {
      "configuration-files": [
        "thar-be-updates-toml"
      ],
      "restart-commands": []
    }
  }
}
```

```
cat var/lib/bottlerocket/datastore/current/live/settings/updates.affected-services
["updog","thar-be-updates"]
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
