### PR TITLE
change the permissions of kubelet-server.key to 0600

### DIFF
--- a/sources/shared-defaults/kubernetes-services.toml
+++ b/sources/shared-defaults/kubernetes-services.toml
@@ -46,6 +46,7 @@ template-path = "/usr/share/templates/kubelet-server-crt"
 [configuration-files.kubelet-server-key]
 path = "/etc/kubernetes/pki/private/kubelet-server.key"
 template-path = "/usr/share/templates/kubelet-server-key"
+mode = "0600"
 
 [configuration-files.kubelet-exec-start-conf]
 path = "/etc/systemd/system/kubelet.service.d/exec-start.conf"


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

change the permissions of kubelet-server.key to 0600

**Testing done:**

Build & ran an AMI.  In EKS this file isn't used, but the permission should be fine for kubelet to read.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
