### PR TITLE
settings: add kernel settings extension

### DIFF
--- a/packages/settings-kernel/Cargo.toml
+++ b/packages/settings-kernel/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-kernel"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/kernel"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-kernel/settings-kernel.spec
+++ b/packages/settings-kernel/settings-kernel.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name kernel
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3625,6 +3625,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-kernel"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "rand",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2629,6 +2629,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings-extension-container-registry",
+ "settings-extension-kernel",
  "settings-extension-motd",
  "settings-extension-ntp",
  "settings-extension-updates",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -79,6 +79,7 @@ members = [
 
     "models",
 
+    "settings-extensions/kernel",
     "settings-extensions/motd",
     "settings-extensions/ntp",
     "settings-extensions/container-registry",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 
 # settings extensions
+settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
+    HostContainer, MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     ecs: ECSSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     ecs: ECSSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate,
+    DnsSettings, ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     ecs: ECSSettings,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, ECSSettings, HostContainer, KernelSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate,
+    DnsSettings, ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -18,7 +18,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     ecs: ECSSettings,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KernelSettings, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/aws-k8s-1.29/mod.rs
+++ b/sources/models/src/aws-k8s-1.29/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KernelSettings, KubernetesSettings,
-    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,

--- a/sources/models/src/metal-k8s-1.24/mod.rs
+++ b/sources/models/src/metal-k8s-1.24/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/metal-k8s-1.29/mod.rs
+++ b/sources/models/src/metal-k8s-1.29/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: AwsSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, KernelSettings, MetricsSettings,
-    NetworkSettings, OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
+    OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -17,7 +17,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,

--- a/sources/models/src/vmware-k8s-1.24/mod.rs
+++ b/sources/models/src/vmware-k8s-1.24/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     boot: BootSettings,
     metrics: MetricsSettings,

--- a/sources/models/src/vmware-k8s-1.29/mod.rs
+++ b/sources/models/src/vmware-k8s-1.29/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::{
     AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KernelSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
-    OciDefaults, OciHooks, PemCertificate,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
-    kernel: KernelSettings,
+    kernel: settings_extension_kernel::KernelSettingsV1,
     aws: AwsSettings,
     boot: BootSettings,
     metrics: MetricsSettings,

--- a/sources/settings-extensions/kernel/Cargo.toml
+++ b/sources/settings-extensions/kernel/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "settings-extension-kernel"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/kernel/kernel.toml
+++ b/sources/settings-extensions/kernel/kernel.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/kernel/src/lib.rs
+++ b/sources/settings-extensions/kernel/src/lib.rs
@@ -1,0 +1,103 @@
+/// The kernel settings can be used to configure settings related to the kernel, e.g.  
+/// kernel modules
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::{KmodKey, Lockdown, SysctlKey};
+use std::collections::HashMap;
+use std::convert::Infallible;
+
+#[model(impl_default = true)]
+struct KernelSettingsV1 {
+    lockdown: Lockdown,
+    modules: HashMap<KmodKey, KmodSetting>,
+    // Values are almost always a single line and often just an integer... but not always.
+    sysctl: HashMap<SysctlKey, String>,
+}
+
+#[model]
+struct KmodSetting {
+    allowed: bool,
+    autoload: bool,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for KernelSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // allow anything that parses as KernelSettingsV1
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_kernel() {
+        let generated = KernelSettingsV1::generate(None, None).unwrap();
+
+        assert_eq!(
+            generated,
+            GenerateResult::Complete(KernelSettingsV1 {
+                lockdown: None,
+                modules: None,
+                sysctl: None,
+            })
+        )
+    }
+
+    #[test]
+    fn test_serde_kernel() {
+        let test_json = r#"{
+            "lockdown": "integrity",
+            "modules": {"foo": {"allowed": true, "autoload": true}},
+            "sysctl": {"key": "value"}
+        }"#;
+
+        let kernel: KernelSettingsV1 = serde_json::from_str(test_json).unwrap();
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            KmodKey::try_from("foo").unwrap(),
+            KmodSetting {
+                allowed: Some(true),
+                autoload: Some(true),
+            },
+        );
+        let modules = Some(modules);
+
+        let mut sysctl = HashMap::new();
+        sysctl.insert(SysctlKey::try_from("key").unwrap(), String::from("value"));
+        let sysctl = Some(sysctl);
+
+        assert_eq!(
+            kernel,
+            KernelSettingsV1 {
+                lockdown: Some(Lockdown::try_from("integrity").unwrap()),
+                modules,
+                sysctl,
+            }
+        );
+    }
+}

--- a/sources/settings-extensions/kernel/src/main.rs
+++ b/sources/settings-extensions/kernel/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_kernel::KernelSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("kernel")
+        .with_models(vec![BottlerocketSetting::<KernelSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket/issues/3653

**Description of changes:**

Ports kernel settings to a settings extension.

**Testing done:**

Built an aws-dev variant with the `settings-kernel` package installed, and launched an ec2 instance with it.

Kernel settings in the API and the setting extension both behaved as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
