### PR TITLE
Update kubernetes sources 1.27, 1.28, 1.29, 1.30

### DIFF
--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.27"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/25/artifacts/kubernetes/v1.27.11/kubernetes-src.tar.gz"
-sha512 = "6d07dabc536149035137332afaa641964d76839d63b0d1b8fe8fbce39c7879370996eece1df0c6d1deb478bb613033527c06934bb6ccfd23cbb18a0ae3d85e0d"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/34/artifacts/kubernetes/v1.27.14/kubernetes-src.tar.gz"
+sha512 = "c7a6acb127cfc510194b44a36d2f56883c89e363007312906e2aea5b21c53fd83b826f8661762e6b7afcab8027079c9d9bc1ba9f6848304845d16248698355b4"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.11
+%global gover 1.27.14
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/25/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/34/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/18/artifacts/kubernetes/v1.28.7/kubernetes-src.tar.gz"
-sha512 = "451e88936d88e07edfd3bd14069a5c33d7c1b21a10feae693f09206ced76170f228f4a12fe666220ddfa39192ca080b7a59b6942d02fdd326759ae24163a483e"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/27/artifacts/kubernetes/v1.28.10/kubernetes-src.tar.gz"
+sha512 = "a7c00d5fd6bca4c6a17c4d57f1b16e30eed6f55ac0c84b01b10c85042f6fa71ed7624f075698da90b873e2dc9a26e22df2de4d0821ee4567bf0d08043343c3f6"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.28.7
+%global gover 1.28.10
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/18/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/27/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/7/artifacts/kubernetes/v1.29.1/kubernetes-src.tar.gz"
-sha512 = "9940027197f83702516775047664d3c30a83e69202dcca5aa89f320e78c27a930eb1373777277f240b3c5a63c351ccab3199c577424e760fe122692065895e2f"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/16/artifacts/kubernetes/v1.29.5/kubernetes-src.tar.gz"
+sha512 = "a79145490ec242d22a079c22c882fedfc283014ee493fb99bd55939b02c94397b3b190d5a994cdeff183a456523782a422834f0201b579179a8e65cba4c67422"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.1
+%global gover 1.29.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/7/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/16/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -15,8 +15,8 @@ package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
 # TODO: update this URL to 1.30 release once available. 
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/3/artifacts/kubernetes/v1.30.0/kubernetes-src.tar.gz"
-sha512 = "2becf971b5ebbc6752509bc04659b036c4fe99e1638a336436555d6403247094b69ab3bde2187391606de59e3a5b23acfce01a2d3c7f4e4b7516025e2812333c"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/9/artifacts/kubernetes/v1.30.1/kubernetes-src.tar.gz"
+sha512 = "314c4cdc3705fa6ded932bb2780e63b78040e75fe7e284aa2cbff93eac177d40eae5dfbe90b7482b682ed97b9d4723b55e4a1d598ec6424df77543e00e7fd6a2"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.0
+%global gover 1.30.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -32,7 +32,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/3/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**


**Description of changes:**

Update kubernetes sources to the latest EKS-D version


**Testing done:**

See: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/35

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
