### PR TITLE
kernel-5.10: update to 5.10.217

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/0a25c63e615af935b4980fb447cdd9e44e2fab61ef15b47c60d34e50907e8a12/kernel-5.10.216-204.855.amzn2.src.rpm"
-sha512 = "c32d9c1b3bddcc4a9f5c014be07681e7990d5cedccf7242e7a943f8f2fb270ae419e9bec44215ff1df4d8afede5af5b16926507af5b86f9dd8982b04648b2cde"
+url = "https://cdn.amazonlinux.com/blobstore/0e8dd42b36d60da0f50a2bce7fecca30610adf37e5a35585e39d2f318cdb1e76/kernel-5.10.217-205.860.amzn2.src.rpm"
+sha512 = "e10c0099384cc5ee8b153594101aea35df8541ec06829472650bb15af72550006d8c436756ebfaa7a40a206bc823dd1edd5a37b076086d8fc860ee2ac4c441c8"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.216
+Version: 5.10.217
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/0a25c63e615af935b4980fb447cdd9e44e2fab61ef15b47c60d34e50907e8a12/kernel-5.10.216-204.855.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/0e8dd42b36d60da0f50a2bce7fecca30610adf37e5a35585e39d2f318cdb1e76/kernel-5.10.217-205.860.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 5.10.217-205.860.amzn2.

**Description of changes:**

Added 6 new patches. All are around hibernate/reboot logic, and ensure that the kernel refuses to resume from hibernate if the hardware configuration appears to change. Apparently Windows does not enforce this, and therefore Linux has also not enforced this behavior, because on real laptops this "appears to change" happens in cases where it is perfectly safe to resume from hibernate. On a virtual machine, though, the specified behavior (clean reboot, do not resume) is more desirable, since many hypervisors use these mechanisms to force reboot rather then resume.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                          STATUS   ROLES    AGE     VERSION                INTERNAL-IP     EXTERNAL-IP   OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-46-39.us-west-2.compute.internal   Ready    <none>   2m51s   v1.23.17-eks-ea94ec3   192.168.46.39   35.93.33.93   Bottlerocket OS 1.21.0 (aws-k8s-1.23)   5.10.217         containerd://1.6.31+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
21:52:08             e2e                                        global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
21:52:08    systemd-logs   ip-192-168-46-39.us-west-2.compute.internal   complete   passed                                        
21:52:08 Sonobuoy plugins have completed. Preparing results for download.
21:52:28 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
