### PR TITLE
build: update twoliter to v0.0.6

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,7 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.0.5"
+TWOLITER_VERSION = "v0.0.6"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION


**Issue number:**

NA

**Description of changes:**

Updates Twoliter to v0.0.6


**Testing done:**

Built a variant, AMI and Repo. Made a call using `cargo make testsys` with varargs (which are now fixed).


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
