### PR TITLE
k8s: update eni-max-pods mapping for latest

### DIFF
--- a/packages/os/eni-max-pods
+++ b/packages/os/eni-max-pods
@@ -298,6 +298,7 @@ i3en.6xlarge 234
 i3en.large 29
 i3en.metal 737
 i3en.xlarge 58
+i3p.16xlarge 51
 i4g.16xlarge 737
 i4g.2xlarge 58
 i4g.4xlarge 234


### PR DESCRIPTION


**Issue number:** [#3736](https://github.com/bottlerocket-os/bottlerocket/issues/3736)

Closes # [#3736](https://github.com/bottlerocket-os/bottlerocket/issues/3736)

**Description of changes:**
This pulls in the new instance types to the eni-max-pods mapping file. It adds the max pod values for a new set of published instance types.

Generated content by using the [update script](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/gen_vpc_ip_limits.go).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
