### PR TITLE
Dns settings extension

### DIFF
--- a/packages/settings-dns/Cargo.toml
+++ b/packages/settings-dns/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-dns"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/dns"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-dns/settings-dns.spec
+++ b/packages/settings-dns/settings-dns.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name dns
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3929,6 +3929,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-dns"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2819,6 +2819,7 @@ dependencies = [
  "serde_json",
  "settings-extension-aws",
  "settings-extension-container-registry",
+ "settings-extension-dns",
  "settings-extension-kernel",
  "settings-extension-metrics",
  "settings-extension-motd",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -130,6 +130,7 @@ members = [
 
     "settings-extensions/aws",
     "settings-extensions/container-registry",
+    "settings-extensions/dns",
     "settings-extensions/kernel",
     "settings-extensions/metrics",
     "settings-extensions/motd",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -20,6 +20,7 @@ toml = "0.8"
 # settings extensions
 settings-extension-aws = { path = "../settings-extensions/aws", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
+settings-extension-dns = { path = "../settings-extensions/dns", version = "0.1" }
 settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
 settings-extension-metrics = { path = "../settings-extensions/metrics", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -2,8 +2,7 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, HostContainer,
-    NetworkSettings,
+    BootSettings, BootstrapContainer, CloudFormationSettings, HostContainer, NetworkSettings,
 };
 use modeled_types::Identifier;
 
@@ -25,5 +24,5 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, ECSSettings, HostContainer,
+    NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -27,5 +27,5 @@ struct Settings {
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, DnsSettings, ECSSettings,
-    HostContainer, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, ECSSettings, HostContainer,
+    NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -27,5 +27,5 @@ struct Settings {
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, ECSSettings,
+    HostContainer, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,5 +28,5 @@ struct Settings {
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, DnsSettings,
-    ECSSettings, HostContainer, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, ECSSettings,
+    HostContainer, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,5 +28,5 @@ struct Settings {
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
     autoscaling: AutoScalingSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/aws-k8s-1.30/mod.rs
+++ b/sources/models/src/aws-k8s-1.30/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, DnsSettings, HostContainer, KubernetesSettings, NetworkSettings,
-    OciDefaults,
+    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -28,7 +27,7 @@ struct Settings {
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
     cloudformation: CloudFormationSettings,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,
 }

--- a/sources/models/src/metal-dev/mod.rs
+++ b/sources/models/src/metal-dev/mod.rs
@@ -1,7 +1,7 @@
 use model_derive::model;
 use std::collections::HashMap;
 
-use crate::{BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings};
+use crate::{BootSettings, BootstrapContainer, HostContainer, NetworkSettings};
 use modeled_types::Identifier;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -20,5 +20,5 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/metal-k8s-1.29/mod.rs
+++ b/sources/models/src/metal-k8s-1.29/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, NetworkSettings, OciDefaults,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer, KubernetesSettings,
+    NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,6 +26,6 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/models/src/vmware-dev/mod.rs
+++ b/sources/models/src/vmware-dev/mod.rs
@@ -1,7 +1,7 @@
 use model_derive::model;
 use std::collections::HashMap;
 
-use crate::{BootSettings, BootstrapContainer, DnsSettings, HostContainer, NetworkSettings};
+use crate::{BootSettings, BootstrapContainer, HostContainer, NetworkSettings};
 use modeled_types::Identifier;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -20,5 +20,5 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/vmware-k8s-1.30/mod.rs
+++ b/sources/models/src/vmware-k8s-1.30/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    BootSettings, BootstrapContainer, ContainerRuntimeSettings, DnsSettings, HostContainer,
-    KubernetesSettings, NetworkSettings, OciDefaults,
+    BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer, KubernetesSettings,
+    NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,6 +26,6 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    dns: DnsSettings,
+    dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
 }

--- a/sources/settings-extensions/dns/Cargo.toml
+++ b/sources/settings-extensions/dns/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-dns"
+version = "0.1.0"
+authors = ["Gaurav Sharma <mgsharm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/dns/dns.toml
+++ b/sources/settings-extensions/dns/dns.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/dns/src/lib.rs
+++ b/sources/settings-extensions/dns/src/lib.rs
@@ -1,0 +1,84 @@
+/// Settings related to custom DNS settings
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::ValidLinuxHostname;
+use std::convert::Infallible;
+use std::net::IpAddr;
+
+#[model(impl_default = true)]
+pub struct DnsSettingsV1 {
+    name_servers: Vec<IpAddr>,
+    search_list: Vec<ValidLinuxHostname>,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for DnsSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Set anything that can be parsed as DnsSettingsV1.
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // DnsSettingsV1 is validated during deserialization.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_generate_dns_settings() {
+        assert_eq!(
+            DnsSettingsV1::generate(None, None),
+            Ok(GenerateResult::Complete(DnsSettingsV1 {
+                name_servers: None,
+                search_list: None,
+            }))
+        )
+    }
+
+    #[test]
+    fn test_serde_dns() {
+        let test_json =
+            r#"{"name-servers":["1.2.3.4","5.6.7.8"],"search-list":["foo.bar","baz.foo"]}"#;
+
+        let dns: DnsSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            dns.name_servers.clone().unwrap(),
+            vec!(
+                IpAddr::from_str("1.2.3.4").unwrap(),
+                IpAddr::from_str("5.6.7.8").unwrap(),
+            )
+        );
+        assert_eq!(
+            dns.search_list.clone().unwrap(),
+            vec!(
+                ValidLinuxHostname::try_from("foo.bar").unwrap(),
+                ValidLinuxHostname::try_from("baz.foo").unwrap(),
+            )
+        );
+
+        let results = serde_json::to_string(&dns).unwrap();
+        assert_eq!(results, test_json);
+    }
+}

--- a/sources/settings-extensions/dns/src/main.rs
+++ b/sources/settings-extensions/dns/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_dns::DnsSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("dns")
+        .with_models(vec![BottlerocketSetting::<DnsSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
**Issue number:**

Closes #[3661](https://github.com/bottlerocket-os/bottlerocket/issues/3661)

**Description of changes:**

- Creates `dns` settings extension and uses it in every variant's settings model. 
- Creates `settings-dns` RPM package that installs the extension binary.

**Testing done:**

- Built `aws-dev` variant with the `settings-dns` installed. Launched `ec2` instance with the `aws-dev` variant ami. Connected with the instance via `SSM` to run `apiclient` commands.
- Called apiclient to verify the `settings-dns` worked as expected.

```bash
[ssm-user@control]$ apiclient set --json '{"settings": {"dns": { "name-servers": ["1.2.3.4", "5.6.7.8"], "search-list":["foo.bar", "baz.foo"]}}}'
[ssm-user@control]$ apiclient get settings.dns.name-servers
{
  "settings": {
    "dns": {
      "name-servers": [
        "1.2.3.4",
        "5.6.7.8"
      ]
    }
  }
}
[ssm-user@control]$ apiclient get settings.dns
{
  "settings": {
    "dns": {
      "name-servers": [
        "1.2.3.4",
        "5.6.7.8"
      ],
      "search-list": [
        "foo.bar",
        "baz.foo"
      ]
    }
  }
}
```

- Also tested by building locally.

``` bash
> cargo run proto1 set --setting-version v1 --value '{"name-servers":["1.2.3.4","5.6.7.8"],"search-list":["foo.bar","baz.foo"]}'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `/home/fedora/bottlerocket/sources/target/debug/settings-extension-dns proto1 set --setting-version v1 --value '{"name-servers":["1.2.3.4","5.6.7.8"],"search-list":["foo.bar","baz.foo"]}'`
```  

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.