### PR TITLE
add aws-creds settings defaults to all AWS variants

### DIFF
--- a/sources/settings-defaults/aws-dev/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-ecs-1-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-ecs-1-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-ecs-1/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-ecs-1/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-ecs-2/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-ecs-2/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: #1667 

**Description of changes:**

The aws-ecs-* and aws-dev variants do not include the aws-creds settings defaults by default. Add these settings as defaults for these variants. This ensures that these corresponding FIPS variants will include the changes from #4268 and
https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/218

**Testing done:**

Launch each variant affected by this change, ensure `settings.aws` appears as expected.

```
[ssm-user@control]$ apiclient get settings.aws
{
  "settings": {
    "aws": {
      "profile": "default",
      "region": "us-west-2"
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
