### PR TITLE
Update README.md - Need to add region flag to the command: aws ssm start-session --target INSTANCE_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you prefer a command-line tool, you can start a session with a recent [AWS CL
 Then you'd be able to start a session using only your instance ID, like this:
 
 ```shell
-aws ssm start-session --target INSTANCE_ID
+aws ssm start-session --target INSTANCE_ID --region REGION_CODE
 ```
 
 With the [default control container](https://github.com/bottlerocket-os/bottlerocket-control-container), you can make [API calls](#api) to configure and manage your Bottlerocket host.


### PR DESCRIPTION
Without region, it throws the below error:

$ aws ssm start-session --target i-XXXXYYYYZZZZ    An error occurred (TargetNotConnected) when calling the StartSession operation: i-XXXXYYYYZZZZ is not connected.

After adding the region, the command runs successfully

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
