### PR TITLE
Cloudformation settings extension

### DIFF
--- a/packages/settings-cloudformation/Cargo.toml
+++ b/packages/settings-cloudformation/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settings-cloudformation"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "settings-extensions/cloudformation"
+]
+
+# RPM BuildRequires
+[build-dependencies]
+glibc = { path = "../glibc" }
+
+# RPM Requires
+[dependencies]

--- a/packages/settings-cloudformation/settings-cloudformation.spec
+++ b/packages/settings-cloudformation/settings-cloudformation.spec
@@ -1,0 +1,39 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+%global extension_name cloudformation
+
+Name: %{_cross_os}settings-%{extension_name}
+Version: 0.0
+Release: 0%{?dist}
+Summary: settings-%{extension_name}
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p settings-extension-%{extension_name}
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 \
+    ${HOME}/.cache/%{__cargo_target}/release/settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}
+
+install -d %{buildroot}%{_cross_libexecdir}/settings
+ln -sf \
+    ../settings-extension-%{extension_name} \
+    %{buildroot}%{_cross_libexecdir}/settings/%{extension_name}
+
+%files
+%{_cross_libexecdir}/settings-extension-%{extension_name}
+%{_cross_libexecdir}/settings/%{extension_name}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3925,6 +3925,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-cloudformation"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "model-derive",
+ "modeled-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2818,6 +2818,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings-extension-aws",
+ "settings-extension-cloudformation",
  "settings-extension-container-registry",
  "settings-extension-dns",
  "settings-extension-ecs",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -130,6 +130,7 @@ members = [
     "models",
 
     "settings-extensions/aws",
+    "settings-extensions/cloudformation",
     "settings-extensions/container-registry",
     "settings-extensions/dns",
     "settings-extensions/ecs",

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -19,6 +19,7 @@ toml = "0.8"
 
 # settings extensions
 settings-extension-aws = { path = "../settings-extensions/aws", version = "0.1" }
+settings-extension-cloudformation = { path = "../settings-extensions/cloudformation", version = "0.1" }
 settings-extension-container-registry = { path = "../settings-extensions/container-registry", version = "0.1" }
 settings-extension-dns = { path = "../settings-extensions/dns", version = "0.1" }
 settings-extension-ecs = { path = "../settings-extensions/ecs", version = "0.1" }

--- a/sources/models/src/aws-dev/mod.rs
+++ b/sources/models/src/aws-dev/mod.rs
@@ -1,9 +1,7 @@
 use model_derive::model;
 use std::collections::HashMap;
 
-use crate::{
-    BootSettings, BootstrapContainer, CloudFormationSettings, HostContainer, NetworkSettings,
-};
+use crate::{BootSettings, BootstrapContainer, HostContainer, NetworkSettings};
 use modeled_types::Identifier;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -23,6 +21,6 @@ struct Settings {
     pki: settings_extension_pki::PkiSettingsV1,
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-1-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-1-nvidia/mod.rs
@@ -1,10 +1,7 @@
 use model_derive::model;
 use std::collections::HashMap;
 
-use crate::{
-    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
-    NetworkSettings, OciDefaults,
-};
+use crate::{AutoScalingSettings, BootstrapContainer, HostContainer, NetworkSettings, OciDefaults};
 use modeled_types::Identifier;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -25,7 +22,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     autoscaling: AutoScalingSettings,
     dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-1/mod.rs
+++ b/sources/models/src/aws-ecs-1/mod.rs
@@ -1,10 +1,7 @@
 use model_derive::model;
 use std::collections::HashMap;
 
-use crate::{
-    AutoScalingSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
-    NetworkSettings, OciDefaults,
-};
+use crate::{AutoScalingSettings, BootstrapContainer, HostContainer, NetworkSettings, OciDefaults};
 use modeled_types::Identifier;
 
 // Note: we have to use 'rename' here because the top-level Settings structure is the only one
@@ -25,7 +22,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     autoscaling: AutoScalingSettings,
     dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-2-nvidia/mod.rs
+++ b/sources/models/src/aws-ecs-2-nvidia/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
-    NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, HostContainer, NetworkSettings,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     autoscaling: AutoScalingSettings,
     dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-ecs-2/mod.rs
+++ b/sources/models/src/aws-ecs-2/mod.rs
@@ -2,8 +2,8 @@ use model_derive::model;
 use std::collections::HashMap;
 
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings, HostContainer,
-    NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, HostContainer, NetworkSettings,
+    OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     autoscaling: AutoScalingSettings,
     dns: settings_extension_dns::DnsSettingsV1,
 }

--- a/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.24-nvidia/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/models/src/aws-k8s-1.24/mod.rs
+++ b/sources/models/src/aws-k8s-1.24/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.25-nvidia/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/models/src/aws-k8s-1.25/mod.rs
+++ b/sources/models/src/aws-k8s-1.25/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.26-nvidia/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/models/src/aws-k8s-1.26/mod.rs
+++ b/sources/models/src/aws-k8s-1.26/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
+++ b/sources/models/src/aws-k8s-1.30-nvidia/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/models/src/aws-k8s-1.30/mod.rs
+++ b/sources/models/src/aws-k8s-1.30/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AutoScalingSettings, BootSettings, BootstrapContainer, CloudFormationSettings,
-    ContainerRuntimeSettings, HostContainer, KubernetesSettings, NetworkSettings, OciDefaults,
+    AutoScalingSettings, BootSettings, BootstrapContainer, ContainerRuntimeSettings, HostContainer,
+    KubernetesSettings, NetworkSettings, OciDefaults,
 };
 use modeled_types::Identifier;
 
@@ -26,7 +26,7 @@ struct Settings {
     container_registry: settings_extension_container_registry::RegistrySettingsV1,
     oci_defaults: OciDefaults,
     oci_hooks: settings_extension_oci_hooks::OciHooksSettingsV1,
-    cloudformation: CloudFormationSettings,
+    cloudformation: settings_extension_cloudformation::CloudFormationSettingsV1,
     dns: settings_extension_dns::DnsSettingsV1,
     container_runtime: ContainerRuntimeSettings,
     autoscaling: AutoScalingSettings,

--- a/sources/settings-extensions/cloudformation/Cargo.toml
+++ b/sources/settings-extensions/cloudformation/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-cloudformation"
+version = "0.1.0"
+authors = ["Gaurav Sharma <mgsharm@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+env_logger = "0.10"
+modeled-types = { path = "../../models/modeled-types", version = "0.1" }
+model-derive = { path = "../../models/model-derive", version = "0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dependencies.bottlerocket-settings-sdk]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-sdk-v0.1.0-alpha.2"
+version = "0.1.0-alpha"

--- a/sources/settings-extensions/cloudformation/cloudformation.toml
+++ b/sources/settings-extensions/cloudformation/cloudformation.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/sources/settings-extensions/cloudformation/src/lib.rs
+++ b/sources/settings-extensions/cloudformation/src/lib.rs
@@ -1,0 +1,89 @@
+///Settings related to CloudFormation signaling
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use model_derive::model;
+use modeled_types::SingleLineString;
+use std::convert::Infallible;
+
+#[model(impl_default = true)]
+pub struct CloudFormationSettingsV1 {
+    should_signal: bool,
+    stack_name: SingleLineString,
+    logical_resource_id: SingleLineString,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for CloudFormationSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Set anything that can be parsed as CloudFormationSettingsV1.
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // CloudFormationSettingsV1 is validated during deserialization.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_generate_cloudformation_settings() {
+        assert_eq!(
+            CloudFormationSettingsV1::generate(None, None),
+            Ok(GenerateResult::Complete(CloudFormationSettingsV1 {
+                should_signal: None,
+                stack_name: None,
+                logical_resource_id: None,
+            }))
+        )
+    }
+
+    #[test]
+    fn test_serde_cloudformation() {
+        let test_json = json!({
+            "logical-resource-id": "MyEC2Instance",
+            "should-signal":true,
+            "stack-name":"MyStack"
+        });
+
+        let test_json_str = test_json.to_string();
+
+        let cloudformation_settings: CloudFormationSettingsV1 =
+            serde_json::from_str(&test_json_str).unwrap();
+
+        assert_eq!(
+            cloudformation_settings,
+            CloudFormationSettingsV1 {
+                logical_resource_id: Some(SingleLineString::try_from("MyEC2Instance").unwrap()),
+                should_signal: Some(true),
+                stack_name: Some(SingleLineString::try_from("MyStack").unwrap())
+            }
+        );
+
+        let serialized_json: serde_json::Value = serde_json::to_string(&cloudformation_settings)
+            .map(|s| serde_json::from_str(&s).unwrap())
+            .unwrap();
+
+        assert_eq!(serialized_json, test_json);
+    }
+}

--- a/sources/settings-extensions/cloudformation/src/main.rs
+++ b/sources/settings-extensions/cloudformation/src/main.rs
@@ -1,0 +1,20 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_cloudformation::CloudFormationSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("cloudformation")
+        .with_models(vec![
+            BottlerocketSetting::<CloudFormationSettingsV1>::model(),
+        ])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
**Issue number:**

Closes #[3660](https://github.com/bottlerocket-os/bottlerocket/issues/3660)

**Description of changes:**

- Creates `cloudformation` settings extension and uses it in every variant's settings model. 
- Creates `settings-cloudformation` RPM package that installs the extension binary.

**Testing done:**

- Built `aws-dev` variant with the `settings-cloudformation` installed. Launched `ec2` instance with the `aws-dev` variant ami. Connected with the instance via `SSM` to run `apiclient` commands.
- Called apiclient to verify the `settings-cloudformation` worked as expected.

```bash
[ssm-user@control]$ apiclient set --json '{"settings": {"cloudformation": {"logical-resource-id": "MyEC2Instance", "should-signal":true, "stack-name":"MyStack"}}}'
[ssm-user@control]$ apiclient get settings.cloudformation
{
  "settings": {
    "cloudformation": {
      "logical-resource-id": "MyEC2Instance",
      "should-signal": true,
      "stack-name": "MyStack"
    }
  }
}
```

- Also tested by building locally.

```bash
> cargo run proto1 set --setting-version v1 --value '{"logical-resource-id": "MyEC2Instance", "should-signal":true, "stack-name":"MyStack"}'
   Compiling settings-extension-cloudformation v0.1.0 (/Users/mgsharm/bottlerocket/bottlerocket/sources/settings-extensions/cloudformation)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.28s
     Running `/Users/mgsharm/bottlerocket/bottlerocket/sources/target/debug/settings-extension-cloudformation proto1 set --setting-version v1 --value '{"logical-resource-id": "MyEC2Instance", "should-signal":true, "stack-name":"MyStack"}'`
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.