### PR TITLE
Update host containers for 1.24.1

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -351,3 +351,7 @@ version = "1.24.0"
     "migrate_v1.23.0_nvidia-container-runtime-settings.lz4",
 ]
 "(1.23.0, 1.24.0)" = []
+"(1.24.0, 1.24.1)" = [
+    "migrate_v1.24.1_aws-admin-container-v0-11-12.lz4",
+    "migrate_v1.24.1_public-admin-container-v0-11-12.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -354,4 +354,6 @@ version = "1.24.0"
 "(1.24.0, 1.24.1)" = [
     "migrate_v1.24.1_aws-admin-container-v0-11-12.lz4",
     "migrate_v1.24.1_public-admin-container-v0-11-12.lz4",
+    "migrate_v1.24.1_aws-control-container-v0-7-16.lz4",
+    "migrate_v1.24.1_public-control-container-v0-7-16.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -300,6 +300,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-12"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-control-container-v0-7-14"
 version = "0.1.0"
 dependencies = [
@@ -1701,6 +1708,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-11"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-12"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -321,6 +321,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-16"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1736,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-15"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-16"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -55,6 +55,8 @@ members = [
     "settings-migrations/v1.23.0/nvidia-container-runtime-settings",
     "settings-migrations/v1.23.0/kubelet-device-plugins-metadata",
     "settings-migrations/v1.23.0/kubelet-device-plugins-settings",
+    "settings-migrations/v1.24.1/aws-admin-container-v0-11-12",
+    "settings-migrations/v1.24.1/public-admin-container-v0-11-12",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -57,6 +57,8 @@ members = [
     "settings-migrations/v1.23.0/kubelet-device-plugins-settings",
     "settings-migrations/v1.24.1/aws-admin-container-v0-11-12",
     "settings-migrations/v1.24.1/public-admin-container-v0-11-12",
+    "settings-migrations/v1.24.1/aws-control-container-v0-7-16",
+    "settings-migrations/v1.24.1/public-control-container-v0-7-16",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-migrations/v1.24.1/aws-admin-container-v0-11-12/Cargo.toml
+++ b/sources/settings-migrations/v1.24.1/aws-admin-container-v0-11-12/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-admin-container-v0-11-12"
+version = "0.1.0"
+authors = ["Kush Upadhyay <kushupad@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.24.1/aws-admin-container-v0-11-12/src/main.rs
+++ b/sources/settings-migrations/v1.24.1/aws-admin-container-v0-11-12/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.11'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.12'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.24.1/aws-control-container-v0-7-16/Cargo.toml
+++ b/sources/settings-migrations/v1.24.1/aws-control-container-v0-7-16/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-control-container-v0-7-16"
+version = "0.1.0"
+authors = ["Kush Upadhyay <kushupad@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.24.1/aws-control-container-v0-7-16/src/main.rs
+++ b/sources/settings-migrations/v1.24.1/aws-control-container-v0-7-16/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.15'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.16'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.24.1/public-admin-container-v0-11-12/Cargo.toml
+++ b/sources/settings-migrations/v1.24.1/public-admin-container-v0-11-12/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-admin-container-v0-11-12"
+version = "0.1.0"
+authors = ["Kush Upadhyay <kushupad@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.24.1/public-admin-container-v0-11-12/src/main.rs
+++ b/sources/settings-migrations/v1.24.1/public-admin-container-v0-11-12/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.11";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.12";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.24.1/public-control-container-v0-7-16/Cargo.toml
+++ b/sources/settings-migrations/v1.24.1/public-control-container-v0-7-16/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-control-container-v0-7-16"
+version = "0.1.0"
+authors = ["Kush Upadhyay <kushupad@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.24.1/public-control-container-v0-7-16/src/main.rs
+++ b/sources/settings-migrations/v1.24.1/public-control-container-v0-7-16/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.15";
+const NEW_CONTROL_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.16";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.control.source",
+        old_val: OLD_CONTROL_CTR_SOURCE_VAL,
+        new_val: NEW_CONTROL_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.15'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.16'"

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.11'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.12'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.12"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.15"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.16"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.11"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.12"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**
Update the admin host container to v0.11.12 and control host container to v0.7.16. 

Also, add migrations to move to these versions on upgrade.

**Testing done:**

- [x] Test migration from `v1.24.0` to `v1.24.1`
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c7070980-dirty",
    "pretty_name": "Bottlerocket OS 1.24.1 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.24.1"
  }
}
bash-5.1# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.12",
        "superpowered": true,
        "user-data": "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbXX19"
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.16",
        "superpowered": false
      }
    }
  }
}
```
- [x] Test rollback from `v1.24.1` to `v1.24.0`
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "800458c4",
    "pretty_name": "Bottlerocket OS 1.24.0 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.24.0"
  }
}
bash-5.1# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.11",
        "superpowered": true,
        "user-data": "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbXX19"
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.15",
        "superpowered": false
      }
    }
  }
}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
