### PR TITLE
chore: bump twoliter to 0.10.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.9.0"
-TWOLITER_SHA256_AARCH64 = "b1cb522c203a52ceacc12c6f5d23687851470dc8f5f279bedcec3d7431ff96cc"
-TWOLITER_SHA256_X86_64 = "a3cea15da3dcbfc7ef3c5273419503da6fda12c641b4707869990a28a8beb46c"
+TWOLITER_VERSION = "v0.10.0"
+TWOLITER_SHA256_AARCH64 = "aebf00a5747d78e4570de4ce521d680a8bbd356205977673e573fef884b5d92e"
+TWOLITER_SHA256_X86_64 = "29e25edd15a2dbe7ced04bcf6efc0d540fae1aa33b43b1f10accfb2fa0d11e1b"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION
**Description:**
https://github.com/bottlerocket-os/twoliter/releases/tag/v0.10.0

**Testing done:**
* [x] CI testing
* [x] Built custom kit and an AMI based on said kit



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
