### PR TITLE
Update linter, fix new warnings.

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,17 +14,17 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21
       - uses: actions/checkout@v4
       - name: lint-host-ctr
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
           working-directory: sources/host-ctr
       - name: lint-ecs-gpu-init
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
           working-directory: sources/ecs-gpu-init

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
 
 run:
   timeout: 3m
-  skip-dirs:
+issues:
+  exclude-dirs:
     - vendor
     - .gomodcache

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -140,7 +140,7 @@ func App() *cli.App {
 					Value:       false,
 				},
 			},
-			Action: func(c *cli.Context) error {
+			Action: func(_ *cli.Context) error {
 				return runCtr(containerdSocket, namespace, containerID, source, superpowered, registryConfig, containerType(cType), useCachedImage)
 			},
 		},
@@ -191,7 +191,7 @@ func App() *cli.App {
 					Required:    true,
 				},
 			},
-			Action: func(c *cli.Context) error {
+			Action: func(_ *cli.Context) error {
 				return cleanUp(containerdSocket, namespace, containerID)
 			},
 		},
@@ -980,7 +980,7 @@ func withSwapManagement(_ context.Context, _ oci.Client, _ *containers.Container
 
 // withProxyEnv reads proxy environment variables and returns a spec option for passing said proxy environment variables
 func withProxyEnv() oci.SpecOpts {
-	noOp := func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error { return nil }
+	noOp := func(_ context.Context, _ oci.Client, _ *containers.Container, _ *runtimespec.Spec) error { return nil }
 	httpsProxy, httpsProxySet := os.LookupEnv("HTTPS_PROXY")
 	noProxy, noProxySet := os.LookupEnv("NO_PROXY")
 	withHTTPSProxy := noOp


### PR DESCRIPTION
**Description of changes:**

Update golangci-lint-action from v3 to v4, update .golangci.yaml for the new version of golangci-lint, and fix the three unused-parameter lints it finds in host-ctr.

Dependabot opened a PR for the upgrade from v3 to v4 on February 12 (#3773). This failed CI because the new lint failed host-ctr.

**Testing done:**

Manual golangci-lint on the directories currently in our golangci-lint workflow. This pull request should trigger an automatic run of that workflow, which should pass if my manual testing reproduced its steps correctly.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
