### PR TITLE
host-containers: render config file with if_not_null

### DIFF
--- a/packages/os/host-containers-toml
+++ b/packages/os/host-containers-toml
@@ -1,20 +1,21 @@
 [required-extensions]
 host-containers = "v1"
+std = { version = "v1", helpers = ["if_not_null"]}
 +++
-{{#if settings.host-containers}}
+{{#if_not_null settings.host-containers}}
 {{#each settings.host-containers}}
 [host-containers."{{{@key}}}"]
-{{#if this.source}}
+{{#if_not_null this.source}}
 source = "{{{this.source}}}"
-{{/if}}
-{{#if this.enabled}}
-enabled = {{{this.enabled}}}
-{{/if}}
-{{#if this.superpowered}}
-superpowered = {{{this.superpowered}}}
-{{/if}}
-{{#if this.user-data}}
+{{/if_not_null}}
+{{#if_not_null this.enabled}}
+enabled = {{this.enabled}}
+{{/if_not_null}}
+{{#if_not_null this.superpowered}}
+superpowered = {{this.superpowered}}
+{{/if_not_null}}
+{{#if_not_null this.user-data}}
 user-data = "{{{this.user-data}}}"
-{{/if}}
+{{/if_not_null}}
 {{/each}}
-{{/if}}
+{{/if_not_null}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

#3777 would skip rendering `enabled` or `superpowered` when they were set to false because the `if` handlebars helper checks for any falsy value. This instead checks that settings values are not null with the new `if_not_null` helper before rendering them, allowing false values to be rendered correctly.

**Testing done:**

Spun up an `aws-dev` instance and modified settings, verifying that the config file was updated correctly.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
