### PR TITLE
Use workspace dependencies for all dependencies

### DIFF
--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -54,6 +54,59 @@ members = [
     "constants",
 ]
 
+[workspace.dependencies]
+apiclient = { version = "0.1", path = "api/apiclient" }
+bottlerocket-release = { version = "0.1", path = "bottlerocket-release" }
+constants = { version = "0.1", path = "constants" }
+datastore = { version = "0.1", path = "api/datastore" }
+generate-readme = { version = "0.1", path = "generate-readme" }
+migration-helpers = { version = "0.1.0", path = "api/migration/migration-helpers" }
+models = { version = "0.1", path = "models" }
+retry-read = { version = "0.1", path = "retry-read" }
+schnauzer = { version = "0.1", path = "api/schnauzer" }
+
+abi_stable = "0.11.3"
+argh = "0.1"
+async-trait = "0.1"
+base64 = "0.21"
+cached = "0.49"
+cargo-readme = "3"
+dns-lookup = "2"
+envy = "0.4"
+futures = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3", default-features = false }
+handlebars = "4"
+http = "0.2"
+httparse = "1"
+hyper = { version = "0.14", default-features = false }
+hyper-unix-connector = "0.2"
+lazy_static = "1"
+libc = "0.2"
+log = "0.4"
+maplit = "1.0"
+nix = "0.26"
+num_cpus = "1"
+percent-encoding = "2"
+pest = "2.5"
+pest_derive = "2.5"
+rand = "0.8"
+regex = "1"
+reqwest = { version = "0.11", default-features = false }
+semver = "1"
+serde = "1"
+serde_json = "1"
+serde_plain = "1"
+shlex = "1"
+signal-hook = "0.3"
+simplelog = "0.12"
+snafu = "0.8"
+tokio = { version = "~1.32", default-features = false }
+tokio-tungstenite = { version = "0.20", default-features = false }
+toml = "0.8"
+unindent = "0.1"
+url = "2"
+walkdir = "2"
+
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
 tag = "bottlerocket-defaults-helper-v0.1.0"

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -10,32 +10,32 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.21"
-constants = { path = "../../constants", version = "0.1" }
-datastore = { path = "../datastore", version = "0.1" }
-futures = { version = "0.3", default-features = false }
-futures-channel = { version = "0.3", default-features = false }
-http = "0.2"
-httparse = "1"
-hyper = { version = "0.14", default-features = false, features = ["client", "http1", "http2"] }
-hyper-unix-connector = "0.2"
-libc = "0.2"
-log = "0.4"
-models = { path = "../../models", version = "0.1" }
-nix = "0.26"
-rand = "0.8"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-native-roots"] }
-retry-read = { path = "../../retry-read", version = "0.1" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-signal-hook = "0.3"
-simplelog = "0.12"
-snafu = { version = "0.8", features = ["futures"] }
-tokio = { version = "~1.32", default-features = false, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
-tokio-tungstenite = { version = "0.20", default-features = false, features = ["connect"] }
-toml = "0.8"
-unindent = "0.1"
-url = "2"
+base64.workspace = true
+constants.workspace = true
+datastore.workspace = true
+futures.workspace = true
+futures-channel.workspace = true
+http.workspace = true
+httparse.workspace = true
+hyper = { workspace = true, features = ["client", "http1", "http2"] }
+hyper-unix-connector.workspace = true
+libc.workspace = true
+log.workspace = true
+models.workspace = true
+nix.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["rustls-tls-native-roots"] }
+retry-read.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+signal-hook.workspace = true
+simplelog.workspace = true
+snafu = { workspace = true, features = ["futures"] }
+tokio = { workspace = true, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
+tokio-tungstenite = { workspace = true, features = ["connect"] }
+toml.workspace = true
+unindent.workspace = true
+url.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/datastore/Cargo.toml
+++ b/sources/api/datastore/Cargo.toml
@@ -10,16 +10,16 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-log = "0.4"
-percent-encoding = "2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-snafu = "0.8"
-walkdir = "2"
+log.workspace = true
+percent-encoding.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+walkdir.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-maplit = "1"
-toml = "0.8"
+maplit.workspace = true
+toml.workspace = true

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -9,15 +9,15 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../../../bottlerocket-release", version = "0.1" }
-datastore = { path = "../../datastore", version = "0.1" }
-handlebars = "4"
-schnauzer = { path = "../../schnauzer", version = "0.1" }
-serde = "1"
-serde_json = "1"
-shlex = "1"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["rt-multi-thread"] }
+bottlerocket-release.workspace = true
+datastore.workspace = true
+handlebars.workspace = true
+schnauzer.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+shlex.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-maplit = "1"
+maplit.workspace = true

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -14,39 +14,39 @@ default = []
 testfakes = []
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
-argh = "0.1"
-async-trait = "0.1"
-base64 = "0.21"
+apiclient.workspace = true
+argh.workspace = true
+async-trait.workspace = true
+base64.workspace = true
 bottlerocket-modeled-types.workspace = true
-cached = { version = "0.49", features = ["async"] }
-constants = { path = "../../constants", version = "0.1" }
-bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
-dns-lookup = "2"
-handlebars = "4"
-http = "0.2"
-lazy_static = "1"
-log = "0.4"
-maplit = "1.0"
-models = { path = "../../models", version = "0.1" }
-num_cpus = "1"
-percent-encoding = "2"
-pest = "2.5"
-pest_derive = "2.5"
-regex = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_plain = "1"
+cached = { workspace = true, features = ["async"] }
+constants.workspace = true
+bottlerocket-release.workspace = true
+dns-lookup.workspace = true
+handlebars.workspace = true
+http.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+maplit.workspace = true
+models.workspace = true
+num_cpus.workspace = true
+percent-encoding.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+regex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_plain.workspace = true
 settings-extension-oci-defaults.workspace = true
-simplelog = "0.12"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
-toml = "0.8"
-url = "2"
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] } # LTS
+toml.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 # Workaround to enable a feature during integration tests.
-schnauzer = { path = ".", version = "0.1.0", features = ["testfakes"] }
+schnauzer = { workspace = true, features = ["testfakes"] }
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/bottlerocket-release/Cargo.toml
+++ b/sources/bottlerocket-release/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-envy = "0.4"
-log = "0.4"
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
-snafu = "0.8"
+envy.workspace = true
+log.workspace = true
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+snafu.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/constants/Cargo.toml
+++ b/sources/constants/Cargo.toml
@@ -11,4 +11,4 @@ exclude = ["README.md"]
 [dependencies]
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/generate-readme/Cargo.toml
+++ b/sources/generate-readme/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-cargo-readme = "3"
-snafu = "0.8"
+cargo-readme.workspace = true
+snafu.workspace = true

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -10,18 +10,18 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../bottlerocket-release", version = "0.1" }
-libc = "0.2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-toml = "0.8"
+bottlerocket-release.workspace = true
+libc.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true
 bottlerocket-settings-plugin.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true
 
 [lib]
 # We're loading the correct *model* at runtime, so users shouldn't think about

--- a/sources/retry-read/Cargo.toml
+++ b/sources/retry-read/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 exclude = ["README.md"]
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/settings-migrations/v1.21.0/add-hostname-override-source/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/add-hostname-override-source/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.0/k8s-reserved-cpus-v0-1-0/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/k8s-reserved-cpus-v0-1-0/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.0/pluto-remove-generators-v0-1-0/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/pluto-remove-generators-v0-1-0/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.0/pod-infra-container-image-affected-services/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/pod-infra-container-image-affected-services/Cargo.toml
@@ -12,4 +12,4 @@ exclude = ["README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.0/pod-infra-container-image-remove-settings-generator/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/pod-infra-container-image-remove-settings-generator/Cargo.toml
@@ -12,4 +12,4 @@ exclude = ["README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.0/pod-infra-container-image-services/Cargo.toml
+++ b/sources/settings-migrations/v1.21.0/pod-infra-container-image-services/Cargo.toml
@@ -12,4 +12,4 @@ exclude = ["README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-migration-helpers = { path = "../../../api/migration/migration-helpers", version = "0.1.0" }
+migration-helpers.workspace = true

--- a/sources/settings-plugins/aws-dev/Cargo.toml
+++ b/sources/settings-plugins/aws-dev/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_aws_dev"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true

--- a/sources/settings-plugins/aws-ecs-1/Cargo.toml
+++ b/sources/settings-plugins/aws-ecs-1/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_aws_ecs_1"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true

--- a/sources/settings-plugins/aws-ecs-2/Cargo.toml
+++ b/sources/settings-plugins/aws-ecs-2/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_aws_ecs_2"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true

--- a/sources/settings-plugins/aws-k8s/Cargo.toml
+++ b/sources/settings-plugins/aws-k8s/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_aws_k8s"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true

--- a/sources/settings-plugins/metal-dev/Cargo.toml
+++ b/sources/settings-plugins/metal-dev/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_metal_dev"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true

--- a/sources/settings-plugins/metal-k8s/Cargo.toml
+++ b/sources/settings-plugins/metal-k8s/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_metal_k8s"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true

--- a/sources/settings-plugins/vmware-dev/Cargo.toml
+++ b/sources/settings-plugins/vmware-dev/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_vmware_dev"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true

--- a/sources/settings-plugins/vmware-k8s/Cargo.toml
+++ b/sources/settings-plugins/vmware-k8s/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 name = "settings_vmware_k8s"
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 # settings plugins
 bottlerocket-settings-models.workspace = true


### PR DESCRIPTION
**Description of changes:**
Most of the heavy lifting here was done by a modified fork of [cargo-autoinherit](https://github.com/cbgbt/cargo-autoinherit/tree/cbgbt-v0.1.6), save for some light formatting. I submitted my patches upstream, but it's not clear yet if they'll take them.

I have a change pending [in the SDK to update `cargo-deny`](https://github.com/bottlerocket-os/bottlerocket-sdk/pull/197) so that we can lint for workspace dependencies.

**Testing done:**
* The builds succeed, Cargo.lock has not changed

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
