### PR TITLE
k8s-*: fix image patterns for ecr dual-stack endpoint

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.40.0"
+version = "1.41.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -421,5 +421,7 @@ version = "1.40.0"
 "(1.39.0, 1.39.1)" = []
 "(1.39.1, 1.40.0)" = [
     "migrate_v1.40.0_kubelet-device-plugins-cdi-settings.lz4"
+]
+"(1.40.0, 1.41.0)" = [
 ]
 

--- a/Release.toml
+++ b/Release.toml
@@ -423,5 +423,6 @@ version = "1.41.0"
     "migrate_v1.40.0_kubelet-device-plugins-cdi-settings.lz4"
 ]
 "(1.40.0, 1.41.0)" = [
+    "migrate_v1.41.0_kubernetes-ecr-credential-providers-correction.lz4",
 ]
 

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.40.0"
+release-version = "1.41.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -863,6 +863,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-ecr-credential-providers-correction"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-ecr-credential-providers-expansion"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "settings-migrations/v1.37.0/delete-configs-and-services-on-downgrade",
     "settings-migrations/v1.39.0/kubelet-setting-container-log-single-process-oom-kill",
     "settings-migrations/v1.40.0/kubelet-device-plugins-cdi-settings",
+    "settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/Cargo.toml
+++ b/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubernetes-ecr-credential-providers-correction"
+version = "0.1.0"
+authors = ["Carter McKinnon <mckdev@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/src/main.rs
+++ b/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/src/main.rs
@@ -1,0 +1,52 @@
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added incorrect hostname patterns to be matched by the ECR credential provider.
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "settings.kubernetes.credential-providers.ecr-credential-provider.image-patterns",
+        old_vals: &[
+            "*.dkr.ecr.*.amazonaws.com",
+            "*.dkr.ecr.*.amazonaws.com.cn",
+            "*.dkr.ecr.*.on.aws",
+            "*.dkr.ecr.*.on.amazonwebservices.com.cn",
+            "*.dkr.ecr-fips.*.amazonaws.com",
+            "*.dkr.ecr.*.cloud.adc-e.uk",
+            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+            "*.dkr.ecr.*.c2s.ic.gov",
+            "*.dkr.ecr-fips.*.c2s.ic.gov",
+            "*.dkr.ecr.*.sc2s.sgov.gov",
+            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+            "*.dkr.ecr.*.csp.hci.ic.gov",
+            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+            "public.ecr.aws",
+        ],
+        new_vals: &[
+            "*.dkr.ecr.*.amazonaws.com",
+            "*.dkr.ecr.*.amazonaws.com.cn",
+            "*.dkr-ecr.*.on.aws",
+            "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+            "*.dkr.ecr-fips.*.amazonaws.com",
+            "*.dkr.ecr.*.cloud.adc-e.uk",
+            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+            "*.dkr.ecr.*.c2s.ic.gov",
+            "*.dkr.ecr-fips.*.c2s.ic.gov",
+            "*.dkr.ecr.*.sc2s.sgov.gov",
+            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+            "*.dkr.ecr.*.csp.hci.ic.gov",
+            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+            "public.ecr.aws",
+        ],
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/kubernetes-aws-credential-provider.toml
+++ b/sources/shared-defaults/kubernetes-aws-credential-provider.toml
@@ -4,8 +4,8 @@ cache-duration = "12h"
 image-patterns = [
     "*.dkr.ecr.*.amazonaws.com",
     "*.dkr.ecr.*.amazonaws.com.cn",
-    "*.dkr.ecr.*.on.aws",
-    "*.dkr.ecr.*.on.amazonwebservices.com.cn",
+    "*.dkr-ecr.*.on.aws",
+    "*.dkr-ecr.*.on.amazonwebservices.com.cn",
     "*.dkr.ecr-fips.*.amazonaws.com",
     "*.dkr.ecr.*.cloud.adc-e.uk",
     "*.dkr.ecr-fips.*.cloud.adc-e.uk",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

I found that it is not possible to use ECR dual-stack endpoints with the default credential provider.
I corrected image patterns.

FYI, the following changes have been made to the EKS-optimized AMI for Amazon Linux:
https://github.com/awslabs/amazon-eks-ami/commit/131c287183573b5bed4dd15c0d757fc20ff2bcf5

**Testing done:**

I confirmed that images can be pulled from ECR dual-stack endpoints on an EKS cluster using the built AMI.

Migration Testing from @KCSesh : 

* Launched a variant with existing setting:
```
bash-5.1# apiclient get settings.kubernetes.credential-providers.ecr-credential-provider
{
  "settings": {
    "kubernetes": {
      "credential-providers": {
        "ecr-credential-provider": {
          "cache-duration": "12h",
          "enabled": true,
          "image-patterns": [
            "*.dkr.ecr.*.amazonaws.com",
            "*.dkr.ecr.*.amazonaws.com.cn",
            "*.dkr.ecr.*.on.aws",
            "*.dkr.ecr.*.on.amazonwebservices.com.cn",
            "*.dkr.ecr-fips.*.amazonaws.com",
            "*.dkr.ecr.*.cloud.adc-e.uk",
            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
            "*.dkr.ecr.*.c2s.ic.gov",
            "*.dkr.ecr-fips.*.c2s.ic.gov",
            "*.dkr.ecr.*.sc2s.sgov.gov",
            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
            "*.dkr.ecr.*.csp.hci.ic.gov",
            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
            "public.ecr.aws"
          ]
        }
      }
    }
  }
}
```

* Triggered an update and verified:
```

bash-5.1# apiclient get settings.kubernetes.credential-providers.ecr-credential-provider
{
  "settings": {
    "kubernetes": {
      "credential-providers": {
        "ecr-credential-provider": {
          "cache-duration": "12h",
          "enabled": true,
          "image-patterns": [
            "*.dkr.ecr.*.amazonaws.com",
            "*.dkr.ecr.*.amazonaws.com.cn",
            "*.dkr-ecr.*.on.aws",
            "*.dkr-ecr.*.on.amazonwebservices.com.cn",
            "*.dkr.ecr-fips.*.amazonaws.com",
            "*.dkr.ecr.*.cloud.adc-e.uk",
            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
            "*.dkr.ecr.*.c2s.ic.gov",
            "*.dkr.ecr-fips.*.c2s.ic.gov",
            "*.dkr.ecr.*.sc2s.sgov.gov",
            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
            "*.dkr.ecr.*.csp.hci.ic.gov",
            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
            "public.ecr.aws"
          ]
        }
      }
    }
  }
}
```

* Verified the downgrade path matched the initial set.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
