### PR TITLE
Update defaults and configuration files for NVIDIA k8s device plugin API. 

### DIFF
--- a/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
+++ b/sources/settings-defaults/aws-k8s-1.26-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin-legacy.toml

--- a/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
+++ b/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin-legacy.toml

--- a/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
+++ b/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin-legacy.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/82-nvidia-k8s-device-plugin-legacy.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin-legacy.toml

--- a/sources/shared-defaults/nvidia-k8s-device-plugin-cdi.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin-cdi.toml
@@ -1,0 +1,2 @@
+[settings.kubelet-device-plugins.nvidia]
+device-list-strategy="cdi-cri"

--- a/sources/shared-defaults/nvidia-k8s-device-plugin-legacy.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin-legacy.toml
@@ -1,0 +1,2 @@
+[settings.kubelet-device-plugins.nvidia]
+device-list-strategy="volume-mounts"

--- a/sources/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -20,11 +20,10 @@ path = "/etc/nvidia-migmanager/nvidia-migmanager.toml"
 template-path = "/usr/share/templates/nvidia-k8s-device-plugin-mig-conf"
 
 [metadata.settings.kubelet-device-plugins.nvidia]
-affected-services = ["nvidia-k8s-device-plugin"]
+affected-services = ["nvidia-k8s-device-plugin", "nvidia-container-toolkit"]
 
 [settings.kubelet-device-plugins.nvidia]
 pass-device-specs = true
 device-id-strategy="index"
-device-list-strategy="volume-mounts"
 device-sharing-strategy="none"
 device-partitioning-strategy="none"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4480

**Description of changes:**
For new variant the default way to support the NVIDIA will be `cdi`, but for the existing variant, the default way to support the NVIDIA will keep the same, but provide `cdi` as a option. Therefore, changing the default config to support that.


**Testing done:**

testing with #4474.

- render without error
```
[root@admin]# sheltie journalctl -u settings-applier.service
Apr 15 16:58:57 localhost systemd[1]: Starting Applies settings to create config files...
Apr 15 16:58:57 localhost settings-committer[1415]: 16:58:57 [INFO] Checking pending settings.
Apr 15 16:58:57 localhost settings-committer[1415]: 16:58:57 [INFO] Committing settings.
Apr 15 16:58:57 localhost thar-be-settings[1421]: 16:58:57 [INFO] thar-be-settings started
Apr 15 16:58:57 localhost thar-be-settings[1421]: 16:58:57 [INFO] Requesting configuration file data for affected services
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] Rendering config files...
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] Writing config files to disk...
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] Restarting all services...
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/certdog"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/host-containers"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart containerd.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["netdog write-resolv-conf"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/corndog sysctl"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["systemctl restart deprecation-warning@log4j-hotpatch-enabled.timer"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plugin.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart metricdog.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["systemctl restart deprecation-warning@pod-infra-container-image.timer"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/static-pods"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart cfsignal.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/systemctl try-restart systemd-modules-load"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/bootstrap-containers create-containers"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-reload-or-restart chronyd.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart host-containerd.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/prairiedog generate-boot-config"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/systemctl try-restart kubelet.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart set-hostname.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/corndog lockdown"]
Apr 15 16:58:58 localhost systemd[1]: Finished Applies settings to create config files.
```
- check the current config file, first boost the OS
```
bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
```
- set the default from `volumn-mounts` to `envvar`

```
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="envvar"
[root@admin]# sheltie cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: envvar
    deviceIDStrategy: index
[root@admin]# sheltie journalctl -u settings-applier.service
Apr 15 16:58:57 localhost systemd[1]: Starting Applies settings to create config files...
Apr 15 16:58:57 localhost settings-committer[1415]: 16:58:57 [INFO] Checking pending settings.
Apr 15 16:58:57 localhost settings-committer[1415]: 16:58:57 [INFO] Committing settings.
Apr 15 16:58:57 localhost thar-be-settings[1421]: 16:58:57 [INFO] thar-be-settings started
Apr 15 16:58:57 localhost thar-be-settings[1421]: 16:58:57 [INFO] Requesting configuration file data for affected services
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] Rendering config files...
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] Writing config files to disk...
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] Restarting all services...
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/certdog"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/host-containers"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart containerd.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["netdog write-resolv-conf"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/corndog sysctl"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["systemctl restart deprecation-warning@log4j-hotpatch-enabled.timer"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plugin.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart metricdog.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["systemctl restart deprecation-warning@pod-infra-container-image.timer"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/static-pods"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart cfsignal.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/systemctl try-restart systemd-modules-load"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/bootstrap-containers create-containers"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-reload-or-restart chronyd.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart host-containerd.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/prairiedog generate-boot-config"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/systemctl try-restart kubelet.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/bin/systemctl try-restart set-hostname.service"]
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands []
Apr 15 16:58:58 localhost thar-be-settings[1421]: 16:58:58 [INFO] restart commands ["/usr/bin/corndog lockdown"]
Apr 15 16:58:58 localhost systemd[1]: Finished Applies settings to create config files.

```
- This changes doesn't influence the deprecated settings.oci-hooks.log4j-hotpatch-enabled. The warning printed.
```
[root@admin]# apiclient set settings.oci-hooks.log4j-hotpatch-enabled=true
[root@admin]# apiclient get settings.oci-hooks.log4j-hotpatch-enabled
{
  "settings": {
    "oci-hooks": {
      "log4j-hotpatch-enabled": true
    }
  }
}

Apr 18 16:24:19 ip-192-168-67-95.us-west-2.compute.internal apiserver[370480]: 16:24:19 [INFO] Requesting affected services for settings: {"settings.oci-hooks.log4j-hotpatch-enabled"}
Apr 18 16:24:19 ip-192-168-67-95.us-west-2.compute.internal apiserver[370480]: 16:24:19 [INFO] restart commands ["systemctl restart deprecation-warning@log4j-hotpatch-enabled.timer"]
Apr 18 16:24:19 ip-192-168-67-95.us-west-2.compute.internal systemd[1]: Started Scheduled deprecation warning for log4j-hotpatch-enabled.
Apr 18 16:24:19 ip-192-168-67-95.us-west-2.compute.internal systemd[1]: Started Deprecation warning for log4j-hotpatch-enabled.
Apr 18 16:24:19 ip-192-168-67-95.us-west-2.compute.internal root[370487]: The setting oci-hooks.log4j-hotpatch-enabled is deprecated and has no effect. It will be removed in future versions of Bottlerocket.
Apr 18 16:24:19 ip-192-168-67-95.us-west-2.compute.internal systemd[1]: deprecation-warning@log4j-hotpatch-enabled.service: Deactivated successfully.
```

- migration test (upgrade)
```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "e5290cd7",
    "pretty_name": "Bottlerocket OS 1.37.0 (aws-k8s-1.32-nvidia)",
    "variant_id": "aws-k8s-1.32-nvidia",
    "version_id": "1.37.0"
  }
}

bash-5.1# updog update -i 1.38.0 -r -n
Starting update to 1.38.0
Reboot scheduled for Fri 2025-04-25 22:27:45 UTC, use 'shutdown -c' to cancel.
```
- update to a version to enable the cdi-cri
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "6f57637e",
    "pretty_name": "Bottlerocket OS 1.38.0 (aws-k8s-1.32-nvidia)",
    "variant_id": "aws-k8s-1.32-nvidia",
    "version_id": "1.38.0"
  }
}

[root@admin]# sheltie cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  nvidiaDriverRoot: "/"
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: cdi-cri
    deviceIDStrategy: index
    containerDriverRoot: "/"
```
- downgrade to the old version

```
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="cdi-cri"
[root@admin]# sheltie
bash-5.1# signpost rollback-to-inactive
bash-5.1# reboot
bash-5.1# [ssm-user@control]$

[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "e5290cd7",
    "pretty_name": "Bottlerocket OS 1.37.0 (aws-k8s-1.32-nvidia)",
    "variant_id": "aws-k8s-1.32-nvidia",
    "version_id": "1.37.0"
  }
}

[ssm-user@control]$ apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="cdi-cri"
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-WPuH5W1Wo0TD522M': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-WPuH5W1Wo0TD522M: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: unknown variant `cdi-cri`, expected `envvar` or `volume-mounts` at line1 column 69
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
