### PR TITLE
install-twoliter: always use host arch for twoliter

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -41,7 +41,8 @@ TWOLITER_LOG_LEVEL = "info"
 # The project file that configures Twoliter.
 TWOLITER_PROJECT = "${BUILDSYS_ROOT_DIR}/Twoliter.toml"
 
-BUILDSYS_ARCH = { script = ['echo "${BUILDSYS_ARCH:-$(uname -m)}"'] }
+UNAME_ARCH = { script = ['uname -m'] }
+BUILDSYS_ARCH = { script = ['echo "${BUILDSYS_ARCH:-${UNAME_ARCH}}"'] }
 BUILDSYS_BUILD_DIR = "${BUILDSYS_ROOT_DIR}/build"
 BUILDSYS_PACKAGES_DIR = "${BUILDSYS_BUILD_DIR}/rpms"
 BUILDSYS_STATE_DIR = "${BUILDSYS_BUILD_DIR}/state"
@@ -273,7 +274,7 @@ if [ "${TWOLITER_REUSE_EXISTING_INSTALL}" = "true" ]; then
 fi
 
 if [ "${TWOLITER_ALLOW_BINARY_INSTALL}" = "true" ]; then
-   if [ "${BUILDSYS_ARCH}" = "aarch64" ]; then
+   if [ "${UNAME_ARCH}" = "aarch64" ]; then
       flags+=("--allow-binary-install" "${TWOLITER_SHA256_AARCH64}")
    else
       flags+=("--allow-binary-install" "${TWOLITER_SHA256_X86_64}")


### PR DESCRIPTION
If, when you first installed twoliter, you were building for a host architecture that differed from your target, twoliter would use the wrong checksum when validating the installed binary.

**Testing done:**
* on an aarch64 host, deleted `tools/twoliter/twoliter` then ran `make build ARCH=x86_64`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
