### PR TITLE
Disable GSP Firmware for select instance families.

### DIFF
--- a/packages/kmod-5.10-nvidia/disable-gsp-tmpfiles.conf
+++ b/packages/kmod-5.10-nvidia/disable-gsp-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /etc/modprobe.d 0750 root root -

--- a/packages/kmod-5.10-nvidia/disable-gsp.conf
+++ b/packages/kmod-5.10-nvidia/disable-gsp.conf
@@ -1,0 +1,2 @@
+# Disable GSP firmware download (for selected hardware)
+options nvidia NVreg_EnableGpuFirmware=0

--- a/packages/kmod-5.10-nvidia/disable-gsp.service.in
+++ b/packages/kmod-5.10-nvidia/disable-gsp.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=Disable GSP for selected instance types
-RequiresMountsFor=/etc/modprobe.d PREFIX/share/factory/etc/modprobe.d
+RequiresMountsFor=/etc
 After=network-online.target
 Before=load-kernel-modules.service
+ConditionPathExists=!/etc/.gsp-disable-check-ran
 # Rerunning this service after the system is fully loaded will accomplish
 # nothing except write to a file that will never be used (after boot).
 # Refuse manual intervention.
@@ -11,10 +12,12 @@ RefuseManualStop=true
 
 [Service]
 Type=oneshot
+# This always returns true, but creates the sentinel file to prevent future checks.
+ExecCondition=/usr/bin/touch /etc/.gsp-disable-check-ran
 ExecCondition=/usr/bin/shibaken does-value-start-with instance-type \
   --value g4dn. --value g5. --value g5g.
-ExecStart=-/usr/bin/cp \
-  PREFIX/share/factory/etc/modprobe.d/disable-gsp.conf \
+ExecStart=/usr/bin/cp \
+  PREFIX/share/nvidia/modprobe.d/disable-gsp.conf \
   /etc/modprobe.d/disable-gsp.conf
 RemainAfterExit=true
 StandardError=journal+console

--- a/packages/kmod-5.10-nvidia/disable-gsp.service.in
+++ b/packages/kmod-5.10-nvidia/disable-gsp.service.in
@@ -1,0 +1,23 @@
+[Unit]
+Description=Disable GSP for selected instance types
+RequiresMountsFor=/etc/modprobe.d PREFIX/share/factory/etc/modprobe.d
+After=network-online.target
+Before=load-kernel-modules.service
+# Rerunning this service after the system is fully loaded will accomplish
+# nothing except write to a file that will never be used (after boot).
+# Refuse manual intervention.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/shibaken does-value-start-with instance-type \
+  --value g4dn. --value g5. --value g5g.
+ExecStart=-/usr/bin/cp \
+  PREFIX/share/factory/etc/modprobe.d/disable-gsp.conf \
+  /etc/modprobe.d/disable-gsp.conf
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -101,8 +101,8 @@ install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
  install -p -m 0644 \
    disable-gsp.service \
    %{buildroot}%{_cross_unitdir}
-install -d %{buildroot}%{_cross_factorydir}/etc/modprobe.d
-install -p -m 0644 %{S:401} %{buildroot}%{_cross_factorydir}/etc/modprobe.d
+install -d %{buildroot}%{_cross_datadir}/nvidia/modprobe.d
+install -p -m 0644 %{S:401} %{buildroot}%{_cross_datadir}/nvidia/modprobe.d
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:402} %{buildroot}%{_cross_tmpfilesdir}/disable-gsp.conf
 
@@ -195,7 +195,7 @@ popd
 %{_cross_libdir}/systemd/system/
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 %{_cross_unitdir}/disable-gsp.service
-%{_cross_factorydir}/etc/modprobe.d/disable-gsp.conf
+%{_cross_datadir}/nvidia/modprobe.d/disable-gsp.conf
 %{_cross_tmpfilesdir}/disable-gsp.conf
 
 %files tesla-470

--- a/packages/kmod-5.15-nvidia/disable-gsp-tmpfiles.conf
+++ b/packages/kmod-5.15-nvidia/disable-gsp-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /etc/modprobe.d 0750 root root -

--- a/packages/kmod-5.15-nvidia/disable-gsp.conf
+++ b/packages/kmod-5.15-nvidia/disable-gsp.conf
@@ -1,0 +1,2 @@
+# Disable GSP firmware download (for selected hardware)
+options nvidia NVreg_EnableGpuFirmware=0

--- a/packages/kmod-5.15-nvidia/disable-gsp.service.in
+++ b/packages/kmod-5.15-nvidia/disable-gsp.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=Disable GSP for selected instance types
-RequiresMountsFor=/etc/modprobe.d PREFIX/share/factory/etc/modprobe.d
+RequiresMountsFor=/etc
 After=network-online.target
 Before=load-kernel-modules.service
+ConditionPathExists=!/etc/.gsp-disable-check-ran
 # Rerunning this service after the system is fully loaded will accomplish
 # nothing except write to a file that will never be used (after boot).
 # Refuse manual intervention.
@@ -11,10 +12,12 @@ RefuseManualStop=true
 
 [Service]
 Type=oneshot
+# This always returns true, but creates the sentinel file to prevent future checks.
+ExecCondition=/usr/bin/touch /etc/.gsp-disable-check-ran
 ExecCondition=/usr/bin/shibaken does-value-start-with instance-type \
   --value g4dn. --value g5. --value g5g.
-ExecStart=-/usr/bin/cp \
-  PREFIX/share/factory/etc/modprobe.d/disable-gsp.conf \
+ExecStart=/usr/bin/cp \
+  PREFIX/share/nvidia/modprobe.d/disable-gsp.conf \
   /etc/modprobe.d/disable-gsp.conf
 RemainAfterExit=true
 StandardError=journal+console

--- a/packages/kmod-5.15-nvidia/disable-gsp.service.in
+++ b/packages/kmod-5.15-nvidia/disable-gsp.service.in
@@ -1,0 +1,23 @@
+[Unit]
+Description=Disable GSP for selected instance types
+RequiresMountsFor=/etc/modprobe.d PREFIX/share/factory/etc/modprobe.d
+After=network-online.target
+Before=load-kernel-modules.service
+# Rerunning this service after the system is fully loaded will accomplish
+# nothing except write to a file that will never be used (after boot).
+# Refuse manual intervention.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/shibaken does-value-start-with instance-type \
+  --value g4dn. --value g5. --value g5g.
+ExecStart=-/usr/bin/cp \
+  PREFIX/share/factory/etc/modprobe.d/disable-gsp.conf \
+  /etc/modprobe.d/disable-gsp.conf
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -48,6 +48,11 @@ Source301: nvidia-tesla-build-config.toml.in
 Source302: nvidia-tesla-path.env.in
 Source303: nvidia-ld.so.conf.in
 
+# disable-gsp files from 400 to 499
+Source400: disable-gsp.service.in
+Source401: disable-gsp.conf
+Source402: disable-gsp-tmpfiles.conf
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}kernel-5.15-archive
 
@@ -85,6 +90,9 @@ tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
 
 %build
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:400} > disable-gsp.service
+
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel
 
 # This recipe was based in the NVIDIA yum/dnf specs:
@@ -122,6 +130,15 @@ sed \
   -e "s|__KERNEL_VERSION__|${KERNEL_VERSION}|" \
   -e "s|__PREFIX__|%{_cross_prefix}|" %{S:200} > nvidia.conf
 install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
+
+# disable-gsp
+ install -p -m 0644 \
+   disable-gsp.service \
+   %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_factorydir}/etc/modprobe.d
+install -p -m 0644 %{S:401} %{buildroot}%{_cross_factorydir}/etc/modprobe.d
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:402} %{buildroot}%{_cross_tmpfilesdir}/disable-gsp.conf
 
 # Install modules-load.d drop-in to autoload required kernel modules
 install -d %{buildroot}%{_cross_libdir}/modules-load.d
@@ -231,6 +248,9 @@ popd
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/nvidia
 %{_cross_tmpfilesdir}/nvidia.conf
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
+%{_cross_unitdir}/disable-gsp.service
+%{_cross_factorydir}/etc/modprobe.d/disable-gsp.conf
+%{_cross_tmpfilesdir}/disable-gsp.conf
 
 %files tesla-%{tesla_major}
 %license %{license_file}

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -135,8 +135,8 @@ install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
  install -p -m 0644 \
    disable-gsp.service \
    %{buildroot}%{_cross_unitdir}
-install -d %{buildroot}%{_cross_factorydir}/etc/modprobe.d
-install -p -m 0644 %{S:401} %{buildroot}%{_cross_factorydir}/etc/modprobe.d
+install -d %{buildroot}%{_cross_datadir}/nvidia/modprobe.d
+install -p -m 0644 %{S:401} %{buildroot}%{_cross_datadir}/nvidia/modprobe.d
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:402} %{buildroot}%{_cross_tmpfilesdir}/disable-gsp.conf
 
@@ -249,7 +249,7 @@ popd
 %{_cross_tmpfilesdir}/nvidia.conf
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 %{_cross_unitdir}/disable-gsp.service
-%{_cross_factorydir}/etc/modprobe.d/disable-gsp.conf
+%{_cross_datadir}/nvidia/modprobe.d/disable-gsp.conf
 %{_cross_tmpfilesdir}/disable-gsp.conf
 
 %files tesla-%{tesla_major}

--- a/packages/kmod-6.1-nvidia/disable-gsp-tmpfiles.conf
+++ b/packages/kmod-6.1-nvidia/disable-gsp-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /etc/modprobe.d 0750 root root -

--- a/packages/kmod-6.1-nvidia/disable-gsp.conf
+++ b/packages/kmod-6.1-nvidia/disable-gsp.conf
@@ -1,0 +1,2 @@
+# Disable GSP firmware download (for selected hardware)
+options nvidia NVreg_EnableGpuFirmware=0

--- a/packages/kmod-6.1-nvidia/disable-gsp.service.in
+++ b/packages/kmod-6.1-nvidia/disable-gsp.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=Disable GSP for selected instance types
-RequiresMountsFor=/etc/modprobe.d PREFIX/share/factory/etc/modprobe.d
+RequiresMountsFor=/etc
 After=network-online.target
 Before=load-kernel-modules.service
+ConditionPathExists=!/etc/.gsp-disable-check-ran
 # Rerunning this service after the system is fully loaded will accomplish
 # nothing except write to a file that will never be used (after boot).
 # Refuse manual intervention.
@@ -11,10 +12,12 @@ RefuseManualStop=true
 
 [Service]
 Type=oneshot
+# This always returns true, but creates the sentinel file to prevent future checks.
+ExecCondition=/usr/bin/touch /etc/.gsp-disable-check-ran
 ExecCondition=/usr/bin/shibaken does-value-start-with instance-type \
   --value g4dn. --value g5. --value g5g.
-ExecStart=-/usr/bin/cp \
-  PREFIX/share/factory/etc/modprobe.d/disable-gsp.conf \
+ExecStart=/usr/bin/cp \
+  PREFIX/share/nvidia/modprobe.d/disable-gsp.conf \
   /etc/modprobe.d/disable-gsp.conf
 RemainAfterExit=true
 StandardError=journal+console

--- a/packages/kmod-6.1-nvidia/disable-gsp.service.in
+++ b/packages/kmod-6.1-nvidia/disable-gsp.service.in
@@ -1,0 +1,23 @@
+[Unit]
+Description=Disable GSP for selected instance types
+RequiresMountsFor=/etc/modprobe.d PREFIX/share/factory/etc/modprobe.d
+After=network-online.target
+Before=load-kernel-modules.service
+# Rerunning this service after the system is fully loaded will accomplish
+# nothing except write to a file that will never be used (after boot).
+# Refuse manual intervention.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/shibaken does-value-start-with instance-type \
+  --value g4dn. --value g5. --value g5g.
+ExecStart=-/usr/bin/cp \
+  PREFIX/share/factory/etc/modprobe.d/disable-gsp.conf \
+  /etc/modprobe.d/disable-gsp.conf
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -48,6 +48,11 @@ Source301: nvidia-tesla-build-config.toml.in
 Source302: nvidia-tesla-path.env.in
 Source303: nvidia-ld.so.conf.in
 
+# disable-gsp files from 400 to 499
+Source400: disable-gsp.service.in
+Source401: disable-gsp.conf
+Source402: disable-gsp-tmpfiles.conf
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}kernel-6.1-archive
 
@@ -85,6 +90,9 @@ tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
 
 %build
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:400} > disable-gsp.service
+
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel
 
 # This recipe was based in the NVIDIA yum/dnf specs:
@@ -122,6 +130,15 @@ sed \
   -e "s|__KERNEL_VERSION__|${KERNEL_VERSION}|" \
   -e "s|__PREFIX__|%{_cross_prefix}|" %{S:200} > nvidia.conf
 install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
+
+# disable-gsp
+ install -p -m 0644 \
+   disable-gsp.service \
+   %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_factorydir}/etc/modprobe.d
+install -p -m 0644 %{S:401} %{buildroot}%{_cross_factorydir}/etc/modprobe.d
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:402} %{buildroot}%{_cross_tmpfilesdir}/disable-gsp.conf
 
 # Install modules-load.d drop-in to autoload required kernel modules
 install -d %{buildroot}%{_cross_libdir}/modules-load.d
@@ -231,6 +248,9 @@ popd
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/nvidia
 %{_cross_tmpfilesdir}/nvidia.conf
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
+%{_cross_unitdir}/disable-gsp.service
+%{_cross_factorydir}/etc/modprobe.d/disable-gsp.conf
+%{_cross_tmpfilesdir}/disable-gsp.conf
 
 %files tesla-%{tesla_major}
 %license %{license_file}

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -135,8 +135,8 @@ install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
  install -p -m 0644 \
    disable-gsp.service \
    %{buildroot}%{_cross_unitdir}
-install -d %{buildroot}%{_cross_factorydir}/etc/modprobe.d
-install -p -m 0644 %{S:401} %{buildroot}%{_cross_factorydir}/etc/modprobe.d
+install -d %{buildroot}%{_cross_datadir}/nvidia/modprobe.d
+install -p -m 0644 %{S:401} %{buildroot}%{_cross_datadir}/nvidia/modprobe.d
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:402} %{buildroot}%{_cross_tmpfilesdir}/disable-gsp.conf
 
@@ -249,7 +249,7 @@ popd
 %{_cross_tmpfilesdir}/nvidia.conf
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 %{_cross_unitdir}/disable-gsp.service
-%{_cross_factorydir}/etc/modprobe.d/disable-gsp.conf
+%{_cross_datadir}/nvidia/modprobe.d/disable-gsp.conf
 %{_cross_tmpfilesdir}/disable-gsp.conf
 
 %files tesla-%{tesla_major}

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -22,8 +22,8 @@ use crate::error::Result;
 
 mod admin_userdata;
 pub(crate) mod error;
-mod value_equal;
 mod partition;
+mod value_equal;
 mod warmpool;
 
 /// Returns information gathered from the AWS instance metadata service (IMDS).
@@ -70,8 +70,12 @@ async fn run() -> Result<ExitCode> {
     log::info!("shibaken started");
     let mut exit_code = ExitCode::SUCCESS;
     match args.command {
-        Commands::GenerateAdminUserdata(generate_admin_userdata) => generate_admin_userdata.run().await?,
-        Commands::DoesValueStartWith(does_value_start) => exit_code = does_value_start.run().await?,
+        Commands::GenerateAdminUserdata(generate_admin_userdata) => {
+            generate_admin_userdata.run().await?
+        }
+        Commands::DoesValueStartWith(does_value_start) => {
+            exit_code = does_value_start.run().await?
+        }
         Commands::IsPartition(is_partition) => is_partition.run().await?,
         Commands::WarmPoolWait(warm_pool_wait) => warm_pool_wait
             .run()
@@ -90,6 +94,6 @@ async fn main() -> ExitCode {
             eprintln!("{}", e);
             ExitCode::FAILURE
         }
-        Ok(code) => code
+        Ok(code) => code,
     }
 }

--- a/sources/api/shibaken/src/value_equal.rs
+++ b/sources/api/shibaken/src/value_equal.rs
@@ -14,14 +14,17 @@ pub(crate) struct ValueStartsWith {
     /// imds variable name (must be instance-type for now)
     variable_name: String,
     #[argh(option)]
-    /// value to compare against that 
+    /// value to compare against that
     value: Vec<String>,
 }
 
 impl ValueStartsWith {
     pub(crate) async fn run(self) -> Result<ExitCode> {
         if self.variable_name != "instance-type" {
-            log::info!("Unknown variable name {}, returning false.", self.variable_name);
+            log::info!(
+                "Unknown variable name {}, returning false.",
+                self.variable_name
+            );
             return Ok(ExitCode::FAILURE);
         }
         if self.value.is_empty() {

--- a/sources/api/shibaken/src/value_equal.rs
+++ b/sources/api/shibaken/src/value_equal.rs
@@ -1,0 +1,56 @@
+use std::process::ExitCode;
+
+use argh::FromArgs;
+use imdsclient::ImdsClient;
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "does-value-start-with")]
+/// Compare IMDS variable with set of values
+pub(crate) struct ValueStartsWith {
+    #[argh(positional)]
+    /// imds variable name (must be instance-type for now)
+    variable_name: String,
+    #[argh(option)]
+    /// value to compare against that 
+    value: Vec<String>,
+}
+
+impl ValueStartsWith {
+    pub(crate) async fn run(self) -> Result<ExitCode> {
+        if self.variable_name != "instance-type" {
+            log::info!("Unknown variable name {}, returning false.", self.variable_name);
+            return Ok(ExitCode::FAILURE);
+        }
+        if self.value.is_empty() {
+            // Is it success or failure to match against the empty set?
+            // Pretend this is the element-of operator. Nothing is an
+            // element of the empty set.
+            return Ok(ExitCode::FAILURE);
+        }
+        let mut client = ImdsClient::new();
+        let instance_type = client
+            .fetch_instance_type()
+            .await
+            .context(error::ImdsClientSnafu)?;
+        match instance_type {
+            // No instance type? No match.
+            None => Ok(ExitCode::FAILURE),
+            Some(instance_type) => {
+                let does_match = self
+                    .value
+                    .iter()
+                    .any(|value| instance_type.starts_with(value));
+                if does_match {
+                    log::info!("Instance type {} matched.", instance_type);
+                    Ok(ExitCode::SUCCESS)
+                } else {
+                    log::info!("Instance type {} did not match.", instance_type);
+                    Ok(ExitCode::FAILURE)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description of changes:**

For some instance families in AWS, we wish to disable GSP firmware download in the NVIDIA kmod. We can do this by creating a configuration file in /etc/modprobe.d with the desired option, conditionally based on the instance family we fetch from IMDS. This must happen before we invoke driverdog to load the kmod. In bottlerocket, /etc is ephemeral, so we have to do this on each boot.

**Testing done:**

Manual testing demonstrates that the setting takes effect on the desired instance families, and does not take effect on other instance families. Tested on each kernel version, on aws-eks and aws-ecs variants.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
