### PR TITLE
aws-k8s-1.33: use gp3 volumes, require imdsv2 by default

### DIFF
--- a/variants/aws-k8s-1.33-fips/amispec.toml
+++ b/variants/aws-k8s-1.33-fips/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.33-nvidia/amispec.toml
+++ b/variants/aws-k8s-1.33-nvidia/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.33/amispec.toml
+++ b/variants/aws-k8s-1.33/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/shared/amispec-split.toml
+++ b/variants/shared/amispec-split.toml
@@ -1,0 +1,9 @@
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html
+imds-support = "v2.0"
+
+# Override the pubsys "gp2" default
+[block-device-mappings."/dev/xvda".ebs]
+volume-type = "gp3"
+
+[block-device-mappings."/dev/xvdb".ebs]
+volume-type = "gp3"


### PR DESCRIPTION
**Issue number:**

Closes #4000

**Description of changes:**
Uses `twoliter`'s new `amispec` feature to, for k8s 1.33 variants:
* use GP3 for the root and data volumes
* require imdsv2 by default

Depends on:
* https://github.com/bottlerocket-os/bottlerocket/pull/4512
* https://github.com/bottlerocket-os/bottlerocket/pull/4507

**Testing done:**
* [x] EC2 describe-image output for `aws-k8s-1.33{,-fips,-nvidia}`
```
aws ec2 describe-images --image-ids REDACTED --query 'Images[0].BlockDeviceMappings'
[
    {
        "Ebs": {
            "DeleteOnTermination": true,
            "SnapshotId": "REDACTED",
            "VolumeSize": 2,
            "VolumeType": "gp3",
            "Encrypted": false
        },
        "DeviceName": "/dev/xvda"
    },
    {
        "Ebs": {
            "DeleteOnTermination": true,
            "SnapshotId": "REDACTED",
            "VolumeSize": 20,
            "VolumeType": "gp3",
            "Encrypted": false
        },
        "DeviceName": "/dev/xvdb"
    }
]

aws ec2 describe-images --image-ids REDACTED --query 'Images[0].ImdsSupport'
"v2.0"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
