### PR TITLE
Prepare 1.27.x branch for 1.27.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Add support for migrations to modify FIPS ecr endpoints ([#4267])
 
 ## Build Changes
-* Update bottlerocket-core-kit to 3.2.0 ([#4286])
+* Update bottlerocket-core-kit to 3.3.0 ([#4292])
 * Update bottlerocket-sdk to 0.47.0 ([#4286])
 
 [#1667]: https://github.com/bottlerocket-os/bottlerocket/pull/1667
@@ -20,6 +20,7 @@
 [#4285]: https://github.com/bottlerocket-os/bottlerocket/pull/4285
 [#4286]: https://github.com/bottlerocket-os/bottlerocket/pull/4286
 [#4287]: https://github.com/bottlerocket-os/bottlerocket/pull/4287
+[#4292]: https://github.com/bottlerocket-os/bottlerocket/pull/4292
 
 # v1.26.2 (2024-11-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v1.27.1 (2024-11-16)
+
+## Release Highlights
+* Add patch for kernel-5.15 to fix issues when using IPv6 ([bottlerocket-core-kit#266](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/266))
+
+## Build Changes
+
+### OS Changes
+* Update bottlerocket-core-kit to 3.3.2 ([#4301])
+
+[#4301]: https://github.com/bottlerocket-os/bottlerocket/pull/4301
+
 # v1.27.0 (2024-11-12)
 
 ## Release Highlights
@@ -38,7 +50,7 @@
 
 ## Release Highlights
 * Revert system-wide configuration to block writeable/executable memory in systemd services ([bottlerocket-core-kit#215](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/215))
- 
+
 ## Build Changes
 
 ### OS Changes
@@ -244,7 +256,7 @@
 
 * Enable k8s reserved cpus ([#3964])
 * Drop k8s 1.27 metal and VMware variants ([#4079])
-* Drop k8s 1.26 metal and VMware variants ([#4018]) 
+* Drop k8s 1.26 metal and VMware variants ([#4018])
 * Build the pause image from upstream ([#3940]) - Thanks @tzneal!
 
 ### ECS
@@ -260,7 +272,7 @@
 
 * Migrate to core kit ([#4060])
 * Remove leftover vendor section ([#4071])
-* Update Twoliter to 0.4.4 ([#4008], [#4086], [#4093], [#4123]) 
+* Update Twoliter to 0.4.4 ([#4008], [#4086], [#4093], [#4123])
 * Update bottlerocket-core-kit to v2.3.1 ([#4122])
 * Update bottlerocket-sdk to 0.43 ([#4122])
 
@@ -333,7 +345,7 @@
 ### Kubernetes
 
 * Add latest instance types to eni-max-pods mapping ([#4108])
-    
+
 [#4104]: https://github.com/bottlerocket-os/bottlerocket/pull/4104
 [#4108]: https://github.com/bottlerocket-os/bottlerocket/pull/4108
 [#4110]: https://github.com/bottlerocket-os/bottlerocket/pull/4110
@@ -500,10 +512,10 @@
 ## Orchestrator Changes
 
 ### Kubernetes
-* Provide runtime cgroup to kubelet ([#3804]) 
- 
+* Provide runtime cgroup to kubelet ([#3804])
+
 ## Build Changes
-* Update twoliter to v0.1.1 ([#3880], [#3900]) 
+* Update twoliter to v0.1.1 ([#3880], [#3900])
 * Update ecs-gpu-init, amazon-ssm-agent, and nvidia-k8s-device-plugin builds for new SDK ([#3920], [#3921], [#3924])
 
 [#3804]: https://github.com/bottlerocket-os/bottlerocket/pull/3804
@@ -605,7 +617,7 @@
 ## Orchestrator Changes
 
 ### Kubernetes
-* Mark pause container image as "pinned" to prevent garbage collection ([#3757]) 
+* Mark pause container image as "pinned" to prevent garbage collection ([#3757])
 
 ### ECS
 * Update Docker engine and Docker CLI to v25.0.2 ([#3759])
@@ -829,7 +841,7 @@
 
 ## Major Features
 
-This release brings support for Secure Boot on platforms using UEFI boot; the Linux 6.1 kernel; systemd-networkd and systemd-resolved for host networking; and XFS as the filesystem for local storage. 
+This release brings support for Secure Boot on platforms using UEFI boot; the Linux 6.1 kernel; systemd-networkd and systemd-resolved for host networking; and XFS as the filesystem for local storage.
 
 These features are enabled by default in the new variants. Existing variants will continue to use earlier kernels, `wicked` for host networking, and EXT4 as the filesystem for local storage.
 

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.27.0"
+version = "1.27.1"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -371,3 +371,4 @@ version = "1.27.0"
 "(1.26.2, 1.27.0)" = [
     "migrate_v1.27.0_aws-config.lz4",
 ]
+"(1.27.0, 1.27.1)" = []

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,7 +9,7 @@ digest = "cKFZsWoMaWa/emD2I6I5TMCPMoHTnGH6X3CpPVH9VBg="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "3.3.1"
+version = "3.3.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v3.3.1"
-digest = "cCjgpGJ+PBP6EgfXm7ay3pdGWFkdisrB9iD3AiRQNGE="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v3.3.2"
+digest = "n2rQ+xpPq1lNsWk+gJprsWt4shG03+FnowDPmKpZybI="

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,7 +9,7 @@ digest = "cKFZsWoMaWa/emD2I6I5TMCPMoHTnGH6X3CpPVH9VBg="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "3.3.0"
+version = "3.3.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v3.3.0"
-digest = "EeVhWOSg1wzt7s4kDvH36yaRVxvVWd/4pjgm5ZP953I="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v3.3.1"
+digest = "cCjgpGJ+PBP6EgfXm7ay3pdGWFkdisrB9iD3AiRQNGE="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,5 +11,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "3.3.0"
+version = "3.3.1"
 vendor = "bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.27.0"
+release-version = "1.27.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,5 +11,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "3.3.1"
+version = "3.3.2"
 vendor = "bottlerocket"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
n/a

**Description of changes:**

Cherry pick from #4298  to prepare the 1.27.x branch for Bottlerocket 1.27.1

**Testing done:**

n/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
