### PR TITLE
Add soci-snapshotter to kubernetes variants

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.43.0"
+version = "1.44.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]

--- a/Release.toml
+++ b/Release.toml
@@ -429,3 +429,7 @@ version = "1.43.0"
     "migrate_v1.42.0_kubernetes-memory-swap-behavior-setting.lz4",
 ]
 "(1.42.0, 1.43.0)" = []
+"(1.43.0, 1.44.0)" = [
+    "migrate_v1.44.0_container-runtime-plugins-settings.lz4",
+    "migrate_v1.44.0_container-runtime-snapshotter-setting.lz4",
+]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.43.0"
+release-version = "1.44.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -52,106 +52,126 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
 [[package]]
 name = "argh"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+checksum = "34ff18325c8a36b82f992e533ece1ec9f9a9db446bd1c14d4f936bac88fcd240"
 dependencies = [
  "argh_derive",
  "argh_shared",
+ "rust-fuzzy-search",
 ]
 
 [[package]]
 name = "argh_derive"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+checksum = "adb7b2b83a50d329d5d8ccc620f5c7064028828538bdf5646acd60dc1f767803"
 dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "argh_shared"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+checksum = "a464143cc82dedcdc3928737445362466b7674b5db4e2eb8e869846d6d84f4f6"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "as_derive_utils"
@@ -167,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -177,19 +197,19 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -201,28 +221,28 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -233,9 +253,21 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -244,6 +276,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -259,17 +314,17 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "darling",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -304,7 +359,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "serde",
  "serde_plain",
@@ -313,7 +368,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -321,24 +376,24 @@ dependencies = [
  "quote",
  "serde",
  "serde_plain",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.11.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+version = "0.12.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -355,6 +410,7 @@ dependencies = [
  "settings-extension-cloudformation",
  "settings-extension-container-registry",
  "settings-extension-container-runtime",
+ "settings-extension-container-runtime-plugins",
  "settings-extension-dns",
  "settings-extension-ecs",
  "settings-extension-host-containers",
@@ -376,7 +432,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -388,7 +444,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -401,7 +457,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "serde",
 ]
@@ -409,23 +465,68 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "bounded-integer"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a6932c88f1d2c29533a3b8a5f5a2f84cc19c3339b431677c3160c5c2e6ca85"
+checksum = "102dbef1187b1893e6dfe05a774e79fd52265f49f214f6879c8ff49f52c8188b"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byte-unit"
+version = "5.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
+dependencies = [
+ "rust_decimal",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-readme"
@@ -442,25 +543,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.16"
+name = "cfg-if"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
-dependencies = [
- "shlex",
-]
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -468,45 +566,45 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const_panic"
-version = "0.2.8"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
+checksum = "2459fc9262a1aa204eb4b5764ad4f189caec88aea9634389c0a25f8be7f6265e"
 
 [[package]]
 name = "constants"
@@ -532,9 +630,9 @@ checksum = "69f3b219d28b6e3b4ac87bc1fc522e0803ab22e055da177bff0068c4150c61a6"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -550,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -566,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -576,34 +674,34 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.85",
+ "strsim",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "datastore"
@@ -646,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -665,20 +763,20 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -686,14 +784,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -708,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fnv"
@@ -726,6 +824,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generate-readme"
@@ -756,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -767,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "handlebars"
@@ -782,14 +886,23 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -798,10 +911,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
+name = "icu_collections"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "ident_case"
@@ -811,30 +1004,81 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kubelet-device-plugins-cdi-settings"
@@ -885,15 +1129,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -906,10 +1150,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
+name = "litemap"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -917,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "maplit"
@@ -929,9 +1179,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "migration-helpers"
@@ -957,11 +1207,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -991,11 +1241,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1017,42 +1266,48 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "oid-registry"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
  "asn1-rs",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1060,22 +1315,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1085,20 +1340,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.8"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1106,33 +1361,56 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.8"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.8"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1142,27 +1420,65 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.36"
+name = "ptr_meta"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1196,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1217,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1228,9 +1544,18 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "repr_offset"
@@ -1249,16 +1574,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
+name = "rkyv"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-fuzzy-search"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
+
+[[package]]
+name = "rust_decimal"
+version = "1.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -1273,10 +1649,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.17"
+name = "rustversion"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1294,41 +1676,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.22"
+name = "seahash"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1344,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1466,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1479,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1492,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1506,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1519,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1532,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1544,8 +1933,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-container-runtime"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1556,9 +1945,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-container-runtime-plugins"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "byte-unit",
+ "env_logger",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_json",
+ "toml",
+]
+
+[[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1571,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1584,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1597,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1610,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1623,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1637,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1650,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -1662,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1675,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1688,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1701,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1715,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1728,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1741,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1853,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1869,43 +2275,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "smallvec"
-version = "1.13.1"
+name = "simdutf8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418b8136fec49956eba89be7da2847ec1909df92a9ae4178b5ff0ff092c8d95e"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4812a669da00d17d8266a0439eddcacbc88b17f732f927e52eeb9d196f7fb5"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "stable_deref_trait"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1920,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,40 +2343,66 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -1977,25 +2415,35 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
+name = "tinystr"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2018,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2030,31 +2478,38 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.40"
+name = "toml_write"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2064,20 +2519,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -2105,42 +2560,27 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2148,16 +2588,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf8-width"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2171,9 +2633,67 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -2193,11 +2713,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2208,26 +2728,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2236,21 +2741,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2260,21 +2759,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2290,21 +2777,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2314,21 +2789,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2338,11 +2801,26 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]
@@ -2358,6 +2836,104 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -614,6 +614,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "container-runtime-plugins-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "container-runtime-snapshotter-setting"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "core_extensions"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -38,6 +38,8 @@ members = [
     "settings-migrations/v1.40.0/kubelet-device-plugins-cdi-settings",
     "settings-migrations/v1.41.0/kubernetes-ecr-credential-providers-correction",
     "settings-migrations/v1.42.0/kubernetes-memory-swap-behavior-setting",
+    "settings-migrations/v1.44.0/container-runtime-plugins-settings",
+    "settings-migrations/v1.44.0/container-runtime-snapshotter-setting",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -112,22 +112,22 @@ version = "0.1.0"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.11.0"
+tag = "bottlerocket-settings-models-v0.12.0"
 version = "0.10.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.11.0"
-version = "0.11.0"
+tag = "bottlerocket-settings-models-v0.12.0"
+version = "0.12.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.11.0"
+tag = "bottlerocket-settings-models-v0.12.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.11.0"
+tag = "bottlerocket-settings-models-v0.12.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/api/datastore/src/deserialization/pairs.rs
+++ b/sources/api/datastore/src/deserialization/pairs.rs
@@ -353,9 +353,7 @@ where
             } else {
                 // No dot, so we have a scalar; hand the data to a scalar deserializer.
                 trace!(
-                    "Key '{}' is scalar, getting '{}' from input to deserialize",
-                    struct_name,
-                    path
+                    "Key '{struct_name}' is scalar, getting '{path}' from input to deserialize"
                 );
                 let val = self.map.get(&path)?;
                 Some((

--- a/sources/api/datastore/src/key.rs
+++ b/sources/api/datastore/src/key.rs
@@ -314,7 +314,7 @@ impl Key {
         // Push final segment (keys don't end with a dot, which is when we normally push)
         segments.push(segment);
 
-        trace!("Parsed key name '{}' to segments {:?}", name, segments);
+        trace!("Parsed key name '{name}' to segments {segments:?}");
         Ok(segments)
     }
 
@@ -348,7 +348,7 @@ impl Key {
 
         // Join the (possibly quoted) segments with our separator.
         let name = outputs.join(KEY_SEPARATOR_STR);
-        trace!("Encoded key '{}' from segments {:?}", name, segments);
+        trace!("Encoded key '{name}' from segments {segments:?}");
         Ok(name)
     }
 

--- a/sources/api/datastore/src/lib.rs
+++ b/sources/api/datastore/src/lib.rs
@@ -205,7 +205,7 @@ pub trait DataStore {
         committed: &Committed,
     ) -> Result<HashMap<Key, String>> {
         let keys = self.list_populated_keys(&find_prefix, committed)?;
-        trace!("Found populated keys: {:?}", keys);
+        trace!("Found populated keys: {keys:?}");
         if keys.is_empty() {
             return Ok(HashMap::new());
         }
@@ -213,7 +213,7 @@ pub trait DataStore {
         let mut result = HashMap::new();
         for key in keys {
             // Already confirmed key via listing keys, so an error is more serious.
-            trace!("Pulling value from datastore for key: {}", key);
+            trace!("Pulling value from datastore for key: {key}");
             let value = self
                 .get_key(&key, committed)?
                 .context(error::ListedKeyNotPresentSnafu { key: key.name() })?;
@@ -238,7 +238,7 @@ pub trait DataStore {
         S2: AsRef<str>,
     {
         let meta_map = self.list_populated_metadata(&find_prefix, committed, metadata_key_name)?;
-        trace!("Found populated metadata: {:?}", meta_map);
+        trace!("Found populated metadata: {meta_map:?}");
         if meta_map.is_empty() {
             return Ok(HashMap::new());
         }

--- a/sources/api/datastore/src/serialization/mod.rs
+++ b/sources/api/datastore/src/serialization/mod.rs
@@ -51,13 +51,13 @@ impl ser::Serializer for &MapKeySerializer {
     fn serialize_str(self, value: &str) -> Result<String> {
         // Make sure string is valid as a key.
         let key = Key::from_segments(KeyType::Data, &[value]).map_err(|e| {
-            debug!("MapKeySerializer got invalid key name: {}", value);
+            debug!("MapKeySerializer got invalid key name: {value}");
             error::InvalidKeySnafu {
                 msg: format!("{e}"),
             }
             .into_error(NoSource)
         })?;
-        trace!("MapKeySerializer got OK key: {}", key);
+        trace!("MapKeySerializer got OK key: {key}");
         Ok(key.to_string())
     }
 

--- a/sources/api/datastore/src/serialization/pairs.rs
+++ b/sources/api/datastore/src/serialization/pairs.rs
@@ -204,7 +204,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         let prefix = match self.prefix {
             p @ Some(_) => p,
             None => {
-                trace!("Had no prefix, starting with struct name: {}", name);
+                trace!("Had no prefix, starting with struct name: {name}");
                 let key = Key::from_segments(KeyType::Data, &[&name]).map_err(|e| {
                     error::InvalidKeySnafu {
                         msg: format!("struct '{name}' not valid as Key: {e}"),

--- a/sources/bottlerocket-release/src/lib.rs
+++ b/sources/bottlerocket-release/src/lib.rs
@@ -88,7 +88,7 @@ impl BottlerocketRelease {
                     value = &value[..value.len() - 1];
                 }
 
-                debug!("Found os-release value {}={}", key, value);
+                debug!("Found os-release value {key}={value}");
                 Some((key.to_owned(), value.to_owned()))
             })
             .collect();

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -17,6 +17,7 @@ allow = [
     "Unlicense",
     "Zlib",
     "MPL-2.0",
+    "Unicode-3.0",
 ]
 
 exceptions = [
@@ -56,10 +57,12 @@ skip = [
     # bottlerocket-settings-sdk requires syn 1.x and 2.x for proc-macros
     # within itself and its dependencies.
     { name = "syn", version = "=1.0" },
-
-    # clap (via generate-readme) depends on strsim 0.11, but the bottlerocket-sdk
-    # depends on 0.10.
-    { name = "strsim", version = "=0.10" },
+    # thiserror v1.x is required by X.509 certificate parsing chain:
+    # asn1-rs -> der-parser -> x509-parser -> bottlerocket-modeled-types
+    # Also required by handlebars templating used in migration-helpers.
+    # thiserror v2.x is required by pest parser used in handlebars.
+    { name = "thiserror", version = "=1.0" },
+    { name = "thiserror-impl", version = "=1.0" },
 ]
 
 skip-tree = [

--- a/sources/settings-migrations/v1.44.0/container-runtime-plugins-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.44.0/container-runtime-plugins-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "container-runtime-plugins-settings"
+version = "0.1.0"
+authors = ["Gavin Inglis <giinglis@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.44.0/container-runtime-plugins-settings/src/main.rs
+++ b/sources/settings-migrations/v1.44.0/container-runtime-plugins-settings/src/main.rs
@@ -1,0 +1,20 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added new settings container-runtime-plugins
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.container-runtime-plugins",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.44.0/container-runtime-snapshotter-setting/Cargo.toml
+++ b/sources/settings-migrations/v1.44.0/container-runtime-snapshotter-setting/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "container-runtime-snapshotter-setting"
+version = "0.1.0"
+authors = ["Gavin Inglis <giinglis@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.44.0/container-runtime-snapshotter-setting/src/main.rs
+++ b/sources/settings-migrations/v1.44.0/container-runtime-snapshotter-setting/src/main.rs
@@ -1,0 +1,20 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added a new container-runtime setting for selecting snapshotter.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.container-runtime.snapshotter",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/settings-plugins/aws-k8s-nvidia/src/lib.rs
+++ b/sources/settings-plugins/aws-k8s-nvidia/src/lib.rs
@@ -23,6 +23,7 @@ struct AwsK8sSettings {
     cloudformation: bottlerocket_settings_models::CloudFormationSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
     container_runtime: bottlerocket_settings_models::ContainerRuntimeSettingsV1,
+    container_runtime_plugins: bottlerocket_settings_models::ContainerRuntimePluginsSettingsV1,
     autoscaling: bottlerocket_settings_models::AutoScalingSettingsV1,
     nvidia_container_runtime: bottlerocket_settings_models::NvidiaContainerRuntimeSettingsV1,
     kubelet_device_plugins: bottlerocket_settings_models::KubeletDevicePluginsV1,

--- a/sources/settings-plugins/aws-k8s/src/lib.rs
+++ b/sources/settings-plugins/aws-k8s/src/lib.rs
@@ -23,5 +23,6 @@ struct AwsK8sSettings {
     cloudformation: bottlerocket_settings_models::CloudFormationSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
     container_runtime: bottlerocket_settings_models::ContainerRuntimeSettingsV1,
+    container_runtime_plugins: bottlerocket_settings_models::ContainerRuntimePluginsSettingsV1,
     autoscaling: bottlerocket_settings_models::AutoScalingSettingsV1,
 }

--- a/sources/settings-plugins/vmware-k8s/src/lib.rs
+++ b/sources/settings-plugins/vmware-k8s/src/lib.rs
@@ -22,4 +22,5 @@ struct VmwareK8sSettings {
     oci_hooks: bottlerocket_settings_models::OciHooksSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
     container_runtime: bottlerocket_settings_models::ContainerRuntimeSettingsV1,
+    container_runtime_plugins: bottlerocket_settings_models::ContainerRuntimePluginsSettingsV1,
 }

--- a/sources/shared-defaults/kubernetes-containerd-nvidia.toml
+++ b/sources/shared-defaults/kubernetes-containerd-nvidia.toml
@@ -4,4 +4,27 @@ template-path = "/usr/share/templates/containerd-config-toml_k8s_nvidia_containe
 
 # Image registries
 [metadata.settings.container-registry]
-affected-services = ["containerd", "host-containers", "bootstrap-containers"]
+affected-services = ["containerd", "host-containers", "bootstrap-containers", "soci-snapshotter"]
+
+[configuration-files.snapshotter-toml]
+path = "/etc/containerd/config.d/001-snapshotter.toml"
+template-path = "/usr/share/templates/snapshotter-toml"
+overwrite-path-if-present = false
+
+# Container runtime - soci.
+[services.soci-snapshotter]
+configuration-files = ["soci-config-toml"]
+restart-commands = ["/bin/systemctl try-restart soci-snapshotter.service"]
+
+[configuration-files.soci-config-toml]
+path = "/etc/soci-snapshotter/config.toml"
+template-path = "/usr/share/templates/soci-config-toml"
+
+[configuration-files.selected-snapshotter]
+path = "/etc/containerd/selected-snapshotter"
+template-path = "/usr/share/templates/selected-snapshotter"
+
+# Container runtime plugins settings.
+
+[metadata.settings.container-runtime-plugins.soci-snapshotter]
+affected-services = ["soci-snapshotter"]

--- a/sources/shared-defaults/kubernetes-containerd.toml
+++ b/sources/shared-defaults/kubernetes-containerd.toml
@@ -4,4 +4,27 @@ template-path = "/usr/share/templates/containerd-config-toml_k8s_containerd_sock
 
 # Image registries
 [metadata.settings.container-registry]
-affected-services = ["containerd", "host-containers", "bootstrap-containers"]
+affected-services = ["containerd", "host-containers", "bootstrap-containers", "soci-snapshotter"]
+
+[configuration-files.snapshotter-toml]
+path = "/etc/containerd/config.d/001-snapshotter.toml"
+template-path = "/usr/share/templates/snapshotter-toml"
+overwrite-path-if-present = false
+
+# Container runtime - soci.
+[services.soci-snapshotter]
+configuration-files = ["soci-config-toml"]
+restart-commands = ["/bin/systemctl try-restart soci-snapshotter.service"]
+
+[configuration-files.soci-config-toml]
+path = "/etc/soci-snapshotter/config.toml"
+template-path = "/usr/share/templates/soci-config-toml"
+
+[configuration-files.selected-snapshotter]
+path = "/etc/containerd/selected-snapshotter"
+template-path = "/usr/share/templates/selected-snapshotter"
+
+# Container runtime plugins settings.
+
+[metadata.settings.container-runtime-plugins.soci-snapshotter]
+affected-services = ["soci-snapshotter"]

--- a/sources/shared-defaults/kubernetes-services.toml
+++ b/sources/shared-defaults/kubernetes-services.toml
@@ -10,6 +10,7 @@ configuration-files = [
   "kubelet-server-crt",
   "kubelet-server-key",
   "credential-provider-config-yaml",
+  "k8s-snapshotter-conf",
 ]
 restart-commands = [
   "/usr/bin/systemctl try-restart kubelet.service"
@@ -23,6 +24,12 @@ template-path = "/usr/share/templates/kubelet-env"
 path = "/etc/kubernetes/kubelet/config"
 template-path = "/usr/share/templates/kubelet-config"
 mode = "0600"
+
+[configuration-files.k8s-snapshotter-conf]
+path = "/etc/kubernetes/kubelet/config.d/001-snapshotter.conf"
+template-path = "/usr/share/templates/k8s-snapshotter-conf"
+mode = "0600"
+overwrite-path-if-present = false
 
 [configuration-files.kubelet-kubeconfig]
 path = "/etc/kubernetes/kubelet/kubeconfig"

--- a/variants/aws-k8s-1.28-fips/Cargo.toml
+++ b/variants/aws-k8s-1.28-fips/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.28",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.28-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.28-nvidia/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.28",
     "aws-iam-authenticator",
+    "soci-snapshotter",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.28/Cargo.toml
+++ b/variants/aws-k8s-1.28/Cargo.toml
@@ -25,6 +25,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.28",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.29-fips/Cargo.toml
+++ b/variants/aws-k8s-1.29-fips/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.29",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.29-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.29-nvidia/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.29",
     "aws-iam-authenticator",
+    "soci-snapshotter",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.29/Cargo.toml
+++ b/variants/aws-k8s-1.29/Cargo.toml
@@ -25,6 +25,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.29",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.30-fips/Cargo.toml
+++ b/variants/aws-k8s-1.30-fips/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.30",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.30-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.30",
     "aws-iam-authenticator",
+    "soci-snapshotter",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.30/Cargo.toml
+++ b/variants/aws-k8s-1.30/Cargo.toml
@@ -25,6 +25,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.30",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.31-fips/Cargo.toml
+++ b/variants/aws-k8s-1.31-fips/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.31",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.31-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.31",
     "aws-iam-authenticator",
+    "soci-snapshotter",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.31/Cargo.toml
+++ b/variants/aws-k8s-1.31/Cargo.toml
@@ -25,6 +25,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.31",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.32-fips/Cargo.toml
+++ b/variants/aws-k8s-1.32-fips/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.32",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.32-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.32",
     "aws-iam-authenticator",
+    "soci-snapshotter",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.32/Cargo.toml
+++ b/variants/aws-k8s-1.32/Cargo.toml
@@ -25,6 +25,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.32",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.33",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -31,6 +31,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.33",
     "aws-iam-authenticator",
+    "soci-snapshotter",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.33",
     "aws-iam-authenticator",
+    "soci-snapshotter",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/vmware-k8s-1.28-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.28-fips/Cargo.toml
@@ -38,6 +38,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.28",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.28/Cargo.toml
+++ b/variants/vmware-k8s-1.28/Cargo.toml
@@ -37,6 +37,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.28",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.29-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.29-fips/Cargo.toml
@@ -38,6 +38,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.29",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.29/Cargo.toml
+++ b/variants/vmware-k8s-1.29/Cargo.toml
@@ -37,6 +37,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.29",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.30-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.30-fips/Cargo.toml
@@ -38,6 +38,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.30",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.30/Cargo.toml
+++ b/variants/vmware-k8s-1.30/Cargo.toml
@@ -37,6 +37,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.30",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.31-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.31-fips/Cargo.toml
@@ -38,6 +38,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.31",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.31/Cargo.toml
+++ b/variants/vmware-k8s-1.31/Cargo.toml
@@ -37,6 +37,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.31",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.32-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.32-fips/Cargo.toml
@@ -38,6 +38,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.32",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.32/Cargo.toml
+++ b/variants/vmware-k8s-1.32/Cargo.toml
@@ -37,6 +37,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.32",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -40,6 +40,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.33",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -40,6 +40,7 @@ included-packages = [
     "cni",
     "cni-plugins",
     "kubelet-1.33",
+    "soci-snapshotter",
     # vmware
     "open-vm-tools",
 ]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Issue number:**

Closes #4578

**Description of changes:**
 
* update settings-sdk to 0.12.0
* Add configuration-files for k8s, containerd and soci.
* Add `soci-snapshotter` to all k8s variants
* Add migrations for new settings


**Testing done:**

Expand below for testing details. AMIs for testing built with this PR and

* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/91
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/582
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/569
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/576

<details>

### Regression testing

Run testsys against:
- [x] aws-k8s-1.33-x86_64
- [x] aws-k8s-1.33-aarch64
- [x] aws-k8s-1.30-x86_64
- [x] aws-k8s-1.29-aarch64
- [x] aws-k8s-1.29-nvidia-x86_64
- [x] aws-k8s-1.33-fips-x86_64

```
  NAME                                                  TYPE                 STATE                           PASSED             FAILED             SKIPPED   BUILD ID                   LAST UPDATE
 x86-64-aws-k8s-129-nvidia-quick                       Test                 passed                               5                  0                7410   5b3a3c0e-dirty             2025-07-21T20:02:44Z
 x86-64-aws-k8s-129-nvidia-test                        Test                 passed                              11                  0                   0   5b3a3c0e-dirty             2025-07-21T20:10:37Z
 x86-64-aws-k8s-129-quick                              Test                 passed                               5                  0                7410   5b3a3c0e-dirty             2025-07-21T19:29:55Z
 x86-64-aws-k8s-133-quick                              Test                 passed                               5                  0                6730   5b3a3c0e-dirty             2025-07-21T19:17:21Z

 aarch64-aws-k8s-129-quick         Test    passed       5      0    7410   13959fa3-dir   2025-07-23T21:15:1
 x86-64-aws-k8s-130-quick          Test    passed       5      0    7202   13959fa3-dir   2025-07-23T21:15:3
 x86-64-aws-k8s-133-fips-quick     Test    passed       5      0    6730   13959fa3-dir   2025-07-23T21:43:4
 aarch64-aws-k8s-133-quick                        Test                   passed                                   5                    0                 6730   13959fa3-dirty              2025-07-23T21:46:13Z
```

### Smoke test setting `settings.container-runtime.soci-snapshotter=soci` and running a pod

Variants, covering containerd-1.7 vs containerd 2.0, FIPS, nvidia, vwmare, etc. Using `i8g.24xlarge` (aarch64) and `i7ie.24xlarge` (x86_64). Pod:

Uses image `763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.22.1-deepspeed0.9.2-cu118` (from https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-models-frameworks-djl-serving.html) as a good candidate for SOCI parallel pull unpack (many layers, multiple multi-GB layers)

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: djl-deployment
  labels:
    app: djl-soci
spec:
  replicas: 1
  selector:
    matchLabels:
      app: djl-soci
  template:
    metadata:
      labels:
        app: djl-soci
    spec:
      containers:
      - name: djl-container
        #image: deepjavalibrary/djl-serving:0.26.0-deepspeed
        image: 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.22.1-deepspeed0.9.2-cu118
        command: ["sleep"]
        args: ["inf"]
```

For vmware, with smaller instance types, used the following pod deployment:

<details>

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: rmq-deployment
  labels:
    app: rmq-soci
spec:
  replicas: 1
  selector:
    matchLabels:
      app: rmq-soci
  template:
    metadata:
      labels:
        app: rmq-soci
    spec:
      containers:
      - name: rmq-container
        image: bitnami/rabbitmq:4.1.0
        command: ["sleep"]
        args: ["inf"]
```
</details>


For each variant, expand details to see:
* kubelet has `imageServiceEndpoint` configured to SOCI socket
* containerd has snapshotter set to `soci` and `proxy_plugins` configured
* snapshots exist under `/var/lib/soci-snapshotter`
* Pod reaches `Running`

- [x] aws-k8s-1.33-x86_64

<details>

```
# pod is running
k get pods -A
NAMESPACE          NAME                                     READY   STATUS    RESTARTS   AGE
default            djl-deployment-7c4bb44f54-hggzh          1/1     Running   0          8m58s


bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "5b3a3c0e-dirty",
    "pretty_name": "Bottlerocket OS 1.42.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.42.0"
  }
}
bash-5.1# apiclient get settings.cont
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}
bash-5.1# containerd config dump | grep soci
    snapshotter = 'soci'
  [proxy_plugins.soci]
    address = '/run/soci-snapshotter/soci-snapshotter.sock'
    [proxy_plugins.soci.exports]
      address = '/run/soci-snapshotter/soci-snapshotter.sock'
      root = '/var/lib/soci-snapshotter'
```
 Kubelet conf:

```
$ k get nodes
NAME                                         STATUS   ROLES    AGE   VERSION
ip-192-168-7-27.us-west-2.compute.internal   Ready    <none>   13m   v1.33.1-eks-b9364f6
# start proxy in another shell, then
$ curl -X GET http://127.0.0.1:8001/api/v1/nodes/ip-192-168-7-27.us-west-2.compute.internal/proxy/configz | jq .
...
    "imageServiceEndpoint": "unix:///run/soci-snapshotter/soci-snapshotter.sock",
...
```

</details>


- [x] aws-k8s-1.33-aarch64
<details>

```
# pod is running
k get pods -A
NAMESPACE          NAME                                     READY   STATUS    RESTARTS   AGE
default            djl-deployment-7c4bb44f54-w9g9v          1/1     Running   0          3m


bash-5.1# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "5b3a3c0e-dirty",
    "pretty_name": "Bottlerocket OS 1.42.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.42.0"
  }
}
bash-5.1# apiclient get settings.cont
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}
bash-5.1# containerd config dump | grep soci
    snapshotter = 'soci'
  [proxy_plugins.soci]
    address = '/run/soci-snapshotter/soci-snapshotter.sock'
    [proxy_plugins.soci.exports]
      address = '/run/soci-snapshotter/soci-snapshotter.sock'
      root = '/var/lib/soci-snapshotter'
bash-5.1# ls -l /usr/bin/soci-gunzip
lrwxrwxrwx. 1 root root 55 Jul 22 03:32 /usr/bin/soci-gunzip -> /aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/unpigz
```

```
$ k get nodes
NAME                                         STATUS   ROLES    AGE   VERSION
ip-192-168-25-178.us-west-2.compute.internal   Ready    <none>   13m   v1.33.1-eks-b9364f6
# start proxy in another shell, then
$ curl -X GET http://127.0.0.1:8001/api/v1/nodes/ip-192-168-7-27.us-west-2.compute.internal/proxy/configz | jq .
...
    "imageServiceEndpoint": "unix:///run/soci-snapshotter/soci-snapshotter.sock",
...
```

</details>

- [x] aws-k8s-1.29-x86_64

<details>

```
# pod is running
k get pods -A
NAMESPACE          NAME                                     READY   STATUS    RESTARTS   AGE
default            djl-deployment-7c4bb44f54-hggzh          1/1     Running   0          8m58s

bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "13959fa3-dirty",
    "pretty_name": "Bottlerocket OS 1.42.0 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.42.0"
  }
}
bash-5.1# apiclient get settings.cont
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "discard-unpacked-layers": true
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}
bash-5.1# containerd config dump | grep soci
      snapshotter = "soci"
  [proxy_plugins.soci]
    address = "/run/soci-snapshotter/soci-snapshotter.sock"
    [proxy_plugins.soci.exports]
      address = "/run/soci-snapshotter/soci-snapshotter.sock"
      root = "/var/lib/soci-snapshotter"
bash-5.1# ls -l /usr/bin/soci-gunzip
lrwxrwxrwx. 1 root root 53 Jul 23 19:52 /usr/bin/soci-gunzip -> /x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/igzip
```
 Kubelet conf:

```
$ k get nodes
NAME                                           STATUS   ROLES    AGE   VERSION
ip-192-168-92-168.us-west-2.compute.internal   Ready    <none>   35m   v1.29.15-eks-c4d80bb
# start proxy in another shell, then
$ curl -X GET http://127.0.0.1:8001/api/v1/nodes/ip-192-168-92-168.us-west-2.compute.internal/proxy/configz | jq .
...
    "imageServiceEndpoint": "unix:///run/soci-snapshotter/soci-snapshotter.sock",
...
```

</details>

- [x] aws-k8s-1.29-aarch64

<details>

```
# pod is running
k get pods -A
NAMESPACE          NAME                                     READY   STATUS    RESTARTS   AGE
default            djl-deployment-5d75f8ff5b-87sxk   1/1     Running  0   5m30s

bash-5.1# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "13959fa3-dirty",
    "pretty_name": "Bottlerocket OS 1.42.0 (aws-k8s-1.29)",
    "variant_id": "aws-k8s-1.29",
    "version_id": "1.42.0"
  }
}
bash-5.1# apiclient get settings.cont
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "discard-unpacked-layers": true
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}
bash-5.1# containerd config dump | grep soci
      snapshotter = "soci"
  [proxy_plugins.soci]
    address = "/run/soci-snapshotter/soci-snapshotter.sock"
    [proxy_plugins.soci.exports]
      address = "/run/soci-snapshotter/soci-snapshotter.sock"
      root = "/var/lib/soci-snapshotter"
bash-5.1# ls -l /usr/bin/soci-gunzip
lrwxrwxrwx. 1 root root 55 Jul 23 20:36 /usr/bin/soci-gunzip -> /aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/unpigz
```
 Kubelet conf:

```
$ k get nodes
NAME                                           STATUS   ROLES    AGE     VERSION
ip-192-168-85-232.us-west-2.compute.internal   Ready    <none>   3m14s   v1.29.15-eks-c4d80bb
# start proxy in another shell, then
$ curl -X GET http://127.0.0.1:8001/api/v1/nodes/ip-192-168-92-168.us-west-2.compute.internal/proxy/configz | jq .
...
    "imageServiceEndpoint": "unix:///run/soci-snapshotter/soci-snapshotter.sock",
...
```

</details>


- [x] vmware-k8s-1.33

```
default       rmq-deployment-6b7db77d4d-bm5m8    1/1     Running                 0             46s

bash-5.1# containerd config dump | grep soci
      snapshotter = "soci"
  [proxy_plugins.soci]
    address = "/run/soci-snapshotter/soci-snapshotter.sock"
    [proxy_plugins.soci.exports]
      address = "/run/soci-snapshotter/soci-snapshotter.sock"
      root = "/var/lib/soci-snapshotter"

bash-5.1# ls -lR /var/lib/soci-snapshotter
... <thousands of lines of content> ...
```

- [x] vmware-k8s-1.31

```
default       rmq-deployment-6b7db77d4d-zst9n    1/1     Running                 0               25s

bash-5.1# containerd config dump | grep soci
      snapshotter = "soci"
  [proxy_plugins.soci]
    address = "/run/soci-snapshotter/soci-snapshotter.sock"
    [proxy_plugins.soci.exports]
      address = "/run/soci-snapshotter/soci-snapshotter.sock"
      root = "/var/lib/soci-snapshotter"

bash-5.1# ls -lR /var/lib/soci-snapshotter
... <thousands of lines of content> ...
```


### All settings.container-runtime-plugins.soci-snapshotter settings are applied correctly ✅ 

On a variant, ensure setting of all settings under `settings.container-runtime-plugins.soci-snapshotter`


```
bash-5.1# apiclient get settings.cont
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "concurrent-download-chunk-size": 8000000,
          "discard-unpacked-layers": true,
          "max-concurrent-downloads": 10,
          "max-concurrent-unpacks": 5
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}

bash-5.1# cat /etc/soci-snapshotter/config.toml
...
[pull_modes.parallel_pull_unpack]
...
discard_unpacked_layers = true
...
bash-5.1# apiclient set container-runtime-plugins.soci-snapshotter.parallel-pull-unpack.discard-unpacked-layers=false
bash-5.1# cat /etc/soci-snapshotter/config.toml
...
[pull_modes.parallel_pull_unpack]
...
discard_unpacked_layers = false
...
```

### Snapshotter state reset on reboot after change to `settings.container-runtime.snapshotter` ✅ 

In each case, launch the same pod listed above. Chosen variant: `aws-k8s-1.33-x86_64`.

- [x] Reboot an instance with no change in snapshotter selection
  * 1x for soci and 1x for overlay configured
  * ensure all pods come back up
- [x] Boot with soci. Run some pods with example images. change snapshotter. reboot
  * ensure pods come back up to `Running`
  * ensure `ls -lR /var/lib/soci-snapshotter` is empty
- [x] Boot with overlay. Run some pods. change snapshotter. reboot.
  * ensure pods come back up to `Running`
  * ensure content via `ls -lR /var/lib/soci-snapshotter`
* **RESULTS: https://gist.github.com/ginglis13/cfc7d1d907e65d889af9b55923476e12**

### aws-ecs-2 ✅ 
    
Run a simple task for regression testing with task:

```
{
    "containerDefinitions": [
        {
            "name": "ecs-bottlerocket-smoke",
            "image": "public.ecr.aws/nginx/nginx:latest",
            "cpu": 0,
            "portMappings": [
                {
                    "name": "ecs-bottlerocket-smoke-80-tcp",
                    "containerPort": 80,
                    "hostPort": 80,
                    "protocol": "tcp",
                    "appProtocol": "http"
                }
            ],
            "essential": true,
            "environment": [],
            "mountPoints": [],
            "volumesFrom": [],
            "logConfiguration": {
                "logDriver": "awslogs",
                "options": {
                    "awslogs-group": "/ecs/bottlerocket-test",
                    "awslogs-region": "us-west-2"
                }
            },
            "systemControls": []
        }
    ],
    "family": "bottlerocket-ecs-smoke",
    "networkMode": "host",
    "revision": 3,
    "volumes": [],
    "status": "ACTIVE",
    "requiresAttributes": [
        {
            "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
        },
        {
            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
        },
        {
            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
        }
    ],
    "placementConstraints": [],
    "compatibilities": [
        "EC2"
    ],
    "requiresCompatibilities": [
        "EC2"
    ],
    "cpu": "1024",
    "memory": "3072",
    "enableFaultInjection": false,
    "tags": []
}
```

and ensure the task reaches state running:

```
{
    "tasks": [
        {
            "attachments": [],
            "attributes": [
                {
                    "name": "ecs.cpu-architecture",
                    "value": "x86_64"
                }
            ],
            "availabilityZone": "us-west-2c",
            "clusterArn": "arn:aws:ecs:us-west-2:<redacted>:cluster/bottlerocket",
            "connectivity": "CONNECTED",
            "connectivityAt": "2025-07-23T21:22:12.771000+00:00",
            "containerInstanceArn": "arn:aws:ecs:us-west-2:<redacted>:container-instance/bottlerocket/b82bcaaeda524847b8188adf7845e680",
            "containers": [
                {
                    "containerArn": "arn:aws:ecs:us-west-2:<redacted>:container/bottlerocket/120555bdf4614104a1db98e673ab34fc/68686b66-0667-40b1-9540-6f655f0e8ab1",
                    "taskArn": "arn:aws:ecs:us-west-2:458358962224:task/bottlerocket/120555bdf4614104a1db98e673ab34fc",
                    "name": "ecs-bottlerocket-smoke",
                    "image": "public.ecr.aws/nginx/nginx:latest",
                    "imageDigest": "sha256:0627d02b6071c63f6df28f49a815cbfed877f654986ec7a3a8af4bb793c03a7a",
                    "runtimeId": "d8de1103f99c92c65d79d9fef6478762921ca9975d34037208a408f7f3c63193",
                    "lastStatus": "RUNNING",
...
```

### settings migration testing 

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c71bcbe9",
    "pretty_name": "Bottlerocket OS 1.43.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.43.0"
  }
}
bash-5.1# apiclient get settings.container-runtime
{}
bash-5.1# apiclient get settings.container-runtime-plugins
{}
bash-5.1# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.33",
    "arch": "x86_64",
    "version": "1.44.0",
    "max_version": "1.44.0",
    "waves": {
      "0": "2025-07-24T21:53:43.981277545Z",
      "20": "2025-07-25T00:53:43.981277545Z",
      "102": "2025-07-25T20:53:43.981277545Z",
      "307": "2025-07-26T20:53:43.981277545Z",
      "819": "2025-07-28T20:53:43.981277545Z",
      "1228": "2025-07-29T20:53:43.981277545Z",
      "1843": "2025-07-30T20:53:43.981277545Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.33-x86_64-1.44.0-5df0641a-dirty-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.33-x86_64-1.44.0-5df0641a-dirty-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.33-x86_64-1.44.0-5df0641a-dirty-root.verity.lz4"
    }
  }
]
bash-5.1# updog update -i 1.44.0 -r -n
Starting update to 1.44.0
Reboot scheduled for Thu 2025-07-24 20:58:44 UTC, use 'shutdown -c' to cancel.
Update applied: aws-k8s-1.33 1.44.0

bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "5df0641a-dirty",
    "pretty_name": "Bottlerocket OS 1.44.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.44.0"
  }
}
bash-5.1# apiclient set settings.container-runtime.snapshotter=soci
bash-5.1# apiclient set settings.container-runtime-plugins.soci-snapshotter.parallel-pull-unpack.discard-unpacked-layers=true
bash-5.1# apiclient get settings.cont
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "discard-unpacked-layers": true
        }
      }
    }
  }
}
bash-5.1# cat /etc/containerd/selected-snapshotter
SELECTED_SNAPSHOTTER="overlayfs"
bash-5.1# cat /var/cache/containerd/active-snapshotter
ACTIVE_SNAPSHOTTER="overlayfs"
bash-5.1# cat /etc/containerd/config.d/001-snapshotter.toml
bash-5.1# cat /etc/kubernetes/kubelet/config.d/001-snapshotter.conf
---
kind: KubeletConfiguration
apiVersion: kubelet.config.k8s.io/v1beta1

bash-5.1# signpost rollback-to-inactive
bash-5.1# reboot

bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c71bcbe9",
    "pretty_name": "Bottlerocket OS 1.43.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.43.0"
  }
}
bash-5.1# apiclient get settings.cont
{}
```

### nvidia smoke test k8s-1.33 x86

Run pod on a g4dn.xlarge:

```
apiVersion: v1
kind: Pod
metadata:
  name: smoke-test
spec:
  hostNetwork: true
  restartPolicy: Never
  containers:
  - name: nvidia-smoke-test
    # Replace with your repo
    image: <redacted>.dkr.ecr.us-west-2.amazonaws.com/nvidia-smoke:latest
    command: ["/bin/sh", "-c"]
    args:
    - while true; do echo 'Running...'; sleep 5; done
    ports:
    - name: nvidia-tcp
      protocol: TCP
      containerPort: 80
      hostPort: 80
    resources:
      limits:
        nvidia.com/gpu: 1
```

where `nvidia-smoke:latest` is an image which simply prints "running" (the smoke test is in the resource request):

```
default            smoke-test                               1/1     Running   0          10s

$ kubelet logs pods/smoke-test
Running...
Running...
Running...
Running...

bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "12c0a0ac-dirty",
    "pretty_name": "Bottlerocket OS 1.44.0 (aws-k8s-1.33-nvidia)",
    "variant_id": "aws-k8s-1.33-nvidia",
    "version_id": "1.44.0"
  }
}
bash-5.1# apiclient get settings.cont
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "concurrent-download-chunk-size": 8000000,
          "discard-unpacked-layers": true,
          "max-concurrent-downloads": 10,
          "max-concurrent-unpacks": 5
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}
```


</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
