### PR TITLE
schnauzer: add if_not_null template helper

### DIFF
--- a/sources/api/schnauzer/src/v2/import/helpers.rs
+++ b/sources/api/schnauzer/src/v2/import/helpers.rs
@@ -60,12 +60,14 @@ fn all_helpers() -> HashMap<ExtensionName, HashMap<HelperName, Box<dyn HelperDef
         },
 
         // globally helpful helpers will be included in a null extension called "std"
+        // Prefer snake case for helper names (we accidentally created a few with kabob case)
         "std" => hashmap! {
             "any_enabled" => helper!(handlebars_helpers::any_enabled),
             "base64_decode" => helper!(handlebars_helpers::base64_decode),
             "default" => helper!(handlebars_helpers::default),
             "join_array" => helper!(handlebars_helpers::join_array),
             "join_map" => helper!(handlebars_helpers::join_map),
+            "if_not_null" => Box::new(handlebars_helpers::IfNotNullHelper),
             "goarch" => helper!(handlebars_helpers::goarch),
         },
     }


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

There's currently not a safe way to render potentially-null falsy values in a schnauzer template. Gating with `{{#if falsy}}` will skip rendering, and `{{default false falsy}}` will always render something, even if `falsy` is unset.

`{{#if-not-null falsy}}` checks only that the value is not null, it doesn't care if it's falsy. This allows us to conditionally render template portions that may contain falsy values.

So for example, in `packages/os/host-containers-toml`, we currently render:

```
{{#each settings.host-containers}}
[host-containers."{{{@key}}}"]
...
{{#if this.enabled}}
enabled = {{{this.enabled}}}
{{/if}}
{{#if this.superpowered}}
superpowered = {{{this.superpowered}}}
{{/if}}
...
{{/each}}
```

where `this.enabled` and `this.superpowered` are booleans. If they are explicitly set to `false`, they will not be rendered. In this particular case it doesn't cause a behavior issue because those settings default to `false`, but it could cause problems in a case where the default is `true`.

With this helper, we can instead write:
```
{{#each settings.host-containers}}
[host-containers."{{{@key}}}"]
...
{{#if-not-null this.enabled}}
enabled = {{{this.enabled}}}
{{/if-not-null}}
{{#if-not-null this.superpowered}}
superpowered = {{{this.superpowered}}}
{{/if-not-null}}
...
{{/each}}
```

This will correctly render `enabled = false` and `superpowered = false`.

Related: https://github.com/bottlerocket-os/bottlerocket/pull/3724, https://github.com/bottlerocket-os/bottlerocket/pull/3777

**Testing done:**

updated the `host-containers-toml` template using the `{{#if-not-null}}` helper, and configured settings to reflect the three different states we care about (set to a truthy value, set to a falsy value, and unset) and confirmed that the template rendered as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
