### PR TITLE
Prepare the 1.46.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# v1.46.0 (2025-09-02)
+
+## Release Highlights
+* Add support for new Kubernetes setting `static-pods-enabled` ([bottlerocket-core-kit#641])
+* Add default bind directories for ephemeral storage ([bottlerocket-core-kit#632])
+
+## OS Changes
+* Update `bottlerocket-sdk` from 0.63.0 to 0.64.0 ([commits](https://github.com/bottlerocket-os/bottlerocket-sdk/compare/v0.63.0...v0.64.0))([#4623])
+* Update `bottlerocket-core-kit` from 10.1.2 to 10.3.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v1030-2025-08-26) ([commits](https://github.com/bottlerocket-os/bottlerocket-core-kit/compare/v10.1.2...v10.3.0)) ([#4623], [#4628])
+* Update `bottlerocket-kernel-kit` from 4.0.1 to 4.2.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v420-2025-08-25) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v4.0.1...v4.2.0)) ([#4623], [#4626])
+
+## Build Changes
+### Twoliter
+* Update `twoliter` from 0.11.0 to 0.12.0 and schema-version to 2 [CHANGELOG](https://github.com/bottlerocket-os/twoliter/blob/develop/CHANGELOG.md#0120---2025-08-21) ([commits](https://github.com/bottlerocket-os/twoliter/compare/v0.11.0...v0.12.0)) ([#4624])
+
+[#4623]: https://github.com/bottlerocket-os/bottlerocket/pull/4623
+[#4624]: https://github.com/bottlerocket-os/bottlerocket/pull/4624
+[#4626]: https://github.com/bottlerocket-os/bottlerocket/pull/4626
+[#4628]: https://github.com/bottlerocket-os/bottlerocket/pull/4628
+[bottlerocket-core-kit#632]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/632
+[bottlerocket-core-kit#641]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/641
+
 # v1.45.0 (2025-08-18)
 
 ## Release Highlights

--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.45.0"
+version = "1.46.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]

--- a/Release.toml
+++ b/Release.toml
@@ -434,3 +434,6 @@ version = "1.45.0"
     "migrate_v1.44.0_container-runtime-snapshotter-setting.lz4",
 ]
 "(1.44.0, 1.45.0)" = []
+"(1.45.0, 1.46.0)" = [
+    "migrate_v1.46.0_kubernetes-static-pods-enabled-setting.lz4",
+]

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "hl4lWZ9WFncH72ZaZ06WOu0yg5dL1Y8/VzWwaOjJu8g="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.2.0"
+version = "10.3.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v10.2.0"
-digest = "8ncIwZGGIjYsTedHkc7i0Ul7NRyc384tUBQ1vUJwJ7A="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v10.3.0"
+digest = "dT7bsoCAZmBVFw7Us7PcMHQg5ru47B6aLM5G6+mmDaQ="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.2.0"
+version = "10.3.0"
 vendor = "bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.45.0"
+release-version = "1.46.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1142,6 +1142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-static-pods-enabled-setting"
+version = "0.1.0"
+dependencies = [
+ "maplit",
+ "migration-helpers",
+ "snafu",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -303,8 +303,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-defaults-helper"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-defaults-helper-v0.1.0#9cb0286b59cd4fcb5df9dd441aee8521ea5698e6"
+version = "0.1.1"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "snafu",
  "toml",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "darling",
  "quote",
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "serde",
  "serde_plain",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -392,8 +392,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.12.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+version = "0.13.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -432,7 +432,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "serde",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1934,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1947,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2003,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2028,8 +2028,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+version = "0.5.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2056,19 +2056,20 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
  "env_logger",
  "serde",
  "serde_json",
+ "snafu",
 ]
 
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2081,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2094,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2107,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2121,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2134,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2147,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "settings-migrations/v1.42.0/kubernetes-memory-swap-behavior-setting",
     "settings-migrations/v1.44.0/container-runtime-plugins-settings",
     "settings-migrations/v1.44.0/container-runtime-snapshotter-setting",
+    "settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -106,27 +106,27 @@ walkdir = "2"
 
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-defaults-helper-v0.1.0"
-version = "0.1.0"
+tag = "bottlerocket-settings-models-v0.13.0"
+version = "0.1.1"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.12.0"
+tag = "bottlerocket-settings-models-v0.13.0"
 version = "0.10.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.12.0"
-version = "0.12.0"
+tag = "bottlerocket-settings-models-v0.13.0"
+version = "0.13.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.12.0"
+tag = "bottlerocket-settings-models-v0.13.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.12.0"
+tag = "bottlerocket-settings-models-v0.13.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting/Cargo.toml
+++ b/sources/settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kubernetes-static-pods-enabled-setting"
+version = "0.1.0"
+authors = ["Vighnesh Maheshwari <vighmah@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+maplit.workspace = true

--- a/sources/settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting/src/main.rs
+++ b/sources/settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new k8s settings for:
+/// - static_pods_enabled
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.static-pods-enabled",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- Updated the settings-sdk
- Added migrations for the new settings
- Update the core-kit
- Bump release version
- Add Changelog

**Testing done:**
- Built and tested a k8s-1.33 variant with sample workload
- Tested migrations for the new settings and verified that they work as expected
<Details>

```
bash-5.1# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.33",
    "arch": "x86_64",
    "version": "1.46.0",
    "max_version": "1.46.0",
    "waves": {
      "0": "2025-08-27T18:23:16.310950870Z",
      "20": "2025-08-27T21:23:16.310950870Z",
      "102": "2025-08-28T17:23:16.310950870Z",
      "307": "2025-08-29T17:23:16.310950870Z",
      "819": "2025-08-31T17:23:16.310950870Z",
      "1228": "2025-09-01T17:23:16.310950870Z",
      "1843": "2025-09-02T17:23:16.310950870Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.33-x86_64-1.46.0-419fc71d-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.33-x86_64-1.46.0-419fc71d-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.33-x86_64-1.46.0-419fc71d-root.verity.lz4"
    }
  }
]
```

#### Testing the migration when set to False:
After Upgrade
```
bash-5.1# cat /etc/kubernetes/kubelet/config | grep static
staticPodPath: "/etc/kubernetes/static-pods/"
bash-5.1# apiclient set settings.kubernetes.static-pods-enabled=false
bash-5.1#
bash-5.1# apiclient get settings.kubernetes.static-pods-enabled
{
  "settings": {
    "kubernetes": {
      "static-pods-enabled": false
    }
  }
}
bash-5.1# cat /etc/kubernetes/kubelet/config | grep static
bash-5.1#
```

After downgrade:
```
bash-5.1# cat /etc/kubernetes/kubelet/config | grep static
staticPodPath: "/etc/kubernetes/static-pods/"
bash-5.1# apiclient set settings.kubernetes.static-pods-enabled
Unknown argument 'settings.kubernetes.static-pods-enabled'
```

#### Testing the migration when set to True:
After Upgrade
```
bash-5.1# apiclient set settings.kubernetes.static-pods-enabled=true
bash-5.1#
bash-5.1# apiclient get settings.kubernetes.static-pods-enabled
{
  "settings": {
    "kubernetes": {
      "static-pods-enabled": true
    }
  }
}
bash-5.1# cat /etc/kubernetes/kubelet/config | grep static
staticPodPath: "/etc/kubernetes/static-pods/"
```
After Downgrade:
```
bash-5.1# cat /etc/kubernetes/kubelet/config | grep static
staticPodPath: "/etc/kubernetes/static-pods/"
```
</Details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
