### PR TITLE
systemd: use bootconfig for unified cgroup hierarchy

### DIFF
--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -10,7 +10,6 @@ path = "../packages.rs"
 
 [package.metadata.build-package]
 releases-url = "https://github.com/systemd/systemd-stable/releases"
-package-features = ["unified-cgroup-hierarchy"]
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/systemd/systemd-stable/archive/v252.22/systemd-stable-252.22.tar.gz"

--- a/packages/systemd/bootconfig-unified-cgroup-hierarchy.conf
+++ b/packages/systemd/bootconfig-unified-cgroup-hierarchy.conf
@@ -1,0 +1,1 @@
+init.systemd.unified_cgroup_hierarchy = 1

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -14,6 +14,7 @@ Source3: journald.conf
 Source4: issue
 Source5: systemd-journald.conf
 Source6: systemd-sysusers.conf
+Source7: bootconfig-unified-cgroup-hierarchy.conf
 
 # Backport of upstream patches that make the netlink default timeout
 # configurable.  Bottlerocket carries this patch and configures the timeout in
@@ -102,6 +103,10 @@ Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}libuuid
 Requires: %{_cross_os}libxcrypt
 
+# Only require a cgroup hierarchy package when building an image, not
+# for packages that need systemd-devel as a build dependency.
+Requires: (%{name}(cgroup-hierarchy) if %{_cross_os}metadata)
+
 %description
 %{summary}.
 
@@ -128,6 +133,24 @@ Summary: Files for networkd
 Summary: Files for resolved
 
 %description resolved
+%{summary}.
+
+%package hybrid-cgroup-hierarchy
+Summary: No-op dependency for hybrid cgroup hierarchy
+Provides: %{name}(cgroup-hierarchy)
+Requires: (%{_cross_os}image-feature(no-unified-cgroup-hierarchy) and %{name})
+Conflicts: (%{_cross_os}image-feature(unified-cgroup-hierarchy) or %{name}-unified-cgroup-hierarchy)
+
+%description hybrid-cgroup-hierarchy
+%{summary}.
+
+%package unified-cgroup-hierarchy
+Summary: Bootconfig snippet for unified cgroup hierarchy
+Provides: %{name}(cgroup-hierarchy)
+Requires: (%{_cross_os}image-feature(unified-cgroup-hierarchy) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-unified-cgroup-hierarchy) or %{name}-hybrid-cgroup-hierarchy)
+
+%description unified-cgroup-hierarchy
 %{summary}.
 
 %prep
@@ -204,11 +227,7 @@ CONFIGURE_OPTS=(
  -Dpkgconfigdatadir='%{_cross_pkgconfigdir}'
  -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
 
- %if %{with unified_cgroup_hierarchy}
- -Ddefault-hierarchy=unified
- %else
  -Ddefault-hierarchy=hybrid
- %endif
 
  -Dadm-group=false
  -Dwheel-group=false
@@ -320,6 +339,9 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
 # Add art to the console
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/issue
+
+install -d %{buildroot}%{_cross_bootconfigdir}
+install -p -m 0644 %{S:7} %{buildroot}%{_cross_bootconfigdir}/10-unified-cgroup-hierarchy.conf
 
 %files
 %license LICENSE.GPL2 LICENSE.LGPL2.1
@@ -508,5 +530,10 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf
+
+%files hybrid-cgroup-hierarchy
+
+%files unified-cgroup-hierarchy
+%{_cross_bootconfigdir}/10-unified-cgroup-hierarchy.conf
 
 %changelog


### PR DESCRIPTION
**Issue number:**
Related: #3883

**Description of changes:**
This takes advantage of the new Twoliter support for [bootconfig drop-ins](https://github.com/bottlerocket-os/twoliter/commit/b4f16204c4bcf831fcbc703b6d48439d1f67eed1) and [variant metadata](https://github.com/bottlerocket-os/twoliter/commit/28b64bb180ae51e7fe56f2d4125873b35e39958d).

Variants with the `unified-cgroup-hierarchy` feature flag set will end up installing the new subpackage when the image is built, which will populate the default bootconfig with the right systemd option.

Default to "hybrid" at build time rather than "unified" since the two variants that don't support boot config (`aws-ecs-1` and `aws-ecs-1-nvidia`) also require "hybrid" mode.


**Testing done:**
When building `aws-dev`, the following capability is logged for the metadata rpm:
```
  #13 0.582 bottlerocket-image-feature(unified-cgroup-hierarchy)
```

Later, this triggers the expected installation of the new subpackage:
```
  #15 1.175 Installing dependencies:
...
  #15 1.175  bottlerocket-systemd                          aarch64 252.22-1      repo 4.4 M
  #15 1.175  bottlerocket-systemd-console                  aarch64 252.22-1      repo  49 k
  #15 1.175  bottlerocket-systemd-networkd                 aarch64 252.22-1      repo 1.6 M
  #15 1.175  bottlerocket-systemd-resolved                 aarch64 252.22-1      repo 416 k
  #15 1.175  bottlerocket-systemd-unified-cgroup-hierarchy aarch64 252.22-1      repo 7.2 k
```

After boot, the expected hierarchy and settings are present:
```
bash-5.2# df /sys/fs/cgroup
Filesystem     1K-blocks  Used Available Use% Mounted on
cgroup2                0     0         0    - /sys/fs/cgroup

bash-5.2# apiclient get settings.boot.init
{
  "settings": {
    "boot": {
      "init": {
        "systemd.unified_cgroup_hierarchy": [
          "1"
        ]
      }
    }
  }
}
```

I also verified I could override the setting and the system would come up in hybrid mode.

For a variant like `aws-k8s-1.24`, the hybrid subpackage is installed and the system comes up in hybrid mode as expected.

```
  #15 1.191 Installing dependencies:
...
  #15 1.191  bottlerocket-systemd                         aarch64 252.22-1       repo 4.4 M
  #15 1.191  bottlerocket-systemd-hybrid-cgroup-hierarchy aarch64 252.22-1       repo 6.6 k
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
