### PR TITLE
twoliter: bump to bottlerocket-core-kit v2.3.5

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -1,6 +1,6 @@
 schema-version = 1
 release-version = "1.21.1"
-digest = "Hfdg+bU2wSXyePFrqGI9uFEuhbf8cAxcXYRcA1Gehcs="
+digest = "ehVP/xB32ewo0VKcxCuzaN/y0A3hQRHjsbERdcsGzE8="
 
 [sdk]
 name = "bottlerocket-sdk"
@@ -11,7 +11,7 @@ digest = "1zKyWC/pXdpzKfNj1Xp1YvEWdyltI7EhAeiNwlikBz8="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.3.4"
+version = "2.3.5"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.3.4"
-digest = "Q9vROBjAa328FByc+ZRaT23Rq/7CU1mMY/PJ5vfGFD0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.3.5"
+digest = "VOcXmMU01S20bs+CoKzi34Ps0LMuyUiSmrO9qvEPAOE="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,5 +11,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.3.4"
+version = "2.3.5"
 vendor = "bottlerocket"


### PR DESCRIPTION
**Description of changes:**

Update to the new core kit release.

**Testing done:**

Built two ECS images and booted them (per the core kit MCM).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
