### PR TITLE
kernel: Update to latest versions for series 5.10, 5.15, 6.1

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/3d52b3205bf9d50e870cd4edaece690532e22b3738f95a1ca05a66f98be13aed/kernel-5.10.209-198.812.amzn2.src.rpm"
-sha512 = "20075e0f9d0def7f41a0dc79711fccb57e3f5b79079791da2f4cc56b11c9d1f306cc63753b6004bfcc43443bb2c6668c44c69a6d326da45d8a169ffe4a510213"
+url = "https://cdn.amazonlinux.com/blobstore/836671087eb8725263480f50a3717b7737dc62ec71b9acc07dbe77d721052145/kernel-5.10.209-198.858.amzn2.src.rpm"
+sha512 = "14b219aad20496915ff7a80fee2a7f57eab0cafe2931936b1e0e51da65b8c80d7b464a5df76f8b62d38515088be3d2ebdde4970eb1c625c43e07ccd2eba612b5"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/3d52b3205bf9d50e870cd4edaece690532e22b3738f95a1ca05a66f98be13aed/kernel-5.10.209-198.812.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/836671087eb8725263480f50a3717b7737dc62ec71b9acc07dbe77d721052145/kernel-5.10.209-198.858.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/099e5401bd8b5ffe59330ca1179847c32a481136173f21b7af16d20b780de422/kernel-5.15.148-97.158.amzn2.src.rpm"
-sha512 = "b2a1169b1d11ca4a93a4267d4d88fb97a87481a3b8f60702c0715fa2ad73d05a3b4ac74d25dd2cea2410038d58d8b6783a25382b3fb68879821595b1d42b230d"
+url = "https://cdn.amazonlinux.com/blobstore/42ac40513bf403555b444c8eb2792a334a4db9983e83106d6a75b335e0ab1a92/kernel-5.15.148-97.161.amzn2.src.rpm"
+sha512 = "2c8f6886da223166196a969ef58f4abaf2549cbe3407599ce92e0529954f520f4eb4d7aaa0574eba38cf64e999b1de4e25c7f237a04b484bd810236a57e3679d"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/099e5401bd8b5ffe59330ca1179847c32a481136173f21b7af16d20b780de422/kernel-5.15.148-97.158.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/42ac40513bf403555b444c8eb2792a334a4db9983e83106d6a75b335e0ab1a92/kernel-5.15.148-97.161.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/5d1de5166545475a39271909f57fe0e4e4527f4ce6f891c94fe741b36357d40b/kernel-6.1.75-99.163.amzn2023.src.rpm"
-sha512 = "7ddc100d62acca20ec1b0f383c9a24424f9e6eb411250a02daaef70459e56a044e791826b5cc6600eea706c38d036d9264bb11f06bdb5f16ec6a6319b47b38d1"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/bb5b0dc5f0e4b3b6c9174c124b0ed7b8a4a9c500b4f2a9ef64a7ac6a44f6c2bc/kernel-6.1.77-99.164.amzn2023.src.rpm"
+sha512 = "a504e14b35437ea3455a3a719e54c5da6520a49ab8026126d10e6ad3fbb079944b9be8d52cd966d750fd8cb77efe11fb76509c1c2fe9418e92dff81d227b5af4"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.75
+Version: 6.1.77
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/5d1de5166545475a39271909f57fe0e4e4527f4ce6f891c94fe741b36357d40b/kernel-6.1.75-99.163.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/bb5b0dc5f0e4b3b6c9174c124b0ed7b8a4a9c500b4f2a9ef64a7ac6a44f6c2bc/kernel-6.1.77-99.164.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                              STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-1-145.eu-central-1.compute.internal    Ready    <none>   53s     v1.28.4-eks-d91a302    192.168.1.145    3.126.153.143    Bottlerocket OS 1.19.2 (aws-k8s-1.28)   6.1.77           containerd://1.6.28+bottlerocket
ip-192-168-81-26.eu-central-1.compute.internal    Ready    <none>   9m2s    v1.23.17-eks-ea94ec3   192.168.81.26    18.193.150.189   Bottlerocket OS 1.19.2 (aws-k8s-1.23)   5.10.209         containerd://1.6.28+bottlerocket
ip-192-168-94-152.eu-central-1.compute.internal   Ready    <none>   5m14s   v1.26.11-eks-b93ee12   192.168.94.152   35.158.101.171   Bottlerocket OS 1.19.2 (aws-k8s-1.26)   5.15.148         containerd://1.6.28+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
11:57:06             e2e                                            global   complete            Passed:  1, Failed:  0, Remaining:  0
11:57:06    systemd-logs    ip-192-168-1-145.eu-central-1.compute.internal   complete                                                 
11:57:06    systemd-logs    ip-192-168-81-26.eu-central-1.compute.internal   complete                                                 
11:57:06    systemd-logs   ip-192-168-94-152.eu-central-1.compute.internal   complete                                                 
11:57:06 Sonobuoy plugins have completed. Preparing results for download.
11:57:26             e2e                                            global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
11:57:26    systemd-logs    ip-192-168-1-145.eu-central-1.compute.internal   complete   passed                                        
11:57:26    systemd-logs    ip-192-168-81-26.eu-central-1.compute.internal   complete   passed                                        
11:57:26    systemd-logs   ip-192-168-94-152.eu-central-1.compute.internal   complete   passed                                        
11:57:26 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:	  0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.28-diff:	  1 removed,   1 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:	  0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:	  1 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:	  1 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:	  1 removed,   0 added,   0 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/foersleo/5934917c645f12c6e2d70a88361b4e5f).

Changes are only on 6.1 kernels:
* `MFD_TI_AM335X_TSCADC` was removed from visibility upstream by fixing up its dependencies (Reference: [6e8c0eda6cca](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.1.77&id=6e8c0eda6cca633bf8ef31ff5168a8bbacec87fb))
* `ARM64_WORKAROUND_SPECULATIVE_UNPRIV_LOAD` - New option introduced to enable a workaround for multiple errata, no fucntional change (Reference: [2b1dc0666e7f](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.1.77&id=2b1dc0666e7f6c8c794147d28270eec53396887f))

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
