### PR TITLE
Kernels 2024 04 02

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/5dc866850c576c78dc05635db2b2cba76b11a08ad012d2a90d7fceac3a41ef0a/kernel-5.10.210-201.855.amzn2.src.rpm"
-sha512 = "6a30c999fb4851b84c580c907ec749f77edc8f424bdc37d10d1325132fac1cf97991918872634ab9fa3493430123a9a637e6dd0f19a67e2a62cf7efe7162adf2"
+url = "https://cdn.amazonlinux.com/blobstore/f2f4a85aff9b0efec71d75bc29454ce8ab73974486a2a8ba541343cee1c7a622/kernel-5.10.213-201.855.amzn2.src.rpm"
+sha512 = "9e61a292106ab4872ff8bd89aa0c32613c7e78f3d6776ada31ba1d63e26f923a5b08e4fb2e5c927459cc057476d0e8e45c2f125ee226a6d402ba0c4025d78cde"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.210
+Version: 5.10.213
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/5dc866850c576c78dc05635db2b2cba76b11a08ad012d2a90d7fceac3a41ef0a/kernel-5.10.210-201.855.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/f2f4a85aff9b0efec71d75bc29454ce8ab73974486a2a8ba541343cee1c7a622/kernel-5.10.213-201.855.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/19610ac0e9db4f43b411af72588acd9a0b4edc3103d72c075a233982bf18f5a5/kernel-5.15.149-99.162.amzn2.src.rpm"
-sha512 = "a51577d353eb3fe639eef06b1db411ddbc23e5f1819995ff5dde146b943533bb09b42bb9c915d0f7d7ee9c71730a45149b335490222934fffbbe22c68bf93a13"
+url = "https://cdn.amazonlinux.com/blobstore/29a1d43caffcebd032ece82a974ba5db68b1354f508a35f6df62d8e1f6106ee8/kernel-5.15.152-100.162.amzn2.src.rpm"
+sha512 = "3d0ea5442f26d315d2d96968c4c1b8a5b2a2bd1a12ac0892351df9ef837efe2bae90cc9d4f3687acf8a5eddb96971d805407fac9dcdcb1d24d7cfef304eda77a"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.149
+Version: 5.15.152
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/19610ac0e9db4f43b411af72588acd9a0b4edc3103d72c075a233982bf18f5a5/kernel-5.15.149-99.162.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/29a1d43caffcebd032ece82a974ba5db68b1354f508a35f6df62d8e1f6106ee8/kernel-5.15.152-100.162.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/c26f813e14f0867fda99398c0bae01ae7990746bf3340bb22a375d16a358b4e7/kernel-6.1.79-99.167.amzn2023.src.rpm"
-sha512 = "8151b4982dc283c508d3448488ddabc22b16366155e798705b8b162d679cb795486cb521af713193fc0bab84ef520dcab37bad02dc7d08d88bfd7cc4931c1439"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/4004a1fe6830de6cabbf60ae7345aef54260400b86ac4973fd29cc6a31d9bf9c/kernel-6.1.82-99.168.amzn2023.src.rpm"
+sha512 = "249f3b440248062cc1b67fe89c0bfc75d2b6f6cdac63c539884c7257d334ef7bdaeb2f87fffbfd12d4a5389cc65627b1a64d7c6b3a32b7247e222811dc06f6bc"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.79
+Version: 6.1.82
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/c26f813e14f0867fda99398c0bae01ae7990746bf3340bb22a375d16a358b4e7/kernel-6.1.79-99.167.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/4004a1fe6830de6cabbf60ae7345aef54260400b86ac4973fd29cc6a31d9bf9c/kernel-6.1.82-99.168.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.
* 5.10.213-201.855.amzn2
* 5.15.152-100.162.amzn2
* 6.1.82-99.168.amzn2023

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-34-176.us-west-2.compute.internal   Ready    <none>   4m55s   v1.26.14-eks-b063426   192.168.34.176   34.217.144.177   Bottlerocket OS 1.20.0 (aws-k8s-1.26)   5.15.152         containerd://1.6.30+bottlerocket
ip-192-168-37-19.us-west-2.compute.internal    Ready    <none>   96s     v1.28.7-eks-c5c5da4    192.168.37.19    35.85.222.82     Bottlerocket OS 1.20.0 (aws-k8s-1.28)   6.1.82           containerd://1.6.30+bottlerocket
ip-192-168-76-173.us-west-2.compute.internal   Ready    <none>   7m53s   v1.23.17-eks-ea94ec3   192.168.76.173   35.86.240.231    Bottlerocket OS 1.20.0 (aws-k8s-1.23)   5.10.213         containerd://1.6.30+bottlerocket

> sonobuoy run --mode=quick --wait
[...]

```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:         2 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:         2 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.28-diff:         3 removed,   1 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          2 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          2 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:          3 removed,   3 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:        2 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:        3 removed,   3 added,   0 changed
config-x86_64-vmware-k8s-1.26-diff:       2 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:       3 removed,   3 added,   0 changed
```

Summary:
* **All kernels:** remove network scheduling "Class Based Queuing" and "Differentiated Services Marker," formerly loadable kmods.
* **6.1:** Add mitigation for Intel Atom® vulnerability where kernel data could be visible in register files (floating-point, vector, or integer).
* **6.1:** Support EFI Handover Protocol.
* **6.1:** Turn off NFS v2 support (for nfsd). NFS v2 was 32-bit-only. NFS v3 was introduced in 1995.

Patches:
* **All kernels:** Update ENA driver to 2.12.0g
* **5.10, 5.15:** Dropped SMB client patch accepted upstream (out of bounds access)

**Terms of contribution**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
