### PR TITLE
Host container updates 1.35.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.34.0"
+version = "1.35.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -407,3 +407,4 @@ version = "1.34.0"
 "(1.33.0, 1.34.0)" = [
     "migrate_v1.34.0_kubelet-device-plugins-mig-settings.lz4",
 ]
+"(1.34.0, 1.35.0)" = []

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.34.0"
+release-version = "1.35.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.16'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.11.17'"
 strength = "weak"
 
 [metadata.settings.host-containers.admin.user-data]

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -14,5 +14,5 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.7.20'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.8.0'"
 strength = "weak"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -16,5 +16,5 @@ enabled = false
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.20'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.8.0'"
 strength = "weak"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -8,7 +8,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.16'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.17'"
 strength = "weak"
 
 [settings.host-containers.control]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to #4429 

**Description of changes:**

- Bumps release version to 1.35.0
- Updates admin container from 0.11.16 to 0.11.17
- Updates control container from 0.7.20 to 0.8.0

**Testing done:**

- [x] Upgrade from 1.34.0 to 1.35.0
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "18d04e52-dirty",
    "pretty_name": "Bottlerocket OS 1.35.0 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.35.0"
  }
}
bash-5.1# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.17",
        "superpowered": true,
        "user-data": ...
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.8.0",
        "superpowered": false
      }
    }
  }
}
```
- [x] Downgrade from 1.35.0 to 1.34.0
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "18d04e52",
    "pretty_name": "Bottlerocket OS 1.34.0 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.34.0"
  }
}
bash-5.1# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.11.16",
        "superpowered": true,
        "user-data": ...
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.7.20",
        "superpowered": false
      }
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
