### PR TITLE
Update golangci/golangci-lint-action to v6

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,12 +19,12 @@ jobs:
           go-version: 1.21
       - uses: actions/checkout@v4
       - name: lint-host-ctr
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: sources/host-ctr
       - name: lint-ecs-gpu-init
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: sources/ecs-gpu-init

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ linters:
     - staticcheck
     - unconvert
     - unused
-    - vet
+    - govet
 
 run:
   timeout: 3m


### PR DESCRIPTION
**Description of changes:**

Update golangci-lint workflow to use golangci/golangci-lint-action@v6 rather than v4.

Update linter configuration golang-ci.yaml to use the linter name `govet` rather than `vet`, since `vet` is deprecated.

**Testing done:**

Manual `cargo make check-golangci-lint` found no problems. This pull request should run the GitHub workflow.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
