### PR TITLE
certdog: fix template encoding

### DIFF
--- a/packages/os/certdog-toml
+++ b/packages/os/certdog-toml
@@ -5,6 +5,6 @@ pki = "v1"
 {{#each settings.pki}}
 ["{{@key}}"]
 trusted = {{this.trusted}}
-data = "{{this.data}}"
+data = "{{{this.data}}}"
 {{/each}}
 {{/if}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Fixes encoding in the certdog toml


**Testing done:**
Tested through aws-ecs-2 variant.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
