### PR TITLE
chore: change kubelets exec-start to 0600

### DIFF
--- a/sources/shared-defaults/kubernetes-services.toml
+++ b/sources/shared-defaults/kubernetes-services.toml
@@ -50,7 +50,7 @@ template-path = "/usr/share/templates/kubelet-server-key"
 [configuration-files.kubelet-exec-start-conf]
 path = "/etc/systemd/system/kubelet.service.d/exec-start.conf"
 template-path = "/usr/share/templates/kubelet-exec-start-conf"
-mode = "0644"
+mode = "0600"
 
 [configuration-files.credential-provider-config-yaml]
 path = "/etc/kubernetes/kubelet/credential-provider-config.yaml"


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

Change kubelet's exec-start file to be 0600 to meet newer CIS K8s guidance.


**Testing done:**

Built and tested an AMI.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
