### PR TITLE
Update host container for 1.21.1 Release

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -330,4 +330,7 @@ version = "1.21.1"
     "migrate_v1.21.0_k8s-reserved-cpus-v0-1-0.lz4",
     "migrate_v1.21.0_add-hostname-override-source.lz4",
 ]
-"(1.21.0, 1.21.1)" = []
+"(1.21.0, 1.21.1)" = [
+    "migrate_v1.21.1_aws-admin-container-v0-11-10.lz4",
+    "migrate_v1.21.1_public-admin-container-v0-11-10.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -333,4 +333,6 @@ version = "1.21.1"
 "(1.21.0, 1.21.1)" = [
     "migrate_v1.21.1_aws-admin-container-v0-11-10.lz4",
     "migrate_v1.21.1_public-admin-container-v0-11-10.lz4",
+    "migrate_v1.21.1_aws-control-container-v0-7-14.lz4",
+    "migrate_v1.21.1_public-control-container-v0-7-14.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -293,6 +293,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-14"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,6 +1636,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-10"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-14"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -286,6 +286,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-admin-container-v0-11-10"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1625,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-10"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -43,6 +43,8 @@ members = [
     "settings-migrations/v1.21.0/add-hostname-override-source",
     "settings-migrations/v1.21.1/aws-admin-container-v0-11-10",
     "settings-migrations/v1.21.1/public-admin-container-v0-11-10",
+    "settings-migrations/v1.21.1/aws-control-container-v0-7-14",
+    "settings-migrations/v1.21.1/public-control-container-v0-7-14",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -41,6 +41,8 @@ members = [
     "settings-migrations/v1.21.0/pod-infra-container-image-services",
     "settings-migrations/v1.21.0/k8s-reserved-cpus-v0-1-0",
     "settings-migrations/v1.21.0/add-hostname-override-source",
+    "settings-migrations/v1.21.1/aws-admin-container-v0-11-10",
+    "settings-migrations/v1.21.1/public-admin-container-v0-11-10",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-migrations/v1.21.1/aws-admin-container-v0-11-10/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/aws-admin-container-v0-11-10/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-admin-container-v0-11-10"
+version = "0.1.0"
+authors = ["Yutong Sun <yutongsu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.1/aws-admin-container-v0-11-10/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/aws-admin-container-v0-11-10/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.9'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.10'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.1/aws-control-container-v0-7-14/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/aws-control-container-v0-7-14/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-control-container-v0-7-14"
+version = "0.1.0"
+authors = ["Yutong Sun <yutongsu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.1/aws-control-container-v0-7-14/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/aws-control-container-v0-7-14/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.13'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.14'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.1/public-admin-container-v0-11-10/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/public-admin-container-v0-11-10/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-admin-container-v0-11-10"
+version = "0.1.0"
+authors = ["Yutong Sun <yutongsu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.1/public-admin-container-v0-11-10/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/public-admin-container-v0-11-10/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.9";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.10";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.21.1/public-control-container-v0-7-14/Cargo.toml
+++ b/sources/settings-migrations/v1.21.1/public-control-container-v0-7-14/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-control-container-v0-7-14"
+version = "0.1.0"
+authors = ["Yutong Sun <yutongsu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.21.1/public-control-container-v0-7-14/src/main.rs
+++ b/sources/settings-migrations/v1.21.1/public-control-container-v0-7-14/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.13";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.14";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.9'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.10'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.13'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.14'"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.10"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.13"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.14"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.9"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.10"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update the admin and control host containers to bottlerocket-admin-container v0.11.10 and bottlerocket-control-container v0.7.14. Also add migrations move to these versions on upgrade.


**Testing done:**

- [x] `cargo make check-migrations`
Seeing error like 
```
Found 4 problem(s) with data store migrations:
    - Migration 'aws-admin-container-v0-11-10' does not exist
    - Migration 'public-admin-container-v0-11-10' does not exist
    - Migration 'aws-control-container-v0-7-14' does not exist
    - Migration 'public-control-container-v0-7-14' does not exist
```
This is because we moved to a new root path for the migration. And this [task definition](https://github.com/bottlerocket-os/twoliter/blob/efd17d998a6b59cb1d26866d155f8c4db3f6bcc2/twoliter/embedded/Makefile.toml#L556) needs an update. Created an issue to track in Twoliter - https://github.com/bottlerocket-os/twoliter/issues/349.

- [x] Test migration from `v1.20.5` to `v1.21.1`
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "9899697b",
    "pretty_name": "Bottlerocket OS 1.21.1 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.21.1"
  }
}

[ssm-user@control]$ apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.10",
        "superpowered": true,
        "user-data": "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbInNzaC1yc2EgQUFBQUIzTnphQzF5YzJFQUFBQURBUUFCQUFBQkFRREN3dWVnVFhTa29KZmpDZm9leDdRLytLTGJWNllVaXdiczFrbVJwc3grdDFEbGFsdS9ZM0VBZDN5TmdKRkdQZ29FZWptejdSaTRZcTZWUDQvWFJoaVl1Z09HNXpmaWtuZ1orMW9lbkppVVRpdDhpeXFYcXAxYTg0T3lWUVllcm5GZkNDWXJtdVFmcmp1d3RiY2VYK3RtS0xqbGtIcjNPVXFjdUxCeXBMSzhaRlVybjVTNUQ1b1EvV2VWeEhiM2NWdW5tVDlOblN0ZU5lZXJtZjVZNXBkMFNQWlNLL3lIVnNqYSttUGVmNFloNVM5YnJqM3hlZWg0THplNXJqQS9OaGpTU2lLVm5oVko2SktkUGhNQ0grM2h6d21Gd3dHK1FiL0VFcFZJSkU4ckl4R0czRWZRQ1I4a2M0OFZqc2tabjlVdzJpOUo2SDdNcHgxbThzdEpuYWVYIHl1dG9uZ3MtMjAyMyJdfX0="
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.14",
        "superpowered": false
      }
    }
  }
}
```
- [x] Test rollback to `v1.20.5` from `v1.21.1`
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "a3e8bda1",
    "pretty_name": "Bottlerocket OS 1.20.5 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.20.5"
  }
}

[ssm-user@control]$ apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.9",
        "superpowered": true,
        "user-data": "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbInNzaC1yc2EgQUFBQUIzTnphQzF5YzJFQUFBQURBUUFCQUFBQkFRREN3dWVnVFhTa29KZmpDZm9leDdRLytLTGJWNllVaXdiczFrbVJwc3grdDFEbGFsdS9ZM0VBZDN5TmdKRkdQZ29FZWptejdSaTRZcTZWUDQvWFJoaVl1Z09HNXpmaWtuZ1orMW9lbkppVVRpdDhpeXFYcXAxYTg0T3lWUVllcm5GZkNDWXJtdVFmcmp1d3RiY2VYK3RtS0xqbGtIcjNPVXFjdUxCeXBMSzhaRlVybjVTNUQ1b1EvV2VWeEhiM2NWdW5tVDlOblN0ZU5lZXJtZjVZNXBkMFNQWlNLL3lIVnNqYSttUGVmNFloNVM5YnJqM3hlZWg0THplNXJqQS9OaGpTU2lLVm5oVko2SktkUGhNQ0grM2h6d21Gd3dHK1FiL0VFcFZJSkU4ckl4R0czRWZRQ1I4a2M0OFZqc2tabjlVdzJpOUo2SDdNcHgxbThzdEpuYWVYIHl1dG9uZ3MtMjAyMyJdfX0="
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.13",
        "superpowered": false
      }
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
