### PR TITLE
host-containers: migrate to use config file

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -280,4 +280,6 @@ version = "1.19.3"
     "migrate_v1.19.3_prairiedog-services-cfg-v0-1-0.lz4",
     "migrate_v1.19.3_thar-be-updates-config-file-v0-1-0.lz4",
     "migrate_v1.19.3_thar-be-updates-affected-services-v0-1-0.lz4",
+    "migrate_v1.19.3_host-containers-config-file-v0-1-0.lz4",
+    "migrate_v1.19.3_host-containers-config-list-v0-1-0.lz4",
 ]

--- a/packages/os/host-containers-toml
+++ b/packages/os/host-containers-toml
@@ -1,0 +1,20 @@
+[required-extensions]
+host-containers = "v1"
++++
+{{#if settings.host-containers}}
+{{#each settings.host-containers}}
+[host-containers."{{{@key}}}"]
+{{#if this.source}}
+source = "{{{this.source}}}"
+{{/if}}
+{{#if this.enabled}}
+enabled = {{{this.enabled}}}
+{{/if}}
+{{#if this.superpowered}}
+superpowered = {{{this.superpowered}}}
+{{/if}}
+{{#if this.user-data}}
+user-data = "{{{this.user-data}}}"
+{{/if}}
+{{/each}}
+{{/if}}

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -34,6 +34,7 @@ Source13: cis-checks-k8s-metadata-json
 Source14: certdog-toml
 Source15: prairiedog-toml
 Source16: thar-be-updates-toml
+Source19: host-containers-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -475,7 +476,8 @@ install -d %{buildroot}%{_cross_datadir}/updog
 install -p -m 0644 %{_cross_repo_root_json} %{buildroot}%{_cross_datadir}/updog
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{S:16} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{S:16} %{S:19} \
+  %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
@@ -594,6 +596,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_tmpfilesdir}/host-containers.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/host-ctr-toml
+%{_cross_templatedir}/host-containers-toml
 
 %files -n %{_cross_os}storewolf
 %{_cross_bindir}/storewolf

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2119,6 +2119,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "host-containers-config-file-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "host-containers-config-list-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2106,17 +2106,16 @@ dependencies = [
 name = "host-containers"
 version = "0.1.0"
 dependencies = [
- "apiclient",
  "base64 0.13.1",
  "constants",
  "generate-readme",
- "http",
  "log",
- "models",
- "serde_json",
+ "modeled-types",
+ "serde",
  "simplelog",
  "snafu",
- "tokio",
+ "tempfile",
+ "toml 0.8.8",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -68,6 +68,8 @@ members = [
     "api/migration/migrations/v1.19.3/prairiedog-services-cfg-v0-1-0",
     "api/migration/migrations/v1.19.3/thar-be-updates-config-file-v0-1-0",
     "api/migration/migrations/v1.19.3/thar-be-updates-affected-services-v0-1-0",
+    "api/migration/migrations/v1.19.3/host-containers-config-file-v0-1-0",
+    "api/migration/migrations/v1.19.3/host-containers-config-list-v0-1-0",
 
     "bloodhound",
 

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -10,16 +10,17 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
 base64 = "0.13"
 constants = { path = "../../constants", version = "0.1" }
-http = "0.2"
 log = "0.4"
-models = { path = "../../models", version = "0.1" }
-serde_json = "1"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
 simplelog = "0.12"
 snafu = "0.7"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/host-containers/README.md
+++ b/sources/api/host-containers/README.md
@@ -6,7 +6,7 @@ Current version: 0.1.0
 
 host-containers ensures that host containers are running as defined in system settings.
 
-It queries the API for their settings, then configures the system by:
+It reads the currently configured containers from its config file, then configures the system by:
 * creating a user-data file in the host container's persistent storage area, if a base64-encoded
   user-data setting is set for the host container.  (The decoded contents are available to the
   container at /.bottlerocket/host-containers/NAME/user-data)

--- a/sources/api/host-containers/src/config.rs
+++ b/sources/api/host-containers/src/config.rs
@@ -1,0 +1,18 @@
+use modeled_types::{Identifier, Url, ValidBase64};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct HostContainersConfig {
+    pub(crate) host_containers: Option<HashMap<Identifier, HostContainer>>,
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct HostContainer {
+    pub(crate) source: Option<Url>,
+    pub(crate) enabled: Option<bool>,
+    pub(crate) superpowered: Option<bool>,
+    pub(crate) user_data: Option<ValidBase64>,
+}

--- a/sources/api/migration/migrations/v1.19.3/host-containers-config-file-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/host-containers-config-file-v0-1-0/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "host-containers-config-file-v0-1-0"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/host-containers-config-file-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/host-containers-config-file-v0-1-0/src/main.rs
@@ -1,0 +1,17 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// Create the new config file
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "configuration-files.host-containers-toml",
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.19.3/host-containers-config-list-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.3/host-containers-config-list-v0-1-0/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "host-containers-config-list-v0-1-0"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.19.3/host-containers-config-list-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.3/host-containers-config-list-v0-1-0/src/main.rs
@@ -1,0 +1,19 @@
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// Add new config file to host-containers
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "services.host-containers.configuration-files",
+        old_vals: &["host-ctr-toml"],
+        new_vals: &["host-ctr-toml", "host-containers-toml"],
+    }]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -69,12 +69,16 @@ seed.setting-generator = "bork seed"
 # HostContainers
 
 [services.host-containers]
-configuration-files = ["host-ctr-toml"]
+configuration-files = ["host-ctr-toml", "host-containers-toml"]
 restart-commands = ["/usr/bin/host-containers"]
 
 [configuration-files.host-ctr-toml]
 path = "/etc/host-containers/host-ctr.toml"
 template-path = "/usr/share/templates/host-ctr-toml"
+
+[configuration-files.host-containers-toml]
+path = "/etc/host-containers/host-containers.toml"
+template-path = "/usr/share/templates/host-containers-toml"
 
 [metadata.settings.host-containers]
 affected-services = ["host-containers"]


### PR DESCRIPTION
**Issue number:**

Closes #3627 

**Description of changes:**

Removes dependency on the API model from host-containers by changing it to use a config file rendered from the settings.

**Testing done:**

- [x] Ran `cargo +nightly udeps` to ensure all unused dependencies have been removed
- [x] Pass the settings on first boot via userdata. Verify config.
- [x] cat /etc/os-release record your build ID include commit sha, record this
- [x] Use apiclient to update relevant settings at runtime. Verify config was updated correctly.
- [x] Downgrade to older version. 
  - [x] verify connectivity
  - [x] cat /etc/os-release to verify lower version
  - [x] verify that migrations have changed the metadata/settings as expected (i.e. they are gone from the datastore, or lists have been changed back)
- [x] Upgrade to newer version.
  - [x] verify connectivity
  - [x] cat /etc/os-release to verify version
  - [x] verify config file

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
