### PR TITLE
Bump SDK, CoreKit, KernelKit versions

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -2,10 +2,10 @@ schema-version = 1
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.63.0"
+version = "0.64.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.63.0"
-digest = "qoCURTMSE+NeT65OVSYlm+Ex9x2iK5w/B1cMTuG5Rz8="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.64.0"
+digest = "kRW2MsSo3jA+rAEO/Mp5gW8Q4/pd62bbB/lT4d5Jzak="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -9,10 +9,10 @@ digest = "kRW2MsSo3jA+rAEO/Mp5gW8Q4/pd62bbB/lT4d5Jzak="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "4.0.1"
+version = "4.1.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v4.0.1"
-digest = "CuQ8Dujb90KwAeH/Pdw2OJGmJvrNT6a58xV7eqe/CpI="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v4.1.0"
+digest = "oUNDxQLeILm/LLB3joN+CXYTrCj6myoM/YJth/lr/0s="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -16,7 +16,7 @@ digest = "oUNDxQLeILm/LLB3joN+CXYTrCj6myoM/YJth/lr/0s="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.1.2"
+version = "10.2.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v10.1.2"
-digest = "6210fd2OJcTT5sX0JMfXCDq6kLwoWkxu4p7GdpWuimU="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v10.2.0"
+digest = "8ncIwZGGIjYsTedHkc7i0Ul7NRyc384tUBQ1vUJwJ7A="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -11,7 +11,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "4.0.1"
+version = "4.1.0"
 vendor = "bottlerocket"
 
 [[kit]]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -6,7 +6,7 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.63.0"
+version = "0.64.0"
 vendor = "bottlerocket"
 
 [[kit]]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -16,5 +16,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.1.2"
+version = "10.2.0"
 vendor = "bottlerocket"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
- bump SDK from 0.63.0 to 0.64.0
- bump kernel-kit from 4.0.1 to 4.1.0
- bump core-kit from 10.1.2 to 10.2.0


**Testing done:**
As part of https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/249, an AMI was build that includes the changes in this PR (minus the version bump of Bottlerocket):

```bash
[root@admin] go version /.bottlerocket/rootfs/usr/bin/containerd
/.bottlerocket/rootfs/usr/bin/containerd: go1.23.12
[root@admin]
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
