### PR TITLE
Add support for nvidia MIG

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -396,6 +396,7 @@ version = "1.33.0"
 ]
 "(1.31.0, 1.32.0)" = []
 "(1.32.0, 1.33.0)" = [
+    "migrate_v1.33.0_kubelet-device-plugins-mig-settings.lz4",
     "migrate_v1.33.0_public-control-container-v0-7-19-update.lz4",
     "migrate_v1.33.0_public-control-container-v0-7-20-update.lz4",
     "migrate_v1.33.0_aws-remove-schnauzer-admin.lz4",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "darling 0.20.8",
  "quote",
@@ -557,8 +557,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.7.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.8.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "serde",
  "serde_plain",
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.8",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-plugin-v0.1.0#9cb0286b59cd4fcb5df9dd441aee8521ea5698e6"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -626,8 +626,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.7.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.8.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-plugin-v0.1.0#9cb0286b59cd4fcb5df9dd441aee8521ea5698e6"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "serde",
 ]
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2857,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2884,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2923,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2949,7 +2949,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2974,8 +2974,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3002,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3040,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3053,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3080,7 +3080,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1635,6 +1635,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-device-plugins-mig-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-device-plugins-settings"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "settings-migrations/v1.31.0/public-admin-container-v0-11-16",
     "settings-migrations/v1.31.0/aws-control-container-v0-7-20",
     "settings-migrations/v1.31.0/public-control-container-v0-7-20",
+    "settings-migrations/v1.33.0/kubelet-device-plugins-mig-settings",
     "settings-migrations/v1.33.0/public-control-container-v0-7-19-update",
     "settings-migrations/v1.33.0/public-control-container-v0-7-20-update",
     "settings-migrations/v1.33.0/aws-remove-schnauzer-admin",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -164,22 +164,22 @@ version = "0.1.0"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
-version = "0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
+version = "0.8.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
-version = "0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
+version = "0.8.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
+tag = "bottlerocket-settings-plugin-v0.1.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -5,7 +5,7 @@ Bottlerocket has different variants supporting different features and use cases.
 Each variant has its own set of software, and therefore needs its own configuration.
 We support having an API model for each variant to support these different configurations.
 
-The model here defines a top-level `Settings` structure, and delegates the actual implementation to a ["settings plugin"](https://github.com/bottlerocket/bottlerocket-settings-sdk/tree/settings-plugins).
+The model here defines a top-level `Settings` structure, and delegates the actual implementation to a ["settings plugin"](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/tree/develop/bottlerocket-settings-plugin).
 Settings plugin are written in Rust as a "cdylib" crate, and loaded at runtime.
 
 Each settings plugin must define its own private `Settings` structure.
@@ -13,7 +13,7 @@ It can use pre-defined structures inside, or custom ones as needed.
 
 `apiserver::datastore` offers serialization and deserialization modules that make it easy to map between Rust types and the data store, and thus, all inputs and outputs are type-checked.
 
-At the field level, standard Rust types can be used, or ["modeled types"](src/modeled_types) that add input validation.
+At the field level, standard Rust types can be used, or ["modeled types"](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/tree/develop/bottlerocket-settings-models/modeled-types) that add input validation.
 
 The `#[model]` attribute on Settings and its sub-structs reduces duplication and adds some required metadata; see [its docs](model-derive/) for details.
 */

--- a/sources/settings-migrations/v1.33.0/kubelet-device-plugins-mig-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.33.0/kubelet-device-plugins-mig-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubelet-device-plugins-mig-settings"
+version = "0.1.0"
+authors = ["Piyush Jena <jepiyush@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.33.0/kubelet-device-plugins-mig-settings/src/main.rs
+++ b/sources/settings-migrations/v1.33.0/kubelet-device-plugins-mig-settings/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for configuring the NVIDIA k8s device plugin.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubelet-device-plugins.nvidia.device-partitioning-strategy",
+        "settings.kubelet-device-plugins.nvidia.mig",
+        "configuration-files.nvidia-k8s-device-plugin-mig-conf",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -4,6 +4,7 @@ restart-commands = ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plug
 configuration-files = [
     "nvidia-k8s-device-plugin-conf",
     "nvidia-k8s-device-plugin-exec-start-conf",
+    "nvidia-k8s-device-plugin-mig-conf"
 ]
 
 [configuration-files.nvidia-k8s-device-plugin-conf]
@@ -14,6 +15,10 @@ template-path = "/usr/share/templates/nvidia-k8s-device-plugin-conf"
 path = "/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf"
 template-path = "/usr/share/templates/nvidia-k8s-device-plugin-exec-start-conf"
 
+[configuration-files.nvidia-k8s-device-plugin-mig-conf]
+path = "/etc/nvidia-migmanager/nvidia-migmanager.toml"
+template-path = "/usr/share/templates/nvidia-k8s-device-plugin-mig-conf"
+
 [metadata.settings.kubelet-device-plugins.nvidia]
 affected-services = ["nvidia-k8s-device-plugin"]
 
@@ -22,3 +27,4 @@ pass-device-specs = true
 device-id-strategy="index"
 device-list-strategy="volume-mounts"
 device-sharing-strategy="none"
+device-partitioning-strategy="none"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
* Added migrations for the following settings and configuration-files
```
settings.kubelet-device-plugins.nvidia.device-partitioning-strategy
settings.kubelet-device-plugins.nvidia.mig
configuration-files.nvidia-k8s-device-plugin-mig-conf
```
* Rebased with core-kit version bump

**Testing done:**
### Migration test between v1.32.0 and v1.33.0

**v1.32.0**
```
[ssm-user@control]$ apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "none",
        "pass-device-specs": true
      }
    }
  }
}
bash-5.1# cat /etc/os-release
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.32.0 (aws-k8s-1.29-nvidia)"
PRETTY_NAME="Bottlerocket OS 1.32.0 (aws-k8s-1.29-nvidia)"
VARIANT_ID=aws-k8s-1.29-nvidia
VERSION_ID=1.32.0
BUILD_ID=cacc4ce9
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
DOCUMENTATION_URL="https://bottlerocket.dev"
bash-5.1# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.29-nvidia",
    "arch": "x86_64",
    "version": "1.33.0",
    "max_version": "1.33.0",
    "waves": {
      "0": "2025-02-07T12:26:28.495108532Z",
      "20": "2025-02-07T15:26:28.495108532Z",
      "102": "2025-02-08T11:26:28.495108532Z",
      "307": "2025-02-09T11:26:28.495108532Z",
      "819": "2025-02-11T11:26:28.495108532Z",
      "1228": "2025-02-12T11:26:28.495108532Z",
      "1843": "2025-02-13T11:26:28.495108532Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.33.0-1fb8b819-dirty-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.33.0-1fb8b819-dirty-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.33.0-1fb8b819-dirty-root.verity.lz4"
    }
  }
]
bash-5.1# updog update -i 1.33.0 -r -n
Starting update to 1.33.0
Reboot scheduled for Fri 2025-02-07 11:37:00 UTC, use 'shutdown -c' to cancel.
Update applied: aws-k8s-1.29-nvidia 1.33.0

```

**Post upgrade to v1.33.0** - Unrelated lines in `apiclient get configuration-files` have been omitted for brevity.
```

[ssm-user@control]$ apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-partitioning-strategy": "none",
        "device-sharing-strategy": "none",
        "pass-device-specs": true
      }
    }
  }
}
[ssm-user@control]$ apiclient get configuration-files
    ****
    "nvidia-k8s-device-plugin-mig-conf": {
      "path": "/etc/nvidia-migmanager/nvidia-migmanager.toml",
      "template-path": "/usr/share/templates/nvidia-k8s-device-plugin-mig-conf"
    },
    ****
bash-5.1# journalctl -u nvidia-migmanager
Feb 07 11:36:39 ip-172-31-0-165.us-west-2.compute.internal systemd[1]: Starting NVIDIA MIG manager service...
Feb 07 11:36:39 ip-172-31-0-165.us-west-2.compute.internal nvidia-migmanager[1394]: 11:36:39 [INFO] nvidia-migmanager started
Feb 07 11:36:39 ip-172-31-0-165.us-west-2.compute.internal nvidia-migmanager[1394]: 11:36:39 [INFO] Fetching GPU devices data ...
Feb 07 11:36:39 ip-172-31-0-165.us-west-2.compute.internal nvidia-migmanager[1394]: 11:36:39 [WARN] Found NVIDIA Device but couldn't confirm variant.
Feb 07 11:36:39 ip-172-31-0-165.us-west-2.compute.internal systemd[1]: Finished NVIDIA MIG manager service.
bash-5.1# signpost rollback-to-inactive

```

**Post downgrade back to v1.32.0** - Unrelated lines in `apiclient get configuration-files` have been omitted for brevity.
```

[ssm-user@control]$ apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "none",
        "pass-device-specs": true
      }
    }
  }
}
[ssm-user@control]$ apiclient get configuration-files
    ****  
    ****
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
