### PR TITLE
Add Nvidia GPU Time-slicing support

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -314,4 +314,6 @@ version = "1.21.0"
 ]
 "(1.20.0, 1.21.0)" = [
     "migrate_v1.21.0_pluto-remove-generators-v0-1-0.lz4",
+    "migrate_v1.21.0_nvidia-k8s-device-plugin-metadata.lz4",
+    "migrate_v1.21.0_nvidia-k8s-device-plugin-settings.lz4",
 ]

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -1,0 +1,19 @@
+[required-extensions]
+kubernetes = "v1"
++++
+version: v1
+flags:
+  migStrategy: "none"
+  failOnInitError: true
+  plugin:
+    passDeviceSpecs: true
+    deviceListStrategy: "volume-mounts"
+    deviceIDStrategy: "index"
+{{#if (gt settings.kubernetes.nvidia.device-plugin.max-sharing-per-gpu 0)}}
+sharing:
+  timeSlicing:
+    renameByDefault: {{settings.kubernetes.nvidia.device-plugin.rename-shared-gpu}}
+    resources:
+    - name: "nvidia.com/gpu"
+      replicas: {{settings.kubernetes.nvidia.device-plugin.max-sharing-per-gpu}}
+{{/if}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-tmpfiles.conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /etc/nvidia-k8s-device-plugin - - - - -

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
@@ -1,12 +1,10 @@
 [Unit]
 Description=Start NVIDIA kubernetes device plugin
-RefuseManualStart=true
-RefuseManualStop=true
 After=kubelet.service
 Wants=kubelet.service
 
 [Service]
-ExecStart=/usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true
+ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
 Type=simple
 TimeoutSec=0
 RestartSec=2

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -13,6 +13,8 @@ License: Apache-2.0
 URL: https://github.com/NVIDIA/k8s-device-plugin
 Source0: https://%{goimport}/archive/v%{gover}/v%{gover}.tar.gz#/k8s-device-plugin-%{gover}.tar.gz
 Source1: nvidia-k8s-device-plugin.service
+Source2: nvidia-k8s-device-plugin-conf
+Source3: nvidia-k8s-device-plugin-tmpfiles.conf
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
@@ -61,11 +63,18 @@ install -p -m 0755 fips/nvidia-device-plugin %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -D -p -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-conf
+install -m 0644 %{S:3} %{buildroot}%{_cross_tmpfilesdir}/nvidia-k8s-device-plugin-tmpfiles.conf
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-k8s-device-plugin
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_unitdir}/nvidia-k8s-device-plugin.service
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/nvidia-k8s-device-plugin
+%{_cross_templatedir}/nvidia-k8s-device-plugin-conf
+%{_cross_tmpfilesdir}/nvidia-k8s-device-plugin-tmpfiles.conf
 
 %files bin
 %{_cross_bindir}/nvidia-device-plugin

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2990,6 +2990,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvidia-k8s-device-plugin-metadata"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
+name = "nvidia-k8s-device-plugin-settings"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -91,6 +91,8 @@ members = [
     "api/migration/migrations/v1.20.0/aws-control-container-v0-7-12",
     "api/migration/migrations/v1.20.0/public-control-container-v0-7-12",
     "api/migration/migrations/v1.21.0/pluto-remove-generators-v0-1-0",
+    "api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-metadata",
+    "api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-settings",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-metadata/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nvidia-k8s-device-plugin-metadata"
+version = "0.1.0"
+edition = "2021"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-metadata/src/build.rs
+++ b/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-metadata/src/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-metadata/src/main.rs
@@ -1,0 +1,26 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, NoOpMigration, SettingMetadata};
+use migration_helpers::migrate;
+use migration_helpers::Result;
+use std::process;
+
+/// We added a new setting for configuring device plugin settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    if cfg!(variant_family = "aws-k8s") && cfg!(variant_flavor = "nvidia") {
+        migrate(AddMetadataMigration(&[SettingMetadata {
+            metadata: &["affected-services"],
+            setting: "settings.kubernetes.nvidia.device-plugin",
+        }]))
+    } else {
+        migrate(NoOpMigration)
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-settings/Cargo.toml
+++ b/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-settings/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nvidia-k8s-device-plugin-settings"
+version = "0.1.0"
+edition = "2021"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-settings/src/build.rs
+++ b/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-settings/src/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-settings/src/main.rs
+++ b/sources/api/migration/migrations/v1.21.0/nvidia-k8s-device-plugin-settings/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring device plugin settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    if cfg!(variant_family = "aws-k8s") && cfg!(variant_flavor = "nvidia") {
+        migrate(AddPrefixesMigration(vec![
+            "settings.kubernetes.nvidia.device-plugin.max-sharing-per-gpu",
+            "settings.kubernetes.nvidia.device-plugin.rename-shared-gpu",
+        ]))
+    } else {
+        migrate(NoOpMigration)
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/models/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -1,0 +1,20 @@
+# nvidia device plugin service
+[services.nvidia-device-plugin]
+restart-commands = ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plugin.service"]
+configuration-files = ["nvidia-device-plugin"]
+
+[configuration-files.nvidia-device-plugin]
+path = "/etc/nvidia-k8s-device-plugin/settings.yaml"
+template-path = "/usr/share/templates/nvidia-k8s-device-plugin-conf"
+
+[metadata.settings.kubernetes.nvidia.device-plugin]
+affected-services = ["nvidia-device-plugin"]
+
+[settings.kubernetes.nvidia.device-plugin]
+# Set this value to non zero value to enable GPU timeslicing. Timeslicing is not enabled by default.
+max-sharing-per-gpu = 0
+
+# Set this value to true to rename the shared GPUs when timeslicing is enabled.
+# For example, nvidia.com/gpu will be renamed as nvidia.com/gpu.shared.
+# The default value is set to true to match the default behavior of nvidia device plugin.
+rename-shared-gpu = true

--- a/sources/models/src/aws-k8s-1.24-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
+++ b/sources/models/src/aws-k8s-1.24-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/models/src/aws-k8s-1.25-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
+++ b/sources/models/src/aws-k8s-1.25-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/models/src/aws-k8s-1.26-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
+++ b/sources/models/src/aws-k8s-1.26-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/models/src/aws-k8s-1.30-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
+++ b/sources/models/src/aws-k8s-1.30-nvidia/defaults.d/80-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -317,6 +317,7 @@ struct KubernetesSettings {
     hostname_override: ValidLinuxHostname,
     // Generated in `k8s-1.25+` variants only
     seccomp_default: bool,
+    nvidia: K8sNvidiaSettings,
 }
 
 // ECS settings.
@@ -571,4 +572,15 @@ struct OciDefaultsResourceLimit {
 struct Report {
     name: String,
     description: String,
+}
+
+#[model]
+struct K8sNvidiaSettings {
+    device_plugin: K8sDevicePluginSettings,
+}
+
+#[model]
+struct K8sDevicePluginSettings {
+    max_sharing_per_gpu: i32,
+    rename_shared_gpu: bool,
 }


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**
NVIDIA GPUs supports Time Slicing feature which allows user to share a GPU among a larger number of workload by dividing the GPU’s time into slices. Each workload gets a turn to use the GPU resources within its allocated time slice. This is similar to how a CPU might time-slice between different processes, ensuring that the GPU is used efficiently and not sitting idle. 
This PR contains the changes required for bottlerocket to enable Timeslicing for kubernetes.

This PR introduces two bottlerocket settings API:

Bottlerocket Settings | Impact | Value | What it means?
-- | -- | -- | --
`settings.kubernetes.nvidia.device-plugin.max-sharing-per-gpu` | sets the value of the `replicas` settings of the device plugin for the timesliced resources | integer default: `0` | When the value is greater than `0`. the timeslicing will be enabled.
`settings.kubernetes.nvidia.device-plugin.rename-shared-gpu` | sets the value of the `renameByDefault` settings of the device plugin for the timesliced resources | `true` \| `false` default: `false` | When this setting is set to `false`, it does not change the shared gpu's resource name. if set to `true`, it renames the gpus and append `.shared` in the gpu name. for example, if the value is set to `true`, the gpu name of `nvidia.com/gpu` will be changed to `nvidia.com/gpu.shared`




**Testing done:**

```
bash-5.1# apiclient set settings.kubernetes.nvidia.device-plugin.max-sharing-per-gpu=10
[root@admin]# cat .bottlerocket/rootfs/etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: "volume-mounts"
    deviceIDStrategy: "index"
sharing:
  timeSlicing:
    renameByDefault: true
    resources:
    - name: "nvidia.com/gpu"
      replicas: 10

$ kubectl describe node ip-192-168-68-216.us-west-2.compute.internal          
Name:               ip-192-168-68-216.us-west-2.compute.internal
...
Capacity:
  cpu:                    8
  ephemeral-storage:      18366Mi
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 32458088Ki
  nvidia.com/gpu.shared:  10
  pods:                   58

```

Note: Migration test is still in progress. I will update once the test is complete.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
