### PR TITLE
Prepare 1.26.x branch for 1.26.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v1.26.1 (2024-10-24)
+
+## Release Highlights
+* Revert system-wide configuration to block writeable/executable memory in systemd services ([bottlerocket-core-kit#215](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/215))
+ 
+## Build Changes
+
+### OS Changes
+* Update bottlerocket-core-kit to 3.1.1 ([#4264])
+
+[#4264]: https://github.com/bottlerocket-os/bottlerocket/pull/4264
+
 # v1.26.0 (2024-10-23)
 
 ## Release Highlights

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.26.0"
+version = "1.26.1"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -366,3 +366,4 @@ version = "1.26.0"
     "migrate_v1.25.0_public-control-container-v0-7-17.lz4",
 ]
 "(1.25.0, 1.26.0)" = []
+"(1.26.0, 1.26.1)" = []

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,7 +9,7 @@ digest = "V2lUX6Rs9rZLg8POxV7P785Mr5nallfyxor0Scrvh3Y="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "3.1.0"
+version = "3.1.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v3.1.0"
-digest = "tnL9owIDl4B7LuMeosgVcusHzx9hykxPVwRfNauVy68="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v3.1.1"
+digest = "8P5eQMZxig/1Ix7oOZ7NO7c5yKdKXVd6Zu8cPQW9MTI="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.26.0"
+release-version = "1.26.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,5 +11,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "3.1.0"
+version = "3.1.1"
 vendor = "bottlerocket"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
n/a

**Description of changes:**

Cherry pick from #4264 to prepare the 1.26.x branch for Bottlerocket 1.26.1

**Testing done:**

n/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
