### PR TITLE
twoliter: bump to v0.4.5

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,7 +8,7 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.4.4"
+TWOLITER_VERSION = "v0.4.5"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION
**Description of changes:**
Updates to the latest version of twoliter.


**Testing done:**
* [x] Locally built `bottlerocket-os/bottlerocket-core-kit`
* [x] Locally built `bottlerocket-os/bottlerocket`
* [x] CI

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
