### PR TITLE
Adds nvidia-fabric-manager package

### DIFF
--- a/packages/nvidia-fabric-manager/Cargo.toml
+++ b/packages/nvidia-fabric-manager/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name    = "nvidia-fabric-manager"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build   = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[[package.metadata.build-package.external-files]]
+url            = "https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-535.104.05-archive.tar.xz"
+sha512         = "945d8dc209910737c2bb1364398859f9852959af36563a059f824ec78a3de43be5e70d2232daec11fc5e662ceed14141f69faa5ebe80953c00a708e30f2a4c49"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
+url            = "https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-535.104.05-archive.tar.xz"
+sha512         = "97f1295e40a73cb2d17b11950c31c69515cb1db03cf7bb3112045add61d727df00ebc29ae779250030b7d23b6cb2869746c5f8e6ca50258b784651dea3abc5ef"
+force-upstream = true

--- a/packages/nvidia-fabric-manager/nvidia-fabric-manager.service
+++ b/packages/nvidia-fabric-manager/nvidia-fabric-manager.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=FabricManager service
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+User=root
+PrivateTmp=false
+Type=forking
+
+ExecStart=/usr/bin/nv-fabricmanager -c /usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/nvidia-fabric-manager/nvidia-fabric-manager.spec
+++ b/packages/nvidia-fabric-manager/nvidia-fabric-manager.spec
@@ -96,6 +96,7 @@ cp include/nv_fm_types.h %{buildroot}%{_includedir}/
 %files
 %{_bindir}/*
 %license LICENSE
+%license third-party-notices.txt
 %{_cross_attribution_file}
 /usr/lib/systemd/system/*
 /usr/share/nvidia/nvswitch/*

--- a/packages/nvidia-fabric-manager/nvidia-fabric-manager.spec
+++ b/packages/nvidia-fabric-manager/nvidia-fabric-manager.spec
@@ -1,0 +1,111 @@
+%global _enable_debug_package 0
+%global debug_package %{nil}
+%global __os_install_post /usr/lib/rpm/brp-compress %{nil}
+%global rpmver 550.54.14
+%global branch 550
+
+%if "%{_cross_arch}" == "aarch64"
+%global arch sbsa
+%endif
+
+Name:           nvidia-fabric-manager
+Version:        %{rpmver}
+Release:        1
+Summary:        Fabric Manager for NVSwitch based systems
+
+License:        NVIDIA Proprietary
+URL:            http://www.nvidia.com
+Source0:        fabricmanager-linux-%{?arch:%{arch}}%{!?arch:%{_cross_arch}}-%{rpmver}-archive.tar.xz
+
+Provides:       nvidia-fabricmanager = %{rpmver}
+Provides:       nvidia-fabricmanager-%{branch} = %{rpmver}
+Obsoletes:      nvidia-fabricmanager-branch < %{rpmver}
+Obsoletes:      nvidia-fabricmanager < %{rpmver}
+
+%description
+Fabric Manager for NVIDIA NVSwitch based systems.
+
+%package -n nvidia-fabric-manager-devel
+Summary:        Fabric Manager API headers and associated library
+# Normally we would have a dev package depend on its runtime package. However
+# FM isn't a normal package. All the libs are in the dev package, and the
+# runtime package is actually a service package.
+Provides:       nvidia-fabricmanager-devel-%{branch} = %{rpmver}
+Obsoletes:      nvidia-fabricmanager-devel-branch < %{rpmver}
+Obsoletes:      nvidia-fabricmanager-devel < %{rpmver}
+
+%description -n nvidia-fabric-manager-devel
+Fabric Manager API headers and associated library
+
+%package -n cuda-drivers-fabricmanager-%{branch}
+Summary:        Meta-package for FM and Driver
+Requires:       nvidia-fabric-manager = %{rpmver}
+Requires:       cuda-drivers-%{branch} = %{rpmver}
+
+Obsoletes:      cuda-drivers-fabricmanager-branch < %{rpmver}
+Conflicts:      cuda-drivers-fabricmanager-%{branch} < %{rpmver}
+Conflicts:      cuda-drivers-fabricmanager-branch
+
+%description -n cuda-drivers-fabricmanager-%{branch}
+Convience meta-package for installing fabricmanager and the cuda-drivers
+meta-package simultaneously while keeping version equivalence. This meta-
+package is branch-specific.
+
+%package -n cuda-drivers-fabricmanager
+Summary:        Meta-package for FM and Driver
+Requires:       cuda-drivers-fabricmanager-%{branch} = %{rpmver}
+
+%description -n cuda-drivers-fabricmanager
+Convience meta-package for installing fabricmanager and the cuda-drivers
+meta-package simultaneously while keeping version equivalence. This meta-
+package is across all driver branches.
+
+%prep
+%setup -q -n fabricmanager-linux-%{?arch:%{arch}}%{!?arch:%{_cross_arch}}-%{rpmver}-archive
+
+%build
+
+%install
+export DONT_STRIP=1
+
+rm -rf %{buildroot}
+
+mkdir -p %{buildroot}%{_bindir}/
+cp -a bin/nv-fabricmanager %{buildroot}%{_bindir}/
+cp -a bin/nvswitch-audit %{buildroot}%{_bindir}/
+
+mkdir -p %{buildroot}/usr/lib/systemd/system
+cp -a systemd/nvidia-fabricmanager.service  %{buildroot}/usr/lib/systemd/system
+
+mkdir -p %{buildroot}/usr/share/nvidia/nvswitch
+cp -a share/nvidia/nvswitch/*_topology %{buildroot}/usr/share/nvidia/nvswitch
+cp -a etc/fabricmanager.cfg %{buildroot}/usr/share/nvidia/nvswitch
+
+mkdir -p %{buildroot}%{_libdir}/
+cp lib/libnvfm.so.1 %{buildroot}%{_libdir}/
+ln -s lib/libnvfm.so.1 %{buildroot}%{_libdir}/libnvfm.so
+
+mkdir -p %{buildroot}%{_includedir}/
+cp include/nv_fm_agent.h %{buildroot}%{_includedir}/
+cp include/nv_fm_types.h %{buildroot}%{_includedir}/
+
+%post -n nvidia-fabric-manager-devel -p /sbin/ldconfig
+
+%postun -n nvidia-fabric-manager-devel -p /sbin/ldconfig
+
+%files
+%{_bindir}/*
+%license LICENSE
+%{_cross_attribution_file}
+/usr/lib/systemd/system/*
+/usr/share/nvidia/nvswitch/*
+%exclude /usr/share/nvidia/nvswitch/fabricmanager.cfg
+%config(noreplace) /usr/share/nvidia/nvswitch/fabricmanager.cfg
+
+%files -n nvidia-fabric-manager-devel
+%{_libdir}/*
+%{_includedir}/*
+
+%files -n cuda-drivers-fabricmanager-%{branch}
+
+%files -n cuda-drivers-fabricmanager

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "kmod-6_1-nvidia",
  "kubernetes-1_29",
  "nvidia-container-toolkit",
+ "nvidia-fabric-manager",
  "nvidia-k8s-device-plugin",
  "release",
 ]
@@ -1027,6 +1028,10 @@ dependencies = [
  "glibc",
  "libnvidia-container",
 ]
+
+[[package]]
+name = "nvidia-fabric-manager"
+version = "0.1.0"
 
 [[package]]
 name = "nvidia-k8s-device-plugin"

--- a/variants/aws-k8s-1.29-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.29-nvidia/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 # This is the aws-k8s-1.29-nvidia variant. "." is not allowed in crate names, but we
 # don't use this crate name anywhere.
-name = "aws-k8s-1_29-nvidia"
+name    = "aws-k8s-1_29-nvidia"
 version = "0.1.0"
 edition = "2021"
 publish = false
-build = "../build.rs"
+build   = "../build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
@@ -13,11 +13,11 @@ exclude = ["README.md"]
 os-image-size-gib = 4
 
 [package.metadata.build-variant.image-features]
-grub-set-private-var = true
+grub-set-private-var     = true
 unified-cgroup-hierarchy = true
-uefi-secure-boot = true
-xfs-data-partition = true
-systemd-networkd = true
+uefi-secure-boot         = true
+xfs-data-partition       = true
+systemd-networkd         = true
 
 [package.metadata.build-variant]
 included-packages = [
@@ -33,6 +33,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-6.1-nvidia-tesla-535",
+    "nvidia-fabric-manager",
 ]
 kernel-parameters = [
     "console=tty0",
@@ -47,14 +48,15 @@ path = "../variants.rs"
 
 [build-dependencies]
 # core
-release = { path = "../../packages/release" }
-kernel-6_1 = { path = "../../packages/kernel-6.1" }
+release    = {path = "../../packages/release"}
+kernel-6_1 = {path = "../../packages/kernel-6.1"}
 # k8s
-cni = { path = "../../packages/cni" }
-cni-plugins = { path = "../../packages/cni-plugins" }
-kubernetes-1_29 = { path = "../../packages/kubernetes-1.29" }
-aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni                   = {path = "../../packages/cni"}
+cni-plugins           = {path = "../../packages/cni-plugins"}
+kubernetes-1_29       = {path = "../../packages/kubernetes-1.29"}
+aws-iam-authenticator = {path = "../../packages/aws-iam-authenticator"}
 # nvidia
-nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
-nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
-kmod-6_1-nvidia = { path = "../../packages/kmod-6.1-nvidia" }
+nvidia-container-toolkit = {path = "../../packages/nvidia-container-toolkit"}
+nvidia-k8s-device-plugin = {path = "../../packages/nvidia-k8s-device-plugin"}
+nvidia-fabric-manager    = {path = "../../packages/nvidia-fabric-manager"}
+kmod-6_1-nvidia          = {path = "../../packages/kmod-6.1-nvidia"}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes bottlerocket-os/bottlerocket#3278

**Description of changes:**

I have made a fairly naive attempt at resolving the above issue to add nvidia-fabric-manager package to Bottlerocket. In the Fabric Manager User Guide there is a lot of additional information around running as non-root, etc etc, I was not sure whether that was a dealbreaker or not. 

I have yet to be able to build an image successfully locally, I saw this issue https://github.com/bottlerocket-os/twoliter/issues/173 from a while ago and seem to be hitting the same error.

I'd appreciate any pointers on whether I have gotten the licensing bits right here, along with any other issues (the specfile didn't work as is, and I had to make a few cosmetic changes to the copying of files etc to the `%{buildroot}`.

It's probably fairly obvious this is my first attempt at an rpmbuild 😄 

**Testing done:**
Added the package to the most recent k8s variant (`aws-k8s-1.29-nvidia`).

```Licenses.toml
[nvidia]
spdx-id = "LicensesRef-NVIDIA-Customer-Use"
licenses = [
    {path = "LICENSE", license-url = "https://www.nvidia.com/en-us/drivers/nvidia-license/"},
]
```

```
cargo make -e BUILDSYS_ARCH=aarch64 -e BUILDSYS_UPSTREAM_LICENSE_FETCH=true fetch-licenses
```

```
cargo make -e BUILDSYS_ARCH=aarch64 -e PACKAGE=nvidia-fabric-manager -e BUILDSYS_VARIANT=aws-k8s-1.29-nvidia build-package
[cargo-make] INFO - cargo make 0.37.10
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: build-package
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
Found Twoliter v0.0.6 installed.
Skipping installation.
[cargo-make] INFO - Execute Command: "<>/code/bottlerocket/tools/twoliter/twoliter" "--log-level=info" "make" "build-package" "--project-path=<>/code/bottlerocket/Twoliter.toml" "--cargo-home=<>/code/bottlerocket/.cargo" "--"
[2024-03-14T12:42:26Z WARN  twoliter::project] A Release.toml file was found. Release.toml is deprecated. Please remove it from your project.
[cargo-make][1] INFO - Build File: <>/code/bottlerocket/build/tools/Makefile.toml
[cargo-make][1] INFO - Task: build-package
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: check-cargo-version
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: setup-build
[cargo-make][1] INFO - Running Task: fetch-sdk
[cargo-make][1] INFO - Running Task: publish-setup
12:42:27 [INFO] No infra config at '<>/code/bottlerocket/Infra.toml' - using local roles/keys
[cargo-make][1] INFO - Running Task: fetch-toolchain
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: fetch-vendored
[cargo-make][1] INFO - Running Task: fetch-licenses
Skipping fetching licenses
[cargo-make][1] INFO - Running Task: build-package
   Compiling nvidia-fabric-manager v0.1.0 (<>/code/bottlerocket/packages/nvidia-fabric-manager)
    Finished dev [optimized] target(s) in 13.80s
[cargo-make][1] INFO - Build Done in 43.17 seconds.
[cargo-make] INFO - Build Done in 43.96 seconds.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
