### PR TITLE
[1.19.x] backport fix for nvidia-k8s-device-plugin linker flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
  
 ## Build Changes
 * Update twoliter to v0.1.1 ([#3880], [#3900]) 
-* Update ecs-gpu-init and amazon-ssm-agent builds for new SDK ([#3920], [#3921])
+* Update ecs-gpu-init, amazon-ssm-agent, and nvidia-k8s-device-plugin builds for new SDK ([#3920], [#3921], [#3924])
 
 [#3804]: https://github.com/bottlerocket-os/bottlerocket/pull/3804
 [#3880]: https://github.com/bottlerocket-os/bottlerocket/pull/3880
@@ -23,6 +23,7 @@
 [#3914]: https://github.com/bottlerocket-os/bottlerocket/pull/3914
 [#3920]: https://github.com/bottlerocket-os/bottlerocket/pull/3920
 [#3921]: https://github.com/bottlerocket-os/bottlerocket/pull/3921
+[#3924]: https://github.com/bottlerocket-os/bottlerocket/pull/3924
 
 # v1.19.4 (2024-04-06)
 

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -27,7 +27,8 @@ BuildRequires: %{_cross_os}glibc-devel
 %cross_go_configure %{goimport}
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host
-export CGO_LDFLAGS="-Wl,-z,relro,-export-dynamic"
+export CGO_LDFLAGS="-Wl,-z,relro -Wl,--export-dynamic"
+export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDFLAGS}'"
 go build -ldflags="${GOLDFLAGS}" -o nvidia-device-plugin ./cmd/nvidia-device-plugin/
 
 %install


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Backport the linker flag fix for `nvidia-k8s-device-plugin`.


**Testing done:**
Tested in #3924.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
