### PR TITLE
[DRAFT] Nvidia Settings API changes

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -330,3 +330,9 @@ version = "1.21.0"
     "migrate_v1.21.0_k8s-reserved-cpus-v0-1-0.lz4",
     "migrate_v1.21.0_add-hostname-override-source.lz4",
 ]
+"(1.21.0, 1.22.0)" = [
+    "migrate_v1.21.1_nvidia-container-runtime-metadata.lz4",
+    "migrate_v1.21.1_nvidia-container-runtime-settings.lz4",
+    "migrate_v1.21.1_nvidia-k8s-device-plugin-metadata.lz4",
+    "migrate_v1.21.1_nvidia-k8s-device-plugin-settings.lz4",
+]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -13,3 +13,4 @@ vendor = "bottlerocket"
 name = "bottlerocket-core-kit"
 version = "2.3.1"
 vendor = "bottlerocket"
+

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -57,24 +57,35 @@ Summary: Settings plugin for the aws-k8s variants
 Requires: %{_cross_os}variant-family(aws-k8s)
 Provides: %{_cross_os}settings-plugin(any)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.23)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.23-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.24)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.24-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.25)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.25-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.26)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.26-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.27)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.27-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.28)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.28-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.29)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.29-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.30)
+Conflicts: %{_cross_os}settings-plugin(any)
+Conflicts: %{_cross_os}variant-flavor(nvidia)
+
+
+%description aws-k8s
+%{summary}.
+
+%package aws-k8s-nvidia
+Summary: Settings plugin for the aws-k8s-nvidia variants
+Requires: (%{_cross_os}variant-family(aws-k8s) and %{_cross_os}variant-flavor(nvidia))
+Provides: %{_cross_os}settings-plugin(any)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.23-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.24-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.25-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.26-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.27-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.28-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.29-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.30-nvidia)
 Conflicts: %{_cross_os}settings-plugin(any)
 
-%description aws-k8s
+%description aws-k8s-nvidia
 %{summary}.
 
 %package metal-dev
@@ -132,11 +143,22 @@ Conflicts: %{_cross_os}settings-plugin(any)
   -p settings-plugin-aws-dev \
   -p settings-plugin-aws-ecs-1 \
   -p settings-plugin-aws-ecs-2 \
-  -p settings-plugin-aws-k8s \
   -p settings-plugin-metal-dev \
   -p settings-plugin-metal-k8s \
   -p settings-plugin-vmware-dev \
   -p settings-plugin-vmware-k8s \
+  %{nil}
+
+# The settings-plugin-aws-k8s and settings-plugin-aws-k8s-nvidia are compiled independently
+# due to the requirement of distinct feature flags. This separation is necessary to prevent
+# feature unification, as detailed in the Rust Cargo documentation:
+# https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+  -p settings-plugin-aws-k8s \
+  %{nil}
+
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+  -p settings-plugin-aws-k8s-nvidia \
   %{nil}
 
 %install
@@ -148,6 +170,7 @@ for plugin in \
   aws-dev \
   aws-ecs-1 \
   aws-ecs-2 \
+  aws-k8s-nvidia \
   aws-k8s \
   metal-dev \
   metal-k8s \
@@ -190,6 +213,11 @@ done
 %{_cross_pluginsdir}/aws-k8s/libsettings.so
 %{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/aws-k8s.conf
 %{_cross_tmpfilesdir}/settings-plugin-aws-k8s.conf
+
+%files aws-k8s-nvidia
+%{_cross_pluginsdir}/aws-k8s-nvidia/libsettings.so
+%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/aws-k8s-nvidia.conf
+%{_cross_tmpfilesdir}/settings-plugin-aws-k8s-nvidia.conf
 
 %files metal-dev
 %{_cross_pluginsdir}/metal-dev/libsettings.so

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-defaults-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-defaults-helper-v0.1.0#9cb0286b59cd4fcb5df9dd441aee8521ea5698e6"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "snafu",
  "toml",
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "darling 0.20.8",
  "quote",
@@ -344,9 +344,10 @@ dependencies = [
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "base64",
+ "bottlerocket-model-derive",
  "bottlerocket-scalar",
  "bottlerocket-scalar-derive",
  "bottlerocket-string-impls-for",
@@ -377,7 +378,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "serde",
  "serde_plain",
@@ -386,7 +387,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.8",
@@ -400,7 +401,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-plugin-v0.1.0#9cb0286b59cd4fcb5df9dd441aee8521ea5698e6"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -411,7 +412,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-models"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -435,6 +436,7 @@ dependencies = [
  "settings-extension-motd",
  "settings-extension-network",
  "settings-extension-ntp",
+ "settings-extension-nvidia-container-runtime",
  "settings-extension-oci-defaults",
  "settings-extension-oci-hooks",
  "settings-extension-pki",
@@ -445,7 +447,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-plugin-v0.1.0#9cb0286b59cd4fcb5df9dd441aee8521ea5698e6"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -457,7 +459,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -470,7 +472,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "serde",
 ]
@@ -478,7 +480,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -1422,6 +1424,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvidia-container-runtime-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "nvidia-container-runtime-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "nvidia-k8s-device-plugin-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "nvidia-k8s-device-plugin-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2133,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2146,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2159,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2172,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2185,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2198,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2211,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2224,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2237,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2250,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2263,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2275,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2288,7 +2318,20 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-nvidia-container-runtime"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2301,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2315,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2328,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2341,7 +2384,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?rev=603cc2d93443b63bdfa3fadbbd14e4738f00b502#603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2387,6 +2430,17 @@ dependencies = [
 
 [[package]]
 name = "settings-plugin-aws-k8s"
+version = "0.1.0"
+dependencies = [
+ "abi_stable",
+ "bottlerocket-settings-models",
+ "bottlerocket-settings-plugin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-plugin-aws-k8s-nvidia"
 version = "0.1.0"
 dependencies = [
  "abi_stable",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -41,11 +41,16 @@ members = [
     "settings-migrations/v1.21.0/pod-infra-container-image-services",
     "settings-migrations/v1.21.0/k8s-reserved-cpus-v0-1-0",
     "settings-migrations/v1.21.0/add-hostname-override-source",
+    "settings-migrations/v1.21.1/nvidia-container-runtime-metadata",
+    "settings-migrations/v1.21.1/nvidia-container-runtime-settings",
+    "settings-migrations/v1.21.1/nvidia-k8s-device-plugin-metadata",
+    "settings-migrations/v1.21.1/nvidia-k8s-device-plugin-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",
     "settings-plugins/aws-ecs-2",
     "settings-plugins/aws-k8s",
+    "settings-plugins/aws-k8s-nvidia",
     "settings-plugins/metal-dev",
     "settings-plugins/metal-k8s",
     "settings-plugins/vmware-dev",
@@ -54,29 +59,34 @@ members = [
     "constants",
 ]
 
+# ======= REMOVE BEFORE FINAL PR =================
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
+rev = "603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 version = "0.1.0"
 
+# ======= REVERT BEFORE FINAL PR =================
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
+rev = "603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 version = "0.2.0"
 
+# ======= REVERT BEFORE FINAL PR =================
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
+rev = "603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 version = "0.2.0"
 
+# ======= REVERT BEFORE FINAL PR =================
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
+rev = "603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 version = "0.1.0"
 
+# ======= REVERT BEFORE FINAL PR =================
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
+rev = "603cc2d93443b63bdfa3fadbbd14e4738f00b502"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.30-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.30-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.30-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.30-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-migrations/v1.21.1/nvidia-container-runtime-metadata/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/nvidia-container-runtime-metadata/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nvidia-container-runtime-metadata"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.1/nvidia-container-runtime-metadata/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/nvidia-container-runtime-metadata/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::migrate;
+use migration_helpers::Result;
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.nvidia-container-runtime",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.1/nvidia-container-runtime-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/nvidia-container-runtime-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nvidia-container-runtime-settings"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.1/nvidia-container-runtime-settings/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/nvidia-container-runtime-settings/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.nvidia-container-runtime",
+        "services.nvidia-container-toolkit",
+        "configuration-files.nvidia-container-toolkit",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-metadata/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-metadata/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nvidia-k8s-device-plugin-metadata"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-metadata/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-metadata/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::migrate;
+use migration_helpers::Result;
+use std::process;
+
+/// We added a new setting for configuring the NVIDIA k8s device plugin.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.kubernetes.device-plugins.nvidia",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nvidia-k8s-device-plugin-settings"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }

--- a/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-settings/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/nvidia-k8s-device-plugin-settings/src/main.rs
@@ -1,0 +1,23 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring the NVIDIA k8s device plugin.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.device-plugins",
+        "services.nvidia-k8s-device-plugin",
+        "configuration-files.nvidia-k8s-device-plugin-conf",
+        "configuration-files.nvidia-k8s-device-plugin-exec-start-conf",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-plugins/aws-k8s-nvidia/Cargo.toml
+++ b/sources/settings-plugins/aws-k8s-nvidia/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-plugin-aws-k8s-nvidia"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "settings_aws_k8s_nvidia"
+
+[dependencies]
+abi_stable = "0.11.3"
+serde = "1.0.198"
+serde_json = "1.0.116"
+
+# settings plugins
+bottlerocket-settings-plugin = { workspace = true }
+bottlerocket-settings-models = { workspace = true, features = ["nvidia-device-plugin"] }

--- a/sources/settings-plugins/aws-k8s-nvidia/src/lib.rs
+++ b/sources/settings-plugins/aws-k8s-nvidia/src/lib.rs
@@ -2,12 +2,12 @@ use bottlerocket_settings_models::model_derive::model;
 use bottlerocket_settings_plugin::SettingsPlugin;
 use bottlerocket_settings_models::kubernetes::NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED;
 
-// check nvidia-device-plugin feature flag is disabled for this pacakge
-const _: () = assert!(!NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED, "nvidia-device-plugin feature flag should be disabled for this package.");
+// check nvidia-device-plugin feature flag is enabled for this pacakge
+const _: () = assert!(NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED, "nvidia-device-plugin feature flag should be enabled for this package.");
 
 #[derive(SettingsPlugin)]
 #[model(rename = "settings", impl_default = true)]
-struct VmwareK8sSettings {
+struct AwsK8sSettings {
     motd: bottlerocket_settings_models::MotdV1,
     kubernetes: bottlerocket_settings_models::KubernetesSettingsV1,
     updates: bottlerocket_settings_models::UpdatesSettingsV1,
@@ -16,13 +16,16 @@ struct VmwareK8sSettings {
     ntp: bottlerocket_settings_models::NtpSettingsV1,
     network: bottlerocket_settings_models::NetworkSettingsV1,
     kernel: bottlerocket_settings_models::KernelSettingsV1,
-    aws: bottlerocket_settings_models::AwsSettingsV1,
     boot: bottlerocket_settings_models::BootSettingsV1,
+    aws: bottlerocket_settings_models::AwsSettingsV1,
     metrics: bottlerocket_settings_models::MetricsSettingsV1,
     pki: bottlerocket_settings_models::PkiSettingsV1,
     container_registry: bottlerocket_settings_models::RegistrySettingsV1,
     oci_defaults: bottlerocket_settings_models::OciDefaultsV1,
     oci_hooks: bottlerocket_settings_models::OciHooksSettingsV1,
+    cloudformation: bottlerocket_settings_models::CloudFormationSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
     container_runtime: bottlerocket_settings_models::ContainerRuntimeSettingsV1,
+    autoscaling: bottlerocket_settings_models::AutoScalingSettingsV1,
+    nvidia_container_runtime: bottlerocket_settings_models::NvidiaContainerRuntimeSettingsV1,
 }

--- a/sources/settings-plugins/aws-k8s/src/lib.rs
+++ b/sources/settings-plugins/aws-k8s/src/lib.rs
@@ -1,5 +1,8 @@
 use bottlerocket_settings_models::model_derive::model;
 use bottlerocket_settings_plugin::SettingsPlugin;
+use bottlerocket_settings_models::kubernetes::NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED;
+// check nvidia-device-plugin feature flag is disabled for this pacakge
+const _: () = assert!(!NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED, "nvidia-device-plugin feature flag should be disabled for this package.");
 
 #[derive(SettingsPlugin)]
 #[model(rename = "settings", impl_default = true)]

--- a/sources/settings-plugins/metal-k8s/src/lib.rs
+++ b/sources/settings-plugins/metal-k8s/src/lib.rs
@@ -1,5 +1,9 @@
 use bottlerocket_settings_models::model_derive::model;
 use bottlerocket_settings_plugin::SettingsPlugin;
+use bottlerocket_settings_models::kubernetes::NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED;
+
+// check nvidia-device-plugin feature flag is disabled for this pacakge
+const _: () = assert!(!NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED, "nvidia-device-plugin feature flag should be disabled for this package.");
 
 #[derive(SettingsPlugin)]
 #[model(rename = "settings", impl_default = true)]

--- a/sources/shared-defaults/nvidia-k8s-container-toolkit.toml
+++ b/sources/shared-defaults/nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,14 @@
+[settings.nvidia-container-runtime]
+visible-devices-as-volume-mounts = true
+visible-devices-envvar-when-unprivileged = false
+
+[metadata.settings.nvidia-container-runtime]
+affected-services = ["nvidia-container-toolkit"]
+
+[services.nvidia-container-toolkit]
+configuration-files = ["nvidia-container-toolkit"]
+restart-commands = []
+
+[configuration-files.nvidia-container-toolkit]
+path = "/etc/nvidia-container-runtime/config.toml"
+template-path = "/usr/share/templates/nvidia-container-runtime/nvidia-container-toolkit-config-k8s"

--- a/sources/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -1,0 +1,23 @@
+# nvidia device plugin service
+[services.nvidia-k8s-device-plugin]
+restart-commands = ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plugin.service"]
+configuration-files = [
+    "nvidia-k8s-device-plugin-conf",
+    "nvidia-k8s-device-plugin-exec-start-conf",
+]
+
+[configuration-files.nvidia-k8s-device-plugin-conf]
+path = "/etc/nvidia-k8s-device-plugin/settings.yaml"
+template-path = "/usr/share/templates/nvidia-k8s-device-plugin-conf"
+
+[configuration-files.nvidia-k8s-device-plugin-exec-start-conf]
+path = "/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf"
+template-path = "/usr/share/templates/nvidia-k8s-device-plugin-exec-start-conf"
+
+[metadata.settings.kubernetes.device-plugins.nvidia]
+affected-services = ["nvidia-k8s-device-plugin"]
+
+[settings.kubernetes.device-plugins.nvidia]
+pass-device-specs = true
+device-id-strategy="index"
+device-list-strategy="volume-mounts"


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**
This PR introduces new settings API for Nvidia GPUs for Kubernetes Nvidia variants. 

New settings are

Bottlerocket Settings | Impact | Value 
-- | -- | -- 
`settings.nvidia-container-runtime.visible-devices-as-volume-mounts` | allows to change the  `accept-nvidia-visible-devices-as-volume-mounts` value for k8s container-toolkit | `true` \| `false` default: `true`
`settings.nvidia-container-runtime.visible-devices-envvar-when-unprivileged` | allows to set value of  `accept-nvidia-visible-devices-envvar-when-unprivileged` settings of nvidia container runtime for k8s varient | `true` \| `false` default: `false` 
`settings.kubernetes.device-plugins.nvidia.pass-device-specs` | sets the value of the `pass-device-specs` settings of the device plugin that pass the list of DeviceSpecs to the kubelet on Allocate | `true` \| `false` default: `true`
`settings.kubernetes.device-plugins.nvidia.device-id-strategy` | sets the value of the `device-id-strategy` settings of the device plugin which specifies how GPUs are identified and selected for workloads running in a Kubernetes cluster | `uuid` \| `index` Default: `index` 
`settings.kubernetes.device-plugins.nvidia.device-list-strategy` | sets the value of  `device-list-strategy` setting in NVIDIA Kubernetes device plugins. It is used to configure how GPUs are listed and allocated to pods in a Kubernetes cluster | `envvar` \| `volume-mounts` default: `volume-mounts`





**Testing done:**
Yes.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
