### PR TITLE
ecs-gpu-init: Fix go lint

### DIFF
--- a/sources/ecs-gpu-init/cmd/ecs-gpu-init/main.go
+++ b/sources/ecs-gpu-init/cmd/ecs-gpu-init/main.go
@@ -25,7 +25,13 @@ func generateGPUInfoConfig() error {
 	if ret := nvml.Init(); ret != nvml.SUCCESS {
 		return fmt.Errorf("Failed to initialize NVML, got ret %v", ret)
 	}
-	defer nvml.Shutdown()
+	defer func() {
+		ret := nvml.Shutdown()
+		if ret != nvml.SUCCESS {
+			fmt.Printf("Failed to shutdown NVML, got ret %v", ret)
+		}
+	}()
+
 	version, ret := nvml.SystemGetDriverVersion()
 	if ret != nvml.SUCCESS {
 		return fmt.Errorf("Failed to get version, got ret %v", ret)


### PR DESCRIPTION
**Description of changes:**
The new lint rules for Go want us to check the return code. For this `defer` its not super useful, but we can still emit a log entry on shutdown just in case things go poorly.

**Testing done:**
`cargo make check-golangci-lint` now passes. It used to say:
```
 Running [/home/runner/golangci-lint-1.59.0-linux-amd64/golangci-lint run --path-prefix=sources/ecs-gpu-init] in [/home/runner/work/bottlerocket/bottlerocket/sources/ecs-gpu-init] ...
  Error: sources/ecs-gpu-init/cmd/ecs-gpu-init/main.go:28:21: Error return value is not checked (errcheck)
  	defer nvml.Shutdown()
  	                   ^
  
  Error: issues found
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
