### PR TITLE
kernel-6.1: update to 6.1.91

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/4deb8487627a15345b5963c9825994ff2ec7c42015380406ab8640590242fe7c/kernel-6.1.90-99.173.amzn2023.src.rpm"
-sha512 = "a055bc88f4d99dd8df2b1272eaecdeb2a25e12e0f5a6639eba8c16ce6dcec0d2b2c8371dc87b507058ff232138e5ab5319a9b5b95314111d3fc5c2f25161c3e4"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/086e4ee2c793afa14e68663f7af853027a04e714f716931d7689976f9c854f38/kernel-6.1.91-99.172.amzn2023.src.rpm"
+sha512 = "aaced4e33283aeb31cbfeb9ba8faebe5e87299e8b882526966065903f9582d00dfc4340aa0ecefce1173a156dea0025caf75781df2617edb5489d79cd5c951e3"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.90
+Version: 6.1.91
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/4deb8487627a15345b5963c9825994ff2ec7c42015380406ab8640590242fe7c/kernel-6.1.90-99.173.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/086e4ee2c793afa14e68663f7af853027a04e714f716931d7689976f9c854f38/kernel-6.1.91-99.172.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 6.1.91-99.172.amzn2023.

**Description of changes:**

Update kernel-6.1 to latest AL kernel available in the repositories.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE    VERSION               INTERNAL-IP      EXTERNAL-IP    OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-79-116.us-west-2.compute.internal   Ready    <none>   116s   v1.28.7-eks-c5c5da4   192.168.79.116   35.86.213.29   Bottlerocket OS 1.21.0 (aws-k8s-1.28)   6.1.91           containerd://1.6.31+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
20:36:17             e2e                                         global   complete            Passed:  1, Failed:  0, Remaining:  0
20:36:17    systemd-logs   ip-192-168-79-116.us-west-2.compute.internal   complete                                                 
20:36:17 Sonobuoy plugins have completed. Preparing results for download.
20:36:37             e2e                                         global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
20:36:37    systemd-logs   ip-192-168-79-116.us-west-2.compute.internal   complete   passed                                        
20:36:37 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

Changes to the configs as reported by `tools/diff-kernel-config`:

```
config-aarch64-aws-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
config-x86_64-aws-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
config-x86_64-metal-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
config-x86_64-vmware-k8s-1.28-diff:	  0 removed,   0 added,   0 changed
```

Upstream dropped one patch (no longer needed).

**Terms of contribution"**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.

