### PR TITLE
Update to core-kit 3.0.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,19 +60,6 @@ The default seccomp policy of older versions of Docker do not support the `clone
 You'll need to have Docker installed and running, with your user account added to the `docker` group.
 Docker's [post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/) will walk you through that.
 
-You'll also need to enable the containerd-snapshotter and buildkit features for your docker daemon. This is required for the tooling to operate
-with OCI images properly during bottlerocket build. You can do so by adding the below to your
-docker daemon configuration at `/etc/docker/daemon.json`.
-
-```json
-{
-    "features": {
-        "buildkit": true,
-        "containerd-snapshotter": true
-    }
-}
-```
-
 > Note: If you're on a newer Linux distribution using the unified cgroup hierarchy with cgroups v2, you may need to disable it to work with current versions of runc.
 > You'll know this is the case if you see an error like `docker: Error response from daemon: OCI runtime create failed: this version of runc doesn't work on cgroups v2: unknown.`
 > Set the kernel parameter `systemd.unified_cgroup_hierarchy=0` in your boot configuration (e.g. GRUB) and reboot.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.4.7"
-TWOLITER_SHA256_AARCH64 = "82fce1895f93946a9e03d71ecaa9a73d0f4681d08cf540be0b7bab3eacbdc41e"
-TWOLITER_SHA256_X86_64 = "3b5773bea848aa94c5501fa3cf03dc0c788916c7a3da7b989495cd2cdb8b49ec"
+TWOLITER_VERSION = "v0.5.0"
+TWOLITER_SHA256_AARCH64 = "cec8d30377f5cb38ee1d3bc99bb8aaf3958213b38be6a75d09a8bc5fcd3da590"
+TWOLITER_SHA256_X86_64 = "d580180969f8b34b1af5d2524ff024e90432f09f991fc044444019da20a027a8"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -2,14 +2,14 @@ schema-version = 1
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.45.0"
+version = "0.46.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.45.0"
-digest = "CIx/G74W+Ie4gdJ40D/N/UbyQ9JqwVOd/9IH4ru3zYk="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.46.0"
+digest = "V2lUX6Rs9rZLg8POxV7P785Mr5nallfyxor0Scrvh3Y="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.9.0"
+version = "3.0.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.9.0"
-digest = "eVsost9ltE9BimWyB9UV2rhPyzr0MlzbvZd0GRexGwc="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v3.0.0"
+digest = "MIaKirjsBvy10HdBFKfgdghDahP3SE1Qn+E0f0qfE/E="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -6,10 +6,10 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.45.0"
+version = "0.46.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "2.9.0"
+version = "3.0.0"
 vendor = "bottlerocket"

--- a/sources/api/apiclient/src/exec.rs
+++ b/sources/api/apiclient/src/exec.rs
@@ -225,10 +225,10 @@ impl ReadFromServer {
     /// * read: The stream of messages from the server.
     ///
     /// * heartbeat_setter: An atomic handle to a timestamp; this will be updated whenever we
-    /// receive a ping or pong from the server so we can make sure the connection isn't stale.
+    ///   receive a ping or pong from the server so we can make sure the connection isn't stale.
     ///
     /// * capacity: When the server sends a capacity update, we update this AtomicCapacity, so we
-    /// can make sure we're not sending (or even reading) data the server can't handle.
+    ///   can make sure we're not sending (or even reading) data the server can't handle.
     fn new(
         read: impl Stream<Item = std::result::Result<Message, WsError>> + 'static,
         heartbeat_setter: Arc<Mutex<Instant>>,
@@ -341,11 +341,11 @@ impl ReadFromUser {
     /// * stdin_tx: The channel to which we should send messages containing user input.
     ///
     /// * capacity_reader: We'll only read input when the server has capacity, according to this
-    /// parameter, so that we don't unnecessarily fill buffers or overwhelm the server.
+    ///   parameter, so that we don't unnecessarily fill buffers or overwhelm the server.
     ///
     /// * is_tty: whether input is coming from a TTY; think of it as whether the command is
-    /// interactive.  If so, we read a byte at a time and send it immediately to the server so that
-    /// things like tab completion work.
+    ///   interactive.  If so, we read a byte at a time and send it immediately to the server so that
+    ///   things like tab completion work.
     fn new(
         stdin_tx: mpsc::UnboundedSender<Message>,
         capacity_reader: Arc<AtomicCapacity>,

--- a/sources/api/apiclient/src/exec/terminal.rs
+++ b/sources/api/apiclient/src/exec/terminal.rs
@@ -26,8 +26,8 @@ pub(crate) struct Terminal {
 impl Terminal {
     /// Parameters:
     /// * tty: Represents the user's desire for a TTY, where `Some(true)` means to use a TTY,
-    /// `Some(false)` means not to use a TTY, and `None` means to detect whether we think we should
-    /// use a TTY.
+    ///   `Some(false)` means not to use a TTY, and `None` means to detect whether we think we should
+    ///   use a TTY.
     ///
     /// For the purposes of terminal settings, "use a TTY" means to set the terminal to
     /// raw mode so that input is read directly, not interpreted; for example, things like ctrl-c

--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -30,7 +30,7 @@ included-packages = [
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",
-    "kmod-5.10-nvidia-tesla-470",
+    "kmod-5.10-nvidia-tesla-535",
 ]
 
 [lib]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
* Bump Twoliter version to `0.5.0`.
* Bump core-kit version to `3.0.0`.
* Bump SDK version to `0.46.0`.
* Update nvidia kmod name from `kmod-5.10-nvidia-tesla-470` to
`kmod-5.10-nvidia-tesla-535`. The Bottlerocket core kit 3.0.0 changes the name of the kmod-5.10-nvidia tesla package from `kmod-5.10-nvidia-tesla-470` to `kmod-5.10-nvidia-tesla-535` due to the NVIDIA branch offered by this package. This change only affects one variant and is done on a major version bump for the core kit.
* Fix clippy errors.


**Testing done:**
* `cargo make unit-tests`
* `cargo make check-fmt`
* `cargo make check-clippy`
* `cargo make check-shell`
* `cargo make -e BUILDSYS_VARIANT=aws-k8s-1.24`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
