### PR TITLE
ntp: Add setting to configure options

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -295,4 +295,5 @@ version = "1.20.0"
     "migrate_v1.20.0_remove-ecs-settings-applier.lz4",
     "migrate_v1.20.0_update-ecs-config-path.lz4",
     "migrate_v1.20.0_update-ecs-config-template-path.lz4",
+    "migrate_v1.20.0_add-ntp-default-options-v0-1-0.lz4",
 ]

--- a/packages/chrony/chrony-conf
+++ b/packages/chrony/chrony-conf
@@ -2,7 +2,7 @@
 ntp = "v1"
 +++
 {{#each settings.ntp.time-servers}}
-pool {{this}} iburst
+pool {{this}}{{#each ../settings.ntp.options}} {{this}}{{/each}}
 {{/each}}
 driftfile /var/lib/chrony/drift
 makestep 1.0 3

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -232,6 +232,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-ntp-default-options-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "api/migration/migrations/v1.20.0/remove-ecs-settings-applier",
     "api/migration/migrations/v1.20.0/update-ecs-config-path",
     "api/migration/migrations/v1.20.0/update-ecs-config-template-path",
+    "api/migration/migrations/v1.20.0/add-ntp-default-options-v0-1-0",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.20.0/add-ntp-default-options-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/add-ntp-default-options-v0-1-0/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "add-ntp-default-options-v0-1-0"
+version = "0.1.0"
+authors = ["Dom Goodwin <domgoodwin@monzo.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}

--- a/sources/api/migration/migrations/v1.20.0/add-ntp-default-options-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/add-ntp-default-options-v0-1-0/src/main.rs
@@ -1,0 +1,18 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added the ability to set additional options for NTP
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&["settings.ntp.options"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -120,6 +120,10 @@ components:
               type: array
               items:
                 type: string
+            options:
+              type: array
+              items:
+                type: string
         network:
           type: object
           properties:

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -119,6 +119,7 @@ template-path = "/usr/share/templates/hosts"
 
 [settings.ntp]
 time-servers = ["169.254.169.123", "2.amazon.pool.ntp.org"]
+options = ["iburst"]
 
 [services.ntp]
 configuration-files = ["chrony-conf"]

--- a/sources/settings-extensions/ntp/src/lib.rs
+++ b/sources/settings-extensions/ntp/src/lib.rs
@@ -8,6 +8,7 @@ use std::convert::Infallible;
 #[model(impl_default = true)]
 pub struct NtpSettingsV1 {
     time_servers: Vec<Url>,
+    options: Vec<String>,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -64,7 +65,8 @@ mod test {
         assert_eq!(
             NtpSettingsV1::generate(None, None),
             Ok(GenerateResult::Complete(NtpSettingsV1 {
-                time_servers: None
+                time_servers: None,
+                options: None,
             }))
         )
     }
@@ -80,6 +82,20 @@ mod test {
                 Url::try_from("https://example.net").unwrap(),
                 Url::try_from("http://www.example.com").unwrap(),
             )
+        );
+
+        let results = serde_json::to_string(&ntp).unwrap();
+        assert_eq!(results, test_json);
+    }
+
+    #[test]
+    fn test_options_ntp() {
+        let test_json = r#"{"time-servers":["https://example.net","http://www.example.com"],"options":["minpoll","1","maxpoll","2"]}"#;
+
+        let ntp: NtpSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            ntp.options.clone().unwrap(),
+            vec!("minpoll", "1", "maxpoll", "2",)
         );
 
         let results = serde_json::to_string(&ntp).unwrap();


### PR DESCRIPTION
**Description of changes:**

Adds the ability to configure further options for the NTP servers. We would like to set `maxpoll` to a lower value so I've added the ability to specify options which get added to the servers too. I've removed the default option `iburst` and added it to this setting default instead.


**Testing done:**
- Ran unit tests locally

Edit: Sam did the testing with Bottlerocket including migration testing, see comment below.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
