### PR TITLE
Oci hooks settings extension

### DIFF
--- a/packages/settings-oci-hooks/Cargo.toml
+++ b/packages/settings-oci-hooks/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-oci-hooks"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/oci-hooks"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-oci-hooks/settings-oci-hooks.spec
+++ b/packages/settings-oci-hooks/settings-oci-hooks.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name oci-hooks
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2823,6 +2823,7 @@ dependencies = [
  "settings-extension-metrics",
  "settings-extension-motd",
  "settings-extension-ntp",
+ "settings-extension-oci-hooks",
  "settings-extension-pki",
  "settings-extension-updates",
  "toml",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3974,6 +3974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-oci-hooks"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -134,6 +134,7 @@ members = [
     "settings-extensions/metrics",
     "settings-extensions/motd",
     "settings-extensions/ntp",
+    "settings-extensions/oci-hooks",
     "settings-extensions/pki",
     "settings-extensions/updates",
 

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -24,6 +24,7 @@ settings-extension-kernel = { path = "../settings-extensions/kernel", version = 
 settings-extension-metrics = { path = "../settings-extensions/metrics", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }
 settings-extension-ntp = { path = "../settings-extensions/ntp", version = "0.1" }
+settings-extension-oci-hooks = { path = "../settings-extensions/oci-hooks", version = "0.1" }
 settings-extension-pki = { path = "../settings-extensions/pki", version = "0.1" }
 settings-extension-updates = { path = "../settings-extensions/updates", version = "0.1" }
 

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    NetworkSettings, OciHooks,
+    NetworkSettings,
 };
 use modeled_types::Identifier;
 
@@ -23,7 +23,7 @@ struct Settings {
     metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
 }

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, NetworkSettings, OciDefaults, OciHooks,
+    HostContainer, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
     dns: DnsSettings,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, NetworkSettings, OciDefaults, OciHooks,
+    HostContainer, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -24,7 +24,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
     dns: DnsSettings,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, NetworkSettings, OciDefaults, OciHooks,
+    ECSSettings, HostContainer, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +25,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
     dns: DnsSettings,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, NetworkSettings, OciDefaults, OciHooks,
+    ECSSettings, HostContainer, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +25,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
     dns: DnsSettings,

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/aws-k8s-1.30/mod.rs
+++ b/sources/models/src/aws-k8s-1.30/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
     ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults, OciHooks,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -1,9 +1,7 @@
 use model_derive::model;
 use std::collections::HashMap;
 
-use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings, OciHooks,
-};
+use crate::{BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings};
 use modeled_types::Identifier;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -21,6 +19,6 @@ struct Settings {
     metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     dns: DnsSettings,
 }

--- a/sources/models/src/metal-k8s-1.29/mod.rs
+++ b/sources/models/src/metal-k8s-1.29/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, NetworkSettings, OciDefaults, OciHooks,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +25,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -1,9 +1,7 @@
 use model_derive::model;
 use std::collections::HashMap;
 
-use crate::{
-    BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings, OciHooks,
-};
+use crate::{BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings};
 use modeled_types::Identifier;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -21,6 +19,6 @@ struct Settings {
     metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     dns: DnsSettings,
 }

--- a/sources/models/src/vmware-k8s-1.30/mod.rs
+++ b/sources/models/src/vmware-k8s-1.30/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::{
     BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, NetworkSettings, OciDefaults, OciHooks,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -25,7 +25,7 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
-    oci_hooks: OciHooks,
+    oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     dns: DnsSettings,
     container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/settings-extensions/oci-hooks/Cargo.toml
+++ b/sources/settings-extensions/oci-hooks/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-oci-hooks"
+version = "0.1.0"
+authors = ["Gaurav Sharma <mgsharm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/oci-hooks/oci-hooks.toml
+++ b/sources/settings-extensions/oci-hooks/oci-hooks.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/oci-hooks/src/lib.rs
+++ b/sources/settings-extensions/oci-hooks/src/lib.rs
@@ -1,0 +1,72 @@
+/// Settings related to host-provided OCI Hooks
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use std::convert::Infallible;
+
+/// The log4j hotpatch functionality is no longer included in Bottlerocket as of v1.15.0.
+/// The setting still exists for backwards compatibility.
+#[model(impl_default = true)]
+pub struct OciHooksSettingsV1 {
+    log4j_hotpatch_enabled: bool,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for OciHooksSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Set anything that can be parsed as OciHooksSettingsV1.
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // OciHooksSettingsV1 is validated during deserialization.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_generate_oci_hooks() {
+        assert_eq!(
+            OciHooksSettingsV1::generate(None, None).unwrap(),
+            GenerateResult::Complete(OciHooksSettingsV1 {
+                log4j_hotpatch_enabled: None,
+            })
+        )
+    }
+
+    #[test]
+    fn test_serde_oci_hooks() {
+        let test_json = r#"{"log4j-hotpatch-enabled":true}"#;
+
+        let oci_hooks: OciHooksSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            oci_hooks,
+            OciHooksSettingsV1 {
+                log4j_hotpatch_enabled: Some(true),
+            }
+        );
+
+        let results = serde_json::to_string(&oci_hooks).unwrap();
+        assert_eq!(results, test_json);
+    }
+}

--- a/sources/settings-extensions/oci-hooks/src/main.rs
+++ b/sources/settings-extensions/oci-hooks/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_oci_hooks::OciHooksSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("oci-hooks")
+        .with_models(vec![BottlerocketSetting::<OciHooksSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes  #3659

**Description of changes:**

- Creates `ock-hooks` settings extension and uses it in every variant's settings model. 
- Creates `settings-oci-hooks` RPM package that installs the extension binary.

**Testing done:**

- Built `aws-dev` variant with the `settings-oci-hooks` installed. Launched `ec2` instance with the `aws-dev` variant ami. Connected with the instance via `SSM` to run `apiclient` commands.
- Called apiclient to verify the `settings-oci-hooks` worked as expected.
```bash
[ssm-user@control]$ apiclient get settings.oci-hooks
{
  "settings": {
    "oci-hooks": {
      "log4j-hotpatch-enabled": false
    }
  }
}
[ssm-user@control]$ apiclient set settings.oci-hooks.log4j-hotpatch-enabled=true
[ssm-user@control]$ apiclient get settings.oci-hooks
{
  "settings": {
    "oci-hooks": {
      "log4j-hotpatch-enabled": true
    }
  }
}
```

- Also tested by building locally.

``` bash
> cargo run proto1 set --setting-version v1 --value '{"log4j-hotpatch-enabled":true}'
   Compiling settings-extension-oci-hooks v0.1.0 (/Users/mgsharm/bottlerocket/bottlerocket/sources/settings-extensions/oci-hooks)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.09s
     Running `/Users/mgsharm/bottlerocket/bottlerocket/sources/target/debug/settings-extension-oci-hooks proto1 set --setting-version v1 --value '{"log4j-hotpatch-enabled":true}'`
```  

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.