### PR TITLE
packages: add mdadm package for software RAID support

### DIFF
--- a/packages/mdadm/0001-report-monitor-output-to-syslog.patch
+++ b/packages/mdadm/0001-report-monitor-output-to-syslog.patch
@@ -1,0 +1,39 @@
+From a277a7b7d171dbc7cee691ee20a9990fec524581 Mon Sep 17 00:00:00 2001
+From: Todd Neal <tnealt@amazon.com>
+Date: Fri, 7 Jun 2024 18:22:52 +0000
+Subject: [PATCH] report monitor output to syslog and remove env script
+
+---
+ systemd/mdmonitor-oneshot.service | 3 +--
+ systemd/mdmonitor.service         | 3 +--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/systemd/mdmonitor-oneshot.service b/systemd/mdmonitor-oneshot.service
+index ba86b44..c54f080 100644
+--- a/systemd/mdmonitor-oneshot.service
++++ b/systemd/mdmonitor-oneshot.service
+@@ -10,7 +10,6 @@ Description=Reminder for degraded MD arrays
+ Documentation=man:mdadm(8)
+ 
+ [Service]
+-Environment=MDADM_MONITOR_ARGS=--scan
++Environment=MDADM_MONITOR_ARGS="--scan --syslog"
+ EnvironmentFile=-/run/sysconfig/mdadm
+-ExecStartPre=-/usr/lib/mdadm/mdadm_env.sh
+ ExecStart=BINDIR/mdadm --monitor --oneshot $MDADM_MONITOR_ARGS
+diff --git a/systemd/mdmonitor.service b/systemd/mdmonitor.service
+index 9c36478..fcf895b 100644
+--- a/systemd/mdmonitor.service
++++ b/systemd/mdmonitor.service
+@@ -11,7 +11,6 @@ DefaultDependencies=no
+ Documentation=man:mdadm(8)
+ 
+ [Service]
+-Environment=  MDADM_MONITOR_ARGS=--scan
++Environment=  MDADM_MONITOR_ARGS="--scan --syslog"
+ EnvironmentFile=-/run/sysconfig/mdadm
+-ExecStartPre=-/usr/lib/mdadm/mdadm_env.sh
+ ExecStart=BINDIR/mdadm --monitor $MDADM_MONITOR_ARGS
+-- 
+2.40.1
+

--- a/packages/mdadm/Cargo.toml
+++ b/packages/mdadm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mdadm"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://cdn.kernel.org/pub/linux/utils/raid/mdadm/"
+
+[[package.metadata.build-package.external-files]]
+url = "https://cdn.kernel.org/pub/linux/utils/raid/mdadm/mdadm-4.3.tar.xz"
+sha512 = "e44977f2f80d2471cb313803a60c92dafe8282ac06bbbfd41ae90ca493c64a3da94db924538788d045fd7f0667333912dabedb0b070f9abf5c0540b32e0fa08f"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+systemd = { path = "../systemd" }

--- a/packages/mdadm/mdadm-tmpfiles.conf
+++ b/packages/mdadm/mdadm-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /var/run/mdadm 0700 root root -
+Z /var/run/mdadm 0700 root root -

--- a/packages/mdadm/mdadm.spec
+++ b/packages/mdadm/mdadm.spec
@@ -1,0 +1,68 @@
+Name: %{_cross_os}mdadm
+Version: 4.3
+Release: 1%{?dist}
+Summary: mdadm is used for controlling Linux md devices (aka RAID arrays)
+License: GPL-2.0-only
+URL: https://cdn.kernel.org/pub/linux/utils/raid/mdadm/
+Source0: https://cdn.kernel.org/pub/linux/utils/raid/mdadm/mdadm-%{version}.tar.xz
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}systemd-devel
+
+Source100: mdadm-tmpfiles.conf
+Patch100: 0001-report-monitor-output-to-syslog.patch
+
+%description
+%{summary}.
+
+%global set_env \
+%set_cross_build_flags \\\
+export CC=%{_cross_target}-gcc \\\
+CXFLAGS="%{_cross_cflags} -DNO_COROSYNC -DNO_DLM" \
+%{nil}
+
+%prep
+%autosetup -n mdadm-%{version} -p1
+
+%build
+%set_env
+make LDFLAGS="%{_cross_ldflags}"
+
+%install
+%set_env
+make install-bin DESTDIR=%{buildroot}%{_cross_rootdir}/usr
+make install-udev DESTDIR=%{buildroot}
+make install-systemd DESTDIR= SYSTEMD_DIR=%{buildroot}%{_cross_unitdir}
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:100} %{buildroot}%{_cross_tmpfilesdir}/mdadm.conf
+
+%files
+%license COPYING
+%{_cross_attribution_file}
+
+%{_cross_sbindir}/mdadm
+%{_cross_sbindir}/mdmon
+
+%{_cross_tmpfilesdir}/mdadm.conf
+
+%{_cross_udevrulesdir}/01-md-raid-creating.rules
+%{_cross_udevrulesdir}/63-md-raid-arrays.rules
+%{_cross_udevrulesdir}/64-md-raid-assembly.rules
+%{_cross_udevrulesdir}/69-md-clustered-confirm-device.rules
+
+%{_cross_unitdir}/mdadm-last-resort@.service
+%{_cross_unitdir}/mdadm-last-resort@.timer
+%{_cross_unitdir}/mdadm-grow-continue@.service
+%{_cross_unitdir}/mdmon@.service
+%{_cross_unitdir}/mdmonitor.service
+%{_cross_unitdir}-shutdown/mdadm.shutdown
+
+# periodically runs an mdcheck bash script
+%exclude %{_cross_unitdir}/mdcheck_continue.service
+%exclude %{_cross_unitdir}/mdcheck_continue.timer
+%exclude %{_cross_unitdir}/mdcheck_start.service
+%exclude %{_cross_unitdir}/mdcheck_start.timer
+
+# no mail address or alert command, so no-ops
+%exclude %{_cross_unitdir}/mdmonitor-oneshot.service
+%exclude %{_cross_unitdir}/mdmonitor-oneshot.timer

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -40,6 +40,7 @@ libaudit = { path = "../libaudit" }
 libgcc = { path = "../libgcc" }
 libkcapi = { path = "../libkcapi" }
 libstd-rust = { path = "../libstd-rust" }
+mdadm = { path = "../mdadm" }
 nvme-cli = { path = "../nvme-cli" }
 makedumpfile = { path = "../../packages/makedumpfile" }
 netdog = {path = "../netdog" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -121,6 +121,7 @@ Requires: %{_cross_os}iptables
 Requires: %{_cross_os}kexec-tools
 Requires: %{_cross_os}keyutils
 Requires: %{_cross_os}makedumpfile
+Requires: %{_cross_os}mdadm
 Requires: %{_cross_os}netdog
 Requires: %{_cross_os}os
 Requires: %{_cross_os}policycoreutils

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -991,6 +991,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdadm"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "systemd",
+]
+
+[[package]]
 name = "metal-dev"
 version = "0.1.0"
 dependencies = [
@@ -1166,6 +1174,7 @@ dependencies = [
  "libkcapi",
  "libstd-rust",
  "makedumpfile",
+ "mdadm",
  "netdog",
  "nvme-cli",
  "oci-add-hooks",


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

Adds the mdadm package to support future software raid configuration of local ephemeral storage.

**Testing done:**

- Built/ran an AMI and used an admin container to run mdadm and configure local storage.
- `cargo make check`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
