### PR TITLE
settings: add host-containers settings extension

### DIFF
--- a/packages/settings-host-containers/Cargo.toml
+++ b/packages/settings-host-containers/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-host-containers"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/host-containers"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-host-containers/settings-host-containers.spec
+++ b/packages/settings-host-containers/settings-host-containers.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name host-containers
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2651,6 +2651,7 @@ dependencies = [
  "serde_json",
  "settings-extension-aws",
  "settings-extension-container-registry",
+ "settings-extension-host-containers",
  "settings-extension-kernel",
  "settings-extension-motd",
  "settings-extension-ntp",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3674,6 +3674,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-host-containers"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2094,6 +2094,7 @@ dependencies = [
  "log",
  "models",
  "serde_json",
+ "settings-extension-host-containers",
  "simplelog",
  "snafu",
  "tokio",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -86,6 +86,7 @@ members = [
 
     "settings-extensions/aws",
     "settings-extensions/container-registry",
+    "settings-extensions/host-containers",
     "settings-extensions/kernel",
     "settings-extensions/motd",
     "settings-extensions/ntp",

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -17,6 +17,7 @@ http = "0.2"
 log = "0.4"
 models = { path = "../../models", version = "0.1" }
 serde_json = "1"
+settings-extension-host-containers = { path = "../../settings-extensions/host-containers", version = "0.1" }
 simplelog = "0.12"
 snafu = "0.7"
 tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -135,7 +135,9 @@ mod error {
 type Result<T> = std::result::Result<T, error::Error>;
 
 /// Query the API for the currently defined host containers
-async fn get_host_containers<P>(socket_path: P) -> Result<HashMap<Identifier, model::HostContainer>>
+async fn get_host_containers<P>(
+    socket_path: P,
+) -> Result<HashMap<Identifier, settings_extension_host_containers::HostContainer>>
 where
     P: AsRef<Path>,
 {
@@ -161,7 +163,7 @@ where
         serde_json::from_str(&response_body).context(error::ResponseJsonSnafu { method, uri })?;
 
     // If host containers aren't defined, return an empty map
-    Ok(settings.host_containers.unwrap_or_default())
+    Ok(settings.host_containers.unwrap_or_default().host_containers)
 }
 
 /// SystemdUnit stores the systemd unit being manipulated
@@ -347,7 +349,10 @@ fn parse_args(args: env::Args) -> Args {
     }
 }
 
-fn handle_host_container<S>(name: S, image_details: &model::HostContainer) -> Result<()>
+fn handle_host_container<S>(
+    name: S,
+    image_details: &settings_extension_host_containers::HostContainer,
+) -> Result<()>
 where
     S: AsRef<str>,
 {

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -20,6 +20,7 @@ toml = "0.5"
 # settings extensions
 settings-extension-aws = { path = "../settings-extensions/aws", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
+settings-extension-host-containers = { path = "../settings-extensions/host-containers", version = "0.1" }
 settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    MetricsSettings, NetworkSettings, OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, MetricsSettings,
+    NetworkSettings, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    ECSSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +13,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    ECSSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +13,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +14,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +15,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +14,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +15,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +14,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +15,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.29-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +14,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/aws-k8s-1.29/mod.rs
+++ b/sources/models/src/aws-k8s-1.29/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    ContainerRuntimeSettings, DnsSettings, KubernetesSettings, MetricsSettings, NetworkSettings,
+    OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -15,7 +15,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
-    OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, DnsSettings, MetricsSettings, NetworkSettings, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/metal-k8s-1.29/mod.rs
+++ b/sources/models/src/metal-k8s-1.29/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, KubernetesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
-    OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, DnsSettings, MetricsSettings, NetworkSettings, OciHooks,
+    PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -13,7 +13,7 @@ use modeled_types::Identifier;
 struct Settings {
     motd: settings_extension_motd::MotdV1,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/models/src/vmware-k8s-1.29/mod.rs
+++ b/sources/models/src/vmware-k8s-1.29/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, KubernetesSettings,
+    MetricsSettings, NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -14,7 +14,7 @@ struct Settings {
     motd: settings_extension_motd::MotdV1,
     kubernetes: KubernetesSettings,
     updates: settings_extension_updates::UpdatesSettingsV1,
-    host_containers: HashMap<Identifier, HostContainer>,
+    host_containers: settings_extension_host_containers::HostContainersSettingsV1,
     bootstrap_containers: HashMap<Identifier, BootstrapContainer>,
     ntp: settings_extension_ntp::NtpSettingsV1,
     network: NetworkSettings,

--- a/sources/settings-extensions/host-containers/Cargo.toml
+++ b/sources/settings-extensions/host-containers/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-host-containers"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/host-containers/host-containers.toml
+++ b/sources/settings-extensions/host-containers/host-containers.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/host-containers/src/lib.rs
+++ b/sources/settings-extensions/host-containers/src/lib.rs
@@ -1,0 +1,119 @@
+/// host-containers settings allow users to configure multiple host containers
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::{Identifier, Url, ValidBase64};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
+use std::convert::Infallible;
+
+/// HostContainersSettingsV1 serializes and deserializes as a
+/// HashMap<Identifier, HostContainer>.
+#[derive(Debug, Default, PartialEq)]
+pub struct HostContainersSettingsV1 {
+    pub host_containers: HashMap<Identifier, HostContainer>,
+}
+
+impl Serialize for HostContainersSettingsV1 {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.host_containers.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for HostContainersSettingsV1 {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let host_containers = HashMap::deserialize(deserializer)?;
+        Ok(Self { host_containers })
+    }
+}
+
+#[model(impl_default = true)]
+struct HostContainer {
+    source: Url,
+    enabled: bool,
+    superpowered: bool,
+    user_data: ValidBase64,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for HostContainersSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // allow anything that parses as HostContainersSettingsV1
+        Ok(())
+    }
+
+    fn generate(
+        _existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(HostContainersSettingsV1 {
+            host_containers: HashMap::new(),
+        }))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_host_containers() {
+        let generated = HostContainersSettingsV1::generate(None, None).unwrap();
+
+        assert_eq!(
+            generated,
+            GenerateResult::Complete(HostContainersSettingsV1 {
+                host_containers: HashMap::new(),
+            })
+        )
+    }
+
+    #[test]
+    fn test_serde_host_containers() {
+        let input_json = r#"{
+            "foo": {
+                "source": "public.ecr.aws/example/example",
+                "enabled": true,
+                "superpowered": true,
+                "user-data": "Zm9vCg=="
+            }
+        }"#;
+
+        let host_containers: HostContainersSettingsV1 = serde_json::from_str(input_json).unwrap();
+
+        let mut expected_host_containers: HashMap<Identifier, HostContainer> = HashMap::new();
+        expected_host_containers.insert(
+            Identifier::try_from("foo").unwrap(),
+            HostContainer {
+                source: Some(Url::try_from("public.ecr.aws/example/example").unwrap()),
+                enabled: Some(true),
+                superpowered: Some(true),
+                user_data: Some(ValidBase64::try_from("Zm9vCg==").unwrap()),
+            },
+        );
+
+        assert_eq!(
+            host_containers,
+            HostContainersSettingsV1 {
+                host_containers: expected_host_containers,
+            }
+        );
+    }
+}

--- a/sources/settings-extensions/host-containers/src/main.rs
+++ b/sources/settings-extensions/host-containers/src/main.rs
@@ -1,0 +1,20 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_host_containers::HostContainersSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("host-containers")
+        .with_models(vec![
+            BottlerocketSetting::<HostContainersSettingsV1>::model(),
+        ])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
**Issue number:**

Closes #3650 

**Description of changes:**

Creates a host-containers settings extension.

Because host-containers still depends on the API to get settings, there are some changes in here to use the settings extension model within `host-containers`. This is definitely not best practice in the long run, but it should be stable for now and will be removed once we migrate `host-containers` to read settings from a config file instead. We can discuss whether we should wait to merge this PR until that change is in.

**Testing done:**

Built an `aws-dev` AMI and ran an instance with it. I tested both that `host-containers` worked as expected (considering I got into the instance via the admin container, it worked just fine) and that the settings extension gave responses as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
