### PR TITLE
kernel: Update to latest versions for series 6.1

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/8a4c9c7ba87d627d236ca69292a052edc0724ac289d48523da77fe3f479d27aa/kernel-6.1.72-96.166.amzn2023.src.rpm"
-sha512 = "538abdc500a3ce35b8faa9b3f9910639e4c81c2c02ea5f382e89d7f6e364b2fd0c945a6869be2942c48901993560c3a8e45c5e7c2f0a4d5c4add3079b8009d0c"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/5d1de5166545475a39271909f57fe0e4e4527f4ce6f891c94fe741b36357d40b/kernel-6.1.75-99.163.amzn2023.src.rpm"
+sha512 = "7ddc100d62acca20ec1b0f383c9a24424f9e6eb411250a02daaef70459e56a044e791826b5cc6600eea706c38d036d9264bb11f06bdb5f16ec6a6319b47b38d1"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.72
+Version: 6.1.75
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/8a4c9c7ba87d627d236ca69292a052edc0724ac289d48523da77fe3f479d27aa/kernel-6.1.72-96.166.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/5d1de5166545475a39271909f57fe0e4e4527f4ce6f891c94fe741b36357d40b/kernel-6.1.75-99.163.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                            STATUS   ROLES    AGE   VERSION               INTERNAL-IP    EXTERNAL-IP      OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-2-39.eu-central-1.compute.internal   Ready    <none>   52s   v1.28.4-eks-d91a302   192.168.2.39   18.184.169.250   Bottlerocket OS 1.19.1 (aws-k8s-1.28)   6.1.75           containerd://1.6.28+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
08:13:57             e2e                                          global   complete            Passed:  1, Failed:  0, Remaining:  0
08:13:57    systemd-logs   ip-192-168-2-39.eu-central-1.compute.internal   complete                                                 
08:13:57 Sonobuoy plugins have completed. Preparing results for download.
08:14:17             e2e                                          global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
08:14:17    systemd-logs   ip-192-168-2-39.eu-central-1.compute.internal   complete   passed                                        
08:14:17 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.28-diff:	  0 removed,   1 added,   2 changed
config-x86_64-aws-k8s-1.28-diff:	  0 removed,   1 added,   2 changed
config-x86_64-metal-k8s-1.28-diff:	  0 removed,   1 added,   2 changed
config-x86_64-vmware-k8s-1.28-diff:	  0 removed,   1 added,   2 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/foersleo/647f470217834202e077c7ebc4a5a516).

* `PAHOLE_HAS_LANG_EXCLUDE` is a new feature flag depending on toolchain versions that was introduced to exclude specific languages (for now used to exclude rust) from pahole handling when BTF debugging is compiled (Reference: [0d242f739cec](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.1.75&id=0d242f739cecfbafd1ee4798c9a5bc1362b28a31))
* `CRYPTO_GF128MUL`, `CRYPTO_GHASH` switched to being built-in on AL to work around a module loading issues with initializing crypto manager.


**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
