### PR TITLE
Add symlink to latest version for amazon-ssm-agent

### DIFF
--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -69,6 +69,9 @@ done
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+ln -sf %{version} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/latest
+ln -sf %{version} %{buildroot}%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/latest
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
@@ -79,9 +82,11 @@ done
 %{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/amazon-ssm-agent
 %{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-agent-worker
 %{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-session-worker
+%{_cross_libexecdir}/amazon-ssm-agent/bin/latest
 
 %files fips-bin
 %dir %{_cross_fips_libexecdir}/amazon-ssm-agent
 %{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/amazon-ssm-agent
 %{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-agent-worker
 %{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-session-worker
+%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/latest


### PR DESCRIPTION
**Issue:** https://github.com/bottlerocket-os/bottlerocket/issues/3988

## v2

**Description of changes:**
Making the following modifications to the `amazon-ssm-agent` package:
- Creating a `latest` symlink so that downstream users can easily pick up the most recent agent version

**Reason for revision:** As per offline discussion with @arnaldo2792  and @bcressey, we are removing the dynamically-linked agent binaries for now since it currently comes with an explicit dependency on `bash`. We want to make this `bash` dependency optional so they will be re-added in a later patch.

**Testing done:**

For the `aws-ecs` variants, verified instance is able to join a cluster and ECS Exec succeeds.

Verified symlink exists in the correct location:
```shell
[root@admin]# sudo sheltie
bash-5.1# ls /usr/libexec/amazon-ssm-agent/bin/
3.3.418.0  latest
```


## v1

**Description of changes:**
Making the following modifications to the `amazon-ssm-agent` package:
- Changing the base package to vendor dynamically-linked agent binaries
- Adding this dynamically-linked agent to the `aws-dev` variant
- Adding a subpackage which vendors statically-linked agent binaries
- Creating a `latest` symlink so that downstream users can easily pick up the most recent agent version
- Adding this statically-linked agent to all `aws-ecs` variants


**Testing done:**

For the `aws-dev` variant, verified that SSM can be used to connect to the instance. Also, SSM `send-command` succeeds.

For the `aws-ecs` variants, verified instance is able to join a cluster and ECS Exec succeeds.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
