### PR TITLE
ecs-1: update kernel from 5.10 to 5.15

### DIFF
--- a/variants/aws-ecs-1-nvidia/Cargo.toml
+++ b/variants/aws-ecs-1-nvidia/Cargo.toml
@@ -20,7 +20,7 @@ kernel-parameters = [
 included-packages = [
 # core
     "release",
-    "kernel-5.10",
+    "kernel-5.15",
 # docker
     "docker-cli",
     "docker-engine",
@@ -30,7 +30,7 @@ included-packages = [
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",
-    "kmod-5.10-nvidia-tesla-535",
+    "kmod-5.15-nvidia-tesla-535",
 ]
 
 [lib]

--- a/variants/aws-ecs-1/Cargo.toml
+++ b/variants/aws-ecs-1/Cargo.toml
@@ -17,7 +17,7 @@ kernel-parameters = [
 included-packages = [
 # core
     "release",
-    "kernel-5.10",
+    "kernel-5.15",
 # docker
     "docker-cli",
     "docker-engine",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4425

**Description of changes:**
Change the `aws-ecs-1` images to use the 5.15 Linux kernel


**Testing done:**
* Built and registered aws-ecs-1 and aws-ecs-1-nvidia
* Ran ECS conformance testing


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
