### PR TITLE
docs: add link to bootstrap-commands documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,10 @@ See the [`settings.host-containers.*` reference](https://bottlerocket.dev/en/os/
 
 See the [Host Containers documentation](https://bottlerocket.dev/en/os/latest/#/concepts/host-containers/).
 
+#### Bootstrap commands settings
+
+See the [`settings.bootstrap-commands.*` reference](https://bottlerocket.dev/en/os/latest/#/api/settings/bootstrap-commands/) as well as the [Bootstrap Commands documentation](https://bottlerocket.dev/en/os/latest/#/concepts/bootstrap-commands/)
+
 #### Bootstrap containers settings
 
 See the [`settings.bootstrap-containers.*` reference](https://bottlerocket.dev/en/os/latest/#/api/settings/bootstrap-containers/) as well as the [Bootstrap Containers documentation](https://bottlerocket.dev/en/os/latest/#/concepts/bootstrap-containers/)


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: #4232 

**Description of changes:**

Adds link to documentation for bootstrap-commands

**Testing done:**
N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
