### PR TITLE
sources: update deny.toml to version 2

### DIFF
--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -1,10 +1,5 @@
 [licenses]
-unlicensed = "deny"
-
-# Deny licenses unless they are specifically listed here
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
+version = 2
 
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93


### PR DESCRIPTION
**Description of changes:**

Several keys have been deprecated in favor of the same default values we were specifying before. By removing them and adding `version = 2` under licenses we will maintain the same behavior, but without the deprecation notices.

**Testing done:**

**BEFORE**
```shell
[cargo-make][1] INFO - Running Task: check-licenses
warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /tmp/sources/deny.toml:2:1
  │
2 │ unlicensed = "deny"
  │ ^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /tmp/sources/deny.toml:6:1
  │
6 │ allow-osi-fsf-free = "neither"
  │ ^^^^^^^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /tmp/sources/deny.toml:5:1
  │
5 │ copyleft = "deny"
  │ ^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /tmp/sources/deny.toml:7:1
  │
7 │ default = "deny"
  │ ^^^^^^^

bans ok, licenses ok, sources ok
```

**AFTER**
```shell
[cargo-make][1] INFO - Running Task: check-licenses
bans ok, licenses ok, sources ok
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
