### PR TITLE
Kernels 5.10.218 and 5.15.160

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/0e8dd42b36d60da0f50a2bce7fecca30610adf37e5a35585e39d2f318cdb1e76/kernel-5.10.217-205.860.amzn2.src.rpm"
-sha512 = "e10c0099384cc5ee8b153594101aea35df8541ec06829472650bb15af72550006d8c436756ebfaa7a40a206bc823dd1edd5a37b076086d8fc860ee2ac4c441c8"
+url = "https://cdn.amazonlinux.com/blobstore/b5fd278db7388155390664828137d2628fc514d69cabad6476b60908577f7ed8/kernel-5.10.218-208.862.amzn2.src.rpm"
+sha512 = "3cc192e5862faa0b3ae9f1c80f65984e8bf96a7f19e9322577d4fe3a564d17668971ac480dc4982cb065f1fac1b18ca8bcf4bd2bd9156671f6d9d68aa053b339"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.217
+Version: 5.10.218
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/0e8dd42b36d60da0f50a2bce7fecca30610adf37e5a35585e39d2f318cdb1e76/kernel-5.10.217-205.860.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/b5fd278db7388155390664828137d2628fc514d69cabad6476b60908577f7ed8/kernel-5.10.218-208.862.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/f75f72cbdb5b3da04159fef0093b7ca471b95b58172bc9630600bc94668e247a/kernel-5.15.158-103.164.amzn2.src.rpm"
-sha512 = "3ba3616cfcbc230208c84dffbbe1648e57a295dd828288e1e330e988f1f14a9a10fc6e6f251573d20e6679e802ac3b3ca53dfef39d1e19f61af4ede42a035af0"
+url = "https://cdn.amazonlinux.com/blobstore/30d3a0d3adde03b0edcad16b16c89e9b3086b4d5594eb3f57e50b0d42ade76d5/kernel-5.15.160-104.158.amzn2.src.rpm"
+sha512 = "368682b26dc17636f760c3ec6f53745bd774b6a482469cd5dcfebb9f7d5418695d344ba5f9b2e3e8189987eeb901c93ac9c0885d21c6d85fb11e6beb0dfcce5f"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.158
+Version: 5.15.160
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/f75f72cbdb5b3da04159fef0093b7ca471b95b58172bc9630600bc94668e247a/kernel-5.15.158-103.164.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/30d3a0d3adde03b0edcad16b16c89e9b3086b4d5594eb3f57e50b0d42ade76d5/kernel-5.15.160-104.158.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
**Description of changes:**

Cherry-pick the latest kernel updates from bottlerocket-core-kit.

**Testing done:**

See [bottlerocket-core-kit #13](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/13).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
