### PR TITLE
gitignore: add Twoliter.override to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /licenses
 *.run
 /tests
+Twoliter.override


### PR DESCRIPTION
**Description of changes:**
```
    gitignore: add Twoliter.override to gitignore

    Twoliter.override allows you to instruct Twoliter to use an alternate
    OCI repository for fetching kit and SDK artifacts, though the digest of
    the referred image is still checked against the digest in Twoliter.lock.

    This is useful for mirroring Twoliter dependencies, or testing against
    new ones.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
