### PR TITLE
switch to systemd defaults and kernel parameters for systemd's cgroup hierarchy

### DIFF
--- a/packages/systemd/bootconfig-unified-cgroup-hierarchy.conf
+++ b/packages/systemd/bootconfig-unified-cgroup-hierarchy.conf
@@ -1,1 +1,0 @@
-init.systemd.unified_cgroup_hierarchy = 1

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -14,7 +14,6 @@ Source3: journald.conf
 Source4: issue
 Source5: systemd-journald.conf
 Source6: systemd-sysusers.conf
-Source7: bootconfig-unified-cgroup-hierarchy.conf
 
 # Backport of upstream patches that make the netlink default timeout
 # configurable.  Bottlerocket carries this patch and configures the timeout in
@@ -103,10 +102,6 @@ Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}libuuid
 Requires: %{_cross_os}libxcrypt
 
-# Only require a cgroup hierarchy package when building an image, not
-# for packages that need systemd-devel as a build dependency.
-Requires: (%{name}(cgroup-hierarchy) if %{_cross_os}metadata)
-
 %description
 %{summary}.
 
@@ -133,24 +128,6 @@ Summary: Files for networkd
 Summary: Files for resolved
 
 %description resolved
-%{summary}.
-
-%package hybrid-cgroup-hierarchy
-Summary: No-op dependency for hybrid cgroup hierarchy
-Provides: %{name}(cgroup-hierarchy)
-Requires: (%{_cross_os}image-feature(no-unified-cgroup-hierarchy) and %{name})
-Conflicts: (%{_cross_os}image-feature(unified-cgroup-hierarchy) or %{name}-unified-cgroup-hierarchy)
-
-%description hybrid-cgroup-hierarchy
-%{summary}.
-
-%package unified-cgroup-hierarchy
-Summary: Bootconfig snippet for unified cgroup hierarchy
-Provides: %{name}(cgroup-hierarchy)
-Requires: (%{_cross_os}image-feature(unified-cgroup-hierarchy) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-unified-cgroup-hierarchy) or %{name}-hybrid-cgroup-hierarchy)
-
-%description unified-cgroup-hierarchy
 %{summary}.
 
 %prep
@@ -227,7 +204,7 @@ CONFIGURE_OPTS=(
  -Dpkgconfigdatadir='%{_cross_pkgconfigdir}'
  -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
 
- -Ddefault-hierarchy=hybrid
+ -Ddefault-hierarchy=unified
 
  -Dadm-group=false
  -Dwheel-group=false
@@ -339,9 +316,6 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
 # Add art to the console
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/issue
-
-install -d %{buildroot}%{_cross_bootconfigdir}
-install -p -m 0644 %{S:7} %{buildroot}%{_cross_bootconfigdir}/10-unified-cgroup-hierarchy.conf
 
 %files
 %license LICENSE.GPL2 LICENSE.LGPL2.1
@@ -530,10 +504,5 @@ install -p -m 0644 %{S:7} %{buildroot}%{_cross_bootconfigdir}/10-unified-cgroup-
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf
-
-%files hybrid-cgroup-hierarchy
-
-%files unified-cgroup-hierarchy
-%{_cross_bootconfigdir}/10-unified-cgroup-hierarchy.conf
 
 %changelog

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -9,7 +9,6 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 xfs-data-partition = true
 uefi-secure-boot = true
 systemd-networkd = true

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -14,6 +14,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 included-packages = [

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -11,6 +11,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 included-packages = [

--- a/variants/aws-ecs-2-nvidia/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia/Cargo.toml
@@ -7,7 +7,6 @@ build = "../build.rs"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/aws-ecs-2/Cargo.toml
+++ b/variants/aws-ecs-2/Cargo.toml
@@ -9,7 +9,6 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/aws-k8s-1.23-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.23-nvidia/Cargo.toml
@@ -32,6 +32,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 

--- a/variants/aws-k8s-1.23/Cargo.toml
+++ b/variants/aws-k8s-1.23/Cargo.toml
@@ -26,6 +26,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 

--- a/variants/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.24-nvidia/Cargo.toml
@@ -32,6 +32,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 

--- a/variants/aws-k8s-1.24/Cargo.toml
+++ b/variants/aws-k8s-1.24/Cargo.toml
@@ -26,6 +26,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 

--- a/variants/aws-k8s-1.25-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.25-nvidia/Cargo.toml
@@ -32,6 +32,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 

--- a/variants/aws-k8s-1.25/Cargo.toml
+++ b/variants/aws-k8s-1.25/Cargo.toml
@@ -26,6 +26,7 @@ kernel-parameters = [
     "console=ttyS0,115200n8",
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "systemd.unified_cgroup_hierarchy=0",
     "quiet",
 ]
 

--- a/variants/aws-k8s-1.26-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.26-nvidia/Cargo.toml
@@ -14,7 +14,6 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.26/Cargo.toml
+++ b/variants/aws-k8s-1.26/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.27-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.27-nvidia/Cargo.toml
@@ -14,7 +14,6 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.27/Cargo.toml
+++ b/variants/aws-k8s-1.27/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 included-packages = [

--- a/variants/aws-k8s-1.28-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.28-nvidia/Cargo.toml
@@ -14,7 +14,6 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/aws-k8s-1.28/Cargo.toml
+++ b/variants/aws-k8s-1.28/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/aws-k8s-1.29-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.29-nvidia/Cargo.toml
@@ -14,7 +14,6 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/aws-k8s-1.29/Cargo.toml
+++ b/variants/aws-k8s-1.29/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/aws-k8s-1.30-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia/Cargo.toml
@@ -14,7 +14,6 @@ os-image-size-gib = 4
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/aws-k8s-1.30/Cargo.toml
+++ b/variants/aws-k8s-1.30/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["README.md"]
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -12,7 +12,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 xfs-data-partition = true
 uefi-secure-boot = true
 systemd-networkd = true

--- a/variants/metal-k8s-1.26/Cargo.toml
+++ b/variants/metal-k8s-1.26/Cargo.toml
@@ -15,7 +15,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/metal-k8s-1.27/Cargo.toml
+++ b/variants/metal-k8s-1.27/Cargo.toml
@@ -15,7 +15,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/metal-k8s-1.28/Cargo.toml
+++ b/variants/metal-k8s-1.28/Cargo.toml
@@ -15,7 +15,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/metal-k8s-1.29/Cargo.toml
+++ b/variants/metal-k8s-1.29/Cargo.toml
@@ -15,7 +15,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -12,7 +12,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 xfs-data-partition = true
 uefi-secure-boot = true
 systemd-networkd = true

--- a/variants/vmware-k8s-1.26/Cargo.toml
+++ b/variants/vmware-k8s-1.26/Cargo.toml
@@ -14,7 +14,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"

--- a/variants/vmware-k8s-1.27/Cargo.toml
+++ b/variants/vmware-k8s-1.27/Cargo.toml
@@ -14,7 +14,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 
 [package.metadata.build-variant]
 image-format = "vmdk"

--- a/variants/vmware-k8s-1.28/Cargo.toml
+++ b/variants/vmware-k8s-1.28/Cargo.toml
@@ -14,7 +14,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/vmware-k8s-1.29/Cargo.toml
+++ b/variants/vmware-k8s-1.29/Cargo.toml
@@ -14,7 +14,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true

--- a/variants/vmware-k8s-1.30/Cargo.toml
+++ b/variants/vmware-k8s-1.30/Cargo.toml
@@ -14,7 +14,6 @@ partition-plan = "unified"
 
 [package.metadata.build-variant.image-features]
 grub-set-private-var = true
-unified-cgroup-hierarchy = true
 uefi-secure-boot = true
 xfs-data-partition = true
 systemd-networkd = true


### PR DESCRIPTION
**Issue number:**

Closes #3909

**Description of changes:**
Build systemd with the unified hierarchy by default. Drop the `unified-cgroup-hierarchy` image feature flag from newer variants, since it's no longer used by anything, and add `systemd.unified_cgroup_hierarchy=0` to older variants.


**Testing done:**
Verified that `aws-ecs-2` uses the unified hierarchy by default, and can be switched back to the hybrid hierarchy:
```
# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "d9b580a5a",
    "pretty_name": "Bottlerocket OS 1.20.0 (aws-ecs-2)",
    "variant_id": "aws-ecs-2",
    "version_id": "1.20.0"
  }
}

# findmnt -o FSTYPE /sys/fs/cgroup
FSTYPE
cgroup2

# journalctl|grep tainted
<no output>

# apiclient apply <<EOF
[settings.boot.init-parameters]
"systemd.unified_cgroup_hierarchy" = ["0"]
EOF

# apiclient reboot

# findmnt -o FSTYPE /sys/fs/cgroup
FSTYPE
tmpfs

# journalctl|grep tainted
May 01 23:34:31 localhost systemd[1]: System is tainted: cgroupsv1
```

Verified that `aws-k8s-1.25` uses the hybrid hierarchy by default, and can be switched to the unified hierarchy:
```
# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "d9b580a5a",
    "pretty_name": "Bottlerocket OS 1.20.0 (aws-k8s-1.25)",
    "variant_id": "aws-k8s-1.25",
    "version_id": "1.20.0"
  }
}

# findmnt -o FSTYPE /sys/fs/cgroup
FSTYPE
tmpfs

# journalctl|grep tainted
May 01 23:22:57 localhost systemd[1]: System is tainted: cgroupsv1

# apiclient apply <<EOF
[settings.boot.init-parameters]
"systemd.unified_cgroup_hierarchy" = ["1"]
EOF

# apiclient reboot

# findmnt -o FSTYPE /sys/fs/cgroup
FSTYPE
cgroup2
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
