### PR TITLE
schnauzer: add aws-config helper

### DIFF
--- a/sources/api/schnauzer/src/v1.rs
+++ b/sources/api/schnauzer/src/v1.rs
@@ -120,6 +120,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("join_node_taints", Box::new(helpers::join_node_taints));
     template_registry.register_helper("default", Box::new(helpers::default));
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
+    template_registry.register_helper("aws-config", Box::new(helpers::aws_config));
     template_registry.register_helper("tuf-prefix", Box::new(helpers::tuf_prefix));
     template_registry.register_helper("metadata-prefix", Box::new(helpers::metadata_prefix));
     template_registry.register_helper("host", Box::new(helpers::host));

--- a/sources/api/schnauzer/src/v2/import/helpers.rs
+++ b/sources/api/schnauzer/src/v2/import/helpers.rs
@@ -35,6 +35,7 @@ fn all_helpers() -> HashMap<ExtensionName, HashMap<HelperName, Box<dyn HelperDef
     hashmap! {
         "aws" => hashmap! {
             "ecr-prefix" => helper!(handlebars_helpers::ecr_prefix),
+            "aws-config" => helper!(handlebars_helpers::aws_config),
         },
 
         "ecs" => hashmap! {


### PR DESCRIPTION
Port the aws-config helper defined in
https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/218/commits/708d5996c40f014fbd6e03341c0b6433a78ff332 to the Bottlerocket repository.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Port the aws-config helper defined in
https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/708d5996c40f014fbd6e03341c0b6433a78ff332
to the Bottlerocket repository.

This must be merged before https://github.com/bottlerocket-os/bottlerocket/pull/4268 to provide the helper as a default.

**Testing done:**

Build and launch a FIPS and non-FIPS variant.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
