### PR TITLE
Fix broken links

### DIFF
--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -61,7 +61,7 @@ A walk-through of creating a storage class using the driver is available [here](
 ##### conntrack configuration
 
 By default `kube-proxy` will set the `nf_conntrack_max` kernel parameter to a default value that may differ from what Bottlerocket originally sets at boot.
-If you prefer to keep Bottlerocket's [default setting](packages/release/release-sysctl.conf), edit the kube-proxy-config ConfigMap with:
+If you prefer to keep Bottlerocket's [default setting](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/packages/release/release-sysctl.conf), edit the kube-proxy-config ConfigMap with:
 
 ```shell
 kubectl edit -n kube-system cm/kube-proxy-config
@@ -250,7 +250,7 @@ Note this down as the `INSTANCE_PROFILE_NAME` for the final launch command.
 ### kube-proxy settings
 
 By default `kube-proxy` will set the `nf_conntrack_max` kernel parameter to a default value that may differ from what Bottlerocket originally sets at boot.
-If you prefer to keep Bottlerocket's [default setting](packages/release/release-sysctl.conf), edit the kube-proxy configuration details with:
+If you prefer to keep Bottlerocket's [default setting](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/packages/release/release-sysctl.conf), edit the kube-proxy configuration details with:
 
 ```shell
 kubectl edit -n kube-system daemonset kube-proxy

--- a/variants/README.md
+++ b/variants/README.md
@@ -19,7 +19,7 @@ We want to keep the footprint of Bottlerocket as small as possible for security 
 Instead, we make different variants available for use, each with its own set of software and API settings.
 
 A variant is essentially a list of packages to install, plus a model that defines the API.
-The documentation for [packages](../packages/) covers how to create a package.
+The documentation for [packages](https://github.com/bottlerocket-os/bottlerocket-core-kit/tree/develop/packages) covers how to create a package.
 Information about API settings for variants can be found in the [models](../sources/models/) documentation.
 
 ### User data


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4442

**Description of changes:**

Fix links to `/packages/` to point to the `bottlerocket-core-kit/packages`

**Testing done:**
 Rendered the markdown locally and validated that the links direct to the correct pages now


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
