### PR TITLE
Update the host containers for 1.19.1

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.19.0"
+version = "1.19.1"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -264,3 +264,4 @@ version = "1.19.0"
 "(1.18.0, 1.19.0)" = [
     "migrate_v1.19.0_add-additional-ecs-settings.lz4",
 ]
+"(1.19.0, 1.19.1)" = []

--- a/Release.toml
+++ b/Release.toml
@@ -264,4 +264,7 @@ version = "1.19.1"
 "(1.18.0, 1.19.0)" = [
     "migrate_v1.19.0_add-additional-ecs-settings.lz4",
 ]
-"(1.19.0, 1.19.1)" = []
+"(1.19.0, 1.19.1)" = [
+    "migrate_v1.19.1_aws-admin-container-v0-11-4.lz4",
+    "migrate_v1.19.1_public-admin-container-v0-11-4.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -267,4 +267,6 @@ version = "1.19.1"
 "(1.19.0, 1.19.1)" = [
     "migrate_v1.19.1_aws-admin-container-v0-11-4.lz4",
     "migrate_v1.19.1_public-admin-container-v0-11-4.lz4",
+    "migrate_v1.19.1_aws-control-container-v0-7-8.lz4",
+    "migrate_v1.19.1_public-control-container-v0-7-8.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.19.0"
+release-version = "1.19.1"
 
 [sdk]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -548,6 +548,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-4"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-config"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3122,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-3"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-4"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -613,6 +613,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-8"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3164,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-7"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-8"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -59,6 +59,8 @@ members = [
     "api/migration/migrations/v1.19.0/add-additional-ecs-settings",
     "api/migration/migrations/v1.19.1/aws-admin-container-v0-11-4",
     "api/migration/migrations/v1.19.1/public-admin-container-v0-11-4",
+    "api/migration/migrations/v1.19.1/aws-control-container-v0-7-8",
+    "api/migration/migrations/v1.19.1/public-control-container-v0-7-8",
 
     "bloodhound",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -57,6 +57,8 @@ members = [
     "api/migration/migrations/v1.18.0/aws-control-container-v0-7-7",
     "api/migration/migrations/v1.18.0/public-control-container-v0-7-7",
     "api/migration/migrations/v1.19.0/add-additional-ecs-settings",
+    "api/migration/migrations/v1.19.1/aws-admin-container-v0-11-4",
+    "api/migration/migrations/v1.19.1/public-admin-container-v0-11-4",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.19.1/aws-admin-container-v0-11-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.1/aws-admin-container-v0-11-4/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-admin-container-v0-11-4"
+version = "0.1.0"
+authors = ["Matthew Yeazel <yeazelm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.19.1/aws-admin-container-v0-11-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.1/aws-admin-container-v0-11-4/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.3'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.4'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.1/aws-control-container-v0-7-8/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.1/aws-control-container-v0-7-8/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-control-container-v0-7-8"
+version = "0.1.0"
+authors = ["Matthew Yeazel <yeazelm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.19.1/aws-control-container-v0-7-8/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.1/aws-control-container-v0-7-8/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.7'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.8'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.1/public-admin-container-v0-11-4/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.1/public-admin-container-v0-11-4/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-admin-container-v0-11-4"
+version = "0.1.0"
+authors = ["Matthew Yeazel <yeazelm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.19.1/public-admin-container-v0-11-4/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.1/public-admin-container-v0-11-4/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.3";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.4";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.1/public-control-container-v0-7-8/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.1/public-control-container-v0-7-8/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-control-container-v0-7-8"
+version = "0.1.0"
+authors = ["Matthew Yeazel <yeazelm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.19.1/public-control-container-v0-7-8/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.1/public-control-container-v0-7-8/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.7";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.8";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.3'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.4'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.7'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.8'"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.3"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.4"
 
 [settings.host-containers.control]
 enabled = false

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.4"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.7"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.8"


### PR DESCRIPTION
**Description of changes:**
Update the admin and control host containers to bottlerocket-admin-container v0.11.4 and bottlerocket-control-container v0.7.8. Also add migrations move to these versions on upgrade.

**Testing done:**
Using a c6i.2xlarge EC2 instance with the aws-k8s-1.28 variant, I successfully tested the following scenarios:

* Bottlerocket v1.19.0 can be upgraded into Bottlerocket v1.19.1 and uses the new host container images.
* A system upgraded from 1.19.0 can be rolled back to Bottlerocket v1.19.0 and revert to using the old host container images.
* A new Bottlerocket v1.19.1 image uses the new host container images.




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
