### PR TITLE
Add support for NVIDIA MIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# v1.34.0 (2025-03-03)
+
+## OS Changes
+
+* Add support for NVIDIA Multi-Instance GPU (MIG) ([#4418])
+
+## Build Changes
+* Update bottlerocket-core-kit from 6.0.1 to 6.0.2 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v602-2025-02-26) ([#4416])
+* Update bottlerocket-kernel-kit from 1.1.2 to 1.2.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v120-2024-02-26) ([#4416])
+
+### Twoliter
+
+* Update Twoliter to 0.7.3 ([#4416])
+
+[#4416]: https://github.com/bottlerocket-os/bottlerocket/pull/4416
+[#4418]: https://github.com/bottlerocket-os/bottlerocket/pull/4418
+
 # v1.33.0 (2025-02-26)
 
 ## Release Highlights

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.33.0"
+version = "1.34.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -403,4 +403,7 @@ version = "1.33.0"
     "migrate_v1.33.0_public-remove-source-admin.lz4",
     "migrate_v1.33.0_public-remove-source-control.lz4",
     "migrate_v1.33.0_remove-metadata-and-weak-settings-migration.lz4",
+]
+"(1.33.0, 1.34.0)" = [
+    "migrate_v1.34.0_kubelet-device-plugins-mig-settings.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.33.0"
+release-version = "1.34.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "darling 0.20.8",
  "quote",
@@ -557,8 +557,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.7.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.8.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "serde",
  "serde_plain",
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.8",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -626,8 +626,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.7.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.8.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "serde",
 ]
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -1629,6 +1629,13 @@ dependencies = [
 
 [[package]]
 name = "kubelet-device-plugins-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kubelet-device-plugins-mig-settings"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",
@@ -2831,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2844,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2857,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2871,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2884,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2897,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2910,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2923,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2936,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2949,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2962,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2974,8 +2981,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2988,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3002,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3015,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -3027,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3040,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3053,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3066,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3080,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3093,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3106,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -88,6 +88,7 @@ members = [
     "settings-migrations/v1.33.0/public-remove-source-admin",
     "settings-migrations/v1.33.0/public-remove-source-control",
     "settings-migrations/v1.33.0/remove-metadata-and-weak-settings-migration",
+    "settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",
@@ -164,22 +165,22 @@ version = "0.1.0"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
-version = "0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
+version = "0.8.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
-version = "0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
+version = "0.8.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubelet-device-plugins-mig-settings"
+version = "0.1.0"
+authors = ["Piyush Jena <jepiyush@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings/src/main.rs
+++ b/sources/settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for configuring the NVIDIA k8s device plugin.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubelet-device-plugins.nvidia.device-partitioning-strategy",
+        "settings.kubelet-device-plugins.nvidia.mig",
+        "configuration-files.nvidia-k8s-device-plugin-mig-conf",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -4,6 +4,7 @@ restart-commands = ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plug
 configuration-files = [
     "nvidia-k8s-device-plugin-conf",
     "nvidia-k8s-device-plugin-exec-start-conf",
+    "nvidia-k8s-device-plugin-mig-conf"
 ]
 
 [configuration-files.nvidia-k8s-device-plugin-conf]
@@ -14,6 +15,10 @@ template-path = "/usr/share/templates/nvidia-k8s-device-plugin-conf"
 path = "/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf"
 template-path = "/usr/share/templates/nvidia-k8s-device-plugin-exec-start-conf"
 
+[configuration-files.nvidia-k8s-device-plugin-mig-conf]
+path = "/etc/nvidia-migmanager/nvidia-migmanager.toml"
+template-path = "/usr/share/templates/nvidia-k8s-device-plugin-mig-conf"
+
 [metadata.settings.kubelet-device-plugins.nvidia]
 affected-services = ["nvidia-k8s-device-plugin"]
 
@@ -22,3 +27,4 @@ pass-device-specs = true
 device-id-strategy="index"
 device-list-strategy="volume-mounts"
 device-sharing-strategy="none"
+device-partitioning-strategy="none"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes: #4406, #4252

**Description of changes:**



**Testing done:**
### Migration Testing
#### v1.32.0
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "cacc4ce9",
    "pretty_name": "Bottlerocket OS 1.32.0 (aws-k8s-1.29-nvidia)",
    "variant_id": "aws-k8s-1.29-nvidia",
    "version_id": "1.32.0"
  }
}
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="mig"
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-vELpjamiDtvsQslp': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-vELpjamiDtvsQslp: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: unknown field `device-partitioning-strategy`, expected one of `pass-device-specs`, `device-id-strategy`, `device-list-strategy`, `device-sharing-strategy`, `time-slicing` at line 1 column 67
bash-5.1# apiclient apply <<EOF
> [settings.kubelet-device-plugins.nvidia.mig.profile]
> "a100.40gb"="7"
> "h100.80gb"="4"
> "g100.80gb"="1g.5gb"
> EOF
Failed to apply settings: Failed to PATCH settings from '-' to '/settings?tx=apiclient-apply-jnaXTAbi9QIbJm0M': Status 400 when PATCHing /settings?tx=apiclient-apply-jnaXTAbi9QIbJm0M: Json deserialize error: unknown field `mig`, expected one of `pass-device-specs`, `device-id-strategy`, `device-list-strategy`, `device-sharing-strategy`, `time-slicing` at line 1 column 42
bash-5.1# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.29-nvidia",
    "arch": "x86_64",
    "version": "1.34.0",
    "max_version": "1.34.0",
    "waves": {
      "0": "2025-02-27T03:28:57.496827355Z",
      "20": "2025-02-27T06:28:57.496827355Z",
      "102": "2025-02-28T02:28:57.496827355Z",
      "307": "2025-03-01T02:28:57.496827355Z",
      "819": "2025-03-03T02:28:57.496827355Z",
      "1228": "2025-03-04T02:28:57.496827355Z",
      "1843": "2025-03-05T02:28:57.496827355Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.34.0-2ac59cde-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.34.0-2ac59cde-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.34.0-2ac59cde-root.verity.lz4"
    }
  }
]
bash-5.1# updog update -i 1.34.0 -r -n
Starting update to 1.34.0
Reboot scheduled for Thu 2025-02-27 02:37:43 UTC, use 'shutdown -c' to cancel.
Update applied: aws-k8s-1.29-nvidia 1.34.0
```

#### Upgrade to v1.34.0
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "2ac59cde",
    "pretty_name": "Bottlerocket OS 1.34.0 (aws-k8s-1.29-nvidia)",
    "variant_id": "aws-k8s-1.29-nvidia",
    "version_id": "1.34.0"
  }
}
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="mig"
bash-5.1# apiclient apply <<EOF
> [settings.kubelet-device-plugins.nvidia.mig.profile]
> "a100.40gb"="7"
> "h100.80gb"="4"
> "g100.80gb"="1g.5gb"
> EOF
bash-5.1# signpost rollback-to-inactive
```
#### Downgrade to v1.32.0
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "cacc4ce9",
    "pretty_name": "Bottlerocket OS 1.32.0 (aws-k8s-1.29-nvidia)",
    "variant_id": "aws-k8s-1.29-nvidia",
    "version_id": "1.32.0"
  }
}
[ssm-user@control]$ apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="mig"
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-3ypsF3ruTrXjCzNq': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-3ypsF3ruTrXjCzNq: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: unknown field `device-partitioning-strategy`, expected one of `pass-device-specs`, `device-id-strategy`, `device-list-strategy`, `device-sharing-strategy`, `time-slicing` at line 1 column 67
[ssm-user@control]$ apiclient apply <<EOF
> [settings.kubelet-device-plugins.nvidia.mig.profile]
> "a100.40gb"="7"
> "h100.80gb"="4"
> "g100.80gb"="1g.5gb"
> EOF
Failed to apply settings: Failed to PATCH settings from '-' to '/settings?tx=apiclient-apply-yGwq7oN11jDcLKqn': Status 400 when PATCHing /settings?tx=apiclient-apply-yGwq7oN11jDcLKqn: Json deserialize error: unknown field `mig`, expected one of `pass-device-specs`, `device-id-strategy`, `device-list-strategy`, `device-sharing-strategy`, `time-slicing` at line 1 column 42
```

### Feature Testing
#### Settings
```
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="mig"
bash-5.1# apiclient apply <<EOF
> [settings.kubelet-device-plugins.nvidia.mig.profile]
> "a100.40gb"="7"
> "h100.80gb"="4"
> "g100.80gb"="1g.5gb"
> EOF
```
#### `kubectl describe node` output
```
Capacity:
  cpu:                96
  ephemeral-storage:  418812624Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             1176277888Ki
  nvidia.com/gpu:     56
  pods:               737
Allocatable:
  cpu:                95690m
  ephemeral-storage:  384903971816
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             1167612800Ki
  nvidia.com/gpu:     56
  pods:               737
  ```
#### `nvidia-k8s-device-plugin` status
```
ash-5.1# systemctl status nvidia-k8s-device-plugin
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
             /etc/systemd/system/nvidia-k8s-device-plugin.service.d
             └─exec-start.conf
     Active: active (running) since Thu 2025-02-27 02:34:58 UTC; 15min ago
   Main PID: 14870 (nvidia-device-p)
      Tasks: 21 (limit: 629145)
     Memory: 61.7M
        CPU: 16.438s
     CGroup: /system.slice/nvidia-k8s-device-plugin.service
             └─14870 /usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml

Feb 27 02:34:59 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]:   },
Feb 27 02:34:59 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]:   "sharing": {
Feb 27 02:34:59 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]:     "timeSlicing": {}
Feb 27 02:34:59 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]:   },
Feb 27 02:34:59 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]:   "imex": {}
Feb 27 02:34:59 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]: }
Feb 27 02:34:59 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]: I0227 02:34:58.722298   14870 main.go:356] Retrieving plugins.
Feb 27 02:35:05 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]: I0227 02:35:05.440287   14870 server.go:195] Starting GRPC server fo…om/gpu'
Feb 27 02:35:05 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]: I0227 02:35:05.446465   14870 server.go:139] Starting to serve 'nvid…pu.sock
Feb 27 02:35:05 ip-192-168-155-1.us-west-2.compute.internal nvidia-device-plugin[14870]: I0227 02:35:05.451689   14870 server.go:146] Registered device plugi…Kubelet
Hint: Some lines were ellipsized, use -l to show in full.
```

#### Workload test
```
[fedora@ip-172-31-48-208 kubernetes]$ cat << EOF | kubectl apply -f -
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nvidia-cuda-workload-deployment-1
spec:
  replicas: 20
  selector:
    matchLabels:
      app: vector-add
  template:
    metadata:
      labels:
        app: vector-add
    spec:
      containers:
      - name: vector-add
        image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
        resources:
          limits:
              nvidia.com/gpu: 1
EOF
deployment.apps/nvidia-cuda-workload-deployment-1 created
[fedora@ip-172-31-48-208 kubernetes]$ kubectl get pods
NAME                                                READY   STATUS              RESTARTS   AGE
nvidia-cuda-workload-deployment-1-c9548dfc4-2wxw2   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-44wmq   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-5j8xd   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-5zldn   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-69gfp   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-9nnqf   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-b74mp   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-bdbwf   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-brvrt   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-dfsnd   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-dhddn   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-dtxnz   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-fwcmn   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-gp86x   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-k4sjd   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-mqwkt   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-p5bt7   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-wl5z8   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-z9vxr   0/1     ContainerCreating   0          6s
nvidia-cuda-workload-deployment-1-c9548dfc4-zhls8   0/1     ContainerCreating   0          6s
[fedora@ip-172-31-48-208 kubernetes]$ kubectl get pods
NAME                                                READY   STATUS      RESTARTS   AGE
nvidia-cuda-workload-deployment-1-c9548dfc4-2wxw2   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-44wmq   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-5j8xd   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-5zldn   0/1     Completed   0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-69gfp   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-9nnqf   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-b74mp   0/1     Completed   0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-bdbwf   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-brvrt   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-dfsnd   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-dhddn   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-dtxnz   0/1     Completed   0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-fwcmn   0/1     Completed   0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-gp86x   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-k4sjd   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-mqwkt   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-p5bt7   0/1     Completed   0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-wl5z8   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-z9vxr   1/1     Running     0          29s
nvidia-cuda-workload-deployment-1-c9548dfc4-zhls8   1/1     Running     0          29s
[fedora@ip-172-31-48-208 kubernetes]$ kubectl logs nvidia-cuda-workload-deployment-1-c9548dfc4-5j8xd
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
```

#### MIG + Time-slicing `kubectl describe node` output (gpus = 8, partitions = 4, replicas = 4)
```
bash-5.1# apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-partitioning-strategy": "mig",
        "device-sharing-strategy": "time-slicing",
        "mig": {
          "profile": {
            "a100.40gb": "7",
            "g100.80gb": "1g.5gb",
            "h100.80gb": "4"
          }
        },
        "pass-device-specs": true,
        "time-slicing": {
          "replicas": 4
        }
      }
    }
  }
}
```
```
[fedora@ip-172-31-48-208 kubernetes]$ kubectl describe node
Capacity:
  cpu:                    192
  ephemeral-storage:      418124376Ki
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 2097096404Ki
  nvidia.com/gpu:         0
  nvidia.com/gpu.shared:  128
  pods:                   100
Allocatable:
  cpu:                    191450m
  ephemeral-storage:      384269682460
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 2095606484Ki
  nvidia.com/gpu:         0
  nvidia.com/gpu.shared:  128
  pods:                   100

```

### P5 Testing
#### NVLink status when MIG is enabled
```
bash-5.1# ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/nvidia-smi nvlink --status
```
#### NVLink status when MIG is disabled
```
bash-5.1# ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/nvidia-smi nvlink --status
GPU 0: NVIDIA H100 80GB HBM3 (UUID: GPU-4039dfe4-0c97-4b1e-683e-eb7d42699053)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
GPU 1: NVIDIA H100 80GB HBM3 (UUID: GPU-dd3b269a-8f3a-d2d5-1518-2713ba03fcf7)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
GPU 2: NVIDIA H100 80GB HBM3 (UUID: GPU-b6c58f85-1f52-9905-5a8e-06ac27805eb9)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
GPU 3: NVIDIA H100 80GB HBM3 (UUID: GPU-0841636d-8d48-9195-ea7f-9d4a9ad9f846)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
GPU 4: NVIDIA H100 80GB HBM3 (UUID: GPU-fd607481-793f-5e10-278c-109552132250)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
GPU 5: NVIDIA H100 80GB HBM3 (UUID: GPU-7da3770c-f6be-cc04-c1c8-a6e0eff2c89c)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
GPU 6: NVIDIA H100 80GB HBM3 (UUID: GPU-a0620bb0-8ae2-7101-4b52-2fa2ac096343)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
GPU 7: NVIDIA H100 80GB HBM3 (UUID: GPU-3b80af25-3116-b375-0333-fcb4c42b1627)
         Link 0: 26.562 GB/s
         Link 1: 26.562 GB/s
         Link 2: 26.562 GB/s
         Link 3: 26.562 GB/s
         Link 4: 26.562 GB/s
         Link 5: 26.562 GB/s
         Link 6: 26.562 GB/s
         Link 7: 26.562 GB/s
         Link 8: 26.562 GB/s
         Link 9: 26.562 GB/s
         Link 10: 26.562 GB/s
         Link 11: 26.562 GB/s
         Link 12: 26.562 GB/s
         Link 13: 26.562 GB/s
         Link 14: 26.562 GB/s
         Link 15: 26.562 GB/s
         Link 16: 26.562 GB/s
         Link 17: 26.562 GB/s
```

### Fabric Statuses
#### MIG enabled - P5
```
bash-5.1# ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/nvidia-smi  -q -i 0 | grep -i -A 2 Fabric
    Fabric
        State                             : In Progress
        Status                            : N/A
```

#### MIG disabled - P5
```
bash-5.1# ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/nvidia-smi  -q -i 0 | grep -i -A 2 Fabric
    Fabric
        State                             : Completed
        Status                            : Success
```

#### MIG disabled - P4
```
bash-5.1# ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/nvidia-smi  -q -i 0 | grep -i -A 2 Fabric
    Fabric
        State                             : N/A
        Status                            : N/A
```

#### MIG enabled - P4
```
bash-5.1# ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/nvidia-smi  -q -i 0 | grep -i -A 2 Fabric
    Fabric
        State                             : N/A
        Status                            : N/A
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
