### PR TITLE
packages: build Go binaries for FIPS and non-FIPS

### DIFF
--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -1,8 +1,3 @@
-# Don't generate debug packages because we are compiling without CGO,
-# and the `gc` compiler doesn't append the  the ".note.gnu.build-id" section
-# https://fedoraproject.org/wiki/PackagingDrafts/Go#Build_ID
-%global debug_package %{nil}
-
 %global goproject github.com/aws
 %global gorepo amazon-ssm-agent
 %global goimport %{goproject}/%{gorepo}
@@ -17,8 +12,27 @@ Source0: %{gorepo}-%{version}.tar.gz
 Source1000: clarify.toml
 
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: Remote management agent binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Remote management agent binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -30,19 +44,28 @@ BuildRequires: %{_cross_os}glibc-devel
 go build -ldflags "${GOLDFLAGS}" -o amazon-ssm-agent \
   ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
 
+gofips build -ldflags "${GOLDFLAGS}" -o fips/amazon-ssm-agent \
+  ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
+
 go build -ldflags "${GOLDFLAGS}" -o ssm-agent-worker \
+  ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
+
+gofips build -ldflags "${GOLDFLAGS}" -o fips/ssm-agent-worker \
   ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
 
 go build -ldflags "${GOLDFLAGS}" -o ssm-session-worker \
   ./agent/framework/processor/executer/outofproc/sessionworker/main.go
 
+gofips build -ldflags "${GOLDFLAGS}" -o fips/ssm-session-worker \
+  ./agent/framework/processor/executer/outofproc/sessionworker/main.go
+
 %install
 # Install the SSM agent under 'libexecdir', since it is meant to be used by other programs
-install -d %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
+install -d %{buildroot}{%{_cross_libexecdir},%{_cross_fips_libexecdir}}/amazon-ssm-agent/bin/%{version}
 for b in amazon-ssm-agent ssm-agent-worker ssm-session-worker; do
-  install -D -p -m 0755 ${b} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
+  install -p -m 0755 ${b} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
+  install -p -m 0755 fips/${b} %{buildroot}%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}
 done
-
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -50,5 +73,15 @@ done
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %dir %{_cross_libexecdir}/amazon-ssm-agent
-%{_cross_libexecdir}/amazon-ssm-agent
+%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/amazon-ssm-agent
+%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-agent-worker
+%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-session-worker
+
+%files fips-bin
+%dir %{_cross_fips_libexecdir}/amazon-ssm-agent
+%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/amazon-ssm-agent
+%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-agent-worker
+%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-session-worker

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -19,8 +19,27 @@ Source1000: clarify.toml
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: AWS IAM authenticator binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: AWS IAM authenticator binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -29,11 +48,15 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %build
 %set_cross_go_flags
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
+go build -ldflags="${GOLDFLAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
+gofips build -ldflags="${GOLDFLAGS}" -o fips/aws-iam-authenticator ./cmd/aws-iam-authenticator
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-iam-authenticator %{buildroot}%{_cross_bindir}
+
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 fips/aws-iam-authenticator %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -41,6 +64,11 @@ install -p -m 0755 aws-iam-authenticator %{buildroot}%{_cross_bindir}
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %{_cross_bindir}/aws-iam-authenticator
+
+%files fips-bin
+%{_cross_fips_bindir}/aws-iam-authenticator
 
 %changelog

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -18,8 +18,27 @@ Source: rolesanywhere-credential-helper-v%{gover}.tar.gz
 Source1: bundled-rolesanywhere-credential-helper-v%{gover}.tar.gz
 
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: AWS signing helper binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: AWS signing helper binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -29,12 +48,17 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 %set_cross_go_flags
 
-go build ${GOFLAGS} -buildmode=pie -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper main.go
+go build -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper main.go
+gofips build -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o fips/aws-signing-helper main.go
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-signing-helper %{buildroot}%{_cross_bindir}/aws_signing_helper
 ln -sf aws_signing_helper %{buildroot}%{_cross_bindir}/aws-signing-helper
+
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 fips/aws-signing-helper %{buildroot}%{_cross_fips_bindir}/aws_signing_helper
+ln -sf aws_signing_helper %{buildroot}%{_cross_fips_bindir}/aws-signing-helper
 
 %cross_scan_attribution go-vendor vendor
 
@@ -42,5 +66,11 @@ ln -sf aws_signing_helper %{buildroot}%{_cross_bindir}/aws-signing-helper
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %{_cross_bindir}/aws_signing_helper
 %{_cross_bindir}/aws-signing-helper
+
+%files fips-bin
+%{_cross_fips_bindir}/aws_signing_helper
+%{_cross_fips_bindir}/aws-signing-helper

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -18,8 +18,27 @@ Source1: cni-plugins-tmpfiles.conf
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}iptables
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: Plugins for container networking binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Plugins for container networking binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -29,12 +48,16 @@ Requires: %{_cross_os}iptables
 %build
 %cross_go_configure %{goimport}
 for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
-  go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o "bin/${d##*/}" %{goimport}/${d}
+  go build -ldflags="${GOLDFLAGS}" -o "bin/${d##*/}" %{goimport}/${d}
+  gofips build -ldflags="${GOLDFLAGS}" -o "fips/bin/${d##*/}" %{goimport}/${d}
 done
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin
 install -p -m 0755 bin/* %{buildroot}%{_cross_libexecdir}/cni/bin
+
+install -d %{buildroot}%{_cross_fips_libexecdir}/cni/bin
+install -p -m 0755 fips/bin/* %{buildroot}%{_cross_fips_libexecdir}/cni/bin
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
@@ -45,6 +68,9 @@ install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_tmpfilesdir}/cni-plugins.conf
+
+%files bin
 %{_cross_libexecdir}/cni/bin/loopback
 %{_cross_libexecdir}/cni/bin/bandwidth
 %{_cross_libexecdir}/cni/bin/bridge
@@ -63,6 +89,25 @@ install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
 %{_cross_libexecdir}/cni/bin/tuning
 %{_cross_libexecdir}/cni/bin/vlan
 %{_cross_libexecdir}/cni/bin/vrf
-%{_cross_tmpfilesdir}/cni-plugins.conf
+
+%files fips-bin
+%{_cross_fips_libexecdir}/cni/bin/loopback
+%{_cross_fips_libexecdir}/cni/bin/bandwidth
+%{_cross_fips_libexecdir}/cni/bin/bridge
+%{_cross_fips_libexecdir}/cni/bin/dhcp
+%{_cross_fips_libexecdir}/cni/bin/dummy
+%{_cross_fips_libexecdir}/cni/bin/firewall
+%{_cross_fips_libexecdir}/cni/bin/host-device
+%{_cross_fips_libexecdir}/cni/bin/host-local
+%{_cross_fips_libexecdir}/cni/bin/ipvlan
+%{_cross_fips_libexecdir}/cni/bin/macvlan
+%{_cross_fips_libexecdir}/cni/bin/portmap
+%{_cross_fips_libexecdir}/cni/bin/ptp
+%{_cross_fips_libexecdir}/cni/bin/sbr
+%{_cross_fips_libexecdir}/cni/bin/static
+%{_cross_fips_libexecdir}/cni/bin/tap
+%{_cross_fips_libexecdir}/cni/bin/tuning
+%{_cross_fips_libexecdir}/cni/bin/vlan
+%{_cross_fips_libexecdir}/cni/bin/vrf
 
 %changelog

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -29,7 +29,7 @@ Requires: %{_cross_os}iptables
 %build
 %set_cross_go_flags
 
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o "bin/cnitool" %{goimport}/cnitool
+go build -ldflags="${GOLDFLAGS}" -o "bin/cnitool" %{goimport}/cnitool
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -21,8 +21,27 @@ Source1000: clarify.toml
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: Docker CLI binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Docker CLI binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -36,15 +55,21 @@ LD_GIT_REV="-X github.com/docker/cli/cli/version.GitCommit=%{gitrev}"
 LD_PLATFORM="-X \"github.com/docker/cli/cli/version.PlatformName=Docker Engine - Community\""
 BUILDTIME=$(date -u -d "@%{source_date_epoch}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 LD_BUILDTIME="-X github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}"
-go build \
-  -buildmode=pie \
-  -ldflags "${GOLDFLAGS} ${LD_VERSION} ${LD_GIT_REV} ${LD_PLATFORM} ${LD_BUILDTIME}" \
-  -o docker \
-  %{goimport}/cmd/docker
+
+declare -a BUILD_ARGS
+BUILD_ARGS=(
+  -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_GIT_REV} ${LD_PLATFORM} ${LD_BUILDTIME}"
+)
+
+go build "${BUILD_ARGS[@]}" -o docker %{goimport}/cmd/docker
+gofips build "${BUILD_ARGS[@]}" -o fips/docker %{goimport}/cmd/docker
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker %{buildroot}%{_cross_bindir}
+
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 fips/docker %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -52,6 +77,11 @@ install -p -m 0755 docker %{buildroot}%{_cross_bindir}
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %{_cross_bindir}/docker
+
+%files fips-bin
+%{_cross_fips_bindir}/docker
 
 %changelog

--- a/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
+++ b/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
@@ -10,7 +10,7 @@
 Name: %{_cross_os}ecr-credential-provider-1.27
 Version: %{rpmver}
 Release: 1%{?dist}
-Summary: Container image registry credential provider for AWS ECR
+Summary: Amazon ECR credential provider
 License: Apache-2.0
 URL: https://github.com/kubernetes/cloud-provider-aws
 
@@ -19,8 +19,27 @@ Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: Amazon ECR credential provider binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Amazon ECR credential provider binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -30,11 +49,15 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 %set_cross_go_flags
 
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+
+install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
+install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -42,4 +65,9 @@ install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kube
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+
+%files fips-bin
+%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -11,7 +11,7 @@
 Name: %{_cross_os}ecr-credential-provider-1.30
 Version: %{rpmver}
 Release: 1%{?dist}
-Summary: Container image registry credential provider for AWS ECR
+Summary: Amazon ECR credential provider
 License: Apache-2.0
 URL: https://github.com/kubernetes/cloud-provider-aws
 
@@ -20,8 +20,27 @@ Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: Amazon ECR credential provider binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Amazon ECR credential provider binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -31,11 +50,15 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 %set_cross_go_flags
 
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+
+install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
+install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -43,4 +66,9 @@ install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kube
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+
+%files fips-bin
+%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider/ecr-credential-provider.spec
+++ b/packages/ecr-credential-provider/ecr-credential-provider.spec
@@ -7,13 +7,10 @@
 
 %global _dwz_low_mem_die_limit 0
 
-%global gitrev 2ca3fc6e5e74e856411e25ae0f26d4c299e2eb3d
-%global shortrev %(c=%{gitrev}; echo ${c:0:7})
-
 Name: %{_cross_os}ecr-credential-provider
 Version: %{rpmver}
 Release: 1%{?dist}
-Summary: Container image registry credential provider for AWS ECR
+Summary: Amazon ECR credential provider
 License: Apache-2.0
 URL: https://github.com/kubernetes/cloud-provider-aws
 
@@ -22,8 +19,27 @@ Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
 BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: Amazon ECR credential provider binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Amazon ECR credential provider binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -33,11 +49,15 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 %set_cross_go_flags
 
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+
+install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
+install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -45,4 +65,9 @@ install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kube
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+
+%files fips-bin
+%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -7,8 +7,17 @@ Release: 1%{?dist}
 Summary: The basic directory layout
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
+Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
 
 %description
+%{summary}.
+
+%package fips
+Summary: The FIPS directory layout
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: %{_cross_os}image-feature(no-fips)
+
+%description fips
 %{summary}.
 
 %prep
@@ -20,8 +29,10 @@ mkdir -p %{buildroot}%{_cross_rootdir}
 mkdir -p %{buildroot}%{_cross_prefix}
 mkdir -p %{buildroot}%{_cross_bindir}
 mkdir -p %{buildroot}%{_cross_sbindir}
+mkdir -p %{buildroot}%{_cross_fips_bindir}
 mkdir -p %{buildroot}%{_cross_libdir}
 mkdir -p %{buildroot}%{_cross_libexecdir}/{cni,csi}/bin
+mkdir -p %{buildroot}%{_cross_fips_libexecdir}/{cni,csi}/bin
 mkdir -p %{buildroot}%{_cross_includedir}
 mkdir -p %{buildroot}%{_cross_sysconfdir}
 mkdir -p %{buildroot}%{_cross_datadir}
@@ -68,5 +79,14 @@ ln -s .%{_sbindir} %{buildroot}/sbin
 /mnt
 /opt
 /srv
+
+%exclude %{_cross_prefix}/fips
+%exclude %{_cross_fips_bindir}
+%exclude %{_cross_fips_libexecdir}
+
+%files fips
+%{_cross_prefix}/fips
+%{_cross_fips_bindir}
+%{_cross_fips_libexecdir}
 
 %changelog

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -9,6 +9,7 @@ License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}containerd
+Requires: %{name}(binaries)
 
 Source10: host-containerd.service
 Source11: host-containerd-tmpfiles.conf
@@ -20,17 +21,39 @@ Source100: etc-host-containers.mount.in
 %description
 %{summary}.
 
+%package bin
+Summary: Bottlerocket host container runner binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Bottlerocket host container runner binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
+%{summary}.
+
 %prep
 %setup -T -c
 cp -r %{_builddir}/sources/%{workspace_name}/* .
 
 %build
 %set_cross_go_flags
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o host-ctr ./cmd/host-ctr
+go build -ldflags="${GOLDFLAGS}" -o host-ctr ./cmd/host-ctr
+gofips build -ldflags="${GOLDFLAGS}" -o fips/host-ctr ./cmd/host-ctr
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 host-ctr %{buildroot}%{_cross_bindir}
+
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 fips/host-ctr %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:10} %{buildroot}%{_cross_unitdir}
@@ -47,10 +70,15 @@ install -p -m 0644 %{S:12} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/
 
 %files
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/host-ctr
 %{_cross_unitdir}/host-containerd.service
 %{_cross_unitdir}/*.mount
 %{_cross_tmpfilesdir}/host-containerd.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/host-containerd/config.toml
+
+%files bin
+%{_cross_bindir}/host-ctr
+
+%files fips-bin
+%{_cross_fips_bindir}/host-ctr
 
 %changelog

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -70,8 +70,27 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.23(binaries)
 
 %description -n %{_cross_os}kubelet-1.23
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.23-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.23(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.23)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.23-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.23-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.23-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.23(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.23)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.23-bin)
+
+%description -n %{_cross_os}kubelet-1.23-fips-bin
 %{summary}.
 
 %prep
@@ -90,16 +109,26 @@ export FORCE_HOST_GO=1
 make generated_files
 
 # Build kubelet with the target toolchain.
+%set_cross_go_flags
+unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
-export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+make WHAT="cmd/kubelet"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
 
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -138,7 +167,6 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount
@@ -161,5 +189,11 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.23-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.23-fips-bin
+%{_cross_fips_bindir}/kubelet
 
 %changelog

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -71,8 +71,27 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.24(binaries)
 
 %description -n %{_cross_os}kubelet-1.24
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.24-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.24(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.24)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.24-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.24-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.24-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.24(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.24)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.24-bin)
+
+%description -n %{_cross_os}kubelet-1.24-fips-bin
 %{summary}.
 
 %prep
@@ -91,16 +110,26 @@ export FORCE_HOST_GO=1
 make generated_files
 
 # Build kubelet with the target toolchain.
+%set_cross_go_flags
+unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
-export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+make WHAT="cmd/kubelet"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
 
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -139,7 +168,6 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount
@@ -162,5 +190,11 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.24-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.24-fips-bin
+%{_cross_fips_bindir}/kubelet
 
 %changelog

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -71,8 +71,27 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.25(binaries)
 
 %description -n %{_cross_os}kubelet-1.25
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.25-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.25(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.25)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.25-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.25-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.25-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.25(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.25)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.25-bin)
+
+%description -n %{_cross_os}kubelet-1.25-fips-bin
 %{summary}.
 
 %prep
@@ -91,16 +110,26 @@ export FORCE_HOST_GO=1
 make generated_files
 
 # Build kubelet with the target toolchain.
+%set_cross_go_flags
+unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
-export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+make WHAT="cmd/kubelet"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
 
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -139,7 +168,6 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount
@@ -162,5 +190,11 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.25-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.25-fips-bin
+%{_cross_fips_bindir}/kubelet
 
 %changelog

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -71,8 +71,27 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.26(binaries)
 
 %description -n %{_cross_os}kubelet-1.26
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.26-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.26(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.26)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.26-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.26-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.26-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.26(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.26)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.26-bin)
+
+%description -n %{_cross_os}kubelet-1.26-fips-bin
 %{summary}.
 
 %prep
@@ -91,16 +110,26 @@ export FORCE_HOST_GO=1
 make hack/update-codegen.sh
 
 # Build kubelet with the target toolchain.
+%set_cross_go_flags
+unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
-export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+make WHAT="cmd/kubelet"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
 
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -139,7 +168,6 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount
@@ -162,5 +190,11 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.26-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.26-fips-bin
+%{_cross_fips_bindir}/kubelet
 
 %changelog

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -71,8 +71,27 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.27
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.28(binaries)
 
 %description -n %{_cross_os}kubelet-1.28
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.28-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.28(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.28)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.28-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.28-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.28-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.28(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.28)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.28-bin)
+
+%description -n %{_cross_os}kubelet-1.28-fips-bin
 %{summary}.
 
 %prep
@@ -91,16 +110,26 @@ export FORCE_HOST_GO=1
 make hack/update-codegen.sh
 
 # Build kubelet with the target toolchain.
+%set_cross_go_flags
+unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
-export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+make WHAT="cmd/kubelet"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
 
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -139,7 +168,6 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount
@@ -162,5 +190,11 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.28-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.28-fips-bin
+%{_cross_fips_bindir}/kubelet
 
 %changelog

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -71,8 +71,27 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.29
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.29(binaries)
 
 %description -n %{_cross_os}kubelet-1.29
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.29-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.29(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.29)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.29-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.29-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.29-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.29(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.29)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.29-bin)
+
+%description -n %{_cross_os}kubelet-1.29-fips-bin
 %{summary}.
 
 %prep
@@ -91,16 +110,26 @@ export FORCE_HOST_GO=1
 make hack/update-codegen.sh
 
 # Build kubelet with the target toolchain.
+%set_cross_go_flags
+unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
-export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+make WHAT="cmd/kubelet"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
 
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -139,7 +168,6 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount
@@ -162,5 +190,11 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.29-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.29-fips-bin
+%{_cross_fips_bindir}/kubelet
 
 %changelog

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -73,8 +73,27 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.29
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.30(binaries)
 
 %description -n %{_cross_os}kubelet-1.30
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.30-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.30(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.30)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.30-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.30-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.30-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.30(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.30)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.30-bin)
+
+%description -n %{_cross_os}kubelet-1.30-fips-bin
 %{summary}.
 
 %prep
@@ -93,16 +112,26 @@ export FORCE_HOST_GO=1
 make hack/update-codegen.sh
 
 # Build kubelet with the target toolchain.
+%set_cross_go_flags
+unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
-export GOFLAGS='-tags=dockerless'
-export GOLDFLAGS="-buildmode=pie -linkmode=external -compressdwarf=false"
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+make WHAT="cmd/kubelet"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
 
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -141,7 +170,6 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/kubelet
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount
@@ -164,5 +192,11 @@ install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 %dir %{_cross_libexecdir}/kubernetes
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.30-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.30-fips-bin
+%{_cross_fips_bindir}/kubelet
 
 %changelog

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -49,8 +49,8 @@ Conflicts: %{name}-ecs
 
 %build
 %cross_go_configure %{goimport}
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime-hook ./cmd/nvidia-container-runtime-hook
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o nvidia-ctk ./cmd/nvidia-ctk
+go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime-hook ./cmd/nvidia-container-runtime-hook
+go build -ldflags="${GOLDFLAGS}" -o nvidia-ctk ./cmd/nvidia-ctk
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/oci-add-hooks/oci-add-hooks.spec
+++ b/packages/oci-add-hooks/oci-add-hooks.spec
@@ -25,7 +25,7 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 %set_cross_go_flags
 export LD_VERSION="-X main.commit=oci-add-hooks-%{gitrev}"
-go build ${GOFLAGS} -v -x -buildmode=pie -ldflags="${GOLDFLAGS} ${LD_VERSION}" -o oci-add-hooks
+go build -ldflags="${GOLDFLAGS} ${LD_VERSION}" -o oci-add-hooks
 
 %install
 install -d %{buildroot}%{_cross_bindir}

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -18,8 +18,27 @@ BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libseccomp-devel
 Requires: %{_cross_os}libseccomp
+Requires: %{name}(binaries)
 
 %description
+%{summary}.
+
+%package bin
+Summary: CLI for running Open Containers binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: CLI for running Open Containers binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
 %{summary}.
 
 %prep
@@ -31,15 +50,22 @@ Requires: %{_cross_os}libseccomp
 export LD_VERSION="-X main.version=%{gover}+bottlerocket"
 export LD_COMMIT="-X main.gitCommit=%{commit}"
 export BUILDTAGS="ambient seccomp selinux"
-go build \
-  -buildmode=pie \
-  -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_COMMIT}" \
-  -tags="${BUILDTAGS}" \
-  -o bin/runc .
+
+declare -a BUILD_ARGS
+BUILD_ARGS=(
+  -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_COMMIT}"
+  -tags="${BUILDTAGS}"
+)
+
+go build "${BUILD_ARGS[@]}" -o bin/runc .
+gofips build "${BUILD_ARGS[@]}" -o fips/bin/runc .
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 bin/runc %{buildroot}%{_cross_bindir}
+
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 fips/bin/runc %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution go-vendor vendor
 
@@ -47,6 +73,11 @@ install -p -m 0755 bin/runc %{buildroot}%{_cross_bindir}
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+
+%files bin
 %{_cross_bindir}/runc
+
+%files fips-bin
+%{_cross_fips_bindir}/runc
 
 %changelog

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -52,10 +52,10 @@
 (filecon "/.*/usr/sbin/wicked.*" file network_exec)
 (filecon "/.*/usr/libexec/wicked/bin/wicked.*" file network_exec)
 (filecon "/.*/usr/lib/systemd/systemd-networkd.*" file network_exec)
-(filecon "/.*/usr/bin/containerd.*" file runtime_exec)
-(filecon "/.*/usr/bin/docker.*" file runtime_exec)
-(filecon "/.*/usr/bin/host-ctr" file runtime_exec)
-(filecon "/.*/usr/bin/runc.*" file runtime_exec)
+(filecon "/.*/usr(/fips)?/bin/containerd.*" file runtime_exec)
+(filecon "/.*/usr(/fips)?/bin/docker.*" file runtime_exec)
+(filecon "/.*/usr(/fips)?/bin/host-ctr" file runtime_exec)
+(filecon "/.*/usr(/fips)?/bin/runc.*" file runtime_exec)
 (filecon "/.*/usr/bin/shibaken" file api_exec)
 
 ; Label local storage mounts.


### PR DESCRIPTION
**Issue number:**
Related: #1667

**Description of changes:**
For every Go package that ran afoul of the new [check-fips](https://github.com/bottlerocket-os/bottlerocket-sdk/blob/develop/macros/check-fips) script, I added "bin" and "fips-bin" subpackages with the corresponding binaries. Apart from the packaging metadata, the core change is very simple: build each binary twice, first with `go build` and then with `gofips build`.

For cases where build arguments would lead to excessive duplication or very long lines, I moved them into arrays so the copy/paste wasn't quite as offensive.

I also touched a handful of Go packages that didn't need to be built twice, to drop arguments like `-buildmode=pie` that come from `GOFLAGS`.

**Testing done:**
Ran a variety of variants - `aws-dev`, `aws-k8s-1.24`, `aws-k8s-1.28-nvidia`, `aws-ecs-1`, `aws-ecs-2` - built with and without the FIPS flag set. The nodes were able to join clusters and run pods.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
