### PR TITLE
settings: add metrics settings extension

### DIFF
--- a/packages/settings-metrics/Cargo.toml
+++ b/packages/settings-metrics/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "settings-metrics"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/metrics"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]
+

--- a/packages/settings-metrics/settings-metrics.spec
+++ b/packages/settings-metrics/settings-metrics.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name metrics
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2820,6 +2820,7 @@ dependencies = [
  "settings-extension-aws",
  "settings-extension-container-registry",
  "settings-extension-kernel",
+ "settings-extension-metrics",
  "settings-extension-motd",
  "settings-extension-ntp",
  "settings-extension-pki",
@@ -3928,6 +3929,18 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kernel"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-metrics"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-settings-sdk",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -131,6 +131,7 @@ members = [
     "settings-extensions/aws",
     "settings-extensions/container-registry",
     "settings-extensions/kernel",
+    "settings-extensions/metrics",
     "settings-extensions/motd",
     "settings-extensions/ntp",
     "settings-extensions/pki",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.8"
 settings-extension-aws = { path = "../settings-extensions/aws", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
+settings-extension-metrics = { path = "../settings-extensions/metrics", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
 settings-extension-pki = { path = "../settings-extensions/pki", version = "0.1" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    MetricsSettings, NetworkSettings, OciHooks,
+    NetworkSettings, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +20,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: OciHooks,

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    HostContainer, NetworkSettings, OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +20,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    HostContainer, NetworkSettings, OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +20,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    ECSSettings, HostContainer, NetworkSettings, OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    ECSSettings, HostContainer, NetworkSettings, OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
     ecs: ECSSettings,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/aws-k8s-1.30/mod.rs
+++ b/sources/models/src/aws-k8s-1.30/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, MetricsSettings,
-    NetworkSettings, OciDefaults, OciHooks,
+    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
+    OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -22,7 +22,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -2,8 +2,7 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
-    OciHooks,
+    BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +18,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: OciHooks,

--- a/sources/models/src/metal-k8s-1.29/mod.rs
+++ b/sources/models/src/metal-k8s-1.29/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    KubernetesSettings, NetworkSettings, OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -2,8 +2,7 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, MetricsSettings, NetworkSettings,
-    OciHooks,
+    BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -19,7 +18,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: OciHooks,

--- a/sources/models/src/vmware-k8s-1.30/mod.rs
+++ b/sources/models/src/vmware-k8s-1.30/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, MetricsSettings, NetworkSettings, OciDefaults, OciHooks,
+    KubernetesSettings, NetworkSettings, OciDefaults, OciHooks,
 };
 use modeled_types::Identifier;
 
@@ -21,7 +21,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: settings_extension_aws::AwsSettingsV1,
     boot: BootSettings,
-    metrics: MetricsSettings,
+    metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,

--- a/sources/settings-extensions/metrics/Cargo.toml
+++ b/sources/settings-extensions/metrics/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-metrics"
+version = "0.1.0"
+authors = ["Sumukh Ballal <sballal@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/metrics/metrics.toml
+++ b/sources/settings-extensions/metrics/metrics.toml
@@ -1,0 +1,14 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]
+

--- a/sources/settings-extensions/metrics/src/lib.rs
+++ b/sources/settings-extensions/metrics/src/lib.rs
@@ -1,0 +1,80 @@
+/// The aws settings can be used to configure settings related to AWS
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::Url;
+use std::convert::Infallible;
+
+// Platform-specific settings
+#[model(impl_default = true)]
+pub struct MetricsSettingsV1 {
+    metrics_url: Url,
+    send_metrics: bool,
+    service_checks: Vec<String>,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for MetricsSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // allow anything that parses as MetricsSettingsV1
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_metrics() {
+        let generated = MetricsSettingsV1::generate(None, None).unwrap();
+        assert_eq!(
+            generated,
+            GenerateResult::Complete(MetricsSettingsV1 {
+                metrics_url: None,
+                send_metrics: None,
+                service_checks: None,
+            })
+        )
+    }
+
+    #[test]
+    fn test_serde_metrics() {
+        let test_json = r#"{"metrics-url":"https://metrics.bottlerocket.aws/v1/metrics","send-metrics":true,"service-checks":["apiserver","chronyd"]}"#;
+
+        let metrics: MetricsSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            metrics,
+            MetricsSettingsV1 {
+                metrics_url: Some(
+                    Url::try_from("https://metrics.bottlerocket.aws/v1/metrics").unwrap()
+                ),
+                send_metrics: Some(true),
+                service_checks: Some(vec![String::from("apiserver"), String::from("chronyd")])
+            }
+        );
+
+        let results = serde_json::to_string(&metrics).unwrap();
+        assert_eq!(results, test_json);
+    }
+}

--- a/sources/settings-extensions/metrics/src/main.rs
+++ b/sources/settings-extensions/metrics/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_metrics::MetricsSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("metrics")
+        .with_models(vec![BottlerocketSetting::<MetricsSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3656

**Description of changes:**

Creates a metrics settings extension and uses it in every variant's settings model.

**Testing done:**

Built an aws-ecs-1 variant with the settings-metrics package installed. Called apiclient to verify that the aws settings worked as before. Also called the settings extension to verify that it was behaving as expected.

```
$ apiclient get settings.metrics
{
  "settings": {
    "metrics": {
      "metrics-url": "https://metrics.bottlerocket.aws/v1/metrics",
      "send-metrics": true,
      "service-checks": [
        "apiserver",
        "chronyd",
        "containerd",
        "host-containerd",
        "docker",
        "ecs"
      ]
    }
  }
}
```

Setting the URL: Happy case

```
[ssm-user@control]$ apiclient set settings.metrics.metrics-url="https://metrics.bottlerocket.aws/v2/metrics-test"
[ssm-user@control]$ apiclient get settings.metrics.metrics-url
{
  "settings": {
    "metrics": {
      "metrics-url": "https://metrics.bottlerocket.aws/v2/metrics-test"
    }
  }
}
```

Setting the service-checks

```
[ssm-user@control]$ apiclient set --json '{"settings": {"metrics": { "service-checks": ["test", "test2"]}}}'
[ssm-user@control]$
[ssm-user@control]$
[ssm-user@control]$ apiclient get settings.metrics.service-checks
{
  "settings": {
    "metrics": {
      "service-checks": [
        "test",
        "test2"
      ]
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
