### PR TITLE
Kernels 2024 03 08

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/836671087eb8725263480f50a3717b7737dc62ec71b9acc07dbe77d721052145/kernel-5.10.209-198.858.amzn2.src.rpm"
-sha512 = "14b219aad20496915ff7a80fee2a7f57eab0cafe2931936b1e0e51da65b8c80d7b464a5df76f8b62d38515088be3d2ebdde4970eb1c625c43e07ccd2eba612b5"
+url = "https://cdn.amazonlinux.com/blobstore/b1e8ee5486de775eb34fe9d96ae2e1dcbb8484d2c657a11db84a52738669af3f/kernel-5.10.210-201.852.amzn2.src.rpm"
+sha512 = "cf944517e594f30140d99b91df7f673eb280af28a459b09c3a4735ae0aa888c0b0cf3a4515c0a50c1ef7840583ef005144941156af0cb13b5ec1967c054e86c0"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.209
+Version: 5.10.210
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/836671087eb8725263480f50a3717b7737dc62ec71b9acc07dbe77d721052145/kernel-5.10.209-198.858.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/b1e8ee5486de775eb34fe9d96ae2e1dcbb8484d2c657a11db84a52738669af3f/kernel-5.10.210-201.852.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/42ac40513bf403555b444c8eb2792a334a4db9983e83106d6a75b335e0ab1a92/kernel-5.15.148-97.161.amzn2.src.rpm"
-sha512 = "2c8f6886da223166196a969ef58f4abaf2549cbe3407599ce92e0529954f520f4eb4d7aaa0574eba38cf64e999b1de4e25c7f237a04b484bd810236a57e3679d"
+url = "https://cdn.amazonlinux.com/blobstore/c9a6f101b5d843eb394fcb0a400dc397ddeb0682a170fa606855688a6364d63e/kernel-5.15.149-99.161.amzn2.src.rpm"
+sha512 = "148ed4c3b84719e69b0a5f1c89ecb548b93593e1c849aa3ab245c93241236443f7056d2af99695eadfee3fb834654398ab363b06712f9bc291be991867eed34d"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.148
+Version: 5.15.149
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/42ac40513bf403555b444c8eb2792a334a4db9983e83106d6a75b335e0ab1a92/kernel-5.15.148-97.161.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/c9a6f101b5d843eb394fcb0a400dc397ddeb0682a170fa606855688a6364d63e/kernel-5.15.149-99.161.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/bb5b0dc5f0e4b3b6c9174c124b0ed7b8a4a9c500b4f2a9ef64a7ac6a44f6c2bc/kernel-6.1.77-99.164.amzn2023.src.rpm"
-sha512 = "a504e14b35437ea3455a3a719e54c5da6520a49ab8026126d10e6ad3fbb079944b9be8d52cd966d750fd8cb77efe11fb76509c1c2fe9418e92dff81d227b5af4"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/d8f882b99ae44db57c86fba424e3be17f0c29d1eb669933169c985eac3cb7c9e/kernel-6.1.79-99.164.amzn2023.src.rpm"
+sha512 = "54efad66a0d7b6db4111b041de8a3463e7feae847a51c795ae072a79d802a2879a7adebf1f880b5d227ce04f577f0b2247a81caaa2d34b890e1d56b99108f22c"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.77
+Version: 6.1.79
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/bb5b0dc5f0e4b3b6c9174c124b0ed7b8a4a9c500b4f2a9ef64a7ac6a44f6c2bc/kernel-6.1.77-99.164.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/d8f882b99ae44db57c86fba424e3be17f0c29d1eb669933169c985eac3cb7c9e/kernel-6.1.79-99.164.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Consume upstream kernels (5.10, 5.15, and 6.1).

Config changes:
- `-MFD_TI_AM335X_TSCADC n` disappears because it now has dependencies, and so has become invisible (for us).
- `+GCC_ASM_GOTO_OUTPUT_WORKAROUND y` compensate for an optimization bug in GCC. Yes, please, I do not want GCC to emit extremely incorrect code.

I have reviewed the patches, and nothing appears untoward here.

Kernel 5.10 patches:
```
Patches that changed:
Patches that were dropped:
0263-arm64-entry-Add-annotation-when-switching-to-from-th.patch
0807-netfilter-nf_tables-use-the-correct-get-put-helpers.patch
0808-netfilter-nf_tables-add-and-use-BE-register-load-sto.patch
0809-netfilter-nf_tables-fix-pointer-math-issue-in-nft_by.patch
0810-cifs-fix-off-by-one-in-SMB2_query_info_init.patch
0811-net-rds-Fix-UBSAN-array-index-out-of-bounds-in-rds_c.patch
0856-netfilter-nf_tables-reject-QUEUE-DROP-verdict-parame.patch
Patches that were added:
0851-AL2-5.10-Update-EFA-driver-to-2.8.0.patch
```

Kernel 5.15 patches:
```
Patches that changed:
Patches that were dropped:
0159-netfilter-nf_tables-reject-QUEUE-DROP-verdict-parame.patch
0160-net-rds-Fix-UBSAN-array-index-out-of-bounds-in-rds_c.patch
Patches that were added:
0159-AL2-5.15-Update-EFA-driver-to-2.8.0.patch
0160-Revert-smb-client-fix-OOB-in-smb2_set_next_command.patch
```

Kernel 6.1 patches:
```
Patches that changed:
0061-Revert-arm64-alternatives-add-shared-NOP-callback.patch -> 0061-Revert-arm64-alternatives-add-shared-NOP-callback.patch
Patches that were dropped:
0162-Revert-netfilter-ipset-fix-race-condition-between-sw.patch
Patches that were added:
0163-AL2023-6.1-Update-EFA-driver-to-2.8.0.patch
```

**Testing done:**
The check_kernels script ran a quick sonobuoy container on each of the three kernels. I learned that CloudFormation is not terribly fast, but the tests all passed. I also learned that the script hates me and refused to create a pull request, so I just typed this in by hand.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
