### PR TITLE
twoliter: bump to bottlerocket-kernel-kit v3.0.2

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,10 +9,10 @@ digest = "Ufe4lJz1PL3MBGZq6aVmdTIL/qF4EkSeQjU3o4sLHdU="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "3.0.1"
+version = "3.0.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v3.0.1"
-digest = "LEq1PrDLvFhedmzd7Jz2f9s/bmRSr8LqZqmBSbPdcY0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v3.0.2"
+digest = "SQxRX/r4a1ahG6SVG7UTNaWPqxa3oNuf5e0jd091YKM="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,7 +11,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "3.0.1"
+version = "3.0.2"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**

Update to the new kernel kit release v3.0.2

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
