### PR TITLE
fix nvidia-k8s-device-plugin linker flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
  
 ## Build Changes
 * Update twoliter to v0.1.1 ([#3880], [#3900]) 
-* Update ecs-gpu-init and amazon-ssm-agent builds for new SDK ([#3920], [#3921])
+* Update ecs-gpu-init, amazon-ssm-agent, and nvidia-k8s-device-plugin builds for new SDK ([#3920], [#3921], [#3924])
 
 [#3804]: https://github.com/bottlerocket-os/bottlerocket/pull/3804
 [#3880]: https://github.com/bottlerocket-os/bottlerocket/pull/3880
@@ -23,6 +23,7 @@
 [#3914]: https://github.com/bottlerocket-os/bottlerocket/pull/3914
 [#3920]: https://github.com/bottlerocket-os/bottlerocket/pull/3920
 [#3921]: https://github.com/bottlerocket-os/bottlerocket/pull/3921
+[#3924]: https://github.com/bottlerocket-os/bottlerocket/pull/3924
 
 # v1.19.4 (2024-04-06)
 

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -27,7 +27,8 @@ BuildRequires: %{_cross_os}glibc-devel
 %cross_go_configure %{goimport}
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host
-export CGO_LDFLAGS="-Wl,-z,relro,-export-dynamic"
+export CGO_LDFLAGS="-Wl,-z,relro -Wl,--export-dynamic"
+export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDFLAGS}'"
 go build -ldflags="${GOLDFLAGS}" -o nvidia-device-plugin ./cmd/nvidia-device-plugin/
 
 %install


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
The flags to compile the nvidia-k8s-device-plugin have to be adjusted for the new SDK.

Specifically, the default `GOLDFLAGS` now includes `-extldflags` set to the stock `LDFLAGS` value. Builds that override `CGO_LDFLAGS` also need to override `GOLDFLAGS` so that the linker flags match.

**Testing done:**
Before:
```
bash-5.1# systemctl status nvidia-k8s-device-plugin
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
     Active: activating (auto-restart) (Result: exit-code) since Sat 2024-04-27 15:40:42 UTC; 1s ago
    Process: 6080 ExecStart=/usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true (code=exited, status=127)
   Main PID: 6080 (code=exited, status=127)
        CPU: 2ms

bash-5.1# /usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true
/usr/bin/nvidia-device-plugin: symbol lookup error: /usr/bin/nvidia-device-plugin: undefined symbol: nvmlGpuInstanceGetComputeInstanceProfileInfoV
bash-5.1# systemctl status nvidia-k8s-device-plugin 
```

After:
```
bash-5.1# systemctl status nvidia-k8s-device-plugin
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
     Active: active (running) since Sat 2024-04-27 15:50:30 UTC; 3min 22s ago
   Main PID: 1390 (nvidia-device-p)
      Tasks: 9 (limit: 9232)
     Memory: 56.6M
        CPU: 5.956s
     CGroup: /system.slice/nvidia-k8s-device-plugin.service
             └─1390 /usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
