### PR TITLE
Add socat package

### DIFF
--- a/packages/socat/0001-xioopts-conditionally-compile-applyopts_termios_valu.patch
+++ b/packages/socat/0001-xioopts-conditionally-compile-applyopts_termios_valu.patch
@@ -1,0 +1,34 @@
+From c1fa329155c1b6805d64fcc7de4cb5c5ca80d387 Mon Sep 17 00:00:00 2001
+From: Kush Upadhyay <kushupad@amazon.com>
+Date: Thu, 13 Jun 2024 15:27:14 +0000
+Subject: [PATCH] xioopts: conditionally compile applyopts_termios_value
+ function
+
+Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
+---
+ xioopts.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/xioopts.c b/xioopts.c
+index 4b651aa..e957ba3 100644
+--- a/xioopts.c
++++ b/xioopts.c
+@@ -4041,6 +4041,7 @@ int applyopt_spec(
+ 	return 0;
+ }
+ 
++#if WITH_TERMIOS
+ int applyopts_termios_value(
+ 	int fd,
+ 	struct opt *opt)
+@@ -4057,6 +4058,7 @@ int applyopts_termios_value(
+ 	 }
+ 	return 0;
+ }
++#endif /* WITH_TERMIOS */
+ 
+ /* Note: not all options can be applied this way (e.g. OFUNC_SPEC with PH_OPEN)
+    implemented are: OFUNC_FCNTL, OFUNC_SOCKOPT (probably not all types),
+-- 
+2.40.1
+

--- a/packages/socat/Cargo.toml
+++ b/packages/socat/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "socat"
+version = "0.1.0"
+edition = "2018"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "http://www.dest-unreach.org/socat/download/socat-1.8.0.0.tar.gz"
+sha512 = "edf459a9f1907a14025e13b3101ad29787f9a72795cffcd00017ce98847562884db29a95b9ae478a6a50868137548b142947c43fb18e975eb5853a763c42902c"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/socat/socat.spec
+++ b/packages/socat/socat.spec
@@ -1,0 +1,84 @@
+Name: %{_cross_os}socat
+Version: 1.8.0.0
+Release: 1%{?dist}
+Summary: Transfer data between two channels
+License: GPL-2.0-only
+URL: http://www.dest-unreach.org/socat/
+Source0: http://www.dest-unreach.org/socat/download/socat-%{version}.tar.gz
+Patch0001: 0001-xioopts-conditionally-compile-applyopts_termios_valu.patch
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n socat-%{version} -p0001
+
+%build
+%cross_configure \
+  CFLAGS="-Wformat ${CFLAGS}" \
+  --enable-help \
+  --enable-ip4 \
+  --enable-ip6 \
+  --enable-listen \
+  --enable-stdio \
+  --enable-tcp \
+  --enable-udp \
+  --enable-unix \
+  --disable-abstract-unixsocket \
+  --disable-creat \
+  --disable-dccp \
+  --disable-exec \
+  --disable-ext2 \
+  --disable-fdnum \
+  --disable-filan \
+  --disable-file \
+  --disable-fips \
+  --disable-fs \
+  --disable-genericsocket \
+  --disable-gopen \
+  --disable-interface \
+  --disable-largefile \
+  --disable-libwrap \
+  --disable-namespaces \
+  --disable-openssl \
+  --disable-option-checking \
+  --disable-pipe \
+  --disable-posixmq \
+  --disable-proxy \
+  --disable-pty \
+  --disable-rawip \
+  --disable-readline \
+  --disable-retry \
+  --disable-sctp \
+  --disable-shell \
+  --disable-socketpair \
+  --disable-socks4 \
+  --disable-socks4a \
+  --disable-stats \
+  --disable-sycls \
+  --disable-system \
+  --disable-termios \
+  --disable-tun \
+  --disable-udplite \
+  --disable-vsock \
+
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING
+%{_cross_attribution_file}
+%{_cross_bindir}/socat
+%{_cross_bindir}/socat1
+%exclude %{_cross_bindir}/filan
+%exclude %{_cross_bindir}/procan
+%exclude %{_cross_bindir}/socat-broker.sh
+%exclude %{_cross_bindir}/socat-chain.sh
+%exclude %{_cross_bindir}/socat-mux.sh
+%exclude %{_cross_mandir}/*
+
+%changelog

--- a/variants/Cargo.lock
+++ b/variants/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "kernel-6_1",
  "login",
  "release",
+ "socat",
  "soci-snapshotter",
  "strace",
 ]
@@ -1210,6 +1211,13 @@ dependencies = [
 [[package]]
 name = "shim"
 version = "0.1.0"
+
+[[package]]
+name = "socat"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
 
 [[package]]
 name = "soci-snapshotter"

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -37,6 +37,7 @@ included-packages = [
     "strace",
     "chrony-tools",
     "soci-snapshotter",
+    "socat",
 ]
 
 [lib]
@@ -56,3 +57,4 @@ iputils = { path = "../../packages/iputils" }
 strace = { path = "../../packages/strace" }
 chrony = { path = "../../packages/chrony" }
 soci-snapshotter = { path = "../../packages/soci-snapshotter" }
+socat = { path = "../../packages/socat" }


### PR DESCRIPTION
**Issue number:** #4055

Closes #4055

**Description of changes:**

This change adds the `socat` package to the `aws-dev` variant to be used by our downstream customers. Specifically, it includes the following:
- `socat.spec` which is similar to [the previous spec file we had for `socat`](https://github.com/bottlerocket-os/bottlerocket/blob/e86305fb6b2ecf7307026a09359ed7f3edb8b900/packages/socat/socat.spec) with some changes to account for new features added to the updated version `1.8.0.0`
- `Cargo.toml` for the new package
- `0001-xioopts-conditionally-compile-applyopts_termios_valu.patch` needed to successfully compile the new `socat` version. Prior to this patch, we got a compilation error for an undefined reference to `xiotermios_value`, which was defined in a conditionally compiled code block that we want disabled. To fix this, in the patch we add that same conditional compilation directive `WITH_TERMIOS` to the function `applyopts_termios_value` which was using that undefined reference.
- Adding `socat` as a dependency to `aws-dev` which includes updates to its `Cargo.toml` and the general variant `Cargo.lock`


**Testing done:**

`aws-dev` variant successfully builds and launches. `socat` binary exists and runs successfully. We tested `socat` by using it to connect a TCP port to a UNIX socket and verifying we can use the port to get responses.

Further testing for the downstream use case also looks good.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
