### PR TITLE
migrations: delete configuration-files and services on downgrade

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "sources/Cargo.toml"
+    ],
+    "files.insertFinalNewline": true
+}

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.36.0"
+version = "1.37.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]

--- a/Release.toml
+++ b/Release.toml
@@ -411,3 +411,6 @@ version = "1.36.0"
 "(1.35.0, 1.36.0)" = [
     "migrate_v1.36.0_kubernetes-ecr-credential-providers-expansion.lz4",
 ]
+"(1.36.0, 1.37.0)" = [
+    "migrate_v1.37.0_delete-configs-and-services-on-downgrade.lz4",
+]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.36.0"
+release-version = "1.37.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -622,6 +622,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "delete-configs-and-services-on-downgrade"
+version = "0.1.0"
+dependencies = [
+ "maplit",
+ "migration-helpers",
+ "snafu",
+]
+
+[[package]]
 name = "der-parser"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     # (all previous migrations archived; add new ones after this line)
     "settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings",
     "settings-migrations/v1.36.0/kubernetes-ecr-credential-providers-expansion",
+    "settings-migrations/v1.37.0/delete-configs-and-services-on-downgrade",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-migrations/v1.37.0/delete-configs-and-services-on-downgrade/Cargo.toml
+++ b/sources/settings-migrations/v1.37.0/delete-configs-and-services-on-downgrade/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "delete-configs-and-services-on-downgrade"
+version = "0.1.0"
+authors = ["Sean P. Kelly <seankell@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+maplit.workspace = true

--- a/sources/settings-migrations/v1.37.0/delete-configs-and-services-on-downgrade/src/main.rs
+++ b/sources/settings-migrations/v1.37.0/delete-configs-and-services-on-downgrade/src/main.rs
@@ -1,0 +1,149 @@
+//! In core-kit 6.4.0, we introduced a change to delete all configuration-files and services on
+//! whenever the migrator runs (https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/456).
+//!
+//! This migrations ensures that nodes downgrading to versions prior to core-kit 6.4.0 will delete
+//! and re-populate these keys.
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+
+const PREFIXES_TO_DELETE: &[&str] = &["configuration-files.", "services."];
+
+#[snafu::report]
+fn main() -> Result<()> {
+    migrate(DeleteConfigsAndServicesOnDowngradeMigration)
+}
+
+pub struct DeleteConfigsAndServicesOnDowngradeMigration;
+
+impl Migration for DeleteConfigsAndServicesOnDowngradeMigration {
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("DeleteConfigsAndServicesOnDowngradeMigration has no work to do on upgrade.",);
+        Ok(input)
+    }
+
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        input.data.retain(|key, _| {
+            let to_keep = !(PREFIXES_TO_DELETE
+                .iter()
+                .any(|prefix| key.starts_with(prefix)));
+            if !to_keep {
+                println!("Removed '{key}'");
+            }
+            to_keep
+        });
+        Ok(input)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use maplit::hashmap;
+    use std::collections::HashMap;
+
+    #[test]
+    fn nothing_to_clear() {
+        let data = MigrationData {
+            data: hashmap! {
+                "settings.hello".into() => "there".into(),
+                "settings.something.configuration-files".into() => "retain this!".into(),
+                "settings.something.services".into() => "and this!".into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = DeleteConfigsAndServicesOnDowngradeMigration
+            .backward(data)
+            .unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                "settings.hello".into() => "there".into(),
+                "settings.something.configuration-files".into() => "retain this!".into(),
+                "settings.something.services".into() => "and this!".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn all_clear() {
+        let data = MigrationData {
+            data: hashmap! {
+                "services.delete-this".into() => "yep".into(),
+                "configuration-files.delete-this".into() => "this too".into(),
+                "configuration-files.another-one".into() => "bye".into(),
+                "services.and-this".into() => "au revoir".into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = DeleteConfigsAndServicesOnDowngradeMigration
+            .backward(data)
+            .unwrap();
+        assert_eq!(result.data, HashMap::new());
+    }
+
+    #[test]
+    fn delete_some() {
+        let data = MigrationData {
+            data: hashmap! {
+                "services.delete-this".into() => "deleted".into(),
+                "configuration-files.and-this".into() => "deleted".into(),
+                "settings.but-not-this".into() => "stays".into(),
+                "or-this-either.configuration-files".into() => "also-stays".into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = DeleteConfigsAndServicesOnDowngradeMigration
+            .backward(data)
+            .unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                "settings.but-not-this".into() => "stays".into(),
+                "or-this-either.configuration-files".into() => "also-stays".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn dont_touch_the_metadata() {
+        let data = MigrationData {
+            data: hashmap! {
+                "configuration-files.delete".into() => "delete".into(),
+                "services.delete".into() => "delete".into(),
+                "settings.keep".into() => "keep".into(),
+            },
+            metadata: hashmap! {
+                "configuration-files.delete".into() => hashmap! {
+                    "keep".into() => "yep!".into(),
+                },
+                "services.delete".into() => hashmap! {
+                    "keep".into() => "yep!".into(),
+                },
+                "settings.keep".into() => hashmap! {
+                    "keep".into() => "yep!".into(),
+                },
+            },
+        };
+        let result = DeleteConfigsAndServicesOnDowngradeMigration
+            .backward(data)
+            .unwrap();
+        assert_eq!(
+            result,
+            MigrationData {
+                data: hashmap! {
+                    "settings.keep".into() => "keep".into(),
+                },
+                metadata: hashmap! {
+                    "configuration-files.delete".into() => hashmap! {
+                        "keep".into() => "yep!".into(),
+                    },
+                    "services.delete".into() => hashmap! {
+                        "keep".into() => "yep!".into(),
+                    },
+                    "settings.keep".into() => hashmap! {
+                        "keep".into() => "yep!".into(),
+                    },
+                },
+            },
+        );
+    }
+}


### PR DESCRIPTION
**Description of changes:**
Related to https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/456


    migrations: clear configs and services on downgrade
    
    In core-kit 6.4.0, the migrator started deleting datastore entries for
    configuration-files and services whenever migrations are run.
    
    In order to ensure that we don't leave behind unexpected keys, we add a
    migration to perform the same delete operation when downgrading to
    versions prior to core-kit 6.4.0.

**Testing done:**
* [x] unit tests pass
* [x] migration tests using live TUF repository (confirmed that newly-added services and configuration-files were removed on downgrade)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
