### PR TITLE
kernel-6.1: update to 6.1.87

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/bdca6b79db0d3d5ad549b61951208fbf474daebe38ca619f8c706070dc252239/kernel-6.1.84-99.169.amzn2023.src.rpm"
-sha512 = "3e1b219fc89e5c051b321088ad464db1e1278bc9e8ca90ffa2b17853a9db23310f7a7f370e3253671c7cf74e492cde4effb38c38500da3b391c7295027b134e1"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/1abc503d6f7da124bf9e7c306ab8119b4b85c9207c943fb2c5a617d0d1716362/kernel-6.1.87-99.174.amzn2023.src.rpm"
+sha512 = "2aaab825ca6bed61366fcdbc67d954191190a6010a9b083c824c9adeeb308000fa7af5b867b450d4bf5c6a9be4234e909ae5210a7157af5e7edcc4ff291a2f61"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.84
+Version: 6.1.87
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/bdca6b79db0d3d5ad549b61951208fbf474daebe38ca619f8c706070dc252239/kernel-6.1.84-99.169.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/1abc503d6f7da124bf9e7c306ab8119b4b85c9207c943fb2c5a617d0d1716362/kernel-6.1.87-99.174.amzn2023.src.rpm
 Source100: config-bottlerocket
 Source101: config-bottlerocket-aws
 Source102: config-bottlerocket-metal


### PR DESCRIPTION
**Description**

Rebase to Amazon Linux upstream version 6.1.87-99.174.amzn2023.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE    VERSION               INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-74-137.us-west-2.compute.internal   Ready    <none>   104s   v1.28.7-eks-c5c5da4   192.168.74.137   44.242.171.195   Bottlerocket OS 1.20.0 (aws-k8s-1.28)   6.1.87           containerd://1.6.31+bottlerocket

> sonobuoy run --mode=quick --wait
[...]

```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.28-diff:         0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:          0 removed,   1 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:        0 removed,   1 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:       0 removed,   1 added,   0 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/larvacea/e0e1d37b7506637692e3d50e63821756).

The one added configuration enables a mitigation on the x86_64 platform.

**Patches**

There are four new patches; they are all compatible with our environment.

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
