### PR TITLE
twoliter: bump twoliter to v0.7.2

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.7.1"
-TWOLITER_SHA256_AARCH64 = "4ca885c9f6994f35e99c3e75b22c43423a7e2cd3f8c4c31fe695b607c96fc7a9"
-TWOLITER_SHA256_X86_64 = "5a667539118c5ffb49ec168ccb2e48c29caa73239151a8d053fff4246b7090e9"
+TWOLITER_VERSION = "v0.7.2"
+TWOLITER_SHA256_AARCH64 = "45fdf25fbc3dc914d1a413aa3a4a87a5569bd17c0f2b7998aa71a03c945842cb"
+TWOLITER_SHA256_X86_64 = "cb17a9332a55d83a1cf200711b745d725a6e2b0440ba34e1cbf3d6456d3a0074"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Bump Twoliter to v0.7.2

**Testing done:**

```bash
cargo make -e BUILDSYS_VARIANT=aws-dev
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
