### PR TITLE
Revert mounting static kmod as /sbin/modprobe 

### DIFF
--- a/packages/containerd/containerd-cri-base-json
+++ b/packages/containerd/containerd-cri-base-json
@@ -102,15 +102,6 @@ oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
                 "mode=755",
                 "size=65536k"
             ]
-        },
-        {
-            "destination": "/sbin/modprobe",
-            "source": "/usr/bin/kmod",
-            "options": [
-                "exec",
-		"bind",
-                "ro"
-            ]
         }
     ],
     "linux": {

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -896,12 +896,6 @@ func withPrivilegedMounts() oci.SpecOpts {
 			Source:      "/mnt",
 			Type:        "bind",
 		},
-		{
-			Options:     []string{"bind", "ro"},
-			Destination: "/sbin/modprobe",
-			Source:      "/usr/bin/kmod",
-			Type:        "bind",
-		},
 	})
 }
 


### PR DESCRIPTION
**Description of changes:**
We found this change to be unsafe for alpine containers in our testing. Reverting this change for the time being until we can find a way to do this safely for all containers. 


**Testing done:**
Attempt to launch an image based upon alpine, the process dies with exit 254 when trying to run alpine images.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
