### PR TITLE
Changelog and Release changes for 1.20.x branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.20.2 (2024-06-12)
+
+## OS Changes
+* Update kernel to 5.10.217 [#4039]
+* Mount static kmod as `/usr/local/sbin/modprobe` [#4037]
+
+[#4037]: https://github.com/bottlerocket-os/bottlerocket/pull/4037
+[#4039]: https://github.com/bottlerocket-os/bottlerocket/pull/4039
+
 # v1.20.1 (2024-06-04)
 
 ## OS Changes

--- a/Release.toml
+++ b/Release.toml
@@ -313,3 +313,10 @@ version = "1.20.1"
     "migrate_v1.20.0_public-control-container-v0-7-12.lz4",
 ]
 "(1.20.0, 1.20.1)" = []
+"(1.20.1, 1.20.2)" = []
+"(1.20.2, 1.21.0)" = [
+    "migrate_v1.21.0_pluto-remove-generators-v0-1-0.lz4",
+    "migrate_v1.21.0_pod-infra-container-image-remove-settings-generator.lz4",
+    "migrate_v1.21.0_pod-infra-container-image-affected-services.lz4",
+    "migrate_v1.21.0_pod-infra-container-image-services.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.20.1"
+version = "1.20.2"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -314,9 +314,3 @@ version = "1.20.1"
 ]
 "(1.20.0, 1.20.1)" = []
 "(1.20.1, 1.20.2)" = []
-"(1.20.2, 1.21.0)" = [
-    "migrate_v1.21.0_pluto-remove-generators-v0-1-0.lz4",
-    "migrate_v1.21.0_pod-infra-container-image-remove-settings-generator.lz4",
-    "migrate_v1.21.0_pod-infra-container-image-affected-services.lz4",
-    "migrate_v1.21.0_pod-infra-container-image-services.lz4",
-]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.20.1"
+release-version = "1.20.2"
 
 [sdk]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#4043

Description of changes:
Cherry pick from develop into 1.20.x for 1.20.2

Testing done:
`cargo make -e BUILDSYS_VARIANT=aws-k8s-1.29` builds without error

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
