### PR TITLE
bump Release.toml to 1.19.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.18.0"
+version = "1.19.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.18.0"
+release-version = "1.19.0"
 
 [sdk]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
**Issue number:**
#3731 

**Description of changes:**
Bump the Release.toml and Twoliter.toml versions to 1.19.0


**Testing done:**
`cargo make`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
