### PR TITLE
1.20.x: static kmod cherry-pick

### DIFF
--- a/packages/containerd/containerd-cri-base-json
+++ b/packages/containerd/containerd-cri-base-json
@@ -102,6 +102,15 @@ oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
                 "mode=755",
                 "size=65536k"
             ]
+        },
+        {
+            "destination": "/sbin/modprobe",
+            "source": "/usr/bin/kmod",
+            "options": [
+                "exec",
+		"bind",
+                "ro"
+            ]
         }
     ],
     "linux": {

--- a/packages/docker-engine/0002-oci-inject-kmod-in-all-containers.patch
+++ b/packages/docker-engine/0002-oci-inject-kmod-in-all-containers.patch
@@ -1,0 +1,31 @@
+From e35f5eeeaa4c7b9ec1ae0720fc7de0fc4d43e02f Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Thu, 30 May 2024 14:38:33 +0000
+Subject: [PATCH] oci: inject kmod in all containers
+
+Append a new mount to the default spec created for Linux containers
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ oci/defaults.go | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/oci/defaults.go b/oci/defaults.go
+index c3dae8b..2e90cfa 100644
+--- a/oci/defaults.go
++++ b/oci/defaults.go
+@@ -100,6 +100,12 @@ func DefaultLinuxSpec() specs.Spec {
+ 				Source:      "shm",
+ 				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777"},
+ 			},
++			{
++				Destination: "/sbin/modprobe",
++				Type:        "bind",
++				Source:      "/usr/bin/kmod",
++				Options:     []string{"exec", "bind", "ro"},
++			},
+ 		},
+ 		Linux: &specs.Linux{
+ 			MaskedPaths: []string{
+-- 
+2.44.0

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -30,6 +30,7 @@ Source100: prepare-var-lib-docker.service
 Source1000: clarify.toml
 
 Patch0001: 0001-Change-default-capabilities-using-daemon-config.patch
+Patch0002: 0002-oci-inject-kmod-in-all-containers.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -896,6 +896,12 @@ func withPrivilegedMounts() oci.SpecOpts {
 			Source:      "/mnt",
 			Type:        "bind",
 		},
+		{
+			Options:     []string{"bind", "ro"},
+			Destination: "/sbin/modprobe",
+			Source:      "/usr/bin/kmod",
+			Type:        "bind",
+		},
 	})
 }
 


### PR DESCRIPTION
**Description of changes:**

Cherry-pick of the three commits in pull request #4007

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
