### PR TITLE
Enable CONFIG_FS_ENCRYPTION in kernel 5.15

### DIFF
--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -204,3 +204,6 @@ CONFIG_MLXFW=m
 # CONFIG_MLX5_IPSEC is not set
 # CONFIG_MLX5_CORE_IPOIB is not set
 # CONFIG_MLX5_SF is not set
+
+# Support filesystem encryption for ext4
+CONFIG_FS_ENCRYPTION=y

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -207,3 +207,4 @@ CONFIG_MLXFW=m
 
 # Support filesystem encryption for ext4
 CONFIG_FS_ENCRYPTION=y
+CONFIG_FS_ENCRYPTION_INLINE_CRYPT=y


### PR DESCRIPTION
**Description of changes:**

Enable CONFIG_FS_ENCRYPTION in 5.15. This is already enabled in the 5.10 and 6.1 kernel configs.

**Testing done:**

Sonobuoy

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
