### PR TITLE
settings: clean up mistakes in settings extensions

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3668,7 +3668,6 @@ dependencies = [
  "env_logger",
  "model-derive",
  "modeled-types",
- "rand",
  "serde",
  "serde_json",
 ]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -84,10 +84,10 @@ members = [
 
     "models",
 
+    "settings-extensions/container-registry",
     "settings-extensions/kernel",
     "settings-extensions/motd",
     "settings-extensions/ntp",
-    "settings-extensions/container-registry",
     "settings-extensions/updates",
 
     "parse-datetime",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -18,10 +18,10 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 
 # settings extensions
+settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
-settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-updates = { path = "../settings-extensions/updates", version = "0.1" }
 
 [build-dependencies]

--- a/sources/settings-extensions/kernel/Cargo.toml
+++ b/sources/settings-extensions/kernel/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 env_logger = "0.10"
 modeled-types = { path = "../../models/modeled-types", version = "0.1" }
 model-derive = { path = "../../models/model-derive", version = "0.1" }
-rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Fixes a couple of minor issues with settings extensions:

- the `kernel` extension has an unused dependency, `rand`, in its `Cargo.toml`. this was a copy-paste error from the `updates` extension.
- the settings extensions are not sorted alphabetically in some files. I already made a change to fix this in https://github.com/bottlerocket-os/bottlerocket/pull/3712, but since that PR is blocked for now, I wanted to decouple that change so we don't need to worry about it for future settings extension PRs.

**Testing done:**

in the `kernel` settings extension:

```bash
cargo build
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
