### PR TITLE
twoliter: update twoliter version to v0.5.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,19 +60,6 @@ The default seccomp policy of older versions of Docker do not support the `clone
 You'll need to have Docker installed and running, with your user account added to the `docker` group.
 Docker's [post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/) will walk you through that.
 
-You'll also need to enable the containerd-snapshotter and buildkit features for your docker daemon. This is required for the tooling to operate
-with OCI images properly during bottlerocket build. You can do so by adding the below to your
-docker daemon configuration at `/etc/docker/daemon.json`.
-
-```json
-{
-    "features": {
-        "buildkit": true,
-        "containerd-snapshotter": true
-    }
-}
-```
-
 > Note: If you're on a newer Linux distribution using the unified cgroup hierarchy with cgroups v2, you may need to disable it to work with current versions of runc.
 > You'll know this is the case if you see an error like `docker: Error response from daemon: OCI runtime create failed: this version of runc doesn't work on cgroups v2: unknown.`
 > Set the kernel parameter `systemd.unified_cgroup_hierarchy=0` in your boot configuration (e.g. GRUB) and reboot.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.4.7"
-TWOLITER_SHA256_AARCH64 = "82fce1895f93946a9e03d71ecaa9a73d0f4681d08cf540be0b7bab3eacbdc41e"
-TWOLITER_SHA256_X86_64 = "3b5773bea848aa94c5501fa3cf03dc0c788916c7a3da7b989495cd2cdb8b49ec"
+TWOLITER_VERSION = "v0.5.0"
+TWOLITER_SHA256_AARCH64 = "cec8d30377f5cb38ee1d3bc99bb8aaf3958213b38be6a75d09a8bc5fcd3da590"
+TWOLITER_SHA256_X86_64 = "d580180969f8b34b1af5d2524ff024e90432f09f991fc044444019da20a027a8"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION
**Description of changes:**
Update to the latest version of twoliter.

Twoliter 0.5.0 creates kits that are incompatible with previous versions, so we cannot merge this until there is a live core-kit built with Twoliter 0.5.0.


**Testing done:**
Built & tested bottlerocket variants using Twoliter 0.5.0.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
