### PR TITLE
Add additional ECS settings

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -261,3 +261,6 @@ version = "1.18.0"
     "migrate_v1.18.0_aws-control-container-v0-7-7.lz4",
     "migrate_v1.18.0_public-control-container-v0-7-7.lz4",
 ]
+"(1.18.0, 1.19.0)" = [
+    "migrate_v1.19.0_add-additional-ecs-settings.lz4",
+]

--- a/packages/ecs-agent/ecs.config
+++ b/packages/ecs-agent/ecs.config
@@ -33,3 +33,9 @@ ECS_IMAGE_CLEANUP_INTERVAL="{{settings.ecs.image-cleanup-wait}}"
 {{# if settings.ecs.image-cleanup-age}}
 ECS_IMAGE_MINIMUM_CLEANUP_AGE="{{settings.ecs.image-cleanup-age}}"
 {{/if}}
+{{#if settings.ecs.backend-host}}
+ECS_BACKEND_HOST="{{settings.ecs.backend-host}}"
+{{/if}}
+{{#if settings.ecs.awsvpc-block-imds}}
+ECS_AWSVPC_BLOCK_IMDS="{{settings.ecs.awsvpc-block-imds}}"
+{{/if}}

--- a/packages/ecs-agent/ecs.service
+++ b/packages/ecs-agent/ecs.service
@@ -7,9 +7,9 @@ Wants=network-online.target configured.target
 
 [Service]
 Type=simple
-Restart=on-failure
+Restart=always
 RestartPreventExitStatus=5
-RestartSec=1s
+RestartSec=5
 EnvironmentFile=-/etc/ecs/ecs.config
 EnvironmentFile=/etc/network/proxy.env
 Environment=ECS_CHECKPOINT=true

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -218,6 +218,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-additional-ecs-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "api/migration/migrations/v1.18.0/public-admin-container-v0-11-3",
     "api/migration/migrations/v1.18.0/aws-control-container-v0-7-7",
     "api/migration/migrations/v1.18.0/public-control-container-v0-7-7",
+    "api/migration/migrations/v1.19.0/add-additional-ecs-settings",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.19.0/add-additional-ecs-settings/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.0/add-additional-ecs-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "add-additional-ecs-settings"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.19.0/add-additional-ecs-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.0/add-additional-ecs-settings/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added additional configurations for the ECS agent
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.ecs.backend-host",
+        "settings.ecs.awsvpc-block-imds",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -333,6 +333,8 @@ struct ECSSettings {
     image_cleanup_delete_per_cycle: i64,
     image_cleanup_enabled: bool,
     image_cleanup_age: ECSDurationValue,
+    backend_host: String,
+    awsvpc_block_imds: bool,
 }
 
 #[model]


### PR DESCRIPTION
**Issue number:**

Part of #3717, I'll deprecate ECS settings applier in a follow up PR

**Description of changes:**

This adds support for two more ECS settings `ECS_BACKEND_HOST` and `ECS_AWSVPC_BLOCK_IMDS`. Additionally, I added a commit to fix the restart configurations for the ECS agent.

**Testing done:**

In aws-ecs-2:

- Tested that the IMDS calls were blocked when `ECS_AWSVPC_BLOCK_IMDS`:

```
[root@ip-172-31-17-243 /]# TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/
curl: (7) Couldn't connect to server
```

```
[root@ip-172-31-24-231 /]# TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" -s` && curl -H "X-aws-ec2-metadata-token: $TOKEN" -q http://169.254.169.254/latest/meta-data/ 2>&1 1>/dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   325  100   325    0     0   299k      0 --:--:-- --:--:-- --:--:--  317k
```

- Tested that the endpoint changed when `BACKED_HOST` setting was configured. I used an invalid URL and the ECS agent failed to start
- Tested the ECS service restarted always on failures

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
