### PR TITLE
sources: move settings-sdk to workspace dependencies

### DIFF
--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -53,5 +53,30 @@ members = [
     "constants",
 ]
 
+[workspace.dependencies.bottlerocket-defaults-helper]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-defaults-helper-v0.1.0"
+version = "0.1.0"
+
+[workspace.dependencies.bottlerocket-modeled-types]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-models-v0.1.0"
+version = "0.1.0"
+
+[workspace.dependencies.bottlerocket-settings-models]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-models-v0.1.0"
+version = "0.1.0"
+
+[workspace.dependencies.bottlerocket-settings-plugin]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-plugin-v0.1.0"
+version = "0.1.0"
+
+[workspace.dependencies.settings-extension-oci-defaults]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-models-v0.1.0"
+version = "0.1.0"
+
 [profile.release]
 debug = true

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -18,6 +18,7 @@ apiclient = { path = "../apiclient", version = "0.1" }
 argh = "0.1"
 async-trait = "0.1"
 base64 = "0.21"
+bottlerocket-modeled-types.workspace = true
 cached = { version = "0.49", features = ["async"] }
 constants = { path = "../../constants", version = "0.1" }
 bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
@@ -36,21 +37,12 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
+settings-extension-oci-defaults.workspace = true
 simplelog = "0.12"
 snafu = "0.8"
 tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
 toml = "0.8"
 url = "2"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
-
-[dependencies.settings-extension-oci-defaults]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
 
 [dev-dependencies]
 # Workaround to enable a feature during integration tests.

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -17,15 +17,8 @@ serde_json = "1"
 toml = "0.8"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../generate-readme" }

--- a/sources/settings-defaults/aws-dev/Cargo.toml
+++ b/sources/settings-defaults/aws-dev/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-ecs-1-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-ecs-1-nvidia/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-ecs-1/Cargo.toml
+++ b/sources/settings-defaults/aws-ecs-1/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-ecs-2-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-ecs-2-nvidia/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-ecs-2/Cargo.toml
+++ b/sources/settings-defaults/aws-ecs-2/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.24-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.24-nvidia/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.24/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.24/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.25-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.25-nvidia/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.25/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.25/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.26-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.26-nvidia/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.26/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.26/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.30-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.30-nvidia/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.30/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.30/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/metal-dev/Cargo.toml
+++ b/sources/settings-defaults/metal-dev/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/metal-k8s-1.30/Cargo.toml
+++ b/sources/settings-defaults/metal-k8s-1.30/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/vmware-dev/Cargo.toml
+++ b/sources/settings-defaults/vmware-dev/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/vmware-k8s-1.30/Cargo.toml
+++ b/sources/settings-defaults/vmware-k8s-1.30/Cargo.toml
@@ -9,7 +9,5 @@ build = "../build-defaults.rs"
 [lib]
 path = "../defaults-toml.rs"
 
-[build-dependencies.bottlerocket-defaults-helper]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-plugins/aws-dev/Cargo.toml
+++ b/sources/settings-plugins/aws-dev/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true

--- a/sources/settings-plugins/aws-ecs-1/Cargo.toml
+++ b/sources/settings-plugins/aws-ecs-1/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true

--- a/sources/settings-plugins/aws-ecs-2/Cargo.toml
+++ b/sources/settings-plugins/aws-ecs-2/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true

--- a/sources/settings-plugins/aws-k8s/Cargo.toml
+++ b/sources/settings-plugins/aws-k8s/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true

--- a/sources/settings-plugins/metal-dev/Cargo.toml
+++ b/sources/settings-plugins/metal-dev/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true

--- a/sources/settings-plugins/metal-k8s/Cargo.toml
+++ b/sources/settings-plugins/metal-k8s/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true

--- a/sources/settings-plugins/vmware-dev/Cargo.toml
+++ b/sources/settings-plugins/vmware-dev/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true

--- a/sources/settings-plugins/vmware-k8s/Cargo.toml
+++ b/sources/settings-plugins/vmware-k8s/Cargo.toml
@@ -15,12 +15,5 @@ serde = "1.0.198"
 serde_json = "1.0.116"
 
 # settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.1.0"
-version = "0.1.0"
+bottlerocket-settings-models.workspace = true
+bottlerocket-settings-plugin.workspace = true


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Within the sources/ workspace, if a crate depends on one of the crates in bottlerocket-settings-sdk, we currently include a section with the full git URL, tag, and version in the crate's Cargo.toml. Because we can't have two versions of the same crate in a workspace, updating one of these Cargo.toml's (in order to test changes in a personal fork, or to bump the version, for example) requires updating all of the other crates that use that dependency.

Making the crates in bottlerocket-settings-sdk workspace dependencies allows us to update to a different version of bottlerocket-settings-sdk by only changing one file.

**Testing done:**

`cargo build` in `sources/`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
