### PR TITLE
Bootstrap container update 1.35.0

### DIFF
--- a/sources/shared-defaults/aws-bootstrap-container.toml
+++ b/sources/shared-defaults/aws-bootstrap-container.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.1.1'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.1.2'"
 strength = "weak"
 depth = 1

--- a/sources/shared-defaults/public-bootstrap-containers.toml
+++ b/sources/shared-defaults/public-bootstrap-containers.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.1.1'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.1.2'"
 strength = "weak"
 depth = 1


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4429 

**Description of changes:**

- Updates bootstrap container from 0.1.1 to 0.1.2

**Testing done:**

- [x] Upgrade from 1.34.0 to 1.35.0
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "18d04e52-dirty",
    "pretty_name": "Bottlerocket OS 1.35.0 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.35.0"
  }
}
bash-5.1# apiclient get settings.bootstrap-containers
{
  "settings": {
    "bootstrap-containers": {
      "foo": {
        "mode": "off",
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.1.2",
        "user-data": "IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCiMgQ3JlYXRlIHRoZSBkaXJlY3RvcnkKdG91Y2ggLy5ib3R0bGVyb2NrZXQvcm9vdGZzL3J1bi9teV90ZXN0X2ZpbGUKbWtkaXIgLXAgL3Zhci9saWIvbXlfZGlyZWN0b3J5CnB3ZApscyAtbCAKCmVjaG8gIlVzZXItZGF0YSBzY3JpcHQgZXhlY3V0ZWQuIgo="
      }
    }
  }
}

```
- [x] Downgrade from 1.35.0 to 1.34.0
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "18d04e52",
    "pretty_name": "Bottlerocket OS 1.34.0 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.34.0"
  }
}
bash-5.1# apiclient get settings.bootstrap-containers
{
  "settings": {
    "bootstrap-containers": {
      "foo": {
        "mode": "off",
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.1.1",
        "user-data": "IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCiMgQ3JlYXRlIHRoZSBkaXJlY3RvcnkKdG91Y2ggLy5ib3R0bGVyb2NrZXQvcm9vdGZzL3J1bi9teV90ZXN0X2ZpbGUKbWtkaXIgLXAgL3Zhci9saWIvbXlfZGlyZWN0b3J5CnB3ZApscyAtbCAKCmVjaG8gIlVzZXItZGF0YSBzY3JpcHQgZXhlY3V0ZWQuIgo="
      }
    }
  }
}
```

- Bootstrap container logs
```
    bash-5.2# journalctl -u bootstrap-containers@foo.service
    Mar 07 03:27:18 ip-172-31-22-126.us-west-2.compute.internal systemd[1]: Starting bootstrap container foo...
    Mar 07 03:27:28 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:28Z" level=info msg="Image does not exist, proceeding to pull image from source." ref="ecr.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-bootstrap:v0.1.2"
    Mar 07 03:27:28 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:28Z" level=info msg="pulling with Amazon ECR Resolver" ref="ecr.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-bootstrap:v0.1.2"
    Mar 07 03:27:29 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:29Z" level=info msg="pulled image successfully" img="ecr.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-bootstrap:v0.1.2"
    Mar 07 03:27:29 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:29Z" level=info msg="unpacking image..." img="ecr.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-bootstrap:v0.1.2"
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:39Z" level=info msg="tagging image" img="328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.1.2"
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:39Z" level=info msg="Container does not exist, proceeding to create it" ctr-id=boot.foo
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:39Z" level=info msg="container task does not exist, proceeding to create it" container-id=boot.foo
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:39Z" level=info msg="successfully started container task"
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + declare -r HOST_CERTS=/.bottlerocket/certs
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + [[ -d /.bottlerocket/certs ]]
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + link_host_certs
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: ++ ls -1 /.bottlerocket/certs
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + for cert in $(ls -1 "${HOST_CERTS}")
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + ln -s /.bottlerocket/certs/ca-bundle.crt /etc/pki/ca-trust/source/anchors/ca-bundle.crt
    Mar 07 03:27:39 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + update-ca-trust
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + USER_DATA_PATH=/.bottlerocket/bootstrap-containers/current/user-data
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + [[ -s /.bottlerocket/bootstrap-containers/current/user-data ]]
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + [[ ! -d /.bottlerocket/bootstrap-containers/current/user-data ]]
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + chmod +x /.bottlerocket/bootstrap-containers/current/user-data
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + '[' -x /.bottlerocket/bootstrap-containers/current/user-data ']'
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: + exec /.bottlerocket/bootstrap-containers/current/user-data
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: /
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: total 0
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: lrwxrwxrwx.   1 root root   7 Jan 30  2023 bin -> usr/bin
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: dr-xr-xr-x.   2 root root   6 Jan 30  2023 boot
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   5 root root 340 Mar  7 03:27 dev
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   1 root root  64 Mar  7 03:27 etc
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   2 root root   6 Jan 30  2023 home
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: lrwxrwxrwx.   1 root root   7 Jan 30  2023 lib -> usr/lib
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: lrwxrwxrwx.   1 root root   9 Jan 30  2023 lib64 -> usr/lib64
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   2 root root   6 Feb 20 21:09 local
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   2 root root   6 Jan 30  2023 media
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   2 root root   6 Jan 30  2023 mnt
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   2 root root   6 Jan 30  2023 opt
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: dr-xr-xr-x. 185 root root   0 Mar  7 03:27 proc
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: dr-xr-x---.   1 root root  18 Mar  4 21:46 root
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   2 root root  60 Mar  7 03:27 run
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: lrwxrwxrwx.   1 root root   8 Jan 30  2023 sbin -> usr/sbin
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   2 root root   6 Jan 30  2023 srv
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: dr-xr-xr-x.  13 root root   0 Mar  7 03:27 sys
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxrwxrwt.   1 root root   6 Mar  4 21:47 tmp
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   1 root root  19 Feb 20 21:09 usr
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: drwxr-xr-x.   1 root root  17 Feb 20 21:09 var
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: User-data script executed.
    Mar 07 03:27:41 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1391]: time="2025-03-07T03:27:41Z" level=info msg="container task exited" code=0
    Mar 07 03:27:44 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1565]: 03:27:44 [INFO] bootstrap-containers started
    Mar 07 03:27:44 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1565]: 03:27:44 [INFO] Mode for 'foo' is 'once'
    Mar 07 03:27:44 ip-172-31-22-126.us-west-2.compute.internal bootstrap-containers@foo[1565]: 03:27:44 [INFO] Turning off container 'foo'
    Mar 07 03:27:44 ip-172-31-22-126.us-west-2.compute.internal systemd[1]: Finished bootstrap container foo.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
