### PR TITLE
packages: update amazon-ssm-agent to 3.2.2222.0

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.2143.0/amazon-ssm-agent-3.2.2143.0.tar.gz"
-sha512 = "8009ccec69a555fcbb414c427e74f05c745526127c8b80465f070379aedecc09cc154e1cad1186ed06e25e893c818f2267abd56e64b71c62ec9a281eb8d46c83"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.2.2222.0/amazon-ssm-agent-3.2.2222.0.tar.gz"
+sha512 = "7547414e57eec32e5507e3b60a49efcdf589697a54e65b755fc0a0c5f2feec2f26ddd26dda9a8fc56aa3dfab7a19567faaad9944a3a22249f736a1c7872bc5d8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -8,12 +8,14 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.2.2143.0
+Version: 3.2.2222.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0
 URL: https://github.com/aws/amazon-ssm-agent
 Source0: %{gorepo}-%{version}.tar.gz
+Source1000: clarify.toml
+
 BuildRequires: %{_cross_os}glibc-devel
 
 %description
@@ -40,7 +42,8 @@ for b in amazon-ssm-agent ssm-agent-worker ssm-session-worker; do
   install -D -p -m 0755 ${b} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
 done
 
-%cross_scan_attribution go-vendor vendor
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
 %license LICENSE

--- a/packages/amazon-ssm-agent/clarify.toml
+++ b/packages/amazon-ssm-agent/clarify.toml
@@ -1,0 +1,6 @@
+[clarify."github.com/cloudflare/circl"]
+expression = "BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xc5e27124 },
+]
+


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```
packages: update amazon-ssm-agent to 3.2.2222.0
```


**Testing done:**
- [x] aws-ecs-1
```
 NAME                                   TYPE           STATE               PASSED	FAILED       SKIPPED   BUILD ID       LAST UPDATE
 x86-64-aws-ecs-1-quick                 Test           passed                   1            0             0   517fa82d       2024-02-06T15:51:44Z
 x86-64-aws-ecs-1                       Resource       completed                                               517fa82d       2024-02-06T15:51:10Z
 x86-64-aws-ecs-1-instances-ifrq        Resource       completed                                               517fa82d       2024-02-06T15:51:21Z
```
- [x] aws-ecs-2
```
x86-64-aws-ecs-2-quick          Test         passed                    1              0               0   517fa82d         2024-02-06T16:03:04Z
```
- [x] aws-ecs-1 ECSexec test using Macis

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
