### PR TITLE
twoliter: bump to bottlerocket-kernel-kit v1.2.0 and bottlerocket-core-kit v6.0.2

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.7.2"
-TWOLITER_SHA256_AARCH64 = "45fdf25fbc3dc914d1a413aa3a4a87a5569bd17c0f2b7998aa71a03c945842cb"
-TWOLITER_SHA256_X86_64 = "cb17a9332a55d83a1cf200711b745d725a6e2b0440ba34e1cbf3d6456d3a0074"
+TWOLITER_VERSION = "v0.7.3"
+TWOLITER_SHA256_AARCH64 = "3dd7c651d01ef44c6e1835e377cd368c54f60a9f2ab1f66248bac65549685cf9"
+TWOLITER_SHA256_X86_64 = "c9913e46de794e5f682bcbed14997f1491273cbb82dc3a2865b5f50b6be3eb96"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,14 +9,14 @@ digest = "HEh3Lx3F6P4OEPnFubF++RMpMW2vlfp/Tc/tGjnBRcM="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "1.1.2"
+version = "1.2.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v1.1.2"
-digest = "H0fbTGkbYi+jXUUXhDh5pv7i2umKgnv/vaZ/SN27xN0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v1.2.0"
+digest = "vc4qk+2gQMK1o1g/A6IrfRBDKLKmcwKoDDSlloZMOfA="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "6.0.1"
+version = "6.0.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v6.0.1"
-digest = "SboBRtwOweOq3YUK3omqTYFDFpz0in6AoBVALu+qJa8="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v6.0.2"
+digest = "36Bv8FOwTzk9UT3cVfyOOoAFqEt5HUJkAM8ElX4fbIs="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,10 +11,10 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "1.1.2"
+version = "1.2.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "6.0.1"
+version = "6.0.2"
 vendor = "bottlerocket"


### PR DESCRIPTION
* Update twoliter to v0.7.3
* Update kernel kit to v1.2.0
* Update core kit to v6.0.2

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
