### PR TITLE
Support Entrypoint command for Host and Bootstrap containers

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -439,4 +439,5 @@ version = "1.47.0"
 ]
 "(1.46.0, 1.47.0)" = [
     "migrate_v1.47.0_container-runtime-concurrent-download-chunk-size.lz4",
+    "migrate_v1.47.0_host-bootstrap-containers-command-setting.lz4"
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "handlebars",
  "maplit",
  "models",
+ "regex",
  "serde",
  "serde_json",
  "shlex",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -933,6 +933,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "host-bootstrap-containers-command-setting"
+version = "0.1.0"
+dependencies = [
+ "maplit",
+ "migration-helpers",
+ "snafu",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "settings-migrations/v1.44.0/container-runtime-snapshotter-setting",
     "settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting",
     "settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size",
+    "settings-migrations/v1.47.0/host-bootstrap-containers-command-setting",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/api/migration/migration-helpers/Cargo.toml
+++ b/sources/api/migration/migration-helpers/Cargo.toml
@@ -13,6 +13,7 @@ bottlerocket-release.workspace = true
 datastore.workspace = true
 handlebars.workspace = true
 models.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shlex.workspace = true

--- a/sources/api/migration/migration-helpers/src/error.rs
+++ b/sources/api/migration/migration-helpers/src/error.rs
@@ -72,6 +72,18 @@ pub enum Error {
         source: Box<datastore::Error>,
     },
 
+    #[snafu(display(
+        "Invalid regex pattern for prefix '{}' and suffix '{}': {}",
+        prefix,
+        suffix,
+        source
+    ))]
+    InvalidPrefixSuffixPattern {
+        prefix: String,
+        suffix: String,
+        source: regex::Error,
+    },
+
     #[snafu(display("Unable to list transactions in data store: {}", source))]
     ListTransactions {
         #[snafu(source(from(datastore::Error, Box::new)))]

--- a/sources/settings-migrations/v1.47.0/host-bootstrap-containers-command-setting/Cargo.toml
+++ b/sources/settings-migrations/v1.47.0/host-bootstrap-containers-command-setting/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "host-bootstrap-containers-command-setting"
+version = "0.1.0"
+authors = ["Yutong Sun <yutongsu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true
+snafu.workspace = true
+
+[dev-dependencies]
+maplit.workspace = true

--- a/sources/settings-migrations/v1.47.0/host-bootstrap-containers-command-setting/src/main.rs
+++ b/sources/settings-migrations/v1.47.0/host-bootstrap-containers-command-setting/src/main.rs
@@ -1,0 +1,27 @@
+use migration_helpers::common_migrations::{AddPrefixSuffixMigration, PrefixSuffix};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added new settings container-runtime-plugins
+fn run() -> Result<()> {
+    migrate(AddPrefixSuffixMigration(vec![
+        PrefixSuffix {
+            prefix: "settings.host-containers",
+            suffix: "command",
+        },
+        PrefixSuffix {
+            prefix: "settings.bootstrap-containers",
+            suffix: "command",
+        },
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/593

**Description of changes:**
This PR adds migration support for the new `command` setting in 
- `settings.host-containers.<name>.command`
- `settings.bootstrap-containers.<name>.command`

Key changes:
- Added `AddPrefixSuffixMigration` helper for migrations that needs both prefix and suffix matches.
- Added the actual migration for the `settings.{host,bootstrap}-containers.<name>.command` settings.

The migration helper uses prefix/suffix patterns to identify and remove settings during downgrades:
```rust
AddPrefixSuffixMigration(vec![
   PrefixSuffix {
       prefix: "settings.host-containers.",
       suffix: ".command",
   },
   PrefixSuffix {
       prefix: "settings.bootstrap-containers.",
       suffix: ".command",
   },
])
```

**Testing done:**
<details>
<summary>Click to expand testing details</summary>

### Initial Setup and Upgrade Testing

**1. Pre-upgrade validation (expected failure)**
```bash
apiclient set -j '{
 "settings": {
   "bootstrap-containers": {
     "test-bootstrap": {
       "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.2.5",
       "mode": "once",
       "command": ["echo", "Message from bootstrap container command"],
       "user-data": "ZWNobyAnTWVzc2FnZSBmcm9tIGJvb3RzdHJhcCBjb250YWluZXIgdXNlci1kYXRhJwo="
     }
   },
   "host-containers": {
     "test-host": {
       "enabled": true,
       "source": "public.ecr.aws/amazonlinux/amazonlinux:2023",
       "command": ["sleep", "infinity"],
       "user-data": "ZWNobyAnTWVzc2FnZSBmcm9tIGhvc3QgY29udGFpbmVyIHVzZXItZGF0YScK"
     }
   }
 }
}'
```
**Result:** Failed as expected with error: `unknown field 'command', expected one of 'source', 'mode', 'user-data', 'essential'`

**2. Post-upgrade to v1.47.0**
Applied the same configuration successfully. Verified settings were properly stored:

```bash
# Host container verification
apiclient get settings.host-containers.test-host
{
 "settings": {
   "host-containers": {
     "test-host": {
       "command": ["sleep", "infinity"],
       "enabled": true,
       "source": "public.ecr.aws/amazonlinux/amazonlinux:2023",
       "user-data": "ZWNobyAnTWVzc2FnZSBmcm9tIGhvc3QgY29udGFpbmVyIHVzZXItZGF0YScK"
     }
   }
 }
}

# Bootstrap container verification
apiclient get settings.bootstrap-containers.test-bootstrap
{
 "settings": {
   "bootstrap-containers": {
     "test-bootstrap": {
       "command": ["echo", "Message from bootstrap container command"],
       "mode": "once",
       "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.2.5",
       "user-data": "ZWNobyAnTWVzc2FnZSBmcm9tIGJvb3RzdHJhcCBjb250YWluZXIgdXNlci1kYXRhJwo="
     }
   }
 }
}
```

### Downgrade Migration Testing
**3. Downgrade migration validation**
After downgrading from v1.47.0, verified that the `command` field was properly removed:

```bash
# Host container - command field removed
apiclient get settings.host-containers.test-host
{
 "settings": {
   "host-containers": {
     "test-host": {
       "enabled": true,
       "source": "public.ecr.aws/amazonlinux/amazonlinux:2023",
       "user-data": "ZWNobyAnTWVzc2FnZSBmcm9tIGhvc3QgY29udGFpbmVyIHVzZXItZGF0YScK"
     }
   }
 }
}

# Bootstrap container - command field removed
apiclient get settings.bootstrap-containers.test-bootstrap
{
 "settings": {
   "bootstrap-containers": {
     "test-bootstrap": {
       "mode": "off",
       "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.2.5",
       "user-data": "ZWNobyAnTWVzc2FnZSBmcm9tIGJvb3RzdHJhcCBjb250YWluZXIgdXNlci1kYXRhJwo="
     }
   }
 }
}
```

### Runtime Verification
After applying the new settings in step 2, reboot the node to verify both bootstrap and host containers pick up the settings.
**4. Container runtime validation**
```bash
# Verified custom host container is running
ctr -a /run/host-containerd/containerd.sock c ls
CONTAINER    IMAGE                                                                                RUNTIME
admin        ecr.aws/arn:aws:ecr:us-west-2:328549459982:repository/bottlerocket-admin:v0.12.2
io.containerd.runc.v2
...
test-host    public.ecr.aws/amazonlinux/amazonlinux:2023
io.containerd.runc.v2
```
**5. Container execution validation**
The custom host-container has entry point ["sleep", "infinity"], so we can exec into it for some extra testing.
```bash
# Verified apiclient exec works
apiclient exec test-host sh
sh-5.2# cat /etc/os-release
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
# ... (output truncated)
```

**6. Host container logs**
```bash
journalctl -u host-containers@test-host
Sep 08 22:29:13 ip-10-0-9-132.us-west-2.compute.internal host-containers@test-host[2583]: time="2025-09-08T22:29:
13Z" level=info msg="Image does not exist, proceeding to pull image from source."
Sep 08 22:29:16 ip-10-0-9-132.us-west-2.compute.internal host-containers@test-host[2583]: time="2025-09-08T22:29:
16Z" level=info msg="successfully started container task"
```

**7. Bootstrap container logs and command execution**
```bash
journalctl -b -u bootstrap-containers@test-bootstrap
Sep 08 22:39:21 ip-10-0-9-132.us-west-2.compute.internal bootstrap-containers@test-bootstrap[1674]: Message from
bootstrap container command
Sep 08 22:39:21 ip-10-0-9-132.us-west-2.compute.internal bootstrap-containers@test-bootstrap[1674]: time="2025-09-
08T22:39:21Z" level=info msg="container task exited" code=0
Sep 08 22:39:21 ip-10-0-9-132.us-west-2.compute.internal bootstrap-containers@test-bootstrap[1762]: 22:39:21 [INFO]
Mode for 'test-bootstrap' is 'once'
```
</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
