### PR TITLE
kmod-*-nvidia: switch source for Fabric Manager binaries

### DIFF
--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -27,13 +27,13 @@ sha512 = "bb96a28b45197003480ae223c71a5426ef5258a31eaa485cab0cf4b86bed1664827347
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-535.161.07-archive.tar.xz"
-sha512 = "868b35d567e4c6dccbff0f7e8f74bc55781c8d71db995fd9e471829afec0b44fd430caba964377052678e244d18ea999133487f9a3c50c7289f381480b24c55d"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.161.07-1.x86_64.rpm"
+sha512 = "6710c40b0e50f974697d2c7078281cd2d28a685c138c20cfe9da4696431a5aceb56f04a30e29f4fe05f2b5eddccb7e456897053051ad91d89d40383629525245"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-535.161.07-archive.tar.xz"
-sha512 = "f37f7a24e31dd6ed184d1041616abb8cfcb0ddaec79778930db79bbef8b23b3d468daaa9c156a6cf7a7f2ffc0507e78e2bb6215f70bc39d11bb0ee16c5ef4c82"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.161.07-1.aarch64.rpm"
+sha512 = "3ac673b6f38fd5fbdca021fbc910b6ec6a506dd34ec814ee0003da59de600d044b11c5a97f087080c8581910db33aef71bace5ddb601ee39474d7fde3deeeaa2"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -31,8 +31,8 @@ Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-
 Source2: NVidiaEULAforAWS.pdf
 
 # fabricmanager for NVSwitch
-Source10: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-%{tesla_ver}-archive.tar.xz
-Source11: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-%{tesla_ver}-archive.tar.xz
+Source10: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
+Source11: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-%{tesla_ver}-1.aarch64.rpm
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
@@ -76,9 +76,10 @@ Provides: %{name}-tesla(fabricmanager)
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 
-# Extract fabricmanager archive. Use `tar` rather than `%%setup` since the
+# Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
-tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
+mkdir fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
 
 # Add the license.
 install -p -m 0644 %{S:2} .
@@ -213,11 +214,11 @@ popd
 
 # Begin NVIDIA fabric manager binaries and topologies
 pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
-install -p -m 0755 bin/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
-install -p -m 0755 bin/nvswitch-audit %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -p -m 0755 usr/bin/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -p -m 0755 usr/bin/nvswitch-audit %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 
 install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
-for t in share/nvidia/nvswitch/*_topology ; do
+for t in usr/share/nvidia/nvswitch/*_topology ; do
   install -p -m 0644 "${t}" %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
 done
 
@@ -236,7 +237,7 @@ popd
 
 %files tesla-%{tesla_major}
 %license NVidiaEULAforAWS.pdf
-%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/third-party-notices.txt
+%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
 %dir %{_cross_datadir}/nvidia/tesla
 %dir %{_cross_libexecdir}/nvidia/tesla/bin
 %dir %{_cross_libdir}/nvidia/tesla

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -27,13 +27,13 @@ sha512 = "bb96a28b45197003480ae223c71a5426ef5258a31eaa485cab0cf4b86bed1664827347
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-535.161.07-archive.tar.xz"
-sha512 = "868b35d567e4c6dccbff0f7e8f74bc55781c8d71db995fd9e471829afec0b44fd430caba964377052678e244d18ea999133487f9a3c50c7289f381480b24c55d"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.161.07-1.x86_64.rpm"
+sha512 = "6710c40b0e50f974697d2c7078281cd2d28a685c138c20cfe9da4696431a5aceb56f04a30e29f4fe05f2b5eddccb7e456897053051ad91d89d40383629525245"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-535.161.07-archive.tar.xz"
-sha512 = "f37f7a24e31dd6ed184d1041616abb8cfcb0ddaec79778930db79bbef8b23b3d468daaa9c156a6cf7a7f2ffc0507e78e2bb6215f70bc39d11bb0ee16c5ef4c82"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.161.07-1.aarch64.rpm"
+sha512 = "3ac673b6f38fd5fbdca021fbc910b6ec6a506dd34ec814ee0003da59de600d044b11c5a97f087080c8581910db33aef71bace5ddb601ee39474d7fde3deeeaa2"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -31,8 +31,8 @@ Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-
 Source2: NVidiaEULAforAWS.pdf
 
 # fabricmanager for NVSwitch
-Source10: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-%{tesla_ver}-archive.tar.xz
-Source11: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-%{tesla_ver}-archive.tar.xz
+Source10: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
+Source11: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-%{tesla_ver}-1.aarch64.rpm
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
@@ -76,9 +76,10 @@ Provides: %{name}-tesla(fabricmanager)
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 
-# Extract fabricmanager archive. Use `tar` rather than `%%setup` since the
+# Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
-tar -xf %{_sourcedir}/fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive.tar.xz
+mkdir fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
 
 # Add the license.
 install -p -m 0644 %{S:2} .
@@ -213,11 +214,11 @@ popd
 
 # Begin NVIDIA fabric manager binaries and topologies
 pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
-install -p -m 0755 bin/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
-install -p -m 0755 bin/nvswitch-audit %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -p -m 0755 usr/bin/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -p -m 0755 usr/bin/nvswitch-audit %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 
 install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
-for t in share/nvidia/nvswitch/*_topology ; do
+for t in usr/share/nvidia/nvswitch/*_topology ; do
   install -p -m 0644 "${t}" %{buildroot}%{_cross_datadir}/nvidia/tesla/nvswitch
 done
 
@@ -236,7 +237,7 @@ popd
 
 %files tesla-%{tesla_major}
 %license NVidiaEULAforAWS.pdf
-%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/third-party-notices.txt
+%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
 %dir %{_cross_datadir}/nvidia/tesla
 %dir %{_cross_libexecdir}/nvidia/tesla/bin
 %dir %{_cross_libdir}/nvidia/tesla


### PR DESCRIPTION

**Description of changes:**
The RPMs vended on the developer portal align with Amazon Linux's consumption of Fabric Manager for AL2023. AL2023 is on different driver versions than Bottlerocket at the moment but this at least  moves the build to use the same RPM distributions they consume.


**Testing done:**
Build aws-k8s-1.29-nvidia for x86_64 and aarch64 as well as aws-k8s-1.26-nvidia and validated smoke tests pass:

<details>

```
=========================================
  Running sample UnifiedMemoryPerf
=========================================

GPU Device 0: "Turing" with compute capability 7.5

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.178   0.252   0.348   0.018   0.034   0.029   0.037   0.028
16        0.238   0.260   0.525   0.043   0.064   0.053   0.070   0.065
64        0.348   0.358   0.838   0.132   0.177   0.161   0.136   0.124
256       0.883   0.831   1.510   0.748   0.619   0.569   0.484   0.473
1024      3.068   3.032   3.785   5.245   2.491   2.321   1.938   1.986
4096     11.928  10.882  14.221  35.107   9.305   9.238   8.692   8.505
16384    57.204  55.393  65.832 275.677  49.163  48.778  46.061  45.991

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "Tesla T4"
  CUDA Driver Version / Runtime Version          12.2 / 11.4
  CUDA Capability Major/Minor version number:    7.5
  Total amount of global memory:                 14931 MBytes (15655829504 bytes)
  (040) Multiprocessors, (064) CUDA Cores/MP:    2560 CUDA Cores
  GPU Max Clock rate:                            1590 MHz (1.59 GHz)
  Memory Clock rate:                             5001 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        65536 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1024
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 3 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 30
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Turing" with compute capability 7.5

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 336.59 GFlop/s, Time= 12.461 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

Initializing...
GPU Device 0: "Turing" with compute capability 7.5

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 4.223904 ms
TOPS: 32.54

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Turing" with compute capability 7.5

33554432 elements
numThreads: 1024
numBlocks: 40

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 1.037900 ms
Bandwidth:    129.316572 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.026592
65536 elements scanned in 0.026592 ms -> 2464.500732 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.030940 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.051200 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.127936 ms
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Turing" with compute capability 7.5

Launching normVecByDotProductAWBarrier kernel with numBlocks = 40 blockSize = 1024
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Turing" with compute capability 7.5

Processing time: 126.327003 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Turing" with compute capability 7.5

> GPU device has 40 Multi-Processors, SM 7.5 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Turing" with compute capability 7.5

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
