### PR TITLE
Revert "Update Lib Nvidia container package"

### DIFF
--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.14.5/libnvidia-container-1.14.5.tar.gz"
-sha512 = "0d50c584af5f222d9e54f8b6b094ddd9b625c965ed519e1b8f74e7b8d26d811084e1c37b3d7fb1a2473890b7b7ef263c0893c15e6bc4586d5155c03f31ab4662"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.13.5/libnvidia-container-1.13.5.tar.gz"
+sha512 = "00de15c2a0168b0c131eae21e10d186053be7f78021fe28785130ea541f1a592f44042697f01b3bf20717d9a93a85b34c7b510028adcc265cc0ac6f97be2bf0e"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/NVIDIA/nvidia-modprobe/archive/495.44/nvidia-modprobe-495.44.tar.gz"

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global nvidia_modprobe_version 495.44
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.14.5
+Version: 1.13.5
 Release: 1%{?dist}
 Summary: NVIDIA container runtime library
 # The COPYING and COPYING.LESSER files in the sources don't apply to libnvidia-container
@@ -59,7 +59,6 @@ export WITH_TIRPC=yes \\\
 export WITH_NVCGO=yes \\\
 export prefix=%{_cross_prefix} \\\
 export DESTDIR=%{buildroot} \\\
-export LIB_VERSION=%{version} \\\
 %{nil}
 
 %build

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.14.5/nvidia-container-toolkit-1.14.5.tar.gz"
-sha512 = "828b69578894be96b6629f5e404e71589700267c9c24593caea7cb8c6c0d668d5393510a4608cb6ce377d4f28fe7a442bf9e08495f142a22616ca2115cb5eb61"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.13.5/nvidia-container-toolkit-1.13.5.tar.gz"
+sha512 = "7266e779abf27f2bc1b7c801e5eb4720b82be22bed3ec90171e4f5499b2bc7376f1369e4931d4db55edc8f5fd5e44d5e817eb258ec39bf55f16424fe725188d6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.14.5
+%global gover 1.13.5
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.14.5/v0.14.5.tar.gz"
-path = "k8s-device-plugin-0.14.5.tar.gz"
-sha512 = "099967fff1e8832b416e5a6db3da39c5cbdec1de19afceaa8b5689a6211da256ca0e258442d2ce9b30d86f0e3e9da0e716a5a501ff47824c02f6b29301db81ea"
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.14.4/v0.14.4.tar.gz"
+path = "k8s-device-plugin-0.14.4.tar.gz"
+sha512 = "055439c2aac797b2d594846d9fb572f2f46ad5caeb9f44107a2fc05211904823c01a8fd8a2329c13a47ef440fd017086067f7ec55d482970cdbc1663b36d714c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.14.5
+%global gover 0.14.4
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-k8s-device-plugin


### PR DESCRIPTION
This reverts commit 60b95c39234cc1cedd0c813114f0da39b318fcdc.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
During 1.19.3 release, aarch64-aws-ecs-1-nvidia and aarch64-aws-ecs-2-nvidia failed on workload tests consistently.
We have confirmed the commit 60b95c39234cc1cedd0c813114f0da39b318fcdc makes the ecs-2-nvidia and ecs-1-nvidia test fail. Revert to solve the issue and unblock the release.
```
commit 999e7953bee89918b5f46b2e050f16f58fab424c (HEAD -> develop, origin/develop, origin/HEAD)
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Mar 26 16:33:19 2024 +0000

    Revert "packages: update nvidia-container-toolkit to 1.14.5"

    This reverts commit 9b661d1a81b56a444d058df29af8140b50dfe6ee.

commit d9a80c411f0f73e6fc773832815a321fce927b9d
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Mar 26 16:33:13 2024 +0000

    Revert "packages: update nvidia-k8s-device-plugin to 0.14.5"

    This reverts commit f9c06447564f846ef574d74da17e7017a20883a1.

commit 5bbc5fc209759f7b11cc221a1b9d15554f79514e
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Mar 26 16:33:04 2024 +0000

    Revert "packages: update libnvidia-container to 1.14.5"

    This reverts commit 60b95c39234cc1cedd0c813114f0da39b318fcdc.
```

**Testing done:**
@vyaghras and @arnaldo2792 completed the and confirmed the AMI without this commit worked as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
