### PR TITLE
update Building.md with latest docker requirements

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,6 +60,19 @@ The default seccomp policy of older versions of Docker do not support the `clone
 You'll need to have Docker installed and running, with your user account added to the `docker` group.
 Docker's [post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/) will walk you through that.
 
+You'll also need to enable the containerd-snapshotter and buildkit features for your docker daemon. This is required for the tooling to operate
+with OCI images properly during bottlerocket build. You can do so by adding the below to your
+docker daemon configuration at `/etc/docker/daemon.json`.
+
+```json
+{
+    "features": {
+        "buildkit": true,
+        "containerd-snapshotter": true
+    }
+}
+```
+
 > Note: If you're on a newer Linux distribution using the unified cgroup hierarchy with cgroups v2, you may need to disable it to work with current versions of runc.
 > You'll know this is the case if you see an error like `docker: Error response from daemon: OCI runtime create failed: this version of runc doesn't work on cgroups v2: unknown.`
 > Set the kernel parameter `systemd.unified_cgroup_hierarchy=0` in your boot configuration (e.g. GRUB) and reboot.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Adds blurb to Building.md to mention the need to enable buildkit and containerd-snapshotter for docker daemon operations with kit images during build.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
