### PR TITLE
Host containers update

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -315,10 +315,13 @@ version = "1.21.0"
 "(1.20.0, 1.20.1)" = []
 "(1.20.1, 1.20.2)" = []
 "(1.20.2, 1.20.3)" = []
-"(1.20.3, 1.21.0)" = [
+"(1.20.3, 1.20.4)" = []
+"(1.20.4, 1.21.0)" = [
     "migrate_v1.21.0_pluto-remove-generators-v0-1-0.lz4",
     "migrate_v1.21.0_pod-infra-container-image-remove-settings-generator.lz4",
     "migrate_v1.21.0_pod-infra-container-image-affected-services.lz4",
     "migrate_v1.21.0_pod-infra-container-image-services.lz4",
     "migrate_v1.21.0_k8s-reserved-cpus-v0-1-0.lz4",
+    "migrate_v1.20.0_aws-control-container-v0-7-12.lz4",
+    "migrate_v1.20.0_public-control-container-v0-7-12.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -322,6 +322,8 @@ version = "1.21.0"
     "migrate_v1.21.0_pod-infra-container-image-affected-services.lz4",
     "migrate_v1.21.0_pod-infra-container-image-services.lz4",
     "migrate_v1.21.0_k8s-reserved-cpus-v0-1-0.lz4",
+    "migrate_v1.21.0_aws-admin-container-v0-11-9.lz4",
+    "migrate_v1.21.0_public-admin-container-v0-11-9.lz4",
     "migrate_v1.20.0_aws-control-container-v0-7-12.lz4",
     "migrate_v1.20.0_public-control-container-v0-7-12.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -279,6 +279,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-admin-container-v0-11-9"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "aws-control-container-v0-7-13"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1617,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-9"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-13"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -40,6 +40,9 @@ members = [
     "settings-migrations/v1.21.0/pod-infra-container-image-remove-settings-generator",
     "settings-migrations/v1.21.0/pod-infra-container-image-services",
     "settings-migrations/v1.21.0/k8s-reserved-cpus-v0-1-0",
+    "settings-migrations/v1.21.0/aws-control-container-v0-7-13",
+    "settings-migrations/v1.21.0/public-control-container-v0-7-13",
+
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -40,6 +40,8 @@ members = [
     "settings-migrations/v1.21.0/pod-infra-container-image-remove-settings-generator",
     "settings-migrations/v1.21.0/pod-infra-container-image-services",
     "settings-migrations/v1.21.0/k8s-reserved-cpus-v0-1-0",
+    "settings-migrations/v1.21.0/aws-admin-container-v0-11-9",
+    "settings-migrations/v1.21.0/public-admin-container-v0-11-9",
     "settings-migrations/v1.21.0/aws-control-container-v0-7-13",
     "settings-migrations/v1.21.0/public-control-container-v0-7-13",
 

--- a/sources/settings-migrations/v1.21.0/aws-admin-container-v0-11-9/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/aws-admin-container-v0-11-9/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aws-admin-container-v0-11-9"
+version = "0.1.0"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.0/aws-admin-container-v0-11-9/src/main.rs
+++ b/sources/settings-migrations/v1.21.0/aws-admin-container-v0-11-9/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.8'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.9'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.0/aws-control-container-v0-7-13/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/aws-control-container-v0-7-13/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aws-control-container-v0-7-13"
+version = "0.1.0"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.0/aws-control-container-v0-7-13/src/main.rs
+++ b/sources/settings-migrations/v1.21.0/aws-control-container-v0-7-13/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.12'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.13'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.0/public-admin-container-v0-11-9/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/public-admin-container-v0-11-9/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "public-admin-container-v0-11-9"
+version = "0.1.0"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.0/public-admin-container-v0-11-9/src/main.rs
+++ b/sources/settings-migrations/v1.21.0/public-admin-container-v0-11-9/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.8";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.9";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.0/public-control-container-v0-7-13/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/public-control-container-v0-7-13/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "public-control-container-v0-7-13"
+version = "0.1.0"
+authors = ["Shikha Vyaghra <vyaghras@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.0/public-control-container-v0-7-13/src/main.rs
+++ b/sources/settings-migrations/v1.21.0/public-control-container-v0-7-13/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.12";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.13";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.8'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.9'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.12'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.13'"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.9"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.12"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.13"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.8"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.9"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Description of changes:**
Update the admin and control host containers to bottlerocket-admin-container v0.11.9 and bottlerocket-control-container v0.7.13. Also add migrations move to these versions on upgrade.

**Testing done:**

- [ ] Bottlerocket v1.20.x can be upgraded into Bottlerocket v1.21.0 and uses the new host container images.
- [ ] A system upgraded from v1.20.x can be rolled back to Bottlerocket v1.20.x and revert to using the old host container images.
- [ ] A new Bottlerocket v1.21.0 image uses the new host container images.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
