### PR TITLE
fix: provide runtime cgroups to kubelet

### DIFF
--- a/packages/kubernetes-1.23/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.23/kubelet-exec-start-conf
@@ -38,4 +38,5 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE} \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.24/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.24/kubelet-exec-start-conf
@@ -37,4 +37,5 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE} \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.25/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.25/kubelet-exec-start-conf
@@ -37,4 +37,5 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE} \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.26/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.26/kubelet-exec-start-conf
@@ -37,4 +37,5 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE} \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.27/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.27/kubelet-exec-start-conf
@@ -34,4 +34,5 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE} \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.28/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.28/kubelet-exec-start-conf
@@ -34,4 +34,5 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE} \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.29/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.29/kubelet-exec-start-conf
@@ -34,4 +34,5 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
-    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE}
+    --pod-infra-container-image ${POD_INFRA_CONTAINER_IMAGE} \
+    --runtime-cgroups=/runtime.slice/containerd.service


### PR DESCRIPTION

**Issue number:**

Closes #3776 

**Description of changes:**

Pass the cgroup where containerd is running to kubelet to enable container resource and performance monitoring via tools like cadvisor.

**Testing done:**

Tested on `aws-k8s-1.23-aarch64` and `aws-k8s-1.29-aarch64`:

```
$ kubectl get --raw "/api/v1/nodes/${NODE_NAME}/proxy/stats/summary" | jq -r '.node.systemContainers[] | .name'
pods
kubelet
runtime
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
