### PR TITLE
kernel: Update to latest versions for series 5.15 5.10

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/44af81a4c59431d8729930480eb04e70c6e3be7d23fccbcbddb17395f16c73ce/kernel-5.10.205-195.807.amzn2.src.rpm"
-sha512 = "e49f39ad7ae0ffc602c28d12e649dcc77c0a3fcff65fe98b2a2e56aab97f501f0af35fb0f257f03a9a4da24f83a0c30c7c64a0c502bcf46d56f412021d10f1d2"
+url = "https://cdn.amazonlinux.com/blobstore/3d52b3205bf9d50e870cd4edaece690532e22b3738f95a1ca05a66f98be13aed/kernel-5.10.209-198.812.amzn2.src.rpm"
+sha512 = "20075e0f9d0def7f41a0dc79711fccb57e3f5b79079791da2f4cc56b11c9d1f306cc63753b6004bfcc43443bb2c6668c44c69a6d326da45d8a169ffe4a510213"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.205
+Version: 5.10.209
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/44af81a4c59431d8729930480eb04e70c6e3be7d23fccbcbddb17395f16c73ce/kernel-5.10.205-195.807.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/3d52b3205bf9d50e870cd4edaece690532e22b3738f95a1ca05a66f98be13aed/kernel-5.10.209-198.812.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/bc7e2bdcb4414f6d629c0ff58bfdfff1c471e5a4e5033c6d371535991233cec4/kernel-5.15.145-95.161.amzn2.src.rpm"
-sha512 = "12df106be137e85b822f10d395b36f7f1edce37fa4704c9ace8e58a4354093f50eaa6f8b121ea85ab21a87eb4ec8108afc999d8a6b8945fe9f04dfe4a7a79f61"
+url = "https://cdn.amazonlinux.com/blobstore/099e5401bd8b5ffe59330ca1179847c32a481136173f21b7af16d20b780de422/kernel-5.15.148-97.158.amzn2.src.rpm"
+sha512 = "b2a1169b1d11ca4a93a4267d4d88fb97a87481a3b8f60702c0715fa2ad73d05a3b4ac74d25dd2cea2410038d58d8b6783a25382b3fb68879821595b1d42b230d"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.145
+Version: 5.15.148
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/bc7e2bdcb4414f6d629c0ff58bfdfff1c471e5a4e5033c6d371535991233cec4/kernel-5.15.145-95.161.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/099e5401bd8b5ffe59330ca1179847c32a481136173f21b7af16d20b780de422/kernel-5.15.148-97.158.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                              STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-68-107.eu-central-1.compute.internal   Ready    <none>   52s     v1.23.17-eks-ea94ec3   192.168.68.107   18.156.134.3    Bottlerocket OS 1.19.0 (aws-k8s-1.23)   5.10.209         containerd://1.6.28+bottlerocket
ip-192-168-81-156.eu-central-1.compute.internal   Ready    <none>   5m58s   v1.26.11-eks-b93ee12   192.168.81.156   3.124.115.195   Bottlerocket OS 1.19.0 (aws-k8s-1.26)   5.15.148         containerd://1.6.28+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
10:09:27             e2e                                            global   complete            Passed:  1, Failed:  0, Remaining:  0
10:09:27    systemd-logs   ip-192-168-68-107.eu-central-1.compute.internal   complete                                                 
10:09:27    systemd-logs   ip-192-168-81-156.eu-central-1.compute.internal   complete                                                 
10:09:27 Sonobuoy plugins have completed. Preparing results for download.
10:09:47             e2e                                            global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
10:09:47    systemd-logs   ip-192-168-68-107.eu-central-1.compute.internal   complete   passed                                        
10:09:47    systemd-logs   ip-192-168-81-156.eu-central-1.compute.internal   complete   passed                                        
10:09:47 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:	  3 removed,   0 added,   1 changed
config-aarch64-aws-k8s-1.26-diff:	  0 removed,   0 added,   2 changed
config-x86_64-aws-k8s-1.23-diff:	  0 removed,   0 added,   2 changed
config-x86_64-aws-k8s-1.26-diff:	  0 removed,   0 added,   2 changed
config-x86_64-metal-k8s-1.26-diff:	  0 removed,   0 added,   2 changed
config-x86_64-vmware-k8s-1.26-diff:	  0 removed,   0 added,   2 changed
```
The full diff-report can be found on [Gist](https://gist.github.com/foersleo/521f75f829ddeae63cccb14887916efd).

**5.10:**
* AL disabled `CONFIG_N_GSM` for 5.10 kernels on `aarch64` as 3G and GPRS support is not needed on AWS.
* `MMC_SDHCI_AM654`, `MMC_SDHCI_OMAP`, `SPI_ZYNQMP_GQSPI` fall off due to changes to the dependencies, which makes them not visible on our kernel config starting with upstream version 5.10.209 (References: [MMC_SDHCI_OMAP](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.10.209&id=bedecbb5a5fce1f70d4ef5753d11bd524ad62906), [MMC_SDHCI_AM654](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.10.209&id=613af7d576220b9234f18a4b58d5f02bf4a9c9a8), [SPI_ZYNQMP_GQSPI](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.10.209&id=f8df7c9886dbdc618ae78505c1cebf57d7353aa3))

**all versions:**
*  `CRYPTO_GF128MUL`, `CRYPTO_GHASH` switched to being built-in on AL to work around a module loading issues with initializing crypto manager.


**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
