### PR TITLE
host-ctr: add label flag to host-ctr pull-image.

### DIFF
--- a/packages/kubernetes-1.23/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.23/prestart-pull-pause-ctr.conf
@@ -6,4 +6,5 @@ ExecStartPre=/usr/bin/host-ctr \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
     --registry-config=/etc/host-containers/host-ctr.toml \
-    --skip-if-image-exists=true
+    --skip-if-image-exists=true \
+    --label="io.cri-containerd.pinned=pinned"

--- a/packages/kubernetes-1.24/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.24/prestart-pull-pause-ctr.conf
@@ -6,4 +6,5 @@ ExecStartPre=/usr/bin/host-ctr \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
     --registry-config=/etc/host-containers/host-ctr.toml \
-    --skip-if-image-exists=true
+    --skip-if-image-exists=true \
+    --label="io.cri-containerd.pinned=pinned"

--- a/packages/kubernetes-1.25/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.25/prestart-pull-pause-ctr.conf
@@ -6,4 +6,5 @@ ExecStartPre=/usr/bin/host-ctr \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
     --registry-config=/etc/host-containers/host-ctr.toml \
-    --skip-if-image-exists=true
+    --skip-if-image-exists=true \
+    --label="io.cri-containerd.pinned=pinned"

--- a/packages/kubernetes-1.26/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.26/prestart-pull-pause-ctr.conf
@@ -6,4 +6,5 @@ ExecStartPre=/usr/bin/host-ctr \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
     --registry-config=/etc/host-containers/host-ctr.toml \
-    --skip-if-image-exists=true
+    --skip-if-image-exists=true \
+    --label="io.cri-containerd.pinned=pinned"

--- a/packages/kubernetes-1.27/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.27/prestart-pull-pause-ctr.conf
@@ -6,4 +6,5 @@ ExecStartPre=/usr/bin/host-ctr \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
     --registry-config=/etc/host-containers/host-ctr.toml \
-    --skip-if-image-exists=true
+    --skip-if-image-exists=true \
+    --label="io.cri-containerd.pinned=pinned"

--- a/packages/kubernetes-1.28/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.28/prestart-pull-pause-ctr.conf
@@ -6,4 +6,5 @@ ExecStartPre=/usr/bin/host-ctr \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
     --registry-config=/etc/host-containers/host-ctr.toml \
-    --skip-if-image-exists=true
+    --skip-if-image-exists=true \
+    --label="io.cri-containerd.pinned=pinned"

--- a/packages/kubernetes-1.29/prestart-pull-pause-ctr.conf
+++ b/packages/kubernetes-1.29/prestart-pull-pause-ctr.conf
@@ -6,4 +6,5 @@ ExecStartPre=/usr/bin/host-ctr \
     pull-image \
     --source=${POD_INFRA_CONTAINER_IMAGE} \
     --registry-config=/etc/host-containers/host-ctr.toml \
-    --skip-if-image-exists=true
+    --skip-if-image-exists=true \
+    --label="io.cri-containerd.pinned=pinned"

--- a/sources/host-ctr/cmd/host-ctr/main_test.go
+++ b/sources/host-ctr/cmd/host-ctr/main_test.go
@@ -222,3 +222,77 @@ func TestFetchECRRef(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertLabel(t *testing.T) {
+	tests := []struct {
+		name             string
+		labels           []string
+		expectedErr      bool
+		expectedLabelMap map[string]string
+	}{
+		{
+			"Valid single label",
+			[]string{"io.cri-containerd.pinned=pinned"},
+			false,
+			map[string]string{
+				"io.cri-containerd.pinned": "pinned",
+			},
+		},
+		{
+			"Valid single label without equals sign",
+			[]string{"io.cri-containerd.pinned,pinned"},
+			false,
+			map[string]string{
+				"io.cri-containerd.pinned,pinned": "",
+			},
+		},
+		{
+			"Empty labels",
+			[]string{""},
+			false,
+			map[string]string{"": ""},
+		},
+		{
+			"Valid multiple labels",
+			[]string{"io.cri-containerd.pinned=pinned", "io.cri-containerd.test=test"},
+			false,
+			map[string]string{
+				"io.cri-containerd.pinned": "pinned",
+				"io.cri-containerd.test":   "test",
+			},
+		},
+		{
+			"valid multiple labels without equals sign",
+			[]string{"io.cri-containerd.pinned=pinned", "io.cri-containerd.test,test"},
+			false,
+			map[string]string{
+				"io.cri-containerd.pinned":    "pinned",
+				"io.cri-containerd.test,test": "",
+			},
+		},
+		{
+			"Value is empty",
+			[]string{"io.cri-containerd.pinned=pinned", "io.cri-containerd.test="},
+			false,
+			map[string]string{
+				"io.cri-containerd.pinned": "pinned",
+				"io.cri-containerd.test":   "",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := convertLabels(tc.labels)
+			if tc.expectedErr {
+				// handle error cases
+				if err == nil {
+					t.Fail()
+				}
+			} else {
+				// handle happy paths
+				assert.Equal(t, tc.expectedLabelMap, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#3745 
Closes #

**Description of changes:**
Sandbox container image on k8s 1.29 isn't pinned and causea the Sandbox container image would be GC. we add label flag to host-ctr pull-image and pass "io.cri-containerd.pinned=pinned" label to all 1.29 varaints. Then the Sandbox contianer image will be pinned and avoid GC issue.

**Testing done:**

- [x] Launch the 1.29 nodes to 1.29 cluster and check if the pause image is pinned
```
602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause             3.1-eksbuild.1       106a8e54d5eb3       299kB
[root@admin]# /crictl --runtime-endpoint unix:///.bottlerocket/rootfs/run/containerd/containerd.sock inspecti 106a8e54d5eb3 | grep pinned
    "pinned": true
```
- [x] conformance test for 1.29 nodes
AWS
```
[cargo-make][1] INFO - Running Task: testsys
 NAME                                           TYPE                STATE                         PASSED            FAILED            SKIPPED   BUILD ID            LAST UPDATE
 x86-64-aws-k8s-129-conformance-test            Test                passed                           392                 0               7019                       2024-02-05T03:18:41Z
 x86-64-aws-k8s-129-instances                   Resource            completed                                                                                       2024-02-05T01:25:21Z
```
VMWARE - a Known kubernetes flake on conformance test.
```
Plugin: e2e
Status: failed
Total: 7411
Passed: 391
Failed: 1
Skipped: 7019

Failed tests:
 [sig-network] Services should serve endpoints on same port and different protocols [Conformance]
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
