### PR TITLE
logdog: switch to use apiclient cli to get settings

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2584,14 +2584,9 @@ dependencies = [
 name = "logdog"
 version = "0.1.0"
 dependencies = [
- "apiclient",
- "bottlerocket-variant",
- "constants",
- "datastore",
  "flate2",
  "generate-readme",
  "glob",
- "models",
  "reqwest",
  "serde_json",
  "shell-words",

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -9,12 +9,8 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../api/apiclient", version = "0.1" }
-constants = { path = "../constants", version = "0.1" }
-datastore = { path = "../api/datastore", version = "0.1" }
 flate2 = "1"
 glob = "0.3"
-models = { path = "../models", version = "0.1" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 serde_json = "1"
 shell-words = "1"
@@ -26,5 +22,4 @@ url = "2"
 walkdir = "2"
 
 [build-dependencies]
-bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }
 generate-readme = { version = "0.1", path = "../generate-readme" }


### PR DESCRIPTION
**Issue number:** 3784

Closes #3784

**Description of changes:**

* Adjusted logdog to get settings via cli apiclient get
* Changed shape to be managed with serde_json::Value
* Used a normalize, denormalize methodology to flatten the object to maintain stripping of secrets

**Testing done:**

* Tested and launched, validated that all secrets were removed after generating bottlerocket-logs.tar.gz


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
