### PR TITLE
twoliter: bump to bottlerocket-kernel-kit v3.0.1

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,10 +9,10 @@ digest = "Ufe4lJz1PL3MBGZq6aVmdTIL/qF4EkSeQjU3o4sLHdU="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "2.5.1"
+version = "3.0.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v2.5.1"
-digest = "tbUxo4NMACfZs/RODxf0lvbpU7llhmtc3CphJbz4Gio="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v3.0.1"
+digest = "LEq1PrDLvFhedmzd7Jz2f9s/bmRSr8LqZqmBSbPdcY0="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,7 +11,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "2.5.1"
+version = "3.0.1"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4553

**Description of changes:**
Update kernel kit to 3.0.1


**Testing done:**
AMI built and booted during kernel kit release.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
