### PR TITLE
docker-engine: update to v25.0.6 for 1.20.5 release

### DIFF
--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v25.0.5/moby-25.0.5.tar.gz"
-sha512 = "42ac2cf271b0a8fe67816844b26216896e4f5ccb0e4b85516b1bcc5a76e5dd5e1dc560b50a6e1d1df4eed2f8b57585e189048edf0a3266e93098004c09dca8cc"
+url = "https://github.com/moby/moby/archive/v25.0.6/moby-25.0.6.tar.gz"
+sha512 = "dc3370927654dd2b0d201d112effc8b83416a4df4ed1c5ac6ffaec40a260b0ebdf95107e8f3dcfe91e54f885697273a2b415541f5ea87ec7c491f6325c51a4cc"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 25.0.5
+%global gover 25.0.6
 %global rpmver %{gover}
-%global gitrev e63daec8672d77ac0b2b5c262ef525c7cf17fd20
+%global gitrev b08a51fe16eed67de3861c03b363ba403643b12e
 
 %global source_date_epoch 1363394400
 


### PR DESCRIPTION
**Issue number:**

Closes #4106

**Description of changes:**

Cherry-pick https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/8d215087dfad421bb58298f99c9a204fe765fcef

**Testing done:**

Built aws-ecs-1, aws-ecs-2 variants with personal publication of kit built with these changes. Tested:
```
 NAME                                   TYPE                STATE                              PASSED                FAILED                SKIPPED   BUILD ID                      LAST UPDATE
 aarch64-aws-ecs-1-quick                Test                passed                                  1                     0                      0   b930eb5f-dirty                2024-07-25T23:19:52Z
 aarch64-aws-ecs-2-quick                Test                passed                                  1                     0                      0   b930eb5f-dirty                2024-07-25T23:19:26Z
```


In the `1.20.x` tree, built `aws-ecs-1` and `aws-ecs-2` variants


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
