### PR TITLE
packages: Update Containerd to 1.6.31

### DIFF
--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.30/containerd-1.6.30.tar.gz"
-sha512 = "0c92412601805757c13f9007cb8a2828da557bcc0e9e4627d1d1c50e5a2f8281c9155d5976d57b51cace497f68bd014c2688b077cf4bfc77d458bdc91dae164c"
+url = "https://github.com/containerd/containerd/archive/v1.6.31/containerd-1.6.31.tar.gz"
+sha512 = "76149262eed061c06bd6f57706b6c194de649c869439b6bea69a5bf5daf999409d47ee00429033b0c377cd17526a2785f816936e18f989cd3b0d2cbdb9f488ef"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.30
+%global gover 1.6.31
 %global rpmver %{gover}
-%global gitrev ae07eda36dd25f8a1b98dfbf587313b99c0190bb
+%global gitrev e377cd56a71523140ca6ae87e30244719194a521
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#3866 , #3867 

Closes #

**Description of changes:**
- Update Containerd to 1.6.31


**Testing done:**
- [x] Run kubectl exec loops in parallel and make sure it runs successfully .


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
