### PR TITLE
Cherry pick commit into develop for 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.20.1 (2024-06-04)
+
+## OS Changes
+* Update kernels to 6.1.90, 5.15.158, and 5.10.216 ([#3976], [#3972])
+* Include statically linked version of kmod ([#3981])
+
+[#3972]: https://github.com/bottlerocket-os/bottlerocket/pull/3972
+[#3976]: https://github.com/bottlerocket-os/bottlerocket/pull/3976
+[#3981]: https://github.com/bottlerocket-os/bottlerocket/pull/3981
+
 # v1.20.0 (2024-05-13)
 
 ## OS Changes

--- a/Release.toml
+++ b/Release.toml
@@ -312,6 +312,7 @@ version = "1.21.0"
     "migrate_v1.20.0_aws-control-container-v0-7-12.lz4",
     "migrate_v1.20.0_public-control-container-v0-7-12.lz4",
 ]
-"(1.20.0, 1.21.0)" = [
+"(1.20.0, 1.20.1)" = []
+"(1.20.1, 1.21.0)" = [
     "migrate_v1.21.0_pluto-remove-generators-v0-1-0.lz4",
 ]


### PR DESCRIPTION
**Description of changes:**
CHANGELOG.md for the four commits (3 kernel, one modprobe). Release.toml: bump patch level to 1.20.1

(cherry picked from commit 33d737d9264ecff91297ac0604f5f166156cbb73)


**Testing done:**
Built to ensure things still line up for Twoliter.toml and Release.toml


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
