### PR TITLE
Bump bottlerocket-core-kit to 2.7.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,7 +9,7 @@ digest = "CIx/G74W+Ie4gdJ40D/N/UbyQ9JqwVOd/9IH4ru3zYk="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.6.0"
+version = "2.7.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.6.0"
-digest = "NQiQjiRiCD6banoz4msYAKrziRqsZEofMiM9KCMGFQM="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.7.0"
+digest = "LRfJmGEHmGYj7FETePibQ34J+gHysB4CcYtH8veYldk="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,5 +11,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.6.0"
+version = "2.7.0"
 vendor = "bottlerocket"


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

Bump bottlerocket-core-kit to 2.7.0

**Testing done:**

Build Bottlerocket `aws-ecs-2` for x86_64 and `aarch64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
