### PR TITLE
ecs-gpu-init: clean up linker flags

### DIFF
--- a/packages/ecs-gpu-init/ecs-gpu-init.spec
+++ b/packages/ecs-gpu-init/ecs-gpu-init.spec
@@ -21,8 +21,9 @@ cp -r %{_builddir}/sources/%{workspace_name}/* .
 %set_cross_go_flags
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host
-export CGO_LDFLAGS="-Wl,-z,relro,-export-dynamic"
-go build -buildmode=pie -ldflags="${GOLDFLAGS}" -o ecs-gpu-init ./cmd/ecs-gpu-init
+export CGO_LDFLAGS="-Wl,-z,relro -Wl,--export-dynamic"
+export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDFLAGS}'"
+go build -ldflags="${GOLDFLAGS}" -o ecs-gpu-init ./cmd/ecs-gpu-init
 
 %install
 install -d %{buildroot}%{_cross_bindir}


### PR DESCRIPTION
This commit was cherry picked from https://github.com/bottlerocket-os/bottlerocket/pull/3887 since we took the SDK where the change was needed. This avoids building `ecs-gpu-init` with broken symbols which show up with these errors in the system log:
```
[   14.946273] ecs-gpu-init[1868]: /usr/bin/ecs-gpu-init: symbol lookup error: /usr/bin/ecs-gpu-init: undefined symbol: nvmlGpuInstanceGetComputeInstanceProfileInfoV
[FAILED] Failed to start Initialize ECS GPU config.
See 'systemctl status ecs-gpu-init.service' for details.
[DEPEND] Dependency failed for Bottlerocket initial configuration complete.
[DEPEND] Dependency failed for Isolates configured.target.
```

From the original commit:
`--export-dynamic` is a separate option, independent of `-z`, so pass it as its own `-Wl` flag.

For consistency, pass the same flags to the external linker.

Thanks for @bcressey for having this fix already under review!

**Testing done:**
Built an aws-ecs-2-nvidia image and it boots correctly and uses the GPU


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
