### PR TITLE
chore: bump twoliter to v0.8.1

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.8.0"
-TWOLITER_SHA256_AARCH64 = "a501445d02fd3f234ea00af19e044b63e87f5989d6259e9a0ba14b88a8cb24bc"
-TWOLITER_SHA256_X86_64 = "69d12da12ae1727860e27eceb6a04375508a27525288edd0192559f380fd3b2f"
+TWOLITER_VERSION = "v0.8.1"
+TWOLITER_SHA256_AARCH64 = "b3df355b5732884bf5e311709bc9a0d0a34ade97c1d7c4cf101cbce4e766de33"
+TWOLITER_SHA256_X86_64 = "cc83689a878f77c1110ca08fb52b23ce5e0cdbe1b38ff074e913e0ebe5be93f9"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes bottlerocket-os/twoliter#508

**Description of changes:**
Update twoliter to v0.8.1


**Testing done:**
```
cargo make -e BUILDSYS_VARIANT=aws-dev
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
