### PR TITLE
Authenticate with ecr public to avoid rate limits

### DIFF
--- a/sources/shared-defaults/kubernetes-aws-credential-provider.toml
+++ b/sources/shared-defaults/kubernetes-aws-credential-provider.toml
@@ -8,5 +8,6 @@ image-patterns = [
     "*.dkr.ecr.eu-isoe-west-1.cloud.adc-e.uk",
     "*.dkr.ecr-fips.eu-isoe-west-1.cloud.adc-e.uk",
     "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
-    "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+    "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov",
+    "public.ecr.aws"
 ]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4396 

**Description of changes:**

Add `pubilc.ecr.aws` to the domains that can be used by the ecr credential provider

**Testing done:**

I'm not sure how to test this locally.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
