### PR TITLE
reduce variant matrix size in CI

### DIFF
--- a/.github/actions/list-variants/action.yml
+++ b/.github/actions/list-variants/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
       run: |
         cd variants
-        output="variants=$(ls -d */ | cut -d'/' -f 1 | grep -vE '^(shared|target)$' | jq -R -s -c 'split("\n")[:-1]')"
+        output="variants=$(ls -d */ | cut -d'/' -f 1 | grep -vE '^(shared|target)$' | sort | awk '$0 != x "-nvidia" && NR>1 {print x} {x=$0} END {print}' | jq -R -s -c 'split("\n")[:-1]')"
         echo $output
         echo $output >> $GITHUB_OUTPUT
         output="aarch-enemies=$(ls -d */ | cut -d'/' -f 1 | grep -E '(^(metal|vmware)|\-dev$)' | jq -R -s -c 'split("\n")[:-1] | [ .[] | {"variant": ., "arch": "aarch64"}]')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,5 +80,4 @@ jobs:
           cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} \
             -e BUILDSYS_ARCH=${{ matrix.arch }} \
             -e BUILDSYS_JOBS=12 \
-            -e BUILDSYS_UPSTREAM_SOURCE_FALLBACK="${{ contains(matrix.variant, 'nvidia') }}" \
             -e BUILDSYS_UPSTREAM_LICENSE_FETCH="${{ contains(matrix.variant, 'nvidia') }}"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -62,5 +62,4 @@ jobs:
           cargo make -e BUILDSYS_VARIANT=${{ matrix.variant }} \
             -e BUILDSYS_ARCH=${{ matrix.arch }} \
             -e BUILDSYS_JOBS=12 \
-            -e BUILDSYS_UPSTREAM_SOURCE_FALLBACK="${{ contains(matrix.variant, 'nvidia') }}" \
             -e BUILDSYS_UPSTREAM_LICENSE_FETCH="${{ contains(matrix.variant, 'nvidia') }}"


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Adjust the `list-variants` action to pick the `*-nvidia` flavors of variants when they exist, since from a CI perspective they provide similar but greater coverage.

Remove the global upstream source fallback for nvidia variants since this should be covered by the package-level exception. This fixes a current issue where if a package is not present in the lookaside cache, the nvidia builds can succeed while all others fail.

**Testing done:**
Ran the equivalent script locally:
```
❯ ls -d */ | cut -d'/' -f 1 | grep -vE '^(shared|target)$' | sort | awk '$0 != x "-nvidia" && NR>1 {print x} {x=$0} END {print}' | jq -R -s 'split("\n")[:-1]
'
[
  "aws-dev",
  "aws-ecs-1-nvidia",
  "aws-ecs-2-nvidia",
  "aws-k8s-1.23-nvidia",
  "aws-k8s-1.24-nvidia",
  "aws-k8s-1.25-nvidia",
  "aws-k8s-1.26-nvidia",
  "aws-k8s-1.27-nvidia",
  "aws-k8s-1.28-nvidia",
  "aws-k8s-1.29-nvidia",
  "aws-k8s-1.30-nvidia",
  "metal-dev",
  "metal-k8s-1.25",
  "metal-k8s-1.26",
  "metal-k8s-1.27",
  "metal-k8s-1.28",
  "metal-k8s-1.29",
  "vmware-dev",
  "vmware-k8s-1.25",
  "vmware-k8s-1.26",
  "vmware-k8s-1.27",
  "vmware-k8s-1.28",
  "vmware-k8s-1.29",
  "vmware-k8s-1.30"
]
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
