### PR TITLE
Update containerd to 1.6.34

### DIFF
--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.6.31/containerd-1.6.31.tar.gz"
-sha512 = "76149262eed061c06bd6f57706b6c194de649c869439b6bea69a5bf5daf999409d47ee00429033b0c377cd17526a2785f816936e18f989cd3b0d2cbdb9f488ef"
+url = "https://github.com/containerd/containerd/archive/v1.6.34/containerd-1.6.34.tar.gz"
+sha512 = "4adbdd7cfaf387fa1d3fe1f5150819fd9232e9e7cdb07777068aa5bf050145ad24b4076860ef36ebb410e7019ff2cee529f1563517064f272dc8fb0261316179"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.31
+%global gover 1.6.34
 %global rpmver %{gover}
-%global gitrev e377cd56a71523140ca6ae87e30244719194a521
+%global gitrev e9e2c7707933f32aa891dda794a1df36a6ec7aee
 
 %global _dwz_low_mem_die_limit 0
 

--- a/sources/host-ctr/go.mod
+++ b/sources/host-ctr/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	github.com/aws/aws-sdk-go v1.51.2
 	github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20240318153621-07ad6deb57bb
-	github.com/containerd/containerd v1.6.30
+	github.com/containerd/containerd v1.6.34
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
@@ -43,6 +43,7 @@ require (
 	github.com/cilium/ebpf v0.13.2 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/continuity v0.4.3 // indirect
+	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/go-cni v1.1.9 // indirect
 	github.com/containerd/imgcrypt v1.1.10 // indirect

--- a/sources/host-ctr/go.sum
+++ b/sources/host-ctr/go.sum
@@ -30,10 +30,12 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/containerd v1.6.30 h1:lPUhOvNDGSjJYb5hqcQSQdJsKWlN9oAFJ+LBP6cbyw4=
-github.com/containerd/containerd v1.6.30/go.mod h1:3paPqb9OdknyWuWBpPSj8By/rMd77Lbrh4+Bq6eZTTE=
+github.com/containerd/containerd v1.6.34 h1:ARR5q8AJRqSJEgMc65UZqus+MNsVpyTZsOmeXUeU6Os=
+github.com/containerd/containerd v1.6.34/go.mod h1:gSufNaPbqri6ifEQ3eihFSXoGwqTENkqB7j//aEgE0s=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=
 github.com/containerd/continuity v0.4.3/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
+github.com/containerd/errdefs v0.1.0 h1:m0wCRBiu1WJT/Fr+iOoQHMQS/eP5myQ8lCv4Dz5ZURM=
+github.com/containerd/errdefs v0.1.0/go.mod h1:YgWiiHtLmSeBrvpw+UfPijzbLaB77mEG1WwJTDETIV0=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
 github.com/containerd/go-cni v1.1.9 h1:ORi7P1dYzCwVM6XPN4n3CbkuOx/NZ2DOqy+SHRdo9rU=


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4105

**Description of changes:**

* Updating containerd to 1.6.34
* Update host-ctr reference

**Testing done:**

```
 aarch64-aws-k8s-123-quick                                        Test                                      passed                                                                         1                                       0                                     7051   4baed053                                 2024-07-26T00:24:35Z
 aarch64-aws-k8s-129-conformance                                  Test                                      passed                                                                       392                                       0                                     7019   4baed053                                 2024-07-26T01:16:16Z
 aarch64-aws-k8s-129-quick                                        Test                                      passed                                                                         5                                       0                                     7406   4baed053                                 2024-07-25T23:13:35Z
 x86-64-aws-k8s-123-quick                                         Test                                      passed                                                                         1                                       0                                     7051   4baed053                                 2024-07-26T00:15:53Z
 x86-64-aws-k8s-129-conformance                                   Test                                      passed                                                                       392                                       0                                     7020   4baed053                                 2024-07-26T01:16:00Z
 x86-64-aws-k8s-129-quick                                         Test                                      passed                                                                         5                                       0                                     7407   4baed053                                 2024-07-25T23:09:19Z
 ```
 * Tested host-ctr changes by validating that the admin and control containers are up and running.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
