### PR TITLE
k8s-*: add support for aws-iso-e ecr url pattern

### DIFF
--- a/sources/shared-defaults/kubernetes-aws-credential-provider.toml
+++ b/sources/shared-defaults/kubernetes-aws-credential-provider.toml
@@ -5,6 +5,8 @@ image-patterns = [
     "*.dkr.ecr.*.amazonaws.com",
     "*.dkr.ecr.*.amazonaws.com.cn",
     "*.dkr.ecr-fips.*.amazonaws.com",
+    "*.dkr.ecr.eu-isoe-west-1.cloud.adc-e.uk",
+    "*.dkr.ecr-fips.eu-isoe-west-1.cloud.adc-e.uk",
     "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
     "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
 ]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Adds default support for aws-iso-e ecr/ecr-fips url pattern.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
