### PR TITLE
Add instance type matching to shibaken.

### DIFF
--- a/sources/api/shibaken/src/instance.rs
+++ b/sources/api/shibaken/src/instance.rs
@@ -1,0 +1,49 @@
+use std::process::ExitCode;
+
+use argh::FromArgs;
+use imdsclient::ImdsClient;
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "instance-type")]
+/// Fetch instance type from IMDS
+pub(crate) struct InstanceType {
+    #[argh(option)]
+    /// prefix string(s) to match against instance type
+    prefix: Vec<String>,
+}
+
+impl InstanceType {
+    pub(crate) async fn run(self) -> Result<ExitCode> {
+        if self.prefix.is_empty() {
+            // Is it success or failure to match against the empty set?
+            // Pretend this is the element-of operator. Nothing is an
+            // element of the empty set.
+            return Ok(ExitCode::FAILURE);
+        }
+        let mut client = ImdsClient::new();
+        let instance_type = client
+            .fetch_instance_type()
+            .await
+            .context(error::ImdsClientSnafu)?;
+        match instance_type {
+            // No instance type? No match.
+            None => Ok(ExitCode::FAILURE),
+            Some(instance_type) => {
+                let does_match = self
+                    .prefix
+                    .iter()
+                    .any(|prefix| instance_type.starts_with(prefix));
+                if does_match {
+                    log::info!("Instance type {} matched.", instance_type);
+                    Ok(ExitCode::SUCCESS)
+                } else {
+                    log::info!("Instance type {} did not match.", instance_type);
+                    Ok(ExitCode::FAILURE)
+                }
+            }
+        }
+    }
+}

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -16,12 +16,13 @@ shibaken can:
 use argh::FromArgs;
 use simplelog::{ColorChoice, Config as LogConfig, LevelFilter, TermLogger, TerminalMode};
 use snafu::ResultExt;
-use std::process;
+use std::process::ExitCode;
 
 use crate::error::Result;
 
 mod admin_userdata;
 pub(crate) mod error;
+mod instance;
 mod partition;
 mod warmpool;
 
@@ -42,6 +43,9 @@ enum Commands {
     /// Fetch and populate the admin container's user-data with authorized ssh keys.
     GenerateAdminUserdata(admin_userdata::GenerateAdminUserdata),
 
+    /// Fetch instance type
+    IsInstanceType(instance::InstanceType),
+
     /// Fetch and return whether or not this host is in the given partition.
     /// Accepts multiple partitions, returning `true` if the host is in any of the given partitions.
     IsPartition(partition::IsPartition),
@@ -50,7 +54,7 @@ enum Commands {
     WarmPoolWait(warmpool::autoscaling_warm_pool::WarmPoolWait),
 }
 
-async fn run() -> Result<()> {
+async fn run() -> Result<ExitCode> {
     let args: Args = argh::from_env();
 
     // TerminalMode::Stderr will send all logs to stderr, as sundog only expects the json output of
@@ -64,26 +68,28 @@ async fn run() -> Result<()> {
     .context(error::LoggerSnafu)?;
 
     log::info!("shibaken started");
-
+    let mut exit_code = ExitCode::SUCCESS;
     match args.command {
-        Commands::GenerateAdminUserdata(generate_admin_userdata) => {
-            generate_admin_userdata.run().await
-        }
-        Commands::IsPartition(is_partition) => is_partition.run().await,
+        Commands::GenerateAdminUserdata(generate_admin_userdata) => generate_admin_userdata.run().await?,
+        Commands::IsInstanceType(is_instance_type) => exit_code = is_instance_type.run().await?,
+        Commands::IsPartition(is_partition) => is_partition.run().await?,
         Commands::WarmPoolWait(warm_pool_wait) => warm_pool_wait
             .run()
             .await
-            .context(error::WarmPoolCheckFailedSnafu),
+            .context(error::WarmPoolCheckFailedSnafu)?,
     }
+    Ok(exit_code)
 }
 
-// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
-// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
-// https://github.com/shepmaster/snafu/issues/110
+// Returning an ExitCode from main will propagate the success or failure to our caller, and permit
+// normal rust teardown (unlike process::exit()): a kinder, gentler failure branch.
 #[tokio::main]
-async fn main() {
-    if let Err(e) = run().await {
-        eprintln!("{}", e);
-        process::exit(1);
+async fn main() -> ExitCode {
+    match run().await {
+        Err(e) => {
+            eprintln!("{}", e);
+            ExitCode::FAILURE
+        }
+        Ok(code) => code
     }
 }


### PR DESCRIPTION
We would like to query and match the instance type for the benefit of systemd unit files. Returning success/failure is useful for conditional execution in systemd unit files.

**Description of changes:**

Adds a subcommand to `shibaken`:

```
shibaken instance-type --prefix m5.x --prefix some-thing
```

Exit code 0 (success or true) if the IMDS instance type starts with one (or more) of the `--prefix` parameters. Otherwise exit code 1 (failure or false). Failure is also returned if we do not get a non-empty instance type, or if the command has no `--prefix` options (no instance is a member of the empty set).

This iterates through the supplied prefixes looking for a match. This is reasonable for a few dozen prefixes, and I expect we will have at most a half dozen. Should we ever have a requirement for thousands of prefixes, we should revisit that search-by-iteration design choice.

**Testing done:**

Manual testing on an EC2 instance running aws-dev:

- `shibaken` returns 0 (true) if the instance type matches at least one `--prefix`.
- `shibaken` returns 1 (false) if the instance type matches no `--prefix`.
- `shibaken` returns 1 (false) if there are no `--prefix` parameters.
- `shibaken` works as expected with 0, 1, or 2 `--prefix` parameters.

Not tested:

- behavior when the IMDS fetcher returns an error.
- behavior when the IMDS fetcher returns an empty string for instance type.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
