### PR TITLE
Enable EFA support

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.27.1"
+version = "1.28.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -372,3 +372,6 @@ version = "1.27.1"
     "migrate_v1.27.0_aws-config.lz4",
 ]
 "(1.27.0, 1.27.1)" = []
+"(1.27.1, 1.28.0)" = [
+    "migrate_v1.28.0_kernel-sysctl-hugepages.lz4"
+]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.27.1"
+release-version = "1.28.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1564,6 +1564,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel-sysctl-hugepages"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-device-plugins-metadata"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "settings-migrations/v1.25.0/aws-control-container-v0-7-17",
     "settings-migrations/v1.25.0/public-control-container-v0-7-17",
     "settings-migrations/v1.27.0/aws-config",
+    "settings-migrations/v1.28.0/kernel-sysctl-hugepages",
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.28.0/kernel-sysctl-hugepages/Cargo.toml
+++ b/sources/settings-migrations/v1.28.0/kernel-sysctl-hugepages/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kernel-sysctl-hugepages"
+version = "0.1.0"
+authors = ["Yutong Sun <yutongsu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.28.0/kernel-sysctl-hugepages/src/main.rs
+++ b/sources/settings-migrations/v1.28.0/kernel-sysctl-hugepages/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+///  We added new settings metadata, `metadata.settings.kernel.sysctl.vm/nr_hugepages.setting-generator`
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["setting-generator"],
+        setting: "settings.kernel.sysctl.vm/nr_hugepages",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/defaults.toml
+++ b/sources/shared-defaults/defaults.toml
@@ -141,6 +141,9 @@ restart-commands = ["/usr/bin/corndog sysctl"]
 [metadata.settings.kernel.sysctl]
 affected-services = ["sysctl"]
 
+[metadata.settings.kernel.sysctl."vm/nr_hugepages"]
+setting-generator = "corndog generate-hugepages-setting"
+
 [services.kernel-modules]
 configuration-files = ["modprobe-conf", "modules-load"]
 restart-commands = ["/usr/bin/systemctl try-restart systemd-modules-load"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related #1031 

**Description of changes:**
1. Note: rdma-core will be vended as part of the `release` package in core-kit. PR https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/252.
2. Added setting generator for `metadata.settings.kernel.sysctl."vm/nr_hugepages"` in shared default
3. Added migration for setting generator.




**Testing done:**

Tested migration:

- [x] Test upgrade:

**kernel.sysctl setting**
Before upgrade:
```
[ssm-user@control]$ apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "none"
    }
  }
}
```
Upgrade:
```
[ssm-user@control]$ apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "none",
      "sysctl": {
        "vm/nr_hugepages": "3520"
      }
    }
  }
}
```

**setting generator for `settings.kernel.sysctl.vm/nr_hugepages`**:
Before:
```
{
    "settings.network.hostname": "netdog generate-hostname",
    "settings.updates.seed": "bork seed",
    "settings.boot": "/usr/bin/prairiedog generate-boot-settings",
    "settings.updates.targets-base-url": "schnauzer-v2 render --requires 'aws@v1' --requires 'updates@v1(helpers=[tuf-prefix])' --template '{{ tuf-prefix settings.aws.region }}/targets/'",
    "settings.host-containers.admin.user-data": "shibaken generate-admin-userdata",
    "settings.host-containers.control.source": "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.17'",
    "settings.metrics.send-metrics": "shibaken is-partition --partition aws --partition aws-us-gov",
    "settings.aws.config": "schnauzer-v2 render --requires 'aws@v1(helpers=[aws-config])' --template '{{ aws-config settings.aws.config settings.aws.profile }}'",
    "settings.host-containers.admin.source": "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.13'",
    "settings.updates.metadata-base-url": "schnauzer-v2 render --requires 'aws@v1' --requires 'updates@v1(helpers=[metadata-prefix, tuf-prefix])' --template '{{ tuf-prefix settings.aws.region }}{{ metadata-prefix settings.aws.region }}/2020-07-07/{{ os.variant_id }}/{{ os.arch }}/'"
}
```

After upgrades:
```
{
  ...
  "settings.kernel.sysctl.vm/nr_hugepages": "corndog generate-hugepages-setting", <--- New
  ...
}
```
- [x] Test downgrade

Verified that settings remains:
```
[root@admin]# apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "none",
      "sysctl": {
        "vm/nr_hugepages": "3520"
      }
    }
  }
}
```
Settings generator is removed after downgrade.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
