### PR TITLE
Mark bootstrap containers service as affected by metadata.settings.network

### DIFF
--- a/sources/settings-defaults/aws-dev/defaults.d/50-aws-dev.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/50-aws-dev.toml
@@ -5,4 +5,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "docker", "host-containerd", "host-containers", "updog"]

--- a/sources/settings-defaults/metal-dev/defaults.d/50-metal-dev.toml
+++ b/sources/settings-defaults/metal-dev/defaults.d/50-metal-dev.toml
@@ -5,4 +5,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "docker", "host-containerd", "host-containers", "updog"]

--- a/sources/settings-defaults/vmware-dev/defaults.d/50-vmware-dev.toml
+++ b/sources/settings-defaults/vmware-dev/defaults.d/50-vmware-dev.toml
@@ -5,4 +5,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "docker", "host-containerd", "host-containers", "updog"]

--- a/sources/shared-defaults/defaults.toml
+++ b/sources/shared-defaults/defaults.toml
@@ -90,7 +90,7 @@ path = "/etc/network/proxy.env"
 template-path = "/usr/share/templates/proxy-env"
 
 [metadata.settings.network]
-affected-services = ["containerd", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "host-containerd", "host-containers", "updog"]
 
 [metadata.settings.network.hostname]
 affected-services = ["hostname", "hosts"]

--- a/sources/shared-defaults/ecs.toml
+++ b/sources/shared-defaults/ecs.toml
@@ -22,7 +22,7 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "dock
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "docker", "ecs", "host-containerd", "host-containers", "updog"]
 
 # Image registry credentials
 [metadata.settings.container-registry.credentials]

--- a/sources/shared-defaults/kubernetes-aws.toml
+++ b/sources/shared-defaults/kubernetes-aws.toml
@@ -23,7 +23,7 @@ template-path = "/usr/share/templates/pod-infra-container-image"
 service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kubelet"]
 
 [metadata.settings.network]
-affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "kubernetes", "host-containerd", "host-containers", "updog"]
 
 [services.autoscaling-warm-pool]
 configuration-files = ["warm-pool-wait-toml"]

--- a/sources/shared-defaults/kubernetes-metal.toml
+++ b/sources/shared-defaults/kubernetes-metal.toml
@@ -16,4 +16,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kube
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "kubernetes", "host-containerd", "host-containers", "updog"]

--- a/sources/shared-defaults/kubernetes-vmware.toml
+++ b/sources/shared-defaults/kubernetes-vmware.toml
@@ -16,4 +16,4 @@ service-checks = ["apiserver", "chronyd", "containerd", "host-containerd", "kube
 
 # Network
 [metadata.settings.network]
-affected-services = ["containerd", "kubernetes", "host-containerd", "host-containers", "updog"]
+affected-services = ["bootstrap-containers", "containerd", "kubernetes", "host-containerd", "host-containers", "updog"]


### PR DESCRIPTION
**Issue number:**

Part of the solution for bottlerocket-os/bottlerocket#4575

**Description of changes:**
This change adds bootstrap-containers to the list of affected services under `metadata.settings.network` for all variants. We need to do this so that whenever any relevant setting in `settings.network` changes, such as `settings.network.proxy`, the bootstrap containers service is restarted to run with the updated configuration.

This change is identical to the changes in https://github.com/bottlerocket-os/bottlerocket/commit/9bbf6220d8163c4b13c7e9a3ac7bc8b2b9c856c6.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
