### PR TITLE
Fix how configurations files are created for the nvidia-container-toolkit

### DIFF
--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles-ecs.conf
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles-ecs.conf
@@ -1,0 +1,1 @@
+C /etc/nvidia-container-runtime/config.toml - - - - /usr/share/factory/nvidia-container-runtime/nvidia-container-toolkit-config-ecs.toml

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles-k8s.conf
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles-k8s.conf
@@ -1,0 +1,1 @@
+C /etc/nvidia-container-runtime/config.toml - - - - /usr/share/factory/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles.conf
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles.conf
@@ -1,1 +1,0 @@
-C /etc/nvidia-container-runtime/config.toml - - - -

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -14,10 +14,11 @@ URL: https://%{goimport}
 
 Source0: https://%{goimport}/archive/v%{gover}/nvidia-container-toolkit-%{gover}.tar.gz
 Source1: nvidia-container-toolkit-config-k8s.toml
-Source2: nvidia-container-toolkit-tmpfiles.conf
+Source2: nvidia-container-toolkit-config-ecs.toml
 Source3: nvidia-oci-hooks-json
 Source4: nvidia-gpu-devices.rules
-Source5: nvidia-container-toolkit-config-ecs.toml
+Source5: nvidia-container-toolkit-tmpfiles-ecs.conf
+Source6: nvidia-container-toolkit-tmpfiles-k8s.conf
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container
@@ -57,20 +58,15 @@ install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -d %{buildroot}%{_cross_datadir}/nvidia-container-toolkit
-install -d %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime
+install -d %{buildroot}%{_cross_factorydir}/nvidia-container-runtime
 install -p -m 0755 nvidia-container-runtime-hook %{buildroot}%{_cross_bindir}/
 install -p -m 0755 nvidia-ctk %{buildroot}%{_cross_bindir}/
-install -m 0644 %{S:1} %{S:5} %{buildroot}%{_cross_factorydir}/etc/nvidia-container-runtime/
-install -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit.conf
+install -m 0644 %{S:1} %{S:2} %{buildroot}%{_cross_factorydir}/nvidia-container-runtime/
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-oci-hooks-json
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules
+install -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit-ecs.conf
+install -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf
 ln -s shimpei %{buildroot}%{_cross_bindir}/nvidia-oci
-
-%post ecs -p <lua>
-posix.link("nvidia-container-toolkit-config-ecs.toml", "%{_cross_factorydir}/etc/nvidia-container-runtime/config.toml")
-
-%post k8s -p <lua>
-posix.link("nvidia-container-toolkit-config-k8s.toml", "%{_cross_factorydir}/etc/nvidia-container-runtime/config.toml")
 
 %files
 %license LICENSE
@@ -79,11 +75,12 @@ posix.link("nvidia-container-toolkit-config-k8s.toml", "%{_cross_factorydir}/etc
 %{_cross_bindir}/nvidia-ctk
 %{_cross_bindir}/nvidia-oci
 %{_cross_templatedir}/nvidia-oci-hooks-json
-%{_cross_tmpfilesdir}/nvidia-container-toolkit.conf
 %{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules
 
 %files ecs
-%{_cross_factorydir}/etc/nvidia-container-runtime/nvidia-container-toolkit-config-ecs.toml
+%{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-ecs.toml
+%{_cross_tmpfilesdir}/nvidia-container-toolkit-ecs.conf
 
 %files k8s
-%{_cross_factorydir}/etc/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml
+%{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml
+%{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

In 911775f, we changed how the configuration files for the nvidia-container-toolkit were created, and used `%post` install scripts to create hard links to the correspondent configuration per variant. However, the hard links weren't created since the lua scripts use relative paths instead of absolute paths and the builds didn't fail since `%post` install scripts fail silently.

With this commit, instead of creating hard links with `%post` install scripts, the configuration files for the nvidia-container-toolkit are copied over with tmpfiles.d configuration files.

**Testing done:**

- [x] In k8s 1.29 x86_64, I verified the containerized workload doesn't have access to all the GPUs when `NVIDIA_VISIBLE_DEVICES=all`:

```bash
~ on Fedora ❯ k describe pod gpu-tests-2-thz4w | rg NVIDIA_VISIBLE_DEVICES
      NVIDIA_VISIBLE_DEVICES:      all
```

```bash
# There are 4 GPUs in the instance, and only two were configured as request in the Daemonset spec
~ on Fedora ❯ k exec gpu-tests-2-thz4w -- nvidia-smi
Wed Feb 21 02:30:31 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.129.03             Driver Version: 535.129.03   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla T4                       Off | 00000000:00:1C.0 Off |                    0 |
| N/A   17C    P8               9W /  70W |      2MiB / 15360MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   1  Tesla T4                       Off | 00000000:00:1E.0 Off |                    0 |
| N/A   18C    P8               8W /  70W |      2MiB / 15360MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
```

- [x] in aws-ecs-2-nvidia x86_64, I confirmed the configuration file was copied over which wasn't when the `%post` install script was used:

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "08dfbd2b",
    "pretty_name": "Bottlerocket OS 1.19.2 (aws-ecs-2-nvidia)",
    "variant_id": "aws-ecs-2-nvidia",
    "version_id": "1.19.2"
  }
}
bash-5.1# ls /etc/nvidia-container-runtime/config.toml
/etc/nvidia-container-runtime/config.toml

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
