### PR TITLE
Add NVIDIA APIs

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.22.0"
+version = "1.23.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -343,4 +343,10 @@ version = "1.22.0"
     "migrate_v1.22.0_public-control-container-v0-7-15.lz4",
     "migrate_v1.22.0_bootstrap-commands-settings.lz4",
     "migrate_v1.22.0_bootstrap-commands-metadata.lz4",
+]
+"(1.22.0, 1.23.0)" = [
+    "migrate_v1.23.0_kubelet-device-plugins-metadata.lz4",
+    "migrate_v1.23.0_kubelet-device-plugins-settings.lz4",
+    "migrate_v1.23.0_nvidia-container-runtime-metadata.lz4",
+    "migrate_v1.23.0_nvidia-container-runtime-settings.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.22.0"
+release-version = "1.23.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -57,26 +57,37 @@ Summary: Settings plugin for the aws-k8s variants
 Requires: %{_cross_os}variant-family(aws-k8s)
 Provides: %{_cross_os}settings-plugin(any)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.23)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.23-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.24)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.24-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.25)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.25-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.26)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.26-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.27)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.27-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.28)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.28-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.29)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.29-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.30)
-Provides: %{_cross_os}settings-plugin(aws-k8s-1.30-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.31)
+Conflicts: %{_cross_os}settings-plugin(any)
+Conflicts: %{_cross_os}variant-flavor(nvidia)
+
+
+%description aws-k8s
+%{summary}.
+
+%package aws-k8s-nvidia
+Summary: Settings plugin for the aws-k8s-nvidia variants
+Requires: (%{_cross_os}variant-family(aws-k8s) and %{_cross_os}variant-flavor(nvidia))
+Provides: %{_cross_os}settings-plugin(any)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.23-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.24-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.25-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.26-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.27-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.28-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.29-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.30-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.31-nvidia)
 Conflicts: %{_cross_os}settings-plugin(any)
 
-%description aws-k8s
+%description aws-k8s-nvidia
 %{summary}.
 
 %package metal-dev
@@ -135,11 +146,22 @@ Conflicts: %{_cross_os}settings-plugin(any)
   -p settings-plugin-aws-dev \
   -p settings-plugin-aws-ecs-1 \
   -p settings-plugin-aws-ecs-2 \
-  -p settings-plugin-aws-k8s \
   -p settings-plugin-metal-dev \
   -p settings-plugin-metal-k8s \
   -p settings-plugin-vmware-dev \
   -p settings-plugin-vmware-k8s \
+  %{nil}
+
+# The settings-plugin-aws-k8s and settings-plugin-aws-k8s-nvidia are compiled independently
+# due to the requirement of distinct feature flags. This separation is necessary to prevent
+# feature unification, as detailed in the Rust Cargo documentation:
+# https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+  -p settings-plugin-aws-k8s \
+  %{nil}
+
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+  -p settings-plugin-aws-k8s-nvidia \
   %{nil}
 
 %install
@@ -151,6 +173,7 @@ for plugin in \
   aws-dev \
   aws-ecs-1 \
   aws-ecs-2 \
+  aws-k8s-nvidia \
   aws-k8s \
   metal-dev \
   metal-k8s \
@@ -193,6 +216,11 @@ done
 %{_cross_pluginsdir}/aws-k8s/libsettings.so
 %{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/aws-k8s.conf
 %{_cross_tmpfilesdir}/settings-plugin-aws-k8s.conf
+
+%files aws-k8s-nvidia
+%{_cross_pluginsdir}/aws-k8s-nvidia/libsettings.so
+%{_cross_factorydir}%{_cross_sysconfdir}/ld.so.conf.d/aws-k8s-nvidia.conf
+%{_cross_tmpfilesdir}/settings-plugin-aws-k8s-nvidia.conf
 
 %files metal-dev
 %{_cross_pluginsdir}/metal-dev/libsettings.so

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "darling 0.20.8",
  "quote",
@@ -391,8 +391,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+version = "0.5.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -426,7 +426,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "serde",
  "serde_plain",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.8",
@@ -459,8 +459,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+version = "0.5.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -481,6 +481,7 @@ dependencies = [
  "settings-extension-ecs",
  "settings-extension-host-containers",
  "settings-extension-kernel",
+ "settings-extension-kubelet-device-plugins",
  "settings-extension-kubernetes",
  "settings-extension-metrics",
  "settings-extension-motd",
@@ -509,7 +510,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -522,7 +523,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "serde",
 ]
@@ -530,7 +531,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -2227,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2240,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2253,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2267,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2280,7 +2281,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2293,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2306,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2319,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2332,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2345,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2358,7 +2359,20 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-kubelet-device-plugins"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2371,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2385,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2398,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2410,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2423,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2436,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2449,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2463,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2476,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2489,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1275,6 +1275,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-device-plugins-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kubelet-device-plugins-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1484,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "nvidia-container-runtime-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "nvidia-container-runtime-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
 ]
 
 [[package]]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2517,6 +2517,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-plugin-aws-k8s-nvidia"
+version = "0.1.0"
+dependencies = [
+ "abi_stable",
+ "bottlerocket-settings-models",
+ "bottlerocket-settings-plugin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "settings-plugin-metal-dev"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "settings-plugins/aws-ecs-1",
     "settings-plugins/aws-ecs-2",
     "settings-plugins/aws-k8s",
+    "settings-plugins/aws-k8s-nvidia",
     "settings-plugins/metal-dev",
     "settings-plugins/metal-k8s",
     "settings-plugins/vmware-dev",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -129,13 +129,13 @@ version = "0.1.0"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.4.0"
-version = "0.4.0"
+tag = "bottlerocket-settings-models-v0.5.0"
+version = "0.5.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.4.0"
-version = "0.4.0"
+tag = "bottlerocket-settings-models-v0.5.0"
+version = "0.5.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -144,7 +144,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.4.0"
+tag = "bottlerocket-settings-models-v0.5.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -51,6 +51,10 @@ members = [
     "settings-migrations/v1.22.0/public-control-container-v0-7-15",
     "settings-migrations/v1.22.0/bootstrap-commands-settings",
     "settings-migrations/v1.22.0/bootstrap-commands-metadata",
+    "settings-migrations/v1.23.0/nvidia-container-runtime-metadata",
+    "settings-migrations/v1.23.0/nvidia-container-runtime-settings",
+    "settings-migrations/v1.23.0/kubelet-device-plugins-metadata",
+    "settings-migrations/v1.23.0/kubelet-device-plugins-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.24-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-migrations/v1.23.0/kubelet-device-plugins-metadata/Cargo.toml
+++ b/sources/settings-migrations/v1.23.0/kubelet-device-plugins-metadata/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubelet-device-plugins-metadata"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.23.0/kubelet-device-plugins-metadata/src/main.rs
+++ b/sources/settings-migrations/v1.23.0/kubelet-device-plugins-metadata/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring the NVIDIA k8s device plugin.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.kubelet-device-plugins",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.23.0/kubelet-device-plugins-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.23.0/kubelet-device-plugins-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubelet-device-plugins-settings"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.23.0/kubelet-device-plugins-settings/src/main.rs
+++ b/sources/settings-migrations/v1.23.0/kubelet-device-plugins-settings/src/main.rs
@@ -1,0 +1,23 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring the NVIDIA k8s device plugin.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubelet-device-plugins",
+        "services.nvidia-k8s-device-plugin",
+        "configuration-files.nvidia-k8s-device-plugin-conf",
+        "configuration-files.nvidia-k8s-device-plugin-exec-start-conf",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.23.0/nvidia-container-runtime-metadata/Cargo.toml
+++ b/sources/settings-migrations/v1.23.0/nvidia-container-runtime-metadata/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nvidia-container-runtime-metadata"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.23.0/nvidia-container-runtime-metadata/src/main.rs
+++ b/sources/settings-migrations/v1.23.0/nvidia-container-runtime-metadata/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["affected-services"],
+        setting: "settings.nvidia-container-runtime",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.23.0/nvidia-container-runtime-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.23.0/nvidia-container-runtime-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nvidia-container-runtime-settings"
+version = "0.1.0"
+authors = ["Monirul Islam <monirulu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.23.0/nvidia-container-runtime-settings/src/main.rs
+++ b/sources/settings-migrations/v1.23.0/nvidia-container-runtime-settings/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring container runtime (containerd) settings only for NVIDIA k8s variants.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.nvidia-container-runtime",
+        "services.nvidia-container-toolkit",
+        "configuration-files.nvidia-container-toolkit",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-plugins/aws-k8s-nvidia/Cargo.toml
+++ b/sources/settings-plugins/aws-k8s-nvidia/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-plugin-aws-k8s-nvidia"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "settings_aws_k8s_nvidia"
+
+[dependencies]
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+# settings plugins
+bottlerocket-settings-plugin = { workspace = true }
+bottlerocket-settings-models = { workspace = true }

--- a/sources/settings-plugins/aws-k8s-nvidia/src/lib.rs
+++ b/sources/settings-plugins/aws-k8s-nvidia/src/lib.rs
@@ -1,0 +1,29 @@
+use bottlerocket_settings_models::model_derive::model;
+use bottlerocket_settings_plugin::SettingsPlugin;
+
+#[derive(SettingsPlugin)]
+#[model(rename = "settings", impl_default = true)]
+struct AwsK8sSettings {
+    motd: bottlerocket_settings_models::MotdV1,
+    kubernetes: bottlerocket_settings_models::KubernetesSettingsV1,
+    updates: bottlerocket_settings_models::UpdatesSettingsV1,
+    host_containers: bottlerocket_settings_models::HostContainersSettingsV1,
+    bootstrap_commands: bottlerocket_settings_models::BootstrapCommandsSettingsV1,
+    bootstrap_containers: bottlerocket_settings_models::BootstrapContainersSettingsV1,
+    ntp: bottlerocket_settings_models::NtpSettingsV1,
+    network: bottlerocket_settings_models::NetworkSettingsV1,
+    kernel: bottlerocket_settings_models::KernelSettingsV1,
+    boot: bottlerocket_settings_models::BootSettingsV1,
+    aws: bottlerocket_settings_models::AwsSettingsV1,
+    metrics: bottlerocket_settings_models::MetricsSettingsV1,
+    pki: bottlerocket_settings_models::PkiSettingsV1,
+    container_registry: bottlerocket_settings_models::RegistrySettingsV1,
+    oci_defaults: bottlerocket_settings_models::OciDefaultsV1,
+    oci_hooks: bottlerocket_settings_models::OciHooksSettingsV1,
+    cloudformation: bottlerocket_settings_models::CloudFormationSettingsV1,
+    dns: bottlerocket_settings_models::DnsSettingsV1,
+    container_runtime: bottlerocket_settings_models::ContainerRuntimeSettingsV1,
+    autoscaling: bottlerocket_settings_models::AutoScalingSettingsV1,
+    nvidia_container_runtime: bottlerocket_settings_models::NvidiaContainerRuntimeSettingsV1,
+    kubelet_device_plugins: bottlerocket_settings_models::KubeletDevicePluginsV1,
+}

--- a/sources/shared-defaults/nvidia-k8s-container-toolkit.toml
+++ b/sources/shared-defaults/nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,14 @@
+[settings.nvidia-container-runtime]
+visible-devices-as-volume-mounts = true
+visible-devices-envvar-when-unprivileged = false
+
+[metadata.settings.nvidia-container-runtime]
+affected-services = ["nvidia-container-toolkit"]
+
+[services.nvidia-container-toolkit]
+configuration-files = ["nvidia-container-toolkit"]
+restart-commands = []
+
+[configuration-files.nvidia-container-toolkit]
+path = "/etc/nvidia-container-runtime/config.toml"
+template-path = "/usr/share/templates/nvidia-container-runtime/nvidia-container-toolkit-config-k8s"

--- a/sources/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -1,0 +1,23 @@
+# nvidia device plugin service
+[services.nvidia-k8s-device-plugin]
+restart-commands = ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plugin.service"]
+configuration-files = [
+    "nvidia-k8s-device-plugin-conf",
+    "nvidia-k8s-device-plugin-exec-start-conf",
+]
+
+[configuration-files.nvidia-k8s-device-plugin-conf]
+path = "/etc/nvidia-k8s-device-plugin/settings.yaml"
+template-path = "/usr/share/templates/nvidia-k8s-device-plugin-conf"
+
+[configuration-files.nvidia-k8s-device-plugin-exec-start-conf]
+path = "/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf"
+template-path = "/usr/share/templates/nvidia-k8s-device-plugin-exec-start-conf"
+
+[metadata.settings.kubelet-device-plugins.nvidia]
+affected-services = ["nvidia-k8s-device-plugin"]
+
+[settings.kubelet-device-plugins.nvidia]
+pass-device-specs = true
+device-id-strategy="index"
+device-list-strategy="volume-mounts"


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

This includes two new APIs to all the NVIDIA variants:
- `settings.nvidia-container-runtime`: used to configure the NVIDIA container toolkit behavior
- `settings.kubelet-device-plugin.nvidia`: used to expose configurations for the NVIDIA k8s device plugin

**Testing done:**

As part of https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/60 and https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/132


1. Instance joined the cluster:

```
NAME                                           STATUS   ROLES    AGE    VERSION
ip-192-168-41-204.us-west-2.compute.internal   Ready    <none>   22s    v1.30.1-eks-e564799
```

2. The safe defaults were used, which prevented the containers from accessing all the GPUs:

```
└─> ❯ k exec safe-defaults-d7g2j -- env | rg NVIDIA_VISIBLE_DEVICES
NVIDIA_VISIBLE_DEVICES=all
└─> ❯ k exec safe-defaults-d7g2j -- cat /proc/self/mountinfo | rg nvidia
┌───────────────────> ~/Code/work/by-feature/nvidia-settings-api/testing on Fedora
└─> ❯
```

3. Files were generated using the new APIs

```
bash-5.1# cat /etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStart=
ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
bash-5.1# cat /etc/nvidia-container-runtime/config.toml
### generated from the template file ###
accept-nvidia-visible-devices-as-volume-mounts = true
accept-nvidia-visible-devices-envvar-when-unprivileged = false

[nvidia-container-cli]
root = "/"
path = "/usr/bin/nvidia-container-cli"
environment = []
ldconfig = "@/sbin/ldconfig"
bash-5.1#
```

4. Device Plugin was restarted after the values changed to allow containers access all GPUs

```
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugin": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "pass-device-specs": true
      }
    }
  }
}
bash-5.1# apiclient set kubelet-device-plugin.nvidia.device-list-strategy=envvar
bash-5.1# systemctl status nvidia-k8s-device-plugin.service
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/nvidia-k8s-device-plugin.service.d
             └─exec-start.conf
     Active: active (running) since Mon 2024-09-09 15:28:10 UTC; 9s ago
   Main PID: 11094 (nvidia-device-p)
      Tasks: 9 (limit: 38028)
     Memory: 17.9M
        CPU: 9.102s
     CGroup: /system.slice/nvidia-k8s-device-plugin.service
             └─11094 /usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml

Sep 09 15:28:10 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]:     ]
Sep 09 15:28:10 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]:   },
Sep 09 15:28:10 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]:   "sharing": {
Sep 09 15:28:10 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]:     "timeSlicing": {}
Sep 09 15:28:10 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]:   }
Sep 09 15:28:10 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]: }
Sep 09 15:28:10 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]: I0909 15:28:10.178566   11094 main.go:317] Retrieving plugins.
Sep 09 15:28:17 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]: I0909 15:28:17.416865   11094 server.go:216] Starting GRPC server for 'nvidia.com/gpu'
Sep 09 15:28:17 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]: I0909 15:28:17.417380   11094 server.go:147] Starting to serve 'nvidia.com/gpu' on /var/lib/kubelet/device-plugins/nvidia-gpu.sock
Sep 09 15:28:17 ip-192-168-41-204.us-west-2.compute.internal nvidia-device-plugin[11094]: I0909 15:28:17.419653   11094 server.go:154] Registered device plugin for 'nvidia.com/gpu' with Kubelet
bash-5.1#
```

5. Newly created container has access to all the GPUs without requesting any, after the configurations were updated:

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: safe-defaults
spec:
  selector:
    matchLabels:
      name: safe-defaults
  template:
    metadata:
      labels:
        name: safe-defaults
    spec:
      # No GPUs requested
      containers:
        - name: safe-defaults
          image: nvidia/cuda:12.4.1-cudnn-devel-rockylinux8
          command: ['sh', '-c', 'sleep infinity']
```

```
└─> ❯ k exec safe-defaults-cnsqn -- nvidia-smi
Mon Sep  9 15:31:38 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.4     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A10G                    Off | 00000000:00:1E.0 Off |                    0 |
|  0%   25C    P8               8W / 300W |      0MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
┌───────────────────> ~/Code/work/by-feature/nvidia-settings-api/testing on Fedora
└─> ❯
```

6. In k8s 1.30, 1.29, 1.28, 1.27, I performed upgrade/downgrade testing. Confirmed that the new APIs were available in the upgrade, and the values were removed on a downgrade. I also performed the same testing described above, to make sure the defaults are set and that the containers with `NVIDIA_VISIBLE_DEVICES=all` can access all GPUs when the configurations to allow this are set.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
