### PR TITLE
Update the host containers for 1.20.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -307,4 +307,6 @@ version = "1.20.0"
     "migrate_v1.20.0_static-pods-services-cfg-v0-1-0.lz4",
     "migrate_v1.20.0_container-runtime-nvidia.lz4",
     "migrate_v1.20.0_container-runtime-metadata-nvidia.lz4",
+    "migrate_v1.20.0_aws-admin-container-v0-11-8.lz4",
+    "migrate_v1.20.0_public-admin-container-v0-11-8.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -309,4 +309,6 @@ version = "1.20.0"
     "migrate_v1.20.0_container-runtime-metadata-nvidia.lz4",
     "migrate_v1.20.0_aws-admin-container-v0-11-8.lz4",
     "migrate_v1.20.0_public-admin-container-v0-11-8.lz4",
+    "migrate_v1.20.0_aws-control-container-v0-7-12.lz4",
+    "migrate_v1.20.0_public-control-container-v0-7-12.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -634,6 +634,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-12"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-control-container-v0-7-4"
 version = "0.1.0"
 dependencies = [
@@ -3350,6 +3357,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-11"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-12"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -583,6 +583,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-8"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-config"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3329,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-7"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-8"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -88,6 +88,8 @@ members = [
     "api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia",
     "api/migration/migrations/v1.20.0/aws-admin-container-v0-11-8",
     "api/migration/migrations/v1.20.0/public-admin-container-v0-11-8",
+    "api/migration/migrations/v1.20.0/aws-control-container-v0-7-12",
+    "api/migration/migrations/v1.20.0/public-control-container-v0-7-12",
 
     "bloodhound",
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -86,6 +86,8 @@ members = [
     "api/migration/migrations/v1.19.5/public-admin-container-v0-11-7",
     "api/migration/migrations/v1.20.0/container-runtime-nvidia",
     "api/migration/migrations/v1.20.0/container-runtime-metadata-nvidia",
+    "api/migration/migrations/v1.20.0/aws-admin-container-v0-11-8",
+    "api/migration/migrations/v1.20.0/public-admin-container-v0-11-8",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.20.0/aws-admin-container-v0-11-8/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/aws-admin-container-v0-11-8/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aws-admin-container-v0-11-8"
+version = "0.1.0"
+authors = ["Kyle Sessions <kssessio@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+

--- a/sources/api/migration/migrations/v1.20.0/aws-admin-container-v0-11-8/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/aws-admin-container-v0-11-8/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.7'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.8'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.20.0/aws-control-container-v0-7-12/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/aws-control-container-v0-7-12/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aws-control-container-v0-7-12"
+version = "0.1.0"
+authors = ["Kyle Sessions <kssessio@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+

--- a/sources/api/migration/migrations/v1.20.0/aws-control-container-v0-7-12/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/aws-control-container-v0-7-12/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.11'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.12'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.20.0/public-admin-container-v0-11-8/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/public-admin-container-v0-11-8/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "public-admin-container-v0-11-8"
+version = "0.1.0"
+authors = ["Kyle Sessions <kssessio@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+

--- a/sources/api/migration/migrations/v1.20.0/public-admin-container-v0-11-8/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/public-admin-container-v0-11-8/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.7";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.8";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.20.0/public-control-container-v0-7-12/Cargo.toml
+++ b/sources/api/migration/migrations/v1.20.0/public-control-container-v0-7-12/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "public-control-container-v0-7-12"
+version = "0.1.0"
+authors = ["Kyle Sessions <kssessio@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+

--- a/sources/api/migration/migrations/v1.20.0/public-control-container-v0-7-12/src/main.rs
+++ b/sources/api/migration/migrations/v1.20.0/public-control-container-v0-7-12/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.11";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.12";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.11'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.12'"

--- a/sources/models/shared-defaults/aws-host-containers.toml
+++ b/sources/models/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.7'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.8'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.7"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.8"
 
 [settings.host-containers.control]
 enabled = false

--- a/sources/models/shared-defaults/public-host-containers.toml
+++ b/sources/models/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.8"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.11"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.12"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Closes #3950 

Update the admin and control host containers to bottlerocket-admin-container v0.11.8 and bottlerocket-control-container v0.7.12. Also add migrations move to these versions on upgrade.


**Testing done:**
Using an EC2 instance with the aws-k8s-1.29 variant, I successfully tested the following scenarios:
- [x] - Bottlerocket v1.19.5 can be upgraded into Bottlerocket v1.20.0 and uses the new host container images.
```
After upgrade: 
bash-5.1# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.8",
        "superpowered": true,
        "user-data": "<removed>"
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.12",
        "superpowered": false
      }
    }
  }
}

bash-5.1# cat /var/lib/bottlerocket/datastore/current/live/os/pretty_name
"Bottlerocket OS 1.20.0 (aws-k8s-1.29)"
```
- [x] - A system upgraded from 1.20.0 can be rolled back to Bottlerocket v1.19.5 and revert to using the old host container images.
```
After Rollback: 
[ec2-user@admin]$ apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.7",
        "superpowered": true,
        "user-data": "<removed>"
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.11",
        "superpowered": false
      }
    }
  }
}
bash-5.1# cat /var/lib/bottlerocket/datastore/current/live/os/pretty_name
"Bottlerocket OS 1.19.5 (aws-k8s-1.29)
```
- [x] - A new Bottlerocket v1.20.0 image uses the new host container images.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
