### PR TITLE
Adjust SSM agent flags

### DIFF
--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -25,14 +25,15 @@ BuildRequires: %{_cross_os}glibc-devel
 %setup -n %{gorepo}-%{version}
 
 %build
-%set_cross_go_flags
+%set_cross_go_flags_static
 
-# Set CGO_ENABLED=0 to statically link binaries that will be bind-mounted by the ECS agent
-CGO_ENABLED=0 go build ${GOFLAGS} -installsuffix cgo -a -ldflags "-s" -o amazon-ssm-agent \
+go build -ldflags "${GOLDFLAGS}" -o amazon-ssm-agent \
   ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
-CGO_ENABLED=0 go build ${GOFLAGS} -installsuffix cgo -a -ldflags "-s" -o ssm-agent-worker \
+
+go build -ldflags "${GOLDFLAGS}" -o ssm-agent-worker \
   ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
-CGO_ENABLED=0 go build ${GOFLAGS} -installsuffix cgo -a -ldflags "-s" -o ssm-session-worker \
+
+go build -ldflags "${GOLDFLAGS}" -o ssm-session-worker \
   ./agent/framework/processor/executer/outofproc/sessionworker/main.go
 
 %install


### PR DESCRIPTION
**Description of changes:**
The flags to compile the statically-linked SSM agent have to be adjustedfor the new SDK.


**Testing done:**
I ran the internal suite of tests for ECS exec, and they are passing.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
