### PR TITLE
variants: add k8s-1.34 variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_34"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_34-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_34-nvidia"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "metal-dev"
 version = "0.1.0"
 dependencies = [
@@ -331,6 +358,24 @@ dependencies = [
 
 [[package]]
 name = "vmware-k8s-1_33-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_34"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_34-fips"
 version = "0.1.0"
 dependencies = [
  "settings-defaults",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,15 @@ members = [
     "variants/aws-k8s-1.32-fips",
     "variants/aws-k8s-1.33",
     "variants/aws-k8s-1.33-fips",
+    "variants/aws-k8s-1.34",
+    "variants/aws-k8s-1.34-fips",
     "variants/aws-k8s-1.28-nvidia",
     "variants/aws-k8s-1.29-nvidia",
     "variants/aws-k8s-1.30-nvidia",
     "variants/aws-k8s-1.31-nvidia",
     "variants/aws-k8s-1.32-nvidia",
     "variants/aws-k8s-1.33-nvidia",
+    "variants/aws-k8s-1.34-nvidia",
     "variants/metal-dev",
     "variants/vmware-dev",
     "variants/vmware-k8s-1.28",
@@ -40,6 +43,8 @@ members = [
     "variants/vmware-k8s-1.32-fips",
     "variants/vmware-k8s-1.33",
     "variants/vmware-k8s-1.33-fips",
+    "variants/vmware-k8s-1.34",
+    "variants/vmware-k8s-1.34-fips",
 ]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ The following variants support EKS, as described above:
 * `aws-k8s-1.31`
 * `aws-k8s-1.32`
 * `aws-k8s-1.33`
+* `aws-k8s-1.34`
 * `aws-k8s-1.28-nvidia`
 * `aws-k8s-1.29-nvidia`
 * `aws-k8s-1.30-nvidia`
 * `aws-k8s-1.31-nvidia`
 * `aws-k8s-1.32-nvidia`
 * `aws-k8s-1.33-nvidia`
+* `aws-k8s-1.34-nvidia`
 
 The following variants support ECS:
 
@@ -87,6 +89,7 @@ We also have variants that are designed to be Kubernetes worker nodes in VMware:
 * `vmware-k8s-1.31`
 * `vmware-k8s-1.32`
 * `vmware-k8s-1.33`
+* `vmware-k8s-1.34`
 
 The following variants are no longer supported:
 

--- a/packages/settings-defaults/settings-defaults.spec
+++ b/packages/settings-defaults/settings-defaults.spec
@@ -147,6 +147,32 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description aws-k8s-1.33-nvidia
 %{summary}.
 
+%package aws-k8s-1.34
+Summary: Settings defaults for the aws-k8s 1.34 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.34)      or
+           %{_cross_os}variant(aws-k8s-1.34-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.34)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.34-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.34
+%{summary}.
+
+%package aws-k8s-1.34-nvidia
+Summary: Settings defaults for the aws-k8s 1.34 nvidia variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.34-nvidia)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.34-nvidia)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.34-nvidia
+%{summary}.
+
 %package metal-dev
 Summary: Settings defaults for the metal-dev variant
 Requires: %{_cross_os}variant(metal-dev)
@@ -211,6 +237,20 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description vmware-k8s-1.33
 %{summary}.
 
+%package vmware-k8s-1.34
+Summary: Settings defaults for the vmware-k8s 1.34 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(vmware-k8s-1.34)      or
+           %{_cross_os}variant(vmware-k8s-1.34-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.34)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.34-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description vmware-k8s-1.34
+%{summary}.
+
 %prep
 %setup -T -c
 %cargo_prep
@@ -227,10 +267,13 @@ for defaults in \
   aws-k8s-1.32-nvidia \
   aws-k8s-1.33 \
   aws-k8s-1.33-nvidia \
+  aws-k8s-1.34 \
+  aws-k8s-1.34-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
   vmware-k8s-1.33 \
+  vmware-k8s-1.34 \
   ;
 do
   projects+=( "-p" "settings-defaults-$(echo "${defaults}" | sed -e 's,\.,_,g')" )
@@ -260,10 +303,13 @@ for defaults in \
   aws-k8s-1.32-nvidia \
   aws-k8s-1.33 \
   aws-k8s-1.33-nvidia \
+  aws-k8s-1.34 \
+  aws-k8s-1.34-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
   vmware-k8s-1.33 \
+  vmware-k8s-1.34 \
   ;
 do
   crate="$(echo "${defaults}" | sed -e 's,\.,_,g')"
@@ -314,6 +360,14 @@ done
 %{_cross_defaultsdir}/aws-k8s-1.33-nvidia.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.33-nvidia.conf
 
+%files aws-k8s-1.34
+%{_cross_defaultsdir}/aws-k8s-1.34.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.34.conf
+
+%files aws-k8s-1.34-nvidia
+%{_cross_defaultsdir}/aws-k8s-1.34-nvidia.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.34-nvidia.conf
+
 %files metal-dev
 %{_cross_defaultsdir}/metal-dev.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-metal-dev.conf
@@ -329,3 +383,7 @@ done
 %files vmware-k8s-1.33
 %{_cross_defaultsdir}/vmware-k8s-1.33.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.33.conf
+
+%files vmware-k8s-1.34
+%{_cross_defaultsdir}/vmware-k8s-1.34.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.34.conf

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -62,6 +62,8 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.32)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.32-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.33)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.33-fips)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.34)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.34-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 Conflicts: %{_cross_os}variant-flavor(nvidia)
 
@@ -79,6 +81,7 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.30-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.31-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.32-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.33-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.34-nvidia)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description aws-k8s-nvidia
@@ -120,6 +123,8 @@ Provides: %{_cross_os}settings-plugin(vmware-k8s-1.32)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.32-fips)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.33)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.33-fips)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.34)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.34-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description vmware-k8s

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1827,6 +1827,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-defaults-aws-k8s-1_34"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-aws-k8s-1_34-nvidia"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
 name = "settings-defaults-metal-dev"
 version = "0.1.0"
 dependencies = [
@@ -1856,6 +1870,13 @@ dependencies = [
 
 [[package]]
 name = "settings-defaults-vmware-k8s-1_33"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-vmware-k8s-1_34"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-defaults-helper",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -22,11 +22,14 @@ members = [
     "settings-defaults/aws-k8s-1.32-nvidia",
     "settings-defaults/aws-k8s-1.33",
     "settings-defaults/aws-k8s-1.33-nvidia",
+    "settings-defaults/aws-k8s-1.34",
+    "settings-defaults/aws-k8s-1.34-nvidia",
     "settings-defaults/metal-dev",
     "settings-defaults/metal-k8s-1.30",
     "settings-defaults/vmware-dev",
     "settings-defaults/vmware-k8s-1.32",
     "settings-defaults/vmware-k8s-1.33",
+    "settings-defaults/vmware-k8s-1.34",
 
     # (all previous migrations archived; add new ones after this line)
     "settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings",

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_34-nvidia"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd-nvidia.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/57-kubernetes-device-ownership-default-false.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/57-kubernetes-device-ownership-default-false.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-false.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/58-kubernetes-graceful-shutdown.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/58-kubernetes-graceful-shutdown.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-graceful-shutdown.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/60-lockdown-none.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/60-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/82-nvidia-k8s-device-plugin-cdi.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/82-nvidia-k8s-device-plugin-cdi.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin-cdi.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/aws-k8s-1.34/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_34"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/57-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/57-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/58-kubernetes-graceful-shutdown.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/58-kubernetes-graceful-shutdown.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-graceful-shutdown.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/Cargo.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-vmware-k8s-1_34"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/15-public-tuf.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/20-public-host-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/20-public-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-host-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/21-public-bootstrap-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/21-public-bootstrap-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-bootstrap-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/31-send-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/50-kubernetes-vmware.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/50-kubernetes-vmware.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-vmware.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/54-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/54-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/55-kubernetes-device-ownership-default-false.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/55-kubernetes-device-ownership-default-false.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-false.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/70-public-ntp.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/70-public-ntp.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-ntp.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/80-oci-hooks.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/80-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/shared-defaults/kubernetes-aws-graceful-shutdown.toml
+++ b/sources/shared-defaults/kubernetes-aws-graceful-shutdown.toml
@@ -1,0 +1,3 @@
+[settings.kubernetes]
+shutdown-grace-period = "150s"
+shutdown-grace-period-for-critical-pods = "30s"

--- a/variants/README.md
+++ b/variants/README.md
@@ -117,6 +117,13 @@ It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazo
 
 This variant is compatible with Kubernetes 1.33, 1.34, 1.35 and 1.36 clusters.
 
+### aws-k8s-1.34: Kubernetes 1.34 node
+
+The [aws-k8s-1.34](aws-k8s-1.34/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.34, 1.35, 1.36 and 1.37 clusters.
+
 ### aws-k8s-1.33-nvidia: Kubernetes 1.33 NVIDIA node
 
 The [aws-k8s-1.33-nvidia](aws-k8s-1.33-nvidia/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
@@ -124,6 +131,14 @@ It also includes the required packages to configure containers to leverage NVIDI
 It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
 
 This variant is compatible with Kubernetes 1.33, 1.34, 1.35 and 1.36 clusters.
+
+### aws-k8s-1.34-nvidia: Kubernetes 1.34 NVIDIA node
+
+The [aws-k8s-1.34-nvidia](aws-k8s-1.34-nvidia/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It also includes the required packages to configure containers to leverage NVIDIA GPUs.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.34, 1.35, 1.36 and 1.37 clusters.
 
 ### aws-ecs-2: Amazon ECS container instance
 
@@ -188,6 +203,13 @@ The [vmware-k8s-1.33](vmware-k8s-1.33/Cargo.toml) variant includes the packages 
 It supports self-hosted clusters.
 
 This variant is compatible with Kubernetes 1.33, 1.34, 1.35, and 1.36 clusters.
+
+## vmware-k8s-1.34: VMware Kubernetes 1.34 node
+
+The [vmware-k8s-1.34](vmware-k8s-1.34/Cargo.toml) variant includes the packages needed to run a Kubernetes worker node as a VMware guest.
+It supports self-hosted clusters.
+
+This variant is compatible with Kubernetes 1.34, 1.35, 1.36, and 1.37 clusters.
 
 ### metal-dev: Metal development build
 

--- a/variants/aws-k8s-1.34-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-fips/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+# This is the aws-k8s-1.34-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_34-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.34",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.34-fips/amispec.toml
+++ b/variants/aws-k8s-1.34-fips/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+# This is the aws-k8s-1.34-nvidia variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_34-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.34",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+    # nvidia
+    "nvidia-container-toolkit-k8s",
+    "nvidia-k8s-device-plugin",
+    "kmod-6.12-nvidia-r580-tesla",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.34-nvidia/amispec.toml
+++ b/variants/aws-k8s-1.34-nvidia/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.34/Cargo.toml
+++ b/variants/aws-k8s-1.34/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+# This is the aws-k8s-1.34 variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_34"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.34",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.34/amispec.toml
+++ b/variants/aws-k8s-1.34/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/vmware-k8s-1.34-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.34-fips/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+# This is the vmware-k8s-1.34 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_34-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.34",
+    "soci-snapshotter",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.34-fips/template.ovf
+++ b/variants/vmware-k8s-1.34-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf

--- a/variants/vmware-k8s-1.34/Cargo.toml
+++ b/variants/vmware-k8s-1.34/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+# This is the vmware-k8s-1.34 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_34"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.34",
+    "soci-snapshotter",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.34/template.ovf
+++ b/variants/vmware-k8s-1.34/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf


### PR DESCRIPTION
Related to: #4620 

Please find test results at https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/653

**Description of changes:**
- Add k8s-1.34 variants

**Noteworthy changes compared to 1.33**
- The new k8s fips variant uses `kernel-6.12`
```
[root@admin]# sheltie
bash-5.1# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "0a1c9e8e",
    "pretty_name": "Bottlerocket OS 1.46.0 (aws-k8s-1.34-fips)",
    "variant_id": "aws-k8s-1.34-fips",
    "version_id": "1.46.0"
  }
}
bash-5.1# apiclient report fips
Benchmark name:  FIPS Security Policy
Version:         v1.0.0
Reference:       https://csrc.nist.gov/
Benchmark level: 1
Start time:      2025-09-09T18:00:15.672997958Z

[PASS] 1.0       FIPS mode is enabled. (Automatic)
[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
[PASS] 1.2       FIPS self-tests passed. (Automatic)

Passed:          3
Failed:          0
Skipped:         0
Total checks:    3

Compliance check result: PASS
bash-5.1# uname -r
6.12.40
```
- `systemd-257`, `containerd-2.1`, `nftables`
```
bash-5.1# systemctl --version
systemd 257 (257.7)
-PAM -AUDIT +SELINUX -APPARMOR -IMA +IPE -SMACK +SECCOMP -GCRYPT -GNUTLS -OPENSSL +ACL +BLKID -CURL -ELFUTILS-FIDO2 -IDN2 -IDN -IPTC +KMOD -LIBCRYPTSETUP -LIBCRYPTSETUP_PLUGINS +LIBFDISK -PCRE2 -PWQUALITY -P11KIT -QRENCODE -TPM2 -BZIP2 -LZ4 -XZ -ZLIB -ZSTD -BPF_FRAMEWORK -BTF -XKBCOMMON -UTMP -SYSVINIT -LIBARCHIVE
bash-5.1# iptables -V
iptables v1.8.11 (nf_tables)
bash-5.1# containerd --version
containerd github.com/containerd/containerd/v2 2.1.4+bottlerocket 75cb2b7193e4e490e9fbdc236c0e811ccaba3376
```
- `cdi` has been made default instead of `volume mounts` for `settings.kubelet-device-plugins.nvidia.device-list-strategy`
```
[ssm-user@control]$ apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "cdi-cri"
      }
    }
  }
}
```
- `graceful shutdown` defaults have been updated to 2 minutes 30 seconds, 30 secs for critical pods.

EC2 documents that an instance is allowed "several minutes" to shut down before it is forcefully terminated: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/how-ec2-instance-stop-start-works.html. While the exact amount of time may change, we're interpreting "several minutes" conservatively as "3 minutes". 

Some amount of time is needed for the rest of the OS to perform an orderly shutdown after kubelet completes its process, so we will limit the total kubelet shutdown grace period to 2 minutes and 30 seconds, with 30 seconds of that being allocated to critical pods.

```
[ssm-user@control]$ apiclient get settings.kubernetes.shutdown-grace-period
{
  "settings": {
    "kubernetes": {
      "shutdown-grace-period": "150s",
      "shutdown-grace-period-for-critical-pods": "30s"
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
