### PR TITLE
Add kubernetes 1.30 sources

### DIFF
--- a/packages/ecr-credential-provider-1.30/Cargo.toml
+++ b/packages/ecr-credential-provider-1.30/Cargo.toml
@@ -15,10 +15,9 @@ package-name = "ecr-credential-provider-1.30"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-# TODO: update to 1.30 release once available
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.29.0"
-path = "cloud-provider-aws-1.29.0.tar.gz" 
-sha512 = "30b08ca55d182de4b2289f58acf0af4476cbeff74ea2668d7e9d4c53e2fdbb38016d7cf434a55bba895230255a699233d4484333b5b516c16acb0515df514876"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.0"
+path = "cloud-provider-aws-1.30.0.tar.gz"
+sha512 = "d9b9c63f2f2b6d9e910650464acc5000ba0cc2e35d0f5f27c4121c5e3cd539682a4b89f80358a5fb2a4c8409e2d82a66c5409e9895c58546c78bbb78b39d96be"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -2,8 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.0
-# %%global gover 1.30.0
+%global gover 1.30.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -49,6 +48,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 %build
 %set_cross_go_flags
+
+export GO_VERSION="1.22.2"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -15,8 +15,8 @@ package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
 # TODO: update this URL to 1.30 release once available. 
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/7/artifacts/kubernetes/v1.29.1/kubernetes-src.tar.gz"
-sha512 = "9940027197f83702516775047664d3c30a83e69202dcca5aa89f320e78c27a930eb1373777277f240b3c5a63c351ccab3199c577424e760fe122692065895e2f"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/3/artifacts/kubernetes/v1.30.0/kubernetes-src.tar.gz"
+sha512 = "2becf971b5ebbc6752509bc04659b036c4fe99e1638a336436555d6403247094b69ab3bde2187391606de59e3a5b23acfce01a2d3c7f4e4b7516025e2812333c"
 
 # RPM BuildRequires
 [build-dependencies]
@@ -25,7 +25,7 @@ glibc = { path = "../glibc" }
 # RPM Requires
 [dependencies]
 aws-signing-helper = { path = "../aws-signing-helper" }
-ecr-credential-provider-1_29 = { path = "../ecr-credential-provider-1.29" }
+ecr-credential-provider-1_30 = { path = "../ecr-credential-provider-1.30" }
 static-pods = { path = "../static-pods" }
 # `conntrack-tools`, `containerd` and `findutils` are only needed at runtime,
 # and are pulled in by `release`.

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,8 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.1
-# %%global gover 1.30.0
+%global gover 1.30.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -33,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/7/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config
@@ -69,8 +68,7 @@ Summary: Container cluster node agent
 Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}findutils
-# TODO: update to ecr-credential-provider-1.30
-Requires: %{_cross_os}ecr-credential-provider-1.29
+Requires: %{_cross_os}ecr-credential-provider-1.30
 Requires: %{_cross_os}aws-signing-helper
 Requires: %{_cross_os}static-pods
 Requires: %{_cross_os}kubelet-1.30(binaries)
@@ -108,6 +106,9 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+
+export GO_VERSION="1.22.2"
+
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -465,6 +465,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecr-credential-provider-1_30"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "ecs-agent"
 version = "0.1.0"
 dependencies = [
@@ -694,7 +701,7 @@ name = "kubernetes-1_30"
 version = "0.1.0"
 dependencies = [
  "aws-signing-helper",
- "ecr-credential-provider-1_29",
+ "ecr-credential-provider-1_30",
  "glibc",
  "static-pods",
 ]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
This updates boilerplate for k8s 1.30 packages and variants to use upstream releases of 1.30 sources.

**Testing done:**
- [x] aarch64 IPv4 conformance tests
- [x] aarch64 IPv6 conformance tests
- [x] aarch64 NVIDIA conformance tests
- [x] aarch64 NVIDIA smoke tests
- [x] x86_64 IPv4 conformance tests
- [x] x86_64 IPv6 conformance tests
- [x] x86_64 NVIDIA conformance tests
- [x] x86_64 NVIDIA smoke tests

```
 NAME                                                            TYPE                        STATE                                         PASSED                    FAILED                    SKIPPED   BUILD ID                    LAST UPDATE
 aarch64-aws-k8s-130-conformance-test                            Test                        passed                                           406                         0                       6795                               2024-05-03T20:08:18Z
 aarch64-aws-k8s-130-nvidia-conformance-test                     Test                        passed                                           406                         0                       6795                               2024-05-03T20:22:29Z
 aarch64-aws-k8s-130-nvidia-nvidia-smoke-test                    Test                        passed                                             1                         0                          0                               2024-05-03T18:27:26Z
 x86-64-aws-k8s-130-conformance-test                             Test                        passed                                           406                         0                       6795                               2024-05-03T20:07:52Z
 x86-64-aws-k8s-130-nvidia-conformance-test                      Test                        passed                                           406                         0                       6795                               2024-05-03T20:13:33Z
 x86-64-aws-k8s-130-nvidia-nvidia-smoke-test                     Test                        passed                                             1                         0                          0                               2024-05-03T18:27:45Z
 aarch64-aws-k8s-130-ipv6-conformance-test                     Test                         passed                                            406                         0                       6795                               2024-05-03T22:45:47Z
 x86-64-aws-k8s-130-ipv6-conformance-test                      Test                         passed                                            406                         0                       6795                               2024-05-03T22:45:13Z
```

-  [x] vmware conformance test

This failure is expected error from Cilium, the EKA-A CNI provider. Seee EKS Anywhere docs: https://anywhere.eks.amazonaws.com/docs/whatsnew/changelog/#:~:text=EKS%20Anywhere%20release,it%20is%20available.

```
sonobuoy results 202405030051_sonobuoy_b5e8692e-9ed0-4322-ab0d-c5b61f938b4e.tar.gz
Plugin: e2e
Status: failed
Total: 7201
Passed: 405
Failed: 1
Skipped: 6795

Failed tests:
 [sig-network] Services should serve endpoints on same port and different protocols [Conformance]

Run Details:
API Server version: v1.30.0-eks-fff26e3
```

-  [x] EBS driver testing
```
 kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
NAME                                  READY   STATUS    RESTARTS   AGE
ebs-csi-controller-74b476c56f-m4bqv   6/6     Running   0          30s
ebs-csi-controller-74b476c56f-sn8gc   6/6     Running   0          30s
ebs-csi-node-2c5gd                    3/3     Running   0          30s
ebs-csi-node-2qqt7                    3/3     Running   0          30s
```

- [x] cloud-provider-credential test
Following the instruction https://github.com/bottlerocket-os/bottlerocket/pull/3329#issuecomment-1667895484 with modification to apply settings in sequence rather than in one batch `apiclient apply`:

```
apiclient apply <<EOF
[settings.kubernetes.credential-providers.ecr-credential-provider]
enabled = true
cache-duration = "30m"
image-patterns = [
  "*.dkr.ecr.us-east-2.amazonaws.com",
  "*.dkr.ecr.us-west-2.amazonaws.com"
]
EOF
```
followed by
```
apiclient set settings.aws.config="<base64 encoded credentials>"

```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
