### PR TITLE
Add udev rule to create symlinks using EBS volumes' device names

### DIFF
--- a/packages/libnvme/0001-linux-Fix-uninitialized-variables.patch
+++ b/packages/libnvme/0001-linux-Fix-uninitialized-variables.patch
@@ -1,0 +1,40 @@
+From a0803d1d6fb6d899cd22bd7b37ee27859bfdf155 Mon Sep 17 00:00:00 2001
+From: Tomas Bzatek <tbzatek@redhat.com>
+Date: Fri, 3 May 2024 17:19:39 +0200
+Subject: [PATCH] linux: Fix uninitialized variables
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In file included from ../src/nvme/linux.c:40:
+In function ‘freep’,
+    inlined from ‘nvme_get_telemetry_log’ at ../src/nvme/linux.c:169:23:
+../src/nvme/cleanup.h:24:9: warning: ‘log’ may be used uninitialized [-Wmaybe-uninitialized]
+   24 |         free(*(void **)p);
+      |         ^~~~~~~~~~~~~~~~~
+../src/nvme/linux.c: In function ‘nvme_get_telemetry_log’:
+../src/nvme/linux.c:169:30: note: ‘log’ was declared here
+  169 |         _cleanup_free_ void *log;
+      |                              ^~~
+
+Signed-off-by: Tomas Bzatek <tbzatek@redhat.com>
+---
+ src/nvme/linux.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/nvme/linux.c b/src/nvme/linux.c
+index 25196fd5..35976011 100644
+--- a/src/nvme/linux.c
++++ b/src/nvme/linux.c
+@@ -166,7 +166,7 @@ int nvme_get_telemetry_log(int fd, bool create, bool ctrl, bool rae, size_t max_
+ 
+ 	struct nvme_telemetry_log *telem;
+ 	enum nvme_cmd_get_log_lid lid;
+-	_cleanup_free_ void *log;
++	_cleanup_free_ void *log = NULL;
+ 	void *tmp;
+ 	int err;
+ 	size_t dalb;
+-- 
+2.44.0
+

--- a/packages/libnvme/Cargo.toml
+++ b/packages/libnvme/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "libnvme"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/linux-nvme/libnvme/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/linux-nvme/libnvme/archive/v1.9/libnvme-1.9.tar.gz"
+sha512 = "39a3346805143f93a17d00cfcb6fb75f82154658db6079134c09dfa989995ac5de79b1ce1ac091b4e997523d3216829ce9eac44110c9f59f9fd21636529c8b25"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libnvme/libnvme.spec
+++ b/packages/libnvme/libnvme.spec
@@ -1,0 +1,53 @@
+Name: %{_cross_os}libnvme
+Version: 1.9
+Release: 1%{?dist}
+Summary: Library for NVM Express
+License: LGPL-2.1-only AND CC0-1.0 AND MIT
+URL: https://github.com/linux-nvme/libnvme
+Source0: https://github.com/linux-nvme/libnvme/archive/v%{version}/libnvme-%{version}.tar.gz
+Patch0001: 0001-linux-Fix-uninitialized-variables.patch
+
+BuildRequires: meson
+BuildRequires: %{_cross_os}glibc-devel
+
+%package devel
+Summary: Files for development using the library for NVM Express
+Requires: %{_cross_os}libnvme
+
+%description devel
+%{summary}.
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n libnvme-%{version} -p1
+
+%build
+CONFIGURE_OPTS=(
+ -Dpython=disabled
+ -Dopenssl=disabled
+ -Djson-c=disabled
+ -Dkeyutils=disabled
+
+ -Ddocs-build=false
+)
+
+%cross_meson "${CONFIGURE_OPTS[@]}"
+%cross_meson_build
+
+%install
+%cross_meson_install
+
+%files
+%license COPYING ccan/licenses/BSD-MIT ccan/licenses/CC0
+%{_cross_libdir}/*.so.*
+%{_cross_attribution_file}
+
+%files devel
+%{_cross_includedir}/*.h
+%{_cross_includedir}/nvme/*.h
+%{_cross_libdir}/*.so
+%{_cross_libdir}/pkgconfig/*.pc
+
+%changelog

--- a/packages/nvme-cli/Cargo.toml
+++ b/packages/nvme-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nvme-cli"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/linux-nvme/nvme-cli/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/linux-nvme/nvme-cli/archive/v2.9.1/nvme-cli-2.9.1.tar.gz"
+sha512 = "c9c86e7567c2d4c59aff1eb9d18f4775923db3c81a89c628b819121c32150d4bc2d65d0dacac764c64594369890b380d0fd06bc7c1f83f4a7f3e71a51a6fee24"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libnvme = { path = "../libnvme" }

--- a/packages/nvme-cli/nvme-cli.spec
+++ b/packages/nvme-cli/nvme-cli.spec
@@ -1,0 +1,45 @@
+Name: %{_cross_os}nvme-cli
+Version: 2.9.1
+Release: 1%{?dist}
+Summary: CLI to interact with NVMe devices
+License: LGPL-2.1-only AND GPL-2.0-only AND CC0-1.0 AND MIT
+URL: https://github.com/linux-nvme/nvme-cli
+Source0: https://github.com/linux-nvme/nvme-cli/archive/v%{version}/nvme-cli-%{version}.tar.gz
+
+BuildRequires: meson
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libnvme-devel
+Requires: %{_cross_os}libnvme
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n nvme-cli-%{version} -p1
+
+%build
+CONFIGURE_OPTS=(
+ -Ddocs=false
+ -Ddocs-build=false
+ -Djson-c=disabled
+)
+
+%cross_meson "${CONFIGURE_OPTS[@]}"
+%cross_meson_build
+
+%install
+%cross_meson_install
+# This is an empty configuration file with comments with examples of how to
+# configure the systemd services
+rm %{buildroot}%{_sysconfdir}/nvme/discovery.conf
+
+%files
+%license LICENSE ccan/licenses/LGPL-2.1 ccan/licenses/BSD-MIT ccan/licenses/CC0
+%{_cross_attribution_file}
+%{_cross_sbindir}/nvme
+%exclude %{_cross_udevrulesdir}
+%exclude %{_cross_unitdir}
+%exclude %{_cross_datadir}
+%exclude %{_cross_prefix}/lib/dracut
+
+%changelog

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -45,3 +45,4 @@ glibc = { path = "../glibc" }
 # binutils = { path = "../binutils" }
 # oci-add-hooks required for shimpei functionality
 # oci-add-hooks = { path = "../oci-add-hooks" }
+# nvme-cli = { path = "../nvme-cli" }

--- a/packages/os/ebs-volumes.rules
+++ b/packages/os/ebs-volumes.rules
@@ -1,8 +1,15 @@
 ACTION=="remove", GOTO="ebs_volumes_end"
+KERNEL!="nvme*", GOTO="ebs_volumes_end"
 SUBSYSTEM!="block", GOTO="ebs_volumes_end"
-ENV{DEVTYPE}!="disk", GOTO="ebs_volumes_end"
+ATTRS{model}!="Amazon Elastic Block Store", GOTO="ebs_volumes_end"
 
 # Follow AWS recommendation of never timing out IO on EBS volumes attached via NVMe
-KERNEL=="nvme*", ATTRS{model}=="Amazon Elastic Block Store", ATTR{queue/io_timeout}="4294967295"
+ENV{DEVTYPE}=="disk", ATTR{queue/io_timeout}="4294967295"
+
+# Add symlink for disk
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", IMPORT{program}="/usr/bin/ghostdog ebs-device-name $devnode", SYMLINK+="$env{XVD_DEVICE_NAME}"
+
+# Add symlink for partition
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", IMPORT{parent}="XVD_DEVICE_NAME", SYMLINK+="$env{XVD_DEVICE_NAME}$number"
 
 LABEL="ebs_volumes_end"

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -174,6 +174,7 @@ Summary: Commits settings from user data, defaults, and generators at boot
 
 %package -n %{_cross_os}ghostdog
 Summary: Tool to manage ephemeral disks
+Requires: %{_cross_os}nvme-cli
 %description -n %{_cross_os}ghostdog
 %{summary}.
 

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -39,6 +39,7 @@ libaudit = { path = "../libaudit" }
 libgcc = { path = "../libgcc" }
 libkcapi = { path = "../libkcapi" }
 libstd-rust = { path = "../libstd-rust" }
+nvme-cli = { path = "../nvme-cli" }
 makedumpfile = { path = "../../packages/makedumpfile" }
 netdog = {path = "../netdog" }
 os = { path = "../os" }

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -886,6 +886,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libnvme"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "libpcre"
 version = "0.1.0"
 dependencies = [
@@ -1081,6 +1088,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvme-cli"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libnvme",
+]
+
+[[package]]
 name = "oci-add-hooks"
 version = "0.1.0"
 dependencies = [
@@ -1169,6 +1184,7 @@ dependencies = [
  "libstd-rust",
  "makedumpfile",
  "netdog",
+ "nvme-cli",
  "oci-add-hooks",
  "os",
  "policycoreutils",


### PR DESCRIPTION
**Issue number:**

Closes #3975

**Description of changes:**

---
#### V2

The first two commits in the series add tools to interact with NVMe devices. They were used to query the device info instead of issuing `ioctl` syscalls, like in the first version of the PR.

The third commit extends `ghostdog` and adds the `ebs-device-name` command to emit the device name from the vendor data returned by `nvme-cli`.

The last commit adds two `udev` rules that use the value emitted by `ghostdog` to create the required symlinks.

---

#### V1

The first commit in the series extends `ghostdog` with a command to query the device using `ioctl`. The implementation was inspired by the [script used in Amazon Linux] and [`libnvme`]. Since the `ioctl` syscall is an actual `C` API, the structs used to interact with it include `repr(C)` so that the struct is in a compatible format for `C`. The [Rustonomicon] suggests the usage of `rust-bindgen` to generate rust bindings to interact with `C` APIs. However, adding the entire `libnvme` would be overkill so I added just the structures that are needed to query the device information we want.

For the created structures, I used [`kvm-bindings`] as a reference to understand how the structures should be configured, as well as how the Rust types are mapped to `C` types.

The second commit in the series updates the existing udev rules to create symlinks to the EBS volumes, for both the devices and the partitions, using the device name configured for the volume.

[script used in Amazon Linux]: (https://github.com/amazonlinux/amazon-ec2-utils/blob/main/ebsnvme-id)
[`libnvme`]: https://github.com/linux-nvme/libnvme
[Rustonomicon]: https://doc.rust-lang.org/nomicon/other-reprs.html
[`kvm-bindings`]: https://github.com/rust-vmm/kvm-bindings

**Testing done:**

With `aws-ecs-2`, x86_64, I confirmed that the symlinks are created pointing at the correct locations. In my instance, `xvda` corresponds to the root volume (`nvme0n1`) and `xvdb` corresponds to the data volume (`nvme1n1`):

```
bash-5.1# ls -la /dev/xv*
lrwxrwxrwx. 1 root root  7 May 21 15:16 /dev/xvda -> nvme0n1
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda1 -> nvme0n1p1
lrwxrwxrwx. 1 root root 10 May 21 15:16 /dev/xvda10 -> nvme0n1p10
lrwxrwxrwx. 1 root root 10 May 21 15:16 /dev/xvda11 -> nvme0n1p11
lrwxrwxrwx. 1 root root 10 May 21 15:16 /dev/xvda12 -> nvme0n1p12
lrwxrwxrwx. 1 root root 10 May 21 15:16 /dev/xvda13 -> nvme0n1p13
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda2 -> nvme0n1p2
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda3 -> nvme0n1p3
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda4 -> nvme0n1p4
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda5 -> nvme0n1p5
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda6 -> nvme0n1p6
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda7 -> nvme0n1p7
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda8 -> nvme0n1p8
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvda9 -> nvme0n1p9
lrwxrwxrwx. 1 root root  7 May 21 15:16 /dev/xvdb -> nvme1n1
lrwxrwxrwx. 1 root root  9 May 21 15:16 /dev/xvdb1 -> nvme1n1p1
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
