### PR TITLE
Kernels 2024 05 01

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/6ed4450682e3cd4bb4a66245eff09d376f623d8bb7646a386814fbf6d8e55691/kernel-5.10.214-202.855.amzn2.src.rpm"
-sha512 = "7f201e8e747ebf3b1d93ad39ced49436d276e8446fc84a56cf971beb1422f8f727c5250750dfee8451f377189ac884d0bf7a156fcaa4d63732a0ee8c0e671394"
+url = "https://cdn.amazonlinux.com/blobstore/962957e692b6ca23e981930d7a3dc644768e89d2ac321745883eaa99bc55e67a/kernel-5.10.215-203.850.amzn2.src.rpm"
+sha512 = "4abdbacaf18bf224c56d4648803a5cad0b1c6a6fab7ffbdff9d38ac6deeb485abb2d4dea4daa61ffa271a848e634969e94bd4438dd48529213518e0671000455"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.214
+Version: 5.10.215
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/6ed4450682e3cd4bb4a66245eff09d376f623d8bb7646a386814fbf6d8e55691/kernel-5.10.214-202.855.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/962957e692b6ca23e981930d7a3dc644768e89d2ac321745883eaa99bc55e67a/kernel-5.10.215-203.850.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/b0b83af53711690ad1bbc3de7e01e03f6d93582a3fc506cf79a063c4937833aa/kernel-5.15.153-100.162.amzn2.src.rpm"
-sha512 = "3d84822f9401d8902b6ecf84cca8d0546be67c9516a51a22e4e0036741f74210a8398159a44e6aff6ee9481dbfd44a297f56b84ef4da4336af2c2e9efcaca680"
+url = "https://cdn.amazonlinux.com/blobstore/72726a4adc0c205ce087f838249744029fc8e51b85ea0e3d395cb10ac99d4864/kernel-5.15.156-102.160.amzn2.src.rpm"
+sha512 = "0964d79ecb44e23273633a831022cd4d43ca9eeb2f029f994d5f52dc1aceed11b985a2b8acf978524033d738e3a4670ea87566e87bfb4c3a6d7bd37b5a6d8e22"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.153
+Version: 5.15.156
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/b0b83af53711690ad1bbc3de7e01e03f6d93582a3fc506cf79a063c4937833aa/kernel-5.15.153-100.162.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/72726a4adc0c205ce087f838249744029fc8e51b85ea0e3d395cb10ac99d4864/kernel-5.15.156-102.160.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
**Description of changes:**

Update kernels 5.10 and 5.15 to the latest upstream kernels.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE     VERSION                INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-27-120.us-west-2.compute.internal   Ready    <none>   101s    v1.26.14-eks-b063426   192.168.27.120   54.184.14.68    Bottlerocket OS 1.20.0 (aws-k8s-1.26)   5.15.156         containerd://1.6.31+bottlerocket
ip-192-168-36-55.us-west-2.compute.internal    Ready    <none>   5m13s   v1.23.17-eks-ea94ec3   192.168.36.55    35.85.153.152   Bottlerocket OS 1.20.0 (aws-k8s-1.23)   5.10.215         containerd://1.6.31+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
21:05:12             e2e                                         global   complete            Passed:  1, Failed:  0, Remaining:  0
21:05:12    systemd-logs   ip-192-168-27-120.us-west-2.compute.internal   complete                                                 
21:05:12    systemd-logs    ip-192-168-36-55.us-west-2.compute.internal   complete                                                 
21:05:12 Sonobuoy plugins have completed. Preparing results for download.
21:05:32             e2e                                         global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
21:05:32    systemd-logs   ip-192-168-27-120.us-west-2.compute.internal   complete   passed                                        
21:05:32    systemd-logs    ip-192-168-36-55.us-west-2.compute.internal   complete   passed                                        
21:05:32 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.23-diff:	  0 removed,   0 added,   0 changed
config-aarch64-aws-k8s-1.26-diff:	  2 removed,   2 added,   0 changed
config-x86_64-aws-k8s-1.23-diff:	  0 removed,   1 added,   0 changed
config-x86_64-aws-k8s-1.26-diff:	  2 removed,   6 added,   0 changed
config-x86_64-metal-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.26-diff:	  0 removed,   0 added,   0 changed
```

The full diff-report can be found on [Gist](https://gist.github.com/larvacea/f22cc2f9910fd25230200202531c3220).

I have reviewed the configuration changes and I see nothing there that could be a problem for bottlerocket. The same is true of the patch changes: all simple, and all benign.

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
