### PR TITLE
CHANGELOG: remove `Update Lib Nvidia container package` from 1.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## OS Changes
 * Update kernel to 5.10.210, 5.15.149, 6.1.78 ([#3816])
-* Update third party packages ([#3793], [#3815], [#3832])
+* Update third party packages ([#3793], [#3832])
 * Update host containers ([#3837])
 * Support auditctl in bootstrap containers ([#3831])
 
@@ -19,7 +19,6 @@
 * twoliter updated to v0.0.7 ([#3839])
 
 [#3793]: https://github.com/bottlerocket-os/bottlerocket/pull/3793
-[#3815]: https://github.com/bottlerocket-os/bottlerocket/pull/3815
 [#3816]: https://github.com/bottlerocket-os/bottlerocket/pull/3816
 [#3824]: https://github.com/bottlerocket-os/bottlerocket/pull/3824
 [#3832]: https://github.com/bottlerocket-os/bottlerocket/pull/3832


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
We revert Update Lib Nvidia container package commits on https://github.com/bottlerocket-os/bottlerocket/pull/3854.
So we need to remove it from 1.19.3 release CHANGELOG.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
