### PR TITLE
systemd: Update to latest stable patch  version 252.22

### DIFF
--- a/packages/systemd/9010-units-keep-modprobe-service-units-running.patch
+++ b/packages/systemd/9010-units-keep-modprobe-service-units-running.patch
@@ -17,7 +17,7 @@ index 85a2c08..2994082 100644
 @@ -18,3 +18,4 @@ StartLimitIntervalSec=0
  [Service]
  Type=oneshot
- ExecStart=-/sbin/modprobe -abq %I
+ ExecStart=-/sbin/modprobe -abq %i
 +RemainAfterExit=true
 -- 
 2.40.1

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://github.com/systemd/systemd-stable/releases"
 package-features = ["unified-cgroup-hierarchy"]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd-stable/archive/v252.18/systemd-stable-252.18.tar.gz"
-sha512 = "0c8ec1aceb43a74693876e27b84df0973e879fca96960c32d28f365703ad6b2c193fce2038c169f0ad6f31e75bca19d880c6106d7737ce26e165f427957ba339"
+url = "https://github.com/systemd/systemd-stable/archive/v252.22/systemd-stable-252.22.tar.gz"
+sha512 = "cc394b7c5f9149bc68b59ff23c4db9384deac073c0b96d5047c4d4ea36e82b930eabc03d5978155e7ab5e8617ccfebd67804cb7b19c3a43fdaf96abc48a3e3e2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -2,7 +2,7 @@
 %global __brp_check_rpaths %{nil}
 
 Name: %{_cross_os}systemd
-Version: 252.18
+Version: 252.22
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later


### PR DESCRIPTION
**Description of changes:**
Updates systemd to the latest stable patch version in the 252 chain: 252.22.


**Testing done:**
WIP

- [X] Ensure the build log contains no relevant warnings or warnings about patch offsets
- [x] Test launches at scale (2000 nodes) for multiple instance types and network backends (wicked / systemd-networkd), ensure nodes are schedule-able and run pods
  - [x]  m5.large (systemd-network and wicked). 
  - [x] t3.medium (systemd-network and wicked)
  - [X] m6g.xlarge (systemd-network and wicked)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
