### PR TITLE
Update NVIDIA drivers to the latest available.

### DIFF
--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -17,13 +17,13 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/470.239.06/NVIDIA-Linux-x86_64-470.239.06.run"
-sha512 = "92bdfb11db405071cd58deed2a0853448932657e256258e0a0bda5069f00485e2b6e49b4a0eeff499a4991be4f884273f3564c164110b1ed1f5d924506f13e2d"
+url = "https://us.download.nvidia.com/tesla/470.256.02/NVIDIA-Linux-x86_64-470.256.02.run"
+sha512 = "a837946dd24d7945c1962a695f1f31965f3ceb6927f52cd08fd51b8db138b7a888bbeab69243f5c8468a7bd7ccd47f5dbdb48a1ca81264866c1ebb7d88628f88"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/470.239.06/NVIDIA-Linux-aarch64-470.239.06.run"
-sha512 = "e448c18cf243233387d3bde4fff4d6fa1eaccc743706f18fd3c6431ce73c8f4ac49009a18ff6bd7796456ce719905bb7611548bf68d61259285f5d5f1d061c0f"
+url = "https://us.download.nvidia.com/tesla/470.256.02/NVIDIA-Linux-aarch64-470.256.02.run"
+sha512 = "38eee5933355c34ca816a2ac0fbc4f55c19c20e1322891bfc98cb6b37d99a31218eea9314877ab0e3cf3ac6eb61f9d9d4d09d0af304b689f18b4efa721b65d5c"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -1,4 +1,4 @@
-%global tesla_470 470.239.06
+%global tesla_470 470.256.02
 %global tesla_470_libdir %{_cross_libdir}/nvidia/tesla/%{tesla_470}
 %global tesla_470_bindir %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-x86_64-535.161.07.run"
-sha512 = "4e8dd709157c15519f01a8d419daa098da64666d20a80edf3894239707ff1e83b48553f3edc5d567109d36e52b31ac7c0c7218ea77862a04e89aa3cc1f16a5ba"
+url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-x86_64-535.183.01.run"
+sha512 = "02b6b679f4fc1d5305f32fca8ce0875eef04cb99f5611d0bb85ac7607ecdd5b2aa4d60b51bf47546477464531a07fffa5bf3db3859868648bd5e86565d85afbb"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-aarch64-535.161.07.run"
-sha512 = "bb96a28b45197003480ae223c71a5426ef5258a31eaa485cab0cf4b86bed166482734784f20c6370a1155f3ff991652cac15f1b1083d2fb056677e6881b219e2"
+url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-aarch64-535.183.01.run"
+sha512 = "d2ac1be8c19b359023c31941374911f3adfe1be34aa2821ef582df4c854ac4eefbbcb10aa22583ac8c9d5caf9326bda12ed1ce6343d67479ed37a4887bd17b5e"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.161.07-1.x86_64.rpm"
-sha512 = "6710c40b0e50f974697d2c7078281cd2d28a685c138c20cfe9da4696431a5aceb56f04a30e29f4fe05f2b5eddccb7e456897053051ad91d89d40383629525245"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.183.01-1.x86_64.rpm"
+sha512 = "d52879d1e552b949a529ede9c4ce3e7b66af0df96e8f43906f211673b99815561c83a7c382be17950b1308457ca496ce49adca41766f808cc5a340471353494b"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.161.07-1.aarch64.rpm"
-sha512 = "3ac673b6f38fd5fbdca021fbc910b6ec6a506dd34ec814ee0003da59de600d044b11c5a97f087080c8581910db33aef71bace5ddb601ee39474d7fde3deeeaa2"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.183.01-1.aarch64.rpm"
+sha512 = "75e1d306b9aa6cc8737bce50f39dc641f64de6a944c50f2c9706345c656f203c4706414dcb51def7671f0fd02fd18605aa3d62958b690d2705cb7011c54ff48e"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
-%global tesla_minor 161
-%global tesla_patch 07
+%global tesla_minor 183
+%global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-x86_64-535.161.07.run"
-sha512 = "4e8dd709157c15519f01a8d419daa098da64666d20a80edf3894239707ff1e83b48553f3edc5d567109d36e52b31ac7c0c7218ea77862a04e89aa3cc1f16a5ba"
+url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-x86_64-535.183.01.run"
+sha512 = "02b6b679f4fc1d5305f32fca8ce0875eef04cb99f5611d0bb85ac7607ecdd5b2aa4d60b51bf47546477464531a07fffa5bf3db3859868648bd5e86565d85afbb"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.161.07/NVIDIA-Linux-aarch64-535.161.07.run"
-sha512 = "bb96a28b45197003480ae223c71a5426ef5258a31eaa485cab0cf4b86bed166482734784f20c6370a1155f3ff991652cac15f1b1083d2fb056677e6881b219e2"
+url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-aarch64-535.183.01.run"
+sha512 = "d2ac1be8c19b359023c31941374911f3adfe1be34aa2821ef582df4c854ac4eefbbcb10aa22583ac8c9d5caf9326bda12ed1ce6343d67479ed37a4887bd17b5e"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.161.07-1.x86_64.rpm"
-sha512 = "6710c40b0e50f974697d2c7078281cd2d28a685c138c20cfe9da4696431a5aceb56f04a30e29f4fe05f2b5eddccb7e456897053051ad91d89d40383629525245"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.183.01-1.x86_64.rpm"
+sha512 = "d52879d1e552b949a529ede9c4ce3e7b66af0df96e8f43906f211673b99815561c83a7c382be17950b1308457ca496ce49adca41766f808cc5a340471353494b"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.161.07-1.aarch64.rpm"
-sha512 = "3ac673b6f38fd5fbdca021fbc910b6ec6a506dd34ec814ee0003da59de600d044b11c5a97f087080c8581910db33aef71bace5ddb601ee39474d7fde3deeeaa2"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.183.01-1.aarch64.rpm"
+sha512 = "75e1d306b9aa6cc8737bce50f39dc641f64de6a944c50f2c9706345c656f203c4706414dcb51def7671f0fd02fd18605aa3d62958b690d2705cb7011c54ff48e"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
-%global tesla_minor 161
-%global tesla_patch 07
+%global tesla_minor 183
+%global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa


### PR DESCRIPTION
**Description of changes:**
This updates the drivers to 470.256.02 for kmod-5.10-nvidia and 535.183.01 for kmod-5.15-nvidia and kmod-6.1-nvidia.


**Testing done:**
Built images for `aws-k8s-1.23-nvidia`, `aws-k8s-1.26-nvidia`, `aws-k8s-1.29-nvidia`, and `aws-ecs-2-nvidia` and ran smoke tests on both `aarch64` and `x86_64`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
