### PR TITLE
README: Add k8s cmd to retrieve log archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,11 @@ See the [`settings.aws.*` reference](https://bottlerocket.dev/en/os/latest/#/api
 ### Logs
 
 You can use `logdog` through the [admin container](#admin-container) to obtain an archive of log files from your Bottlerocket host.
+
+For a list of what is collected, see the logdog [command list](sources/logdog/src/log_request.rs).
+
+#### Generating logs
+
 SSH to the Bottlerocket host or `apiclient exec admin bash` to access the admin container, then run:
 
 ```shell
@@ -471,18 +476,29 @@ logdog
 
 This will write an archive of the logs to `/var/log/support/bottlerocket-logs.tar.gz`.
 This archive is accessible from host containers at `/.bottlerocket/support`.
-You can use SSH to retrieve the file.
-Once you have exited from the Bottlerocket host, run a command like:
 
-```shell
-ssh -i YOUR_KEY_FILE \
-  ec2-user@YOUR_HOST \
-  "cat /.bottlerocket/support/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
-```
+#### Fetching logs
 
-(If your instance isn't accessible through SSH, you can use [SSH over SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html).)
+There are multiple methods to retrieve the generated log archive.
 
-For a list of what is collected, see the logdog [command list](sources/logdog/src/log_request.rs).
+- **Via SSH if already enabled**
+
+    Once you have exited from the Bottlerocket host, run a command like:
+
+    ```shell
+    ssh -i YOUR_KEY_FILE \
+    ec2-user@YOUR_HOST \
+    "cat /.bottlerocket/support/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
+    ```
+
+- **With `kubectl get` if running Kubernetes**
+
+    ```shell
+    kubectl get --raw \
+    "/api/v1/nodes/NODE_NAME/proxy/logs/support/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz
+    ```
+
+- **Using [SSH over SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html) if your instance isn't accessible through SSH or Kubernetes**
 
 ### Kdump Support
 


### PR DESCRIPTION
**Issue number:**

Closes #3973

**Description of changes:**

Customer @maiconrocha found an alternative command to retrieve the log archive without using SSH for `aws-k8s` variants.

Updating the README with this command.


**Testing done:**

AMI: `bottlerocket-aws-k8s-1.24-x86_64-v1.20.0-fcf71a47`

*Connected to instance via SSM*

On instance:
1. `enter-admin-container`
2. `sudo sheltie`
3. `logdog`

On local machine:
1. `kubectl get --raw "/api/v1/nodes/NODE_NAME/proxy/logs/support/bottlerocket-logs.tar.gz" > bottlerocket-logs.tar.gz`
2. Verified that log archive was fetched

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
