### PR TITLE
libsepol: add patch to fix checking "all" permissions

### DIFF
--- a/packages/libsepol/0001-libsepol-cil-Check-common-perms-when-verifiying-all.patch
+++ b/packages/libsepol/0001-libsepol-cil-Check-common-perms-when-verifiying-all.patch
@@ -1,0 +1,56 @@
+From a4596b5ef889f30f3e1c1cbb6685b7f4727eb4de Mon Sep 17 00:00:00 2001
+From: James Carter <jwcart2@gmail.com>
+Date: Mon, 1 Apr 2024 10:49:24 -0400
+Subject: [PATCH] libsepol/cil: Check common perms when verifiying "all"
+
+Commit e81c466 "Fix class permission verification in CIL", added a
+check for the use of "all" in a permission expression for a class
+that had no permissions. Unfortunately, that change did not take
+into account a class that had common permissions, so a class that
+has no permmissions of its own, but inherits permissions from a
+common, will fail the verification check.
+
+If the class inherits from a common, then add those permissions to
+the permmission list when verifying the permission expression.
+
+Example/
+(common co1 (cop1))
+(class cl1 ())
+(classcommon cl1 co1)
+(classorder (CLASS cl1))
+
+(classpermission cp1)
+(classpermissionset cp1 (cl1 (all)))
+
+(classmap cm1 (cmp1))
+(classmapping cm1 cmp1 (cl1 (all)))
+
+Previously, both the classpermissionset and the classmapping rules
+would fail verification, but now they pass as expected.
+
+Patch originally from Ben Cressey <bcressey@amazon.com>, I have
+expanded the explanation.
+
+Reported-by: Ben Cressey <bcressey@amazon.com>
+Signed-off-by: James Carter <jwcart2@gmail.com>
+---
+ cil/src/cil_verify.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cil/src/cil_verify.c b/cil/src/cil_verify.c
+index 0c6d50a1..4ef2cbab 100644
+--- a/cil/src/cil_verify.c
++++ b/cil/src/cil_verify.c
+@@ -1842,6 +1842,9 @@ static int __cil_verify_perms(struct cil_class *class, struct cil_list *perms, s
+ 				int count2 = 0;
+ 				cil_list_init(&perm_list, CIL_MAP_PERM);
+ 				cil_symtab_map(&class->perms, __add_perm_to_list, perm_list);
++				if (class->common != NULL) {
++					cil_symtab_map(&class->common->perms, __add_perm_to_list, perm_list);
++				}
+ 				cil_list_for_each(j, perm_list) {
+ 					count2++;
+ 					struct cil_perm *perm = j->data;
+-- 
+2.44.0
+

--- a/packages/libsepol/libsepol.spec
+++ b/packages/libsepol/libsepol.spec
@@ -5,6 +5,7 @@ Summary: Library for SELinux policy manipulation
 License: LGPL-2.1-or-later
 URL: https://github.com/SELinuxProject/
 Source0: https://github.com/SELinuxProject/selinux/releases/download/%{version}/libsepol-%{version}.tar.gz
+Patch0001: 0001-libsepol-cil-Check-common-perms-when-verifiying-all.patch
 BuildRequires: %{_cross_os}glibc-devel
 
 %description


### PR DESCRIPTION
**Description of changes:**

This patch fixes a bug introduced in the latest release, which prevents classes with inherited permissions from passing verification checks.

**Testing done:**

Without this patch, in a custom OOTB, I see this error:

```
Operator "all" used for sem which has no permissions associated with it at /var/lib/selinux/fortified/tmp/modules/100/class/cil:215
Error verifying class permissions for map class ipcs, permission use at /var/lib/selinux/fortified/tmp/modules/100/ipcs/cil:2
Failed to verify cil database
Failed to verify cil database
Post process failed
```

With this patch, the error is gone.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
