### PR TITLE
Build soci-snapshotter package

### DIFF
--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "soci-snapshotter"
+version = "0.1.0"
+publish = false
+build = "../build.rs"
+edition = "2021"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.5.0.tar.gz"
+sha512 = "9980688b71c149ea0f36c52906ba0cc862ca65b9ee0e4b813fef0df83716e313137886986cc78b694e35516fb21095b0cd0436caf485d4b63bd01b150769b6f4"
+bundle-root-path = "soci-snapshotter-0.5.0/cmd"
+bundle-output-path = "bundled-cmd.tar.gz"
+bundle-modules = [ "go" ]
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.5.0.tar.gz"
+sha512 = "9980688b71c149ea0f36c52906ba0cc862ca65b9ee0e4b813fef0df83716e313137886986cc78b694e35516fb21095b0cd0436caf485d4b63bd01b150769b6f4"
+bundle-modules = [ "go" ]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+libz = { path = "../libz" }

--- a/packages/soci-snapshotter/clarify.toml
+++ b/packages/soci-snapshotter/clarify.toml
@@ -1,0 +1,5 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xcdf3ae00},
+]

--- a/packages/soci-snapshotter/soci-snapshotter.service
+++ b/packages/soci-snapshotter/soci-snapshotter.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=soci snapshotter containerd plugin
+Documentation=https://github.com/awslabs/soci-snapshotter
+After=configured.target
+Wants=configured.target
+Before=containerd.service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/soci-snapshotter-grpc
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+RequiredBy=containerd.service

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,0 +1,82 @@
+%global gorepo soci-snapshotter
+%global gover 0.5.0
+%global rpmver %{gover}
+
+Name: %{_cross_os}soci-snapshotter
+Version: %{gover}
+Release: 1%{?dist}
+Summary: A containerd snapshotter plugin which enables lazy loading for OCI images.
+License: Apache-2.0
+URL: https://github.com/awslabs/soci-snapshotter
+Source0: https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.5.0.tar.gz
+Source1: bundled-v%{gover}.tar.gz
+Source2: bundled-cmd.tar.gz
+Source101: soci-snapshotter.service
+Source1000: clarify.toml
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libz-devel
+Requires: %{name}(binaries)
+
+%description
+%{summary}.
+
+%package bin
+Summary: Remote management agent binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Remote management agent binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
+%{summary}.
+
+%prep
+%setup -n %{gorepo}-%{gover} -q
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
+%setup -T -D -n %{gorepo}-%{gover} -b 2 -q
+
+%build
+%set_cross_go_flags
+
+go build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/soci-snapshotter-grpc" ./soci-snapshotter-grpc
+go build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/soci" ./soci
+
+gofips build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/fips/soci-snapshotter-grpc" ./soci-snapshotter-grpc
+gofips build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/fips/soci" ./soci
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_fips_bindir}
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0755 out/soci-snapshotter-grpc %{buildroot}%{_cross_bindir}
+install -p -m 0755 out/soci %{buildroot}%{_cross_bindir}
+install -p -m 0755 out/fips/soci-snapshotter-grpc %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 out/fips/soci %{buildroot}%{_cross_fips_bindir}
+install -D -p -m 0644 %{S:101} %{buildroot}%{_cross_unitdir}
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+%files
+%license LICENSE NOTICE.md
+%{_cross_unitdir}/soci-snapshotter.service
+%{_cross_attribution_vendor_dir}
+%{_cross_attribution_file}
+
+%files bin
+%{_cross_bindir}/soci-snapshotter-grpc
+%{_cross_bindir}/soci
+
+%files fips-bin
+%{_cross_fips_bindir}/soci-snapshotter-grpc
+%{_cross_fips_bindir}/soci
+
+%changelog

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "kernel-6_1",
  "login",
  "release",
+ "soci-snapshotter",
  "strace",
 ]
 
@@ -1195,6 +1196,14 @@ version = "0.1.0"
 [[package]]
 name = "shim"
 version = "0.1.0"
+
+[[package]]
+name = "soci-snapshotter"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libz",
+]
 
 [[package]]
 name = "static-pods"

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -36,6 +36,7 @@ included-packages = [
     "iputils",
     "strace",
     "chrony-tools",
+    "soci-snapshotter",
 ]
 
 [lib]
@@ -54,3 +55,4 @@ login = { path = "../../packages/login" }
 iputils = { path = "../../packages/iputils" }
 strace = { path = "../../packages/strace" }
 chrony = { path = "../../packages/chrony" }
+soci-snapshotter = { path = "../../packages/soci-snapshotter" }


### PR DESCRIPTION
**Description of changes:**
This builds the soci-snapshotter containerd plugin. The plugin has two components:

- `soci-snapshotter-grpc` is a daemon (systemd service).
- `soci` is a CLI tool for working with SOCI indices. 

In addition, the rpm packages (and should install) `soci-snapshotter.service`, the unit file for systemd, so the daemon starts during boot (after network, and before containerd).

The aws-dev variant (and no other variant) includes the package.

**Testing done:**
[Edit] Manual testing on an aws-dev ec2 instance, following the soci-snapshotter installation and getting-started guides. The soci-snapshotter documentation uses nerdctl, so these packages were tested using nerdctl. That required a few extra steps:

* Create an overlay file system on the /root directory because nerdctl wants to store registry credentials in $HOME/.docker/config.json.
* Install wget and tar in the admin container, download, then copy nerdctl over to the host.
* Add the soci-snapshotter plugin to containerd's configuration (in the AMI)

Following the steps outlined in the soci-snapshotter repo, I can verify containerd will happily pull and run an image through soci. I see exactly the transactions I expect with ECR and the plugin is able to find and download the soci index, ztoc, and manifest files given the package URI. Both pull and run benefit from lazy loading on the test image they suggested.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
