### PR TITLE
twoliter: update twoliter version to v0.4.7

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.4.6"
-TWOLITER_SHA256_AARCH64 = "12ac3f5a6c641e29481c79289bd07cf1c3494a65e3d283d582feb1d28d8bf2a7"
-TWOLITER_SHA256_X86_64 = "4a2db7c4d0aac75c6b682336539ee57371cfb6dfea81689d07fc1f4a940fd5c5"
+TWOLITER_VERSION = "v0.4.7"
+TWOLITER_SHA256_AARCH64 = "82fce1895f93946a9e03d71ecaa9a73d0f4681d08cf540be0b7bab3eacbdc41e"
+TWOLITER_SHA256_X86_64 = "3b5773bea848aa94c5501fa3cf03dc0c788916c7a3da7b989495cd2cdb8b49ec"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION
**Description of changes:**
* This moves to twoliter `0.4.7`

~~This PR is currently meant to test the release-candidate via the PR CI.~~


**Testing done:**
* Built bottlerocket using the new twoliter

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
