### PR TITLE
fix: update permission bits for kubelet-exec-start-conf

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.24.1"
+version = "1.25.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -356,4 +356,7 @@ version = "1.24.1"
     "migrate_v1.24.1_public-admin-container-v0-11-12.lz4",
     "migrate_v1.24.1_aws-control-container-v0-7-16.lz4",
     "migrate_v1.24.1_public-control-container-v0-7-16.lz4",
+]
+"(1.24.1, 1.25.0)" = [
+    "migrate_v1.25.0_kubernetes-service-config.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.24.1"
+release-version = "1.25.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1304,6 +1304,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-service-config"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -59,6 +59,7 @@ members = [
     "settings-migrations/v1.24.1/public-admin-container-v0-11-12",
     "settings-migrations/v1.24.1/aws-control-container-v0-7-16",
     "settings-migrations/v1.24.1/public-control-container-v0-7-16",
+    "settings-migrations/v1.25.0/kubernetes-service-config",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-migrations/v1.25.0/kubernetes-service-config/Cargo.toml
+++ b/sources/settings-migrations/v1.25.0/kubernetes-service-config/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubernetes-service-config"
+version = "0.1.0"
+authors = ["Sparks Song <shijiao@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.25.0/kubernetes-service-config/src/main.rs
+++ b/sources/settings-migrations/v1.25.0/kubernetes-service-config/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_MODE: &str = "0600";
+const NEW_MODE: &str = "0644";
+
+/// We changed the version of configuration mode
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "configuration-files.kubelet-exec-start-conf.mode",
+        old_val: OLD_MODE,
+        new_val: NEW_MODE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/kubernetes-services.toml
+++ b/sources/shared-defaults/kubernetes-services.toml
@@ -50,7 +50,7 @@ template-path = "/usr/share/templates/kubelet-server-key"
 [configuration-files.kubelet-exec-start-conf]
 path = "/etc/systemd/system/kubelet.service.d/exec-start.conf"
 template-path = "/usr/share/templates/kubelet-exec-start-conf"
-mode = "0600"
+mode = "0644"
 
 [configuration-files.credential-provider-config-yaml]
 path = "/etc/kubernetes/kubelet/credential-provider-config.yaml"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #4173 

**Description of changes:**
Changed the mode code for configuration-files.kubelet-exec-start-conf, such that it will not generate error message.
![Screenshot 2024-09-16 at 2 52 51 PM](https://github.com/user-attachments/assets/93298fc1-4ce3-4868-a91b-920156569e0a)

![Screenshot 2024-09-16 at 4 55 59 PM](https://github.com/user-attachments/assets/b874c635-ac1a-4854-be5c-56fb5c514469)


**Testing done:**
Required migration test was done.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
