### PR TITLE
Update golangci/golangci-lint-action to v6

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,6 +1,6 @@
 name: golangci-lint
 on:
-  pull_request:
+  push:
     branches: [develop]
     # Only run this workflow if Go files or this workflow have been modified
     paths:
@@ -19,12 +19,12 @@ jobs:
           go-version: 1.21
       - uses: actions/checkout@v4
       - name: lint-host-ctr
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: sources/host-ctr
       - name: lint-ecs-gpu-init
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: sources/ecs-gpu-init

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ linters:
     - staticcheck
     - unconvert
     - unused
-    - vet
+    - govet
 
 run:
   timeout: 3m


### PR DESCRIPTION
**Description of changes:**

Update our golangci-lint workflow to use the most recent version of the golangci/golangci-lint-action (from v4 to v6).

Update our configuration: the golangci-lint linter formerly known as `vet` in  is now named `govet` and the old name is deprecated. Running `cargo make check-golangci-lint` with the old configuration produces two warning messages.

**Testing done:**

Ran `cargo make check-golangci-lint`, which passed. This pull request will trigger the workflow and actually test this change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
