### PR TITLE
variants: add early-boot-config to k8s-1.30 variants

### DIFF
--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "aws-iam-authenticator",
  "cni",
  "cni-plugins",
+ "early-boot-config",
  "kernel-6_1",
  "kubernetes-1_30",
  "release",
@@ -319,6 +320,7 @@ dependencies = [
  "aws-iam-authenticator",
  "cni",
  "cni-plugins",
+ "early-boot-config",
  "kernel-6_1",
  "kmod-6_1-nvidia",
  "kubernetes-1_30",
@@ -1331,6 +1333,7 @@ version = "0.1.0"
 dependencies = [
  "cni",
  "cni-plugins",
+ "early-boot-config",
  "kernel-6_1",
  "kubernetes-1_30",
  "open-vm-tools",

--- a/variants/aws-k8s-1.30-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia/Cargo.toml
@@ -22,6 +22,7 @@ systemd-networkd = true
 [package.metadata.build-variant]
 included-packages = [
     # core
+    "early-boot-config-aws",
     "release",
     "kernel-6.1",
     # k8s
@@ -48,6 +49,7 @@ path = "../variants.rs"
 [build-dependencies]
 # core
 release = { path = "../../packages/release" }
+early-boot-config = { path = "../../packages/early-boot-config" }
 kernel-6_1 = { path = "../../packages/kernel-6.1" }
 # k8s
 cni = { path = "../../packages/cni" }

--- a/variants/aws-k8s-1.30/Cargo.toml
+++ b/variants/aws-k8s-1.30/Cargo.toml
@@ -19,6 +19,7 @@ systemd-networkd = true
 [package.metadata.build-variant]
 included-packages = [
 # core
+    "early-boot-config-aws",
     "release",
     "kernel-6.1",
 # k8s
@@ -41,6 +42,7 @@ path = "../variants.rs"
 [build-dependencies]
 # core
 release = { path = "../../packages/release" }
+early-boot-config = { path = "../../packages/early-boot-config" }
 kernel-6_1 = { path = "../../packages/kernel-6.1" }
 # k8s
 cni = { path = "../../packages/cni" }

--- a/variants/vmware-k8s-1.30/Cargo.toml
+++ b/variants/vmware-k8s-1.30/Cargo.toml
@@ -32,6 +32,7 @@ kernel-parameters = [
 ]
 included-packages = [
     # core
+    "early-boot-config-vmware",
     "release",
     "kernel-6.1",
     # k8s
@@ -48,6 +49,7 @@ path = "../variants.rs"
 [build-dependencies]
 # core
 release = { path = "../../packages/release" }
+early-boot-config = { path = "../../packages/early-boot-config" }
 kernel-6_1 = { path = "../../packages/kernel-6.1" }
 # k8s
 cni = { path = "../../packages/cni" }


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

Add early-boot config to all the kubernetes 1.30 variants.

**Testing done:**

Built and launched variants. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
