### PR TITLE
Nvidia settings API for container runtime

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -314,4 +314,5 @@ version = "1.21.0"
 ]
 "(1.20.0, 1.21.0)" = [
     "migrate_v1.21.0_pluto-remove-generators-v0-1-0.lz4",
+    "migrate_v1.21.0_container-runtime-nvidia-k8s.lz4"
 ]

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
@@ -1,0 +1,12 @@
+[required-extensions]
+kubernetes = "v1"
+
++++
+accept-nvidia-visible-devices-as-volume-mounts = {{settings.kubernetes.nvidia.container-runtime.visible-devices-as-volume-mounts}}
+accept-nvidia-visible-devices-envvar-when-unprivileged = {{settings.kubernetes.nvidia.container-runtime.visible-devices-envvar-when-unprivileged}}
+
+[nvidia-container-cli]
+root = "/"
+path = "/usr/bin/nvidia-container-cli"
+environment = []
+ldconfig = "@/sbin/ldconfig"

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s.toml
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s.toml
@@ -1,8 +1,0 @@
-accept-nvidia-visible-devices-as-volume-mounts = true
-accept-nvidia-visible-devices-envvar-when-unprivileged = false
-
-[nvidia-container-cli]
-root = "/"
-path = "/usr/bin/nvidia-container-cli"
-environment = []
-ldconfig = "@/sbin/ldconfig"

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles-k8s.conf
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-tmpfiles-k8s.conf
@@ -1,1 +1,1 @@
-C /etc/nvidia-container-runtime/config.toml - - - - /usr/share/factory/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml
+d /etc/nvidia-container-runtime - - - - -

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -13,7 +13,7 @@ License: Apache-2.0
 URL: https://%{goimport}
 
 Source0: https://%{goimport}/archive/v%{gover}/nvidia-container-toolkit-%{gover}.tar.gz
-Source1: nvidia-container-toolkit-config-k8s.toml
+Source1: nvidia-container-toolkit-config-k8s
 Source2: nvidia-container-toolkit-config-ecs.toml
 Source3: nvidia-oci-hooks-json
 Source4: nvidia-gpu-devices.rules
@@ -82,5 +82,5 @@ ln -s shimpei %{buildroot}%{_cross_bindir}/nvidia-oci
 %{_cross_tmpfilesdir}/nvidia-container-toolkit-ecs.conf
 
 %files k8s
-%{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml
+%{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s
 %{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1435,6 +1435,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "container-runtime-nvidia-k8s"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-variant",
+ "migration-helpers",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "api/migration/migrations/v1.20.0/aws-control-container-v0-7-12",
     "api/migration/migrations/v1.20.0/public-control-container-v0-7-12",
     "api/migration/migrations/v1.21.0/pluto-remove-generators-v0-1-0",
+    "api/migration/migrations/v1.21.0/container-runtime-nvidia-k8s",
 
     "bloodhound",
 

--- a/sources/api/migration/migrations/v1.21.0/container-runtime-nvidia-k8s/Cargo.toml
+++ b/sources/api/migration/migrations/v1.21.0/container-runtime-nvidia-k8s/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "container-runtime-nvidia-k8s"
+version = "0.1.0"
+edition = "2021"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers", version = "0.1.0"}
+
+[build-dependencies]
+bottlerocket-variant = { version = "0.1", path = "../../../../../bottlerocket-variant" }

--- a/sources/api/migration/migrations/v1.21.0/container-runtime-nvidia-k8s/build.rs
+++ b/sources/api/migration/migrations/v1.21.0/container-runtime-nvidia-k8s/build.rs
@@ -1,0 +1,6 @@
+use bottlerocket_variant::Variant;
+
+fn main() {
+    let variant = Variant::from_env().unwrap();
+    variant.emit_cfgs();
+}

--- a/sources/api/migration/migrations/v1.21.0/container-runtime-nvidia-k8s/src/main.rs
+++ b/sources/api/migration/migrations/v1.21.0/container-runtime-nvidia-k8s/src/main.rs
@@ -1,0 +1,24 @@
+use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    if cfg!(variant_family = "aws-k8s") && cfg!(variant_flavor = "nvidia") {
+        migrate(AddPrefixesMigration(vec![
+            "settings.kubernetes.nvidia.container-runtime",
+        ]))
+    } else {
+        migrate(NoOpMigration)
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/models/shared-defaults/nvidia-k8s-container-toolkit.toml
+++ b/sources/models/shared-defaults/nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,14 @@
+[settings.kubernetes.nvidia.container-runtime]
+visible-devices-as-volume-mounts = false
+visible-devices-envvar-when-unprivileged = true
+
+[metadata.settings.kubernetes.nvidia.container-runtime]
+affected-services = ["nvidia-container-toolkit"]
+
+[services.nvidia-container-toolkit]
+configuration-files = ["nvidia-container-toolkit"]
+restart-commands = []
+
+[configuration-files.nvidia-container-toolkit]
+path = "/etc/nvidia-container-runtime/config.toml"
+template-path = "/usr/share/factory/nvidia-container-runtime/nvidia-container-toolkit-config-k8s"

--- a/sources/models/src/aws-k8s-1.30-nvidia/defaults.d/81-nvidia-k8s-container-toolkit.toml
+++ b/sources/models/src/aws-k8s-1.30-nvidia/defaults.d/81-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -317,6 +317,7 @@ struct KubernetesSettings {
     hostname_override: ValidLinuxHostname,
     // Generated in `k8s-1.25+` variants only
     seccomp_default: bool,
+    nvidia: K8sNvidiaSettings,
 }
 
 // ECS settings.
@@ -571,4 +572,15 @@ struct OciDefaultsResourceLimit {
 struct Report {
     name: String,
     description: String,
+}
+
+#[model]
+struct K8sNvidiaSettings {
+    container_runtime: K8sContainerRuntimeSettings,
+}
+
+#[model]
+struct K8sContainerRuntimeSettings {
+    visible_devices_as_volume_mounts: bool,
+    visible_devices_envvar_when_unprivileged: bool,
 }


### PR DESCRIPTION

**Issue number:**

Closes #

**Description of changes:**
This PR will expose two new APIs that will allow customer to configure value of `accept-nvidia-visible-devices-as-volume-mounts` and `accept-nvidia-visible-devices-envvar-when-unprivileged` for nvidia container runtime.


Bottlerocket Settings | Impact | Value | What it means?
-- | -- | -- | --
`settings.kubernetes.nvidia.container-runtime.visible-devices-as-volume-mounts` | allows to change the  `accept-nvidia-visible-devices-as-volume-mounts` value for k8s container-toolkit | `true` \| `false` default: `true` | Adjusting the `visible-devices-as-volume-mounts` settings will alters the method of GPU detection and integration within container environments. Setting this parameter to `true` enables the NVIDIA runtime to recognize GPU devices listed in the `NVIDIA_VISIBLE_DEVICES` environment variable and mount them as volumes, which permits applications within the container to interact with and leverage the GPUs as if they were local resources.
`settings.kubernetes.nvidia.container-runtime.visible-devices-envvar-when-unprivileged` | allows to set value of `accept-nvidia-visible-devices-envvar-when-unprivileged` settings of nvidia container runtime for k8s varient | `true` \| `false` default: `false` | When this setting is set to `false`, it prevents unprivileged containers from accessing all GPU devices on the host by default. If `NVIDIA_VISIBLE_DEVICES` is set to all within the container images and `visible-devices-envvar-when-unprivileged` is set to true, all GPUs on the host will be accessible to the containers, regardless of the limits set via nvidia.com/gpu. This could lead to situations where more GPUs are allocated to a pod than intended, which can affect resource scheduling and isolation.



**Testing done:**
Yes. 
```
$ apiclient set settings.kubernetes.nvidia.container-runtime.visible-devices-as-volume-mounts = true
$ apiclient set settings.kubernetes.nvidia.container-runtime.visible-devices-envvar-when-unprivileged = false
$ apiclient get settings.kubernetes.nvidia.container-runtime
{
  "settings": {
    "kubernetes": {
      "nvidia": {
        "container-runtime": {
          "visible-devices-as-volume-mounts": true,
          "visible-devices-envvar-when-unprivileged": false
        }
      }
    }
  }
}

$ cat /etc/nvidia-container-runtime/config.toml
accept-nvidia-visible-devices-as-volume-mounts = true
accept-nvidia-visible-devices-envvar-when-unprivileged = false

[nvidia-container-cli]
root = "/"
path = "/usr/bin/nvidia-container-cli"
environment = []
ldconfig = "@/sbin/ldconfig"
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
