### PR TITLE
Release host containers for 1.31.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -388,3 +388,7 @@ version = "1.30.0"
     "migrate_v1.30.0_aws-control-container-v0-7-19.lz4",
     "migrate_v1.30.0_public-control-container-v0-7-19.lz4",
 ]
+"(1.30.0, 1.31.0)" = [
+    "migrate_v1.31.0_aws-admin-container-v0-11-16.lz4",
+    "migrate_v1.31.0_public-admin-container-v0-11-16.lz4",
+]

--- a/Release.toml
+++ b/Release.toml
@@ -391,4 +391,6 @@ version = "1.30.0"
 "(1.30.0, 1.31.0)" = [
     "migrate_v1.31.0_aws-admin-container-v0-11-16.lz4",
     "migrate_v1.31.0_public-admin-container-v0-11-16.lz4",
+    "migrate_v1.31.0_aws-control-container-v0-7-20.lz4",
+    "migrate_v1.31.0_public-control-container-v0-7-20.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.30.0"
+version = "1.31.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.30.0"
+release-version = "1.31.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -330,6 +330,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-admin-container-v0-11-16"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-config"
 version = "0.1.0"
 dependencies = [
@@ -2118,6 +2125,13 @@ dependencies = [
 
 [[package]]
 name = "public-admin-container-v0-11-15"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-admin-container-v0-11-16"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -386,6 +386,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-control-container-v0-7-20"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "aws-lc-fips-sys"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,6 +2181,13 @@ dependencies = [
 
 [[package]]
 name = "public-control-container-v0-7-19"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "public-control-container-v0-7-20"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -81,6 +81,8 @@ members = [
     "settings-migrations/v1.30.0/public-control-container-v0-7-19",
     "settings-migrations/v1.31.0/aws-admin-container-v0-11-16",
     "settings-migrations/v1.31.0/public-admin-container-v0-11-16",
+    "settings-migrations/v1.31.0/aws-control-container-v0-7-20",
+    "settings-migrations/v1.31.0/public-control-container-v0-7-20",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -79,6 +79,8 @@ members = [
     "settings-migrations/v1.30.0/public-admin-container-v0-11-15",
     "settings-migrations/v1.30.0/aws-control-container-v0-7-19",
     "settings-migrations/v1.30.0/public-control-container-v0-7-19",
+    "settings-migrations/v1.31.0/aws-admin-container-v0-11-16",
+    "settings-migrations/v1.31.0/public-admin-container-v0-11-16",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-migrations/v1.31.0/aws-admin-container-v0-11-16/Cargo.toml
+++ b/sources/settings-migrations/v1.31.0/aws-admin-container-v0-11-16/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-admin-container-v0-11-16"
+version = "0.1.0"
+authors = ["Sparks Song <shijiao@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.31.0/aws-admin-container-v0-11-16/src/main.rs
+++ b/sources/settings-migrations/v1.31.0/aws-admin-container-v0-11-16/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.15'";
+const NEW_ADMIN_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.16'";
+
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.admin.source",
+        old_schnauzer_cmdline: OLD_ADMIN_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_ADMIN_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.31.0/aws-control-container-v0-7-20/Cargo.toml
+++ b/sources/settings-migrations/v1.31.0/aws-control-container-v0-7-20/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aws-control-container-v0-7-20"
+version = "0.1.0"
+authors = ["Sparks Song <shijiao@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.31.0/aws-control-container-v0-7-20/src/main.rs
+++ b/sources/settings-migrations/v1.31.0/aws-control-container-v0-7-20/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.19'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.20'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.31.0/public-admin-container-v0-11-16/Cargo.toml
+++ b/sources/settings-migrations/v1.31.0/public-admin-container-v0-11-16/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-admin-container-v0-11-16"
+version = "0.1.0"
+authors = ["Sparks Song <shijiao@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.31.0/public-admin-container-v0-11-16/src/main.rs
+++ b/sources/settings-migrations/v1.31.0/public-admin-container-v0-11-16/src/main.rs
@@ -1,0 +1,24 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.15";
+const NEW_ADMIN_CTR_SOURCE_VAL: &str = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.16";
+/// We bumped the version of the default admin container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "settings.host-containers.admin.source",
+        old_val: OLD_ADMIN_CTR_SOURCE_VAL,
+        new_val: NEW_ADMIN_CTR_SOURCE_VAL,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.31.0/public-control-container-v0-7-20/Cargo.toml
+++ b/sources/settings-migrations/v1.31.0/public-control-container-v0-7-20/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "public-control-container-v0-7-20"
+version = "0.1.0"
+authors = ["Sparks Song <shijiao@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.31.0/public-control-container-v0-7-20/src/main.rs
+++ b/sources/settings-migrations/v1.31.0/public-control-container-v0-7-20/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::ReplaceSchnauzerMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.19'";
+const NEW_CONTROL_CTR_CMDLINE: &str =
+    "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.20'";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceSchnauzerMigration {
+        setting: "settings.host-containers.control.source",
+        old_schnauzer_cmdline: OLD_CONTROL_CTR_CMDLINE,
+        new_schnauzer_cmdline: NEW_CONTROL_CTR_CMDLINE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -13,4 +13,4 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.19'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.20'"

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source]
-setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.15'"
+setting-generator = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.16'"
 
 [metadata.settings.host-containers.admin.user-data]
 setting-generator = "shibaken generate-admin-userdata"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -11,4 +11,4 @@ source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.16"
 [settings.host-containers.control]
 enabled = false
 superpowered = false
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.19"
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.20"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -6,7 +6,7 @@
 [settings.host-containers.admin]
 enabled = false
 superpowered = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.15"
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.16"
 
 [settings.host-containers.control]
 enabled = false


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update the admin and control host containers to bottlerocket-admin-container v0.11.16 and bottlerocket-control-container v0.7.20. Also add migrations move to these versions on upgrade.


**Testing done:**
- [x] **Migration from 1.30.0 to 1.31.0**

After migrate to 1.31.0

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0fd52114-dirty",
    "pretty_name": "Bottlerocket OS 1.31.0 (aws-k8s-1.31)",
    "variant_id": "aws-k8s-1.31",
    "version_id": "1.31.0"
  }
}
bash-5.1# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.16",
        "superpowered": true,
        "user-data": "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbInNzaC1yc2EgQUFBQUIzTnphQzF5YzJFQUFBQURBUUFCQUFBQkFRQ0srSWFTS20xSk94SUlHdWdjdzVCYkR0V0VsWWo1czJWdFYwSmhURWZ4cno2bUlYUWdMOE90bGJiL3hTUTljU1RMZ1ZRTXYrUXh1ckFIcUFCa1pNVlJzcnJZTzJ5L0FGa3M3U2pNdzVRbnVoVm1Wa0NGemp4Rnc4RkZtUVgrWGRaVHlreFZFUk1KTXFTN0FaRDhoWHBMV3lYZ1l0RFYzN1lrbElFMVBLSWpPS3AvdTBaZGVqSzRaVHBvQjM2UWQzd2U1SFNpb3Q2dDk3aUcyS1VSUFlMTmR5aUhVMFMxdk02M2E0NUo4bGNLcnErdW16c0hOcDM2VW1Bc1d3ejE5N0oxelBmR3RnalhlUjQwYUJ3TkhhYS82eDdJWXd2bERkZytJOUVpMkZYbnI4d0lPcDJSNXVtMUdDaUU3WjlEMUF4NFRjS2xxOXB3NzhBV3YySE9LZWRmIGJyLWRldiJdfX0="
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.20",
        "superpowered": false
      }
    }
  }
}
```

Rolling back to 1.30.0

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "ca9b9399",
    "pretty_name": "Bottlerocket OS 1.30.0 (aws-k8s-1.31)",
    "variant_id": "aws-k8s-1.31",
    "version_id": "1.30.0"
  }
}
bash-5.1# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.15",
        "superpowered": true,
        "user-data": "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbInNzaC1yc2EgQUFBQUIzTnphQzF5YzJFQUFBQURBUUFCQUFBQkFRQ0srSWFTS20xSk94SUlHdWdjdzVCYkR0V0VsWWo1czJWdFYwSmhURWZ4cno2bUlYUWdMOE90bGJiL3hTUTljU1RMZ1ZRTXYrUXh1ckFIcUFCa1pNVlJzcnJZTzJ5L0FGa3M3U2pNdzVRbnVoVm1Wa0NGemp4Rnc4RkZtUVgrWGRaVHlreFZFUk1KTXFTN0FaRDhoWHBMV3lYZ1l0RFYzN1lrbElFMVBLSWpPS3AvdTBaZGVqSzRaVHBvQjM2UWQzd2U1SFNpb3Q2dDk3aUcyS1VSUFlMTmR5aUhVMFMxdk02M2E0NUo4bGNLcnErdW16c0hOcDM2VW1Bc1d3ejE5N0oxelBmR3RnalhlUjQwYUJ3TkhhYS82eDdJWXd2bERkZytJOUVpMkZYbnI4d0lPcDJSNXVtMUdDaUU3WjlEMUF4NFRjS2xxOXB3NzhBV3YySE9LZWRmIGJyLWRldiJdfX0="
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.19",
        "superpowered": false
      }
    }
  }
}

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
