### PR TITLE
update grub and shim

### DIFF
--- a/packages/grub/0046-Revert-sb-Add-fallback-to-EFI-LoadImage-if-shim_lock.patch
+++ b/packages/grub/0046-Revert-sb-Add-fallback-to-EFI-LoadImage-if-shim_lock.patch
@@ -1,0 +1,96 @@
+From 2773f01f5d9292c68b08f9392a8ae0bf9c2e3e30 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 13 Feb 2024 22:20:16 +0000
+Subject: [PATCH] Revert "sb: Add fallback to EFI LoadImage if shim_lock is
+ absent"
+
+For Secure Boot in Bottlerocket, we expect that shim_lock will always
+be present, and don't need a fallback.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ grub-core/Makefile.core.def |  1 -
+ grub-core/kern/efi/sb.c     | 43 +++----------------------------------
+ 2 files changed, 3 insertions(+), 41 deletions(-)
+
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 5b8728e..3096cd4 100644
+--- a/grub-core/Makefile.core.def
++++ b/grub-core/Makefile.core.def
+@@ -214,7 +214,6 @@ kernel = {
+   efi = kern/efi/sb.c;
+   efi = kern/lockdown.c;
+   efi = lib/envblk.c;
+-  efi = lib/crc.c;
+   i386_coreboot = kern/i386/pc/acpi.c;
+   i386_multiboot = kern/i386/pc/acpi.c;
+   i386_coreboot = kern/acpi.c;
+diff --git a/grub-core/kern/efi/sb.c b/grub-core/kern/efi/sb.c
+index 70f9d9d..db42c25 100644
+--- a/grub-core/kern/efi/sb.c
++++ b/grub-core/kern/efi/sb.c
+@@ -29,7 +29,6 @@
+ #include <grub/mm.h>
+ #include <grub/types.h>
+ #include <grub/verify.h>
+-#include <grub/lib/crc.h>
+ 
+ static grub_efi_guid_t shim_lock_guid = GRUB_EFI_SHIM_LOCK_GUID;
+ 
+@@ -171,50 +170,14 @@ shim_lock_verifier_init (grub_file_t io __attribute__ ((unused)),
+     }
+ }
+ 
+-static int grub_shim_lock_load_image_fallback(void *data, grub_uint32_t size)
+-{
+-  grub_efi_memory_mapped_device_path_t *mempath;
+-  grub_efi_handle_t image_handle = 0;
+-  grub_efi_boot_services_t *b;
+-  grub_efi_status_t status;
+-  int len;
+-
+-  mempath = grub_malloc (2 * sizeof (grub_efi_memory_mapped_device_path_t));
+-  if (!mempath)
+-    return grub_errno;
+-
+-  mempath[0].header.type = GRUB_EFI_HARDWARE_DEVICE_PATH_TYPE;
+-  mempath[0].header.subtype = GRUB_EFI_MEMORY_MAPPED_DEVICE_PATH_SUBTYPE;
+-  mempath[0].header.length = grub_cpu_to_le16_compile_time (sizeof (*mempath));
+-  mempath[0].memory_type = GRUB_EFI_LOADER_DATA;
+-  mempath[0].start_address = (grub_addr_t)data;
+-  mempath[0].end_address =  (grub_addr_t)data + size;
+-
+-  mempath[1].header.type = GRUB_EFI_END_DEVICE_PATH_TYPE;
+-  mempath[1].header.subtype = GRUB_EFI_END_ENTIRE_DEVICE_PATH_SUBTYPE;
+-  mempath[1].header.length = sizeof (grub_efi_device_path_t);
+-
+-  b = grub_efi_system_table->boot_services;
+-  status = efi_call_6 (b->load_image, 0, grub_efi_image_handle,
+-		       (grub_efi_device_path_t *) mempath,
+-		       data, size, &image_handle);
+-  if (status != GRUB_EFI_SUCCESS) {
+-	  return grub_error (GRUB_ERR_ACCESS_DENIED,
+-			     "Cannot verify image, EFI err: %ld", (long)status);
+-  }
+-  efi_call_1 (b->unload_image, image_handle);
+-  return GRUB_ERR_NONE;
+-}
+-
+ static grub_err_t
+ shim_lock_verifier_write (void *context __attribute__ ((unused)), void *buf, grub_size_t size)
+ {
+   grub_efi_shim_lock_protocol_t *sl = grub_efi_locate_protocol (&shim_lock_guid, 0);
+ 
+-  if (!sl) {
+-    grub_dprintf ("secureboot", "shim not available, trying UEFI validation\n");
+-    return grub_shim_lock_load_image_fallback(buf, size);
+-  }
++  if (!sl)
++    return grub_error (GRUB_ERR_ACCESS_DENIED, N_("shim_lock protocol not found"));
++
+   if (sl->verify (buf, size) != GRUB_EFI_SUCCESS)
+     return grub_error (GRUB_ERR_BAD_SIGNATURE, N_("bad shim signature"));
+ 
+-- 
+2.43.0
+

--- a/packages/grub/0047-Revert-UBUNTU-Move-verifiers-after-decompressors.patch
+++ b/packages/grub/0047-Revert-UBUNTU-Move-verifiers-after-decompressors.patch
@@ -1,0 +1,48 @@
+From 95cafe6cf7dd2a02bd33ddee624bb9b7c3a931ae Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 13 Feb 2024 22:21:41 +0000
+Subject: [PATCH] Revert "UBUNTU: Move verifiers after decompressors"
+
+We use the PGP verifier to validate the signature of grub.cfg, and do
+not want to expose the decompressors to untrusted input.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ include/grub/file.h        | 4 ++--
+ tests/file_filter/test.cfg | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/grub/file.h b/include/grub/file.h
+index fa23688..96827a4 100644
+--- a/include/grub/file.h
++++ b/include/grub/file.h
+@@ -180,13 +180,13 @@ extern grub_disk_read_hook_t EXPORT_VAR(grub_file_progress_hook);
+ /* Filters with lower ID are executed first.  */
+ typedef enum grub_file_filter_id
+   {
++    GRUB_FILE_FILTER_VERIFY,
+     GRUB_FILE_FILTER_GZIO,
+     GRUB_FILE_FILTER_XZIO,
+     GRUB_FILE_FILTER_LZOPIO,
++    GRUB_FILE_FILTER_MAX,
+     GRUB_FILE_FILTER_COMPRESSION_FIRST = GRUB_FILE_FILTER_GZIO,
+     GRUB_FILE_FILTER_COMPRESSION_LAST = GRUB_FILE_FILTER_LZOPIO,
+-    GRUB_FILE_FILTER_VERIFY,
+-    GRUB_FILE_FILTER_MAX,
+   } grub_file_filter_id_t;
+ 
+ typedef grub_file_t (*grub_file_filter_t) (grub_file_t in, enum grub_file_type type);
+diff --git a/tests/file_filter/test.cfg b/tests/file_filter/test.cfg
+index 17dc4a8..4308aac 100644
+--- a/tests/file_filter/test.cfg
++++ b/tests/file_filter/test.cfg
+@@ -1,5 +1,5 @@
+ trust /keys.pub
+-set check_signatures=
++set check_signatures=enforce
+ cat /file.gz
+ cat /file.xz
+ cat /file.lzop
+-- 
+2.43.0
+

--- a/packages/grub/0048-add-flag-to-only-search-root-dev.patch
+++ b/packages/grub/0048-add-flag-to-only-search-root-dev.patch
@@ -1,0 +1,163 @@
+From 115f44e341b8f204bccaf63686579a66507c2ded Mon Sep 17 00:00:00 2001
+From: Marta Lewandowska <mlewando@redhat.com>
+Date: Mon, 9 Oct 2023 08:53:18 +0200
+Subject: [PATCH] add flag to only search root dev
+
+fixes bz#2223437
+
+Signed-off-by: Marta Lewandowska <mlewando@redhat.com>
+---
+ grub-core/commands/search.c      | 36 ++++++++++++++++++++++++++++++++
+ grub-core/commands/search_wrap.c |  5 +++++
+ grub-core/kern/misc.c            | 30 ++++++++++++++++++++++++++
+ include/grub/misc.h              |  1 +
+ include/grub/search.h            |  3 ++-
+ 5 files changed, 74 insertions(+), 1 deletion(-)
+
+diff --git a/grub-core/commands/search.c b/grub-core/commands/search.c
+index ec03c75..e0a3b22 100644
+--- a/grub-core/commands/search.c
++++ b/grub-core/commands/search.c
+@@ -89,6 +89,42 @@ iterate_device (const char *name, void *data)
+       grub_device_close (dev);
+     }
+ 
++  /* Skip it if it's not the root device when requested. */
++  if (ctx->flags & SEARCH_FLAGS_ROOTDEV_ONLY)
++    {
++      const char *root_dev;
++      root_dev = grub_env_get ("root");
++      if (root_dev != NULL && *root_dev != '\0')
++      {
++        char *root_disk = grub_malloc (grub_strlen(root_dev) + 1);
++        char *name_disk = grub_malloc (grub_strlen(name) + 1);
++        char *rem_1 = grub_malloc(grub_strlen(root_dev) + 1);
++        char *rem_2 = grub_malloc(grub_strlen(name) + 1);
++
++	if (root_disk != NULL && name_disk != NULL && 
++	    rem_1 != NULL && rem_2 != NULL)
++  	  {
++            /* get just the disk name; partitions will be different. */
++            grub_str_sep (root_dev, root_disk, ',', rem_1);
++            grub_str_sep (name, name_disk, ',', rem_2);
++            if (root_disk != NULL && *root_disk != '\0' &&
++    	        name_disk != NULL && *name_disk != '\0')
++              if (grub_strcmp(root_disk, name_disk) != 0)
++                {
++                  grub_free (root_disk);
++                  grub_free (name_disk);
++                  grub_free (rem_1);
++                  grub_free (rem_2);
++                  return 0;
++                }
++	  }
++        grub_free (root_disk);
++        grub_free (name_disk);
++        grub_free (rem_1);
++        grub_free (rem_2);
++      }
++    }
++
+ #if defined(DO_SEARCH_FS_UUID) || defined(DO_SEARCH_DISK_UUID)
+ #define compare_fn grub_strcasecmp
+ #else
+diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
+index c8152b1..fd77b1c 100644
+--- a/grub-core/commands/search_wrap.c
++++ b/grub-core/commands/search_wrap.c
+@@ -47,6 +47,7 @@ static const struct grub_arg_option options[] =
+      ARG_TYPE_STRING},
+     {"no-floppy",	'n', 0, N_("Do not probe any floppy drive."), 0, 0},
+     {"efidisk-only",	0, 0, N_("Only probe EFI disks."), 0, 0},
++    {"root-dev-only",  'r', 0, N_("Only probe root device."), 0, 0},
+     {"hint",	        'h', GRUB_ARG_OPTION_REPEATABLE,
+      N_("First try the device HINT. If HINT ends in comma, "
+ 	"also try subpartitions"), N_("HINT"), ARG_TYPE_STRING},
+@@ -84,6 +85,7 @@ enum options
+     SEARCH_SET,
+     SEARCH_NO_FLOPPY,
+     SEARCH_EFIDISK_ONLY,
++    SEARCH_ROOTDEV_ONLY,
+     SEARCH_HINT,
+     SEARCH_HINT_IEEE1275,
+     SEARCH_HINT_BIOS,
+@@ -198,6 +200,9 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
+   if (state[SEARCH_EFIDISK_ONLY].set)
+     flags |= SEARCH_FLAGS_EFIDISK_ONLY;
+ 
++  if (state[SEARCH_ROOTDEV_ONLY].set)
++    flags |= SEARCH_FLAGS_ROOTDEV_ONLY;
++
+   if (state[SEARCH_LABEL].set)
+     grub_search_label (id, var, flags, hints, nhints);
+   else if (state[SEARCH_FS_UUID].set)
+diff --git a/grub-core/kern/misc.c b/grub-core/kern/misc.c
+index 5d2b246..a95d182 100644
+--- a/grub-core/kern/misc.c
++++ b/grub-core/kern/misc.c
+@@ -598,6 +598,36 @@ grub_reverse (char *str)
+     }
+ }
+ 
++/* Separate string into two parts, broken up by delimiter delim. */
++void
++grub_str_sep (const char *s, char *p, char delim, char *r)
++{
++  char* t = grub_strndup(s, grub_strlen(s));
++
++  if (t != NULL && *t != '\0')
++  {
++    char* tmp = t;
++  
++    while (((*p = *t) != '\0') && ((*p = *t) != delim))
++    {
++      p++;
++      t++;
++    }
++    *p = '\0';
++  
++    if (*t != '\0')
++    {
++      t++;
++      while ((*r++ = *t++) != '\0')
++        ;
++      *r = '\0';
++    }
++    grub_free (tmp);
++  }
++  else
++    grub_free (t);
++}
++
+ /* Divide N by D, return the quotient, and store the remainder in *R.  */
+ grub_uint64_t
+ grub_divmod64 (grub_uint64_t n, grub_uint64_t d, grub_uint64_t *r)
+diff --git a/include/grub/misc.h b/include/grub/misc.h
+index 0a26855..a359b0d 100644
+--- a/include/grub/misc.h
++++ b/include/grub/misc.h
+@@ -314,6 +314,7 @@ void *EXPORT_FUNC(grub_memset) (void *s, int c, grub_size_t n);
+ grub_size_t EXPORT_FUNC(grub_strlen) (const char *s) WARN_UNUSED_RESULT;
+ int EXPORT_FUNC(grub_printf) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
+ int EXPORT_FUNC(grub_printf_) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
++void EXPORT_FUNC(grub_str_sep) (const char *s, char *p, char delim, char *r);
+ 
+ /* Replace all `ch' characters of `input' with `with' and copy the
+    result into `output'; return EOS address of `output'. */
+diff --git a/include/grub/search.h b/include/grub/search.h
+index a5f56b2..8727409 100644
+--- a/include/grub/search.h
++++ b/include/grub/search.h
+@@ -22,7 +22,8 @@
+ enum search_flags
+   {
+     SEARCH_FLAGS_NO_FLOPPY	= 1,
+-    SEARCH_FLAGS_EFIDISK_ONLY	= 2
++    SEARCH_FLAGS_EFIDISK_ONLY	= 2,
++    SEARCH_FLAGS_ROOTDEV_ONLY	= 4
+   };
+ 
+ void grub_search_fs_file (const char *key, const char *var,
+-- 
+2.43.0
+

--- a/packages/grub/Cargo.toml
+++ b/packages/grub/Cargo.toml
@@ -9,5 +9,5 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.amazonlinux.com/al2023/blobstore/74f9ee6e75b8f89fe91ccda86896243179968a8664ba045bece11dc5aff61f4e/grub2-2.06-61.amzn2023.0.6.src.rpm"
-sha512 = "aac3fbee3ec5e5a28176d338eab85c660c9525ef3b34ccf84f7c837c724c72b089bc2b57207e36b12c09a7cdd2c7d6e658288c98b9a66cb98e8edd650f302ba5"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/f4fa28cb4e1586d622925449b1e24748c6ab09ccebe0fd8ddfa20cf5e7ce182a/grub2-2.06-61.amzn2023.0.9.src.rpm"
+sha512 = "57886df0580f166bd741126f19109a0e464bc2408aafca38e68def077a2ab1f64c239d85015c44162b88d787da7ec55a623f4e7d2601942391f0996038393f99"

--- a/packages/grub/bios.cfg
+++ b/packages/grub/bios.cfg
@@ -5,7 +5,7 @@ gptprio.next -d boot_dev -u boot_uuid
 set root=$boot_dev
 set prefix=($root)/grub
 export boot_uuid
-search --no-floppy --set private --part-label BOTTLEROCKET-PRIVATE
+search --no-floppy --root-dev-only --set private --part-label BOTTLEROCKET-PRIVATE
 configfile /grub/grub.cfg
 echo "boot failed (device ($boot_dev), uuid $boot_uuid)"
 echo "rebooting in 30 seconds..."

--- a/packages/grub/efi.cfg
+++ b/packages/grub/efi.cfg
@@ -4,7 +4,7 @@ gptprio.next -d boot_dev -u boot_uuid
 set root=$boot_dev
 set prefix=($root)/grub
 export boot_uuid
-search --no-floppy --set private --part-label BOTTLEROCKET-PRIVATE
+search --no-floppy --root-dev-only --set private --part-label BOTTLEROCKET-PRIVATE
 configfile /grub/grub.cfg
 echo "boot failed (device ($boot_dev), uuid $boot_uuid)"
 echo "rebooting in 30 seconds..."

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -15,7 +15,7 @@ Release: 1%{?dist}
 Summary: Bootloader with support for Linux and more
 License: GPL-3.0-or-later AND Unicode-DFS-2015
 URL: https://www.gnu.org/software/grub/
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/74f9ee6e75b8f89fe91ccda86896243179968a8664ba045bece11dc5aff61f4e/grub2-2.06-61.amzn2023.0.6.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/f4fa28cb4e1586d622925449b1e24748c6ab09ccebe0fd8ddfa20cf5e7ce182a/grub2-2.06-61.amzn2023.0.9.src.rpm
 Source1: bios.cfg
 Source2: efi.cfg
 Source3: sbat.csv.in
@@ -64,6 +64,8 @@ Patch0042: 0042-util-mkimage-Bump-EFI-PE-header-size-to-accommodate-.patch
 Patch0043: 0043-util-mkimage-avoid-adding-section-table-entry-outsid.patch
 Patch0044: 0044-efi-return-virtual-size-of-section-found-by-grub_efi.patch
 Patch0045: 0045-mkimage-pgp-move-single-public-key-into-its-own-sect.patch
+Patch0046: 0046-Revert-sb-Add-fallback-to-EFI-LoadImage-if-shim_lock.patch
+Patch0047: 0047-Revert-UBUNTU-Move-verifiers-after-decompressors.patch
 
 BuildRequires: automake
 BuildRequires: bison

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -66,6 +66,7 @@ Patch0044: 0044-efi-return-virtual-size-of-section-found-by-grub_efi.patch
 Patch0045: 0045-mkimage-pgp-move-single-public-key-into-its-own-sect.patch
 Patch0046: 0046-Revert-sb-Add-fallback-to-EFI-LoadImage-if-shim_lock.patch
 Patch0047: 0047-Revert-UBUNTU-Move-verifiers-after-decompressors.patch
+Patch0048: 0048-add-flag-to-only-search-root-dev.patch
 
 BuildRequires: automake
 BuildRequires: bison

--- a/packages/grub/sbat.csv.in
+++ b/packages/grub/sbat.csv.in
@@ -1,3 +1,3 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,3,Free Software Foundation,grub,__VERSION__,https://www.gnu.org/software/grub/
+grub,4,Free Software Foundation,grub,__VERSION__,https://www.gnu.org/software/grub/
 grub.bottlerocket,1,Bottlerocket,grub,__VERSION__,https://github.com/bottlerocket-os/bottlerocket/blob/develop/SECURITY.md

--- a/packages/shim/Cargo.toml
+++ b/packages/shim/Cargo.toml
@@ -9,10 +9,5 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/rhboot/shim/archive/15.7/shim-15.7.tar.gz"
-sha512 = "95ef9c0125269cfa0263a32e4f343d8ccc8813d71fa918a2f54850781e3a2d6a06a719249be355fdb24c935899e0e11370815501ecde1800bdd974a9a79c5612"
-
-[[package.metadata.build-package.external-files]]
-url = "https://github.com/rhboot/gnu-efi/archive/refs/heads/shim-15.6.tar.gz"
-path = "gnu-efi-shim-15.6.tar.gz"
-sha512 = "d09dbb9e461d60e23294326ed4178301a6ab5959ade912bf559dbeb050362d994c8e63c8e062c19569055a269e5dbb65f0572317da4725177e19aae82e3c6978"
+url = "https://github.com/rhboot/shim/releases/download/15.8/shim-15.8.tar.bz2"
+sha512 = "30b3390ae935121ea6fe728d8f59d37ded7b918ad81bea06e213464298b4bdabbca881b30817965bd397facc596db1ad0b8462a84c87896ce6c1204b19371cd1"

--- a/packages/shim/shim.spec
+++ b/packages/shim/shim.spec
@@ -7,9 +7,8 @@
 %global shim_efi_image shim%{_cross_efi_arch}.efi
 %global mokm_efi_image mm%{_cross_efi_arch}.efi
 
-%global shimver 15.7
-%global gnuefiver 15.6
-%global commit 11491619f4336fef41c3519877ba242161763580
+%global shimver 15.8
+%global commit 5914984a1ffeab841f482c791426d7ca9935a5e6
 
 Name: %{_cross_os}shim
 Version: %{shimver}
@@ -17,17 +16,13 @@ Release: 1%{?dist}
 Summary: UEFI shim loader
 License: BSD-3-Clause
 URL: https://github.com/rhboot/shim/
-Source0: https://github.com/rhboot/shim/archive/%{shimver}/shim-%{shimver}.tar.gz
-Source1: https://github.com/rhboot/gnu-efi/archive/refs/heads/shim-%{gnuefiver}.tar.gz#/gnu-efi-shim-%{gnuefiver}.tar.gz
+Source0: https://github.com/rhboot/shim/archive/%{shimver}/shim-%{shimver}.tar.bz2
 
 %description
 %{summary}.
 
 %prep
 %autosetup -n shim-%{shimver} -p1
-%setup -T -D -n shim-%{shimver} -a 1
-rmdir gnu-efi
-mv gnu-efi-shim-%{gnuefiver} gnu-efi
 
 # Make sure the `.vendor_cert` section is large enough to cover a replacement
 # certificate, or `objcopy` may silently retain the existing section.
@@ -45,6 +40,7 @@ truncate -s 4080 empty.cer
   DESTDIR="%{buildroot}"\\\
   EFIDIR="BOOT"\\\
   VENDOR_CERT_FILE="empty.cer"\\\
+  POST_PROCESS_PE_FLAGS="-N"\\\
 %{nil}
 
 %build


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Update `shim` to 15.8 which includes recent CVE fixes.

Update `grub` to the latest version from AL23, and revert two patches that aren't required for Bottlerocket's Secure Boot implementation. This includes fixes for CVE-2023-4692 and CVE-2023-4693, which don't apply to Bottlerocket since the NTFS module isn't built. Overall, this update is a bit of a no-op but I wanted to get it in to record the decision to revert the patches, rather than leaving that for a future update.

I also added a patch from Red Hat that fixes CVE-2023-4001. That doesn't apply to Bottlerocket because the `search` directive isn't used to locate `grub.cfg`, so there is no ability to bypass a password that might be set. On variants that support Secure Boot there's also no way to modify `grub.cfg` to set a password. However, the functionality is useful to ensure that we read the expected boot config file for extending the kernel command line.

**Testing done:**
Confirmed that Secure Boot works for the following variants:
* `aws-k8s-1.28` - x86_64, aarch64
* `vmware-dev` - x86_64
* `metal-dev` - x86_64 (under QEMU)

I also tested legacy BIOS boot on c3.large to confirm the "uefi-preferred" functionality works as expected.

Verified that in-place upgrades and downgrades worked for `aws-k8s-1.28` (x86_64) and `aws-k8s-1.28-nvidia` (aarch64).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
