### PR TITLE
updog: use modeled-types directly

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4741,7 +4741,7 @@ dependencies = [
  "futures-core",
  "log",
  "lz4",
- "models",
+ "modeled-types",
  "semver",
  "serde",
  "serde_json",

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -32,7 +32,7 @@ tough = { version = "0.17", features = ["http"] }
 update_metadata = { path = "../update_metadata", version = "0.1" }
 url = "2"
 signal-hook = "0.3"
-models = { path = "../../models", version = "0.1" }
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -22,7 +22,7 @@ pub(crate) enum Error {
     #[snafu(display("Bad version string '{}' in config: {}", version_str, source))]
     BadVersionConfig {
         version_str: String,
-        source: model::modeled_types::error::Error,
+        source: modeled_types::error::Error,
     },
 
     #[snafu(display("Failed to parse config file {}: {}", path.display(), source))]

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -8,7 +8,7 @@ use crate::transport::{reader_from_stream, HttpQueryTransport, QueryParams};
 use bottlerocket_release::BottlerocketRelease;
 use chrono::Utc;
 use log::debug;
-use model::modeled_types::FriendlyVersion;
+use modeled_types::FriendlyVersion;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use signal_hook::consts::SIGTERM;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

As part of conditional compilation removal, we need to remove dependencies on the `models` crate. `updog` unnecessarily uses the `models` crate to access its child crate, `modeled-types`. We can just depend on the child crate directly to avoid conditional compilation in `updog`.

**Testing done:**

Built `aws-dev` variant

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
