### PR TITLE
Twoliter: remove left-over vendor section

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -1,6 +1,6 @@
 schema-version = 1
 release-version = "1.21.0"
-digest = "3RiFnOqLalBlo5k2Avahn2m0tQRwEWC6cGIzuAvC+yg="
+digest = "lMRATwxexxX5BpTiTdquj57hPGq1PMsYspMsmPgNLTc="
 
 [sdk]
 name = "bottlerocket-sdk"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -4,9 +4,6 @@ release-version = "1.21.0"
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"
 
-[vendor.agarrcia]
-registry = "public.ecr.aws/bottlerocket-agarrcia"
-
 [sdk]
 name = "bottlerocket-sdk"
 version = "0.42.0"


### PR DESCRIPTION
**Issue number:**


**Description of changes:**

This removes left-over vendor section

**Testing done:**

`cargo make` to make sure my kit wasn't used.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
