### PR TITLE
sources: bump tokio to latest LTS v1.43.x

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -789,12 +789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,16 +980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1989,12 +1973,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.1"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777d57dcc6bb4cf084e3212e1858447222aa451f21b5e2452497d9100da65b91"
+checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
 dependencies = [
  "backtrace",
- "num_cpus",
  "pin-project-lite",
 ]
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -94,7 +94,7 @@ shlex = "1"
 signal-hook = "0.3"
 simplelog = "0.12"
 snafu = "0.8"
-tokio = { version = "~1.32", default-features = false }
+tokio = { version = "~1.43", default-features = false }
 tokio-tungstenite = { version = "0.20", default-features = false }
 toml = "0.8"
 unindent = "0.1"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/460

**Description of changes:**

Upgrades `tokio` from 1.32.x to latest LTS release 1.43.x.

**Testing done:**
-  Default variant builds for both platforms: `cargo make -e BUILDSYS_ARCH=x86_64 && cargo make -e BUILDSYS_ARCH=aarch64`
- [tokio CHANGELOG](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md) from 1.32 to 1.43 has [1 feature Removed](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md#removed) which we do not use (`stats`)



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
