### PR TITLE
allow CSI helpers in the SELinux policy

### DIFF
--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -21,7 +21,7 @@ mkdir -p %{buildroot}%{_cross_prefix}
 mkdir -p %{buildroot}%{_cross_bindir}
 mkdir -p %{buildroot}%{_cross_sbindir}
 mkdir -p %{buildroot}%{_cross_libdir}
-mkdir -p %{buildroot}%{_cross_libexecdir}/cni/bin
+mkdir -p %{buildroot}%{_cross_libexecdir}/{cni,csi}/bin
 mkdir -p %{buildroot}%{_cross_includedir}
 mkdir -p %{buildroot}%{_cross_sysconfdir}
 mkdir -p %{buildroot}%{_cross_datadir}

--- a/packages/kubernetes-1.23/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.23/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/kubernetes-1.24/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.24/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/kubernetes-1.25/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.25/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/kubernetes-1.26/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.26/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/kubernetes-1.27/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.27/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/kubernetes-1.28/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.28/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/kubernetes-1.29/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.29/kubernetes-tmpfiles.conf
@@ -3,3 +3,5 @@ L /etc/kubernetes/manifests - - - - static-pods
 L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
 r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/release/opt-cni.mount
+++ b/packages/release/opt-cni.mount
@@ -1,5 +1,5 @@
 [Unit]
-Description=CNI Plugin Directory (/opt/cni/bin)
+Description=CNI Plugin Directory (/opt/cni)
 DefaultDependencies=no
 Conflicts=umount.target
 Before=local-fs.target umount.target
@@ -9,10 +9,10 @@ RequiresMountsFor=/opt /var
 
 [Mount]
 What=overlay
-Where=/opt/cni/bin
+Where=/opt/cni
 Type=overlay
 # "noexec" omitted because containerd needs to execute CNI plugins
-Options=nosuid,nodev,noatime,lowerdir=/usr/libexec/cni/bin,upperdir=/var/lib/cni-plugins/.overlay/upper,workdir=/var/lib/cni-plugins/.overlay/work,context=system_u:object_r:cni_exec_t:s0
+Options=nosuid,nodev,noatime,lowerdir=/usr/libexec/cni,upperdir=/var/lib/cni-plugins/.overlay/upper,workdir=/var/lib/cni-plugins/.overlay/work,context=system_u:object_r:cni_exec_t:s0
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/release/opt-csi.mount
+++ b/packages/release/opt-csi.mount
@@ -1,0 +1,18 @@
+[Unit]
+Description=CSI Helper Directory (/opt/csi)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+Wants=prepare-opt.service prepare-var.service
+After=prepare-opt.service prepare-var.service
+RequiresMountsFor=/opt /var
+
+[Mount]
+What=overlay
+Where=/opt/csi
+Type=overlay
+# "noexec" omitted because containerd needs to execute CSI helpers
+Options=nosuid,nodev,noatime,lowerdir=/usr/libexec/csi,upperdir=/var/lib/csi-helpers/.overlay/upper,workdir=/var/lib/csi-helpers/.overlay/work,context=system_u:object_r:csi_exec_t:s0
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/release/prepare-opt.service
+++ b/packages/release/prepare-opt.service
@@ -10,7 +10,7 @@ Type=oneshot
 
 # Create the directories for a read-write overlayfs for CNI plugins.
 ExecStart=/usr/bin/rm -rf /opt/cni
-ExecStart=/usr/bin/mkdir -p /opt/cni/bin
+ExecStart=/usr/bin/mkdir -p /opt/cni
 
 RemainAfterExit=true
 StandardError=journal+console

--- a/packages/release/prepare-opt.service
+++ b/packages/release/prepare-opt.service
@@ -12,6 +12,10 @@ Type=oneshot
 ExecStart=/usr/bin/rm -rf /opt/cni
 ExecStart=/usr/bin/mkdir -p /opt/cni
 
+# Create the directories for a read-write overlayfs for CSI helpers.
+ExecStart=/usr/bin/rm -rf /opt/csi
+ExecStart=/usr/bin/mkdir -p /opt/csi
+
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/prepare-var.service
+++ b/packages/release/prepare-var.service
@@ -15,7 +15,8 @@ Type=oneshot
 ExecStart=/usr/bin/rm -rf \
     /var/lib/kernel-devel \
     /var/lib/kernel-modules \
-    /var/lib/cni-plugins
+    /var/lib/cni-plugins \
+    /var/lib/csi-helpers
 
 ExecStart=/usr/bin/mkdir -p \
     /var/lib/kernel-devel/.overlay/lower \
@@ -24,14 +25,17 @@ ExecStart=/usr/bin/mkdir -p \
     /var/lib/kernel-modules/.overlay/upper \
     /var/lib/kernel-modules/.overlay/work \
     /var/lib/cni-plugins/.overlay/upper \
-    /var/lib/cni-plugins/.overlay/work
+    /var/lib/cni-plugins/.overlay/work \
+    /var/lib/csi-helpers/.overlay/upper \
+    /var/lib/csi-helpers/.overlay/work
 
 # Ensure the directories are labeled as expected.
 ExecStart=/usr/sbin/setfiles \
     -F /etc/selinux/fortified/contexts/files/file_contexts \
     /var/lib/kernel-devel \
     /var/lib/kernel-modules \
-    /var/lib/cni-plugins
+    /var/lib/cni-plugins \
+    /var/lib/csi-helpers
 
 RemainAfterExit=true
 StandardError=journal+console

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -44,7 +44,7 @@ Source1024: mnt.mount
 Source1025: local.mount
 Source1026: media-cdrom.mount
 Source1027: root-.aws.mount
-Source1028: opt-cni-bin.mount
+Source1028: opt-cni.mount
 
 # Mounts that require helper programs.
 Source1040: prepare-boot.service
@@ -240,7 +240,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/mnt.mount
 %{_cross_unitdir}/etc-cni.mount
-%{_cross_unitdir}/opt-cni-bin.mount
+%{_cross_unitdir}/opt-cni.mount
 %{_cross_unitdir}/media-cdrom.mount
 %{_cross_unitdir}/local.mount
 %{_cross_unitdir}/*-lower.mount

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -45,6 +45,7 @@ Source1025: local.mount
 Source1026: media-cdrom.mount
 Source1027: root-.aws.mount
 Source1028: opt-cni.mount
+Source1029: opt-csi.mount
 
 # Mounts that require helper programs.
 Source1040: prepare-boot.service
@@ -156,7 +157,7 @@ install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} \
   %{S:1006} %{S:1007} \
   %{S:1020} %{S:1021} %{S:1022} %{S:1023} %{S:1024} \
-  %{S:1025} %{S:1026} %{S:1027} %{S:1028} \
+  %{S:1025} %{S:1026} %{S:1027} %{S:1028} %{S:1029} \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} \
   %{S:1045} %{S:1046} %{S:1047} %{S:1048} %{S:1049} \
   %{S:1060} %{S:1061} %{S:1062} %{S:1063} %{S:1064} \
@@ -241,6 +242,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/mnt.mount
 %{_cross_unitdir}/etc-cni.mount
 %{_cross_unitdir}/opt-cni.mount
+%{_cross_unitdir}/opt-csi.mount
 %{_cross_unitdir}/media-cdrom.mount
 %{_cross_unitdir}/local.mount
 %{_cross_unitdir}/*-lower.mount

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -55,6 +55,7 @@
 (filecon "/.*/usr/bin/containerd.*" file runtime_exec)
 (filecon "/.*/usr/bin/docker.*" file runtime_exec)
 (filecon "/.*/usr/bin/host-ctr" file runtime_exec)
+(filecon "/.*/usr/bin/runc.*" file runtime_exec)
 (filecon "/.*/usr/bin/shibaken" file api_exec)
 
 ; Label local storage mounts.

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -88,6 +88,8 @@
 ; Label local directories for overlayfs mounts.
 (filecon "/var/lib/cni-plugins" any state)
 (filecon "/var/lib/cni-plugins/.*" any state)
+(filecon "/var/lib/csi-helpers" any state)
+(filecon "/var/lib/csi-helpers/.*" any state)
 (filecon "/var/lib/kernel-devel" any state)
 (filecon "/var/lib/kernel-devel/.*" any state)
 (filecon "/var/lib/kernel-modules" any state)

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -49,6 +49,11 @@
 (roletype object_r cni_exec_t)
 (context cni_exec (system_u object_r cni_exec_t s0))
 
+; Executable CSI helpers.
+(type csi_exec_t)
+(roletype object_r csi_exec_t)
+(context csi_exec (system_u object_r csi_exec_t s0))
+
 ; Files under /proc.
 (type proc_t)
 (roletype object_r proc_t)
@@ -152,7 +157,7 @@
 ; modified by system-level processes.
 (typeattribute write_restricted_o)
 (typeattributeset write_restricted_o (
-  cache_t lease_t measure_t secret_t state_t private_t))
+  cache_t csi_exec_t lease_t measure_t secret_t state_t private_t))
 
 ; Read-restricted objects are files on local storage that can only be
 ; opened by system-level processes.
@@ -163,7 +168,7 @@
 ; Sensitive objects are files on local storage that can only be modified
 ; by unconfined system-level processes.
 (typeattribute sensitive_o)
-(typeattributeset sensitive_o (secret_t state_t))
+(typeattributeset sensitive_o (csi_exec_t secret_t state_t))
 
 ; Immutable objects reside on read-only storage.
 (typeattribute immutable_o)
@@ -182,7 +187,7 @@
 
 ; Executable objects that are entry points into containers.
 (typeattribute container_exec_o)
-(typeattributeset container_exec_o (data_t cache_t secret_t cni_exec_t))
+(typeattributeset container_exec_o (data_t cache_t secret_t cni_exec_t csi_exec_t))
 
 ; Executable objects that transition into unprivileged containers by default.
 (typeattribute unprivileged_container_exec_o)
@@ -198,7 +203,7 @@
 (typeattributeset all_o (
   os_t init_exec_t api_exec_t clock_exec_t
   network_exec_t bus_exec_t runtime_exec_t
-  mount_exec_t cni_exec_t
+  mount_exec_t cni_exec_t csi_exec_t
   any_t etc_t proc_t
   local_t data_t private_t secret_t cache_t
   lease_t measure_t state_t

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -148,14 +148,22 @@
 (typeattribute unconstrained_o)
 (typeattributeset unconstrained_o (xor (all_o) (constrained_o)))
 
-; Protected objects are files on local storage with special rules.
-(typeattribute protected_o)
-(typeattributeset protected_o (
-  cache_t private_t lease_t measure_t secret_t state_t))
+; Write-restricted objects are files on local storage that can only be
+; modified by system-level processes.
+(typeattribute write_restricted_o)
+(typeattributeset write_restricted_o (
+  cache_t lease_t measure_t secret_t state_t private_t))
 
-; Restricted objects are files that cannot be read by all processes.
-(typeattribute restricted_o)
-(typeattributeset restricted_o (private_t secret_t))
+; Read-restricted objects are files on local storage that can only be
+; opened by system-level processes.
+(typeattribute read_restricted_o)
+(typeattributeset read_restricted_o (
+  xor (write_restricted_o) (cache_t lease_t measure_t state_t)))
+
+; Sensitive objects are files on local storage that can only be modified
+; by unconfined system-level processes.
+(typeattribute sensitive_o)
+(typeattributeset sensitive_o (secret_t state_t))
 
 ; Immutable objects reside on read-only storage.
 (typeattribute immutable_o)

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -172,6 +172,19 @@
 (typeattribute ephemeral_o)
 (typeattributeset ephemeral_o (any_t proc_t))
 
+; Executable objects that are entry points into containers.
+(typeattribute container_exec_o)
+(typeattributeset container_exec_o (data_t cache_t secret_t cni_exec_t))
+
+; Executable objects that transition into unprivileged containers by default.
+(typeattribute unprivileged_container_exec_o)
+(typeattributeset unprivileged_container_exec_o (cni_exec_t))
+
+; Executable objects that transition into privileged containers by default.
+(typeattribute privileged_container_exec_o)
+(typeattributeset privileged_container_exec_o (
+  xor (container_exec_o) (unprivileged_container_exec_o)))
+
 ; The set of all objects.
 (typeattribute all_o)
 (typeattributeset all_o (

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -66,6 +66,11 @@
 (allow init_t runtime_t (processes (transform)))
 (allow runtime_t runtime_exec_t (file (entrypoint)))
 
+; `runc` can transition to any of the container subject labels, for
+; a process started from any of the container object labels.
+(allow runtime_t container_s (processes (transform)))
+(allow container_s container_exec_o (file (entrypoint)))
+
 ; `runc` starts container processes as "control_t" by default, but it
 ; can use other "container" subject labels like "container_t". This
 ; depends on correct labeling for objects on local storage.
@@ -73,24 +78,15 @@
 ; Runtimes that use the Go SELinux library will override this label
 ; with the "process" label from the `lxc_contexts` when launching
 ; unprivileged containers, unless automatic labeling is disabled.
-(typetransition runtime_t data_t process control_t)
-(typetransition runtime_t cache_t process control_t)
-(typetransition runtime_t secret_t process control_t)
-(allow runtime_t container_s (processes (transform)))
-(allow container_s data_t (file (entrypoint)))
-(allow container_s cache_t (file (entrypoint)))
-(allow container_s secret_t (file (entrypoint)))
-
-; Adjust the level range to span all categories, since privileged
+;
+; The level range is adjusted to span all categories, since privileged
 ; containers won't get an MCS pair assigned.
-(rangetransition runtime_t data_t process s0-s0)
-(rangetransition runtime_t cache_t process s0-s0)
-(rangetransition runtime_t secret_t process s0-s0)
+(typetransition runtime_t privileged_container_exec_o process control_t)
+(rangetransition runtime_t privileged_container_exec_o process s0-s0)
 
-; Run CNI plugins as unprivileged containers.
-(typetransition runtime_t cni_exec_t process container_t)
-(rangetransition runtime_t cni_exec_t process s0)
-(allow container_t cni_exec_t (file (entrypoint)))
+; Some processes should transition to unprivileged containers by default.
+(typetransition runtime_t unprivileged_container_exec_o process container_t)
+(rangetransition runtime_t unprivileged_container_exec_o process s0)
 
 ; Allow transitions to container labels for programs invoked by OCI
 ; hooks. There's no matching type or range transition since `runc`

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -8,7 +8,7 @@
 
 ; Define a subset of these types which are considered public.
 (typeattribute public)
-(typeattributeset public (xor (global) (restricted_o)))
+(typeattributeset public (xor (global) (read_restricted_o)))
 
 ; All subjects are allowed to describe all processes.
 (allow all_s all_s (processes (describe)))
@@ -129,7 +129,7 @@
 (allow privileged_s global (files (load)))
 
 ; Unprivileged subjects cannot read or execute restricted objects.
-(neverallow unprivileged_s restricted_o (files (load execute)))
+(neverallow unprivileged_s read_restricted_o (files (load execute)))
 
 ; Container subjects can execute anything that's public.
 (allow container_s public (files (execute)))
@@ -181,30 +181,27 @@
 ; most of the files and directories on /local.
 (allow unconfined_s shared_o (files (mutate mount)))
 
-; Subjects that control the OS, including helpers spawned by apiserver, can
-; write to and manage mounts for "secret" files and directories on /local.
-; Our runtimes also need to be able to perform these operations so that
-; they can launch host containers.
+; Helpers spawned by apiserver can write to and manage mounts for
+; "secret" files and directories on /local. Our runtimes also need to
+; be able to perform these operations so that they can launch host
+; containers.
 (allow api_s secret_t (files (mutate mount)))
-(allow control_s secret_t (files (mutate mount)))
 (allow runtime_s secret_t (files (mutate mount)))
 
-; Subjects that control the OS can write to and manage mounts for "state"
-; files and directories on /local.
-(allow control_s state_t (files (mutate mount)))
+; Subjects that control the OS can write to and manage mounts for
+; "sensitive" files and directories on /local.
+(allow control_s sensitive_o (files (mutate mount)))
 
-; `mount` can also write to these directories, to set up overlayfs mounts
-; that use them for work directories.
-(allow mount_t state_t (files (mutate)))
+; `mount` can also write to sensitive directories, which is required
+; to set up overlayfs mounts that can subsequently be written to.
+(allow mount_t sensitive_o (files (mutate)))
 
-; Unprivileged subjects cannot modify "state" or "secret" files.
-(neverallow unprivileged_s state_t (files (mutate mount)))
-(neverallow unprivileged_s secret_t (files (mutate mount)))
+; Unprivileged subjects cannot modify "sensitive" files.
+(neverallow unprivileged_s sensitive_o (files (mutate mount)))
 
-; Confined subjects cannot modify "state", "secret", or "shared" files.
+; Confined subjects are a subset of unprivileged subjects that cannot
+; modify "shared" files either.
 (neverallow confined_s shared_o (files (mutate mount)))
-(neverallow confined_s state_t (files (mutate mount)))
-(neverallow confined_s secret_t (files (mutate mount)))
 
 ; Trusted components are allowed to manage mounts everywhere.
 (allow trusted_s global (files (mount)))
@@ -219,7 +216,7 @@
 
 ; Other components should not be permitted to modify these files,
 ; or to manage mounts for these directories.
-(neverallow other_s protected_o (files (mutate mount)))
+(neverallow other_s write_restricted_o (files (mutate mount)))
 
 ; Only the API server and specific components can use the API
 ; socket, as this provides a means to escalate privileges and
@@ -272,8 +269,8 @@
 (allow all_o self (filesystem (associate)))
 (allow all_o ephemeral_o (filesystem (associate)))
 
-; Protected object labels can be used on local storage.
-(allow protected_o local_t (filesystem (associate)))
+; Write-restricted object labels can be used on local storage.
+(allow write_restricted_o local_t (filesystem (associate)))
 
 ; Shared object labels can also be used, so that volume types like
 ; emptyDir can be relabeled on behalf of containers.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -88,6 +88,12 @@
 (typetransition runtime_t unprivileged_container_exec_o process container_t)
 (rangetransition runtime_t unprivileged_container_exec_o process s0)
 
+; If PID 1 is used to invoke a CSI helper directly, it should also
+; run as a privileged container.
+(typetransition init_t csi_exec_t process control_t)
+(rangetransition init_t csi_exec_t process s0-s0)
+(allow init_t control_t (processes (transform)))
+
 ; Allow transitions to container labels for programs invoked by OCI
 ; hooks. There's no matching type or range transition since `runc`
 ; also needs to run other OS programs.
@@ -151,6 +157,11 @@
 ; also run other system binaries.
 (allow api_t any_t (files (execute)))
 (allow api_t immutable_o (files (execute)))
+
+; `systemd` can only run immutable files, with the exception of CSI helpers
+; that may be required for FUSE mounts.
+(allow init_t immutable_o (files (execute)))
+(allow init_t csi_exec_t (files (execute)))
 
 ; Subjects that must run verified code can execute immutable objects, since
 ; those are all protected by dm-verity.

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -121,7 +121,7 @@
 
 ; Subjects shipped with the OS that should only execute verified code.
 (typeattribute verified_s)
-(typeattributeset verified_s (xor (host_s) (runtime_t mount_t api_t)))
+(typeattributeset verified_s (xor (host_s) (runtime_t mount_t api_t init_t)))
 
 ; Subjects that are allowed to manage the system clock.
 (typeattribute clock_s)


### PR DESCRIPTION
**Issue number:**
#3684

**Description of changes:**
There's a fair amount of refactoring here, but the essential change involves adding a new `/opt/csi` mount with a special label - `csi_exec_t` - where privileged containers can write binaries that systemd is allowed to execute. This is intended for the special case of FUSE mounts, where the mounted filesystem needs to survive a restart or upgrade of the CSI driver daemonset.

Ideally these binaries would either be statically linked or else wrapped by a `runc` invocation to minimize host dependencies, but this isn't enforced. Asking `systemd` to run a unit requires the break-glass `super_t` label so it can be assumed that the caller knows the risks and asserts that it is correct.

In terms of policy refactoring, some of the type attribute identifiers have been renamed for clarity, and new ones have been added so that rules can be applied to the set rather than one-by-one to individual types.

At the OS level, the `cni_exec_t` label is now applied to all of `/opt/cni` rather than just `/opt/cni/bin`. This is done for symmetry with the new `/opt/csi` mount, and is expected to be safe because `/opt/cni` is unconditionally removed on each boot.

The only part of this change that's specific to the mountpoint S3 CSI driver is the compat symlink from `/opt/mountpoint-s3-csi` to redirect into `/opt/csi` so those files receive the correct label. This is similar to the compat symlink added for the secrets store CSI provider.


**Testing done:**
Deployed the mountpoint S3 CSI driver to my cluster and made these edits to the `s3-csi-node` daemonset:
```
# add to s3-plugin container to allow it to interact with systemd
securityContext:
    seLinuxOptions:
        type: super_t

# add to install-mp initContainer to allow it to write to `/opt/csi`
securityContext:
    privileged: true
```

I also ran through my SELinux-related test suite and verified that it passed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
