### PR TITLE
Document -nvidia variants in public SSM parameters

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -40,6 +40,9 @@ Supported variants and architectures are described in the [README](README.md#var
 For the purposes of SSM parameters, the valid architecture names are `x86_64` and `arm64` (also known as `aarch64`).
 Also, if you know a specific Bottlerocket version you'd like to use, for example `1.0.6`, you can replace `latest` with that version.
 
+Bottlerocket ECS variants with NVIDIA support append `-nvidia` to the variant name.
+For instance, the NVIDIA variant corresponding to `aws-ecs-2` is `aws-ecs-2-nvidia`.
+
 Once you have the parameter name you want to use, the easiest way to use it is to pass it directly to EC2.
 Just prefix the parameter name with `resolve:ssm:` and EC2 will fetch the current value for you.
 (You can also use this method for CloudFormation and other services that launch EC2 instances for you.)

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -105,6 +105,9 @@ Supported variants and architectures are described in the [README](README.md#var
 For the purposes of SSM parameters, the valid architecture names are `x86_64` and `arm64` (also known as `aarch64`).
 Also, if you know a specific Bottlerocket version you'd like to use, for example `1.11.0`, you can replace `latest` with that version.
 
+Bottlerocket EKS variants with NVIDIA support append `-nvidia` to the variant name.
+For instance, the variant for Kubernetes version 1.28 with NVIDIA support is `aws-k8s-1.28-nvidia`.
+
 Once you have the parameter name you want to use, the easiest way to use it is to pass it directly to EC2.
 (You can also use this method for CloudFormation and other services that launch EC2 instances for you.)
 Just prefix the parameter name with `resolve:ssm:` and EC2 will fetch the current value for you.


### PR DESCRIPTION
Explain the naming convention for NVIDIA variants as part of the documentation for our public SSM parameters.

**Issue number:**

Closes #4046

**Description of changes:**

Add one paragraph to the QUICKSTART-EKS guide to call out our naming convention for NVIDIA variants, since we did not have an example of such a variant in the SSM parameters section.

**Testing done:**

Markdown preview.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
