### PR TITLE
migrations: use rust 2021 edition

### DIFF
--- a/sources/settings-migrations/v1.36.0/kubernetes-ecr-credential-providers-expansion/Cargo.toml
+++ b/sources/settings-migrations/v1.36.0/kubernetes-ecr-credential-providers-expansion/Cargo.toml
@@ -3,7 +3,7 @@ name = "kubernetes-ecr-credential-providers-expansion"
 version = "0.1.0"
 authors = ["Sean P. Kelly <seankell@amazon.com>"]
 license = "Apache-2.0 OR MIT"
-edition = "2024"
+edition = "2021"
 publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]

--- a/sources/settings-migrations/v1.36.0/kubernetes-ecr-credential-providers-expansion/src/main.rs
+++ b/sources/settings-migrations/v1.36.0/kubernetes-ecr-credential-providers-expansion/src/main.rs
@@ -1,5 +1,5 @@
 use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
-use migration_helpers::{Result, migrate};
+use migration_helpers::{migrate, Result};
 use std::process;
 
 /// We added new hostname patterns to be matched by the ECR credential provider.


### PR DESCRIPTION
**Description of changes:**
We aren't currently using features from 2024 edition, and it caused an unnecessary MSRV bump.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
