### PR TITLE
Update NVIDIA drivers from 535 to 570

### DIFF
--- a/variants/aws-ecs-2-nvidia/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia/Cargo.toml
@@ -28,7 +28,7 @@ included-packages = [
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",
-    "kmod-6.1-nvidia-tesla-535",
+    "kmod-6.1-nvidia-r570-tesla",
 ]
 
 kernel-parameters = [

--- a/variants/aws-k8s-1.28-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.28-nvidia/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-tesla-535",
+    "kmod-6.1-nvidia-r570-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.29-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.29-nvidia/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-tesla-535",
+    "kmod-6.1-nvidia-r570-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.30-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-tesla-535",
+    "kmod-6.1-nvidia-r570-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.31-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-tesla-535",
+    "kmod-6.1-nvidia-r570-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.32-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-tesla-535",
+    "kmod-6.1-nvidia-r570-tesla",
 ]
 kernel-parameters = [
     "console=tty0",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4441 

**Description of changes:**
Updates the NVIDIA graphics drivers from r535 to r570 in variants using the 6.1 kernel


**Testing done:**
* Built all images
* Booted and confirmed r570 is on aws-k8s-1.32


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
