### PR TITLE
Support for ECS_ENABLE_CONTAINER_METADATA

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -273,4 +273,5 @@ version = "1.19.2"
 "(1.19.1, 1.19.2)" = [
     "migrate_v1.19.2_certdog-config-file-v0-1-0.lz4",
     "migrate_v1.19.2_certdog-service-cfg-v0-1-0.lz4",
+    "migrate_v1.19.2_add-ecs-enable-container-metadata.lz4",
 ]

--- a/packages/ecs-agent/0006-containermetadata-don-t-use-dataDirOnHost-for-metada.patch
+++ b/packages/ecs-agent/0006-containermetadata-don-t-use-dataDirOnHost-for-metada.patch
@@ -1,0 +1,50 @@
+From b1c29a82de3d567ab84cea71a7142dffd34d7c03 Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Tue, 13 Feb 2024 17:38:29 +0000
+Subject: [PATCH] containermetadata: don't use dataDirOnHost for metadata path
+
+The ECS agent stores the metadata file for a container task under
+ECS_DATADIR. Under normal circumstances, the ECS agent runs as a
+container and the ECS_DATADIR configuration points to a bind-mounted
+directory in the host under the path at ECS_HOST_DATA_DIR. The setup for
+these two configurations is as follows:
+
+- ECS_HOST_DATA_DIR: /var/lib/ecs/, in the host
+- ECS_DATADIR: /data, in the container, that points to /var/lib/ecs/data
+  in the host
+
+When the ECS agent writes the metadata file, it uses the path at
+ECS_DATADIR, e.g. /data/metadata/<task.id>/*.json. However, when it sets
+up the mounts for the container task it uses the composite path
+ECS_HOST_DATA_DIR/ECS_DATADIR. This works for the ECS agent, since the
+final source path will be the correct path: /var/lib/ecs/data.
+
+In Bottlerocket, the ECS agent doesn't run as a container. Thus, the
+ECS_DATADIR configuration points to /var/lib/ecs/data in the host. The
+problem with this configuration is that the source of the bind-mount
+path will be wrong when ECS_HOST_DATA_DIR and ECS_DATADIR are
+concatenated, the resulting path will include /var/lib/ecs twice.
+
+With this commit, only the ECS_HOST_DATA_DIR configuration is ignored
+when the bind-mount configuration is generated, and the correct metadata
+file is bind-mounted onto the container.
+---
+ agent/containermetadata/write_metadata_unix.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/agent/containermetadata/write_metadata_unix.go b/agent/containermetadata/write_metadata_unix.go
+index 1c9e799..0181c95 100644
+--- a/agent/containermetadata/write_metadata_unix.go
++++ b/agent/containermetadata/write_metadata_unix.go
+@@ -47,7 +47,7 @@ func createBindsEnv(binds []string, env []string, dataDirOnHost string, metadata
+ 	}
+ 
+ 	randID := uuid.New()
+-	instanceBind := fmt.Sprintf(`%s/%s:%s/%s`, dataDirOnHost, metadataDirectoryPath, mountPoint, randID)
++	instanceBind := fmt.Sprintf(`%s:%s/%s`, metadataDirectoryPath, mountPoint, randID)
+ 	if selinuxEnabled {
+ 		seelog.Info("Selinux is enabled on docker, mounting data directory in Z mode")
+ 		instanceBind = fmt.Sprintf(`%s:%s`, instanceBind, bindMode)
+-- 
+2.41.0
+

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -71,6 +71,9 @@ Patch0004: 0004-bottlerocket-fix-procfs-path-on-host.patch
 # Bottlerocket-specific - fix ECS exec directories
 Patch0005: 0005-bottlerocket-change-execcmd-directories-for-Bottlero.patch
 
+# Bottlerocket-specific - fix container metadata path
+Patch0006: 0006-containermetadata-don-t-use-dataDirOnHost-for-metada.patch
+
 # Bottlerocket-specific - filesystem location for ECS CNI plugins
 Patch1001: 1001-bottlerocket-default-filesystem-locations.patch
 

--- a/packages/ecs-agent/ecs.config
+++ b/packages/ecs-agent/ecs.config
@@ -39,3 +39,6 @@ ECS_BACKEND_HOST="{{settings.ecs.backend-host}}"
 {{#if settings.ecs.awsvpc-block-imds}}
 ECS_AWSVPC_BLOCK_IMDS="{{settings.ecs.awsvpc-block-imds}}"
 {{/if}}
+{{#if settings.ecs.enable-container-metadata}}
+ECS_ENABLE_CONTAINER_METADATA="{{settings.ecs.enable-container-metadata}}"
+{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -225,6 +225,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-ecs-enable-container-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "api/migration/migrations/v1.19.1/public-control-container-v0-7-8",
     "api/migration/migrations/v1.19.2/certdog-config-file-v0-1-0",
     "api/migration/migrations/v1.19.2/certdog-service-cfg-v0-1-0",
+    "api/migration/migrations/v1.19.2/add-ecs-enable-container-metadata",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.19.2/add-ecs-enable-container-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.19.2/add-ecs-enable-container-metadata/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "add-ecs-enable-container-metadata"
+version = "0.1.0"
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.19.2/add-ecs-enable-container-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.19.2/add-ecs-enable-container-metadata/src/main.rs
@@ -1,0 +1,20 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added additional configurations for the ECS agent
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.ecs.enable-container-metadata",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -335,6 +335,7 @@ struct ECSSettings {
     image_cleanup_age: ECSDurationValue,
     backend_host: String,
     awsvpc_block_imds: bool,
+    enable_container_metadata: bool,
 }
 
 #[model]


### PR DESCRIPTION
**Issue number:**

Closes #3717

**Description of changes:**

As described in the #3717, the ECS agent will try to mount a file into the task using both `ECS_HOST_DATA_DIR` and `ECS_DATADIR` to create the path of the source file for the mount. This is a problem in Bottlerocket because both paths include `/var/lib/ecs` so the final source path ends up including that path twice, e.g.: `/var/lib/ecs/var/lib/ecs/data`. 

The source file is created in the correct location (that is `/var/lib/ecs/data`), because the ECS agent only uses `ECS_DATADIR` to write to the metadata file for the task. The problem is on the source file used for the mount, as described above.

With this change, the ECS agent is patched to ignore `ECS_HOST_DATA_DIR` while creating the source path for the mount, and only `ECS_DATADIR` is used instead. 

**Testing done:**
- [X] In `aws-ecs-2`, I tested that an ECS task can read from the file at `${ECS_CONTAINER_METADATA_FILE}`
- [X] Ran migration testing
- [x] There isn't a test that covers this case in the internal testing suite, but still I'll run it to confirm nothing breaks due to the patch


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
