### PR TITLE
variants: add k8s-1.33 variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_33"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_33-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_33-nvidia"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "metal-dev"
 version = "0.1.0"
 dependencies = [
@@ -340,6 +367,24 @@ dependencies = [
 
 [[package]]
 name = "vmware-k8s-1_32-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_33"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_33-fips"
 version = "0.1.0"
 dependencies = [
  "settings-defaults",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,15 @@ members = [
     "variants/aws-k8s-1.31-fips",
     "variants/aws-k8s-1.32",
     "variants/aws-k8s-1.32-fips",
+    "variants/aws-k8s-1.33",
+    "variants/aws-k8s-1.33-fips",
     "variants/aws-k8s-1.27-nvidia",
     "variants/aws-k8s-1.28-nvidia",
     "variants/aws-k8s-1.29-nvidia",
     "variants/aws-k8s-1.30-nvidia",
     "variants/aws-k8s-1.31-nvidia",
     "variants/aws-k8s-1.32-nvidia",
+    "variants/aws-k8s-1.33-nvidia",
     "variants/metal-dev",
     "variants/vmware-dev",
     "variants/vmware-k8s-1.28",
@@ -41,6 +44,8 @@ members = [
     "variants/vmware-k8s-1.31-fips",
     "variants/vmware-k8s-1.32",
     "variants/vmware-k8s-1.32-fips",
+    "variants/vmware-k8s-1.33",
+    "variants/vmware-k8s-1.33-fips",
 ]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following variants support EKS, as described above:
 * `aws-k8s-1.30`
 * `aws-k8s-1.31`
 * `aws-k8s-1.32`
+* `aws-k8s-1.33`
 * `aws-k8s-1.26-nvidia`
 * `aws-k8s-1.27-nvidia`
 * `aws-k8s-1.28-nvidia`
@@ -75,6 +76,7 @@ The following variants support EKS, as described above:
 * `aws-k8s-1.30-nvidia`
 * `aws-k8s-1.31-nvidia`
 * `aws-k8s-1.32-nvidia`
+* `aws-k8s-1.33-nvidia`
 
 The following variants support ECS:
 
@@ -90,6 +92,7 @@ We also have variants that are designed to be Kubernetes worker nodes in VMware:
 * `vmware-k8s-1.30`
 * `vmware-k8s-1.31`
 * `vmware-k8s-1.32`
+* `vmware-k8s-1.33`
 
 The following variants are no longer supported:
 

--- a/packages/settings-defaults/settings-defaults.spec
+++ b/packages/settings-defaults/settings-defaults.spec
@@ -165,6 +165,32 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description aws-k8s-1.32-nvidia
 %{summary}.
 
+%package aws-k8s-1.33
+Summary: Settings defaults for the aws-k8s 1.33 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.33)      or
+           %{_cross_os}variant(aws-k8s-1.33-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.33)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.33-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.33
+%{summary}.
+
+%package aws-k8s-1.33-nvidia
+Summary: Settings defaults for the aws-k8s 1.33 nvidia variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.33-nvidia)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.33-nvidia)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.33-nvidia
+%{summary}.
+
 %package metal-dev
 Summary: Settings defaults for the metal-dev variant
 Requires: %{_cross_os}variant(metal-dev)
@@ -217,6 +243,20 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description vmware-k8s-1.32
 %{summary}.
 
+%package vmware-k8s-1.33
+Summary: Settings defaults for the vmware-k8s 1.33 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(vmware-k8s-1.33)      or
+           %{_cross_os}variant(vmware-k8s-1.33-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.33)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.33-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description vmware-k8s-1.33
+%{summary}.
+
 %prep
 %setup -T -c
 %cargo_prep
@@ -235,9 +275,12 @@ for defaults in \
   aws-k8s-1.31-nvidia \
   aws-k8s-1.32 \
   aws-k8s-1.32-nvidia \
+  aws-k8s-1.33 \
+  aws-k8s-1.33-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
+  vmware-k8s-1.33 \
   ;
 do
   projects+=( "-p" "settings-defaults-$(echo "${defaults}" | sed -e 's,\.,_,g')" )
@@ -269,9 +312,12 @@ for defaults in \
   aws-k8s-1.31-nvidia \
   aws-k8s-1.32 \
   aws-k8s-1.32-nvidia \
+  aws-k8s-1.33 \
+  aws-k8s-1.33-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
+  vmware-k8s-1.33 \
   ;
 do
   crate="$(echo "${defaults}" | sed -e 's,\.,_,g')"
@@ -330,6 +376,14 @@ done
 %{_cross_defaultsdir}/aws-k8s-1.32-nvidia.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.32-nvidia.conf
 
+%files aws-k8s-1.33
+%{_cross_defaultsdir}/aws-k8s-1.33.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.33.conf
+
+%files aws-k8s-1.33-nvidia
+%{_cross_defaultsdir}/aws-k8s-1.33-nvidia.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.33-nvidia.conf
+
 %files metal-dev
 %{_cross_defaultsdir}/metal-dev.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-metal-dev.conf
@@ -341,3 +395,7 @@ done
 %files vmware-k8s-1.32
 %{_cross_defaultsdir}/vmware-k8s-1.32.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.32.conf
+
+%files vmware-k8s-1.33
+%{_cross_defaultsdir}/vmware-k8s-1.33.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.33.conf

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -73,6 +73,8 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.31)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.31-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.32)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.32-fips)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.33)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.33-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 Conflicts: %{_cross_os}variant-flavor(nvidia)
 
@@ -91,6 +93,7 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.29-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.30-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.31-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.32-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.33-nvidia)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description aws-k8s-nvidia
@@ -131,6 +134,8 @@ Provides: %{_cross_os}settings-plugin(vmware-k8s-1.31)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.31-fips)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.32)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.32-fips)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.33)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.33-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description vmware-k8s

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1405,6 +1405,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-defaults-aws-k8s-1_33"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-aws-k8s-1_33-nvidia"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
 name = "settings-defaults-metal-dev"
 version = "0.1.0"
 dependencies = [
@@ -1427,6 +1441,13 @@ dependencies = [
 
 [[package]]
 name = "settings-defaults-vmware-k8s-1_32"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-vmware-k8s-1_33"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-defaults-helper",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -24,10 +24,13 @@ members = [
     "settings-defaults/aws-k8s-1.31-nvidia",
     "settings-defaults/aws-k8s-1.32",
     "settings-defaults/aws-k8s-1.32-nvidia",
+    "settings-defaults/aws-k8s-1.33",
+    "settings-defaults/aws-k8s-1.33-nvidia",
     "settings-defaults/metal-dev",
     "settings-defaults/metal-k8s-1.30",
     "settings-defaults/vmware-dev",
     "settings-defaults/vmware-k8s-1.32",
+    "settings-defaults/vmware-k8s-1.33",
 
     # (all previous migrations archived; add new ones after this line)
     "settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings",

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_33-nvidia"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd-nvidia.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/57-kubernetes-device-ownership-default-false.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/57-kubernetes-device-ownership-default-false.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-false.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/60-lockdown-none.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/60-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/aws-k8s-1.33/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_33"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/57-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/57-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/Cargo.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-vmware-k8s-1_33"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/15-public-tuf.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/20-public-host-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/20-public-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-host-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/21-public-bootstrap-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/21-public-bootstrap-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-bootstrap-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/31-send-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/50-kubernetes-vmware.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/50-kubernetes-vmware.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-vmware.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/54-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/54-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/55-kubernetes-device-ownership-default-false.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/55-kubernetes-device-ownership-default-false.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-false.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/70-public-ntp.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/70-public-ntp.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-ntp.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/80-oci-hooks.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/80-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/shared-defaults/kubernetes-seccomp-default-true.toml
+++ b/sources/shared-defaults/kubernetes-seccomp-default-true.toml
@@ -1,0 +1,2 @@
+[settings.kubernetes]
+seccomp-default = true

--- a/variants/README.md
+++ b/variants/README.md
@@ -140,6 +140,21 @@ It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazo
 
 This variant is compatible with Kubernetes 1.32, 1.33, 1.34 and 1.35 clusters.
 
+### aws-k8s-1.33: Kubernetes 1.33 node
+
+The [aws-k8s-1.33](aws-k8s-1.33/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.33, 1.34, 1.35 and 1.36 clusters.
+
+### aws-k8s-1.33-nvidia: Kubernetes 1.33 NVIDIA node
+
+The [aws-k8s-1.33-nvidia](aws-k8s-1.33-nvidia/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It also includes the required packages to configure containers to leverage NVIDIA GPUs.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.33, 1.34, 1.35 and 1.36 clusters.
+
 ### aws-ecs-1: Amazon ECS container instance
 
 The [aws-ecs-1](aws-ecs-1/Cargo.toml) variant includes the packages needed to run an [Amazon ECS](https://ecs.aws)
@@ -207,6 +222,13 @@ The [vmware-k8s-1.32](vmware-k8s-1.32/Cargo.toml) variant includes the packages 
 It supports self-hosted clusters.
 
 This variant is compatible with Kubernetes 1.32, 1.33, 1.34, and 1.35 clusters.
+
+## vmware-k8s-1.33: VMware Kubernetes 1.33 node
+
+The [vmware-k8s-1.33](vmware-k8s-1.33/Cargo.toml) variant includes the packages needed to run a Kubernetes worker node as a VMware guest.
+It supports self-hosted clusters.
+
+This variant is compatible with Kubernetes 1.33, 1.34, 1.35, and 1.36 clusters.
 
 ### metal-dev: Metal development build
 

--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+# This is the aws-k8s-1.33-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_33-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.1",
+    "containerd-2.0",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.33",
+    "aws-iam-authenticator",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+# This is the aws-k8s-1.33-nvidia variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_33-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.12",
+    "containerd-2.0",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.33",
+    "aws-iam-authenticator",
+    # nvidia
+    "nvidia-container-toolkit-k8s",
+    "nvidia-k8s-device-plugin",
+    "kmod-6.12-nvidia-r570-tesla",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+# This is the aws-k8s-1.33 variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_33"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.12",
+    "containerd-2.0",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.33",
+    "aws-iam-authenticator",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+# This is the vmware-k8s-1.33-fips variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_33-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.1",
+    "containerd-2.0",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.33",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.33-fips/template.ovf
+++ b/variants/vmware-k8s-1.33-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+# This is the vmware-k8s-1.33 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_33"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.12",
+    "containerd-2.0",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.33",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.33/template.ovf
+++ b/variants/vmware-k8s-1.33/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#4477 

**Description of changes:**
Add the definitions for upcoming new k8s-1.33 variants of Bottlerocket.

Configurations:
- Non-fips variants: `aws-k8s-1.33`, `vmware-k8s-1.33`
    - kernel-6.12 
    - containerd-2.0   
- Fips variants:  `aws-k8s-1.33-fips`, `vmware-k8s-1.33-fips`
    - kernel-6.1
    - containerd-2.0   
- Nvidia variant: `aws-k8s-1.33-nvidia`
    - kernel-6.12
    - kmod-6.12-nvidia-r570-tesla driver
    - containerd-2.0   

**Testing done:**
1. The bottlerocket repo builds
`cargo make -e BUILDSYS_VARIANT=aws-k8s-1.33-fips -e BUILDSYS_ARCH=x86_64`
`cargo make -e BUILDSYS_VARIANT=aws-k8s-1.33 -e BUILDSYS_ARCH=x86_64`
`cargo make -e BUILDSYS_VARIANT=aws-k8s-1.33-nvidia -e BUILDSYS_ARCH=x86_64`
`cargo make -e BUILDSYS_VARIANT=aws-k8s-1.33 -e BUILDSYS_ARCH=aarch64`
`cargo make -e BUILDSYS_VARIANT=aws-k8s-1.33-nvidia -e BUILDSYS_ARCH=aarch64`
`cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.33-fips -e BUILDSYS_ARCH=x86_64`
`cargo make -e BUILDSYS_VARIANT=vmware-k8s-1.33 -e BUILDSYS_ARCH=x86_64`

2. Updated `seccomp` default
Verifying the setting in a k8s-1.33 instance
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "4f1c02f8",
    "pretty_name": "Bottlerocket OS 1.38.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.38.0"
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.seccomp-default
{
  "settings": {
    "kubernetes": {
      "seccomp-default": true
    }
  }
}
```

Testing in nginx container
```
[fedora@ip-xxxx kubernetes]$ kubectl exec -it nginx-test -- cat /proc/1/status | grep Seccomp
Seccomp:        2
Seccomp_filters:        1
```

Verifying the setting is false by default in a k8s-1.32 instance
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "fff21095",
    "pretty_name": "Bottlerocket OS 1.38.0 (aws-k8s-1.32)",
    "variant_id": "aws-k8s-1.32",
    "version_id": "1.38.0"
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.seccomp-default
{
  "settings": {
    "kubernetes": {
      "seccomp-default": false
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
