### PR TITLE
Update github checkout and cache actions to v4

### DIFF
--- a/.github/actions/list-variants/action.yml
+++ b/.github/actions/list-variants/action.yml
@@ -10,7 +10,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: get-variants
       name: Determine variants
       shell: bash

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -13,13 +13,13 @@ runs:
         echo "OS_ARCH=`uname -m`" >> $GITHUB_ENV
         sudo apt -y install build-essential openssl libssl-dev pkg-config liblz4-tool
       shell: bash
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       # Cache `cargo-make`, `cargo-cache`
       with:
         path: |
           ~/.cargo
         key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       # Cache first-party code dependencies
       with:
         path: |


### PR DESCRIPTION
Github has deprecated node 16, so we should be using the @v4 versions of the checkout and cache actions.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3800

**Description of changes:**

We had deprecated versions of cache and checkout in two files.

**Testing done:**

With any luck, this pull request will launch a workflow.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
