### PR TITLE
Release.toml: add migration for hostname-override-source

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -328,4 +328,5 @@ version = "1.21.0"
     "migrate_v1.21.0_pod-infra-container-image-affected-services.lz4",
     "migrate_v1.21.0_pod-infra-container-image-services.lz4",
     "migrate_v1.21.0_k8s-reserved-cpus-v0-1-0.lz4",
+    "migrate_v1.21.0_add-hostname-override-source.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2655,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2678,9 +2678,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
**Description of changes:**
Adds the migration introduced in #4118 to `Release.toml`

**Testing done:**
* [x] Migration testing in progress
  * `settings.kubernetes.hostname-override-source` becomes present on upgrade
  * The setting is removed on downgrade


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
