### PR TITLE
1.20.x

### DIFF
--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v25.0.2/cli-25.0.2.tar.gz"
-sha512 = "66c6c408f4f5f42ded007948a69fb66cf0d1f0462a1700fb4efaaf70755285e7179d5bd61e7963f77a088e5f27a8a42b0501be1331948d0ff30bd829b205b5ad"
+url = "https://github.com/docker/cli/archive/v25.0.5/cli-25.0.5.tar.gz"
+sha512 = "39f49514605a3c78661f105094f9c28beb01927a2d7dc474048c2a27135ca8c3f075a6f05157a176c032d5e7c105f00c9100c15713298b33bd34a6f399bac84d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 25.0.2
+%global gover 25.0.5
 %global rpmver %{gover}
-%global gitrev 29cf62922279a56e122dc132eb84fe98f61d5950
+%global gitrev 5dc9bcc5b78ed23f12cdd68e4285ea1c216ce2a1 
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v25.0.2/moby-25.0.2.tar.gz"
-sha512 = "f0cf5e1792bf54a0e3878663dace55b9e713adba61d8b464888991da2bdf670aebeb22da86f1a7335b79cc9dcde59379afba32249bd3c6a79e5291dbc9faa997"
+url = "https://github.com/moby/moby/archive/v25.0.5/moby-25.0.5.tar.gz"
+sha512 = "42ac2cf271b0a8fe67816844b26216896e4f5ccb0e4b85516b1bcc5a76e5dd5e1dc560b50a6e1d1df4eed2f8b57585e189048edf0a3266e93098004c09dca8cc"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 25.0.2
+%global gover 25.0.5
 %global rpmver %{gover}
-%global gitrev fce6e0ca9bc000888de3daa157af14fa41fcd0ff
+%global gitrev e63daec8672d77ac0b2b5c262ef525c7cf17fd20
 
 %global source_date_epoch 1363394400
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Updating docker to address https://nvd.nist.gov/vuln/detail/CVE-2024-29018

```
docker-cli: update to v25.0.5
docker-engine: update to v25.0.5
```

**Testing done:**

- Testing performed for https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/36

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
