### PR TITLE
clean up CNI results cache on boot

### DIFF
--- a/packages/cni-plugins/cni-plugins-tmpfiles.conf
+++ b/packages/cni-plugins/cni-plugins-tmpfiles.conf
@@ -1,0 +1,1 @@
+R! /var/lib/cni/results

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -14,6 +14,7 @@ Summary: Plugins for container networking
 License: Apache-2.0
 URL: https://%{goimport}
 Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
+Source1: cni-plugins-tmpfiles.conf
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}iptables
@@ -34,6 +35,9 @@ done
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin
 install -p -m 0755 bin/* %{buildroot}%{_cross_libexecdir}/cni/bin
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
 
 %cross_scan_attribution go-vendor vendor
 
@@ -59,5 +63,6 @@ install -p -m 0755 bin/* %{buildroot}%{_cross_libexecdir}/cni/bin
 %{_cross_libexecdir}/cni/bin/tuning
 %{_cross_libexecdir}/cni/bin/vlan
 %{_cross_libexecdir}/cni/bin/vrf
+%{_cross_tmpfilesdir}/cni-plugins.conf
 
 %changelog


### PR DESCRIPTION
**Issue number:**

Related: https://github.com/containerd/containerd/issues/8197

**Description of changes:**
The network device configurations referenced in the results do not persist across reboot, so the cache isn't useful. Malformed or empty files can also cause errors that interfere with subsequent operations on pod sandboxes.


**Testing done:**
Verified that `/var/lib/cni/results` was cleaned up on reboot:
```
# journalctl -b |grep results
Feb 21 19:53:25 localhost systemd-tmpfiles[1010]: Running remove action for entry R /var/lib/cni/results
Feb 21 19:53:25 localhost systemd-tmpfiles[1010]: rm -rf "/var/lib/cni/results"
Feb 21 19:53:25 localhost systemd-tmpfiles[1010]: Running create action for entry R /var/lib/cni/results
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
