### PR TITLE
fix(ecr-credential-provider): dual-stack endpoint patterns

### DIFF
--- a/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/Cargo.toml
+++ b/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubernetes-ecr-credential-providers-correction"
+version = "0.1.0"
+authors = ["Carter McKinnon <mckdev@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/src/main.rs
+++ b/sources/settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction/src/main.rs
@@ -1,0 +1,52 @@
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added incorrect hostname patterns to be matched by the ECR credential provider.
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "settings.kubernetes.credential-providers.ecr-credential-provider.image-patterns",
+        old_vals: &[
+            "*.dkr.ecr.*.amazonaws.com",
+            "*.dkr.ecr.*.amazonaws.com.cn",
+            "*.dkr.ecr.*.on.aws",
+            "*.dkr.ecr.*.on.amazonwebservices.com.cn",
+            "*.dkr.ecr-fips.*.amazonaws.com",
+            "*.dkr.ecr.*.cloud.adc-e.uk",
+            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+            "*.dkr.ecr.*.c2s.ic.gov",
+            "*.dkr.ecr-fips.*.c2s.ic.gov",
+            "*.dkr.ecr.*.sc2s.sgov.gov",
+            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+            "*.dkr.ecr.*.csp.hci.ic.gov",
+            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+            "public.ecr.aws",
+        ],
+        new_vals: &[
+            "*.dkr.ecr.*.amazonaws.com",
+            "*.dkr.ecr.*.amazonaws.com.cn",
+            "*.dkr-ecr.*.on.aws",
+            "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+            "*.dkr.ecr-fips.*.amazonaws.com",
+            "*.dkr.ecr.*.cloud.adc-e.uk",
+            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+            "*.dkr.ecr.*.c2s.ic.gov",
+            "*.dkr.ecr-fips.*.c2s.ic.gov",
+            "*.dkr.ecr.*.sc2s.sgov.gov",
+            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+            "*.dkr.ecr.*.csp.hci.ic.gov",
+            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+            "public.ecr.aws",
+        ],
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/kubernetes-aws-credential-provider.toml
+++ b/sources/shared-defaults/kubernetes-aws-credential-provider.toml
@@ -4,8 +4,8 @@ cache-duration = "12h"
 image-patterns = [
     "*.dkr.ecr.*.amazonaws.com",
     "*.dkr.ecr.*.amazonaws.com.cn",
-    "*.dkr.ecr.*.on.aws",
-    "*.dkr.ecr.*.on.amazonwebservices.com.cn",
+    "*.dkr-ecr.*.on.aws",
+    "*.dkr-ecr.*.on.amazonwebservices.com.cn",
     "*.dkr.ecr-fips.*.amazonaws.com",
     "*.dkr.ecr.*.cloud.adc-e.uk",
     "*.dkr.ecr-fips.*.cloud.adc-e.uk",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**

The hostname patterns in the `ecr-credential-provider` config are not correct. See: https://docs.aws.amazon.com/general/latest/gr/ecr.html

We're also missing `*.dkr-ecr-fips.*.on.aws`, which I haven't added here.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
