### PR TITLE
Remove APIClient dependency on the Settings model

### DIFF
--- a/sources/api/apiclient/src/set.rs
+++ b/sources/api/apiclient/src/set.rs
@@ -1,4 +1,4 @@
-use crate::rando;
+use crate::{rando, SettingsInput};
 use snafu::ResultExt;
 use std::path::Path;
 
@@ -6,7 +6,7 @@ use std::path::Path;
 /// containing those changes.  The given Settings only has to be populated (i.e. Option::Some) with
 /// the settings you want to change.  If you're deserializing a request from a user, for example,
 /// the created Settings will only have the requested keys populated.
-pub async fn set<P>(socket_path: P, settings: &model::Settings) -> Result<()>
+pub async fn set<P>(socket_path: P, settings: SettingsInput) -> Result<()>
 where
     P: AsRef<Path>,
 {
@@ -14,19 +14,21 @@ where
     let transaction = format!("apiclient-set-{}", rando());
 
     // Send the settings changes to the server.
-    let uri = format!("/settings?tx={}", transaction);
+    let (uri, settings_data) = match settings {
+        SettingsInput::KeyPair(value) => (format!("/settings/keypair?tx={}", transaction), value),
+        SettingsInput::Json(value) => (format!("/settings?tx={}", transaction), value),
+    };
     let method = "PATCH";
-    let request_body = serde_json::to_string(&settings).context(error::SerializeSnafu)?;
-    let (_status, _body) = crate::raw_request(&socket_path, &uri, method, Some(request_body))
+    let (_status, _body) = crate::raw_request(&socket_path, &uri, method, Some(settings_data))
         .await
-        .context(error::RequestSnafu { uri, method })?;
+        .context(error::RequestSnafu)?;
 
     // Commit the transaction and apply it to the system.
     let uri = format!("/tx/commit_and_apply?tx={}", transaction);
     let method = "POST";
     let (_status, _body) = crate::raw_request(&socket_path, &uri, method, None)
         .await
-        .context(error::RequestSnafu { uri, method })?;
+        .context(error::RequestSnafu)?;
 
     Ok(())
 }
@@ -40,10 +42,8 @@ mod error {
         #[snafu(display("Unable to serialize data: {}", source))]
         Serialize { source: serde_json::Error },
 
-        #[snafu(display("Failed {} request to '{}': {}", method, uri, source))]
+        #[snafu(display("{}", source))]
         Request {
-            method: String,
-            uri: String,
             #[snafu(source(from(crate::Error, Box::new)))]
             source: Box<crate::Error>,
         },

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -83,11 +83,25 @@ pub enum Error {
         source: deserialization::Error,
     },
 
+    // This is an important error, it's shown when the user uses 'apiclient set' with the
+    // key=value form and we don't have enough data to deserialize the value.  It's not the
+    // user's fault and so we want to be very clear and give an alternative.
+    #[snafu(display("Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: {}", source))]
+    DeserializeMap {
+        source: datastore::deserialization::Error,
+    },
+
+    #[snafu(display("Unable to serialize data: {}", source))]
+    Serialize { source: serde_json::Error },
+
     #[snafu(display("Error serializing {}: {} ", given, source))]
     DataStoreSerialization {
         given: String,
         source: serialization::Error,
     },
+
+    #[snafu(display("Unable to deserialize input JSON into model: {}", source))]
+    DeserializeJson { source: serde_json::Error },
 
     #[snafu(display("Error serializing {}: {} ", given, source))]
     CommandSerialization {
@@ -107,6 +121,16 @@ pub enum Error {
     InvalidMetadata {
         key: String,
         source: serde_json::Error,
+    },
+
+    #[snafu(display("Failed to split the string: {}", input))]
+    InvalidKeyPair { input: String },
+
+    #[snafu(display("Prefix '{}' is not a valid key: {}", prefix, source))]
+    InvalidPrefix {
+        prefix: String,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
     },
 
     #[snafu(display("Config applier was unable to fork child, returned {}", code))]

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -100,6 +100,11 @@ components:
           $ref: '#/components/schemas/StagedImage'
         most-recent-command:
           $ref: '#/components/schemas/CommandResult'
+    SettingsKeyPair:
+      type: object
+      properties:
+        request_payload:
+          type: string
     Settings:
       type: object
       properties:
@@ -270,7 +275,30 @@ paths:
           description: "Invalid body"
         500:
           description: "Server error"
-
+  /settings/keypair/:
+    patch:
+      summary: "Update settings which come in key value form"
+      operationId: "set_key_pair_settings"
+      parameters:
+        - in: query
+          name: tx
+          description: "Transaction in which to update settings; defaults to user 'default' transaction"
+          schema:
+            type: string
+          required: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "SettingsKeyPair"
+      responses:
+        204:
+          description: "Settings successfully staged for update"
+        400:
+          description: "Invalid body"
+        500:
+          description: "Server error"
   /tx:
     get:
       summary: "Get pending settings in a transaction"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes 

**Description of changes:**

We removed the APIClient's dependency on the Settings model. We did this for two dependent subcommands, `set` and `apply`. 

1. For the `apply` command, client-side model verification before serialization was removed. 
2. For the `set` command, for key-value pair inputs a new APIserver endpoint /settings/keypair was introduced. This had its benefits as it allowed the current JSON inputs to work as is, but allowed the transfer of key-pair specific logic from the Client to the Server without any major changes i.e no real change in the data-format for the APIServer to be input (key-value or json) aware.

**Testing done:**

Testing was done `locally` & on an aws-ecs-1 AMI instance. Additionally, Testing between existing AMI and new AMI;s with the code changes was done to prove consistent behavior.

1. Single Set (Map type) works as is.
```
[ssm-user@control]$ apiclient set motd=test
[ssm-user@control]$ apiclient get settings.motd
{
  "settings": {
    "motd": "test"
  }
}
```
4. Multiple Set (Map type) works as is.
```
[ssm-user@control]$ apiclient set motd=random kernel.lockdown=integrity
[ssm-user@control]$ apiclient get settings.kernel.lockdown
{
  "settings": {
    "kernel": {
      "lockdown": "integrity"
    }
  }
}
[ssm-user@control]$ apiclient get settings.motd
{
  "settings": {
    "motd": "random"
  }
}
```
5. Invalid Set (Map type).
```
[ssm-user@control]$  apiclient set motd=random kernel.lockdown=random

Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-tTZRnB3Bi2B8ksZp': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-tTZRnB3Bi2B8ksZp: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error deserializing scalar value: Unable to deserialize into Lockdown: Invalid Linux lockdown mode 'random'
```
6. Passing json and key value pairs should not work.
```
[ssm-user@control]$ apiclient set kernel.lockdown=integrity --json '{"motd": "test"}'

Cannot specify key=value pairs and --json settings with 'set'
```
7. JSON form, with multiple values, internal dots, and quotes/types working as expected:
```
[ssm-user@control]$ apiclient set --json '{"kernel": {"sysctl": {"vm.max_map_count": "888888", "user.max_user_namespaces": "9999"}}}'
[ssm-user@control]$
[ssm-user@control]$ apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "integrity",
      "sysctl": {
        "user.max_user_namespaces": "9999",
        "vm.max_map_count": "888888"
      }
    }
  }
}
```
8. 'Apply' works as is. 
```
[ssm-user@control]$ apiclient apply
[settings]
motd = "from stdin, TOML"

[ssm-user@control]$ apiclient get settings.motd
{
  "settings": {
    "motd": "from stdin, TOML"
  }
}
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
