### PR TITLE
Port ecs settings extension

### DIFF
--- a/packages/settings-ecs/Cargo.toml
+++ b/packages/settings-ecs/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-ecs"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/ecs"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-ecs/settings-ecs.spec
+++ b/packages/settings-ecs/settings-ecs.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name ecs
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3948,6 +3948,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-ecs"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2820,6 +2820,7 @@ dependencies = [
  "settings-extension-aws",
  "settings-extension-container-registry",
  "settings-extension-dns",
+ "settings-extension-ecs",
  "settings-extension-kernel",
  "settings-extension-metrics",
  "settings-extension-motd",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -132,6 +132,7 @@ members = [
     "settings-extensions/aws",
     "settings-extensions/container-registry",
     "settings-extensions/dns",
+    "settings-extensions/ecs",
     "settings-extensions/kernel",
     "settings-extensions/metrics",
     "settings-extensions/motd",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.8"
 settings-extension-aws = { path = "../settings-extensions/aws", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-dns = { path = "../settings-extensions/dns", version = "0.1" }
+settings-extension-ecs = { path = "../settings-extensions/ecs", version = "0.1" }
 settings-extension-kernel = { path = "../settings-extensions/kernel", version = "0.1" }
 settings-extension-metrics = { path = "../settings-extensions/metrics", version = "0.1" }
 settings-extension-motd = { path = "../settings-extensions/motd", version = "0.1" }

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -2,7 +2,7 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, ECSSettings, HostContainer,
+    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
     NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
@@ -19,7 +19,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: settings_extension_aws::AwsSettingsV1,
-    ecs: ECSSettings,
+    ecs: settings_extension_ecs::ECSSettingsV1,
     metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -2,7 +2,7 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, ECSSettings, HostContainer,
+    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
     NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
@@ -19,7 +19,7 @@ struct Settings {
     network: NetworkSettings,
     kernel: settings_extension_kernel::KernelSettingsV1,
     aws: settings_extension_aws::AwsSettingsV1,
-    ecs: ECSSettings,
+    ecs: settings_extension_ecs::ECSSettingsV1,
     metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, ECSSettings,
-    HostContainer, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
+    NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +20,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    ecs: ECSSettings,
+    ecs: settings_extension_ecs::ECSSettingsV1,
     metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, ECSSettings,
-    HostContainer, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
+    NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -20,7 +20,7 @@ struct Settings {
     kernel: settings_extension_kernel::KernelSettingsV1,
     boot: BootSettings,
     aws: settings_extension_aws::AwsSettingsV1,
-    ecs: ECSSettings,
+    ecs: settings_extension_ecs::ECSSettingsV1,
     metrics: settings_extension_metrics::MetricsSettingsV1,
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,

--- a/sources/settings-extensions/ecs/Cargo.toml
+++ b/sources/settings-extensions/ecs/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-ecs"
+version = "0.1.0"
+authors = ["Gaurav Sharma <mgsharm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/ecs/ecs.toml
+++ b/sources/settings-extensions/ecs/ecs.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/ecs/src/lib.rs
+++ b/sources/settings-extensions/ecs/src/lib.rs
@@ -1,0 +1,171 @@
+/// Settings related to Amazon ECS
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::{
+    ECSAgentImagePullBehavior, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue,
+    ECSDurationValue, SingleLineString,
+};
+use std::{collections::HashMap, convert::Infallible};
+
+#[model(impl_default = true)]
+pub struct ECSSettingsV1 {
+    cluster: String,
+    instance_attributes: HashMap<ECSAttributeKey, ECSAttributeValue>,
+    allow_privileged_containers: bool,
+    logging_drivers: Vec<SingleLineString>,
+    loglevel: ECSAgentLogLevel,
+    enable_spot_instance_draining: bool,
+    image_pull_behavior: ECSAgentImagePullBehavior,
+    container_stop_timeout: ECSDurationValue,
+    task_cleanup_wait: ECSDurationValue,
+    metadata_service_rps: i64,
+    metadata_service_burst: i64,
+    reserved_memory: u16,
+    image_cleanup_wait: ECSDurationValue,
+    image_cleanup_delete_per_cycle: i64,
+    image_cleanup_enabled: bool,
+    image_cleanup_age: ECSDurationValue,
+    backend_host: String,
+    awsvpc_block_imds: bool,
+    enable_container_metadata: bool,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for ECSSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Set anything that can be parsed as ECSSettingsV1.
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // ECSSettingsV1 is validated during deserialization.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_generate_ecs_settings() {
+        assert_eq!(
+            ECSSettingsV1::generate(None, None),
+            Ok(GenerateResult::Complete(ECSSettingsV1 {
+                cluster: None,
+                instance_attributes: None,
+                allow_privileged_containers: None,
+                logging_drivers: None,
+                loglevel: None,
+                enable_spot_instance_draining: None,
+                image_pull_behavior: None,
+                container_stop_timeout: None,
+                task_cleanup_wait: None,
+                metadata_service_rps: None,
+                metadata_service_burst: None,
+                reserved_memory: None,
+                image_cleanup_wait: None,
+                image_cleanup_delete_per_cycle: None,
+                image_cleanup_enabled: None,
+                image_cleanup_age: None,
+                backend_host: None,
+                awsvpc_block_imds: None,
+                enable_container_metadata: None,
+            }))
+        )
+    }
+
+    #[test]
+    fn test_serde_ecs() {
+        let test_json = json!({
+            "cluster": "test-cluster",
+            "instance-attributes": {
+                "attribute1": "value1",
+                "attribute2": "value2"
+            },
+            "allow-privileged-containers": true,
+            "logging-drivers": ["json-file", "awslogs"],
+            "loglevel": "info",
+            "enable-spot-instance-draining": true,
+            "image-pull-behavior": "always",
+            "container-stop-timeout": "30s",
+            "task-cleanup-wait": "1h",
+            "metadata-service-rps": 50,
+            "metadata-service-burst": 100,
+            "reserved-memory": 512,
+            "image-cleanup-wait": "1h",
+            "image-cleanup-delete-per-cycle": 2,
+            "image-cleanup-enabled": true,
+            "image-cleanup-age": "1h",
+            "backend-host": "ecs.us-east-1.amazonaws.com",
+            "awsvpc-block-imds": true,
+            "enable-container-metadata": true,
+        });
+
+        let test_json_str = test_json.to_string();
+
+        let ecs_settings: ECSSettingsV1 = serde_json::from_str(&test_json_str).unwrap();
+
+        let mut expected_instance_attributes: HashMap<ECSAttributeKey, ECSAttributeValue> =
+            HashMap::new();
+        expected_instance_attributes.insert(
+            ECSAttributeKey::try_from("attribute1").unwrap(),
+            ECSAttributeValue::try_from("value1").unwrap(),
+        );
+        expected_instance_attributes.insert(
+            ECSAttributeKey::try_from("attribute2").unwrap(),
+            ECSAttributeValue::try_from("value2").unwrap(),
+        );
+
+        let expected_ecs_settings = ECSSettingsV1 {
+            cluster: Some("test-cluster".to_string()),
+            instance_attributes: Some(expected_instance_attributes),
+            allow_privileged_containers: Some(true),
+            logging_drivers: Some(vec![
+                SingleLineString::try_from("json-file").unwrap(),
+                SingleLineString::try_from("awslogs").unwrap(),
+            ]),
+            loglevel: Some(ECSAgentLogLevel::Info),
+            enable_spot_instance_draining: Some(true),
+            image_pull_behavior: Some(ECSAgentImagePullBehavior::Always),
+            container_stop_timeout: Some(ECSDurationValue::try_from("30s").unwrap()),
+            task_cleanup_wait: Some(ECSDurationValue::try_from("1h").unwrap()),
+            metadata_service_rps: Some(50),
+            metadata_service_burst: Some(100),
+            reserved_memory: Some(512),
+            image_cleanup_wait: Some(ECSDurationValue::try_from("1h").unwrap()),
+            image_cleanup_delete_per_cycle: Some(2),
+            image_cleanup_enabled: Some(true),
+            image_cleanup_age: Some(ECSDurationValue::try_from("1h").unwrap()),
+            backend_host: Some("ecs.us-east-1.amazonaws.com".to_string()),
+            awsvpc_block_imds: Some(true),
+            enable_container_metadata: Some(true),
+        };
+
+        assert_eq!(ecs_settings, expected_ecs_settings);
+
+        let serialized_json: serde_json::Value = serde_json::to_string(&ecs_settings)
+            .map(|s| serde_json::from_str(&s).unwrap())
+            .unwrap();
+
+        assert_eq!(serialized_json, test_json);
+    }
+}

--- a/sources/settings-extensions/ecs/src/main.rs
+++ b/sources/settings-extensions/ecs/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_ecs::ECSSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("ecs")
+        .with_models(vec![BottlerocketSetting::<ECSSettingsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #[3662](https://github.com/bottlerocket-os/bottlerocket/issues/3662)

**Description of changes:**

- Creates `ecs` settings extension and uses it in every variant's settings model. 
- Creates `settings-ecs` RPM package that installs the extension binary.

**Testing done:**

- Built `aws-ecs-1` variant with the `settings-ecs` installed. Launched `ec2` instance with the `aws-ecs-1` variant ami. Connected with the instance via `SSM` to run `apiclient` commands.
- Called apiclient to verify the `settings-ecs` worked as expected.

```bash
[ssm-user@control]$ apiclient set --json '{"settings": {"ecs": {"cluster":"test-cluster","instance-attributes":{"attribute1":"value1","attribute2":"value2"},"allow-privileged-containers":true,"logging-drivers":["json-file","awslogs"],"loglevel":"info","enable-spot-instance-draining":true,"image-pull-behavior":"always","container-stop-timeout":"30s","task-cleanup-wait":"1h","metadata-service-rps":50,"metadata-service-burst":100,"reserved-memory":512,"image-cleanup-wait":"1h","image-cleanup-delete-per-cycle":2,"image-cleanup-enabled":true,"image-cleanup-age":"1h","backend-host":"ecs.us-east-1.amazonaws.com","awsvpc-block-imds":true,"enable-container-metadata":true}}}'
[ssm-user@control]$ apiclient get settings.ecs
{
  "settings": {
    "ecs": {
      "allow-privileged-containers": true,
      "awsvpc-block-imds": true,
      "backend-host": "ecs.us-east-1.amazonaws.com",
      "cluster": "test-cluster",
      "container-stop-timeout": "30s",
      "enable-container-metadata": true,
      "enable-spot-instance-draining": true,
      "image-cleanup-age": "1h",
      "image-cleanup-delete-per-cycle": 2,
      "image-cleanup-enabled": true,
      "image-cleanup-wait": "1h",
      "image-pull-behavior": "always",
      "instance-attributes": {
        "attribute1": "value1",
        "attribute2": "value2"
      },
      "logging-drivers": [
        "json-file",
        "awslogs"
      ],
      "loglevel": "info",
      "metadata-service-burst": 100,
      "metadata-service-rps": 50,
      "reserved-memory": 512,
      "task-cleanup-wait": "1h"
    }
  }
}
```

- Also tested by building locally.

``` bash
> cargo run proto1 set --setting-version v1 --value '{"cluster":"test-cluster","instance-attributes":{"attribute1":"value1","attribute2":"value2"},"allow-privileged-containers":true,"logging-drivers":["json-file","awslogs"],"loglevel":"info","enable-spot-instance-draining":true,"image-pull-behavior":"always","container-stop-timeout":"30s","task-cleanup-wait":"1h","metadata-service-rps":50,"metadata-service-burst":100,"reserved-memory":512,"image-cleanup-wait":"1h","image-cleanup-delete-per-cycle":2,"image-cleanup-enabled":true,"image-cleanup-age":"1h","backend-host":"ecs.us-east-1.amazonaws.com","awsvpc-block-imds":true,"enable-container-metadata":true}'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
     Running `/Users/mgsharm/bottlerocket/bottlerocket/sources/target/debug/settings-extension-ecs proto1 set --setting-version v1 --value '{"cluster":"test-cluster","instance-attributes":{"attribute1":"value1","attribute2":"value2"},"allow-privileged-containers":true,"logging-drivers":["json-file","awslogs"],"loglevel":"info","enable-spot-instance-draining":true,"image-pull-behavior":"always","container-stop-timeout":"30s","task-cleanup-wait":"1h","metadata-service-rps":50,"metadata-service-burst":100,"reserved-memory":512,"image-cleanup-wait":"1h","image-cleanup-delete-per-cycle":2,"image-cleanup-enabled":true,"image-cleanup-age":"1h","backend-host":"ecs.us-east-1.amazonaws.com","awsvpc-block-imds":true,"enable-container-metadata":true}'`
```  

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.