### PR TITLE
testsys: workaround in Makefile.toml for arg parsing issue

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -549,7 +549,24 @@ run_task = "run-twoliter"
 
 # This task is useful for using the current tree's testsys without symlinks
 [tasks.testsys]
-run_task = "run-twoliter"
+dependencies = ["install-twoliter"]
+script_runner = "bash"
+script = [
+'''
+# TODO - remove this workaround when https://github.com/bottlerocket-os/twoliter/issues/139
+# is fixed. Clap in Twoliter is greedily taking ownership of args intended for testsys
+# so we need to call testsys directly here.
+
+# Ensure tools are installed in the canonical location
+mkdir -p "./build/tools"
+"${TWOLITER}" debug check-tools --install-dir ./build/tools 2>&1 >/dev/null
+
+./build/tools/testsys \
+  --log-level "${TWOLITER_LOG_LEVEL}" \
+  ${CARGO_MAKE_TESTSYS_ARGS} \
+  ${@}
+'''
+]
 
 [tasks.default]
 alias = "build"


### PR DESCRIPTION

**Issue number:**

Underlying issue https://github.com/bottlerocket-os/twoliter/issues/139

**Description of changes:**

There is an issue with the way Clap interprets "additional" arguments in Twoliter. Until the fix for that can be found, this workaround calls testsys directly, bypassing the issue with Twoliter and Clap.

**Testing done:**

The problematic command that was brought to my attention now works. It was something like this:

```
cargo make testsys add secret map  \
 --name "foo" \
 "x=bar" \
 "y=baz"
```

Which now works.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
