### PR TITLE
Makefile: add task for reset-single-test

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -558,6 +558,10 @@ run_task = "run-twoliter"
 [tasks.reset-test]
 run_task = "run-twoliter"
 
+# This task will clear a specific test and its resources from the testsys cluster.
+[tasks.reset-single-test]
+run_task = "run-twoliter"
+
 # This task will clear all testsys components from the testsys cluster.
 [tasks.uninstall-test]
 run_task = "run-twoliter"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: https://github.com/bottlerocket-os/twoliter/issues/548

**Description of changes:**

Adding a task for the new `reset-single-test` testsys command added to twoliter here: https://github.com/bottlerocket-os/twoliter/pull/549

**Testing done:**

As a part of https://github.com/bottlerocket-os/twoliter/pull/549, I ran this task with my custom Twoliter

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
