### PR TITLE
Kernels: update 5.10, 5.15, 6.1

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/b1e8ee5486de775eb34fe9d96ae2e1dcbb8484d2c657a11db84a52738669af3f/kernel-5.10.210-201.852.amzn2.src.rpm"
-sha512 = "cf944517e594f30140d99b91df7f673eb280af28a459b09c3a4735ae0aa888c0b0cf3a4515c0a50c1ef7840583ef005144941156af0cb13b5ec1967c054e86c0"
+url = "https://cdn.amazonlinux.com/blobstore/5dc866850c576c78dc05635db2b2cba76b11a08ad012d2a90d7fceac3a41ef0a/kernel-5.10.210-201.855.amzn2.src.rpm"
+sha512 = "6a30c999fb4851b84c580c907ec749f77edc8f424bdc37d10d1325132fac1cf97991918872634ab9fa3493430123a9a637e6dd0f19a67e2a62cf7efe7162adf2"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/b1e8ee5486de775eb34fe9d96ae2e1dcbb8484d2c657a11db84a52738669af3f/kernel-5.10.210-201.852.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/5dc866850c576c78dc05635db2b2cba76b11a08ad012d2a90d7fceac3a41ef0a/kernel-5.10.210-201.855.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/c9a6f101b5d843eb394fcb0a400dc397ddeb0682a170fa606855688a6364d63e/kernel-5.15.149-99.161.amzn2.src.rpm"
-sha512 = "148ed4c3b84719e69b0a5f1c89ecb548b93593e1c849aa3ab245c93241236443f7056d2af99695eadfee3fb834654398ab363b06712f9bc291be991867eed34d"
+url = "https://cdn.amazonlinux.com/blobstore/19610ac0e9db4f43b411af72588acd9a0b4edc3103d72c075a233982bf18f5a5/kernel-5.15.149-99.162.amzn2.src.rpm"
+sha512 = "a51577d353eb3fe639eef06b1db411ddbc23e5f1819995ff5dde146b943533bb09b42bb9c915d0f7d7ee9c71730a45149b335490222934fffbbe22c68bf93a13"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/c9a6f101b5d843eb394fcb0a400dc397ddeb0682a170fa606855688a6364d63e/kernel-5.15.149-99.161.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/19610ac0e9db4f43b411af72588acd9a0b4edc3103d72c075a233982bf18f5a5/kernel-5.15.149-99.162.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/d8f882b99ae44db57c86fba424e3be17f0c29d1eb669933169c985eac3cb7c9e/kernel-6.1.79-99.164.amzn2023.src.rpm"
-sha512 = "54efad66a0d7b6db4111b041de8a3463e7feae847a51c795ae072a79d802a2879a7adebf1f880b5d227ce04f577f0b2247a81caaa2d34b890e1d56b99108f22c"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/c26f813e14f0867fda99398c0bae01ae7990746bf3340bb22a375d16a358b4e7/kernel-6.1.79-99.167.amzn2023.src.rpm"
+sha512 = "8151b4982dc283c508d3448488ddabc22b16366155e798705b8b162d679cb795486cb521af713193fc0bab84ef520dcab37bad02dc7d08d88bfd7cc4931c1439"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/d8f882b99ae44db57c86fba424e3be17f0c29d1eb669933169c985eac3cb7c9e/kernel-6.1.79-99.164.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/c26f813e14f0867fda99398c0bae01ae7990746bf3340bb22a375d16a358b4e7/kernel-6.1.79-99.167.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP    OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-50-68.us-west-2.compute.internal    Ready    <none>   2m      v1.28.7-eks-c5c5da4    192.168.50.68    34.222.1.83    Bottlerocket OS 1.19.3 (aws-k8s-1.28)   6.1.79           containerd://1.6.30+bottlerocket
ip-192-168-66-181.us-west-2.compute.internal   Ready    <none>   5m5s    v1.26.14-eks-b063426   192.168.66.181   35.81.170.74   Bottlerocket OS 1.19.3 (aws-k8s-1.26)   5.15.149         containerd://1.6.30+bottlerocket
ip-192-168-77-66.us-west-2.compute.internal    Ready    <none>   7m54s   v1.23.17-eks-ea94ec3   192.168.77.66    35.86.203.79   Bottlerocket OS 1.19.3 (aws-k8s-1.23)   5.10.210         containerd://1.6.30+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
21:05:24    systemd-logs   ip-192-168-66-181.us-west-2.compute.internal   complete
21:05:44             e2e                                         global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
21:05:44    systemd-logs    ip-192-168-50-68.us-west-2.compute.internal   complete   passed
21:05:44    systemd-logs   ip-192-168-66-181.us-west-2.compute.internal   complete   passed
21:05:44    systemd-logs    ip-192-168-77-66.us-west-2.compute.internal   complete   passed
21:05:44 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.28-diff:         0 removed,   6 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:          0 removed,   6 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:        0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:        0 removed,   6 added,   0 changed
config-x86_64-vmware-k8s-1.26-diff:       0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:       0 removed,   6 added,   0 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/larvacea/825e2638d307979dff8eff02cb453de2).

**Summary of changes**

* **5.10, 5.15, and 6.1** Fix potential ext4 file system corruption during resize.
* **5.10** Support for getting and setting SACLs in smb.
* **6.1** Add support for LustreFS.
* No changes to bottlerocket-specific patches or config. Upstream config additions are for Lustre in 6.1 kernels.

**Terms of contribution**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
