### PR TITLE
Add default bootstrap container

### DIFF
--- a/sources/settings-defaults/aws-dev/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-ecs-1-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-ecs-1-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-ecs-1/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-ecs-1/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-ecs-2/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-ecs-2/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.25-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.25/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.25/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.26/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.26/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.31/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.31/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.32/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.32/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/metal-k8s-1.30/defaults.d/21-public-bootstrap-containers.toml
+++ b/sources/settings-defaults/metal-k8s-1.30/defaults.d/21-public-bootstrap-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-bootstrap-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.32/defaults.d/21-public-bootstrap-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.32/defaults.d/21-public-bootstrap-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-bootstrap-containers.toml

--- a/sources/shared-defaults/aws-bootstrap-container.toml
+++ b/sources/shared-defaults/aws-bootstrap-container.toml
@@ -1,0 +1,4 @@
+[metadata.settings.bootstrap-containers.source.setting-generator]
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.1.1'"
+strength = "weak"
+depth = 1

--- a/sources/shared-defaults/public-bootstrap-containers.toml
+++ b/sources/shared-defaults/public-bootstrap-containers.toml
@@ -1,0 +1,4 @@
+[metadata.settings.bootstrap-containers.source.setting-generator]
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.1.1'"
+strength = "weak"
+depth = 1


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
This pull request will add the default image to be used for Bootstrap container in Bottlerocket AMIs. We will use region based image URIs for AWS variants like aws-k8s-1.29 etc. And we will use public Bootstrap container image for Vmware and Metal variants AMIs.

This PR is dependednt on the changes in https://github.com/bottlerocket-os/bottlerocket/pull/4324 and needs to be merged after that.

**Testing done:**
- [x] Should be able run a bootstrap container with default Bootstrap container image for AWS variants.
- [x] Should be able run a bootstrap container with default Bootstrap container image for VMware and Metal variants.
- [x] Should use the provided bootstrap container image if the image URI has been provided in user-data.
- [x] One without source should use the default Bootstrap container and another with the given source should use that source.
- [x] The bootstrap containers should not be changed to strong if we pass enabled and other bootstrap container settings from userdata or apiclient set
- [x] Upgrade/Downgrade migration with the version containing default Bootstrap container.
- [x] Upgrade/Downgrade migration for Bootstrap container version change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
