### PR TITLE
kernel-6.1: update to 6.1.90

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/1abc503d6f7da124bf9e7c306ab8119b4b85c9207c943fb2c5a617d0d1716362/kernel-6.1.87-99.174.amzn2023.src.rpm"
-sha512 = "2aaab825ca6bed61366fcdbc67d954191190a6010a9b083c824c9adeeb308000fa7af5b867b450d4bf5c6a9be4234e909ae5210a7157af5e7edcc4ff291a2f61"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/4deb8487627a15345b5963c9825994ff2ec7c42015380406ab8640590242fe7c/kernel-6.1.90-99.173.amzn2023.src.rpm"
+sha512 = "a055bc88f4d99dd8df2b1272eaecdeb2a25e12e0f5a6639eba8c16ce6dcec0d2b2c8371dc87b507058ff232138e5ab5319a9b5b95314111d3fc5c2f25161c3e4"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.87
+Version: 6.1.90
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/1abc503d6f7da124bf9e7c306ab8119b4b85c9207c943fb2c5a617d0d1716362/kernel-6.1.87-99.174.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/4deb8487627a15345b5963c9825994ff2ec7c42015380406ab8640590242fe7c/kernel-6.1.90-99.173.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 6.1.90-99.173.amzn2023.

**Description of changes:**

Update kernels to latest AL kernels available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE     VERSION               INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-82-182.us-east-2.compute.internal   Ready    <none>   3m22s   v1.28.7-eks-c5c5da4   192.168.82.182   3.137.170.173   Bottlerocket OS 1.21.0 (aws-k8s-1.28)   6.1.90           containerd://1.6.31+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
18:39:18             e2e                                         global   complete            Passed:  1, Failed:  0, Remaining:  0
18:39:18    systemd-logs   ip-192-168-82-182.us-east-2.compute.internal   complete                                                 
18:39:18 Sonobuoy plugins have completed. Preparing results for download.
18:39:38             e2e                                         global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
18:39:38    systemd-logs   ip-192-168-82-182.us-east-2.compute.internal   complete   passed                                        
18:39:38 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
==> configs_k61-2024-05-17/config-aarch64-aws-k8s-1.28-diff <==
+CPU_MITIGATIONS y

==> configs_k61-2024-05-17/config-x86_64-aws-k8s-1.28-diff <==
-SPECULATION_MITIGATIONS y
+ARCH_CONFIGURES_CPU_MITIGATIONS y
+CPU_MITIGATIONS y

==> configs_k61-2024-05-17/config-x86_64-metal-k8s-1.28-diff <==
-SPECULATION_MITIGATIONS y
+ARCH_CONFIGURES_CPU_MITIGATIONS y
+CPU_MITIGATIONS y

==> configs_k61-2024-05-17/config-x86_64-vmware-k8s-1.28-diff <==
-SPECULATION_MITIGATIONS y
+ARCH_CONFIGURES_CPU_MITIGATIONS y
+CPU_MITIGATIONS y
```

The full diff-report can be found on [Gist]().

Upstream patch changes dropped one mitigation patch (see the config changes above; the patch was no longer needed) and changed one patch (change function definitions to __head).

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
