### PR TITLE
docs: Correct documentation to state that NVIDIA container runtime is included, not CUDA toolkit

### DIFF
--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -201,7 +201,7 @@ Once it launches, you should be able to run tasks on your Bottlerocket instance 
 ### aws-ecs-*-nvidia variants
 
 The `aws-ecs-*-nvidia` variants include the required packages and configurations to leverage NVIDIA GPUs.
-They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [CUDA toolkit](https://developer.nvidia.com/cuda-toolkit) included in your ECS tasks.
+They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [NVIDIA container runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit) included in your ECS tasks.
 In hosts with multiple GPUs (ex. EC2 `g4dn` instances) you can assign one or multiple GPUs per container by specifying the resource requirements in your container definitions as described in the [official ECS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html):
 
 ```json

--- a/QUICKSTART-ECS.md
+++ b/QUICKSTART-ECS.md
@@ -201,7 +201,7 @@ Once it launches, you should be able to run tasks on your Bottlerocket instance 
 ### aws-ecs-*-nvidia variants
 
 The `aws-ecs-*-nvidia` variants include the required packages and configurations to leverage NVIDIA GPUs.
-They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [NVIDIA container runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit) included in your ECS tasks.
+They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [NVIDIA container runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit).
 In hosts with multiple GPUs (ex. EC2 `g4dn` instances) you can assign one or multiple GPUs per container by specifying the resource requirements in your container definitions as described in the [official ECS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html):
 
 ```json

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -350,11 +350,11 @@ For example, to run busybox:
 ### aws-k8s-*-nvidia variants
 
 The `aws-k8s-*-nvidia` variants include the required packages and configurations to leverage NVIDIA GPUs.
-They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [CUDA toolkit](https://developer.nvidia.com/cuda-toolkit) included in your orchestrated containers.
+They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [NVIDIA container runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit) included in your orchestrated containers.
 They also include the [NVIDIA k8s device plugin](https://github.com/NVIDIA/k8s-device-plugin).
 If you already have a daemonset for the device plugin in your cluster, you may need to use taints and tolerations to keep it from running on Bottlerocket nodes.
 
-Additional NVIDIA tools such as [DCGM](https://github.com/NVIDIA/dcgm-exporter) and [GPU Feature Discovery](https://github.com/NVIDIA/gpu-feature-discovery) will work as expected.
+Additional NVIDIA tools such as [DCGM exporter](https://github.com/NVIDIA/dcgm-exporter) and [GPU Feature Discovery](https://github.com/NVIDIA/gpu-feature-discovery) will work as expected.
 You can install them in your cluster by following the `helm install` instructions provided for each project.
 
 The [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html#install-nvidia-gpu-operator) can also be used to install these tools.

--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -350,7 +350,7 @@ For example, to run busybox:
 ### aws-k8s-*-nvidia variants
 
 The `aws-k8s-*-nvidia` variants include the required packages and configurations to leverage NVIDIA GPUs.
-They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [NVIDIA container runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit) included in your orchestrated containers.
+They come with the [NVIDIA Tesla driver](https://docs.nvidia.com/datacenter/tesla/drivers/index.html) along with the libraries required by the [NVIDIA container runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit).
 They also include the [NVIDIA k8s device plugin](https://github.com/NVIDIA/k8s-device-plugin).
 If you already have a daemonset for the device plugin in your cluster, you may need to use taints and tolerations to keep it from running on Bottlerocket nodes.
 


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**
- Correct documentation to state that NVIDIA container runtime is included, not the CUDA toolkit
  - The NVIDIA container runtime (usually installed/configured via the NVIDIA *container toolkit) is required on the host when wanting to utilize NVIDIA GPUs within your containers
  - The NVIDIA CUDA toolkit is a user space component for developing CUDA based applications - this not required on the host, nor should it be for containerized environments

XRef - https://github.com/awslabs/amazon-eks-ami/pull/1924#discussion_r1719173076

**Testing done:**
None


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
