### PR TITLE
Add Nvidia Time-Slicing

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -359,4 +359,5 @@ version = "1.25.0"
 ]
 "(1.24.1, 1.25.0)" = [
     "migrate_v1.25.0_kubernetes-service-config.lz4",
+    "migrate_v1.25.0_kubelet-device-plugins-time-slicing-settings.lz4",
 ]

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,7 +9,7 @@ digest = "CIx/G74W+Ie4gdJ40D/N/UbyQ9JqwVOd/9IH4ru3zYk="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.8.4"
+version = "2.9.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.8.4"
-digest = "3HaJokkQgfZONwthRVqXFsZHCmIVQTarzWP2jo8gLaM="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.9.0"
+digest = "eVsost9ltE9BimWyB9UV2rhPyzr0MlzbvZd0GRexGwc="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,5 +11,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.8.4"
+version = "2.9.0"
 vendor = "bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "darling 0.20.8",
  "quote",
@@ -405,14 +405,15 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+version = "0.6.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
  "bottlerocket-scalar",
  "bottlerocket-scalar-derive",
  "bottlerocket-string-impls-for",
+ "bounded-integer",
  "indexmap",
  "lazy_static",
  "regex",
@@ -440,7 +441,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "serde",
  "serde_plain",
@@ -449,7 +450,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.8",
@@ -473,8 +474,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+version = "0.6.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -524,7 +525,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -537,7 +538,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "serde",
 ]
@@ -545,13 +546,22 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "bounded-integer"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a6932c88f1d2c29533a3b8a5f5a2f84cc19c3339b431677c3160c5c2e6ca85"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2263,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2276,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2289,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2303,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2316,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2329,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2342,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2355,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2368,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2381,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2394,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2407,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2420,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2434,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2447,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2459,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2472,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2485,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2498,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2512,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2525,7 +2535,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2538,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1314,6 +1314,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-device-plugins-time-slicing-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-service-config"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -60,6 +60,7 @@ members = [
     "settings-migrations/v1.24.1/aws-control-container-v0-7-16",
     "settings-migrations/v1.24.1/public-control-container-v0-7-16",
     "settings-migrations/v1.25.0/kubernetes-service-config",
+    "settings-migrations/v1.25.0/kubelet-device-plugins-time-slicing-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -134,13 +134,13 @@ version = "0.1.0"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.5.0"
-version = "0.5.0"
+tag = "bottlerocket-settings-models-v0.6.0"
+version = "0.6.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.5.0"
-version = "0.5.0"
+tag = "bottlerocket-settings-models-v0.6.0"
+version = "0.6.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -149,7 +149,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.5.0"
+tag = "bottlerocket-settings-models-v0.6.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/settings-migrations/v1.25.0/kubelet-device-plugins-time-slicing-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.25.0/kubelet-device-plugins-time-slicing-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubelet-device-plugins-time-slicing-settings"
+version = "0.1.0"
+authors = ["Kyle Sessions <kssessio@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.25.0/kubelet-device-plugins-time-slicing-settings/src/main.rs
+++ b/sources/settings-migrations/v1.25.0/kubelet-device-plugins-time-slicing-settings/src/main.rs
@@ -1,0 +1,23 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for configuring the NVIDIA k8s device plugin.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubelet-device-plugins.nvidia.device-sharing-strategy",
+        "settings.kubelet-device-plugins.nvidia.time-slicing.replicas",
+        "settings.kubelet-device-plugins.nvidia.time-slicing.rename-by-default",
+        "settings.kubelet-device-plugins.nvidia.time-slicing.fail-requests-greater-than-one",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -21,3 +21,4 @@ affected-services = ["nvidia-k8s-device-plugin"]
 pass-device-specs = true
 device-id-strategy="index"
 device-list-strategy="volume-mounts"
+device-sharing-strategy="none"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: 
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/62
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/169 
* https://github.com/bottlerocket-os/bottlerocket/issues/2347


**Description of changes:**
Adding time-slicing apis and migrations.

Added:
* settings.kubelet-device-plugins.nvidia.device-sharing-strategy
* settings.kubelet-device-plugins.nvidia.time-slicing.replicas
* settings.kubelet-device-plugins.nvidia.time-slicing.rename-by-default
* settings.kubelet-device-plugins.nvidia.time-slicing.fail-requests-greater-than-one



**Testing done:**

0. Migration:

```
bash-5.1# cat /etc/os-release
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.24.1 (aws-k8s-1.26-nvidia)"
PRETTY_NAME="Bottlerocket OS 1.24.1 (aws-k8s-1.26-nvidia)"
VARIANT_ID=aws-k8s-1.26-nvidia
VERSION_ID=1.24.1
BUILD_ID=acfd0abe
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
DOCUMENTATION_URL="https://bottlerocket.dev"
...
bash-5.1# cat /etc/os-release
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.25.0 (aws-k8s-1.26-nvidia)"
PRETTY_NAME="Bottlerocket OS 1.25.0 (aws-k8s-1.26-nvidia)"
VARIANT_ID=aws-k8s-1.26-nvidia
VERSION_ID=1.25.0
BUILD_ID=5c12e860
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
DOCUMENTATION_URL="https://bottlerocket.dev"
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "time-slicing",
        "pass-device-specs": true,
        "time-slicing": {
          "fail-requests-greater-than-one": true,
          "rename-by-default": true,
          "replicas": 2
        }
      }
    }
  }
}
...
bash-5.1# cat /etc/os-release
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.24.1 (aws-k8s-1.26-nvidia)"
PRETTY_NAME="Bottlerocket OS 1.24.1 (aws-k8s-1.26-nvidia)"
VARIANT_ID=aws-k8s-1.26-nvidia
VERSION_ID=1.24.1
BUILD_ID=acfd0abe
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
DOCUMENTATION_URL="https://bottlerocket.dev"
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "pass-device-specs": true
      }
    }
  }
}

```
1. Instance joined the cluster

```
NAME                                           STATUS   ROLES    AGE   VERSION
ip-XXXX.us-west-2.compute.internal   Ready    <none>   15h   v1.29.5-eks-1109419
```

2. Model Default:

```
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "none",
        "pass-device-specs": true,
      }
    }
  }
}
```

3. Model Updates:
```
bash-5.1#: apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=time-slicing settings.kubelet-device-plugins.nvidia.time-slicing.replicas=2 settings.kubelet-device-plugins.nvidia.time-slicing.rename-by-default=true settings.kubelet-device-plugins.nvidia.time-slicing.fail-requests-greater-than-one=true
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "none",
        "pass-device-specs": true,
        "time-slicing": {
          "fail-requests-greater-than-one": true,
          "rename-by-default": true,
          "replicas": 2
        }
      }
    }
  }
}
```

4. Bounded check:

```
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.time-slicing.replicas=1
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-Ne2SavnsTF7Fweq0': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-Ne2SavnsTF7Fweq0: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: integer out of range, expected it to be between 2 and 2147483647 at line 1 column 107
bash-5.1#
```

5. Files generated:

```
bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
sharing:
  timeSlicing:
    renameByDefault: true
    failRequestsGreaterThanOne: true
    resources:
    - name: "nvidia.com/gpu"
      replicas: 2
 ``` 
 
 ```
 nvidia-device-plugin[360007]:   "resources": {
nvidia-device-plugin[360007]:     "gpus": [
nvidia-device-plugin[360007]:       {
nvidia-device-plugin[360007]:         "pattern": "*",
nvidia-device-plugin[360007]:         "name": "nvidia.com/gpu"
nvidia-device-plugin[360007]:       }
nvidia-device-plugin[360007]:     ]
nvidia-device-plugin[360007]:   },
nvidia-device-plugin[360007]:   "sharing": {
nvidia-device-plugin[360007]:     "timeSlicing": {
nvidia-device-plugin[360007]:       "renameByDefault": true,
nvidia-device-plugin[360007]:       "failRequestsGreaterThanOne": true,
nvidia-device-plugin[360007]:       "resources": [
nvidia-device-plugin[360007]:         {
nvidia-device-plugin[360007]:           "name": "nvidia.com/gpu",
nvidia-device-plugin[360007]:           "rename": "nvidia.com/gpu.shared",
nvidia-device-plugin[360007]:           "devices": "all",
nvidia-device-plugin[360007]:           "replicas": 2
nvidia-device-plugin[360007]:         }
nvidia-device-plugin[360007]:       ]
nvidia-device-plugin[360007]:     }
nvidia-device-plugin[360007]:   }
nvidia-device-plugin[360007]: }
```

6. Time slicing on 1 instance with 1 GPU with 2 containers:

```
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=time-slicing settings.kubelet-device-plugins.nvidia.time-slicing.replicas=2 
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "time-slicing",
        "pass-device-specs": true,
        "time-slicing": {
          "replicas": 2
        }
      }
    }
  }
}

bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
sharing:
  timeSlicing:
    renameByDefault: true
    failRequestsGreaterThanOne: true
    resources:
    - name: "nvidia.com/gpu"
      replicas: 2
bash-5.1#

➜  kubectl apply -f node-1-gpu-2.yaml
pod/gpu-test-2-pod-node-one created

 ➜  kubectl get pods
NAME                      READY   STATUS    RESTARTS   AGE
gpu-test-1-pod-node-one   1/1     Running   0          13m
gpu-test-2-pod-node-one   1/1     Running   0          3s
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
