### PR TITLE
netdog: fix build warning from unnecessary scope change

### DIFF
--- a/sources/netdog/src/networkd/config/netdev.rs
+++ b/sources/netdog/src/networkd/config/netdev.rs
@@ -142,7 +142,7 @@ impl Display for NetDevMacAddress {
 }
 
 impl NetDevConfig {
-    const FILE_EXT: &'static str = "netdev";
+    const FILE_EXT: &str = "netdev";
 
     /// Write the config to the proper directory with the proper prefix and file extention
     pub(crate) fn write_config_file<P: AsRef<Path>>(&self, config_dir: P) -> Result<()> {

--- a/sources/netdog/src/networkd/config/network.rs
+++ b/sources/netdog/src/networkd/config/network.rs
@@ -208,7 +208,7 @@ impl Display for KeepConfiguration {
 }
 
 impl NetworkConfig {
-    const FILE_EXT: &'static str = "network";
+    const FILE_EXT: &str = "network";
 
     fn new_with_name(name: InterfaceName) -> Self {
         Self {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Quick fix for a build warning. This was falsely done and slipped through. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
