### PR TITLE
Update SDK, Core and Kernel kits

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -16,7 +16,7 @@ digest = "+ldam3twr3adnmhXGMql/SAVUZYVIiRbDt0LEV3XOto="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "6.0.2"
+version = "6.1.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v6.0.2"
-digest = "36Bv8FOwTzk9UT3cVfyOOoAFqEt5HUJkAM8ElX4fbIs="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v6.1.0"
+digest = "3Ggr3k0pIbA87cNsIEeugURf/S7Pb49WI/VPttoQv7Y="

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -2,10 +2,10 @@ schema-version = 1
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.50.1"
+version = "0.60.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.50.1"
-digest = "HEh3Lx3F6P4OEPnFubF++RMpMW2vlfp/Tc/tGjnBRcM="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.60.0"
+digest = "aVbABC86XWBbfyems1C3lrEhEvL1XmNt1hcwF0oAzSs="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,10 +9,10 @@ digest = "aVbABC86XWBbfyems1C3lrEhEvL1XmNt1hcwF0oAzSs="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "1.2.0"
+version = "1.3.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v1.2.0"
-digest = "vc4qk+2gQMK1o1g/A6IrfRBDKLKmcwKoDDSlloZMOfA="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v1.3.0"
+digest = "+ldam3twr3adnmhXGMql/SAVUZYVIiRbDt0LEV3XOto="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,7 +11,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "1.2.0"
+version = "1.3.0"
 vendor = "bottlerocket"
 
 [[kit]]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -6,7 +6,7 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.50.1"
+version = "0.60.0"
 vendor = "bottlerocket"
 
 [[kit]]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -16,5 +16,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "6.0.2"
+version = "6.1.0"
 vendor = "bottlerocket"


### PR DESCRIPTION
**Description of changes:**
- Bump SDK to 0.60.0
- Bump Kernel Kit to 1.3.0
- Bump Core Kit to 6.1.0


**Testing done:**

(@KCSesh )Adding quick k8 test : 

```
 NAME                                              TYPE                      STATE                                     PASSED                  FAILED                  SKIPPED   BUILD ID                        LAST UPDATE
 aarch64-aws-k8s-131-quick                         Test                      passed                                         5                       0                     6604   40e97afe                        2025-03-15T00:06:33Z
 x86-64-aws-k8s-131-quick                          Test                      passed                                         5                       0                     6604   40e97afe                        2025-03-14T23:48:26Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
