### PR TITLE
fixes for pluto

### DIFF
--- a/packages/os/pluto.service
+++ b/packages/os/pluto.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=Generate additional settings for Kubernetes
+# Treat pluto as an honorary settings generator. It should run after sundog runs other
+# settings generators, and before settings-applier commits all the settings, renders
+# config files, and restarts services.
 After=network-online.target apiserver.service sundog.service
+Before=settings-applier.service
 Requires=sundog.service
 # We don't want to restart the unit if the network goes offline or apiserver restarts
 Wants=network-online.target apiserver.service
@@ -11,10 +15,16 @@ RefuseManualStop=true
 
 [Service]
 Type=oneshot
+# pluto needs access to any Kubernetes settings supplied through user-data, along with
+# network-related settings such as proxy servers. Commit any settings that might have
+# been generated during the sundog phase.
 ExecStartPre=/usr/bin/settings-committer
 ExecStart=/usr/bin/pluto
 RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+# settings-applier requires sundog to succeed as a signal that all settings generators ran
+# successfully. Since pluto is an honorary settings generator, settings-applier also needs
+# it to succeed before it can start.
+RequiredBy=settings-applier.service

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2940,6 +2940,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "constants",
  "futures-util",
  "generate-readme",
  "headers",

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 bytes = "1"
+constants = { path = "../../constants", version = "0.1" }
 futures-util = { version = "0.3", default-features = false }
 headers = "0.3"
 http = "0.2"

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -395,7 +395,12 @@ async fn run() -> Result<()> {
         "kubernetes": settings
     });
     let json_str = generated_settings.to_string();
-    api::client_command(&["set", "-j", json_str.as_str()])
+    let uri = &format!(
+        "{}?tx={}",
+        constants::API_SETTINGS_URI,
+        constants::LAUNCH_TRANSACTION
+    );
+    api::client_command(&["raw", "-m", "PATCH", "-u", uri, "-d", json_str.as_str()])
         .await
         .context(error::SetFailureSnafu)?;
 


### PR DESCRIPTION
**Issue number:**
Fixes #3828

**Description of changes:**
Conceptually, these changes make `pluto` act a bit more like a settings generator: it now runs in between `sundog` and `thar-be-settings`, and it lets `thar-be-settings` handle the actual commit.


**Testing done:**
Annotated output after these changes:
```
bash-5.1# journalctl -o short-monotonic -b |grep -A30 'Generate additional'
# pluto.service starts
[   12.504233] localhost systemd[1]: Starting Generate additional settings for Kubernetes...

# pluto needs settings to be committed so it can read them for its own use
[   12.505915] localhost settings-committer[1149]: 18:01:36 [INFO] Checking pending settings.
[   12.506639] localhost settings-committer[1149]: 18:01:36 [INFO] Committing settings.
[   12.506923] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.metrics.send-metrics
[   12.507106] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.network.hostname
[   12.507106] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.updates.seed
[   12.507106] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.updates.metadata-base-url
[   12.507106] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.host-containers.admin.source
[   12.507106] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.kubernetes.pod-infra-container-image
[   12.507106] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.host-containers.control.source
[   12.507215] localhost apiserver[1063]: 18:01:36 [INFO] Committed data key settings.updates.targets-base-url

# mysterious 3 second pause while pluto does stuff!
[   15.353395] localhost systemd[1]: Finished Generate additional settings for Kubernetes.

# settings-applier.service starts
[   15.355579] localhost systemd[1]: Starting Applies settings to create config files...

# settings-committer now commits the settings from pluto.
[   15.357889] localhost settings-committer[1170]: 18:01:39 [INFO] Checking pending settings.
[   15.358380] localhost settings-committer[1170]: 18:01:39 [INFO] Committing settings.
[   15.358659] localhost apiserver[1063]: 18:01:39 [INFO] Committed data key settings.kubernetes.node-ip
[   15.358877] localhost apiserver[1063]: 18:01:39 [INFO] Committed data key settings.kubernetes.hostname-override
[   15.358877] localhost apiserver[1063]: 18:01:39 [INFO] Committed data key settings.kubernetes.cluster-name
[   15.358877] localhost apiserver[1063]: 18:01:39 [INFO] Committed data key settings.kubernetes.cluster-dns-ip
[   15.358877] localhost apiserver[1063]: 18:01:39 [INFO] Committed data key settings.kubernetes.max-pods

# then thar-be-settings is kicked off - not sure about the 600 ms delay though ...
[   15.950790] localhost thar-be-settings[1175]: 18:01:40 [INFO] thar-be-settings started
[   15.950790] localhost thar-be-settings[1175]: 18:01:40 [INFO] Requesting configuration file data for affected services
[   16.053302] localhost thar-be-settings[1175]: 18:01:40 [INFO] Rendering config files...
[   16.088655] localhost thar-be-settings[1175]: 18:01:40 [INFO] Writing config files to disk...
[   16.089046] localhost thar-be-settings[1175]: 18:01:40 [INFO] Restarting all services...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
