### PR TITLE
shim: replace %make_build with make

### DIFF
--- a/packages/shim/shim.spec
+++ b/packages/shim/shim.spec
@@ -35,7 +35,7 @@ mv gnu-efi-shim-%{gnuefiver} gnu-efi
 truncate -s 4080 empty.cer
 
 %global shim_make \
-%make_build\\\
+make\\\
   ARCH="%{_cross_arch}"\\\
   CROSS_COMPILE="%{_cross_target}-"\\\
   COMMIT_ID="%{commit}"\\\


### PR DESCRIPTION
**Issue number:**

Closes #3710

**Description of changes:**

Switches from a parallel make macro to a standard make command to avoid a race condition that can occur during a Bottlerocket build.

**Testing done:**

Built and smoke tested AMI. Although the shim issue is intermittent, if actions pass the first time then that is a good sign.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
