### PR TITLE
settings: Add container-runtime settings to AWS K8s NVIDIA variants

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -305,4 +305,6 @@ version = "1.20.0"
     "migrate_v1.20.0_add-ntp-default-options-v0-1-0.lz4",
     "migrate_v1.20.0_static-pods-add-prefix-v0-1-0.lz4",
     "migrate_v1.20.0_static-pods-services-cfg-v0-1-0.lz4",
+    "migrate_v1.20.0_container-runtime-nvidia.lz4",
+    "migrate_v1.20.0_container-runtime-metadata-nvidia.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1405,6 +1405,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "container-runtime-metadata-nvidia"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
+name = "container-runtime-nvidia"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -84,6 +84,8 @@ members = [
     "api/migration/migrations/v1.19.5/public-control-container-v0-7-11",
     "api/migration/migrations/v1.19.5/aws-admin-container-v0-11-7",
     "api/migration/migrations/v1.19.5/public-admin-container-v0-11-7",
+    "api/migration/migrations/v1.20.0/container-runtime-nvidia",
+    "api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "container-runtime-metadata-nvidia"
+version = "0.1.0"
+edition = "2021"
+authors = ["Matthew Yeazel <yeazelm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia/build.rs
+++ b/sources/api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia/src/main.rs
@@ -1,0 +1,26 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, NoOpMigration, SettingMetadata};
+use migration_helpers::migrate;
+use migration_helpers::Result;
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    if cfg!(variant_family = "aws-k8s") && cfg!(variant_flavor = "nvidia") {
+        migrate(AddMetadataMigration(&[SettingMetadata {
+            metadata: &["affected-services"],
+            setting: "settings.container-runtime",
+        }]))
+    } else {
+        migrate(NoOpMigration)
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.20.0/container-runtime-nvidia/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/container-runtime-nvidia/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "container-runtime-nvidia"
+version = "0.1.0"
+edition = "2021"
+authors = ["Matthew Yeazel <yeazelm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.20.0/container-runtime-nvidia/build.rs
+++ b/sources/api/migration/migrations/v1.20.0/container-runtime-nvidia/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.20.0/container-runtime-nvidia/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/container-runtime-nvidia/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    if cfg!(variant_family = "aws-k8s") && cfg!(variant_flavor = "nvidia") {
+        migrate(AddPrefixesMigration(vec!["settings.container-runtime"]))
+    } else {
+        migrate(NoOpMigration)
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -29,5 +29,6 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -29,5 +29,6 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -29,5 +29,6 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    HostContainer, KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
-    PemCertificate,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
+    NetworkSettings, OciDefaults, OciHooks, PemCertificate,
 };
 use modeled_types::Identifier;
 
@@ -29,5 +29,6 @@ struct Settings {
     oci_hooks: OciHooks,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
+    container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }


### PR DESCRIPTION

**Description of changes:**
The settings were originally added for 1.10.1 but nvidia flavors were excluded. This adds those in for those variants and creates migrations for them.

**Testing done:**
Tested by building 1.19.5 and doing upgrade testing for both `aws-k8s-1.28` and `aws-k8s-1.28-nvidia`.
Confirmed for `aws-k8s-1.28`
[x] Settings apply fine on 1.19.5
[x] Settings are untouched on upgrade to 1.20.0
[x] Settings are untouched on downgrade to 1.19.5 
Confirmed for `aws-k8s-1.28-nvidia`
[x] Settings don't work on 1.19.5
[x] Upgrade to 1.20.0 allows settings the settings
[x] Downgrade removes the settings
[x] Confirmed the setting makes it into `/etc/containerd/config.yaml`

After running `apiclient set settings.container-runtime.max-concurrent-downloads=4` on upgraded node:
```
[root@admin]# sheltie
bash-5.1# cat /etc/containerd/
config.toml    cri-base.json  nvidia.env
bash-5.1# cat /etc/containerd/config.toml
version = 2
root = "/var/lib/containerd"
state = "/run/containerd"
disabled_plugins = [
    "io.containerd.internal.v1.opt",
    "io.containerd.snapshotter.v1.aufs",
    "io.containerd.snapshotter.v1.devmapper",
    "io.containerd.snapshotter.v1.native",
    "io.containerd.snapshotter.v1.zfs",
]

[grpc]
address = "/run/containerd/containerd.sock"

[plugins."io.containerd.grpc.v1.cri"]
enable_selinux = true
# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
sandbox_image = "XXXXXXX.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.1-eksbuild.1"
max_concurrent_downloads = 4

[plugins."io.containerd.grpc.v1.cri".containerd]
default_runtime_name = "nvidia"

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
runtime_type = "io.containerd.runc.v2"
base_runtime_spec = "/etc/containerd/cri-base.json"

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
SystemdCgroup = true
BinaryName = "nvidia-oci"

[plugins."io.containerd.grpc.v1.cri".cni]
bin_dir = "/opt/cni/bin"
conf_dir = "/etc/cni/net.d"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
