### PR TITLE
Define FIPS variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-ecs-2-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "aws-ecs-2-nvidia"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,3 +346,12 @@ dependencies = [
  "settings-migrations",
  "settings-plugins",
 ]
+
+[[package]]
+name = "vmware-k8s-1_31-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_29-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "aws-k8s-1_29-nvidia"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_31-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "aws-k8s-1_31-nvidia"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vmware-k8s-1_29-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "vmware-k8s-1_30"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_28-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "aws-k8s-1_28-nvidia"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vmware-k8s-1_28-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "vmware-k8s-1_29"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vmware-k8s-1_30-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "vmware-k8s-1_31"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_30-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "aws-k8s-1_30-nvidia"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "variants/aws-dev",
     "variants/aws-ecs-1",
     "variants/aws-ecs-2",
+    "variants/aws-ecs-2-fips",
     "variants/aws-ecs-1-nvidia",
     "variants/aws-ecs-2-nvidia",
     "variants/aws-k8s-1.24",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "variants/aws-k8s-1.28",
     "variants/aws-k8s-1.28-fips",
     "variants/aws-k8s-1.29",
+    "variants/aws-k8s-1.29-fips",
     "variants/aws-k8s-1.30",
     "variants/aws-k8s-1.31",
     "variants/aws-k8s-1.27-nvidia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "variants/vmware-k8s-1.30",
     "variants/vmware-k8s-1.30-fips",
     "variants/vmware-k8s-1.31",
+    "variants/vmware-k8s-1.31-fips",
 ]
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "variants/aws-k8s-1.26-nvidia",
     "variants/aws-k8s-1.27",
     "variants/aws-k8s-1.28",
+    "variants/aws-k8s-1.28-fips",
     "variants/aws-k8s-1.29",
     "variants/aws-k8s-1.30",
     "variants/aws-k8s-1.31",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "variants/metal-k8s-1.29",
     "variants/vmware-dev",
     "variants/vmware-k8s-1.28",
+    "variants/vmware-k8s-1.28-fips",
     "variants/vmware-k8s-1.29",
     "variants/vmware-k8s-1.30",
     "variants/vmware-k8s-1.31",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "variants/aws-k8s-1.29",
     "variants/aws-k8s-1.29-fips",
     "variants/aws-k8s-1.30",
+    "variants/aws-k8s-1.30-fips",
     "variants/aws-k8s-1.31",
     "variants/aws-k8s-1.27-nvidia",
     "variants/aws-k8s-1.28-nvidia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "variants/vmware-k8s-1.28",
     "variants/vmware-k8s-1.28-fips",
     "variants/vmware-k8s-1.29",
+    "variants/vmware-k8s-1.29-fips",
     "variants/vmware-k8s-1.30",
     "variants/vmware-k8s-1.31",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "variants/aws-k8s-1.30",
     "variants/aws-k8s-1.30-fips",
     "variants/aws-k8s-1.31",
+    "variants/aws-k8s-1.31-fips",
     "variants/aws-k8s-1.27-nvidia",
     "variants/aws-k8s-1.28-nvidia",
     "variants/aws-k8s-1.29-nvidia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "variants/vmware-k8s-1.29",
     "variants/vmware-k8s-1.29-fips",
     "variants/vmware-k8s-1.30",
+    "variants/vmware-k8s-1.30-fips",
     "variants/vmware-k8s-1.31",
 ]
 

--- a/packages/settings-defaults/settings-defaults.spec
+++ b/packages/settings-defaults/settings-defaults.spec
@@ -48,10 +48,14 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %{summary}.
 
 %package aws-ecs-2
-Summary: Settings defaults for the aws-ecs-2 variant
-Requires: %{_cross_os}variant(aws-ecs-2)
+Summary: Settings defaults for the aws-ecs-2 FIPS and non-FIPS variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-ecs-2) or
+           %{_cross_os}variant(aws-ecs-2-fips)
+          %{nil}})
 Provides: %{_cross_os}settings-defaults(any)
 Provides: %{_cross_os}settings-defaults(aws-ecs-2)
+Provides: %{_cross_os}settings-defaults(aws-ecs-2-fips)
 Conflicts: %{_cross_os}settings-defaults(any)
 
 %description aws-ecs-2
@@ -130,18 +134,26 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %package aws-k8s-1.31
 Summary: Settings defaults for the aws-k8s 1.27 through 1.30 variants
 Requires: (%{shrink:
-           %{_cross_os}variant(aws-k8s-1.27) or
-           %{_cross_os}variant(aws-k8s-1.28) or
-           %{_cross_os}variant(aws-k8s-1.29) or
-           %{_cross_os}variant(aws-k8s-1.30) or
-           %{_cross_os}variant(aws-k8s-1.31)
+           %{_cross_os}variant(aws-k8s-1.27)      or
+           %{_cross_os}variant(aws-k8s-1.28)      or
+           %{_cross_os}variant(aws-k8s-1.28-fips) or
+           %{_cross_os}variant(aws-k8s-1.29)      or
+           %{_cross_os}variant(aws-k8s-1.29-fips) or
+           %{_cross_os}variant(aws-k8s-1.30)      or
+           %{_cross_os}variant(aws-k8s-1.30-fips) or
+           %{_cross_os}variant(aws-k8s-1.31)      or
+           %{_cross_os}variant(aws-k8s-1.31-fips)
            %{nil}})
 Provides: %{_cross_os}settings-defaults(any)
 Provides: %{_cross_os}settings-defaults(aws-k8s-1.27)
 Provides: %{_cross_os}settings-defaults(aws-k8s-1.28)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.28-fips)
 Provides: %{_cross_os}settings-defaults(aws-k8s-1.29)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.29-fips)
 Provides: %{_cross_os}settings-defaults(aws-k8s-1.30)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.30-fips)
 Provides: %{_cross_os}settings-defaults(aws-k8s-1.31)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.31-fips)
 Conflicts: %{_cross_os}settings-defaults(any)
 
 %description aws-k8s-1.31
@@ -208,18 +220,26 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %package vmware-k8s-1.31
 Summary: Settings defaults for the vmware-k8s 1.27 through 1.30 variants
 Requires: (%{shrink:
-           %{_cross_os}variant(vmware-k8s-1.27) or
-           %{_cross_os}variant(vmware-k8s-1.28) or
-           %{_cross_os}variant(vmware-k8s-1.29) or
-           %{_cross_os}variant(vmware-k8s-1.30) or
-           %{_cross_os}variant(vmware-k8s-1.31)
+           %{_cross_os}variant(vmware-k8s-1.27)      or
+           %{_cross_os}variant(vmware-k8s-1.28)      or
+           %{_cross_os}variant(vmware-k8s-1.28-fips) or
+           %{_cross_os}variant(vmware-k8s-1.29)      or
+           %{_cross_os}variant(vmware-k8s-1.29-fips) or
+           %{_cross_os}variant(vmware-k8s-1.30)      or
+           %{_cross_os}variant(vmware-k8s-1.30-fips) or
+           %{_cross_os}variant(vmware-k8s-1.31)      or
+           %{_cross_os}variant(vmware-k8s-1.31-fips)
            %{nil}})
 Provides: %{_cross_os}settings-defaults(any)
 Provides: %{_cross_os}settings-defaults(vmware-k8s-1.27)
 Provides: %{_cross_os}settings-defaults(vmware-k8s-1.28)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.28-fips)
 Provides: %{_cross_os}settings-defaults(vmware-k8s-1.29)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.29-fips)
 Provides: %{_cross_os}settings-defaults(vmware-k8s-1.30)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.30-fips)
 Provides: %{_cross_os}settings-defaults(vmware-k8s-1.31)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.31-fips)
 Conflicts: %{_cross_os}settings-defaults(any)
 
 %description vmware-k8s-1.31

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -43,10 +43,15 @@ Conflicts: %{_cross_os}settings-plugin(any)
 
 %package aws-ecs-2
 Summary: Settings plugin for the aws-ecs-2 variant
-Requires: (%{_cross_os}variant(aws-ecs-2) or %{_cross_os}variant(aws-ecs-2-nvidia))
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-ecs-2) or
+           %{_cross_os}variant(aws-ecs-2-fips) or
+           %{_cross_os}variant(aws-ecs-2-nvidia)
+           %{nil}})
 Provides: %{_cross_os}settings-plugin(any)
 Provides: %{_cross_os}settings-plugin(aws-ecs-2)
 Provides: %{_cross_os}settings-plugin(aws-ecs-2-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-ecs-2-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description aws-ecs-2
@@ -61,9 +66,13 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.25)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.26)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.27)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.28)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.28-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.29)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.29-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.30)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.30-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.31)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.31-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 Conflicts: %{_cross_os}variant-flavor(nvidia)
 
@@ -127,9 +136,13 @@ Requires: %{_cross_os}variant-family(vmware-k8s)
 Provides: %{_cross_os}settings-plugin(any)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.27)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.28)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.28-fips)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.29)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.29-fips)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.30)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.30-fips)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.31)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.31-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description vmware-k8s

--- a/variants/aws-ecs-2-fips/Cargo.toml
+++ b/variants/aws-ecs-2-fips/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "aws-ecs-2-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+# ecs
+    "ecs-agent-config",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.28-fips/Cargo.toml
+++ b/variants/aws-k8s-1.28-fips/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+# This is the aws-k8s-1.28-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_28-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.28",
+    "aws-iam-authenticator",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.29-fips/Cargo.toml
+++ b/variants/aws-k8s-1.29-fips/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+# This is the aws-k8s-1.29-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_29-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.29",
+    "aws-iam-authenticator",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.30-fips/Cargo.toml
+++ b/variants/aws-k8s-1.30-fips/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+# This is the aws-k8s-1.30-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_30-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.30",
+    "aws-iam-authenticator",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.31-fips/Cargo.toml
+++ b/variants/aws-k8s-1.31-fips/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+# This is the aws-k8s-1.31-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_31-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.31",
+    "aws-iam-authenticator",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.28-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.28-fips/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+# This is the vmware-k8s-1.28-fips variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_28-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.1",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.28",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.28-fips/template.ovf
+++ b/variants/vmware-k8s-1.28-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf

--- a/variants/vmware-k8s-1.29-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.29-fips/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+# This is the vmware-k8s-1.29-fips variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_29-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.1",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.29",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.29-fips/template.ovf
+++ b/variants/vmware-k8s-1.29-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf

--- a/variants/vmware-k8s-1.30-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.30-fips/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+# This is the vmware-k8s-1.30-fips variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_30-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.1",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.30",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.30-fips/template.ovf
+++ b/variants/vmware-k8s-1.30-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf

--- a/variants/vmware-k8s-1.31-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.31-fips/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+# This is the vmware-k8s-1.31-fips variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_31-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.1",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.31",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.31-fips/template.ovf
+++ b/variants/vmware-k8s-1.31-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf


### PR DESCRIPTION
**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**

This defines the AWS and VMware FIPS variants. I used my own core kit that includes all the FIPS-related work provided by the Core Kit, so the variants used FIPS-constrained go and rust binaries. 

**Testing done:**

- [x] Quick tests for AWS variants, both arches
- [x] Conformance tests for AWS variants, both arches
- [x] Migration tests for AWS variants, both arches
- [x] Quick tests for VMware variants
- [x] Conformance tests for VMware variants
- [x] Migration tests for VMware variants


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
