### PR TITLE
variants/aws-ecs-1-nvidia: update nvidia kmod name

### DIFF
--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -30,7 +30,7 @@ included-packages = [
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",
-    "kmod-5.10-nvidia-tesla-470",
+    "kmod-5.10-nvidia-tesla-535",
 ]
 
 [lib]


### PR DESCRIPTION

**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/4220

**Description of changes:**
The Bottlerocket core kit 3.0.0 changes the name of the kmod-5.10-nvidia tesla package from `kmod-5.10-nvidia-tesla-470` to `kmod-5.10-nvidia-tesla-535` due to the NVIDIA branch offered by this package. This change only affects one variant and is done on a major version bump for the core kit. 

**Testing done:**
Built `aws-ecs-1-nvidia` with this change, it breaks without it on build of tip of `develop` in bottlerocket-core-kit.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
