### PR TITLE
migrations: add migrations for nvidia deviceliststrategy

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.39.1"
+version = "1.40.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]

--- a/Release.toml
+++ b/Release.toml
@@ -419,4 +419,7 @@ version = "1.39.1"
     "migrate_v1.39.0_kubelet-setting-container-log-single-process-oom-kill.lz4"
 ]
 "(1.39.0, 1.39.1)" = []
+"(1.39.1, 1.40.0)" = [
+    "migrate_v1.40.0_kubelet-device-plugins-cdi-settings.lz4"
+]
 

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.39.1"
+release-version = "1.40.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sbkeys/README.md
+++ b/sbkeys/README.md
@@ -28,10 +28,10 @@ It also uses [virt-fw-vars](https://pypi.org/project/virt-firmware/) to generate
 When specifying an SDK image, these dependencies are run within a container started from that image, and do not need to be installed on the host.
 
 ```shell
-ARCH="$(uname -m)"
-SDK_VERSION="v0.29.0"
+# replace v0.61.0 with the current SDK version
+SDK_VERSION="v0.61.0"
 ./generate-local-sbkeys \
-  --sdk-image "public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:${SDK_VERSION}" \
+  --sdk-image "public.ecr.aws/bottlerocket/bottlerocket-sdk:${SDK_VERSION}" \
   --output-dir "${PWD}/my-local-profile"
 ```
 
@@ -50,8 +50,8 @@ Note that the cost of these resources, **especially the private CAs**, is nontri
 Although it is possible to use the same private CA and the same KMS key for all roles, doing so would weaken the security of the implementation, and is **strongly discouraged**.
 
 ```shell
-ARCH="$(uname -m)"
-SDK_VERSION="v0.29.0"
+# replace v0.61.0 with the current SDK version
+SDK_VERSION="v0.61.0"
 
 # AWS Private CAs
 PK_CA="arn:aws:acm-pca:us-west-2:999999999999:certificate-authority/11111111-1111-1111-1111-111111111111"
@@ -65,7 +65,7 @@ CODE_SIGN_KEY="arn:aws:kms:us-west-2:999999999999:key/bbbbbbbb-bbbb-bbbb-bbbb-bb
 CONFIG_SIGN_KEY="arn:aws:kms:us-west-2:999999999999:key/cccccccc-cccc-cccc-cccc-cccccccccccc"
 
 ./generate-aws-sbkeys \
-  --sdk-image "public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:${SDK_VERSION}" \
+  --sdk-image "public.ecr.aws/bottlerocket/bottlerocket-sdk:${SDK_VERSION}" \
   --aws-region us-west-2 \
   --pk-ca "${PK_CA}" \
   --kek-ca "${KEK_CA}" \

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "darling",
  "quote",
@@ -268,8 +268,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.8.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+version = "0.9.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "serde",
  "serde_plain",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -327,7 +327,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -337,8 +337,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.9.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+version = "0.10.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "serde",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1519,7 +1519,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1609,8 +1609,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
-version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+version = "0.3.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1623,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1715,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1728,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -837,6 +837,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "kubelet-device-plugins-cdi-settings"
+version = "0.1.0"
+dependencies = [
+ "maplit",
+ "migration-helpers",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "kubelet-device-plugins-mig-settings"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "settings-migrations/v1.36.0/kubernetes-ecr-credential-providers-expansion",
     "settings-migrations/v1.37.0/delete-configs-and-services-on-downgrade",
     "settings-migrations/v1.39.0/kubelet-setting-container-log-single-process-oom-kill",
+    "settings-migrations/v1.40.0/kubelet-device-plugins-cdi-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -112,22 +112,22 @@ version = "0.1.0"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.9.0"
-version = "0.8.0"
+tag = "bottlerocket-settings-models-v0.10.0"
+version = "0.9.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.9.0"
-version = "0.9.0"
+tag = "bottlerocket-settings-models-v0.10.0"
+version = "0.10.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.8.0"
+tag = "bottlerocket-settings-models-v0.9.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.9.0"
+tag = "bottlerocket-settings-models-v0.10.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -121,6 +121,9 @@ pub enum Error {
         source
     ))]
     DeserializeSettingsGenerator { source: serde_json::Error },
+
+    #[snafu(display("Setting data '{}' must be either a string or a list", data))]
+    InvalidSettingType { data: String },
 }
 
 /// Result alias containing our Error type.

--- a/sources/settings-migrations/v1.40.0/kubelet-device-plugins-cdi-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.40.0/kubelet-device-plugins-cdi-settings/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kubelet-device-plugins-cdi-settings"
+version = "0.1.0"
+authors = ["Jingwei Wang <jweiw@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+maplit.workspace = true

--- a/sources/settings-migrations/v1.40.0/kubelet-device-plugins-cdi-settings/src/main.rs
+++ b/sources/settings-migrations/v1.40.0/kubelet-device-plugins-cdi-settings/src/main.rs
@@ -1,0 +1,215 @@
+use migration_helpers::{error, migrate, Migration, MigrationData, Result};
+use snafu::OptionExt;
+
+const DEVICE_LIST_STRATEGY_SETTING: &str =
+    "settings.kubelet-device-plugins.nvidia.device-list-strategy";
+
+#[snafu::report]
+fn main() -> Result<()> {
+    migrate(ReplaceDeviceListStrategy)
+}
+
+/// We changed the type of the device-list-strategy in the NVIDIA Kubernetes Device
+/// plugin API from a string to a list, and accept "cdi-cri" as a valid value
+pub struct ReplaceDeviceListStrategy;
+
+impl Migration for ReplaceDeviceListStrategy {
+    /// New versions must either have a default for the settings or generate them; we don't need to
+    /// do anything.
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("ReplaceDeviceListStrategy has no work to do on upgrade.");
+        Ok(input)
+    }
+
+    /// Older versions don't know about the setting now accepting both a string, a list and a new accepted value "cdi-cri";
+    /// we remove the list option and the "cdi-cri" value so that old versions don't see them and fail deserialization.
+    /// (The settings must be defaulted or generated in new versions, and safe to remove.)
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        let setting = DEVICE_LIST_STRATEGY_SETTING;
+        if let Some(data) = input.data.get_mut(setting) {
+            match data {
+                serde_json::Value::Array(arr) => {
+                    let list: Vec<&str> = arr
+                        .iter()
+                        .map(|v| v.as_str())
+                        .collect::<Option<Vec<&str>>>()
+                        .context(error::ReplaceListContentsSnafu {
+                            setting,
+                            data: arr.clone(),
+                        })?;
+
+                    let new_value = match list.first() {
+                        None | Some(&"cdi-cri") => "volume-mounts".to_string(),
+                        Some(value) => value.to_string(),
+                    };
+
+                    *data = serde_json::Value::String(new_value.to_string());
+                }
+
+                serde_json::Value::String(setting_str) => {
+                    if setting_str == "cdi-cri" {
+                        *data = serde_json::Value::String("volume-mounts".to_string());
+                    } else {
+                        *data = serde_json::Value::String(setting_str.to_string());
+                    }
+                }
+
+                _ => error::InvalidSettingTypeSnafu {
+                    data: setting.to_string(),
+                }
+                .fail()?,
+            }
+        } else {
+            println!("Found no '{}' to change on downgrade", setting);
+        }
+
+        Ok(input)
+    }
+}
+
+#[cfg(test)]
+mod test_replace_list {
+    use super::*;
+    use crate::{Migration, MigrationData};
+    use maplit::hashmap;
+    use serde_json::Value;
+    use std::collections::HashMap;
+
+    #[test]
+    fn forward_test() {
+        let data = MigrationData {
+            data: hashmap! {
+                DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = ReplaceDeviceListStrategy.forward(data).unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn backward_test() {
+        let test_cases: Vec<(MigrationData, HashMap<String, Value>)> = vec![
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => vec!["cdi-cri"].into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => Vec::<String>::new().into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => vec!["volume-mounts", "envvar"].into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => vec!["envvar", "volume-mounts"].into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "envvar".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => vec!["cdi-cri", "envvar"].into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => vec!["cdi-cri", "envvar", "volume-mounts"].into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => vec!["envvar", "volume-mounts"].into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "envvar".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => vec!["volume-mounts", "envvar"].into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => "cdi-cri".into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "volume-mounts".into(),
+                },
+            ),
+            (
+                MigrationData {
+                    data: hashmap! {
+                        DEVICE_LIST_STRATEGY_SETTING.into() => "envvar".into(),
+                    },
+                    metadata: HashMap::new(),
+                },
+                hashmap! {
+                    DEVICE_LIST_STRATEGY_SETTING.into() => "envvar".into(),
+                },
+            ),
+        ];
+
+        for (input, expected) in test_cases {
+            let result = ReplaceDeviceListStrategy.backward(input).unwrap();
+            assert_eq!(result.data, expected);
+        }
+    }
+}


### PR DESCRIPTION
**Description of changes:**
migration when downgrade from enable cdi to un-cdi.
- when the `nvidia-k8s-device-list-strategy` set to below values

| value 1 | value 2 | value 3 | Downgrade Result |
|-----------|-----------|-----------|---------|
| envvar | | | envvar |
| envvar | volume-mounts | | ennvar |
| envvar | volume-mounts | cdi-cri | ennvar |
| envvar | cdi-cri | | ennvar |
| ennvar | cdi-cri | volume-mounts | ennvar |
| volume-mounts | | | volume-mounts |
| volume-mounts | envvar | | volume-mounts |
| volume-mounts | envvar | cdi-cri | volume-mounts |
| volume-mounts | cdi-cri | | volume-mounts |
| volume-mounts | cdi-cri | envvar | volume-mounts |
| cdi-cri | | | volume-mounts |
| cdi-cri | volume-mounts | | volume-mounts |
| cdi-cri | volume-mounts | envvar | volume-mounts |
| cdi-cri | envvar | | volume-mounts |
| cdi-cri | envvar | volume-mounts | volume-mounts |

**Testing done:**

<details>

```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": []}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": []
      }
    }
  }
}

bash: api: command not found
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

  }
}

Bottlerocket host's root filesystem.
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}

< settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "cdi-cri"
        ]
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
< settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}


string:

(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

    "version_id": "1.40.0"
  }
}
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="cdi-cri"
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "cdi-cri"
      }
    }
  }
}
ottlerocket host's root filesystem.
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}

<vidia": {"device-list-strategy": ["volume-mounts","envvar"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-li>
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "volume-mounts",
          "envvar"
        ]
      }
    }
  }
}
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": <!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
"1.40.0"
  }
}
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["volumn-mounts"]}}}}'
Failed to change settings: Failed PATCH request to '/settings?tx=apiclient-set-Q5P7hIRGMUiehHaC': Status 400 when PATCHing /settings?tx=apiclient-set-Q5P7hIRGMUiehHaC: Json deserialize error: data did not match any variant of untagged enum NvidiaDeviceListStrategy at line 1 column 78
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["volume-mounts"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "volume-mounts"
        ]
      }
    }
  }
}

h: ]apiclient: command not found
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[ssm-user@control]$ apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}

(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}

[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["envvar","cdi-cri","volume-mounts"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "envvar",
          "cdi-cri",
          "volume-mounts"
        ]
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
< settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "envvar"
      }
    }
  }
}
[root@admin]#


[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}

[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["envvar","volume-mounts"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "envvar",
          "volume-mounts"
        ]
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "envvar"
      }
    }
  }
}


[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["envvar"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "envvar"
        ]
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "envvar"
      }
    }
  }
}


Bottlerocket host's root filesystem.
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["cdi-cri","envvar","volume-mounts"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "cdi-cri",
          "envvar",
          "volume-mounts"
        ]
      }
    }
  }
}
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}




Bottlerocket host's root filesystem.
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["cdi-cri","volume-mounts"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "cdi-cri",
          "volume-mounts"
        ]
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
< settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "7edb3c30-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.40.0"
  }
}
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["cdi-cri","volume-mounts"]}}}}'
[root@admin]# apiclient set --json '{"settings": {"kubelet-device-plugins": {"nvidia": {"device-list-strategy": ["volume-mounts","envvar","cdi-cri"]}}}}'
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": [
          "volume-mounts",
          "envvar",
          "cdi-cri"
        ]
      }
    }
  }
}

[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}

```

</details>



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
