### PR TITLE
Build: Update twoliter to v0.1.0 & SDK to v0.40.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,7 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.0.7"
+TWOLITER_VERSION = "v0.1.0"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -3,10 +3,5 @@ release-version = "1.20.0"
 
 [sdk]
 registry = "public.ecr.aws/bottlerocket"
-name = "bottlerocket-sdk"
-version = "v0.37.0"
-
-[toolchain]
-registry = "public.ecr.aws/bottlerocket"
-name = "bottlerocket-toolchain"
-version = "v0.37.0"
+repo = "bottlerocket-sdk"
+tag = "v0.40.0"

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -67,7 +67,7 @@ struct Config {
     // mode: Option<{Automatic, Managed, Disabled}>
 }
 
-/// Prints a more specific message before exiting through usage().
+/// Prints a more specific message before exiting through `usage()`.
 fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
     eprintln!("{}\n", msg.as_ref());
     usage();
@@ -248,6 +248,7 @@ async fn write_target_to_disk<P: AsRef<Path>>(
         let mut f = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&disk_path)
             .context(error::OpenPartitionSnafu { path: disk_path })?;
         std::io::copy(&mut reader, &mut f).context(error::WriteUpdateSnafu)?;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # N/A

**Description of changes:**

- Update twoliter to v0.1.0.
- Update SDK to v0.40.0. 
- Clippy lint fixes for version 0.1.77:
   - Auto-fixed by cargo clippy --fix [Doc markdown](https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown)
   - Manual fix following [Suspicious Open Options](https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_open_options). Added the `truncate(true)` option because it *always* creates a fresh file (removes old contents if the file already exists).

**Testing done:**

- [x] Build Image  
- [x] Make AMI
- [x] Make update repo
- [x] Run a testsys command


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
