### PR TITLE
Kernels 2024 04 22

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/f2f4a85aff9b0efec71d75bc29454ce8ab73974486a2a8ba541343cee1c7a622/kernel-5.10.213-201.855.amzn2.src.rpm"
-sha512 = "9e61a292106ab4872ff8bd89aa0c32613c7e78f3d6776ada31ba1d63e26f923a5b08e4fb2e5c927459cc057476d0e8e45c2f125ee226a6d402ba0c4025d78cde"
+url = "https://cdn.amazonlinux.com/blobstore/6ed4450682e3cd4bb4a66245eff09d376f623d8bb7646a386814fbf6d8e55691/kernel-5.10.214-202.855.amzn2.src.rpm"
+sha512 = "7f201e8e747ebf3b1d93ad39ced49436d276e8446fc84a56cf971beb1422f8f727c5250750dfee8451f377189ac884d0bf7a156fcaa4d63732a0ee8c0e671394"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.213
+Version: 5.10.214
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/f2f4a85aff9b0efec71d75bc29454ce8ab73974486a2a8ba541343cee1c7a622/kernel-5.10.213-201.855.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/6ed4450682e3cd4bb4a66245eff09d376f623d8bb7646a386814fbf6d8e55691/kernel-5.10.214-202.855.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/29a1d43caffcebd032ece82a974ba5db68b1354f508a35f6df62d8e1f6106ee8/kernel-5.15.152-100.162.amzn2.src.rpm"
-sha512 = "3d0ea5442f26d315d2d96968c4c1b8a5b2a2bd1a12ac0892351df9ef837efe2bae90cc9d4f3687acf8a5eddb96971d805407fac9dcdcb1d24d7cfef304eda77a"
+url = "https://cdn.amazonlinux.com/blobstore/b0b83af53711690ad1bbc3de7e01e03f6d93582a3fc506cf79a063c4937833aa/kernel-5.15.153-100.162.amzn2.src.rpm"
+sha512 = "3d84822f9401d8902b6ecf84cca8d0546be67c9516a51a22e4e0036741f74210a8398159a44e6aff6ee9481dbfd44a297f56b84ef4da4336af2c2e9efcaca680"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.152
+Version: 5.15.153
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/29a1d43caffcebd032ece82a974ba5db68b1354f508a35f6df62d8e1f6106ee8/kernel-5.15.152-100.162.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/b0b83af53711690ad1bbc3de7e01e03f6d93582a3fc506cf79a063c4937833aa/kernel-5.15.153-100.162.amzn2.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/4004a1fe6830de6cabbf60ae7345aef54260400b86ac4973fd29cc6a31d9bf9c/kernel-6.1.82-99.168.amzn2023.src.rpm"
-sha512 = "249f3b440248062cc1b67fe89c0bfc75d2b6f6cdac63c539884c7257d334ef7bdaeb2f87fffbfd12d4a5389cc65627b1a64d7c6b3a32b7247e222811dc06f6bc"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/bdca6b79db0d3d5ad549b61951208fbf474daebe38ca619f8c706070dc252239/kernel-6.1.84-99.169.amzn2023.src.rpm"
+sha512 = "3e1b219fc89e5c051b321088ad464db1e1278bc9e8ca90ffa2b17853a9db23310f7a7f370e3253671c7cf74e492cde4effb38c38500da3b391c7295027b134e1"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/config-bottlerocket
+++ b/packages/kernel-6.1/config-bottlerocket
@@ -1,11 +1,6 @@
 # Because Bottlerocket does not have an initramfs, modules required to mount
 # the root filesystem must be set to y.
 
-# disable filesystem encryption support as it may lock users into certain
-# filesystems inadvertantly. For now EBS volume encryption or dm-crypt seems
-# to be the more universal choice.
-# CONFIG_FS_ENCRYPTION is not set
-
 # The root filesystem is ext4
 CONFIG_EXT4_FS=y
 

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.82
+Version: 6.1.84
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/4004a1fe6830de6cabbf60ae7345aef54260400b86ac4973fd29cc6a31d9bf9c/kernel-6.1.82-99.168.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/bdca6b79db0d3d5ad549b61951208fbf474daebe38ca619f8c706070dc252239/kernel-6.1.84-99.169.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-6-133.us-west-2.compute.internal    Ready    <none>   8m17s   v1.23.17-eks-ea94ec3   192.168.6.133    35.90.61.65   Bottlerocket OS 1.20.0 (aws-k8s-1.23)   5.10.214         containerd://1.6.31+bottlerocket
ip-192-168-77-134.us-west-2.compute.internal   Ready    <none>   5m15s   v1.26.14-eks-b063426   192.168.77.134   35.80.9.191   Bottlerocket OS 1.20.0 (aws-k8s-1.26)   5.15.153         containerd://1.6.31+bottlerocket
ip-192-168-91-99.us-west-2.compute.internal    Ready    <none>   2m23s   v1.28.7-eks-c5c5da4    192.168.91.99    35.94.90.7    Bottlerocket OS 1.20.0 (aws-k8s-1.28)   6.1.84           containerd://1.6.31+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
19:32:48             e2e                                         global   complete            Passed:  1, Failed:  0, Remaining:  0
19:32:48    systemd-logs    ip-192-168-6-133.us-west-2.compute.internal   complete                                                 
19:32:48    systemd-logs   ip-192-168-77-134.us-west-2.compute.internal   complete                                                 
19:32:48    systemd-logs    ip-192-168-91-99.us-west-2.compute.internal   complete                                                 
19:32:48 Sonobuoy plugins have completed. Preparing results for download.
19:33:08             e2e                                         global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
19:33:08    systemd-logs    ip-192-168-6-133.us-west-2.compute.internal   complete   passed                                        
19:33:08    systemd-logs   ip-192-168-77-134.us-west-2.compute.internal   complete   passed                                        
19:33:08    systemd-logs    ip-192-168-91-99.us-west-2.compute.internal   complete   passed                                        
19:33:08 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:         0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.28-diff:         0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:          0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:          0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:        0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:        0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.26-diff:       0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:       0 removed,   0 added,   0 changed
```

The diff-kernel-config script does not include the explicit change (in bottlerocket) to CONFIG_FS_ENCRYPTION in kernel 6.1. The script correctly reports that there are no upstream configuration changes.

The full diff-report can be found on [Gist](https://gist.github.com/larvacea/34cf1b2057da7a5914fecaf3c68ab9d2).

**Patches**

All three kernels receive a new patch to fix a bug in the kernel's Key Retention Service that overwrote the desired lifetime of a key (making keys live forever).

Kernel 6.1 gets a new patch to improve error detection in KVM on AMD processors using Secure Encrypted Virtualization.

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.