### PR TITLE
Enable k8s reserved cpus

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -319,4 +319,5 @@ version = "1.21.0"
     "migrate_v1.21.0_pod-infra-container-image-remove-settings-generator.lz4",
     "migrate_v1.21.0_pod-infra-container-image-affected-services.lz4",
     "migrate_v1.21.0_pod-infra-container-image-services.lz4",
+    "migrate_v1.21.0_k8s-reserved-cpus-v0-1-0.lz4",
 ]

--- a/packages/kubernetes-1.23/kubelet-config
+++ b/packages/kubernetes-1.23/kubelet-config
@@ -87,13 +87,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -181,4 +185,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -87,13 +87,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -180,4 +184,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -87,13 +87,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -181,4 +185,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -87,13 +87,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -181,4 +185,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -91,13 +91,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -182,4 +186,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -91,13 +91,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -180,4 +184,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -91,13 +91,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -180,4 +184,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -91,13 +91,17 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
+{{/unless}}
 {{#if settings.kubernetes.system-reserved}}
 systemReserved:
   {{#each settings.kubernetes.system-reserved}}
   {{@key}}: "{{this}}"
   {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
 systemReservedCgroup: "/system"
+{{/unless}}
 {{/if}}
 cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
 cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
@@ -180,4 +184,7 @@ reservedMemory:
 {{/if}}
 {{/each}}
 {{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2392,6 +2392,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-reserved-cpus-v0-1-0"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "api/migration/migrations/v1.21.0/pod-infra-container-image-affected-services",
     "api/migration/migrations/v1.21.0/pod-infra-container-image-remove-settings-generator",
     "api/migration/migrations/v1.21.0/pod-infra-container-image-services",
+    "api/migration/migrations/v1.21.0/k8s-reserved-cpus-v0-1-0",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.21.0/k8s-reserved-cpus-v0-1-0/Cargo.toml
+++ b/sources/api/migration/migrations/v1.21.0/k8s-reserved-cpus-v0-1-0/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "k8s-reserved-cpus-v0-1-0"
+version = "0.1.0"
+authors = ["James Masson <james.masson@weareadaptive.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0" }

--- a/sources/api/migration/migrations/v1.21.0/k8s-reserved-cpus-v0-1-0/src/main.rs
+++ b/sources/api/migration/migrations/v1.21.0/k8s-reserved-cpus-v0-1-0/src/main.rs
@@ -1,0 +1,18 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// Add the option to set Kubernetes reserved-cpus
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&["settings.kubernetes.reserved-cpus"]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/modeled-types/src/lib.rs
+++ b/sources/models/modeled-types/src/lib.rs
@@ -150,6 +150,9 @@ pub mod error {
             input: String,
             source: std::num::ParseIntError,
         },
+
+        #[snafu(display("Invalid Kernel CpuSet value '{}'", input))]
+        InvalidKernelCpuSetValue { input: String },
     }
 
     /// Creates a `ValidationError` with a consistent message for strings with regex validations

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -48,13 +48,13 @@ use std::net::IpAddr;
 use crate::de::{deserialize_limit, deserialize_mirrors, deserialize_node_taints};
 use modeled_types::{
     BootConfigKey, BootConfigValue, BootstrapContainerMode, CpuManagerPolicy, CredentialProvider,
-    DNSDomain, EtcHostsEntries, Identifier, IntegerPercent, KubernetesAuthenticationMode,
-    KubernetesBootstrapToken, KubernetesCloudProvider, KubernetesClusterDnsIp,
-    KubernetesClusterName, KubernetesDurationValue, KubernetesLabelKey, KubernetesLabelValue,
-    KubernetesQuantityValue, KubernetesReservedResourceKey, KubernetesTaintValue,
-    KubernetesThresholdValue, OciDefaultsCapability, OciDefaultsResourceLimitType,
-    PemCertificateString, SingleLineString, TopologyManagerPolicy, TopologyManagerScope, Url,
-    ValidBase64, ValidLinuxHostname,
+    DNSDomain, EtcHostsEntries, Identifier, IntegerPercent, KernelCpuSetValue,
+    KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesCloudProvider,
+    KubernetesClusterDnsIp, KubernetesClusterName, KubernetesDurationValue, KubernetesLabelKey,
+    KubernetesLabelValue, KubernetesQuantityValue, KubernetesReservedResourceKey,
+    KubernetesTaintValue, KubernetesThresholdValue, OciDefaultsCapability,
+    OciDefaultsResourceLimitType, PemCertificateString, SingleLineString, TopologyManagerPolicy,
+    TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -137,6 +137,7 @@ struct KubernetesSettings {
     shutdown_grace_period_for_critical_pods: KubernetesDurationValue,
     memory_manager_reserved_memory: HashMap<Identifier, KubernetesMemoryReservation>,
     memory_manager_policy: KubernetesMemoryManagerPolicy,
+    reserved_cpus: KernelCpuSetValue,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.


### PR DESCRIPTION
**Issue number:**

As per discussions with @yeazelm 

**Description of changes:**

Adds support for K8s reserved-cpus functionality

https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list


**Testing done:**

~~Warning - not functional.~~

~~Seems I've added a new package to Cargo for the migrations, but can't figure out how to only update the Cargo.lock with only my package changes.~~

Local build, unit-test, deployed AMI using new config.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
