### PR TITLE
Update QUICKSTART-EKS.md

### DIFF
--- a/QUICKSTART-EKS.md
+++ b/QUICKSTART-EKS.md
@@ -385,7 +385,11 @@ Bottlerocket `v1.30.0+` supports Neuron Instance Types such as: `inf1`, `inf2`, 
 [settings.kubernetes]
 device-ownership-from-security-context = true
 ```
-This setting allows the container to take ownership of the mounted Neuron device based on the `runAsUser` and `runAsGroup` values provided in the spec.
+
+If you are provisioning nodes via [EKS Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/automode.html) the setting above is applied automatically - when using
+different provisioning mechanisms such as Karpenter or modified AMIs, we recommend you set [user-data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html).
+
+The following setting allows the container to take ownership of the mounted Neuron device based on the `runAsUser` and `runAsGroup` values provided in the spec.
 For more details on this, see the [Kubernetes documentation](https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/):
 
 ```yaml
@@ -404,8 +408,10 @@ spec:
   - name: test
     image: amazonlinux:2023
     resources:
+      requests:
+        aws.amazon.com/neuroncore: "1"
       limits:
         aws.amazon.com/neuron: "1"
 ```
 
-Along with the `device-ownership-from-secuirity-context` setting, you will need to deploy the [neuron-device-plugin](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-device-plugin), and optionally, the [neuron-scheduler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-scheduler-extension).
+Along with the `device-ownership-from-secuirity-context` setting, you will need to deploy the [neuron-device-plugin](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-device-plugin) in order to make neuron devices available to the container, and optionally, the [neuron-scheduler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-scheduler-extension).


### PR DESCRIPTION
Adding details pertinent to EKS Auto Mode

Last week I reached out to AWS support. The NodePool provisioned nodes and the containers running on them did not see the neuron devices. The AWS Support wasn't aware of the QUICKSTART and it is only Provisioners that are described in AWS Documentation (the auto-generated response, before I got to speak to an engineer was: this is known issue, see screenshot)

I reached to internal slack channel where I got help. The critical piece was specifying the request so that the neuron-plugin exposes the device. And other critical piece was: EKS Auto Mode should work.

Here is a screenshot of AWS support Q:

<img width="948" height="512" alt="image" src="https://github.com/user-attachments/assets/f7320961-451e-45b9-a093-066b3f69d73f" />


**Testing done:**

After the changes, deployed via flyte. And tested the devices were doing inference. Here is my pod definition:

```
return PodTemplate(
        primary_container_name="inferentia-primary",
        pod_spec=V1PodSpec(
            containers=[
                V1Container(
                    name="inferentia-primary",
                    # IPC_LOCK is required for the neuron devices to be visible to the container
                    # https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/docker-example/
                    security_context=V1SecurityContext(
                        capabilities=V1Capabilities(add=["IPC_LOCK"])
                    ),
                    # must be requested, neuron devices aren't exposed automatically (7/22/25)
                    resources={
                        "requests": {"aws.amazon.com/neuroncore": str(num_cores)},
                        "limits": {"aws.amazon.com/neuroncore": str(num_cores)},
                    },
                )
            ],
            affinity=V1Affinity(
                node_affinity=V1NodeAffinity(
                    required_during_scheduling_ignored_during_execution=V1NodeSelector(
                        node_selector_terms=[
                            V1NodeSelectorTerm(
                                match_expressions=[
                                    V1NodeSelectorRequirement(
                                        key="eks.amazonaws.com/instance-family",
                                        operator="In",
                                        values=[instance_type],
                                    )
                                ]
                            )
                        ]
                    )
                )
            ),
            tolerations=[
                V1Toleration(
                    key="aws.amazon.com/neuron",
                    operator="Exists",
                    effect="NoSchedule",
                )
            ],
            host_ipc=True,
            host_network=True,
            # must be set explicitly for the neuron devices to be visible to the container
            # https://github.com/bottlerocket-os/bottlerocket/blob/develop/QUICKSTART-EKS.md#neuron-support
            security_context=V1PodSecurityContext(
                run_as_user=1001,
                run_as_group=2001,
                fs_group=3001,
            ),
        ),
    )
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
