### PR TITLE
fixes for settings plugins

### DIFF
--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -3,7 +3,7 @@
 
 # Do not prefer shared linking, since the libstd we use at build time
 # may not match the one installed on the final image.
-%global __global_rustflags_shared %__global_rustflags
+%global __global_rustflags_shared %__global_rustflags -C link-arg=-Wl,-soname=libsettings.so
 
 %global _cross_pluginsdir %{_cross_libdir}/settings-plugins
 

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -14,7 +14,7 @@ Summary: Settings plugins
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}glibc
 Requires: %{_cross_os}settings-plugin(any)
 
 %description


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/204

**Description of changes:**
Drop the runtime requirement on `glibc-devel`, which results in unnecessary header files and static library archives on the final system.

Work around a [behavior change](https://github.com/rust-lang/rust/pull/126094/commits/565ddfb48ca2a3b24236c2b393ec14eb86d64a7a) in Rust 1.81.0 where the soname is now set for cdylib artifacts. We need the soname to stay "libsettings.so" for compatibility reasons.


**Testing done:**
Verified that the soname was set as expected.
```
for d in x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/settings-plugins/*/libsettings.so ; do
  echo "# ${d}"
  readelf -a ${d} | grep SONAME
done

# x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/settings-plugins/aws-dev/libsettings.so
 0x000000000000000e (SONAME)             Library soname: [libsettings.so]
# x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/settings-plugins/metal-dev/libsettings.so
 0x000000000000000e (SONAME)             Library soname: [libsettings.so]
# x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/settings-plugins/vmware-dev/libsettings.so
 0x000000000000000e (SONAME)             Library soname: [libsettings.so]
```

Also verified that the settings plugins were correctly loaded on variants built with both the older and newer Rust toolchains.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
