### PR TITLE
settings: add aws settings extension

### DIFF
--- a/packages/settings-aws/Cargo.toml
+++ b/packages/settings-aws/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-aws"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/aws"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-aws/settings-aws.spec
+++ b/packages/settings-aws/settings-aws.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name aws
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2649,6 +2649,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "settings-extension-aws",
  "settings-extension-container-registry",
  "settings-extension-kernel",
  "settings-extension-motd",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3649,6 +3649,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-aws"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -84,6 +84,7 @@ members = [
 
     "models",
 
+    "settings-extensions/aws",
     "settings-extensions/container-registry",
     "settings-extensions/kernel",
     "settings-extensions/motd",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 
 # settings extensions
+settings-extension-aws = { path = "../settings-extensions/aws", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
+    MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +19,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -2,9 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
+    HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +18,7 @@ struct Settings {
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -2,9 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, AwsSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
+    HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +18,7 @@ struct Settings {
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -2,9 +2,9 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +20,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -2,9 +2,9 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +20,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
     NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
     NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
     NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    DnsSettings, HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults,
-    OciHooks, PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
+    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-k8s-1.29/mod.rs
+++ b/sources/models/src/aws-k8s-1.29/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AutoScalingSettings, AwsSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
     NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
@@ -21,7 +21,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/metal-k8s-1.29/mod.rs
+++ b/sources/models/src/metal-k8s-1.29/mod.rs
@@ -2,9 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
+    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +20,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/vmware-k8s-1.29/mod.rs
+++ b/sources/models/src/vmware-k8s-1.29/mod.rs
@@ -2,9 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AwsSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
+    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +19,7 @@ struct Settings {
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
-    aws: AwsSettings,
+    aws: settings_extension_aws::AwsSettingsV1,
     boot: BootSettings,
     metrics: MetricsSettings,
     pki: HashMap<Identifier, PemCertificate>,

--- a/sources/settings-extensions/aws/Cargo.toml
+++ b/sources/settings-extensions/aws/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-aws"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/aws/aws.toml
+++ b/sources/settings-extensions/aws/aws.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/aws/src/lib.rs
+++ b/sources/settings-extensions/aws/src/lib.rs
@@ -1,0 +1,84 @@
+/// The aws settings can be used to configure settings related to AWS
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::{SingleLineString, ValidBase64};
+use std::convert::Infallible;
+
+// Platform-specific settings
+#[model(impl_default = true)]
+pub struct AwsSettingsV1 {
+    region: SingleLineString,
+    config: ValidBase64,
+    credentials: ValidBase64,
+    profile: SingleLineString,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for AwsSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // allow anything that parses as AwsSettingsV1
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_aws() {
+        let generated = AwsSettingsV1::generate(None, None).unwrap();
+        assert_eq!(
+            generated,
+            GenerateResult::Complete(AwsSettingsV1 {
+                region: None,
+                config: None,
+                credentials: None,
+                profile: None,
+            })
+        )
+    }
+
+    #[test]
+    fn test_serde_aws() {
+        let test_json = r#"{
+            "region": "us-east-1",
+            "config": "Zm9vCg==",
+            "credentials": "Zm9vCg==",
+            "profile": "foo"
+        }"#;
+
+        let aws: AwsSettingsV1 = serde_json::from_str(test_json).unwrap();
+
+        assert_eq!(
+            aws,
+            AwsSettingsV1 {
+                region: Some(SingleLineString::try_from("us-east-1").unwrap()),
+                config: Some(ValidBase64::try_from("Zm9vCg==").unwrap()),
+                credentials: Some(ValidBase64::try_from("Zm9vCg==").unwrap()),
+                profile: Some(SingleLineString::try_from("foo").unwrap()),
+            }
+        );
+    }
+}

--- a/sources/settings-extensions/aws/src/main.rs
+++ b/sources/settings-extensions/aws/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_aws::AwsSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("aws")
+        .with_models(vec![BottlerocketSetting::<AwsSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
**Issue number:**

Closes #3655 

**Description of changes:**

Creates an `aws` settings extension and uses it in every variant's settings model.

**Testing done:**

Built an `aws-dev` variant with the `settings-aws` package installed. Called apiclient to verify that the aws settings worked as before. Also called the settings extension to verify that it was behaving as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
