### PR TITLE
Enable low-jitter kernel options for kernel-6.1

### DIFF
--- a/packages/kernel-6.1/config-bottlerocket
+++ b/packages/kernel-6.1/config-bottlerocket
@@ -352,3 +352,7 @@ CONFIG_QLCNIC_SRIOV=y
 # Cisco UCS HBA support
 CONFIG_FCOE_FNIC=m
 CONFIG_SCSI_SNIC=m
+
+# Enable support for adaptive-tick low-jitter configurations
+CONFIG_RCU_NOCB_CPU=y
+CONFIG_NO_HZ_FULL=y


### PR DESCRIPTION
**Issue number:**

From private discussions.

**Description of changes:**

Enabling a selection of Kernel build-options to allow users to select various low-latency and low-jitter behaviours from the kernel.

These kernel options are fairly typical, you'll find them in Redhat and Ubuntu distro kernels.

None of these options do anything without the user opting into them via kernel parameters - default behaviour for your users will stay the same.

**Testing done:**

Local build and deploy into our AWS accounts, benchmarking using these kernel options.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
