### PR TITLE
Add Fabric Manager Support

### DIFF
--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -22,6 +22,16 @@ url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-aarch64-535.
 sha512 = "bb96a28b45197003480ae223c71a5426ef5258a31eaa485cab0cf4b86bed166482734784f20c6370a1155f3ff991652cac15f1b1083d2fb056677e6881b219e2"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-535.161.07-archive.tar.xz"
+sha512 = "868b35d567e4c6dccbff0f7e8f74bc55781c8d71db995fd9e471829afec0b44fd430caba964377052678e244d18ea999133487f9a3c50c7289f381480b24c55d"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
+url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-535.161.07-archive.tar.xz"
+sha512 = "f37f7a24e31dd6ed184d1041616abb8cfcb0ddaec79778930db79bbef8b23b3d468daaa9c156a6cf7a7f2ffc0507e78e2bb6215f70bc39d11bb0ee16c5ef4c82"
+force-upstream = true
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 kernel-5_15 = { path = "../kernel-5.15" }

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -2,6 +2,12 @@
 %global tesla_minor 161
 %global tesla_patch 07
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
+%if "%{?_cross_arch}" == "aarch64"
+%global fm_arch sbsa
+%else
+%global fm_arch %{_cross_arch}
+%endif
+
 %global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)
 %global license_file %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml path nvidia -p ./licenses)
 
@@ -21,13 +27,20 @@ Summary: NVIDIA drivers for the 5.15 kernel
 License: Apache-2.0 OR MIT
 URL: http://www.nvidia.com/
 
-# NVIDIA .run scripts from 0 to 199
+# NVIDIA archives from 0 to 199
+# NVIDIA .run scripts for kernel and userspace drivers
 Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
+
+# fabricmanager for NVSwitch
+Source10: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-%{tesla_ver}-archive.tar.xz
+Source11: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-%{tesla_ver}-archive.tar.xz
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
 Source202: nvidia-dependencies-modules-load.conf
+Source203: nvidia-fabricmanager.service
+Source204: nvidia-fabricmanager.cfg
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -41,11 +54,20 @@ BuildRequires: %{_cross_os}kernel-5.15-archive
 %description
 %{summary}.
 
+%package fabricmanager
+Summary: NVIDIA fabricmanager config and service files
+Requires: %{name}-tesla(fabricmanager)
+
+%description fabricmanager
+%{summary}.
+
 %package tesla-%{tesla_major}
 Summary: NVIDIA %{tesla_major} Tesla driver
 Version: %{tesla_ver}
 License: %{spdx_id}
 Requires: %{name}
+Requires: %{name}-fabricmanager
+Provides: %{name}-tesla(fabricmanager)
 
 %description tesla-%{tesla_major}
 %{summary}
@@ -54,6 +76,10 @@ Requires: %{name}
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
+
+# Extract fabricmanager archive. Use `tar` rather than `%%setup` since the
+# correct source is architecture-dependent.
+tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
@@ -100,6 +126,11 @@ install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
 # Install modules-load.d drop-in to autoload required kernel modules
 install -d %{buildroot}%{_cross_libdir}/modules-load.d
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
+
+# NVIDIA fabric manager service unit and config
+install -p -m 0644 %{S:203} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia
+install -p -m 0644 %{S:204} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg
 
 # Begin NVIDIA tesla driver
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
@@ -178,6 +209,18 @@ install -p -m 0644 firmware/gsp_tu10x.bin %{buildroot}%{_cross_libdir}/firmware/
 
 popd
 
+# Begin NVIDIA fabric manager binaries and topologies
+pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+install -p -m 0755 bin/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -p -m 0755 bin/nvswitch-audit %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
+for t in share/nvidia/nvswitch/*_topology ; do
+  install -p -m 0644 "${t}" %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
+done
+
+popd
+
 %files
 %{_cross_attribution_file}
 %dir %{_cross_libexecdir}/nvidia
@@ -185,12 +228,13 @@ popd
 %dir %{_cross_datadir}/nvidia
 %dir %{_cross_libdir}/modules-load.d
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/drivers
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/nvidia
 %{_cross_tmpfilesdir}/nvidia.conf
-%{_cross_libdir}/systemd/system/
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
 %files tesla-%{tesla_major}
 %license %{license_file}
+%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/third-party-notices.txt
 %dir %{_cross_datadir}/nvidia/tesla
 %dir %{_cross_libexecdir}/nvidia/tesla/bin
 %dir %{_cross_libdir}/nvidia/tesla
@@ -201,6 +245,15 @@ popd
 # Binaries
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-debugdump
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-smi
+%{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
+%{_cross_libexecdir}/nvidia/tesla/bin/nvswitch-audit
+
+# nvswitch topologies
+%dir %{_cross_datadir}/nvidia/tesla/nvswitch
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgxa100_hgxa100_topology
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgx2_hgx2_topology
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgxh100_hgxh100_topology
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgxh800_hgxh800_topology
 
 # Configuration files
 %{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla.toml
@@ -332,3 +385,7 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.0
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.11
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-wayland-client.so.%{tesla_ver}
+
+%files fabricmanager
+%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg
+%{_cross_unitdir}/nvidia-fabricmanager.service

--- a/packages/kmod-5.15-nvidia/nvidia-fabricmanager.cfg
+++ b/packages/kmod-5.15-nvidia/nvidia-fabricmanager.cfg
@@ -1,0 +1,34 @@
+# Modern, systemd-aware settings:
+# - Log to journal via stderr
+# - Keep running in the foreground
+LOG_LEVEL=4
+LOG_FILE_NAME=
+DAEMONIZE=0
+
+# Use Unix domain sockets instead of localhost ports.
+UNIX_SOCKET_PATH=/run/nvidia/fabricmanager.sock
+FM_CMD_UNIX_SOCKET_PATH=/run/nvidia/fabricmanager-cmd.sock
+
+# Start Fabric Manager in bare metal or full pass through virtualization mode.
+FABRIC_MODE=0
+FABRIC_MODE_RESTART=0
+
+# Terminate on NVSwitch and GPU config failure.
+FM_STAY_RESIDENT_ON_FAILURES=0
+
+# When there is a GPU to NVSwitch NVLink failure, remove the GPU with the failure
+# from NVLink P2P capability.
+ACCESS_LINK_FAILURE_MODE=0
+
+# When there is an NVSwitch to NVSwitch NVLink failure, exit Fabric Manager.
+TRUNK_LINK_FAILURE_MODE=0
+
+# When there is an NVSwitch failure or an NVSwitch is excluded, abort Fabric Manager.
+NVSWITCH_FAILURE_MODE=0
+
+# When Fabric Manager service is stopped or terminated, abort all running CUDA jobs.
+ABORT_CUDA_JOBS_ON_FM_EXIT=1
+
+# Path to topology and database files.
+TOPOLOGY_FILE_PATH=/usr/share/nvidia/tesla/nvswitch
+DATABASE_PATH=/usr/share/nvidia/tesla/nvswitch

--- a/packages/kmod-5.15-nvidia/nvidia-fabricmanager.service
+++ b/packages/kmod-5.15-nvidia/nvidia-fabricmanager.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NVIDIA fabric manager service
+
+[Service]
+ExecStart=/usr/libexec/nvidia/tesla/bin/nv-fabricmanager -c /etc/nvidia/fabricmanager.cfg
+Type=simple
+TimeoutSec=0
+RestartSec=5
+Restart=always
+RemainAfterExit=true
+StandardError=journal+console
+SuccessExitStatus=255
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/kmod-5.15-nvidia/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-5.15-nvidia/nvidia-tmpfiles.conf.in
@@ -1,2 +1,4 @@
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla 0755 root root - -
+C /etc/nvidia/fabricmanager.cfg - - - -
+d /run/nvidia 0700 root root -

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -22,6 +22,16 @@ url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-aarch64-535.
 sha512 = "bb96a28b45197003480ae223c71a5426ef5258a31eaa485cab0cf4b86bed166482734784f20c6370a1155f3ff991652cac15f1b1083d2fb056677e6881b219e2"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-535.161.07-archive.tar.xz"
+sha512 = "868b35d567e4c6dccbff0f7e8f74bc55781c8d71db995fd9e471829afec0b44fd430caba964377052678e244d18ea999133487f9a3c50c7289f381480b24c55d"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
+url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-535.161.07-archive.tar.xz"
+sha512 = "f37f7a24e31dd6ed184d1041616abb8cfcb0ddaec79778930db79bbef8b23b3d468daaa9c156a6cf7a7f2ffc0507e78e2bb6215f70bc39d11bb0ee16c5ef4c82"
+force-upstream = true
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 kernel-6_1 = { path = "../kernel-6.1" }

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -2,6 +2,12 @@
 %global tesla_minor 161
 %global tesla_patch 07
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
+%if "%{?_cross_arch}" == "aarch64"
+%global fm_arch sbsa
+%else
+%global fm_arch %{_cross_arch}
+%endif
+
 %global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)
 %global license_file %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml path nvidia -p ./licenses)
 
@@ -21,13 +27,20 @@ Summary: NVIDIA drivers for the 6.1 kernel
 License: Apache-2.0 OR MIT
 URL: http://www.nvidia.com/
 
-# NVIDIA .run scripts from 0 to 199
+# NVIDIA archives from 0 to 199
+# NVIDIA .run scripts for kernel and userspace drivers
 Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
+
+# fabricmanager for NVSwitch
+Source10: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-%{tesla_ver}-archive.tar.xz
+Source11: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-%{tesla_ver}-archive.tar.xz
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
 Source202: nvidia-dependencies-modules-load.conf
+Source203: nvidia-fabricmanager.service
+Source204: nvidia-fabricmanager.cfg
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -41,11 +54,20 @@ BuildRequires: %{_cross_os}kernel-6.1-archive
 %description
 %{summary}.
 
+%package fabricmanager
+Summary: NVIDIA fabricmanager config and service files
+Requires: %{name}-tesla(fabricmanager)
+
+%description fabricmanager
+%{summary}.
+
 %package tesla-%{tesla_major}
 Summary: NVIDIA %{tesla_major} Tesla driver
 Version: %{tesla_ver}
 License: %{spdx_id}
 Requires: %{name}
+Requires: %{name}-fabricmanager
+Provides: %{name}-tesla(fabricmanager)
 
 %description tesla-%{tesla_major}
 %{summary}
@@ -54,6 +76,10 @@ Requires: %{name}
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
+
+# Extract fabricmanager archive. Use `tar` rather than `%%setup` since the
+# correct source is architecture-dependent.
+tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
@@ -100,6 +126,11 @@ install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
 # Install modules-load.d drop-in to autoload required kernel modules
 install -d %{buildroot}%{_cross_libdir}/modules-load.d
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
+
+# NVIDIA fabric manager service unit and config
+install -p -m 0644 %{S:203} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia
+install -p -m 0644 %{S:204} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg
 
 # Begin NVIDIA tesla driver
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
@@ -178,6 +209,18 @@ install -p -m 0644 firmware/gsp_tu10x.bin %{buildroot}%{_cross_libdir}/firmware/
 
 popd
 
+# Begin NVIDIA fabric manager binaries and topologies
+pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+install -p -m 0755 bin/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -p -m 0755 bin/nvswitch-audit %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
+for t in share/nvidia/nvswitch/*_topology ; do
+  install -p -m 0644 "${t}" %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
+done
+
+popd
+
 %files
 %{_cross_attribution_file}
 %dir %{_cross_libexecdir}/nvidia
@@ -185,12 +228,13 @@ popd
 %dir %{_cross_datadir}/nvidia
 %dir %{_cross_libdir}/modules-load.d
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/drivers
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/nvidia
 %{_cross_tmpfilesdir}/nvidia.conf
-%{_cross_libdir}/systemd/system/
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
 %files tesla-%{tesla_major}
 %license %{license_file}
+%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/third-party-notices.txt
 %dir %{_cross_datadir}/nvidia/tesla
 %dir %{_cross_libexecdir}/nvidia/tesla/bin
 %dir %{_cross_libdir}/nvidia/tesla
@@ -201,6 +245,15 @@ popd
 # Binaries
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-debugdump
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-smi
+%{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
+%{_cross_libexecdir}/nvidia/tesla/bin/nvswitch-audit
+
+# nvswitch topologies
+%dir %{_cross_datadir}/nvidia/tesla/nvswitch
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgxa100_hgxa100_topology
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgx2_hgx2_topology
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgxh100_hgxh100_topology
+%{_cross_datadir}/nvidia/tesla/nvswitch/dgxh800_hgxh800_topology
 
 # Configuration files
 %{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla.toml
@@ -332,3 +385,7 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.0
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.11
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-wayland-client.so.%{tesla_ver}
+
+%files fabricmanager
+%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg
+%{_cross_unitdir}/nvidia-fabricmanager.service

--- a/packages/kmod-6.1-nvidia/nvidia-fabricmanager.cfg
+++ b/packages/kmod-6.1-nvidia/nvidia-fabricmanager.cfg
@@ -1,0 +1,34 @@
+# Modern, systemd-aware settings:
+# - Log to journal via stderr
+# - Keep running in the foreground
+LOG_LEVEL=4
+LOG_FILE_NAME=
+DAEMONIZE=0
+
+# Use Unix domain sockets instead of localhost ports.
+UNIX_SOCKET_PATH=/run/nvidia/fabricmanager.sock
+FM_CMD_UNIX_SOCKET_PATH=/run/nvidia/fabricmanager-cmd.sock
+
+# Start Fabric Manager in bare metal or full pass through virtualization mode.
+FABRIC_MODE=0
+FABRIC_MODE_RESTART=0
+
+# Terminate on NVSwitch and GPU config failure.
+FM_STAY_RESIDENT_ON_FAILURES=0
+
+# When there is a GPU to NVSwitch NVLink failure, remove the GPU with the failure
+# from NVLink P2P capability.
+ACCESS_LINK_FAILURE_MODE=0
+
+# When there is an NVSwitch to NVSwitch NVLink failure, exit Fabric Manager.
+TRUNK_LINK_FAILURE_MODE=0
+
+# When there is an NVSwitch failure or an NVSwitch is excluded, abort Fabric Manager.
+NVSWITCH_FAILURE_MODE=0
+
+# When Fabric Manager service is stopped or terminated, abort all running CUDA jobs.
+ABORT_CUDA_JOBS_ON_FM_EXIT=1
+
+# Path to topology and database files.
+TOPOLOGY_FILE_PATH=/usr/share/nvidia/tesla/nvswitch
+DATABASE_PATH=/usr/share/nvidia/tesla/nvswitch

--- a/packages/kmod-6.1-nvidia/nvidia-fabricmanager.service
+++ b/packages/kmod-6.1-nvidia/nvidia-fabricmanager.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NVIDIA fabric manager service
+
+[Service]
+ExecStart=/usr/libexec/nvidia/tesla/bin/nv-fabricmanager -c /etc/nvidia/fabricmanager.cfg
+Type=simple
+TimeoutSec=0
+RestartSec=5
+Restart=always
+RemainAfterExit=true
+StandardError=journal+console
+SuccessExitStatus=255
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/kmod-6.1-nvidia/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.1-nvidia/nvidia-tmpfiles.conf.in
@@ -1,2 +1,4 @@
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla 0755 root root - -
+C /etc/nvidia/fabricmanager.cfg - - - -
+d /run/nvidia 0700 root root -


### PR DESCRIPTION
**Issue number:** https://github.com/bottlerocket-os/bottlerocket/issues/3278
Closes #  https://github.com/bottlerocket-os/bottlerocket/issues/3278

**Description of changes:**
Bottlerocket currently lacks support for Fabric Manager, which is necessary for utilizing GPUs in p4 and p5 instance types. This pull request introduces support for the Fabric Manager, enhancing Bottlerocket's capabilities to manage GPU resources efficiently and enables customer to use Bottlerocket as container host OS in p4 and p5 instances.
The fabric manager support is added in kernel kmod-5.15 and kmod-6.1. As a result, k8s-1.24+ will have the changes. However, the kmod-5.10 kernel module utilizes the 470 legacy driver, which lacks compatibility with the latest GPUs found in p4 and p5 instances. Therefore, the Fabric Manager updates have not been applied to kmod-5.10, and as such, k8s-1.23 variant will not include Fabric Manager capabilities.

The change is based of https://github.com/bcressey/bottlerocket/commit/75eab6728b9f65dc5ad097a0b7da9d8a42deb1b8 branch.

**Testing done:**\
Testing Summary:
* K8S-1.29 (kernel-6.1) & K8S-1.27 (kernel-5.15):
    * Instances P5, P3, G5, and G5dn operated as expected.
    *  P2 instance encountered failure because the Nvidia 535 driver lacks support for the NVIDIA Tesla K80 GPU. Irrespective of the fabric manager changes, P2 instances will not function for K8S-1.24 to K8S-1.29 variants as it uses 535 driver.


| # | K8S version | Instance Types | Successfully Booted? | Run Nvidia Smoke Test | Comments |
| -- | -- | -- | -- | -- | -- |
| 1 | 1.29 | p5 | Yes | Success | -- |
| 2  | 1.29 | p4 | Not Tested | N/A | Not able to test due to resource contraint |
| 3  | 1.29 | p3 | Yes | Success | Generates a warning log during boot time `request to query NVSwitch device information from NVSwitch driver failed with error:WARNING Nothing to do [NV_WARN_NOTHING_TO_DO]` |
| 4  | 1.29 | p2 | No | N/A | Error: `could not insert 'nvidia_modeset': No such device` <br>Reason: NVIDIA Tesla K80 supported through the NVIDIA 470.xx Legacy drivers. This bottlerocket variant uses 535 driver. |
| 5 | 1.29 | g5 | Yes | Success | Generates a warning log during boot time `request to query NVSwitch device information from NVSwitch driver failed with error:WARNING Nothing to do [NV_WARN_NOTHING_TO_DO]` |
| 6 | 1.29 | g4dn | Yes | Success | Generates a warning log during boot time `request to query NVSwitch device information from NVSwitch driver failed with error:WARNING Nothing to do [NV_WARN_NOTHING_TO_DO]` |
| 7 | 1.27 | p5 | Yes | Success |  -- |
| 9 | 1.27 | p4 | Not Tested | N/A | Not able to test due to resource contraint
| 10 | 1.27 | p3 | Yes | Success |  Generates a warning log during boot time `request to query NVSwitch device information from NVSwitch driver failed with error:WARNING Nothing to do [NV_WARN_NOTHING_TO_DO]` |
| 11 | 1.27 | p2 | No | N/A | Error: `could not insert 'nvidia_modeset': No such device` <br>Reason: NVIDIA Tesla K80 supported through the NVIDIA 470.xx Legacy drivers. This bottlerocket variant uses 535 driver. |
| 12 | 1.27 | g5 | Yes | Success |  Generates a warning log during boot time `request to query NVSwitch device information from NVSwitch driver failed with error:WARNING Nothing to do [NV_WARN_NOTHING_TO_DO]` |
| 13 | 1.27 | g4dn | Yes | Success | Generates a warning log during boot time `request to query NVSwitch device information from NVSwitch driver failed with error:WARNING Nothing to do [NV_WARN_NOTHING_TO_DO]` |




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
