### PR TITLE
defaults: drop setting generator for hugepages

### DIFF
--- a/sources/shared-defaults/defaults.toml
+++ b/sources/shared-defaults/defaults.toml
@@ -141,9 +141,6 @@ restart-commands = ["/usr/bin/corndog sysctl"]
 [metadata.settings.kernel.sysctl]
 affected-services = ["sysctl"]
 
-[metadata.settings.kernel.sysctl."vm/nr_hugepages"]
-setting-generator = "corndog generate-hugepages-setting"
-
 [services.kernel-modules]
 configuration-files = ["modprobe-conf", "modules-load"]
 restart-commands = ["/usr/bin/systemctl try-restart systemd-modules-load"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Relevant #4385 

**Description of changes:**
Drop setting generator for hugepages.


**Testing done:**
# 

1. Build a test AMI and launch with userdata

```
[settings.kernel.sysctl]
"vm.nr_hugepages" = "3000"
```

Verified that no hugepages settings got generated for “vm/nr_hugepages”

```
bash-5.1# apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "integrity",
      "sysctl": {
        "vm.nr_hugepages": "3000"
      }
    }
  }
}
```

The hugepages value is honored

```
bash-5.1# cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
3000
```

Settings generator not showing up - no entry ("vm/nr_hugepages") found in the setting generators.

2. Build a 1.33.0 AMI and confirm the existing behavior

```
[settings.updates]
metadata-base-url = "$METADATA_BASE_URL"
targets-base-url ="$TARGETS_BASE_URL"
ignore-waves = true
 
[settings.host-containers.admin]
enabled = true

[settings.kernel.sysctl]
"vm.nr_hugepages" = "3000"
```

See that the setting generator generates the extra entry “vm/nr_hugepages”

```
bash-5.1# apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "integrity",
      "sysctl": {
        "vm.nr_hugepages": "3000",
        "vm/nr_hugepages": "0"
      }
    }
  }
}
```

And the hugepages value gets overwritten

```
bash-5.1# cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
0
```

hugepages settings generator exists of course

```
{
    ...
    "settings.kernel.sysctl.vm/nr_hugepages": "corndog generate-hugepages-setting",
    ...
}
```

3. Build a custom repo with 1.34.0 version that drops the setting generator. Upgrade the 1.33.0 node to the custom 1.34.0 version. Settings for the generated hugepages persists.

```
bash-5.1# apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "integrity",
      "sysctl": {
        "vm.nr_hugepages": "3000",
        "vm/nr_hugepages": "0"
      }
    }
  }
}
```

Settings generator for hugepages is removed, no entry ("vm/nr_hugepages") found in the setting generators.

3. Downgrade back to the 1.33.0 version. Settings generator for hugepages is showing up.

```
{
    ...
    "settings.kernel.sysctl.vm/nr_hugepages": "corndog generate-hugepages-setting",
    ...
}
```

Everything is exactly the same as observed from case 2.


5. On 1.33.0 version, manually set “vm/nr_hugepages” value to a non-zero value.

```
apiclient set --json '{"kernel": {"sysctl": {"vm/nr_hugepages": "3000"}}}'
```

Then upgrade to 1.34.0 again. Verified that the settings value persists while settings generator is removed (confirmed in case 3). This ensures customer who mitigated the issue by manually setting `"vm/nr_hugepages"` to the desired value will not be affected by the setting generator drop.

```
bash-5.1# apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "integrity",
      "sysctl": {
        "vm.nr_hugepages": "3000",
        "vm/nr_hugepages": "3000"
      }
    }
  }
}

bash-5.1# cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
3000
```




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
