### PR TITLE
Allow downstream users to use a different containerd templated configuration

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -305,4 +305,5 @@ version = "1.20.0"
     "migrate_v1.20.0_add-ntp-default-options-v0-1-0.lz4",
     "migrate_v1.20.0_static-pods-add-prefix-v0-1-0.lz4",
     "migrate_v1.20.0_static-pods-services-cfg-v0-1-0.lz4",
+    "migrate_v1.20.0_update-containerd-config-template-path.lz4",
 ]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -55,6 +55,26 @@ Requires: (%{_cross_os}image-feature(fips) and %{name})
 Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 %description fips-bin
+
+%package basic
+Summary: Basic containerd configuration
+Requires: %{name}
+
+%description basic
+%{summary}.
+
+%package cri
+Summary: Containerd configuration for CRI
+Requires: %{name}
+
+%description cri
+%{summary}.
+
+%package cri-nvidia
+Summary: Containerd configuration for CRI-nvidia
+Requires: %{name}
+
+%description cri-nvidia
 %{summary}.
 
 %prep
@@ -109,6 +129,15 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%post basic -p <lua>
+posix.symlink("containerd-config-toml_basic", "%{_cross_templatedir}/containerd-config")
+
+%post cri -p <lua>
+posix.symlink("containerd-config-toml_k8s_containerd_sock", "%{_cross_templatedir}/containerd-config")
+
+%post cri-nvidia -p <lua>
+posix.symlink("containerd-config-toml_k8s_nvidia_containerd_sock", "%{_cross_templatedir}/containerd-config")
+
 %files
 %license LICENSE NOTICE
 %{_cross_attribution_file}
@@ -117,7 +146,6 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
 %{_cross_unitdir}/etc-containerd.mount
 %{_cross_unitdir}/prepare-var-lib-containerd.service
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/containerd
-%{_cross_templatedir}/containerd-config-toml*
 %{_cross_templatedir}/containerd-cri-base-json
 %{_cross_tmpfilesdir}/containerd.conf
 
@@ -134,5 +162,14 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
 %{_cross_fips_bindir}/containerd-shim-runc-v1
 %{_cross_fips_bindir}/containerd-shim-runc-v2
 %{_cross_fips_bindir}/ctr
+
+%files basic
+%{_cross_templatedir}/containerd-config-toml_basic
+
+%files cri
+%{_cross_templatedir}/containerd-config-toml_k8s_containerd_sock
+
+%files cri-nvidia
+%{_cross_templatedir}/containerd-config-toml_k8s_nvidia_containerd_sock
 
 %changelog

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4740,6 +4740,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "update-containerd-config-template-path"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "update-ecs-config-path"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -85,6 +85,7 @@ members = [
     "api/migration/migrations/v1.19.5/public-control-container-v0-7-11",
     "api/migration/migrations/v1.19.5/aws-admin-container-v0-11-7",
     "api/migration/migrations/v1.19.5/public-admin-container-v0-11-7",
+    "api/migration/migrations/v1.20.0/update-containerd-config-template-path",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.20.0/update-containerd-config-template-path/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/update-containerd-config-template-path/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "update-containerd-config-template-path"
+version = "0.1.0"
+edition = "2021"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.20.0/update-containerd-config-template-path/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/update-containerd-config-template-path/src/main.rs
@@ -1,0 +1,37 @@
+use migration_helpers::common_migrations::{NoOpMigration, ReplaceStringMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We updated the 'path' string for 'Containerd configuration template'.
+fn run() -> Result<()> {
+    if cfg!(variant_runtime = "ecs") {
+        migrate(ReplaceStringMigration {
+            setting: "configuration-files.containerd-config-toml.path",
+            old_val: "/usr/share/templates/containerd-config-toml_basic",
+            new_val: "/usr/share/templates/containerd-config",
+        })
+    } else if cfg!(variant_runtime = "k8s") {
+        if cfg!(variant_flavor = "nvidia") {
+            migrate(ReplaceStringMigration {
+                setting: "configuration-files.containerd-config-toml.template-path",
+                old_val: "/usr/share/templates/containerd-config-toml_k8s_nvidia_containerd_sock",
+                new_val: "/usr/share/templates/containerd-config",
+            })
+        } else {
+            migrate(ReplaceStringMigration {
+                setting: "configuration-files.containerd-config-toml.template-path",
+                old_val: "/usr/share/templates/containerd-config-toml_k8s_containerd_sock",
+                new_val: "/usr/share/templates/containerd-config",
+            })
+        }
+    } else {
+        migrate(NoOpMigration)
+    }
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -27,7 +27,7 @@ restart-commands = ["/bin/systemctl try-restart containerd.service"]
 
 [configuration-files.containerd-config-toml]
 path = "/etc/containerd/config.toml"
-template-path = "/usr/share/templates/containerd-config-toml_basic"
+template-path = "/usr/share/templates/containerd-config"
 
 # Container runtime settings.
 

--- a/sources/models/shared-defaults/kubernetes-containerd-nvidia.toml
+++ b/sources/models/shared-defaults/kubernetes-containerd-nvidia.toml
@@ -1,6 +1,6 @@
 [configuration-files.containerd-config-toml]
 # No override to path
-template-path = "/usr/share/templates/containerd-config-toml_k8s_nvidia_containerd_sock"
+template-path = "/usr/share/templates/containerd-config"
 
 # Image registries
 [metadata.settings.container-registry]

--- a/sources/models/shared-defaults/kubernetes-containerd.toml
+++ b/sources/models/shared-defaults/kubernetes-containerd.toml
@@ -1,6 +1,6 @@
 [configuration-files.containerd-config-toml]
 # No override to path
-template-path = "/usr/share/templates/containerd-config-toml_k8s_containerd_sock"
+template-path = "/usr/share/templates/containerd-config"
 
 # Image registries
 [metadata.settings.container-registry]

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -26,6 +26,8 @@ included-packages = [
     "docker-init",
 # ecs
     "ecs-agent-nvidia-config",
+# containerd
+    "containerd-basic",
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -23,6 +23,8 @@ included-packages = [
     "docker-init",
 # ecs
     "ecs-agent-config",
+# containerd 
+    "containerd-basic",
 ]
 
 [lib]

--- a/variants/aws-ecs-2-nvidia/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia/Cargo.toml
@@ -26,6 +26,8 @@ included-packages = [
     "docker-init",
 # ecs
     "ecs-agent-nvidia-config",
+# containerd
+    "containerd-basic",
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",

--- a/variants/aws-ecs-2/Cargo.toml
+++ b/variants/aws-ecs-2/Cargo.toml
@@ -25,6 +25,8 @@ included-packages = [
     "docker-init",
 # ecs
     "ecs-agent-config",
+# containerd
+    "containerd-basic",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.23-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.23-nvidia/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-5.10-nvidia-tesla-470",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.23/Cargo.toml
+++ b/variants/aws-k8s-1.23/Cargo.toml
@@ -20,6 +20,7 @@ included-packages = [
     "kernel-5.10",
     "kubelet-1.23",
     "release",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.24-nvidia/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-5.15-nvidia-tesla-535",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.24/Cargo.toml
+++ b/variants/aws-k8s-1.24/Cargo.toml
@@ -20,6 +20,7 @@ included-packages = [
     "kernel-5.15",
     "kubelet-1.24",
     "release",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.25-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.25-nvidia/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-5.15-nvidia-tesla-535",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.25/Cargo.toml
+++ b/variants/aws-k8s-1.25/Cargo.toml
@@ -20,6 +20,7 @@ included-packages = [
     "kernel-5.15",
     "kubelet-1.25",
     "release",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.26-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.26-nvidia/Cargo.toml
@@ -27,6 +27,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-5.15-nvidia-tesla-535",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.26/Cargo.toml
+++ b/variants/aws-k8s-1.26/Cargo.toml
@@ -21,6 +21,7 @@ included-packages = [
     "kernel-5.15",
     "kubelet-1.26",
     "release",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.27-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.27-nvidia/Cargo.toml
@@ -27,6 +27,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-5.15-nvidia-tesla-535",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.27/Cargo.toml
+++ b/variants/aws-k8s-1.27/Cargo.toml
@@ -21,6 +21,7 @@ included-packages = [
     "kernel-5.15",
     "kubelet-1.27",
     "release",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.28-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.28-nvidia/Cargo.toml
@@ -33,6 +33,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-6.1-nvidia-tesla-535",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.28/Cargo.toml
+++ b/variants/aws-k8s-1.28/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.28",
     "aws-iam-authenticator",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.29-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.29-nvidia/Cargo.toml
@@ -33,6 +33,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-6.1-nvidia-tesla-535",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.29/Cargo.toml
+++ b/variants/aws-k8s-1.29/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.29",
     "aws-iam-authenticator",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.30-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia/Cargo.toml
@@ -33,6 +33,7 @@ included-packages = [
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
     "kmod-6.1-nvidia-tesla-535",
+    "containerd-cri-nvidia",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.30/Cargo.toml
+++ b/variants/aws-k8s-1.30/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.30",
     "aws-iam-authenticator",
+    "containerd-cri",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/metal-k8s-1.26/Cargo.toml
+++ b/variants/metal-k8s-1.26/Cargo.toml
@@ -32,6 +32,7 @@ included-packages = [
     "linux-firmware",
     "kubelet-1.26",
     "release",
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/metal-k8s-1.27/Cargo.toml
+++ b/variants/metal-k8s-1.27/Cargo.toml
@@ -32,6 +32,7 @@ included-packages = [
     "linux-firmware",
     "kubelet-1.27",
     "release",
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/metal-k8s-1.28/Cargo.toml
+++ b/variants/metal-k8s-1.28/Cargo.toml
@@ -36,6 +36,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.28",
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/metal-k8s-1.29/Cargo.toml
+++ b/variants/metal-k8s-1.29/Cargo.toml
@@ -36,6 +36,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.29",
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/vmware-k8s-1.26/Cargo.toml
+++ b/variants/vmware-k8s-1.26/Cargo.toml
@@ -34,6 +34,8 @@ included-packages = [
     "kubelet-1.26",
     "open-vm-tools",
     "release",
+     # containerd
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/vmware-k8s-1.27/Cargo.toml
+++ b/variants/vmware-k8s-1.27/Cargo.toml
@@ -34,6 +34,8 @@ included-packages = [
     "kubelet-1.27",
     "open-vm-tools",
     "release",
+     # containerd
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/vmware-k8s-1.28/Cargo.toml
+++ b/variants/vmware-k8s-1.28/Cargo.toml
@@ -40,6 +40,8 @@ included-packages = [
     "kubelet-1.28",
     # vmware
     "open-vm-tools",
+     # containerd
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/vmware-k8s-1.29/Cargo.toml
+++ b/variants/vmware-k8s-1.29/Cargo.toml
@@ -40,6 +40,8 @@ included-packages = [
     "kubelet-1.29",
     # vmware
     "open-vm-tools",
+    # containerd
+    "containerd-cri",
 ]
 
 [lib]

--- a/variants/vmware-k8s-1.30/Cargo.toml
+++ b/variants/vmware-k8s-1.30/Cargo.toml
@@ -40,6 +40,8 @@ included-packages = [
     "kubelet-1.30",
     # vmware
     "open-vm-tools",
+    # containerd
+    "containerd-cri",
 ]
 
 [lib]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
 This will allow downstream users to provide their own containerd templated configuration, so that they can provide more configurations: 
- The API system uses the templated configuration provided by the users.
- The existing variants use the existing templated containerd configurations using links. 
- Migration to use new template on upgrade and old template on downgrade.


**Testing done:**
- Migration from old version to new version k8s
  - [x] /etc/containerd/config.toml remains same.
  - [x] ls -ltr usr/share/templates conatins following files before migration
  ```
  ls -ltr usr/share/templates
  -rw-r--r--. 1 root root 2564 Mar 18 21:23 containerd-config-toml_k8s_nvidia_containerd_sock
  -rw-r--r--. 1 root root 2563 Mar 18 21:23 containerd-config-toml_k8s_containerd_sock
  -rw-r--r--. 1 root root  386 Mar 18 21:23 containerd-config-toml_basic
  ```
  And following files after migration
  ```
  -rw-r--r--. 1 root root 2563 Mar 18 21:23 containerd-config-toml_k8s_containerd_sock
  lrwxrwxrwx. 1 root root   42 Apr 25 22:49 containerd-config -> containerd-config-toml_k8s_containerd_sock
  ```
  - [x] Previously running pods keeps running successfully.
  - [x] Downgrade to old version bring the system in the same state as earlier.
- Migration from old Bottlerocket version for k8s Nvidia
  - [x] /etc/containerd/config.toml remains same.
  - [x] ls -ltr usr/share/templates conatins following files before migration
  ```
  ls -ltr usr/share/templates
  -rw-r--r--. 1 root root 2564 Mar 18 21:23 containerd-config-toml_k8s_nvidia_containerd_sock
  -rw-r--r--. 1 root root 2563 Mar 18 21:23 containerd-config-toml_k8s_containerd_sock
  -rw-r--r--. 1 root root  386 Mar 18 21:23 containerd-config-toml_basic
  ```
  And following files after migration
  ```
  ls -ltr usr/share/templates/
  -rw-r--r--. 1 root root 2564 Mar 18 21:23 containerd-config-toml_k8s_nvidia_containerd_sock
   lrwxrwxrwx. 1 root root   49 Apr 26 16:09 containerd-config -> containerd-config-toml_k8s_nvidia_containerd_sock
  ```
  - [x] Previously running pods keeps running successfully.
  - [x] Downgrade to old version bring the system in the same state as earlier.
- Migration from old Bottlerocket version for ECS
- Migration from old Bottlerocket version for Vmware
- Migration from old Bottlerocket version for Metal 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
