### PR TITLE
kernel-6.1: update to 6.1.92

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/086e4ee2c793afa14e68663f7af853027a04e714f716931d7689976f9c854f38/kernel-6.1.91-99.172.amzn2023.src.rpm"
-sha512 = "aaced4e33283aeb31cbfeb9ba8faebe5e87299e8b882526966065903f9582d00dfc4340aa0ecefce1173a156dea0025caf75781df2617edb5489d79cd5c951e3"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/56c452d9992a4b8c25e5ff09f38a1464761196c1462a341e438301b6d56bfe50/kernel-6.1.92-99.174.amzn2023.src.rpm"
+sha512 = "134d231c7c87e9136a6ceb2f125bd7d2163d7b73590d821f0d2192effd1a5f0850c612e0f9e03bcbd92f47014fd99fe6e9e8a1b45c5e01dab6d074faf74b4df4"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.91
+Version: 6.1.92
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/086e4ee2c793afa14e68663f7af853027a04e714f716931d7689976f9c854f38/kernel-6.1.91-99.172.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/56c452d9992a4b8c25e5ff09f38a1464761196c1462a341e438301b6d56bfe50/kernel-6.1.92-99.174.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 6.1.92-99.174.amzn2023.


**Description of changes:**

Update the kernel-6.1 package with the latest upstream. There are no changed kernel configuration settings since our last update. There are two new patches from upstream, both around handling NUMA DMA memory regions.

**Testing done:**

Validate basic functionality through sonobuoy quick test:

```
> kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE    VERSION               INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-18-188.us-west-2.compute.internal   Ready    <none>   115s   v1.28.7-eks-c5c5da4   192.168.18.188   35.93.197.146   Bottlerocket OS 1.21.0 (aws-k8s-1.28)   6.1.92           containerd://1.6.31+bottlerocket

> sonobuoy run --mode=quick --wait
[...]
21:53:22             e2e                                         global   complete            Passed:  1, Failed:  0, Remaining:  0
21:53:22    systemd-logs   ip-192-168-18-188.us-west-2.compute.internal   complete                                                 
21:53:22 Sonobuoy plugins have completed. Preparing results for download.
21:53:42             e2e                                         global   complete   passed   Passed:  1, Failed:  0, Remaining:  0
21:53:42    systemd-logs   ip-192-168-18-188.us-west-2.compute.internal   complete   passed                                        
21:53:42 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
