### PR TITLE
kmod-*-nvidia: specify AWS EULA as license

### DIFF
--- a/packages/kmod-5.10-nvidia/.gitignore
+++ b/packages/kmod-5.10-nvidia/.gitignore
@@ -1,0 +1,1 @@
+NVidiaEULAforAWS.pdf

--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -13,6 +13,10 @@ package-name = "kmod-5.10-nvidia"
 releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 
 [[package.metadata.build-package.external-files]]
+url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
+sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
+
+[[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/470.239.06/NVIDIA-Linux-x86_64-470.239.06.run"
 sha512 = "92bdfb11db405071cd58deed2a0853448932657e256258e0a0bda5069f00485e2b6e49b4a0eeff499a4991be4f884273f3564c164110b1ed1f5d924506f13e2d"
 force-upstream = true

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -1,8 +1,6 @@
 %global tesla_470 470.239.06
 %global tesla_470_libdir %{_cross_libdir}/nvidia/tesla/%{tesla_470}
 %global tesla_470_bindir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
-%global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)
-%global license_file %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml path nvidia -p ./licenses)
 
 Name: %{_cross_os}kmod-5.10-nvidia
 Version: 1.0.0
@@ -16,6 +14,7 @@ URL: http://www.nvidia.com/
 # NVIDIA .run scripts from 0 to 199
 Source0: https://us.download.nvidia.com/tesla/%{tesla_470}/NVIDIA-Linux-x86_64-%{tesla_470}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_470}/NVIDIA-Linux-aarch64-%{tesla_470}.run
+Source2: NVidiaEULAforAWS.pdf
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
@@ -36,7 +35,8 @@ BuildRequires: %{_cross_os}kernel-5.10-archive
 %package tesla-470
 Summary: NVIDIA 470 Tesla driver
 Version: %{tesla_470}
-License: %{spdx_id}
+License: LicenseRef-NVIDIA-AWS-EULA
+Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
 
 %description tesla-470
@@ -46,6 +46,9 @@ Requires: %{name}
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_470}.run -x
+
+# Add the license.
+install -p -m 0644 %{S:2} .
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
@@ -179,7 +182,7 @@ popd
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
 %files tesla-470
-%license %{license_file}
+%license NVidiaEULAforAWS.pdf
 %dir %{_cross_datadir}/nvidia/tesla/%{tesla_470}
 %dir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %dir %{tesla_470_libdir}

--- a/packages/kmod-5.15-nvidia/.gitignore
+++ b/packages/kmod-5.15-nvidia/.gitignore
@@ -1,0 +1,1 @@
+NVidiaEULAforAWS.pdf

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -13,6 +13,10 @@ package-name = "kmod-5.15-nvidia"
 releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 
 [[package.metadata.build-package.external-files]]
+url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
+sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
+
+[[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-x86_64-535.161.07.run"
 sha512 = "4e8dd709157c15519f01a8d419daa098da64666d20a80edf3894239707ff1e83b48553f3edc5d567109d36e52b31ac7c0c7218ea77862a04e89aa3cc1f16a5ba"
 force-upstream = true

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -8,9 +8,6 @@
 %global fm_arch %{_cross_arch}
 %endif
 
-%global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)
-%global license_file %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml path nvidia -p ./licenses)
-
 # With the split of the firmware binary from firmware/gsp.bin to firmware/gsp_ga10x.bin
 # and firmware/gsp_tu10x.bin the file format changed from executable to relocatable.
 # The __spec_install_post macro will by default try to strip all binary files.
@@ -31,6 +28,7 @@ URL: http://www.nvidia.com/
 # NVIDIA .run scripts for kernel and userspace drivers
 Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
+Source2: NVidiaEULAforAWS.pdf
 
 # fabricmanager for NVSwitch
 Source10: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-%{tesla_ver}-archive.tar.xz
@@ -64,7 +62,8 @@ Requires: %{name}-tesla(fabricmanager)
 %package tesla-%{tesla_major}
 Summary: NVIDIA %{tesla_major} Tesla driver
 Version: %{tesla_ver}
-License: %{spdx_id}
+License: LicenseRef-NVIDIA-AWS-EULA
+Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
 Requires: %{name}-fabricmanager
 Provides: %{name}-tesla(fabricmanager)
@@ -80,6 +79,9 @@ sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 # Extract fabricmanager archive. Use `tar` rather than `%%setup` since the
 # correct source is architecture-dependent.
 tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
+
+# Add the license.
+install -p -m 0644 %{S:2} .
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
@@ -233,7 +235,7 @@ popd
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
 %files tesla-%{tesla_major}
-%license %{license_file}
+%license NVidiaEULAforAWS.pdf
 %license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/third-party-notices.txt
 %dir %{_cross_datadir}/nvidia/tesla
 %dir %{_cross_libexecdir}/nvidia/tesla/bin

--- a/packages/kmod-6.1-nvidia/.gitignore
+++ b/packages/kmod-6.1-nvidia/.gitignore
@@ -1,0 +1,1 @@
+NVidiaEULAforAWS.pdf

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -13,6 +13,10 @@ package-name = "kmod-6.1-nvidia"
 releases-url = "https://docs.nvidia.com/datacenter/tesla/"
 
 [[package.metadata.build-package.external-files]]
+url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
+sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
+
+[[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-x86_64-535.161.07.run"
 sha512 = "4e8dd709157c15519f01a8d419daa098da64666d20a80edf3894239707ff1e83b48553f3edc5d567109d36e52b31ac7c0c7218ea77862a04e89aa3cc1f16a5ba"
 force-upstream = true

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -8,9 +8,6 @@
 %global fm_arch %{_cross_arch}
 %endif
 
-%global spdx_id %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml spdx-id nvidia)
-%global license_file %(bottlerocket-license-tool -l %{_builddir}/Licenses.toml path nvidia -p ./licenses)
-
 # With the split of the firmware binary from firmware/gsp.bin to firmware/gsp_ga10x.bin
 # and firmware/gsp_tu10x.bin the file format changed from executable to relocatable.
 # The __spec_install_post macro will by default try to strip all binary files.
@@ -31,6 +28,7 @@ URL: http://www.nvidia.com/
 # NVIDIA .run scripts for kernel and userspace drivers
 Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
+Source2: NVidiaEULAforAWS.pdf
 
 # fabricmanager for NVSwitch
 Source10: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-%{tesla_ver}-archive.tar.xz
@@ -64,7 +62,8 @@ Requires: %{name}-tesla(fabricmanager)
 %package tesla-%{tesla_major}
 Summary: NVIDIA %{tesla_major} Tesla driver
 Version: %{tesla_ver}
-License: %{spdx_id}
+License: LicenseRef-NVIDIA-AWS-EULA
+Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
 Requires: %{name}-fabricmanager
 Provides: %{name}-tesla(fabricmanager)
@@ -80,6 +79,9 @@ sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 # Extract fabricmanager archive. Use `tar` rather than `%%setup` since the
 # correct source is architecture-dependent.
 tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
+
+# Add the license.
+install -p -m 0644 %{S:2} .
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
@@ -233,7 +235,7 @@ popd
 %{_cross_libdir}/modules-load.d/nvidia-dependencies.conf
 
 %files tesla-%{tesla_major}
-%license %{license_file}
+%license NVidiaEULAforAWS.pdf
 %license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/third-party-notices.txt
 %dir %{_cross_datadir}/nvidia/tesla
 %dir %{_cross_libexecdir}/nvidia/tesla/bin


### PR DESCRIPTION
**Issue number:**

Closes #3990

**Description of changes:**
Previously, the NVIDIA packages were special-cased with a "bring your own license" step, to support the case where a developer building the project might choose the terms of a different license under which to distribute the software or to make it available to end users.

With the advent of out-of-tree builds, packages are moving into kits that contain pre-compiled binary RPMs, which means they will always have a header indicating which license applies.

This commit makes it explicit what license those RPMs will have at the time they are published.

Since the terms of the AWS EULA indicate that the software should be used to develop AMIs for use on AWS, add an install-time requirement for `aws-*` variants.


**Testing done:**
```
❯ ls -1 build/rpms/bottlerocket-kmod-*-nvidia-*tesla*.rpm
build/rpms/bottlerocket-kmod-5.10-nvidia-tesla-470-470.239.06-1.aarch64.rpm
build/rpms/bottlerocket-kmod-5.10-nvidia-tesla-470-470.239.06-1.x86_64.rpm
build/rpms/bottlerocket-kmod-5.15-nvidia-tesla-535-535.161.07-1.aarch64.rpm
build/rpms/bottlerocket-kmod-5.15-nvidia-tesla-535-535.161.07-1.x86_64.rpm
build/rpms/bottlerocket-kmod-6.1-nvidia-tesla-535-535.161.07-1.aarch64.rpm
build/rpms/bottlerocket-kmod-6.1-nvidia-tesla-535-535.161.07-1.x86_64.rpm

❯ rpm -qip build/rpms/bottlerocket-kmod-*-nvidia-*tesla*.rpm|rg License
License     : LicenseRef-NVIDIA-AWS-EULA
License     : LicenseRef-NVIDIA-AWS-EULA
License     : LicenseRef-NVIDIA-AWS-EULA
License     : LicenseRef-NVIDIA-AWS-EULA
License     : LicenseRef-NVIDIA-AWS-EULA
License     : LicenseRef-NVIDIA-AWS-EULA

❯ rpm -qlp build/rpms/bottlerocket-kmod-*-nvidia-*tesla*.rpm|rg EULA
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/licenses/kmod-5.10-nvidia/NVidiaEULAforAWS.pdf
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/licenses/kmod-5.10-nvidia/NVidiaEULAforAWS.pdf
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/licenses/kmod-5.15-nvidia/NVidiaEULAforAWS.pdf
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/licenses/kmod-5.15-nvidia/NVidiaEULAforAWS.pdf
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/licenses/kmod-6.1-nvidia/NVidiaEULAforAWS.pdf
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/licenses/kmod-6.1-nvidia/NVidiaEULAforAWS.pdf
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
